### PR TITLE
feat: auto-reset stale plugin state on IntelliJ plugin upgrade (#3547)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftPluginResetService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftPluginResetService.java
@@ -63,11 +63,29 @@ public final class ShaftPluginResetService {
      * the setup view.
      */
     public void resetEverything() {
+        resetState(true);
+    }
+
+    /**
+     * Factory-resets settings, stored provider credentials, and tool approvals exactly like
+     * {@link #resetEverything()} does, but preserves every open project's Assistant chat history.
+     * Used when an upgrade is detected ({@code ShaftPluginUpgradeActivity}): the stale UI/setup
+     * state (including a cached {@code mcpCommand} that would otherwise keep launching an old
+     * shaft-mcp) must not survive the upgrade, but a user's conversation history is not "stale" and
+     * must not be silently deleted just because the plugin updated.
+     */
+    public void resetForUpgrade() {
+        resetState(false);
+    }
+
+    private void resetState(boolean clearChat) {
         settingsReset.run();
         credentialsReset.run();
         approvalsReset.run();
-        for (ShaftAssistantChatState chatState : chatStatesSupplier.get()) {
-            chatState.clearAll();
+        if (clearChat) {
+            for (ShaftAssistantChatState chatState : chatStatesSupplier.get()) {
+                chatState.clearAll();
+            }
         }
         toolWindowRerenderer.run();
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftPluginUpgradeActivity.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftPluginUpgradeActivity.java
@@ -1,0 +1,106 @@
+package com.shaft.intellij.settings;
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.ProjectActivity;
+import kotlin.Unit;
+import kotlin.coroutines.Continuation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Detects a plugin version upgrade (the running version differs from the last-seen version
+ * persisted in settings) once per IDE session and, on upgrade, factory-resets the stale local
+ * UI/setup state -- settings, stored provider credentials, and tool approvals -- while
+ * preserving every open project's Assistant chat history, then re-renders any open SHAFT tool
+ * window. This fixes two upgrade-time bugs: the setup page failing to re-render after an update,
+ * and the recorder launching an old shaft-mcp because a stale {@code mcpCommand} survived the
+ * update.
+ *
+ * <p>{@link com.intellij.openapi.startup.ProjectActivity} fires once per opened project, but the
+ * version compare-and-reset must run exactly once per IDE session; {@link #CHECKED} guards that,
+ * mirroring the process-wide {@code AtomicBoolean} pattern used by
+ * {@link com.shaft.intellij.ui.ShaftRecordingActivity#active()}.
+ */
+public final class ShaftPluginUpgradeActivity implements ProjectActivity {
+    private static final AtomicBoolean CHECKED = new AtomicBoolean();
+    private static final String PLUGIN_ID = "io.github.shafthq.shaft";
+
+    /** Outcome of comparing the stored last-seen version against the running version. */
+    enum UpgradeDecision {
+        /** No version was ever stored: a fresh install, not an upgrade -- no reset. */
+        FRESH_INSTALL,
+        /** Stored version differs from the running version: an upgrade -- reset required. */
+        UPGRADED,
+        /** Stored version matches the running version: nothing to do. */
+        UNCHANGED
+    }
+
+    @Nullable
+    @Override
+    public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
+        if (CHECKED.compareAndSet(false, true)) {
+            checkForUpgrade(runningPluginVersion(), ShaftSettingsState.getInstance(),
+                    ShaftPluginResetService.getInstance());
+        }
+        return Unit.INSTANCE;
+    }
+
+    /**
+     * Compares the running plugin version against the last-seen version stored in
+     * {@code settingsState}, resetting via {@code resetService} on an upgrade and persisting the
+     * running version afterward (issue: plugin-upgrade auto-reset). A no-op when the running
+     * version could not be resolved.
+     *
+     * @param runningVersion the currently running plugin version, or {@code null} if unresolved
+     * @param settingsState  the application settings state holding {@code lastSeenPluginVersion}
+     * @param resetService   the service used to reset stale state on an upgrade
+     */
+    static void checkForUpgrade(@Nullable String runningVersion,
+                                 @NotNull ShaftSettingsState settingsState,
+                                 @NotNull ShaftPluginResetService resetService) {
+        if (runningVersion == null || runningVersion.isBlank()) {
+            return;
+        }
+        ShaftSettingsState.Settings settings = settingsState.getState();
+        UpgradeDecision decision = shouldResetForUpgrade(settings.lastSeenPluginVersion, runningVersion);
+        if (decision == UpgradeDecision.UPGRADED) {
+            resetService.resetForUpgrade();
+        }
+        if (decision != UpgradeDecision.UNCHANGED) {
+            // getState() always returns the same live Settings instance (loadState() copies field
+            // values onto it via XmlSerializerUtil.copyBean rather than swapping the reference), so
+            // this write lands after resetForUpgrade()'s factory-defaults reset above and survives it,
+            // exactly as required: lastSeenPluginVersion must reflect the running version once this
+            // method returns, whether or not a reset happened.
+            settings.lastSeenPluginVersion = runningVersion;
+        }
+    }
+
+    /**
+     * Decides what to do given the stored (last-seen) and running plugin versions. Extracted as a
+     * pure function so the decision is unit-testable without a running IDE / real
+     * {@link ProjectActivity}.
+     *
+     * @param storedVersion  the last-seen version persisted in settings; blank or {@code null}
+     *                       means no version has ever been recorded
+     * @param runningVersion the currently running plugin version (assumed non-blank)
+     * @return the resulting decision
+     */
+    static UpgradeDecision shouldResetForUpgrade(@Nullable String storedVersion, @NotNull String runningVersion) {
+        if (storedVersion == null || storedVersion.isBlank()) {
+            return UpgradeDecision.FRESH_INSTALL;
+        }
+        return storedVersion.equals(runningVersion) ? UpgradeDecision.UNCHANGED : UpgradeDecision.UPGRADED;
+    }
+
+    @Nullable
+    private static String runningPluginVersion() {
+        IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID));
+        return plugin == null ? null : plugin.getVersion();
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsState.java
@@ -103,6 +103,14 @@ public final class ShaftSettingsState implements PersistentStateComponent<ShaftS
          * assistant web/mobile recording flows.
          */
         public boolean recorderHeadless = false;
+        /**
+         * The plugin version last seen by {@code ShaftPluginUpgradeActivity} (issue: plugin-upgrade
+         * auto-reset). Blank on a fresh install. Deliberately left out of {@link #factoryDefaults()}'s
+         * special-cased overrides: a plain {@code new Settings()} already defaults it to {@code ""},
+         * and an upgrade reset must overwrite it with the running version <em>after</em> the reset runs
+         * so it survives that same reset instead of being wiped by it.
+         */
+        public String lastSeenPluginVersion = "";
 
         /**
          * Returns whether the configured MCP command has passed setup verification.

--- a/shaft-intellij/src/main/resources/META-INF/plugin.xml
+++ b/shaft-intellij/src/main/resources/META-INF/plugin.xml
@@ -30,6 +30,7 @@
                                  id="shaft.settings"
                                  displayName="SHAFT"/>
         <notificationGroup id="SHAFT Notifications" displayType="BALLOON"/>
+        <postStartupActivity implementation="com.shaft.intellij.settings.ShaftPluginUpgradeActivity"/>
     </extensions>
 
     <projectListeners>

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftPluginResetServiceTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftPluginResetServiceTest.java
@@ -187,6 +187,39 @@ class ShaftPluginResetServiceTest {
     }
 
     @Test
+    void resetForUpgradeRunsEveryResetStepButPreservesEveryOpenProjectChatState() {
+        // Mirrors resetEverythingRunsEveryResetStepAndClearsEveryOpenProjectChatState above, but
+        // asserts the opposite outcome for chat: an upgrade must reset the same stale UI/setup state
+        // (settings, credentials, approvals) while leaving a user's conversation history alone.
+        ShaftAssistantChatState projectOne = new ShaftAssistantChatState();
+        ShaftAssistantChatState projectTwo = new ShaftAssistantChatState();
+        projectOne.loadState(sessionWithOneMessage("session-1", "hello from project one"));
+        projectTwo.loadState(sessionWithOneMessage("session-2", "hello from project two"));
+
+        boolean[] settingsResetRan = {false};
+        boolean[] credentialsResetRan = {false};
+        boolean[] approvalsResetRan = {false};
+        boolean[] toolWindowRerendered = {false};
+
+        ShaftPluginResetService service = new ShaftPluginResetService(
+                () -> settingsResetRan[0] = true,
+                () -> credentialsResetRan[0] = true,
+                () -> approvalsResetRan[0] = true,
+                () -> List.of(projectOne, projectTwo),
+                () -> toolWindowRerendered[0] = true);
+
+        service.resetForUpgrade();
+
+        assertAll(
+                () -> assertTrue(settingsResetRan[0], "Settings reset step must run"),
+                () -> assertTrue(credentialsResetRan[0], "Credential clear step must run"),
+                () -> assertTrue(approvalsResetRan[0], "Tool approval clear step must run"),
+                () -> assertFalse(projectOne.isCleared(), "resetForUpgrade must preserve chat history"),
+                () -> assertFalse(projectTwo.isCleared(), "resetForUpgrade must preserve chat history"),
+                () -> assertTrue(toolWindowRerendered[0], "Tool window re-render step must run"));
+    }
+
+    @Test
     void productionNoArgConstructorDoesNotEagerlyResolvePlatformServices() {
         // The no-arg constructor (the one plugin.xml's <applicationService> instantiates) wires
         // ShaftSettingsState.getInstance(), ShaftCredentialService.getInstance(),
@@ -227,6 +260,19 @@ class ShaftPluginResetServiceTest {
                 () -> assertTrue(pluginXml.contains(
                         "<applicationService serviceImplementation=\"com.shaft.intellij.settings.ShaftPluginResetService\"/>"),
                         "ShaftPluginResetService must be registered as an applicationService"));
+    }
+
+    @Test
+    void pluginXmlRegistersThePostStartupActivityAndTheClassResolves() throws Exception {
+        // ShaftPluginUpgradeActivity must be registered as a postStartupActivity or it never fires at
+        // IDE runtime, silently disabling plugin-upgrade auto-reset.
+        String pluginXml = Files.readString(Path.of("src/main/resources/META-INF/plugin.xml"));
+
+        assertTrue(pluginXml.contains(
+                "<postStartupActivity implementation=\"com.shaft.intellij.settings.ShaftPluginUpgradeActivity\"/>"),
+                "ShaftPluginUpgradeActivity must be registered as a postStartupActivity");
+        assertDoesNotThrow(() -> Class.forName("com.shaft.intellij.settings.ShaftPluginUpgradeActivity"),
+                "The registered class must resolve");
     }
 
     private static ShaftAssistantChatState.StateData sessionWithOneMessage(String sessionId, String markdown) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftPluginUpgradeActivityTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftPluginUpgradeActivityTest.java
@@ -1,0 +1,115 @@
+package com.shaft.intellij.settings;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the upgrade-decision logic and the {@code checkForUpgrade} orchestration in isolation
+ * from a real {@link com.intellij.openapi.startup.ProjectActivity} / running IDE, mirroring the
+ * constructor-injection pattern already used by {@link ShaftPluginResetServiceTest}.
+ */
+class ShaftPluginUpgradeActivityTest {
+
+    @Test
+    void shouldResetForUpgradeTreatsABlankOrMissingStoredVersionAsAFreshInstall() {
+        assertAll(
+                () -> assertEquals(ShaftPluginUpgradeActivity.UpgradeDecision.FRESH_INSTALL,
+                        ShaftPluginUpgradeActivity.shouldResetForUpgrade(null, "1.2.3")),
+                () -> assertEquals(ShaftPluginUpgradeActivity.UpgradeDecision.FRESH_INSTALL,
+                        ShaftPluginUpgradeActivity.shouldResetForUpgrade("", "1.2.3")),
+                () -> assertEquals(ShaftPluginUpgradeActivity.UpgradeDecision.FRESH_INSTALL,
+                        ShaftPluginUpgradeActivity.shouldResetForUpgrade("   ", "1.2.3")));
+    }
+
+    @Test
+    void shouldResetForUpgradeTreatsADifferentStoredVersionAsAnUpgrade() {
+        assertEquals(ShaftPluginUpgradeActivity.UpgradeDecision.UPGRADED,
+                ShaftPluginUpgradeActivity.shouldResetForUpgrade("1.2.2", "1.2.3"));
+    }
+
+    @Test
+    void shouldResetForUpgradeTreatsAMatchingStoredVersionAsUnchanged() {
+        assertEquals(ShaftPluginUpgradeActivity.UpgradeDecision.UNCHANGED,
+                ShaftPluginUpgradeActivity.shouldResetForUpgrade("1.2.3", "1.2.3"));
+    }
+
+    @Test
+    void checkForUpgradeOnAFreshInstallRecordsTheRunningVersionWithoutResetting() {
+        ShaftSettingsState settingsState = new ShaftSettingsState();
+        boolean[] resetRan = {false};
+        ShaftPluginResetService resetService = new ShaftPluginResetService(
+                () -> resetRan[0] = true, () -> { }, () -> { }, List::of, () -> { });
+
+        ShaftPluginUpgradeActivity.checkForUpgrade("1.2.3", settingsState, resetService);
+
+        assertAll(
+                () -> assertFalse(resetRan[0], "A fresh install must not trigger a reset"),
+                () -> assertEquals("1.2.3", settingsState.getState().lastSeenPluginVersion));
+    }
+
+    @Test
+    void checkForUpgradeOnAVersionChangeResetsStaleStateAndRecordsTheNewVersionAfterward() {
+        ShaftSettingsState settingsState = new ShaftSettingsState();
+        settingsState.getState().lastSeenPluginVersion = "1.2.2";
+        settingsState.getState().mcpCommand = "old-shaft-mcp-command";
+        settingsState.getState().mcpSetupComplete = true;
+        boolean[] resetRan = {false};
+        // Mirror the production wiring (ShaftPluginResetService's no-arg constructor uses
+        // resetSettings(ShaftSettingsState.getInstance()) as its settingsReset step) so this proves the
+        // real interaction: resetSettings() wipes lastSeenPluginVersion back to "" via
+        // factoryDefaults(), and checkForUpgrade must still land on the running version afterward.
+        ShaftPluginResetService resetService = new ShaftPluginResetService(
+                () -> {
+                    resetRan[0] = true;
+                    ShaftPluginResetService.resetSettings(settingsState);
+                },
+                () -> { }, () -> { }, List::of, () -> { });
+
+        ShaftPluginUpgradeActivity.checkForUpgrade("1.2.3", settingsState, resetService);
+
+        assertAll(
+                () -> assertTrue(resetRan[0], "A version change must trigger a reset"),
+                () -> assertEquals("", settingsState.getState().mcpCommand,
+                        "The stale mcpCommand must not survive an upgrade reset"),
+                () -> assertFalse(settingsState.getState().mcpSetupComplete),
+                () -> assertEquals("1.2.3", settingsState.getState().lastSeenPluginVersion,
+                        "The running version must be persisted after the reset, not wiped by it"));
+    }
+
+    @Test
+    void checkForUpgradeWhenVersionsMatchDoesNothing() {
+        ShaftSettingsState settingsState = new ShaftSettingsState();
+        settingsState.getState().lastSeenPluginVersion = "1.2.3";
+        boolean[] resetRan = {false};
+        ShaftPluginResetService resetService = new ShaftPluginResetService(
+                () -> resetRan[0] = true, () -> { }, () -> { }, List::of, () -> { });
+
+        ShaftPluginUpgradeActivity.checkForUpgrade("1.2.3", settingsState, resetService);
+
+        assertAll(
+                () -> assertFalse(resetRan[0], "Matching versions must not trigger a reset"),
+                () -> assertEquals("1.2.3", settingsState.getState().lastSeenPluginVersion));
+    }
+
+    @Test
+    void checkForUpgradeWithAnUnresolvedRunningVersionIsANoOp() {
+        ShaftSettingsState settingsState = new ShaftSettingsState();
+        settingsState.getState().lastSeenPluginVersion = "1.2.2";
+        boolean[] resetRan = {false};
+        ShaftPluginResetService resetService = new ShaftPluginResetService(
+                () -> resetRan[0] = true, () -> { }, () -> { }, List::of, () -> { });
+
+        ShaftPluginUpgradeActivity.checkForUpgrade(null, settingsState, resetService);
+
+        assertAll(
+                () -> assertFalse(resetRan[0], "An unresolved running version must not trigger a reset"),
+                () -> assertEquals("1.2.2", settingsState.getState().lastSeenPluginVersion,
+                        "Stored version must be untouched when the running version is unknown"));
+    }
+}


### PR DESCRIPTION
## What

Fixes the reported upgrade regression: after updating the SHAFT IntelliJ plugin, the setup page looked like it hadn't re-rendered and the recorder showed the old white (non-theme-aware) UI. Root cause — stale cached plugin state (a persisted `mcpCommand`, old setup flags, credentials, approvals) survived the upgrade, so the plugin kept driving an old shaft-mcp and the setup view never refreshed.

This adds a one-per-IDE-session **upgrade detector** that, on a plugin version change, factory-resets the stale local state and re-renders open SHAFT tool windows so the user is dropped into a fresh onboarding — **while preserving Assistant chat history**, exactly as requested. No generated code, user skills, or `~/.m2` files are touched (only IntelliJ-managed plugin settings/credentials/approvals).

## How

- **`ShaftSettingsState.Settings`** — new `lastSeenPluginVersion` (blank on fresh install). Written *after* the reset so it survives factory defaults (same live `Settings` instance via `copyBean`).
- **`ShaftPluginResetService`** — extracted `resetState(boolean clearChat)`; new `resetForUpgrade()` runs every reset step (settings → factory defaults, credentials, approvals) but **skips** clearing chat. Reuses the existing `toolWindowRerenderer` → `resetToSetupView()` path (no new probe). Because the reset blanks `mcpCommand`, the panel correctly renders the fresh setup wizard; once setup completes again, the existing ready→main-view path lands on the Assistant tab with prior chat intact.
- **`ShaftPluginUpgradeActivity`** (new `ProjectActivity`) — `AtomicBoolean`-guarded compare-and-reset once per session; resolves the running version via `PluginManagerCore.getPlugin(...).getVersion()`. Decision (`shouldResetForUpgrade`) and orchestration (`checkForUpgrade`) are pure/package-private and unit-testable without a running IDE.
- **`plugin.xml`** — registers the `postStartupActivity`.

## Tests (JDK 21, `ms-21.0.11`)

`./gradlew test --tests "*ShaftPluginResetServiceTest" --tests "*ShaftPluginUpgradeActivityTest"` — **18/18 green** (11 reset-service + 7 upgrade-activity), 0 failures/errors, verified from JUnit XML. `buildPlugin` also green. New tests assert chat is *preserved* on `resetForUpgrade()` while every other reset step runs, and that the activity is registered in `plugin.xml`.

Closes part of #3547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)