### PR TITLE
fix(capture): navigation-consequence check compares against wrong interaction after a later, unrelated one arrives

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -66,12 +66,13 @@ final class CaptureEventPipeline implements AutoCloseable {
     private final Map<String, BrowserSignal> pendingClicks = new LinkedHashMap<>();
     // Collector-synthesized navigations (BiDi navigationCommitted / URL polling, blank
     // navigationSource) race the click that caused them: the native signal often reaches accept()
-    // before the click's own slower JS-channel signal, so lastInteractionAt would still be stale
+    // before the click's own slower JS-channel signal, so no interaction would be recorded yet
     // when interactionConsequence is evaluated, misclassifying a click-caused navigation as
     // spontaneous (phantom step). Buffering them one debounce window lets the click's signal —
-    // which stamps lastInteractionAt as soon as accept() sees it, regardless of buffering — win
-    // the race. Keyed by an incrementing counter, not targetKey(signal): several redirect hops
-    // within the window must each get their own consequence/duplicate evaluation, not coalesce.
+    // recorded into recentInteractionTimestamps as soon as accept() sees it, regardless of
+    // buffering — win the race. Keyed by an incrementing counter, not targetKey(signal): several
+    // redirect hops within the window must each get their own consequence/duplicate evaluation,
+    // not coalesce.
     private final Map<String, BrowserSignal> pendingNavigations = new LinkedHashMap<>();
     private long pendingNavigationSequence;
     private final Map<String, String> logicalWindows = new LinkedHashMap<>();
@@ -85,11 +86,19 @@ final class CaptureEventPipeline implements AutoCloseable {
     // A step the user revoked (dblclick coalescing, the overlay delete button) must stay deleted
     // even when the revocation overtakes the original event across channels.
     private final Set<String> deletedClientActionIds = new LinkedHashSet<>();
+    // Bounded history (not a single scalar) of recent user-interaction timestamps: a scalar
+    // "lastInteractionAt" gets overwritten by a *later, unrelated* interaction that occurs while an
+    // earlier interaction's caused navigation still sits buffered in pendingNavigations, wrongly
+    // making that navigation appear to predate its own (real, earlier) cause once evaluated
+    // against the newer interaction's timestamp instead. Regression: an ENTER-triggered search
+    // whose results page performs a second location.replace() navigation, followed shortly after
+    // by an unrelated click, misclassified both buffered navigations as spontaneous once the click
+    // advanced the old scalar past them. Pruned to the interaction window's worth of history.
+    private final List<Instant> recentInteractionTimestamps = new ArrayList<>();
     private final ScheduledExecutorService debounceExecutor;
     private long sequence;
     private String lastNavigationUrl = "";
     private Instant lastNavigationAt = Instant.EPOCH;
-    private Instant lastInteractionAt = Instant.EPOCH;
     private String lastAppendedNavigationUrl = "";
     private Instant lastAppendedNavigationAt = Instant.EPOCH;
     private String lastWindow = "";
@@ -126,8 +135,8 @@ final class CaptureEventPipeline implements AutoCloseable {
         if (isDuplicate(signal)) {
             return;
         }
-        if (isUserInteraction(signal.kind()) && signal.timestamp().isAfter(lastInteractionAt)) {
-            lastInteractionAt = signal.timestamp();
+        if (isUserInteraction(signal.kind())) {
+            recordInteraction(signal.timestamp());
         }
         try {
             switch (signal.kind()) {
@@ -312,14 +321,14 @@ final class CaptureEventPipeline implements AutoCloseable {
         boolean duplicateDelivery = url.equals(lastNavigationUrl)
                 && Duration.between(lastNavigationAt, signal.timestamp()).abs()
                 .compareTo(NAVIGATION_DEBOUNCE) < 0;
-        // Forward-only: buffered navigations are now evaluated after lastInteractionAt may have
-        // advanced past their own timestamp (a later, unrelated interaction stamped it while this
-        // navigation sat in pendingNavigations). Only a navigation at or after the interaction can
-        // be its consequence; a negative gap means this navigation predates the interaction and
-        // must never be suppressed by it.
-        Duration sinceInteraction = Duration.between(lastInteractionAt, signal.timestamp());
-        boolean interactionConsequence = !sinceInteraction.isNegative()
-                && sinceInteraction.compareTo(INTERACTION_NAVIGATION_WINDOW) < 0;
+        // Forward-only, searched against history rather than a single scalar: a buffered
+        // navigation is a consequence only of an interaction that happened at or before it, within
+        // the window. Using the closest preceding interaction (not whatever is currently most
+        // recent) keeps this correct even when a later, unrelated interaction has since occurred
+        // while this navigation sat in pendingNavigations.
+        Instant causingInteraction = mostRecentInteractionAtOrBefore(signal.timestamp());
+        boolean interactionConsequence = causingInteraction != null
+                && Duration.between(causingInteraction, signal.timestamp()).compareTo(INTERACTION_NAVIGATION_WINDOW) < 0;
         lastNavigationUrl = url;
         lastNavigationAt = signal.timestamp();
         currentUrlConsumer.accept(url);
@@ -401,6 +410,36 @@ final class CaptureEventPipeline implements AutoCloseable {
             case "click", "input", "select", "toggle", "upload", "keyboard" -> true;
             default -> false;
         };
+    }
+
+    /**
+     * Records an interaction timestamp and prunes entries older than the interaction window
+     * relative to it, keeping {@link #recentInteractionTimestamps} bounded.
+     */
+    private void recordInteraction(Instant timestamp) {
+        recentInteractionTimestamps.add(timestamp);
+        Instant cutoff = timestamp.minus(INTERACTION_NAVIGATION_WINDOW);
+        recentInteractionTimestamps.removeIf(candidate -> candidate.isBefore(cutoff));
+    }
+
+    /**
+     * Finds the most recent recorded interaction at or before {@code navigationTimestamp} -- the
+     * interaction that could plausibly have caused a navigation observed at that time. Searching
+     * history instead of comparing against whatever interaction is currently most recent is what
+     * keeps a navigation's classification stable even after a later, unrelated interaction occurs
+     * while that navigation still sits buffered in {@link #pendingNavigations}.
+     *
+     * @param navigationTimestamp the navigation's own timestamp
+     * @return the closest preceding interaction timestamp, or {@code null} if none qualifies
+     */
+    private Instant mostRecentInteractionAtOrBefore(Instant navigationTimestamp) {
+        Instant candidate = null;
+        for (Instant interaction : recentInteractionTimestamps) {
+            if (!interaction.isAfter(navigationTimestamp) && (candidate == null || interaction.isAfter(candidate))) {
+                candidate = interaction;
+            }
+        }
+        return candidate;
     }
 
     /**

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -491,6 +491,45 @@ class CaptureEventPipelineTest {
     }
 
     @Test
+    void navigationRemainsAConsequenceOfItsCausingInteractionAfterALaterUnrelatedInteraction(@TempDir Path temp) {
+        // Regression (the ENTER-triggered "second-replace search journey"): a navigation genuinely
+        // caused by an earlier interaction (ENTER) must stay suppressed even when a later,
+        // unrelated interaction (a click on the newly loaded page) is recorded before this
+        // buffered navigation is evaluated. A single scalar "lastInteractionAt" would be
+        // overwritten by the later click, wrongly making the navigation appear to predate its own
+        // real, earlier cause once compared only against whatever interaction is currently most
+        // recent instead of the one that actually preceded it.
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("navigation", START, Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/search")));
+        pipeline.accept(signal("keyboard", START.plusMillis(50), buttonTarget(),
+                Map.of("keys", List.of("ENTER")), Map.of()));
+        // The ENTER-caused navigation's own timestamp: genuinely after ENTER, but it still sits in
+        // pendingNavigations when the unrelated click below is recorded.
+        pipeline.accept(signal("navigation", START.plusMillis(120), Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/results")));
+        pipeline.accept(signal("click", START.plusMillis(400), buttonTarget(),
+                Map.of("button", 0, "clickCount", 1), Map.of()));
+        pipeline.close();
+
+        List<CaptureEvent.NavigationEvent> navigations = store.read().events().stream()
+                .filter(CaptureEvent.NavigationEvent.class::isInstance)
+                .map(CaptureEvent.NavigationEvent.class::cast)
+                .toList();
+        assertEquals(1, navigations.size(),
+                "The ENTER-caused navigation must stay suppressed even after a later unrelated click; got: "
+                        + navigations.stream().map(CaptureEvent.NavigationEvent::targetUrl).toList());
+        assertEquals("https://example.test/search", navigations.getFirst().targetUrl());
+        assertEquals(1, store.read().events().stream().filter(CaptureEvent.ClickEvent.class::isInstance).count());
+    }
+
+    @Test
     void recordsStandaloneNavigationWithNoPrecedingInteraction(@TempDir Path temp) {
         // Address-bar navigation (or the initial page open) with no click anywhere near it must
         // still be recorded even though it now goes through the pendingNavigations buffer like


### PR DESCRIPTION
## Summary
- Fixes a regression discovered while chasing an unrelated PR's failing CI: `capture-browser-e2e`'s `ManagedCaptureRecorderBrowserTest#searchWithSecondReplaceNavigationRecordsOnlyUserPerformedSteps` was failing consistently (2/2 reruns) on `main` and on 3 other unrelated open branches today -- a regression of previously-closed, verified-green issue #3549.
- Root cause: #3586 (`fix(capture): suppress phantom navigation step when a click causes a redirect`) introduced a single scalar `lastInteractionAt` compared against buffered navigations at *flush* time. When multiple interactions happen in quick succession while an earlier interaction's caused navigation still sits in `pendingNavigations` (ENTER submits a form -> results page does a second `location.replace()` -> user clicks a result link before the buffered navigations are evaluated), the scalar gets overwritten by the later, unrelated click. Both navigations then compare against the click's timestamp instead of ENTER's, appear to predate their own real cause, and get wrongly recorded as phantom "Navigate to" steps.
- Fix: replaced the scalar with a bounded history of recent interaction timestamps (`recentInteractionTimestamps`, pruned to the interaction window). A buffered navigation is now checked against the most recent interaction *at or before its own timestamp* -- the interaction that could actually have caused it -- instead of whatever interaction happens to be most recent by flush time.
- This is a source-level fix, not a tolerance/fudge-factor: the original #3586 regression test (`suppressesNavigationWhenCollectorSignalWinsTheRaceAgainstItsCausingClick`) and the general suppression test (`suppressesNavigationsCausedByRecentInteractions`) both still pass, confirming the original bug stays fixed.

## Verification
- [x] `mvn -pl shaft-capture test -Dtest=CaptureEventPipelineTest` -- 24/24 pass (1 new regression test: `navigationRemainsAConsequenceOfItsCausingInteractionAfterALaterUnrelatedInteraction`)
- [x] `mvn -pl shaft-capture test -DincludeCaptureBrowserE2E -Dtest=ManagedCaptureRecorderBrowserTest` (real browser E2E, matching CI) -- 23/23 pass, across **two consecutive runs** (this test is timing-sensitive; reproduced the failure locally first via added trace logging before fixing, then confirmed the fix resolves it, not just passes by luck)

## Test plan
- [x] Automated tests above