### PR TITLE
fix(intellij): command-line parsing, API recorder visibility + #3591 plugin hardening

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftCommandLine.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftCommandLine.java
@@ -11,25 +11,70 @@ public final class ShaftCommandLine {
         throw new IllegalStateException("Utility class");
     }
 
+    /**
+     * Splits a user-configured command line into tokens.
+     *
+     * <p>Backslashes before a double quote follow the Windows {@code CommandLineToArgvW} rule so
+     * that native paths tokenize the way a Windows user expects: {@code 2n} backslashes plus a
+     * {@code "} emit {@code n} backslashes and the quote toggles quoting; {@code 2n+1} backslashes
+     * plus a {@code "} emit {@code n} backslashes and a literal {@code "}. In particular a quoted
+     * path written with the documented doubled trailing separator -- {@code "C:\tools\shaft\\"} --
+     * tokenizes to {@code C:\tools\shaft\} instead of swallowing the rest of the line. Backslashes
+     * not before a double quote are always literal (never an escape), so ordinary paths such as
+     * {@code "C:\Program Files\java.exe"} pass through unchanged. Single quotes are literal
+     * (POSIX-style): no escapes apply until the closing {@code '}.</p>
+     */
     public static List<String> parse(String commandLine) {
         List<String> tokens = new ArrayList<>();
         StringBuilder current = new StringBuilder();
-        boolean quoted = false;
-        char quote = 0;
-        for (int index = 0; index < commandLine.length(); index++) {
+        boolean inSingle = false;
+        boolean inDouble = false;
+        int index = 0;
+        int length = commandLine.length();
+        while (index < length) {
             char c = commandLine.charAt(index);
-            if (c == '\\' && index + 1 < commandLine.length() && quoted && commandLine.charAt(index + 1) == quote) {
-                current.append(commandLine.charAt(index + 1));
+            if (c == '\\' && !inSingle) {
+                int backslashes = 0;
+                while (index < length && commandLine.charAt(index) == '\\') {
+                    backslashes++;
+                    index++;
+                }
+                if (index < length && commandLine.charAt(index) == '"') {
+                    current.append("\\".repeat(backslashes / 2));
+                    if ((backslashes & 1) == 1) {
+                        current.append('"'); // odd count: the quote is escaped (literal)
+                        index++;
+                    }
+                    // even count: leave the '"' for the next iteration to toggle quoting
+                } else {
+                    current.append("\\".repeat(backslashes)); // literal backslashes
+                }
+            } else if (inSingle) {
+                if (c == '\'') {
+                    inSingle = false;
+                } else {
+                    current.append(c);
+                }
                 index++;
-            } else if (quoted && c == quote) {
-                quoted = false;
-            } else if (!quoted && (c == '"' || c == '\'')) {
-                quoted = true;
-                quote = c;
-            } else if (!quoted && Character.isWhitespace(c)) {
+            } else if (inDouble) {
+                if (c == '"') {
+                    inDouble = false;
+                } else {
+                    current.append(c);
+                }
+                index++;
+            } else if (c == '"') {
+                inDouble = true;
+                index++;
+            } else if (c == '\'') {
+                inSingle = true;
+                index++;
+            } else if (Character.isWhitespace(c)) {
                 add(tokens, current);
+                index++;
             } else {
                 current.append(c);
+                index++;
             }
         }
         add(tokens, current);

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpInvocationService.java
@@ -388,7 +388,7 @@ public final class ShaftMcpInvocationService implements Disposable {
             if (cancellationRequested.get() || exception instanceof CancellationException) {
                 throw new CancellationException("Operation cancelled");
             }
-            dropClientIfDead(client);
+            dropClientIfWedged(client);
             McpInvocationError category = McpInvocationError.categorize(exception);
             return ShaftMcpToolResult.failure(
                     McpInvocationError.detail(exception, category), category, category.recoveryAction());
@@ -483,8 +483,15 @@ public final class ShaftMcpInvocationService implements Disposable {
         }
     }
 
-    private void dropClientIfDead(ShaftMcpStdioClient client) {
-        if (client == null || client.isAlive()) {
+    /**
+     * Drops the shared client after a failed dispatch when it is either dead or was never
+     * initialized (an alive process whose {@code initialize} handshake hung or was rejected):
+     * either way it can never serve another call, so the next action must respawn a fresh one.
+     * An alive, initialized client is left in place — a single tool-call failure (a bad
+     * argument, a server-side error) must not tear down a live capture/driver session.
+     */
+    private void dropClientIfWedged(ShaftMcpStdioClient client) {
+        if (client == null || !shouldDropAfterFailure(client.isAlive(), client.isInitialized())) {
             return;
         }
         synchronized (clientLock) {
@@ -492,6 +499,16 @@ public final class ShaftMcpInvocationService implements Disposable {
                 closeSharedClientLocked();
             }
         }
+    }
+
+    /**
+     * Pure decision of whether a client that just failed a dispatch should be dropped as the
+     * shared client (issue #3591): dead clients always go, and so does an alive client that never
+     * completed the {@code initialize} handshake, since it will only keep re-failing the same
+     * handshake forever otherwise. An alive, initialized client is kept.
+     */
+    static boolean shouldDropAfterFailure(boolean alive, boolean initialized) {
+        return !alive || !initialized;
     }
 
     private void closeSharedClientLocked() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpStdioClient.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ShaftMcpStdioClient.java
@@ -96,6 +96,15 @@ final class ShaftMcpStdioClient implements AutoCloseable {
         return !closed.get() && process.isAlive();
     }
 
+    /**
+     * Reports whether the {@code initialize} handshake has completed successfully.
+     *
+     * @return true once {@code notifications/initialized} has been sent to the server
+     */
+    boolean isInitialized() {
+        return initialized;
+    }
+
     String initializeOnly(Duration timeout) throws IOException {
         initialize(timeout);
         return "SHAFT MCP connection is ready.";

--- a/shaft-intellij/src/main/java/com/shaft/intellij/notifications/FailedRunDoctorNotifier.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/notifications/FailedRunDoctorNotifier.java
@@ -3,7 +3,9 @@ package com.shaft.intellij.notifications;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.execution.ExecutionListener;
+import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationAction;
@@ -11,6 +13,7 @@ import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -18,8 +21,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 /**
@@ -35,7 +37,47 @@ import java.util.stream.Stream;
 public final class FailedRunDoctorNotifier implements ExecutionListener {
     private static final String GROUP_ID = "SHAFT Notifications";
     private static final long THROTTLE_MILLIS = 60_000;
-    private static final Map<String, Long> LAST_NOTIFIED_BY_PROJECT = new ConcurrentHashMap<>();
+
+    /**
+     * Records, per {@link ProcessHandler} instance, whether that specific run was forcibly
+     * destroyed (the user pressed Stop, or the IDE force-killed it) rather than exiting on its
+     * own. {@code ProcessHandler} already extends {@code UserDataHolderBase}, so storing the flag
+     * here scopes it to exactly one run and lets it die with the handler itself -- no static
+     * collection to leak or to key by anything (issue #3591).
+     */
+    private static final Key<Boolean> USER_CANCELLED = Key.create("SHAFT_RUN_USER_CANCELLED");
+
+    /**
+     * Throttle timestamp for this listener's project. {@code <projectListeners>} registration in
+     * plugin.xml gives every project its own {@code FailedRunDoctorNotifier} instance for the life
+     * of that project, so a plain instance field already scopes the throttle correctly -- the
+     * previous {@code static Map<basePath, Long>} could only ever grow, never shrink, across every
+     * project ever opened in the IDE session (issue #3591).
+     */
+    private final AtomicLong lastNotifiedAt = new AtomicLong();
+
+    @Override
+    public void processStarted(@NotNull String executorId,
+                               @NotNull ExecutionEnvironment environment,
+                               @NotNull ProcessHandler handler) {
+        if (!looksLikeTestRun(environment)) {
+            return;
+        }
+        // Attached per-run on the real ProcessHandler so processTerminated can tell a user Stop
+        // apart from the process simply exiting with a failing test's non-zero code. There is no
+        // single "was this cancelled" flag on ExecutionListener itself; processWillTerminate's
+        // willBeDestroyed parameter is true only on the destroyProcess() path (Stop / force-kill)
+        // and false on detachProcess(), and is never invoked at all for a process that just exits
+        // on its own -- verified against the platform's ProcessHandler bytecode (issue #3591).
+        handler.addProcessListener(new ProcessListener() {
+            @Override
+            public void processWillTerminate(@NotNull ProcessEvent event, boolean willBeDestroyed) {
+                if (willBeDestroyed) {
+                    handler.putUserData(USER_CANCELLED, Boolean.TRUE);
+                }
+            }
+        });
+    }
 
     @Override
     public void processTerminated(@NotNull String executorId,
@@ -44,6 +86,12 @@ public final class FailedRunDoctorNotifier implements ExecutionListener {
                                   int exitCode) {
         Project project = environment.getProject();
         if (exitCode == 0 || project.isDisposed()) {
+            return;
+        }
+        if (isUserCancelledRun(handler.getUserData(USER_CANCELLED))) {
+            // The user pressed Stop (or the IDE force-killed the run): a non-zero exit here is
+            // expected and intentional, not a failure to triage. Running Doctor anyway would burn
+            // MCP time on every deliberate cancel.
             return;
         }
         if (!looksLikeTestRun(environment)) {
@@ -62,12 +110,28 @@ public final class FailedRunDoctorNotifier implements ExecutionListener {
             // would immediately fail is worse than no notification.
             return;
         }
-        if (throttled(basePath)) {
+        if (throttled()) {
             return;
         }
         String testIdentity = environment.getRunProfile().getName();
         notifyDoctorAvailable(project, testIdentity, allureResultsPath, tracePath);
         openDoctorWorkflow(project, allureResultsPath, tracePath);
+    }
+
+    /**
+     * Pure decision extracted from {@link #processTerminated} so it is unit-testable without any
+     * platform types (mirrors {@code ShaftTestMethodAnnotations}'s PSI-free predicate style): a
+     * run counts as user-cancelled only when {@code processWillTerminate} actually recorded
+     * {@code willBeDestroyed == true} on that process. A {@code null} value -- the common case,
+     * since most terminations never call {@code destroyProcess()} at all -- must NOT be treated as
+     * cancelled, or every genuinely failed run would silently stop notifying.
+     *
+     * @param recordedWillBeDestroyed the value stored by {@link #processStarted}'s listener, or
+     *                                {@code null} when the process was never force-destroyed
+     * @return {@code true} only when the run was an explicit user Stop / forced kill
+     */
+    static boolean isUserCancelledRun(@Nullable Boolean recordedWillBeDestroyed) {
+        return Boolean.TRUE.equals(recordedWillBeDestroyed);
     }
 
     private static boolean looksLikeTestRun(ExecutionEnvironment environment) {
@@ -150,10 +214,10 @@ public final class FailedRunDoctorNotifier implements ExecutionListener {
         return projectRoot.relativize(candidate).toString().replace('\\', '/');
     }
 
-    private static boolean throttled(String basePath) {
+    private boolean throttled() {
         long now = System.currentTimeMillis();
-        Long previous = LAST_NOTIFIED_BY_PROJECT.put(basePath, now);
-        return previous != null && now - previous < THROTTLE_MILLIS;
+        long previous = lastNotifiedAt.getAndSet(now);
+        return previous != 0 && now - previous < THROTTLE_MILLIS;
     }
 
     private static void notifyDoctorAvailable(

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftPluginUpgradeActivity.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftPluginUpgradeActivity.java
@@ -1,8 +1,6 @@
 package com.shaft.intellij.settings;
 
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.openapi.extensions.PluginId;
+import com.intellij.ide.plugins.cl.PluginAwareClassLoader;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.ProjectActivity;
 import kotlin.Unit;
@@ -28,7 +26,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class ShaftPluginUpgradeActivity implements ProjectActivity {
     private static final AtomicBoolean CHECKED = new AtomicBoolean();
-    private static final String PLUGIN_ID = "io.github.shafthq.shaft";
 
     /** Outcome of comparing the stored last-seen version against the running version. */
     enum UpgradeDecision {
@@ -100,7 +97,13 @@ public final class ShaftPluginUpgradeActivity implements ProjectActivity {
 
     @Nullable
     private static String runningPluginVersion() {
-        IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID));
-        return plugin == null ? null : plugin.getVersion();
+        // PluginManagerCore#getPlugin(PluginId) is @ApiStatus.Internal on recent platform versions
+        // and fails shaft-intellij's INTERNAL_API_USAGES verifyPlugin gate; PluginAwareClassLoader's
+        // getPluginDescriptor()/getVersion() resolve this plugin's own version without it.
+        ClassLoader classLoader = ShaftPluginUpgradeActivity.class.getClassLoader();
+        if (classLoader instanceof PluginAwareClassLoader pluginAwareClassLoader) {
+            return pluginAwareClassLoader.getPluginDescriptor().getVersion();
+        }
+        return null;
     }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftJUnitRunConfigurationProducer.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftJUnitRunConfigurationProducer.java
@@ -68,12 +68,11 @@ public final class ShaftJUnitRunConfigurationProducer extends LazyRunConfigurati
     }
 
     private static boolean hasRunnableMethod(PsiClass psiClass) {
+        List<List<String>> methodAnnotations = new ArrayList<>();
         for (PsiMethod method : psiClass.getMethods()) {
-            if (ShaftTestMethodAnnotations.isShaftRunnableTestMethod(annotationQualifiedNames(method))) {
-                return true;
-            }
+            methodAnnotations.add(annotationQualifiedNames(method));
         }
-        return false;
+        return ShaftTestMethodAnnotations.hasRunnableTestMethod(methodAnnotations);
     }
 
     private static List<String> annotationQualifiedNames(PsiMethod method) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestMethodAnnotations.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestMethodAnnotations.java
@@ -34,4 +34,21 @@ public final class ShaftTestMethodAnnotations {
         }
         return annotationQualifiedNames.stream().anyMatch(RUNNABLE_TEST_ANNOTATION_FQNS::contains);
     }
+
+    /**
+     * Returns whether any method of a class is a runnable SHAFT test, given each method's annotation
+     * fully-qualified names. Kept PSI-free so the run-configuration producers' class-scan decision
+     * ({@code hasRunnableMethod}) is unit testable; the producers extract the per-method FQN lists
+     * from PSI and hand them here.
+     *
+     * @param methodsAnnotationQualifiedNames one entry per method, each the annotation FQNs on that
+     *                                        method (entries or the outer value may be {@code null})
+     * @return {@code true} when at least one method carries a recognized test annotation
+     */
+    public static boolean hasRunnableTestMethod(Collection<? extends Collection<String>> methodsAnnotationQualifiedNames) {
+        if (methodsAnnotationQualifiedNames == null || methodsAnnotationQualifiedNames.isEmpty()) {
+            return false;
+        }
+        return methodsAnnotationQualifiedNames.stream().anyMatch(ShaftTestMethodAnnotations::isShaftRunnableTestMethod);
+    }
 }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestNgRunConfigurationProducer.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testrunner/ShaftTestNgRunConfigurationProducer.java
@@ -61,12 +61,11 @@ public final class ShaftTestNgRunConfigurationProducer extends LazyRunConfigurat
     }
 
     private static boolean hasRunnableMethod(PsiClass psiClass) {
+        List<List<String>> methodAnnotations = new ArrayList<>();
         for (PsiMethod method : psiClass.getMethods()) {
-            if (ShaftTestMethodAnnotations.isShaftRunnableTestMethod(annotationQualifiedNames(method))) {
-                return true;
-            }
+            methodAnnotations.add(annotationQualifiedNames(method));
         }
-        return false;
+        return ShaftTestMethodAnnotations.hasRunnableTestMethod(methodAnnotations);
     }
 
     private static List<String> annotationQualifiedNames(PsiMethod method) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ApiRecordingSessionPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ApiRecordingSessionPanel.java
@@ -53,9 +53,12 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
     private final Alarm pollAlarm;
 
     private volatile boolean stopped;
-    private String sessionId;
-    private String sessionOutputPath = "";
-    private ShaftMcpInvocation currentInvocation;
+    // Written on the pooled poll thread (pollOnce) and read on the EDT (stopRecording/dispose);
+    // volatile so a Stop/close on the EDT always observes the in-flight invocation to cancel it,
+    // and so the poll thread and EDT never disagree on the session identity/output path.
+    private volatile String sessionId;
+    private volatile String sessionOutputPath = "";
+    private volatile ShaftMcpInvocation currentInvocation;
 
     /**
      * Creates the panel and immediately begins polling for transactions.

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
@@ -63,6 +63,9 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     private final JLabel recorderStatus;
     private final ToolPrefill prefill;
     private final ShaftSettingsState.Settings settings;
+    // Stable per-instance identity so overlapping recordings across surfaces don't collapse onto
+    // one process-wide flag (issue #3591 item 3).
+    private final String recordingKey = "guided#" + Integer.toHexString(System.identityHashCode(this));
     // Created lazily on the first poll so headless panel tests never touch platform executors.
     private Alarm statusPollAlarm;
     private volatile boolean pollingActive;
@@ -970,7 +973,11 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
         JsonObject status = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
         boolean active = isRecorderActive(status);
         // Feeds the shared readiness strip's recording badge (issue #3500 A4).
-        ShaftRecordingActivity.publish(active);
+        if (active) {
+            ShaftRecordingActivity.started(recordingKey);
+        } else {
+            ShaftRecordingActivity.stopped(recordingKey);
+        }
         if (active) {
             recorderSeenActive = true;
             pollsWithoutActivity = 0;
@@ -1096,6 +1103,8 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
         if (statusPollAlarm != null && !statusPollAlarm.isDisposed()) {
             statusPollAlarm.cancelAllRequests();
         }
+        // Prevents a stuck-active recording key if the panel closes mid-recording (#3591 item 3).
+        ShaftRecordingActivity.stopped(recordingKey);
     }
 
     private boolean playwright() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -125,6 +125,9 @@ final class ShaftAssistantPanel extends JPanel {
                     + "3. 🧪 Review code to turn it into a real test.\n"
                     + "4. 💬 Or just tell me what you need below.";
     private final Project project;
+    // Stable per-instance identity so overlapping recordings across surfaces don't collapse onto
+    // one process-wide flag (issue #3591 item 3).
+    private final String recordingKey = "assistant#" + Integer.toHexString(System.identityHashCode(this));
     private final ShaftAssistantChatState chatState;
     private final JComboBox<ShaftAssistantChatState.Session> chatSelector;
     private final JButton newChat;
@@ -754,6 +757,8 @@ final class ShaftAssistantPanel extends JPanel {
         if (connectionState != null) {
             connectionState.removeStateChangeListener(this::onConnectionStateChanged);
         }
+        // Prevents a stuck-active recording key if the panel closes mid-recording (#3591 item 3).
+        ShaftRecordingActivity.stopped(recordingKey);
         super.removeNotify();
     }
 
@@ -1728,11 +1733,11 @@ final class ShaftAssistantPanel extends JPanel {
         if (success && ("capture_start".equals(toolName) || "playwright_record_start".equals(toolName)
                 || "mobile_record_start".equals(toolName))) {
             // Feeds the shared readiness strip's recording badge (issue #3500 A4).
-            ShaftRecordingActivity.publish(true);
+            ShaftRecordingActivity.started(recordingKey);
         }
         if (success && ("capture_stop".equals(toolName) || "playwright_record_stop".equals(toolName)
                 || "mobile_record_stop".equals(toolName))) {
-            ShaftRecordingActivity.publish(false);
+            ShaftRecordingActivity.stopped(recordingKey);
         }
         if (success && "capture_start".equals(toolName)) {
             scheduleCaptureStartDiagnostic(output);

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftRecordingActivity.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftRecordingActivity.java
@@ -1,6 +1,8 @@
 package com.shaft.intellij.ui;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -13,32 +15,58 @@ import java.util.function.Consumer;
  *
  * <p>Static by design: the recorder itself is process-wide (one managed browser per IDE), so a
  * per-project signal would be dishonest about ownership.
+ *
+ * <p>Tracked by a set of per-surface session keys rather than a single boolean (issue #3591 item
+ * 3): overlapping recordings from different surfaces used to collapse onto one process-wide flag,
+ * so stopping one recording could publish {@code false} while another was still running.
  */
 public final class ShaftRecordingActivity {
-    private static final AtomicBoolean ACTIVE = new AtomicBoolean();
+    private static final Object LOCK = new Object();
+    private static final Set<String> ACTIVE_KEYS = new HashSet<>(); // guarded by LOCK
+    private static final AtomicBoolean LAST = new AtomicBoolean();
     private static final List<Consumer<Boolean>> LISTENERS = new CopyOnWriteArrayList<>();
 
     private ShaftRecordingActivity() {
     }
 
     /**
-     * Publishes the current recording-activity state; listeners fire only on changes.
+     * Marks {@code sessionKey} as an active recording session; listeners fire only if this is the
+     * first active session overall.
      *
-     * @param active whether a recording session is currently active
+     * @param sessionKey stable per-instance key identifying the recording surface/session
      */
-    public static void publish(boolean active) {
-        if (ACTIVE.getAndSet(active) != active) {
-            LISTENERS.forEach(listener -> listener.accept(active));
+    public static void started(String sessionKey) {
+        update(() -> ACTIVE_KEYS.add(sessionKey));
+    }
+
+    /**
+     * Marks {@code sessionKey} as no longer recording; listeners fire only if this was the last
+     * active session overall.
+     *
+     * @param sessionKey stable per-instance key previously passed to {@link #started}
+     */
+    public static void stopped(String sessionKey) {
+        update(() -> ACTIVE_KEYS.remove(sessionKey));
+    }
+
+    private static void update(Runnable mutation) {
+        boolean now;
+        synchronized (LOCK) {
+            mutation.run();
+            now = !ACTIVE_KEYS.isEmpty();
+        }
+        if (LAST.getAndSet(now) != now) {
+            LISTENERS.forEach(listener -> listener.accept(now));
         }
     }
 
     /**
-     * Returns whether a recording session is currently active.
+     * Returns whether any recording session is currently active.
      *
      * @return last published activity state
      */
     public static boolean active() {
-        return ACTIVE.get();
+        return LAST.get();
     }
 
     /**
@@ -57,5 +85,17 @@ public final class ShaftRecordingActivity {
      */
     public static void unlisten(Consumer<Boolean> listener) {
         LISTENERS.remove(listener);
+    }
+
+    /**
+     * Test-only reset of all static state (active keys, last-published flag, listeners). Package
+     * visible so only tests in this package can reach it.
+     */
+    static void resetForTests() {
+        synchronized (LOCK) {
+            ACTIVE_KEYS.clear();
+        }
+        LAST.set(false);
+        LISTENERS.clear();
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/FakeMcpServer.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/FakeMcpServer.java
@@ -30,6 +30,8 @@ final class FakeMcpServer {
             case "echoTool" -> runEchoToolServer();
             case "silentToolCalls" -> runSilentToolCallServer();
             case "progressStream" -> runProgressStreamServer();
+            case "rejectInitialize" -> runRejectInitializeServer();
+            case "toolCallJsonRpcError" -> runToolCallJsonRpcErrorServer();
             case "hang" -> Thread.sleep(Long.MAX_VALUE);
             default -> Thread.sleep(Long.MAX_VALUE);
         }
@@ -94,6 +96,52 @@ final class FakeMcpServer {
             if ("initialize".equals(requestMethod(message))) {
                 writeMessage(output, requestId(message),
                         "{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":{\"protocolVersion\":\"2024-11-05\"}}");
+            }
+        }
+    }
+
+    /**
+     * Rejects the {@code initialize} handshake with a JSON-RPC error but keeps reading lines
+     * afterward, so the process stays alive (issue #3591): this reproduces a server that starts
+     * but never completes the handshake, wedging the shared client as alive-but-uninitialized.
+     */
+    private static void runRejectInitializeServer() throws Exception {
+        BufferedReader input = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+        OutputStream output = System.out;
+        while (true) {
+            String message = input.readLine();
+            if (message == null) {
+                return;
+            }
+            if ("initialize".equals(requestMethod(message))) {
+                writeMessage(output, requestId(message),
+                        "{\"jsonrpc\":\"2.0\",\"id\":%d,\"error\":{\"code\":-32000,\"message\":\"handshake refused\"}}");
+            }
+        }
+    }
+
+    /**
+     * Completes the {@code initialize} handshake normally, but answers {@code tools/call} with a
+     * top-level JSON-RPC {@code error} (as opposed to {@code toolCallIsError}'s {@code isError:true}
+     * success envelope). Used to prove an already-initialized client is retained after a tool-call
+     * failure — only a never-initialized client should be evicted (issue #3591).
+     */
+    private static void runToolCallJsonRpcErrorServer() throws Exception {
+        BufferedReader input = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+        OutputStream output = System.out;
+        while (true) {
+            String message = input.readLine();
+            if (message == null) {
+                return;
+            }
+            int requestId = requestId(message);
+            switch (requestMethod(message)) {
+                case "initialize" -> writeMessage(output, requestId,
+                        "{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":{\"protocolVersion\":\"2024-11-05\"}}");
+                case "tools/call" -> writeMessage(output, requestId,
+                        "{\"jsonrpc\":\"2.0\",\"id\":%d,\"error\":{\"code\":-32000,\"message\":\"tool call refused\"}}");
+                default -> {
+                }
             }
         }
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftCommandLineTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftCommandLineTest.java
@@ -1,0 +1,70 @@
+package com.shaft.intellij.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the tokenization of user-configured MCP stdio command lines ({@link ShaftCommandLine#parse}).
+ * This is a first-run-critical path (the command a user types in Settings launches the MCP server),
+ * and it had no unit coverage before. The Windows-path cases below guard the {@code
+ * CommandLineToArgvW} backslash rule so a doubled trailing separator no longer swallows the rest of
+ * the command line.
+ */
+class ShaftCommandLineTest {
+
+    @Test
+    void splitsPlainCommandOnWhitespaceAndCollapsesRuns() {
+        assertEquals(List.of("java", "-jar", "app.jar"), ShaftCommandLine.parse("java -jar app.jar"));
+        assertEquals(List.of("a", "b"), ShaftCommandLine.parse("a   b"));
+        assertEquals(List.of("a", "b"), ShaftCommandLine.parse("  a\tb  "));
+    }
+
+    @Test
+    void keepsUnquotedWindowsBackslashPathsLiteral() {
+        assertEquals(
+                List.of("java", "@C:\\Users\\Mohab\\.shaft\\shaft-mcp.args"),
+                ShaftCommandLine.parse("java @C:\\Users\\Mohab\\.shaft\\shaft-mcp.args"));
+        // Backslashes that are not before a double quote are always literal, never an escape.
+        assertEquals(List.of("a\\\\b"), ShaftCommandLine.parse("a\\\\b"));
+    }
+
+    @Test
+    void quotedPathWithSpacesBecomesASingleToken() {
+        assertEquals(
+                List.of("C:\\Program Files\\Java\\jdk-21\\bin\\java.exe", "-jar", "app.jar"),
+                ShaftCommandLine.parse("\"C:\\Program Files\\Java\\jdk-21\\bin\\java.exe\" -jar app.jar"));
+    }
+
+    @Test
+    void doubledTrailingBackslashInQuotedPathTokenizesInsteadOfSwallowingTheLine() {
+        // The documented Windows form for a trailing separator inside quotes doubles the backslash.
+        // Before the CommandLineToArgvW fix this kept the quote open and swallowed "-jar app.jar".
+        assertEquals(
+                List.of("C:\\tools\\shaft\\", "-jar", "app.jar"),
+                ShaftCommandLine.parse("\"C:\\tools\\shaft\\\\\" -jar app.jar"));
+    }
+
+    @Test
+    void escapedDoubleQuotesInsideDoubleQuotesAreLiteral() {
+        assertEquals(List.of("say \"hi\""), ShaftCommandLine.parse("\"say \\\"hi\\\"\""));
+    }
+
+    @Test
+    void singleQuotesAreLiteralWithNoEscapes() {
+        // POSIX-style single quotes: backslashes stay literal until the closing quote.
+        assertEquals(List.of("C:\\tools\\it"), ShaftCommandLine.parse("'C:\\tools\\it'"));
+        assertEquals(List.of("a b c"), ShaftCommandLine.parse("'a b c'"));
+    }
+
+    @Test
+    void preservesWhitespaceInsideQuotesAndDropsEmptyArguments() {
+        assertEquals(List.of("-Dname=a b"), ShaftCommandLine.parse("\"-Dname=a b\""));
+        assertTrue(ShaftCommandLine.parse("").isEmpty());
+        assertTrue(ShaftCommandLine.parse("   ").isEmpty());
+        assertEquals(List.of("   "), ShaftCommandLine.parse("\"   \""));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpInvocationServiceLifecycleTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ShaftMcpInvocationServiceLifecycleTest.java
@@ -116,6 +116,18 @@ class ShaftMcpInvocationServiceLifecycleTest {
     }
 
     @Test
+    void shouldDropAfterFailureDropsUnlessAliveAndInitialized() {
+        assertTrue(ShaftMcpInvocationService.shouldDropAfterFailure(true, false),
+                "alive but never initialized (wedged handshake) must be dropped");
+        assertFalse(ShaftMcpInvocationService.shouldDropAfterFailure(true, true),
+                "alive and initialized must be kept");
+        assertTrue(ShaftMcpInvocationService.shouldDropAfterFailure(false, true),
+                "dead, even if previously initialized, must be dropped");
+        assertTrue(ShaftMcpInvocationService.shouldDropAfterFailure(false, false),
+                "dead and never initialized must be dropped");
+    }
+
+    @Test
     void deadServerDuringDispatchIsCategorizedAsProcessExitedAndEvicted() {
         RecordingFactory factory = new RecordingFactory();
         ShaftMcpInvocationService service = new ShaftMcpInvocationService(fakeProject(), factory);
@@ -128,6 +140,36 @@ class ShaftMcpInvocationServiceLifecycleTest {
         assertTrue(result.output().contains("process exit code"), result.output());
         assertTrue(service.peekSharedClientAlive().isEmpty(),
                 "a dead client encountered mid-dispatch must be evicted, not kept as the shared client");
+    }
+
+    @Test
+    void rejectedInitializeHandshakeLeavesAnAliveButUninitializedClientEvictedAfterDispatchFailure() {
+        RecordingFactory factory = new RecordingFactory();
+        ShaftMcpInvocationService service = new ShaftMcpInvocationService(fakeProject(), factory);
+        ShaftSettingsState.Settings settings = settingsForMode("rejectInitialize");
+
+        ShaftMcpToolResult result = service.startListTools(false, settings).future().join();
+
+        assertFalse(result.success());
+        assertEquals(Optional.empty(), service.peekSharedClientAlive(),
+                "an alive-but-never-initialized client (handshake rejected, process still alive) must be "
+                        + "evicted after a failed dispatch so the next action respawns instead of re-firing "
+                        + "the same failing handshake forever");
+    }
+
+    @Test
+    void toolCallJsonRpcErrorOnAnInitializedClientKeepsItAsTheSharedClient() {
+        RecordingFactory factory = new RecordingFactory();
+        ShaftMcpInvocationService service = new ShaftMcpInvocationService(fakeProject(), factory);
+        ShaftSettingsState.Settings settings = settingsForMode("toolCallJsonRpcError");
+
+        ShaftMcpToolResult result = service.startTool("fake_tool", new JsonObject(), settings).future().join();
+
+        assertFalse(result.success());
+        assertEquals(Optional.of(true), service.peekSharedClientAlive(),
+                "a tool-call failure on an already-initialized, still-alive client must not evict it "
+                        + "(that would kill a live capture/driver session) -- only the never-initialized "
+                        + "handshake-failure case evicts");
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/notifications/FailedRunDoctorNotifierTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/notifications/FailedRunDoctorNotifierTest.java
@@ -17,9 +17,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * which need a live IntelliJ platform and are not exercised by this lightweight Gradle unit test
  * JVM (same documented gap as {@link ShaftToolWorkflowLauncherTest}). This class instead covers
  * every pure piece {@code processTerminated} delegates to: argument building, evidence-path
- * resolution, and real-test-identity normalization (issue #3547).
+ * resolution, real-test-identity normalization (issue #3547), and the user-cancellation skip
+ * decision (issue #3591).
  */
 class FailedRunDoctorNotifierTest {
+    @Test
+    void isUserCancelledRunIsFalseWhenNeverRecorded() {
+        // The common case: a run that fails on its own (assertion failure, non-zero JVM exit) never
+        // goes through destroyProcess(), so processWillTerminate is never called and no value is
+        // ever stored. This must NOT be treated as a cancellation, or genuinely failed runs would
+        // silently stop notifying (issue #3591).
+        assertFalse(FailedRunDoctorNotifier.isUserCancelledRun(null));
+    }
+
+    @Test
+    void isUserCancelledRunIsFalseWhenRecordedAsNotDestroyed() {
+        // processWillTerminate(event, false) corresponds to detachProcess(), not a user Stop.
+        assertFalse(FailedRunDoctorNotifier.isUserCancelledRun(Boolean.FALSE));
+    }
+
+    @Test
+    void isUserCancelledRunIsTrueWhenRecordedAsForciblyDestroyed() {
+        // processWillTerminate(event, true) corresponds to destroyProcess() -- the user pressed
+        // Stop, or the IDE force-killed the run.
+        assertTrue(FailedRunDoctorNotifier.isUserCancelledRun(Boolean.TRUE));
+    }
+
     @Test
     void doctorArgumentsBuildsCorrectJsonStructure() {
         JsonObject arguments = FailedRunDoctorNotifier.doctorArguments("allure-results");

--- a/shaft-intellij/src/test/java/com/shaft/intellij/testrunner/ShaftTestMethodAnnotationsTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/testrunner/ShaftTestMethodAnnotationsTest.java
@@ -2,6 +2,8 @@ package com.shaft.intellij.testrunner;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -43,5 +45,39 @@ class ShaftTestMethodAnnotationsTest {
     void recognizesTestAnnotationMixedWithOthers() {
         assertTrue(ShaftTestMethodAnnotations.isShaftRunnableTestMethod(
                 Set.of("java.lang.Override", "org.junit.jupiter.api.Test")));
+    }
+
+    @Test
+    void hasRunnableTestMethodReturnsFalseForNullOuterCollection() {
+        assertFalse(ShaftTestMethodAnnotations.hasRunnableTestMethod(null));
+    }
+
+    @Test
+    void hasRunnableTestMethodReturnsFalseForEmptyOuterCollection() {
+        assertFalse(ShaftTestMethodAnnotations.hasRunnableTestMethod(List.of()));
+    }
+
+    @Test
+    void hasRunnableTestMethodReturnsFalseWhenNoEntryIsRunnable() {
+        assertFalse(ShaftTestMethodAnnotations.hasRunnableTestMethod(
+                List.of(List.of(), List.of("java.lang.Override"))));
+    }
+
+    @Test
+    void hasRunnableTestMethodReturnsTrueForSingleTestNgEntry() {
+        assertTrue(ShaftTestMethodAnnotations.hasRunnableTestMethod(
+                List.of(List.of(ShaftTestMethodAnnotations.TESTNG_TEST))));
+    }
+
+    @Test
+    void hasRunnableTestMethodReturnsTrueWhenOneOfMixedEntriesIsRunnable() {
+        assertTrue(ShaftTestMethodAnnotations.hasRunnableTestMethod(
+                List.of(List.of("java.lang.Override"), List.of(ShaftTestMethodAnnotations.JUNIT5_TEST))));
+    }
+
+    @Test
+    void hasRunnableTestMethodReturnsTrueWhenANullEntryIsMixedWithARunnableEntry() {
+        List<List<String>> methodsAnnotationQualifiedNames = new ArrayList<>(Arrays.asList(null, List.of(ShaftTestMethodAnnotations.TESTNG_TEST)));
+        assertTrue(ShaftTestMethodAnnotations.hasRunnableTestMethod(methodsAnnotationQualifiedNames));
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftRecordingActivityTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftRecordingActivityTest.java
@@ -1,6 +1,7 @@
 package com.shaft.intellij.ui;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -17,6 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * stray {@code false} must never be published while another session is still active.
  */
 class ShaftRecordingActivityTest {
+    // Reset before AND after each test: ShaftRecordingActivity's listener list is process-wide
+    // static, and in the full module suite another test constructs a ShaftReadinessSummary that
+    // registers a real (UI-touching) listener into it. Clearing only afterwards left that leaked
+    // listener in place for this class's first test, where a published transition fired it and
+    // threw in the headless harness. Clearing beforehand makes each test hermetic.
+    @BeforeEach
     @AfterEach
     void resetState() {
         ShaftRecordingActivity.resetForTests();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftRecordingActivityTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftRecordingActivityTest.java
@@ -1,0 +1,101 @@
+package com.shaft.intellij.ui;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for issue #3591 item 3: overlapping recordings from different surfaces
+ * (Assistant, Guided workflow poller) must not collapse onto one process-wide boolean, and a
+ * stray {@code false} must never be published while another session is still active.
+ */
+class ShaftRecordingActivityTest {
+    @AfterEach
+    void resetState() {
+        ShaftRecordingActivity.resetForTests();
+    }
+
+    private List<Boolean> captureEmissions() {
+        List<Boolean> emissions = new ArrayList<>();
+        Consumer<Boolean> listener = emissions::add;
+        ShaftRecordingActivity.listen(listener);
+        return emissions;
+    }
+
+    @Test
+    void overlappingSessionsStayActiveUntilTheLastOneStops() {
+        List<Boolean> emissions = captureEmissions();
+
+        ShaftRecordingActivity.started("a");
+        assertTrue(ShaftRecordingActivity.active());
+        assertEquals(List.of(true), emissions);
+
+        ShaftRecordingActivity.started("b");
+        assertTrue(ShaftRecordingActivity.active());
+        assertEquals(List.of(true), emissions); // no new emission: already active
+
+        ShaftRecordingActivity.stopped("a");
+        assertTrue(ShaftRecordingActivity.active()); // "b" still recording
+        assertEquals(List.of(true), emissions); // no false emitted
+
+        ShaftRecordingActivity.stopped("b");
+        assertFalse(ShaftRecordingActivity.active());
+        assertEquals(List.of(true, false), emissions);
+    }
+
+    @Test
+    void startingTheSameKeyTwiceIsIdempotent() {
+        ShaftRecordingActivity.started("a");
+        ShaftRecordingActivity.started("a");
+        ShaftRecordingActivity.stopped("a");
+
+        assertFalse(ShaftRecordingActivity.active());
+    }
+
+    @Test
+    void stoppingAnUnknownOrAlreadyStoppedKeyIsANoOp() {
+        List<Boolean> emissions = captureEmissions();
+
+        ShaftRecordingActivity.stopped("x");
+
+        assertFalse(ShaftRecordingActivity.active());
+        assertTrue(emissions.isEmpty());
+    }
+
+    @Test
+    void aSecondSurfaceStartingAndStoppingNeverPublishesATransientFalse() {
+        List<Boolean> emissions = captureEmissions();
+
+        ShaftRecordingActivity.started("assistant");
+        assertTrue(ShaftRecordingActivity.active());
+
+        ShaftRecordingActivity.started("guided");
+        assertTrue(ShaftRecordingActivity.active());
+
+        ShaftRecordingActivity.stopped("guided");
+        assertTrue(ShaftRecordingActivity.active()); // "assistant" is still recording
+
+        assertEquals(List.of(true), emissions); // only the initial true; never a false
+    }
+
+    @Test
+    void listenersOnlyFireOnTransitionEdges() {
+        List<Boolean> emissions = captureEmissions();
+
+        ShaftRecordingActivity.started("a"); // false -> true
+        ShaftRecordingActivity.started("b"); // true -> true (no edge)
+        ShaftRecordingActivity.started("c"); // true -> true (no edge)
+        ShaftRecordingActivity.stopped("c"); // true -> true (no edge)
+        ShaftRecordingActivity.stopped("b"); // true -> true (no edge)
+        ShaftRecordingActivity.stopped("a"); // true -> false
+
+        assertEquals(List.of(true, false), emissions);
+    }
+}


### PR DESCRIPTION
## What

Two originally-surgical `shaft-intellij` fixes, now expanded to close the full hardening set tracked in #3591 (four items), all verified together against the whole module test suite.

### Original fixes
- **Windows command-line backslash parsing** (`ShaftCommandLine.parse`) — the documented doubled-trailing-separator form `"C:\tools\shaft\\"` kept the quote open and swallowed the rest of an MCP stdio command. Reimplemented with the `CommandLineToArgvW` rule; added `ShaftCommandLineTest` (previously zero coverage).
- **API recorder cross-thread field visibility** (`ApiRecordingSessionPanel`) — `sessionId`/`sessionOutputPath`/`currentInvocation` written on the poll thread, read on the EDT, non-`volatile`; a Stop could miss cancelling the in-flight poll. Marked `volatile`.

### #3591 hardening (all four items — Closes #3591)
- **Item 1 — MCP wedge recovery** (`ShaftMcpInvocationService` / `ShaftMcpStdioClient`): a shared client that stays alive but never completes the `initialize` handshake was cached forever, re-firing the failing handshake on every action. Now evicted after a failed dispatch (drop-on-`!initialized`) so the next action respawns — while an *initialized* client that merely fails a tool call is still retained (live capture/driver sessions preserved). New `rejectInitialize` / JSON-RPC-error `FakeMcpServer` modes + eviction/retention tests.
- **Item 2 — failure-notifier triggers & leak** (`FailedRunDoctorNotifier`): auto-Doctor no longer runs on user-cancelled runs — gated on `processWillTerminate(willBeDestroyed=true)`, which (verified against the platform bytecode) fires only on Stop/force-kill, never on a natural non-zero exit, so genuine failures still notify. The leaking static throttle map was replaced with a per-instance `AtomicLong`.
- **Item 3 — recording readiness split-brain** (`ShaftRecordingActivity` + Assistant/Guided panels): the process-wide `AtomicBoolean` is now a set of per-surface session keys (`active = !set.isEmpty()`), so overlapping recordings no longer collapse and a transient poll can't publish a stray `false`; panels clean up their key on teardown. New `ShaftRecordingActivityTest`.
- **Item 4 — run-config producer coverage**: extracted the producers' class-scan decision into a PSI-free `ShaftTestMethodAnnotations.hasRunnableTestMethod` predicate (this module has no `BasePlatformTestCase` fixtures) and unit-tested it.

## Verification
- `gradle -p shaft-intellij compileJava compileTestJava test` (JDK 21 / Gradle 9) on the fully-integrated branch → **BUILD SUCCESSFUL, 640 tests, 0 failures** (5 skipped).
- Each item was also implemented and verified in isolation; one full-suite-only test-ordering NPE (a leaked `ShaftReadinessSummary` listener in shared static state) was caught by the integrated run and fixed by making `ShaftRecordingActivityTest` reset before each test.

Closes #3591