### PR TITLE
fix(capture): finalize soft-deleted steps on stop so they never resurface (#3560)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Owns one SHAFT-managed browser and its deterministic capture pipeline.
@@ -89,6 +90,11 @@ class ManagedCaptureRecorder {
     private CaptureEventPipeline pipeline;
     private CaptureNetworkRecorder networkRecorder;
     private final Path networkBodiesDirectory;
+    /**
+     * Reads the client action ids the overlay has soft-deleted but not yet committed (#3560);
+     * injectable so the stop-time flush can be tested without launching a real browser.
+     */
+    private Supplier<List<String>> pendingBrowserDeletesReader = this::readPendingBrowserDeletesFromOverlay;
     private String currentUrl;
     private volatile boolean paused;
     private volatile boolean uiStopRequested;
@@ -384,6 +390,14 @@ class ManagedCaptureRecorder {
         this.store = store;
         this.pipeline = pipeline;
         this.state = CaptureStatus.State.ACTIVE;
+    }
+
+    /**
+     * Overrides the overlay-pending-delete reader so the stop-time flush (#3560) can be exercised
+     * without launching a real browser to script {@code __shaftCapturePendingDeletes} against.
+     */
+    void pendingBrowserDeletesReaderForTesting(Supplier<List<String>> reader) {
+        this.pendingBrowserDeletesReader = reader;
     }
 
     private void configureShaft() {
@@ -1207,11 +1221,55 @@ class ManagedCaptureRecorder {
             }
         }
         if (pipeline != null) {
+            // Finalize any step the user soft-deleted inside the undo grace window before the
+            // pipeline (and, right after, the browser) is torn down (#3560). The collector is
+            // already closed above, so there is no competing drain; the browser is still alive
+            // (closeBrowser() runs later in stop()/interrupt()), so the overlay can still be read.
+            flushPendingBrowserDeletes();
             try {
                 pipeline.close();
             } catch (RuntimeException ignored) {
                 warn("Pending browser events could not all be finalized.");
             }
+        }
+    }
+
+    /**
+     * Replays, through the normal {@code step_delete} path, every step the overlay has soft-deleted
+     * but not yet committed (#3560). The IDE's Stop button drives {@code capture_stop -> stop()}
+     * directly and never runs the in-overlay {@code confirmStop} that would otherwise commit the
+     * pending delete, so without this a step deleted in the last few seconds of recording survives
+     * in the session store and resurfaces in the generated JSON/code. {@code deleteStep} is
+     * idempotent (guarded by its own deleted-id set), so a delete the overlay timer had already
+     * committed is harmlessly re-applied.
+     */
+    private void flushPendingBrowserDeletes() {
+        if (pipeline == null) {
+            return;
+        }
+        String context = safeWindowHandle();
+        for (String clientActionId : pendingBrowserDeletesReader.get()) {
+            if (clientActionId != null && !clientActionId.isBlank()) {
+                pipeline.accept(BrowserSignal.generated(
+                        "step_delete", context, Map.of(), Map.of("clientActionId", clientActionId)));
+            }
+        }
+    }
+
+    private List<String> readPendingBrowserDeletesFromOverlay() {
+        if (!(driver instanceof JavascriptExecutor javascript)) {
+            return List.of();
+        }
+        try {
+            Object result = javascript.executeScript(
+                    "return (globalThis.__shaftCapturePendingDeletes && globalThis.__shaftCapturePendingDeletes()) || [];");
+            if (!(result instanceof List<?> list)) {
+                return List.of();
+            }
+            return list.stream().filter(item -> item != null).map(String::valueOf).toList();
+        } catch (RuntimeException ignored) {
+            // The browser may already be gone or unresponsive during shutdown; nothing else to do.
+            return List.of();
         }
     }
 
@@ -1271,7 +1329,7 @@ class ManagedCaptureRecorder {
 
     private String safeWindowHandle() {
         try {
-            return driver.getWindowHandle();
+            return driver == null ? "" : driver.getWindowHandle();
         } catch (WebDriverException exception) {
             return "";
         }

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -1926,6 +1926,14 @@
       }
     });
   };
+  // Expose any soft-delete still inside its undo grace window so a server-driven stop can finalize
+  // it before the browser is torn down (#3560). The IDE's Stop button reaches the capture_stop tool
+  // directly and never runs the in-overlay confirmStop that would otherwise commit the pending
+  // delete, so without this a step deleted in the last few seconds of recording survives in the
+  // session store and resurfaces in the generated JSON/code. Read-only: it never sends or mutates,
+  // so the overlay's own undo-grace behaviour is untouched.
+  globalThis.__shaftCapturePendingDeletes = () =>
+    pendingDelete ? [clientActionId(pendingDelete.item)] : [];
   const undoDelete = () => {
     if (!pendingDelete) return;
     const restored = pendingDelete;

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java
@@ -91,6 +91,55 @@ class ManagedCaptureRecorderControlTest {
     }
 
     @Test
+    void stopFinalizesAStepSoftDeletedInsideTheUndoGraceWindowBeforeTeardown() {
+        // Regression for issue #3560: the IDE's Stop button reaches capture_stop -> stop() directly,
+        // never the in-overlay confirmStop that commits a pending soft delete, so a step deleted in
+        // the last few seconds of recording used to survive the undo grace window's teardown and
+        // resurface in the generated JSON/code. stop() must now read the overlay's not-yet-committed
+        // deletes and finalize them before the pipeline (and browser) is torn down.
+        CaptureStartRequest request = request(CaptureBrowser.CHROME, CaptureStartOptions.defaults());
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(request);
+        CaptureSessionStore store = new CaptureSessionStore(request.outputPath());
+        store.start(CaptureSession.start(
+                "soft-delete-session",
+                Instant.parse("2026-01-02T03:04:05Z"),
+                new BrowserMetadata("chrome", "149", "test", "browser", Map.of())));
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store,
+                request.outputPath(),
+                CapturePrivacyPolicy.defaults(),
+                ignored -> { },
+                ignored -> { });
+        recorder.activeSessionForTesting(store, pipeline);
+
+        recorder.acceptSignal(userTraversal("ui-keep", "https://example.test/keep"));
+        recorder.acceptSignal(userTraversal("ui-drop", "https://example.test/drop"));
+        assertTrue(store.steps().stream().anyMatch(step -> "ui-keep".equals(step.clientActionId())),
+                "The kept step must be persisted before stop.");
+        assertTrue(store.steps().stream().anyMatch(step -> "ui-drop".equals(step.clientActionId())),
+                "The soft-deleted step is still persisted server-side until the delete is committed.");
+
+        // The overlay reports "ui-drop" as soft-deleted but not yet committed when stop is pressed.
+        recorder.pendingBrowserDeletesReaderForTesting(() -> List.of("ui-drop"));
+        CaptureStatus status = recorder.stop(false);
+
+        assertEquals(CaptureStatus.State.COMPLETED, status.state());
+        assertTrue(store.steps().stream().anyMatch(step -> "ui-keep".equals(step.clientActionId())),
+                "The step the user did not delete must survive.");
+        assertFalse(store.steps().stream().anyMatch(step -> "ui-drop".equals(step.clientActionId())),
+                "A step soft-deleted in the undo grace window must not resurface after stop.");
+    }
+
+    private static BrowserSignal userTraversal(String clientActionId, String url) {
+        return BrowserSignal.generated(
+                "navigation",
+                "window-1",
+                Map.of("url", url, "title", url),
+                Map.of("action", "OPEN", "navigationSource", "user_traversal",
+                        "clientActionId", clientActionId, "stepDescription", "Navigate to " + url));
+    }
+
+    @Test
     void stopCompletesOnAnAlreadyInterruptedThreadAndRestoresTheInterruptFlag() throws Exception {
         // Regression for issue #3409: the overlay Stop button delivered its STOP control on a
         // collector-owned thread that stop() itself interrupts while closing that collector.


### PR DESCRIPTION
## Bug

When you delete a step in the recorder overlay and then **Stop recording**, the deleted step reappeared in the generated JSON session and the generated Java code.

## Root cause

Deleting a step uses a **5-second undo grace window** (#3496 B3): the row disappears immediately, but the `step_delete` signal is only sent to the server once the window elapses — so Undo needs no server-side reverse operation (the server never learned about the delete). The catch: the IDE's **Stop** button reaches `capture_stop` → `ManagedCaptureRecorder.stop()` directly, and never runs the in-overlay `confirmStop` that would commit the pending delete. So a step deleted in the last few seconds of recording is torn down (browser quit) before the grace timer fires — the `step_delete` is lost and the step survives in the `CaptureSessionStore`, resurfacing in generated output.

## Fix

`stop()` now finalizes any not-yet-committed overlay soft-delete **before** the pipeline/browser are torn down:

- **Overlay** exposes a **read-only** `globalThis.__shaftCapturePendingDeletes()` returning the client action ids still inside the grace window. It never sends or mutates, so the overlay's own undo-grace behavior is untouched.
- **`closeCollectorAndPipeline()`** reads those ids (after the collector is closed → no competing drain; while the browser is still alive) and replays each through the **normal `step_delete` path**. `deleteStep` is idempotent (guarded by its own deleted-id set), so a delete the overlay timer had already committed is harmlessly re-applied.
- The overlay reader is injectable and `safeWindowHandle()` is now null-safe, so the flush is unit-testable without launching a browser.

## Test

New `stopFinalizesAStepSoftDeletedInsideTheUndoGraceWindowBeforeTeardown` (`ManagedCaptureRecorderControlTest`) plants two persisted steps, marks one as pending-deleted in the overlay, calls `stop()`, and asserts **only the undeleted step survives**.

**Verified both ways** (evidence-over-inference): with the flush **neutered**, the test fails — `A step soft-deleted in the undo grace window must not resurface after stop ==> expected: <false> but was: <true>` (reproduces the exact bug); with the fix in place it passes. Full class **12/12** green (surefire XML), rebased onto current `main` (which includes #3586). Recorder JS passes `node --check`.

Closes part of #3560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)