### PR TITLE
feat: polish IntelliJ MCP setup panel — no green by default, merged MCP row, always-on Check/Copy (#3560)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -12,7 +12,6 @@ import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
-import com.intellij.util.ui.WrapLayout;
 import com.shaft.intellij.mcp.ShaftMcpConnectionProbe;
 import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.shaft.intellij.settings.ShaftPluginResetService;
@@ -37,8 +36,11 @@ import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
@@ -128,7 +130,6 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JButton checkMcpVersion;
     private final JButton copyMcpInstallCommand;
     private final JLabel mcpVersionDetail;
-    private final JButton copyInstallerCommand;
     private final JButton test;
     private final JButton startChatting;
     private final JButton startWithoutAgent;
@@ -146,8 +147,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JLabel installState;
     private final JLabel testStep;
     private final JLabel testState;
-    private final JLabel mcpVersionStep;
-    private final JLabel mcpVersionState;
+    private final JLabel readyStep;
     private final JLabel readyState;
     private final JLabel status;
     private final JLabel recommendedAgent;
@@ -169,7 +169,6 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JPanel chooseRow;
     private final JPanel installRow;
     private final JPanel checkRow;
-    private final JPanel mcpVersionRow;
     private final JPanel chatRow;
     private java.util.function.Function<String, List<SetupPrerequisites.Prerequisite>> prerequisitesDetector =
             SetupPrerequisites::detect;
@@ -177,10 +176,16 @@ final class ShaftMcpSetupPanel extends JPanel {
     private String diagnosticOutput = "";
     /** Real on-disk state (issue #3426 A5): whether an installed shaft-mcp was found locally. */
     private boolean installedCommandDetected;
-    /** Whether the selected agent's runtime was actually detected on this machine. */
-    private boolean selectedAgentDetected;
     /** Whether the last explicit "Check now" run failed, for the failed step badge. */
     private boolean lastCheckFailed;
+    /**
+     * Whether the user has explicitly pressed "Check" for the upgrade/MCP-version rows
+     * (issue #3560): a step badge only earns green after this real, user-triggered check passes —
+     * never from passive on-disk detection alone, so a fresh landing (or a post-reset re-render)
+     * never shows green by default.
+     */
+    private boolean upgradeChecked;
+    private boolean mcpVersionChecked;
     private ShaftProjectVersionCheck.Result upgradeCheckResult;
     /** Runs the real project-vs-latest SHAFT version comparison; injectable for tests. */
     private java.util.function.Supplier<ShaftProjectVersionCheck.Result> upgradeChecker = () ->
@@ -298,7 +303,7 @@ final class ShaftMcpSetupPanel extends JPanel {
                 + "a terminal interface to the same SHAFT MCP tools");
         installShaftCli.addActionListener(event -> installerTargetChanged());
         installerCommand.setText(installerCommand());
-        copyUpgradeCommand = new JButton("Copy command");
+        copyUpgradeCommand = new JButton("Copy");
         copyUpgradeCommand.getAccessibleContext().setAccessibleName("Copy SHAFT upgrade command");
         copyUpgradeCommand.setToolTipText("Copy the SHAFT upgrade command and open a terminal with it pre-typed "
                 + "— just press Enter there to run it");
@@ -317,21 +322,15 @@ final class ShaftMcpSetupPanel extends JPanel {
         checkMcpVersion.setToolTipText("Compare the installed SHAFT MCP version against the latest release");
         applyLabeledAction(checkMcpVersion, ShaftIcons.CHECK);
         checkMcpVersion.addActionListener(event -> runMcpVersionCheck(true));
-        copyMcpInstallCommand = new JButton("Copy command");
+        copyMcpInstallCommand = new JButton("Copy");
         copyMcpInstallCommand.getAccessibleContext().setAccessibleName("Copy SHAFT MCP install command");
         copyMcpInstallCommand.setToolTipText("Copy the SHAFT MCP install/update command and open a terminal with "
                 + "it pre-typed — just press Enter there to run it");
+        copyMcpInstallCommand.setMnemonic(KeyEvent.VK_C);
         applyLabeledAction(copyMcpInstallCommand, ShaftIcons.COPY);
         copyMcpInstallCommand.addActionListener(event -> copyMcpInstallCommand());
         mcpVersionDetail = setupStatusLabel("SHAFT MCP version status");
-        copyInstallerCommand = new JButton("Copy command");
-        copyInstallerCommand.getAccessibleContext().setAccessibleName("Copy MCP installer command");
-        copyInstallerCommand.setToolTipText("Copy the installer command and open a terminal with it pre-typed "
-                + "— just press Enter there to run it");
-        copyInstallerCommand.setMnemonic(KeyEvent.VK_C);
-        applyLabeledAction(copyInstallerCommand, ShaftIcons.COPY);
-        copyInstallerCommand.addActionListener(event -> copyInstallerCommand());
-        test = new JButton("Check now");
+        test = new JButton("Check");
         test.getAccessibleContext().setAccessibleName("Test SHAFT MCP connection");
         test.setToolTipText("Infer the stdio command and verify SHAFT MCP");
         test.setMnemonic(KeyEvent.VK_K);
@@ -351,7 +350,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         applyLabeledAction(startWithoutAgent, ShaftIcons.SEND);
         startWithoutAgent.setVisible(false);
         startWithoutAgent.addActionListener(event -> connected.run());
-        resetAndReinstall = new JButton("Reset / reinstall");
+        resetAndReinstall = new JButton("Reinstall");
         resetAndReinstall.getAccessibleContext().setAccessibleName("Reset and reinstall SHAFT MCP");
         resetAndReinstall.setToolTipText("Clear the saved MCP command and copy a fresh installer command");
         resetAndReinstall.setMnemonic(KeyEvent.VK_R);
@@ -449,8 +448,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         installState = setupStateLabel("Install SHAFT MCP setup state");
         testStep = setupStepLabel("Check now setup step");
         testState = setupStateLabel("Check now setup state");
-        mcpVersionStep = setupStepLabel("SHAFT MCP version setup step");
-        mcpVersionState = setupStateLabel("SHAFT MCP version setup state");
+        readyStep = setupStepLabel("Start chatting setup step");
         readyState = setupStateLabel("Start chatting setup state");
         JPanel agentControls = new JPanel();
         agentControls.setLayout(new javax.swing.BoxLayout(agentControls, javax.swing.BoxLayout.Y_AXIS));
@@ -473,20 +471,17 @@ final class ShaftMcpSetupPanel extends JPanel {
         upgradeActions.add(checkUpgrade);
         upgradeActions.add(copyUpgradeCommand);
         upgradeActions.add(upgradeDetail);
+        // Merged row #3 (issue #3560): the old separate "SHAFT MCP version" row is folded into
+        // "3 Install SHAFT MCP" — one row, one Check, one Copy, badge driven by mcpVersionStepState().
         JPanel installActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         installActions.setOpaque(false);
-        installActions.add(copyInstallerCommand);
-        installActions.add(installShaftCli);
-        JPanel mcpVersionActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-        mcpVersionActions.setOpaque(false);
-        mcpVersionActions.add(checkMcpVersion);
-        mcpVersionActions.add(copyMcpInstallCommand);
-        mcpVersionActions.add(mcpVersionDetail);
+        installActions.add(checkMcpVersion);
+        installActions.add(copyMcpInstallCommand);
+        installActions.add(mcpVersionDetail);
         upgradeRow = stepRow(upgradeStep, upgradeState, upgradeActions);
         chooseRow = stepRow(chooseStep, chooseState, agentControls);
         installRow = stepRow(installStep, installState, installActions);
         checkRow = stepRow(testStep, testState, checkActions);
-        mcpVersionRow = stepRow(mcpVersionStep, mcpVersionState, mcpVersionActions);
         prerequisitesList = new JPanel();
         prerequisitesList.setLayout(new javax.swing.BoxLayout(prerequisitesList, javax.swing.BoxLayout.Y_AXIS));
         prerequisitesList.setOpaque(false);
@@ -496,7 +491,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         recheckPrerequisites.setToolTipText("Detect the required tools again after installing one");
         applyLabeledAction(recheckPrerequisites, ShaftIcons.CHECK);
         recheckPrerequisites.addActionListener(event -> refreshPrerequisites());
-        JButton copyEngineWarmup = new JButton("Copy SHAFT Engine warm-up command");
+        JButton copyEngineWarmup = new JButton("Warm up Engine");
         // Resolve the latest engine release off-EDT now so the click below can pin a real version.
         SetupPrerequisites.prefetchLatestEngineVersion();
         // Same fire-once, off-EDT pattern for the latest shaft-mcp release (issue #3538).
@@ -521,7 +516,6 @@ final class ShaftMcpSetupPanel extends JPanel {
         prerequisitesStep = setupStepLabel("Prerequisites setup step");
         prerequisitesState = setupStateLabel("Prerequisites setup state");
         prerequisitesRow = stepRow(prerequisitesStep, prerequisitesState, prerequisitesControls);
-        JLabel readyStep = setupStepLabel("Start chatting setup step");
         readyStep.setText("Ready");
         JPanel readyActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         readyActions.setOpaque(false);
@@ -550,8 +544,6 @@ final class ShaftMcpSetupPanel extends JPanel {
         workflow.add(installRow);
         workflow.add(javax.swing.Box.createVerticalStrut(6));
         workflow.add(checkRow);
-        workflow.add(javax.swing.Box.createVerticalStrut(6));
-        workflow.add(mcpVersionRow);
         workflow.add(javax.swing.Box.createVerticalStrut(6));
         workflow.add(chatRow);
         JPanel targetRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
@@ -586,6 +578,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         intro.add(summary, BorderLayout.CENTER);
         installerDetailsPanel = FormBuilder.createFormBuilder()
                 .addComponent(targetRow)
+                .addComponent(installShaftCli)
                 .addLabeledComponent("Installer command", new JBScrollPane(installerCommand))
                 .getPanel();
         installerDetailsPanel.setVisible(false);
@@ -647,8 +640,6 @@ final class ShaftMcpSetupPanel extends JPanel {
         add(footer, BorderLayout.SOUTH);
         refreshPrerequisites();
         refreshRealChecks();
-        runUpgradeCheck(false);
-        runMcpVersionCheck(false);
         if (!currentCommand().isBlank()) {
             setStatusText(CHECK_NEXT_STEP);
         }
@@ -656,24 +647,14 @@ final class ShaftMcpSetupPanel extends JPanel {
     }
 
     /**
-     * Re-runs the cheap on-disk/PATH detections every step badge is derived from, so no step is
-     * ever marked done just because a button was clicked (issue #3426 A5): the install step is
-     * done only when an installed shaft-mcp is actually found, and the agent step only when the
-     * selected agent runtime is really detected.
+     * Re-runs the cheap on-disk detection the "4 Check setup" badge falls back to, so its Waiting
+     * vs. Next distinction reflects whether an installed shaft-mcp actually exists on disk rather
+     * than a button click (issue #3426 A5). Agent readiness is no longer derived here: the "2 Pick
+     * agent" badge earns green only from a verified connection check (issue #3560), never from a
+     * passive PATH probe at construction time.
      */
     private void refreshRealChecks() {
         installedCommandDetected = !inferInstalledStdioCommand().isBlank();
-        selectedAgentDetected = detectSelectedAgent();
-    }
-
-    private boolean detectSelectedAgent() {
-        if (cloudFamilySelected()) {
-            return cloudKeyStore.hasKey(GEMINI_KEY_NAME);
-        }
-        ShaftMcpToolResult result = readinessProbe.test(
-                clientFromFamily(normalize(String.valueOf(family.getSelectedItem()), "CODEX")),
-                normalize(String.valueOf(runtime.getSelectedItem()), "CLI"));
-        return result != null && result.success();
     }
 
     /**
@@ -682,6 +663,9 @@ final class ShaftMcpSetupPanel extends JPanel {
      */
     private void runUpgradeCheck(boolean announce) {
         upgradeCheckResult = upgradeChecker.get();
+        if (announce) {
+            upgradeChecked = true;
+        }
         upgradeDetail.setText(upgradeDetailText());
         upgradeDetail.setForeground(switch (upgradeCheckResult.state()) {
             case UP_TO_DATE -> ShaftStatusPresentation.success();
@@ -723,6 +707,9 @@ final class ShaftMcpSetupPanel extends JPanel {
      */
     private void runMcpVersionCheck(boolean announce) {
         mcpVersionCheckResult = mcpVersionChecker.get();
+        if (announce) {
+            mcpVersionChecked = true;
+        }
         mcpVersionDetail.setText(mcpVersionDetailText());
         mcpVersionDetail.setForeground(switch (mcpVersionCheckResult.state()) {
             case UP_TO_DATE -> ShaftStatusPresentation.success();
@@ -811,7 +798,7 @@ final class ShaftMcpSetupPanel extends JPanel {
             label.getAccessibleContext().setAccessibleName(prerequisite.name() + stateText.trim());
             row.add(label);
             if (!prerequisite.present()) {
-                JButton copyInstall = new JButton("Copy install command");
+                JButton copyInstall = new JButton("Copy");
                 copyInstall.getAccessibleContext().setAccessibleName(
                         "Copy " + prerequisite.name() + " install command");
                 copyInstall.setToolTipText("Copy the terminal command that installs " + prerequisite.name());
@@ -825,6 +812,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         }
         setStep(prerequisitesStep, prerequisitesState, "0 Prerequisites", allRequiredPresent ? "done" : "next");
         styleStepRow(prerequisitesRow, allRequiredPresent ? "done" : "next");
+        alignStepLabelWidths();
         prerequisitesList.revalidate();
         prerequisitesList.repaint();
     }
@@ -1001,28 +989,15 @@ final class ShaftMcpSetupPanel extends JPanel {
     private void updateActionState(boolean running) {
         boolean hasCommand = !currentCommand().isBlank();
         boolean complete = settings.mcpSetupComplete && hasCommand;
-        boolean showCopy = !complete && !(installedCommandDetected || hasCommand);
-        // The real check is always available while setup is incomplete: verification is how a
-        // step earns its Done badge, never a button click (issue #3426 A5).
-        boolean showTest = !complete;
-        copyInstallerCommand.setVisible(showCopy);
-        copyInstallerCommand.setEnabled(!running && showCopy);
-        installShaftCli.setVisible(showCopy);
+        // Check and Copy stay visible in every state (issue #3560): verification is how a step
+        // earns its Done badge, never a button click or button visibility (issue #3426 A5) — the
+        // row's own blue/green/red styling is what conveys pass/fail now.
+        test.setEnabled(!running);
         installShaftCli.setEnabled(!running);
-        test.setVisible(showTest);
-        test.setEnabled(!running && showTest);
-        boolean upgradeDone = upgradeCheckResult != null
-                && upgradeCheckResult.state() == ShaftProjectVersionCheck.State.UP_TO_DATE;
-        copyUpgradeCommand.setVisible(!upgradeDone);
-        copyUpgradeCommand.setEnabled(!running && !upgradeDone);
         checkUpgrade.setEnabled(!running);
-        // Never gates the rest of setup (issue #3538): the copy button stays available for every
-        // state except an already-up-to-date install, including the offline LATEST_UNKNOWN state.
-        boolean mcpVersionUpToDate = mcpVersionCheckResult != null
-                && mcpVersionCheckResult.state() == ShaftMcpVersionCheck.State.UP_TO_DATE;
-        copyMcpInstallCommand.setVisible(!mcpVersionUpToDate);
-        copyMcpInstallCommand.setEnabled(!running && !mcpVersionUpToDate);
+        copyUpgradeCommand.setEnabled(!running);
         checkMcpVersion.setEnabled(!running);
+        copyMcpInstallCommand.setEnabled(!running);
         startChatting.setVisible((complete && !startWithoutAgent.isVisible()) || startChatting.isVisible());
         startChatting.setEnabled(!running && startChatting.isVisible());
         startWithoutAgent.setEnabled(!running && startWithoutAgent.isVisible());
@@ -1325,27 +1300,16 @@ final class ShaftMcpSetupPanel extends JPanel {
         updateActionState(false);
     }
 
-    private void copyInstallerCommand() {
-        String command = installerCommand();
-        copy(command, "Copied MCP installer command");
-        boolean opened = terminalOpener.open("SHAFT MCP install", command, typed -> { });
-        if (opened) {
-            openIntellijTerminal();
-        }
-        setStatusText(opened
-                ? "Terminal opened with the installer pre-typed. Press Enter there to run it; when it finishes, press Check now."
-                : "Installer command copied. Paste it into a terminal, run it; when it finishes, press Check now.");
-        updateActionState(false);
-        test.requestFocusInWindow();
-    }
-
     /**
      * Copies the SHAFT MCP install/update command for the selected client. Install and upgrade are
      * the same command — re-running the installer script always fetches the latest release — so
-     * there is no separate "install" vs "upgrade" flavor of this command (issue #3538).
+     * there is no separate "install" vs "upgrade" flavor of this command (issue #3538). This is now
+     * the single copy action for the merged "3 Install SHAFT MCP" row (issue #3560), so it goes
+     * through {@link #installerCommand()} — the same helper the Advanced installer options panel
+     * uses — to honor the "Also install shaft-cli" checkbox.
      */
     private void copyMcpInstallCommand() {
-        String command = installerCommandFor(installerArgumentFor(String.valueOf(installerTarget.getSelectedItem())));
+        String command = installerCommand();
         copy(command, "Copied SHAFT MCP install command");
         boolean opened = terminalOpener.open("SHAFT MCP install", command, typed -> { });
         if (opened) {
@@ -1373,7 +1337,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         copyCommandIntoTerminal(installerCommand(), "SHAFT MCP install",
                 "Installer command copied. Run it in terminal, then check.");
         updateActionState(false);
-        copyInstallerCommand.requestFocusInWindow();
+        copyMcpInstallCommand.requestFocusInWindow();
     }
 
     /**
@@ -1765,7 +1729,13 @@ final class ShaftMcpSetupPanel extends JPanel {
         JLabel label = new JLabel();
         label.setOpaque(true);
         label.setHorizontalAlignment(JLabel.CENTER);
-        label.setPreferredSize(JBUI.size(74, 22));
+        Dimension badgeSize = JBUI.size(74, 22);
+        label.setPreferredSize(badgeSize);
+        // Also pin the minimum size (issue #3560): a JLabel's UI-computed minimum size ignores an
+        // overridden preferred size and falls back to its own short text's natural width (e.g.
+        // "Next"), so under a width-constrained row a GridBagLayout column can silently shrink this
+        // badge below its intended 74px unless the minimum matches the preferred size exactly.
+        label.setMinimumSize(badgeSize);
         label.setBorder(JBUI.Borders.compound(
                 JBUI.Borders.customLine(UIManagerColors.border(), 1),
                 JBUI.Borders.empty(2, 6)));
@@ -1792,15 +1762,18 @@ final class ShaftMcpSetupPanel extends JPanel {
     }
 
     /**
-     * Every step badge below reflects a real check, never a click (issue #3426 A4/A5): the
-     * upgrade step compares the project pom against the latest release, the agent step requires
-     * the selected runtime to actually be detected, the install step requires an installed
-     * shaft-mcp (or an explicit command) to exist on disk, and the check step requires the probe
-     * to have actually passed — with an explicit Failed badge when it did not.
+     * Every step badge below reflects a real, user-triggered check, never a click's mere
+     * side-effect or passive on-disk detection (issue #3426 A4/A5, issue #3560): a badge only
+     * turns green once the user has pressed that row's Check and it passed — a fresh landing (or a
+     * post-"Reset everything" re-render) always starts neutral/blue, never green. The upgrade step
+     * compares the project pom against the latest release once checked, the agent step requires the
+     * connection check to have verified the agent (not just detected it), the merged install/MCP-
+     * version row borrows the version check's state, and the check step requires the probe to have
+     * actually passed — with an explicit Failed badge when it did not.
      */
     private String upgradeStepState() {
-        if (upgradeCheckResult == null) {
-            return "optional";
+        if (!upgradeChecked || upgradeCheckResult == null) {
+            return "next";
         }
         return switch (upgradeCheckResult.state()) {
             case UP_TO_DATE -> "done";
@@ -1810,11 +1783,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     }
 
     private String chooseStepState() {
-        return selectedAgentDetected ? "done" : "next";
-    }
-
-    private String installStepState(boolean hasCommand) {
-        return installedCommandDetected || hasCommand ? "done" : "next";
+        return settings.agentLaneReady ? "done" : "next";
     }
 
     private String checkStepState(boolean running, boolean complete, boolean hasCommand) {
@@ -1833,11 +1802,12 @@ final class ShaftMcpSetupPanel extends JPanel {
     /**
      * Never "failed" (issue #3538): an offline latest-version lookup is surfaced as "optional" —
      * the same neutral badge the upgrade step's LATEST_UNKNOWN uses — so this row can never block
-     * the rest of setup.
+     * the rest of setup. Also drives the merged "3 Install SHAFT MCP" row's badge (issue #3560):
+     * that row is green only once this check has actually run and passed.
      */
     private String mcpVersionStepState() {
-        if (mcpVersionCheckResult == null) {
-            return "optional";
+        if (!mcpVersionChecked || mcpVersionCheckResult == null) {
+            return "next";
         }
         return switch (mcpVersionCheckResult.state()) {
             case UP_TO_DATE -> "done";
@@ -1851,10 +1821,10 @@ final class ShaftMcpSetupPanel extends JPanel {
         boolean complete = settings.mcpSetupComplete && hasCommand;
         setStep(upgradeStep, upgradeState, "1 Upgrade project", upgradeStepState());
         setStep(chooseStep, chooseState, "2 Pick agent", chooseStepState());
-        setStep(installStep, installState, "3 Install SHAFT MCP", installStepState(hasCommand));
+        setStep(installStep, installState, "3 Install SHAFT MCP", mcpVersionStepState());
         setStep(testStep, testState, "4 Check setup", checkStepState(running, complete, hasCommand));
-        setStep(mcpVersionStep, mcpVersionState, "SHAFT MCP version", mcpVersionStepState());
         setStep(null, readyState, "Ready", complete ? "next" : "wait");
+        alignStepLabelWidths();
     }
 
     private void updateWorkflowRows(boolean running) {
@@ -1862,9 +1832,8 @@ final class ShaftMcpSetupPanel extends JPanel {
         boolean complete = settings.mcpSetupComplete && hasCommand;
         styleStepRow(upgradeRow, upgradeStepState());
         styleStepRow(chooseRow, chooseStepState());
-        styleStepRow(installRow, installStepState(hasCommand));
+        styleStepRow(installRow, mcpVersionStepState());
         styleStepRow(checkRow, checkStepState(running, complete, hasCommand));
-        styleStepRow(mcpVersionRow, mcpVersionStepState());
         styleStepRow(chatRow, complete ? "next" : "wait");
     }
 
@@ -1918,16 +1887,75 @@ final class ShaftMcpSetupPanel extends JPanel {
         });
     }
 
+    /**
+     * Symmetric row (issue #3560): step label and state badge sit in consistent, aligned columns
+     * across every workflow row — fixing the ragged left edges a wrapping FlowLayout produced —
+     * with the (often much wider, per-row-variable) actions content given its own full-width line
+     * underneath. Actions cannot share the label/badge line: the setup panel also renders at a
+     * deliberately narrow width (see the plugin's narrow-tool-window screenshot coverage), and a
+     * three-column single-line GridBagLayout row has no minimum width to shrink into without
+     * cropping — GridBagLayout, once a row's assigned width falls below the combined minimum width
+     * of all its columns, shrinks every column proportionally including "no-fill" ones, with no
+     * escape valve short of literal text clipping. Splitting the wide, variable-width actions
+     * content onto its own line sidesteps that degenerate case entirely: it always gets the row's
+     * full width to itself.
+     */
     private static JPanel stepRow(JLabel label, JLabel stateLabel, JComponent action) {
-        JPanel row = new JPanel(new WrapLayout(FlowLayout.LEFT, 8, 4));
+        JPanel row = new JPanel(new GridBagLayout());
         row.setOpaque(true);
-        row.add(label);
-        row.add(stateLabel);
-        row.add(action);
+        GridBagConstraints labelConstraints = new GridBagConstraints();
+        labelConstraints.gridx = 0;
+        labelConstraints.gridy = 0;
+        labelConstraints.anchor = GridBagConstraints.WEST;
+        labelConstraints.insets = JBUI.insets(0, 0, 0, 10);
+        row.add(label, labelConstraints);
+        GridBagConstraints stateConstraints = new GridBagConstraints();
+        stateConstraints.gridx = 1;
+        stateConstraints.gridy = 0;
+        stateConstraints.anchor = GridBagConstraints.WEST;
+        stateConstraints.insets = JBUI.insets(0, 0, 0, 10);
+        row.add(stateLabel, stateConstraints);
+        GridBagConstraints actionConstraints = new GridBagConstraints();
+        actionConstraints.gridx = 0;
+        actionConstraints.gridy = 1;
+        actionConstraints.gridwidth = 2;
+        actionConstraints.anchor = GridBagConstraints.WEST;
+        actionConstraints.fill = GridBagConstraints.HORIZONTAL;
+        actionConstraints.weightx = 1.0;
+        actionConstraints.insets = JBUI.insets(6, 0, 0, 0);
+        row.add(action, actionConstraints);
         row.setBorder(JBUI.Borders.compound(
                 JBUI.Borders.customLine(UIManagerColors.border(), 1),
                 JBUI.Borders.empty(8, 10)));
         return row;
+    }
+
+    /**
+     * Keeps every workflow row's step-label column the same width (issue #3560) so the state
+     * badges and action columns line up across rows despite each row being an independently laid
+     * out {@link GridBagLayout} panel. The shared width is the widest label's own natural preferred
+     * width — recomputed on every call since bold/plain font weight (see {@link #setStep}) shifts a
+     * label's natural width slightly — so no label is ever clamped narrower than its own text needs.
+     */
+    private void alignStepLabelWidths() {
+        JLabel[] stepLabels = {prerequisitesStep, upgradeStep, chooseStep, installStep, testStep, readyStep};
+        int maxWidth = 0;
+        for (JLabel label : stepLabels) {
+            label.setMinimumSize(null);
+            label.setPreferredSize(null);
+            maxWidth = Math.max(maxWidth, label.getPreferredSize().width);
+        }
+        for (JLabel label : stepLabels) {
+            Dimension shared = new Dimension(maxWidth, label.getPreferredSize().height);
+            label.setPreferredSize(shared);
+            // Pin the minimum to the same shared width (issue #3560): a JLabel's UI-computed
+            // minimum size ignores an overridden preferred size and falls back to that label's own
+            // (narrower) natural width, so a width-constrained row's GridBagLayout would otherwise
+            // silently shrink this column back down and break the cross-row alignment/cropping
+            // guarantee — the row's actions column (weightx=1, fill=HORIZONTAL) is the one column
+            // meant to absorb any width pressure instead.
+            label.setMinimumSize(shared);
+        }
     }
 
     private void updateLiveSummary() {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -295,7 +295,7 @@ class ShaftPanelSetupTest {
             assertFalse(nextStep.isVisible());
             assertFalse(installerDetailsPanel.isVisible());
             assertFalse(detailsPanel.isVisible());
-            assertTrue(findByAccessibleName(toolWindow, "Copy MCP installer command", JButton.class).isVisible());
+            assertTrue(findByAccessibleName(toolWindow, "Copy SHAFT MCP install command", JButton.class).isVisible());
             // No shaft-mcp is installed in this isolated data root, so the real check is offered
             // immediately: verification, not clicking, is what completes setup (issue #3426 A5).
             assertTrue(findByAccessibleName(toolWindow, "Test SHAFT MCP connection", JButton.class).isVisible());
@@ -421,7 +421,7 @@ class ShaftPanelSetupTest {
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
         });
         JTextComponent command = (JTextComponent) getField(panel, "mcpCommand");
-        JButton test = findButton(panel, "Check now");
+        JButton test = findButton(panel, "Test SHAFT MCP connection");
         JComboBox<?> family = findByAccessibleName(panel, "Assistant family", JComboBox.class);
         JComboBox<?> runtime = findByAccessibleName(panel, "Assistant runtime", JComboBox.class);
 
@@ -490,12 +490,13 @@ class ShaftPanelSetupTest {
                     () -> assertTrue(command.getText().isBlank()),
                     () -> assertNull(findButton(panel, "Install / Update SHAFT MCP")));
 
-            // A real shaft-mcp install exists in this data root, so the install step is already
-            // detected as done: the copy button is hidden and the real check is offered instead
-            // (issue #3426 A5). The inferred stdio command points at the installed artifacts.
+            // A real shaft-mcp install exists in this data root, so on-disk detection is true, but
+            // the row only earns its green badge once the user presses Check (issue #3560/#3426
+            // A5): Check and Copy both stay visible regardless of on-disk state. The inferred stdio
+            // command still points at the installed artifacts.
             String inferred = ShaftMcpSetupPanel.inferInstalledStdioCommand(appData, bootstrap);
             assertAll(
-                    () -> assertFalse(findByAccessibleName(panel, "Copy MCP installer command", JButton.class).isVisible()),
+                    () -> assertTrue(findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()),
                     () -> assertNull(findByAccessibleName(panel, "Open terminal for MCP installer", JButton.class)),
                     () -> assertTrue(findByAccessibleName(panel, "Test SHAFT MCP connection", JButton.class).isVisible()),
                     () -> assertFalse(installerDetailsPanel.isVisible()),
@@ -735,13 +736,35 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void setupPanelShowsNoGreenStepsOnFreshLanding() {
+        // Issue #3560: none of the numbered verification steps may be green until the user has
+        // explicitly clicked that row's Check and it passed -- a fresh landing always starts
+        // neutral/blue ("Next"), never green ("Done"), regardless of what passive on-disk/PATH
+        // detection would otherwise reveal.
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
+        });
+        assertAll(
+                () -> assertEquals("Next",
+                        findByAccessibleName(panel, "Upgrade project setup state", JLabel.class).getText()),
+                () -> assertEquals("Next",
+                        findByAccessibleName(panel, "Choose agent setup state", JLabel.class).getText()),
+                () -> assertEquals("Next",
+                        findByAccessibleName(panel, "Install SHAFT MCP setup state", JLabel.class).getText()),
+                () -> assertNotEquals("Done",
+                        findByAccessibleName(panel, "Check now setup state", JLabel.class).getText()));
+    }
+
+    @Test
     void setupPanelUpgradeStepReflectsRealProjectVersionCheck() throws Exception {
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
         });
         JLabel upgradeState = findByAccessibleName(panel, "Upgrade project setup state", JLabel.class);
         JLabel upgradeDetail = findByAccessibleName(panel, "SHAFT project version status", JLabel.class);
 
-        // A project already on the latest release (or newer) is green without any clicks (#3426 A4).
+        // Nothing is green until the user presses Check (issue #3560/#3426 A4/A5).
+        assertEquals("Next", upgradeState.getText());
+
+        // A project already on the latest release (or newer) is green once checked.
         setField(panel, "upgradeChecker", (java.util.function.Supplier<ShaftProjectVersionCheck.Result>) () ->
                 new ShaftProjectVersionCheck.Result(
                         ShaftProjectVersionCheck.State.UP_TO_DATE, "10.3.20260710", "10.3.20260710"));
@@ -749,7 +772,9 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertEquals("Done", upgradeState.getText()),
                 () -> assertTrue(upgradeDetail.getText().contains("already the latest")),
-                () -> assertFalse(findByAccessibleName(panel, "Copy SHAFT upgrade command", JButton.class).isVisible()));
+                // Check and Copy stay visible in every state now (issue #3560): the row's
+                // blue/green/red styling conveys pass/fail, not button visibility.
+                () -> assertTrue(findByAccessibleName(panel, "Copy SHAFT upgrade command", JButton.class).isVisible()));
 
         // An older project version keeps the step actionable and says exactly what to do.
         setField(panel, "upgradeChecker", (java.util.function.Supplier<ShaftProjectVersionCheck.Result>) () ->
@@ -766,19 +791,26 @@ class ShaftPanelSetupTest {
     void setupPanelMcpVersionStepReflectsRealVersionCheck() throws Exception {
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
         });
-        JLabel mcpVersionState = findByAccessibleName(panel, "SHAFT MCP version setup state", JLabel.class);
+        // The merged "3 Install SHAFT MCP" row's badge is driven by this same check (issue #3560):
+        // there is no separate "SHAFT MCP version" row anymore.
+        JLabel installState = findByAccessibleName(panel, "Install SHAFT MCP setup state", JLabel.class);
         JLabel mcpVersionDetail = findByAccessibleName(panel, "SHAFT MCP version status", JLabel.class);
 
-        // Installed at or above the latest release is green without any clicks, matching the
+        // Nothing is green until the user presses Check (issue #3560/#3426 A4/A5).
+        assertEquals("Next", installState.getText());
+
+        // Installed at or above the latest release is green once checked, matching the
         // "Upgrade project" row's real-check pattern (issue #3538).
         setField(panel, "mcpVersionChecker", (java.util.function.Supplier<ShaftMcpVersionCheck.Result>) () ->
                 new ShaftMcpVersionCheck.Result(
                         ShaftMcpVersionCheck.State.UP_TO_DATE, "10.3.20260710", "10.3.20260710"));
         clickAccessible(panel, "Check SHAFT MCP version");
         assertAll(
-                () -> assertEquals("Done", mcpVersionState.getText()),
+                () -> assertEquals("Done", installState.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("is up to date")),
-                () -> assertFalse(
+                // Check and Copy stay visible in every state now (issue #3560): the row's
+                // blue/green/red styling conveys pass/fail, not button visibility.
+                () -> assertTrue(
                         findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()));
 
         // Installed but behind the latest release keeps the row actionable.
@@ -787,7 +819,7 @@ class ShaftPanelSetupTest {
                         ShaftMcpVersionCheck.State.UPGRADE_AVAILABLE, "10.2.20260101", "10.3.20260710"));
         clickAccessible(panel, "Check SHAFT MCP version");
         assertAll(
-                () -> assertEquals("Next", mcpVersionState.getText()),
+                () -> assertEquals("Next", installState.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("latest 10.3.20260710")),
                 () -> assertTrue(
                         findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()));
@@ -797,7 +829,7 @@ class ShaftPanelSetupTest {
                 new ShaftMcpVersionCheck.Result(ShaftMcpVersionCheck.State.NOT_INSTALLED, "", ""));
         clickAccessible(panel, "Check SHAFT MCP version");
         assertAll(
-                () -> assertEquals("Next", mcpVersionState.getText()),
+                () -> assertEquals("Next", installState.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("not installed yet")),
                 () -> assertTrue(
                         findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()));
@@ -809,7 +841,7 @@ class ShaftPanelSetupTest {
                 new ShaftMcpVersionCheck.Result(ShaftMcpVersionCheck.State.LATEST_UNKNOWN, "10.3.20260703", ""));
         clickAccessible(panel, "Check SHAFT MCP version");
         assertAll(
-                () -> assertEquals("Offline", mcpVersionState.getText()),
+                () -> assertEquals("Offline", installState.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("offline")),
                 () -> assertTrue(mcpVersionDetail.getText().contains("Press Check to retry."),
                         mcpVersionDetail.getText()),
@@ -831,12 +863,15 @@ class ShaftPanelSetupTest {
         try {
             assertEquals("10.3.20260703", ShaftMcpSetupPanel.installedShaftMcpVersion(appData));
 
-            // Real on-disk detection runs once in the constructor (issue #3538); regardless of
-            // network availability for the "latest" half of the comparison, the installed version
-            // this test just wrote to disk must flow through into the row's detail text.
+            // Real on-disk detection no longer auto-runs in the constructor (issue #3560): nothing
+            // is green/populated by default, only after the user presses Check. Once pressed, the
+            // installed version this test just wrote to disk must flow through into the detail text.
             ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
             });
             JLabel mcpVersionDetail = findByAccessibleName(panel, "SHAFT MCP version status", JLabel.class);
+            assertTrue(mcpVersionDetail.getText().isBlank(), mcpVersionDetail.getText());
+
+            clickAccessible(panel, "Check SHAFT MCP version");
             assertTrue(mcpVersionDetail.getText().contains("10.3.20260703"), mcpVersionDetail.getText());
         } finally {
             restoreProperty("shaft.intellij.mcp.applicationDataRoot", oldAppData);
@@ -994,7 +1029,7 @@ class ShaftPanelSetupTest {
             setField(panel, "copySink", (Consumer<String>) copied::set);
             JComponent detailsPanel = (JComponent) getField(panel, "detailsPanel");
 
-            clickAccessible(panel, "Copy MCP installer command");
+            clickAccessible(panel, "Copy SHAFT MCP install command");
             clickAccessible(panel, "Test SHAFT MCP connection");
 
             assertAll(
@@ -1035,7 +1070,9 @@ class ShaftPanelSetupTest {
                 () -> assertNull(findByAccessibleName(panel, "MCP stdio command", JTextComponent.class)),
                 () -> assertFalse(connected.get()),
                 () -> assertTrue(findByAccessibleName(panel, "Start chatting with SHAFT Assistant", JButton.class).isVisible()),
-                () -> assertFalse(findByAccessibleName(panel, "Test SHAFT MCP connection", JButton.class).isVisible()),
+                // Check stays visible in every state now (issue #3560): the row's own styling
+                // conveys pass/fail, not button visibility, so the user can always re-check.
+                () -> assertTrue(findByAccessibleName(panel, "Test SHAFT MCP connection", JButton.class).isVisible()),
                 () -> assertTrue(settings.mcpSetupComplete),
                 // fakeProject()'s base path has no AGENTS.md, so the guidance-optimization
                 // prompt (which references a validator only meaningful for a project that
@@ -2931,7 +2968,7 @@ class ShaftPanelSetupTest {
                 () -> assertIcon(findButton(panel, "Rerun")),
                 () -> assertIcon(findButton(panel, "Cancel")),
                 () -> assertIcon(findByAccessibleName(panel, "Send assistant prompt", JButton.class)),
-                () -> assertIcon(findButton(setupPanel, "Copy MCP installer command")),
+                () -> assertIcon(findButton(setupPanel, "Copy SHAFT MCP install command")),
                 () -> assertIcon(findButton(setupPanel, "Copy SHAFT upgrade command")),
                 () -> assertIcon(findButton(setupPanel, "Check SHAFT project version")),
                 () -> assertIcon(findButton(setupPanel, "Test SHAFT MCP connection")),
@@ -3283,11 +3320,12 @@ class ShaftPanelSetupTest {
             });
             AtomicReference<String> copied = new AtomicReference<>("");
             setField(panel, "copySink", (Consumer<String>) copied::set);
-            // Both the installer copy and the real verification are available from the start:
-            // the check is what completes setup, so it is never hidden behind click sequencing.
-            assertVisiblePrimarySetupActions(panel, "Copy MCP installer command", "Test SHAFT MCP connection");
+            // Both the installer copy and the real verification are available from the start,
+            // and stay visible in every state (issue #3560): the check is what completes setup,
+            // so it is never hidden behind click sequencing or button visibility.
+            assertVisiblePrimarySetupActions(panel, "Copy SHAFT MCP install command", "Test SHAFT MCP connection");
 
-            clickAccessible(panel, "Copy MCP installer command");
+            clickAccessible(panel, "Copy SHAFT MCP install command");
             assertAll(
                     () -> assertTrue(copied.get().contains("install-shaft-mcp")),
                     () -> assertTrue(copied.get().contains("codex")),
@@ -3301,10 +3339,10 @@ class ShaftPanelSetupTest {
             } else {
                 assertTrue(copied.get().contains("sh \"$tmp\" --codex"));
             }
-            assertVisiblePrimarySetupActions(panel, "Copy MCP installer command", "Test SHAFT MCP connection");
+            assertVisiblePrimarySetupActions(panel, "Copy SHAFT MCP install command", "Test SHAFT MCP connection");
 
             clickAccessible(panel, "Test SHAFT MCP connection");
-            assertVisiblePrimarySetupActions(panel, "Copy MCP installer command", "Test SHAFT MCP connection");
+            assertVisiblePrimarySetupActions(panel, "Copy SHAFT MCP install command", "Test SHAFT MCP connection");
         } finally {
             restoreProperty("shaft.intellij.mcp.applicationDataRoot", oldAppData);
             restoreProperty("shaft.intellij.mcp.bootstrapRoot", oldBootstrap);
@@ -3313,10 +3351,13 @@ class ShaftPanelSetupTest {
         ShaftSettingsState.Settings settings = unverifiedMcpSettings();
         ShaftMcpSetupPanel connectedPanel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
         }, readyProbe());
-        assertVisiblePrimarySetupActions(connectedPanel, "Test SHAFT MCP connection");
+        assertVisiblePrimarySetupActions(connectedPanel, "Copy SHAFT MCP install command", "Test SHAFT MCP connection");
 
         showTestResult(connectedPanel, ShaftMcpToolResult.success("Probe OK"));
-        assertVisiblePrimarySetupActions(connectedPanel, "Start chatting with SHAFT Assistant");
+        // Check and Copy remain visible/enabled alongside "Start chatting" (issue #3560): the row
+        // color, not button visibility, now conveys that setup already passed.
+        assertVisiblePrimarySetupActions(connectedPanel, "Copy SHAFT MCP install command",
+                "Test SHAFT MCP connection", "Start chatting with SHAFT Assistant");
     }
 
     @Test
@@ -3347,7 +3388,7 @@ class ShaftPanelSetupTest {
                     () -> assertTrue(copied.get().contains("install-shaft-mcp")),
                     () -> assertTrue(copied.get().contains("--install-shaft-skills")),
                     () -> assertVisiblePrimarySetupActions(panel,
-                            "Copy MCP installer command", "Test SHAFT MCP connection"),
+                            "Copy SHAFT MCP install command", "Test SHAFT MCP connection"),
                     () -> assertTrue(containsText(panel, "Installer command copied. Run it in terminal, then check.")));
         } finally {
             restoreProperty("shaft.intellij.mcp.applicationDataRoot", oldAppData);
@@ -3391,7 +3432,7 @@ class ShaftPanelSetupTest {
 
         JButton resetAndReinstall = findByAccessibleName(toolWindow, "Reset and reinstall SHAFT MCP", JButton.class);
         assertAll(
-                () -> assertEquals("Reset / reinstall", resetAndReinstall.getText()),
+                () -> assertEquals("Reinstall", resetAndReinstall.getText()),
                 () -> assertEquals("Clear the saved MCP command and copy a fresh installer command",
                         resetAndReinstall.getToolTipText()),
                 () -> assertTrue(resetAndReinstall.isVisible()),
@@ -4934,7 +4975,7 @@ class ShaftPanelSetupTest {
 
     private static boolean isSetupPrimaryAction(JButton button) {
         return List.of(
-                "Copy MCP installer command",
+                "Copy SHAFT MCP install command",
                 "Test SHAFT MCP connection",
                 "Start chatting with SHAFT Assistant").contains(accessibleName(button));
     }


### PR DESCRIPTION
## What

Reworks the first-run / post-reset **SHAFT MCP setup panel** (`ShaftMcpSetupPanel`) per user feedback. Six changes:

1. **No green by default.** The numbered verification steps — *1 Upgrade project, 2 Pick agent, 3 Install SHAFT MCP, 4 Check setup* — now start neutral **blue "Next"** on a fresh landing **and** after *Reset everything*. A row turns green only once the user presses that row's **Check** and it passes — never from a passive on-disk/PATH probe. The constructor no longer pre-runs the upgrade/version checks; new `upgradeChecked`/`mcpVersionChecked` flags gate green, and *2 Pick agent* green now requires a verified connection (`agentLaneReady`).
2. **Pass → blue-to-green, fail → red.** Existing state→color mapping; the state functions now feed it correctly. Step 4 shows a red **Failed** row on a failed probe.
3. **Check + Copy always visible** on every applicable row, in every state — removed the `setVisible` toggling that used to hide buttons once a step was "done". The **row styling** (blue/green/red), not button visibility, now conveys pass/fail. SVG check/copy icons preserved.
4. **One MCP entry.** The separate *"SHAFT MCP version"* row is merged into **"3 Install SHAFT MCP"** — a single row with one **Check** (version) + one **Copy** (install/update command, honoring the Advanced *Also install shaft-cli* toggle).
5. **Shorter button labels** ("Copy", "Check", "Reinstall", "Warm up Engine") — accessible names and tooltips unchanged (a11y + tests rely on them).
6. **Symmetric alignment.** Step rows now use `GridBagLayout` with a shared, re-measured label-column width so labels + state badges line up across every row (was ragged `WrapLayout`). The wide, per-row-variable actions content gets its own full-width line so it never crops at the narrow tool-window width.

## Verification (JDK 21, `ms-21.0.11`)

- `ShaftPanelSetupTest`: **171/171**, 0 failures/errors (from JUnit XML)
- `ShaftPluginScreenshotRendererTest`: **1/1**, 0 failures/errors
- Rendered and reviewed setup / narrow-dark / success / error screenshots — alignment holds and the blue (unchecked) / green (verified) / red (failed) states render correctly in both themes.

### Screenshots
| Fresh landing (no green on steps 1–4) | Success (only verified steps green) | Failure (red step 4) |
|---|---|---|
| neutral blue Next badges | 2 & 4 green after real checks | step 4 red "Failed" |

## Note for reviewer — one interpretation call
"No green by default" is applied to the **numbered verification steps (1–4)**, which is what the report was about. The **Prerequisites** row still shows real-time factual tool detection (e.g. "Java (JDK) detected") in green on landing — that's an accurate live detection of what's installed, not a stale setup-complete claim, and gating it behind a click would hide "what's missing" on a fresh machine. Happy to also neutralize the Prerequisites aggregate badge until its **Recheck** is clicked if you'd prefer the stricter reading.

Closes part of #3560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)