### PR TITLE
fix(capture): suppress phantom navigation step when a click causes a redirect

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -64,6 +64,16 @@ final class CaptureEventPipeline implements AutoCloseable {
     /** Last flushed input value per target, to drop the duplicate change-on-submit re-emission. */
     private final Map<String, String> lastEmittedInputValues = new LinkedHashMap<>();
     private final Map<String, BrowserSignal> pendingClicks = new LinkedHashMap<>();
+    // Collector-synthesized navigations (BiDi navigationCommitted / URL polling, blank
+    // navigationSource) race the click that caused them: the native signal often reaches accept()
+    // before the click's own slower JS-channel signal, so lastInteractionAt would still be stale
+    // when interactionConsequence is evaluated, misclassifying a click-caused navigation as
+    // spontaneous (phantom step). Buffering them one debounce window lets the click's signal —
+    // which stamps lastInteractionAt as soon as accept() sees it, regardless of buffering — win
+    // the race. Keyed by an incrementing counter, not targetKey(signal): several redirect hops
+    // within the window must each get their own consequence/duplicate evaluation, not coalesce.
+    private final Map<String, BrowserSignal> pendingNavigations = new LinkedHashMap<>();
+    private long pendingNavigationSequence;
     private final Map<String, String> logicalWindows = new LinkedHashMap<>();
     private final Map<String, LocatorPreference> locatorPreferences = new LinkedHashMap<>();
     private final Map<String, Instant> recentSignals = new LinkedHashMap<>();
@@ -124,10 +134,28 @@ final class CaptureEventPipeline implements AutoCloseable {
                 case "input" -> {
                     pendingInputs.put(targetKey(signal), signal);
                     if (signal.dataBoolean("committed")) {
+                        // This commit flushes immediately, bypassing flushPendingBefore; an
+                        // older buffered navigation must still be appended first so persisted
+                        // step order matches browser occurrence order.
+                        List<BrowserSignal> readyNavigations = new ArrayList<>();
+                        collectReady(pendingNavigations, signal.timestamp(), readyNavigations);
+                        flushOrdered(readyNavigations);
                         flushSignal(pendingInputs.remove(targetKey(signal)));
                     }
                 }
                 case "click" -> pendingClicks.put(targetKey(signal), signal);
+                case "navigation" -> {
+                    if (signal.dataString("navigationSource").isBlank()) {
+                        pendingNavigations.put(
+                                "navigation-" + (++pendingNavigationSequence), signal);
+                    } else {
+                        // history/user_annotation/user_traversal/user_reported are authoritative
+                        // (user_traversal in particular must never be delayed or swallowed): keep
+                        // their existing immediate handling.
+                        flushPendingBefore(signal.timestamp());
+                        emit(signal);
+                    }
+                }
                 case "keyboard" -> {
                     // Suppress standalone editing key actions (Backspace, Delete, arrow keys)
                     // when recorded on a text-entry element without modifiers.
@@ -165,12 +193,13 @@ final class CaptureEventPipeline implements AutoCloseable {
     }
 
     /**
-     * Returns the number of debounced signals (uncommitted typed input, pending clicks) that have
-     * not yet been persisted as semantic events. During that window {@link #eventCount()}
-     * under-reports; status consumers surface this so live monitors do not misread a quiet count.
+     * Returns the number of debounced signals (uncommitted typed input, pending clicks, buffered
+     * blank-source navigations) that have not yet been persisted as semantic events. During that
+     * window {@link #eventCount()} under-reports; status consumers surface this so live monitors
+     * do not misread a quiet count.
      */
     synchronized int pendingSignalCount() {
-        return pendingInputs.size() + pendingClicks.size();
+        return pendingInputs.size() + pendingClicks.size() + pendingNavigations.size();
     }
 
     @Override
@@ -190,6 +219,7 @@ final class CaptureEventPipeline implements AutoCloseable {
         Instant now = Instant.now();
         List<BrowserSignal> ready = new ArrayList<>();
         collectReady(pendingClicks, now.minus(CLICK_DEBOUNCE), ready);
+        collectReady(pendingNavigations, now.minus(CLICK_DEBOUNCE), ready);
         flushOrdered(ready);
     }
 
@@ -197,6 +227,7 @@ final class CaptureEventPipeline implements AutoCloseable {
         List<BrowserSignal> ready = new ArrayList<>();
         collectReady(pendingInputs, timestamp, ready);
         collectReady(pendingClicks, timestamp, ready);
+        collectReady(pendingNavigations, timestamp, ready);
         flushOrdered(ready);
     }
 
@@ -214,8 +245,10 @@ final class CaptureEventPipeline implements AutoCloseable {
     private void flushAll() {
         List<BrowserSignal> pending = new ArrayList<>(pendingInputs.values());
         pending.addAll(pendingClicks.values());
+        pending.addAll(pendingNavigations.values());
         pendingInputs.clear();
         pendingClicks.clear();
+        pendingNavigations.clear();
         flushOrdered(pending);
     }
 
@@ -279,8 +312,14 @@ final class CaptureEventPipeline implements AutoCloseable {
         boolean duplicateDelivery = url.equals(lastNavigationUrl)
                 && Duration.between(lastNavigationAt, signal.timestamp()).abs()
                 .compareTo(NAVIGATION_DEBOUNCE) < 0;
-        boolean interactionConsequence = Duration.between(lastInteractionAt, signal.timestamp()).abs()
-                .compareTo(INTERACTION_NAVIGATION_WINDOW) < 0;
+        // Forward-only: buffered navigations are now evaluated after lastInteractionAt may have
+        // advanced past their own timestamp (a later, unrelated interaction stamped it while this
+        // navigation sat in pendingNavigations). Only a navigation at or after the interaction can
+        // be its consequence; a negative gap means this navigation predates the interaction and
+        // must never be suppressed by it.
+        Duration sinceInteraction = Duration.between(lastInteractionAt, signal.timestamp());
+        boolean interactionConsequence = !sinceInteraction.isNegative()
+                && sinceInteraction.compareTo(INTERACTION_NAVIGATION_WINDOW) < 0;
         lastNavigationUrl = url;
         lastNavigationAt = signal.timestamp();
         currentUrlConsumer.accept(url);

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -405,10 +405,12 @@ class CaptureEventPipelineTest {
                 Map.of("button", 0, "clickCount", 1, "clientActionId", "ui-2"),
                 Map.of("domSnapshot", "<html><body><button id=\"submit\">Save</button>"
                         + "<span>bearer abcdefghijklmnop</span></body></html>")));
-        // The navigation flushes the debounced click immediately; it is itself a consequence of
-        // that click (within the interaction window) so it never becomes a recorded step.
+        // The navigation is buffered (blank navigationSource); it is itself a consequence of that
+        // click (within the interaction window) so once flushed at stop it never becomes a
+        // recorded step.
         pipeline.accept(signal("navigation", START.plusMillis(1), Map.of(),
                 Map.of("action", "OPEN"), Map.of("url", "https://example.test/next")));
+        pipeline.close();
 
         CaptureSession session = store.read();
         assertEquals(1, session.events().size());
@@ -455,6 +457,59 @@ class CaptureEventPipelineTest {
         assertEquals("https://example.test/home", navigations.get(0).targetUrl());
         assertEquals("https://example.test/pricing", navigations.get(1).targetUrl());
         assertEquals(1, events.stream().filter(CaptureEvent.ClickEvent.class::isInstance).count());
+    }
+
+    @Test
+    void suppressesNavigationWhenCollectorSignalWinsTheRaceAgainstItsCausingClick(@TempDir Path temp) {
+        // Root cause of the phantom-navigation bug: the BiDi collector's navigationCommitted /
+        // URL-polling signal (blank navigationSource) can reach accept() before the click's own
+        // slower JS-channel signal, even though the click happened first and caused the
+        // navigation. Simulate the race directly: accept() the navigation before the click, with
+        // the navigation's own timestamp after the click's (it really is the click's consequence).
+        // Buffering the navigation lets the click's accept() call -- which stamps
+        // lastInteractionAt immediately regardless of buffering -- win before the navigation is
+        // evaluated at the debounce flush.
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("navigation", START.plusMillis(50), Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/redirected")));
+        pipeline.accept(signal("click", START, buttonTarget(),
+                Map.of("button", 0, "clickCount", 1), Map.of()));
+        pipeline.close();
+
+        List<CaptureEvent> events = store.read().events();
+        assertEquals(1, events.stream().filter(CaptureEvent.ClickEvent.class::isInstance).count(),
+                "The click that caused the navigation must still be recorded.");
+        assertFalse(events.stream().anyMatch(CaptureEvent.NavigationEvent.class::isInstance),
+                "The racy collector-generated navigation must be suppressed as a click consequence, "
+                        + "not persisted as a phantom step.");
+    }
+
+    @Test
+    void recordsStandaloneNavigationWithNoPrecedingInteraction(@TempDir Path temp) {
+        // Address-bar navigation (or the initial page open) with no click anywhere near it must
+        // still be recorded even though it now goes through the pendingNavigations buffer like
+        // every other blank-navigationSource signal.
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("navigation", START, Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/standalone")));
+        pipeline.close();
+
+        List<CaptureEvent> events = store.read().events();
+        assertEquals(1, events.size());
+        assertEquals("https://example.test/standalone",
+                assertInstanceOf(CaptureEvent.NavigationEvent.class, events.getFirst()).targetUrl());
     }
 
     @Test


### PR DESCRIPTION
## Bug
In the web capture recorder, when a **click causes a redirect**, a phantom "navigation" step was inserted into the recorded steps. It shouldn't — a navigation that is the consequence of a recorded click is not a separate user step.

## Root cause
Collector-synthesized navigation signals (WebDriver BiDi `navigationCommitted` / URL polling) carry a **blank `navigationSource`** and were emitted immediately by `CaptureEventPipeline`. That native signal usually reaches `accept()` **before** the click's own (slower, JS-channel-delivered) signal, so `lastInteractionAt` was still stale when the `interactionConsequence` check ran → the navigation was misclassified as a real step.

## Fix
- Buffer blank-`navigationSource` navigations in a `pendingNavigations` map (mirroring the existing `pendingClicks`/`pendingInputs` debounce), flushed via the same tick — giving the click's signal a real ~300 ms window to arrive and update `lastInteractionAt` before the consequence check.
- Navigations carrying a `navigationSource` (`history`, `user_annotation`, **`user_traversal`**, `user_reported`) keep immediate handling — back/forward is never delayed or swallowed.
- Made `interactionConsequence` **forward-only** (a navigation is a consequence only if it occurs at/after its causing interaction, within the window) — required once navigations are evaluated post-buffering, so a later unrelated interaction can't cause an earlier spontaneous navigation to be wrongly suppressed.

## Verification (scoped `-pl shaft-capture`)
`CaptureEventPipelineTest` → **23/23**, 0 failures. New: the race test (collector nav wins vs its causing click → suppressed; **fails without the fix**), and a standalone-navigation-still-recorded test. Existing history/traversal/suppression tests unchanged.

This is part 1 of a multi-part recorder/plugin request; PRs for the delete-persistence race, plugin-upgrade cache reset, and setup-panel UX follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)