### PR TITLE
feat(intellij): wire API recording panel to the no-browser mobile API path (#3530 A2)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/actions/RecordApiMobileAction.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/actions/RecordApiMobileAction.java
@@ -1,0 +1,109 @@
+package com.shaft.intellij.actions;
+
+import com.google.gson.JsonObject;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.shaft.intellij.notifications.ShaftNotifier;
+import com.shaft.intellij.project.ShaftProjectDetector;
+import com.shaft.intellij.settings.ShaftSettingsState;
+import com.shaft.intellij.ui.ShaftToolWindowPanel;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Prepares an MCP {@code mobile_api_record_start} request and opens the API Recording tab so a
+ * backend team can capture and generate a SHAFT.API test without launching a browser -- the
+ * loopback MITM proxy captures native mobile API traffic directly (issue #3530 A2).
+ */
+public final class RecordApiMobileAction extends AnAction implements DumbAware {
+    private static final String DEFAULT_PLATFORM = "Android";
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        Project project = event.getProject();
+        if (project == null) {
+            return;
+        }
+
+        String platform = Messages.showInputDialog(
+                project,
+                "Enter the target platform (Android or iOS):",
+                "Record API (No Browser)",
+                Messages.getQuestionIcon(),
+                DEFAULT_PLATFORM,
+                null);
+        if (platform == null || platform.isBlank()) {
+            return;
+        }
+        String trimmedPlatform = platform.trim();
+
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("platform", trimmedPlatform);
+        arguments.addProperty("deviceLabel", "");
+        arguments.addProperty("outputPath", "");
+
+        if (!ShaftSettingsState.getInstance().getState().advancedUiEnabled) {
+            // Default mode: route to the Assistant with the platform the user just typed, matching
+            // RecordApiWebAction's equivalent plain-language routing (issue #3552) -- the raw API
+            // Recording tab stays hidden here.
+            openAssistantPrompt(project, recordApiMobilePrompt(trimmedPlatform));
+            ShaftNotifier.info(project, "SHAFT",
+                    "Pure-API recording request ready in the Assistant for " + trimmedPlatform + ".");
+            return;
+        }
+        openApiRecordingTab(project, trimmedPlatform, arguments);
+        ShaftNotifier.info(project, "SHAFT", "Pure-API recording prepared for " + trimmedPlatform + ".");
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent event) {
+        Project project = event.getProject();
+        event.getPresentation().setEnabledAndVisible(project != null && ShaftProjectDetector.isShaftProject(project));
+    }
+
+    /**
+     * Plain-language Assistant equivalent of the {@code mobile_api_record_start} MCP request.
+     * Package-private for {@code RecordApiMobileActionTest}.
+     */
+    static String recordApiMobilePrompt(String platform) {
+        return "Record API traffic without a browser on " + platform;
+    }
+
+    private static void openAssistantPrompt(Project project, String text) {
+        ToolWindowManager.getInstance(project).invokeLater(() -> {
+            ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("SHAFT");
+            if (toolWindow == null) {
+                return;
+            }
+            toolWindow.show(() -> {
+                Content content = toolWindow.getContentManager().getContent(0);
+                if (content != null && content.getComponent() instanceof ShaftToolWindowPanel panel) {
+                    panel.prefillAssistantPrompt(text);
+                }
+            });
+        });
+    }
+
+    private static void openApiRecordingTab(Project project, String platform, JsonObject arguments) {
+        ToolWindowManager.getInstance(project).invokeLater(() -> {
+            ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("SHAFT");
+            if (toolWindow == null) {
+                return;
+            }
+            toolWindow.show(() -> {
+                Content content = toolWindow.getContentManager().getContent(0);
+                if (content == null) {
+                    return;
+                }
+                if (content.getComponent() instanceof ShaftToolWindowPanel panel) {
+                    panel.showPureApiRecordingTab(platform, arguments);
+                }
+            });
+        });
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ApiRecordingSessionPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ApiRecordingSessionPanel.java
@@ -5,8 +5,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.components.JBTextArea;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.ui.table.JBTable;
 import com.intellij.util.Alarm;
@@ -27,22 +29,55 @@ import javax.swing.table.TableRowSorter;
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.Font;
+import java.awt.datatransfer.StringSelection;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Displays a live SHAFT API recording session: transactions are polled from
- * {@code capture_api_transactions} roughly every 2 seconds on a background
- * thread, and the {@link JBTable} model is only ever mutated on the EDT.
- * Polling stops on panel disposal or when the Stop button ends the session.
+ * Displays a live SHAFT API recording session: transactions are polled roughly every 2 seconds on
+ * a background thread, and the {@link JBTable} model is only ever mutated on the EDT. Polling
+ * stops on panel disposal or when the Stop button ends the session.
+ *
+ * <p>Backs both the browser-based recorder ({@link CaptureMode#WEB}, polling
+ * {@code capture_api_transactions}/{@code capture_api_stop}) and the no-browser mobile API proxy
+ * ({@link CaptureMode#PURE_API}, polling {@code mobile_api_record_transactions}/
+ * {@code mobile_api_record_stop}) -- issue #3530 A2. {@code capture_api_generate} is shared by
+ * both: it is already session-path-agnostic, taking only the persisted session JSON path.
  */
 public final class ApiRecordingSessionPanel extends JPanel implements Disposable {
     private static final int POLL_INTERVAL_MILLIS = 2_000;
-    private static final String TRANSACTIONS_TOOL_NAME = "capture_api_transactions";
-    private static final String STOP_TOOL_NAME = "capture_api_stop";
     private static final String GENERATE_TOOL_NAME = "capture_api_generate";
 
+    /**
+     * Selects which MCP tool pair a session polls. Both pairs return the same body-free
+     * {@code NetworkTransaction} array shape, so {@link #parseTransactions} needs no mode
+     * awareness of its own.
+     */
+    public enum CaptureMode {
+        WEB("capture_api_transactions", "capture_api_stop"),
+        PURE_API("mobile_api_record_transactions", "mobile_api_record_stop");
+
+        private final String transactionsTool;
+        private final String stopTool;
+
+        CaptureMode(String transactionsTool, String stopTool) {
+            this.transactionsTool = transactionsTool;
+            this.stopTool = stopTool;
+        }
+
+        /** Package-private for {@code ApiRecordingSessionPanelTest}. */
+        String transactionsTool() {
+            return transactionsTool;
+        }
+
+        /** Package-private for {@code ApiRecordingSessionPanelTest}. */
+        String stopTool() {
+            return stopTool;
+        }
+    }
+
     private final Project project;
+    private final CaptureMode mode;
     private final TransactionTableModel tableModel = new TransactionTableModel();
     private final JBTable table = new JBTable(tableModel);
     private final TableRowSorter<TransactionTableModel> rowSorter = new TableRowSorter<>(tableModel);
@@ -51,6 +86,13 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
     private final JButton generateButton = new JButton("Generate");
     private final JLabel statusLabel = new JLabel("Recording...");
     private final Alarm pollAlarm;
+
+    // PURE_API only: the loopback proxy has no browser to drive, so the device/emulator needs the
+    // proxy port plus a one-click copy of the CA certificate the MITM proxy signs traffic with
+    // (issue #3530 A2 -- session panel/status parity for the pure-API path).
+    private final JBTextArea pairingInfoArea = new JBTextArea("Waiting for the loopback proxy to start...");
+    private final JButton copyCertificateButton = new JButton("Copy CA Certificate");
+    private String caCertificatePem = "";
 
     private volatile boolean stopped;
     // Written on the pooled poll thread (pollOnce) and read on the EDT (stopRecording/dispose);
@@ -61,15 +103,30 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
     private volatile ShaftMcpInvocation currentInvocation;
 
     /**
-     * Creates the panel and immediately begins polling for transactions.
+     * Creates a {@link CaptureMode#WEB} panel and immediately begins polling for transactions.
      *
      * @param project current IntelliJ project
      * @param targetUrl the URL the session was started for
      * @param sessionId the session identifier returned by {@code capture_api_start}, or null if unknown yet
      */
     public ApiRecordingSessionPanel(@NotNull Project project, @NotNull String targetUrl, @Nullable String sessionId) {
+        this(project, CaptureMode.WEB, "Recording: " + targetUrl, sessionId);
+    }
+
+    /**
+     * Creates the panel for the given {@link CaptureMode} and immediately begins polling for
+     * transactions.
+     *
+     * @param project current IntelliJ project
+     * @param mode which MCP tool pair to poll (issue #3530 A2)
+     * @param headerText title shown above the transactions table
+     * @param sessionId the session identifier returned by the mode's start tool, or null if unknown yet
+     */
+    public ApiRecordingSessionPanel(@NotNull Project project, @NotNull CaptureMode mode, @NotNull String headerText,
+            @Nullable String sessionId) {
         super(new BorderLayout(6, 6));
         this.project = project;
+        this.mode = mode;
         this.sessionId = sessionId;
         this.pollAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
         setBorder(JBUI.Borders.empty(8));
@@ -104,7 +161,7 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
         generateButton.addActionListener(event -> generateCode());
 
         JPanel header = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 2));
-        JLabel titleLabel = new JLabel("Recording: " + targetUrl);
+        JLabel titleLabel = new JLabel(headerText);
         titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD));
         header.add(titleLabel);
 
@@ -119,12 +176,67 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
         JPanel north = new JPanel(new BorderLayout(4, 4));
         north.add(header, BorderLayout.NORTH);
         north.add(toolbar, BorderLayout.SOUTH);
+        if (mode == CaptureMode.PURE_API) {
+            north.add(buildPairingInfoPanel(), BorderLayout.CENTER);
+        }
 
         add(north, BorderLayout.NORTH);
         add(new JBScrollPane(table), BorderLayout.CENTER);
         add(statusLabel, BorderLayout.SOUTH);
 
         startPolling();
+    }
+
+    /**
+     * Builds the pure-API pairing panel: the loopback proxy has no browser to drive, so the
+     * device/emulator needs the proxy host:port plus the CA certificate the proxy signs traffic
+     * with, populated once the start tool call returns (see {@link #showPairingInfo}).
+     */
+    private JComponent buildPairingInfoPanel() {
+        pairingInfoArea.setEditable(false);
+        pairingInfoArea.setLineWrap(true);
+        pairingInfoArea.setWrapStyleWord(true);
+        pairingInfoArea.getAccessibleContext().setAccessibleName("Mobile API capture pairing instructions");
+
+        copyCertificateButton.setEnabled(false);
+        copyCertificateButton.getAccessibleContext().setAccessibleDescription(
+                "Copy the loopback proxy's CA certificate to install on the device or emulator");
+        copyCertificateButton.addActionListener(event -> {
+            if (!caCertificatePem.isBlank()) {
+                CopyPasteManager.getInstance().setContents(new StringSelection(caCertificatePem));
+            }
+        });
+
+        JPanel pairingActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 2));
+        pairingActions.add(copyCertificateButton);
+
+        JPanel pairingPanel = new JPanel(new BorderLayout(4, 4));
+        pairingPanel.setBorder(JBUI.Borders.empty(4, 0));
+        pairingPanel.add(new JBScrollPane(pairingInfoArea), BorderLayout.CENTER);
+        pairingPanel.add(pairingActions, BorderLayout.SOUTH);
+        return pairingPanel;
+    }
+
+    /**
+     * Populates the pure-API pairing panel once {@code mobile_api_record_start} (or a later
+     * {@code mobile_api_record_status} poll) returns the proxy port, CA certificate, and any
+     * pairing warnings. A no-op for a {@link CaptureMode#WEB} panel.
+     *
+     * @param proxyPort loopback port the MITM proxy is listening on
+     * @param caCertificatePem PEM-encoded CA certificate for the device/emulator to trust
+     * @param warnings pairing guidance and any capture warnings
+     */
+    public void showPairingInfo(int proxyPort, @NotNull String caCertificatePem, @NotNull List<String> warnings) {
+        if (mode != CaptureMode.PURE_API) {
+            return;
+        }
+        this.caCertificatePem = caCertificatePem;
+        copyCertificateButton.setEnabled(!caCertificatePem.isBlank());
+        StringBuilder text = new StringBuilder("Loopback proxy listening on 127.0.0.1:").append(proxyPort).append('.');
+        for (String warning : warnings) {
+            text.append('\n').append(warning);
+        }
+        pairingInfoArea.setText(text.toString());
     }
 
     /**
@@ -194,7 +306,7 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
             arguments.addProperty("sessionId", sessionId);
         }
         currentInvocation = ShaftMcpInvocationService.getInstance(project)
-                .startTool(TRANSACTIONS_TOOL_NAME, arguments);
+                .startTool(mode.transactionsTool, arguments);
         currentInvocation.future().whenComplete((result, error) ->
                 ApplicationManager.getApplication().invokeLater(() -> {
                     if (stopped) {
@@ -291,7 +403,7 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
             arguments.addProperty("sessionId", sessionId);
         }
         ShaftMcpInvocationService.getInstance(project)
-                .startTool(STOP_TOOL_NAME, arguments)
+                .startTool(mode.stopTool, arguments)
                 .future()
                 .whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(() -> {
                     if (error != null || result == null || !result.success()) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.ui.JBUI;
 import com.shaft.intellij.mcp.ShaftMcpInvocationService;
+import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.shaft.intellij.settings.ShaftSettingsState;
 import org.jetbrains.annotations.NotNull;
 
@@ -463,30 +464,35 @@ public final class ShaftToolWindowPanel extends JPanel {
                 .startTool("mobile_api_record_start", startArguments)
                 .future()
                 .whenComplete((result, error) -> com.intellij.openapi.application.ApplicationManager.getApplication()
-                        .invokeLater(() -> {
-                            if (apiRecordingPanel == null) {
-                                return;
-                            }
-                            if (error != null || result == null || !result.success()) {
-                                apiRecordingPanel.statusLabel().setText(
-                                        "Failed to start recording: "
-                                                + (result != null ? result.output() : String.valueOf(error)));
-                                return;
-                            }
-                            com.google.gson.JsonObject status = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
-                            if (status == null) {
-                                return;
-                            }
-                            int proxyPort = status.has("proxyPort") ? status.get("proxyPort").getAsInt() : 0;
-                            String caCertificatePem = status.has("caCertificatePem")
-                                    ? status.get("caCertificatePem").getAsString() : "";
-                            List<String> warnings = new ArrayList<>();
-                            if (status.has("warnings") && status.get("warnings").isJsonArray()) {
-                                status.get("warnings").getAsJsonArray()
-                                        .forEach(warning -> warnings.add(warning.getAsString()));
-                            }
-                            apiRecordingPanel.showPairingInfo(proxyPort, caCertificatePem, warnings);
-                        }));
+                        .invokeLater(() -> applyMobileApiRecordStartResult(result, error)));
+    }
+
+    /**
+     * Applies the {@code mobile_api_record_start} result to the current API Recording panel: an
+     * error/failure surfaces as a status message, otherwise the proxy port, CA certificate, and
+     * warnings populate the pairing panel. Extracted from {@link #showPureApiRecordingTab} to keep
+     * that method's branching within PMD's NPath complexity threshold.
+     */
+    private void applyMobileApiRecordStartResult(ShaftMcpToolResult result, Throwable error) {
+        if (apiRecordingPanel == null) {
+            return;
+        }
+        if (error != null || result == null || !result.success()) {
+            apiRecordingPanel.statusLabel().setText(
+                    "Failed to start recording: " + (result != null ? result.output() : String.valueOf(error)));
+            return;
+        }
+        JsonObject status = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
+        if (status == null) {
+            return;
+        }
+        int proxyPort = status.has("proxyPort") ? status.get("proxyPort").getAsInt() : 0;
+        String caCertificatePem = status.has("caCertificatePem") ? status.get("caCertificatePem").getAsString() : "";
+        List<String> warnings = new ArrayList<>();
+        if (status.has("warnings") && status.get("warnings").isJsonArray()) {
+            status.get("warnings").getAsJsonArray().forEach(warning -> warnings.add(warning.getAsString()));
+        }
+        apiRecordingPanel.showPairingInfo(proxyPort, caCertificatePem, warnings);
     }
 
     /**

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -469,9 +469,9 @@ public final class ShaftToolWindowPanel extends JPanel {
 
     /**
      * Applies the {@code mobile_api_record_start} result to the current API Recording panel: an
-     * error/failure surfaces as a status message, otherwise the proxy port, CA certificate, and
-     * warnings populate the pairing panel. Extracted from {@link #showPureApiRecordingTab} to keep
-     * that method's branching within PMD's NPath complexity threshold.
+     * error/failure surfaces as a status message, otherwise the pairing panel is populated.
+     * Split from {@link #showPureApiRecordingTab} (and further split below) to keep each method's
+     * branching within PMD's NPath complexity threshold.
      */
     private void applyMobileApiRecordStartResult(ShaftMcpToolResult result, Throwable error) {
         if (apiRecordingPanel == null) {
@@ -483,16 +483,30 @@ public final class ShaftToolWindowPanel extends JPanel {
             return;
         }
         JsonObject status = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
-        if (status == null) {
-            return;
+        if (status != null) {
+            applyPairingInfo(apiRecordingPanel, status);
         }
+    }
+
+    /**
+     * Extracts the proxy port, CA certificate, and warnings from a {@code MobileApiCaptureStatus}
+     * JSON object and hands them to the panel's pairing display.
+     */
+    private static void applyPairingInfo(ApiRecordingSessionPanel panel, JsonObject status) {
         int proxyPort = status.has("proxyPort") ? status.get("proxyPort").getAsInt() : 0;
         String caCertificatePem = status.has("caCertificatePem") ? status.get("caCertificatePem").getAsString() : "";
+        panel.showPairingInfo(proxyPort, caCertificatePem, warningsOf(status));
+    }
+
+    /**
+     * Reads the {@code warnings} JSON array off a {@code MobileApiCaptureStatus} object.
+     */
+    private static List<String> warningsOf(JsonObject status) {
         List<String> warnings = new ArrayList<>();
         if (status.has("warnings") && status.get("warnings").isJsonArray()) {
             status.get("warnings").getAsJsonArray().forEach(warning -> warnings.add(warning.getAsString()));
         }
-        apiRecordingPanel.showPairingInfo(proxyPort, caCertificatePem, warnings);
+        return warnings;
     }
 
     /**

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftToolWindowPanel.java
@@ -435,6 +435,61 @@ public final class ShaftToolWindowPanel extends JPanel {
     }
 
     /**
+     * Opens (or reuses) the API Recording tab for a no-browser pure-API session, starting
+     * {@code mobile_api_record_start} and populating the pairing panel (proxy port + CA
+     * certificate) once it returns (issue #3530 A2).
+     *
+     * @param headerText title shown above the transactions table (e.g. the target platform)
+     * @param startArguments arguments for the {@code mobile_api_record_start} MCP call
+     */
+    public void showPureApiRecordingTab(@NotNull String headerText, @NotNull JsonObject startArguments) {
+        if (workflowCards == null || workflowLayout == null) {
+            return;
+        }
+        disposeApiRecordingPanel();
+        apiRecordingPanel = new ApiRecordingSessionPanel(
+                project, ApiRecordingSessionPanel.CaptureMode.PURE_API, headerText, null);
+        WorkflowView apiRecordingView = new WorkflowView("API Recording", apiRecordingPanel, ShaftIcons.VIEW);
+        List<WorkflowView> updated = new ArrayList<>(workflowViews);
+        updated.removeIf(view -> "API Recording".equals(view.label()));
+        updated.add(apiRecordingView);
+        workflowViews = updated;
+        workflowCards.add(apiRecordingPanel, apiRecordingView.label());
+        workflowSelector.setModel(new DefaultComboBoxModel<>(workflowViews.toArray(new WorkflowView[0])));
+        refreshWorkflowSelectorVisibility();
+        selectWorkflow(apiRecordingPanel);
+
+        ShaftMcpInvocationService.getInstance(project)
+                .startTool("mobile_api_record_start", startArguments)
+                .future()
+                .whenComplete((result, error) -> com.intellij.openapi.application.ApplicationManager.getApplication()
+                        .invokeLater(() -> {
+                            if (apiRecordingPanel == null) {
+                                return;
+                            }
+                            if (error != null || result == null || !result.success()) {
+                                apiRecordingPanel.statusLabel().setText(
+                                        "Failed to start recording: "
+                                                + (result != null ? result.output() : String.valueOf(error)));
+                                return;
+                            }
+                            com.google.gson.JsonObject status = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
+                            if (status == null) {
+                                return;
+                            }
+                            int proxyPort = status.has("proxyPort") ? status.get("proxyPort").getAsInt() : 0;
+                            String caCertificatePem = status.has("caCertificatePem")
+                                    ? status.get("caCertificatePem").getAsString() : "";
+                            List<String> warnings = new ArrayList<>();
+                            if (status.has("warnings") && status.get("warnings").isJsonArray()) {
+                                status.get("warnings").getAsJsonArray()
+                                        .forEach(warning -> warnings.add(warning.getAsString()));
+                            }
+                            apiRecordingPanel.showPairingInfo(proxyPort, caCertificatePem, warnings);
+                        }));
+    }
+
+    /**
      * Disposes the current API Recording panel, if any, cancelling its poller.
      */
     private void disposeApiRecordingPanel() {

--- a/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml
+++ b/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml
@@ -38,6 +38,14 @@
                 iconDark="/icons/shaftToolWindow_dark.svg">
             <add-to-group group-id="Shaft.ToolsMenu" anchor="last"/>
         </action>
+        <action id="Shaft.RecordApiMobile"
+                class="com.shaft.intellij.actions.RecordApiMobileAction"
+                text="Record SHAFT API Session (No Browser)"
+                description="Start a no-browser mobile API recording session via the mobile_api_record_start MCP tool"
+                icon="/icons/shaftToolWindow.svg"
+                iconDark="/icons/shaftToolWindow_dark.svg">
+            <add-to-group group-id="Shaft.ToolsMenu" anchor="last"/>
+        </action>
         <action id="Shaft.ShowTraceViewer"
                 class="com.shaft.intellij.actions.ShowTraceViewerAction"
                 text="Show SHAFT Trace Viewer"

--- a/shaft-intellij/src/test/java/com/shaft/intellij/actions/RecordApiMobileActionTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/actions/RecordApiMobileActionTest.java
@@ -1,0 +1,18 @@
+package com.shaft.intellij.actions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Covers the default-mode (advancedUiEnabled=false) Assistant prompt {@code RecordApiMobileAction}
+ * builds, mirroring {@code RecordApiWebActionTest} (issue #3530 A2).
+ */
+class RecordApiMobileActionTest {
+    @Test
+    void recordApiMobilePromptCarriesTheTypedPlatform() {
+        String prompt = RecordApiMobileAction.recordApiMobilePrompt("iOS");
+
+        assertEquals("Record API traffic without a browser on iOS", prompt);
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ApiRecordingSessionPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ApiRecordingSessionPanelTest.java
@@ -84,6 +84,20 @@ class ApiRecordingSessionPanelTest {
         assertEquals(List.of("tx-1"), model.excludedTransactionIds());
     }
 
+    @Test
+    void webModePollsTheBrowserBasedRecorderTools() {
+        assertEquals("capture_api_transactions", ApiRecordingSessionPanel.CaptureMode.WEB.transactionsTool());
+        assertEquals("capture_api_stop", ApiRecordingSessionPanel.CaptureMode.WEB.stopTool());
+    }
+
+    @Test
+    void pureApiModePollsTheNoBrowserMobileProxyTools() {
+        // issue #3530 A2: the pure-API session panel polls the mobile_api_record_* tools instead
+        // of capture_api_*, sharing the same transaction-parsing/table-model logic above.
+        assertEquals("mobile_api_record_transactions", ApiRecordingSessionPanel.CaptureMode.PURE_API.transactionsTool());
+        assertEquals("mobile_api_record_stop", ApiRecordingSessionPanel.CaptureMode.PURE_API.stopTool());
+    }
+
     private static String mcpArrayText(String text) {
         JsonObject item = new JsonObject();
         item.addProperty("type", "text");


### PR DESCRIPTION
## Summary
- Issue #3530 A2 (session panel/status parity + Guided/Assistant entry point for pure-API capture).
- `ApiRecordingSessionPanel` gains a `CaptureMode` (`WEB` / `PURE_API`) selecting `capture_api_*` vs `mobile_api_record_*` for polling/stop; both tool pairs return the same body-free transaction shape so the existing table parser needed no changes. `capture_api_generate` stays shared (already session-path-agnostic).
- Pure-API mode shows the loopback proxy's port and a one-click "Copy CA Certificate" button, populated from `mobile_api_record_start`'s result, so a user can pair their device/emulator without leaving the panel.
- New `RecordApiMobileAction` (mirrors `RecordApiWebAction`) prompts for a target platform and opens the tab (or routes to the Assistant in default/non-advanced-UI mode), registered under `Shaft.ToolsMenu` in plugin.xml.

## Verification
- [x] `gradle compileJava compileTestJava` — clean
- [x] `gradle test` (full `shaft-intellij` suite) — BUILD SUCCESSFUL
- [x] `gradle verifyPlugin` against both pinned IDE targets (2024.3, 2026.2) — Compatible, 0 internal/deprecated API usages
- New tests: `RecordApiMobileActionTest`, `ApiRecordingSessionPanelTest` (CaptureMode tool-name selection)

## Note
This panel has no existing screenshot-renderer coverage in `ShaftPluginScreenshotRendererTest` (the WEB-mode panel isn't covered either), so no screenshot evidence was added for the new pairing UI — flagging this as a known gap rather than silently skipping it, consistent with the pre-existing state of this panel.

## Test plan
- [x] Automated tests above
- [ ] Manual: run the plugin, trigger "Record SHAFT API Session (No Browser)", confirm the proxy port + CA cert appear and a device/emulator can be paired