### PR TITLE
feat(report): embed a SHAFT Overview toggle/panel in the generated Allure report

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -10,6 +10,7 @@ import tools.jackson.databind.node.ObjectNode;
 import com.shaft.driver.SHAFT;
 import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.internal.support.ReportHtmlTheme;
 import org.apache.commons.lang3.SystemUtils;
 
 import java.io.BufferedInputStream;
@@ -89,6 +90,7 @@ public class AllureManager {
     private static final String ALLURE_ATTACHMENT_PREVIEW_FIX_ID = "shaft-allure-attachment-preview-fix";
     private static final String ALLURE_ATTACHMENT_PREVIEW_SCRIPT_ID = "shaft-allure-attachment-preview-script";
     private static final String ALLURE_THEME_COLORS_ID = "shaft-allure-theme-colors";
+    private static final String ALLURE_OVERVIEW_PANEL_ID = "shaft-overview-panel-style";
     private static final String ALLURE_ATTACHMENT_PREVIEW_FIX_STYLE = """
             <style id="shaft-allure-attachment-preview-fix">
             .shaft-allure-image-modal {
@@ -305,6 +307,184 @@ public class AllureManager {
      */
     static String allureThemeColorsStyle() {
         return ALLURE_THEME_COLORS_STYLE;
+    }
+
+    private static final String ALLURE_OVERVIEW_PANEL_STYLE = """
+            <style id="shaft-overview-panel-style">
+            #shaft-overview-toggle-wrap {
+                position: fixed;
+                right: 20px;
+                bottom: 20px;
+                z-index: 2147483000;
+            }
+
+            #shaft-overview-toggle {
+                font-family: inherit;
+                font-size: 14px;
+                font-weight: 600;
+                line-height: 1.2;
+                padding: 10px 18px;
+                border: none;
+                border-radius: 999px;
+                cursor: pointer;
+                background: var(--color-intent-primary-bg);
+                color: var(--color-intent-primary-on-bg);
+                box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3);
+                transition: background-color 0.15s ease;
+            }
+
+            #shaft-overview-toggle:hover {
+                background: var(--color-intent-primary-bg-hover);
+            }
+
+            #shaft-overview-toggle:active {
+                background: var(--color-intent-primary-bg-active);
+            }
+
+            #shaft-overview-toggle:focus-visible {
+                outline: 2px solid var(--color-focus-ring);
+                outline-offset: 2px;
+            }
+
+            #shaft-overview-backdrop {
+                display: none;
+                position: fixed;
+                inset: 0;
+                align-items: center;
+                justify-content: center;
+                padding: 24px;
+                background: rgba(0, 0, 0, 0.5);
+                z-index: 2147483001;
+            }
+
+            #shaft-overview-panel {
+                position: relative;
+                display: flex;
+                flex-direction: column;
+                width: min(1100px, 92vw);
+                height: min(88vh, 900px);
+                border: 1px solid var(--color-border-default);
+                border-radius: 16px;
+                background: var(--color-control-bg-active);
+                box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+                overflow: hidden;
+            }
+
+            #shaft-overview-close {
+                position: absolute;
+                top: 8px;
+                right: 8px;
+                z-index: 1;
+                width: 34px;
+                height: 34px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                border: none;
+                border-radius: 50%;
+                cursor: pointer;
+                font-size: 20px;
+                line-height: 1;
+                background: var(--color-control-bg);
+                color: var(--color-icon-primary);
+            }
+
+            #shaft-overview-close:hover {
+                background: var(--color-control-bg-hover);
+            }
+
+            #shaft-overview-close:focus-visible {
+                outline: 2px solid var(--color-focus-ring);
+                outline-offset: 2px;
+            }
+
+            #shaft-overview-frame {
+                flex: 1 1 auto;
+                width: 100%;
+                height: 100%;
+                border: 0;
+                border-radius: 15px;
+                background: #fff;
+            }
+
+            @media (max-width: 640px) {
+                #shaft-overview-toggle {
+                    padding: 8px 14px;
+                    font-size: 13px;
+                }
+
+                #shaft-overview-panel {
+                    width: 96vw;
+                    height: 92vh;
+                }
+            }
+            </style>
+            """;
+
+    private static final String ALLURE_OVERVIEW_PANEL_SCRIPT = """
+            <script id="shaft-overview-panel-script">
+            (function () {
+                var toggle = document.getElementById('shaft-overview-toggle');
+                var closeBtn = document.getElementById('shaft-overview-close');
+                var backdrop = document.getElementById('shaft-overview-backdrop');
+                var root = document.documentElement;
+
+                if (!backdrop) return;
+
+                function openPanel() {
+                    backdrop.style.display = 'flex';
+                    root.classList.add('shaft-overview-open');
+                }
+
+                function closePanel() {
+                    backdrop.style.display = 'none';
+                    root.classList.remove('shaft-overview-open');
+                }
+
+                if (toggle) toggle.addEventListener('click', openPanel);
+                if (closeBtn) closeBtn.addEventListener('click', closePanel);
+
+                backdrop.addEventListener('click', function (event) {
+                    if (event.target === backdrop) closePanel();
+                });
+
+                document.addEventListener('keydown', function (event) {
+                    if (event.key === 'Escape' && backdrop.style.display === 'flex') closePanel();
+                });
+            })();
+            </script>
+            """;
+
+    /**
+     * Builds the embedded "SHAFT Overview" toggle button + modal panel patched into the generated
+     * Allure report's {@code <body>} (issue #3534 P2), or {@code ""} when no checkpoints were
+     * recorded. The panel's content is {@link CheckpointCounter#overviewReportHtml()} — the exact
+     * same standalone document already published as the "SHAFT Overview" HTML attachment — embedded
+     * via {@code <iframe srcdoc="...">} so it renders fully isolated from Allure's own obfuscated,
+     * client-rendered app DOM (which exposes no stable, documented extension point to hook a native
+     * tab into; verified against the real Allure 3 "awesome" plugin output before choosing this
+     * approach over reverse-engineering that internal DOM).
+     *
+     * @return the HTML fragment to splice before {@code </body>}, or {@code ""} when there is
+     *         nothing to show
+     */
+    private static String allureOverviewPanelPatch() {
+        String overviewHtml = CheckpointCounter.overviewReportHtml();
+        if (overviewHtml.isEmpty()) {
+            return "";
+        }
+        String escapedOverviewHtml = ReportHtmlTheme.escapeHtml(overviewHtml);
+        return ALLURE_OVERVIEW_PANEL_STYLE
+                + "<div id=\"shaft-overview-toggle-wrap\">"
+                + "<button type=\"button\" id=\"shaft-overview-toggle\" aria-label=\"Open SHAFT Overview\">SHAFT Overview</button>"
+                + "</div>"
+                + "<div id=\"shaft-overview-backdrop\">"
+                + "<div id=\"shaft-overview-panel\" role=\"dialog\" aria-modal=\"true\" aria-label=\"SHAFT Overview\">"
+                + "<button type=\"button\" id=\"shaft-overview-close\" aria-label=\"Close SHAFT Overview\">&times;</button>"
+                + "<iframe id=\"shaft-overview-frame\" title=\"SHAFT Overview\" srcdoc=\"" + escapedOverviewHtml + "\"></iframe>"
+                + "</div>"
+                + "</div>"
+                + ALLURE_OVERVIEW_PANEL_SCRIPT;
     }
 
     // ─── Portable Node.js bootstrap ────────────────────────────────────────────
@@ -760,7 +940,8 @@ public class AllureManager {
      */
     // package-private so unit tests can assert scan results without reflection
     record IndexMarkerScan(boolean previewFixPresent, boolean previewScriptPresent,
-                           boolean themeColorsPresent, long headEndOffset, long bodyEndOffset) {
+                           boolean themeColorsPresent, boolean overviewPanelPresent,
+                           long headEndOffset, long bodyEndOffset) {
     }
 
     /** A byte-range insertion to apply while streaming {@code index.html} to its patched copy. */
@@ -797,6 +978,9 @@ public class AllureManager {
                 headPatch += ALLURE_ATTACHMENT_PREVIEW_FIX_SCRIPT;
             }
             String bodyPatch = scan.themeColorsPresent() ? "" : ALLURE_THEME_COLORS_STYLE;
+            if (!scan.overviewPanelPresent()) {
+                bodyPatch += allureOverviewPanelPatch();
+            }
             if (headPatch.isEmpty() && bodyPatch.isEmpty()) {
                 return;
             }
@@ -815,12 +999,14 @@ public class AllureManager {
         byte[] previewFixMarker = ("id=\"" + ALLURE_ATTACHMENT_PREVIEW_FIX_ID + "\"").getBytes(StandardCharsets.UTF_8);
         byte[] previewScriptMarker = ("id=\"" + ALLURE_ATTACHMENT_PREVIEW_SCRIPT_ID + "\"").getBytes(StandardCharsets.UTF_8);
         byte[] themeColorsMarker = ("id=\"" + ALLURE_THEME_COLORS_ID + "\"").getBytes(StandardCharsets.UTF_8);
+        byte[] overviewPanelMarker = ("id=\"" + ALLURE_OVERVIEW_PANEL_ID + "\"").getBytes(StandardCharsets.UTF_8);
         byte[] headEndMarker = "</head>".getBytes(StandardCharsets.UTF_8);
         byte[] bodyEndMarker = "</body>".getBytes(StandardCharsets.UTF_8);
 
         boolean previewFixPresent = false;
         boolean previewScriptPresent = false;
         boolean themeColorsPresent = false;
+        boolean overviewPanelPresent = false;
         boolean headFound = false;
         long headEndOffset = -1;
         long bodyEndOffset = -1;
@@ -828,7 +1014,8 @@ public class AllureManager {
         int maxMarkerLength = Math.max(previewFixMarker.length,
                 Math.max(previewScriptMarker.length,
                         Math.max(themeColorsMarker.length,
-                                Math.max(headEndMarker.length, bodyEndMarker.length))));
+                                Math.max(overviewPanelMarker.length,
+                                        Math.max(headEndMarker.length, bodyEndMarker.length)))));
         int carryLength = maxMarkerLength - 1;
         byte[] window = new byte[carryLength + INDEX_PATCH_BUFFER_SIZE];
         int carried = 0;
@@ -856,6 +1043,10 @@ public class AllureManager {
                 int minStart = Math.max(0, carried - themeColorsMarker.length + 1);
                 themeColorsPresent = indexOfMarker(window, windowLength, minStart, themeColorsMarker, false) >= 0;
             }
+            if (!overviewPanelPresent) {
+                int minStart = Math.max(0, carried - overviewPanelMarker.length + 1);
+                overviewPanelPresent = indexOfMarker(window, windowLength, minStart, overviewPanelMarker, false) >= 0;
+            }
             if (!headFound) {
                 int minStart = Math.max(0, carried - headEndMarker.length + 1);
                 int matchIndex = indexOfMarker(window, windowLength, minStart, headEndMarker, false);
@@ -876,7 +1067,7 @@ public class AllureManager {
             carried = newCarry;
         }
 
-        return new IndexMarkerScan(previewFixPresent, previewScriptPresent, themeColorsPresent, headEndOffset, bodyEndOffset);
+        return new IndexMarkerScan(previewFixPresent, previewScriptPresent, themeColorsPresent, overviewPanelPresent, headEndOffset, bodyEndOffset);
     }
 
     /**

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
@@ -118,8 +118,28 @@ public class CheckpointCounter {
      * <p>If no checkpoints were recorded, this method does nothing.
      */
     public static void attach() {
-        if (checkpoints.isEmpty()) {
+        String overviewHtml = overviewReportHtml();
+        if (overviewHtml.isEmpty()) {
             return;
+        }
+        ReportManagerHelper.attach("HTML", "SHAFT Overview", overviewHtml);
+        attachCheckpointsJson();
+    }
+
+    /**
+     * Builds the full standalone "SHAFT Overview" HTML document from the accumulated checkpoints
+     * (summary metrics, per-type breakdown, and the filterable checkpoint-details table), or an
+     * empty string when no checkpoints were recorded.
+     *
+     * <p>Shared by the Allure HTML attachment ({@link #attach()}) and the embedded overview panel
+     * that {@code AllureManager} patches into the generated Allure report (issue #3534 P2), so both
+     * surfaces render from the exact same data instead of drifting apart.
+     *
+     * @return the built HTML document, or {@code ""} when {@link #checkpoints} is empty
+     */
+    static String overviewReportHtml() {
+        if (checkpoints.isEmpty()) {
+            return "";
         }
         String checkpointsDetails = checkpointDetailsHtml();
 
@@ -128,25 +148,21 @@ public class CheckpointCounter {
         long verificationsPassed = typeStatusCount(VERIFICATION, PASS);
         long verificationsFailed = typeStatusCount(VERIFICATION, FAIL);
 
-        ReportManagerHelper.attach("HTML",
-                "SHAFT Overview",
-                HTMLHelper.CHECKPOINT_COUNTER.getValue()
-                        .replace("${CHECKPOINTS_PASSED_PERCENTAGE_LABEL}", String.valueOf(Math.round(passedCheckpoints.get() * 100d / checkpoints.size())))
-                        .replace("${CHECKPOINTS_PASSED_DEGREES}", String.valueOf(passedCheckpoints.get() * 360d / checkpoints.size()))
-                        .replace("${CHECKPOINTS_TOTAL}", String.valueOf(checkpoints.size()))
-                        .replace("${CHECKPOINTS_PASSED}", String.valueOf(passedCheckpoints.get()))
-                        .replace("${CHECKPOINTS_FAILED}", String.valueOf(failedCheckpoints.get()))
-                        .replace("${TRACES_CAPTURED}", String.valueOf(capturedTraceCount()))
-                        .replace("${ASSERTIONS_PASSED}", String.valueOf(assertionsPassed))
-                        .replace("${ASSERTIONS_FAILED}", String.valueOf(assertionsFailed))
-                        .replace("${ASSERTIONS_TOTAL}", String.valueOf(assertionsPassed + assertionsFailed))
-                        .replace("${VERIFICATIONS_PASSED}", String.valueOf(verificationsPassed))
-                        .replace("${VERIFICATIONS_FAILED}", String.valueOf(verificationsFailed))
-                        .replace("${VERIFICATIONS_TOTAL}", String.valueOf(verificationsPassed + verificationsFailed))
-                        .replace("${CHECKPOINTS_TEST_OPTIONS}", checkpointTestFilterOptions())
-                        .replace("${CHECKPOINTS_DETAILS}", checkpointsDetails));
-
-        attachCheckpointsJson();
+        return HTMLHelper.CHECKPOINT_COUNTER.getValue()
+                .replace("${CHECKPOINTS_PASSED_PERCENTAGE_LABEL}", String.valueOf(Math.round(passedCheckpoints.get() * 100d / checkpoints.size())))
+                .replace("${CHECKPOINTS_PASSED_DEGREES}", String.valueOf(passedCheckpoints.get() * 360d / checkpoints.size()))
+                .replace("${CHECKPOINTS_TOTAL}", String.valueOf(checkpoints.size()))
+                .replace("${CHECKPOINTS_PASSED}", String.valueOf(passedCheckpoints.get()))
+                .replace("${CHECKPOINTS_FAILED}", String.valueOf(failedCheckpoints.get()))
+                .replace("${TRACES_CAPTURED}", String.valueOf(capturedTraceCount()))
+                .replace("${ASSERTIONS_PASSED}", String.valueOf(assertionsPassed))
+                .replace("${ASSERTIONS_FAILED}", String.valueOf(assertionsFailed))
+                .replace("${ASSERTIONS_TOTAL}", String.valueOf(assertionsPassed + assertionsFailed))
+                .replace("${VERIFICATIONS_PASSED}", String.valueOf(verificationsPassed))
+                .replace("${VERIFICATIONS_FAILED}", String.valueOf(verificationsFailed))
+                .replace("${VERIFICATIONS_TOTAL}", String.valueOf(verificationsPassed + verificationsFailed))
+                .replace("${CHECKPOINTS_TEST_OPTIONS}", checkpointTestFilterOptions())
+                .replace("${CHECKPOINTS_DETAILS}", checkpointsDetails);
     }
 
     /**

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
@@ -230,6 +230,8 @@ public class AllureManagerCoverageUnitTest {
         Path index = reportDirectory.resolve("index.html");
         Files.writeString(index, "<html><head></head><body></body></html>", StandardCharsets.UTF_8);
 
+        CheckpointCounter.increment(CheckpointType.ASSERTION, "overview-panel-injection-marker", CheckpointStatus.PASS);
+
         invoke("patchGeneratedAllureReportIndex", new Class[]{Path.class}, reportDirectory);
         invoke("patchGeneratedAllureReportIndex", new Class[]{Path.class}, reportDirectory);
 
@@ -247,6 +249,15 @@ public class AllureManagerCoverageUnitTest {
         Assert.assertFalse(html.contains("--color-bg-"), html);
         Assert.assertTrue(html.contains("width: 100% !important"), html);
         Assert.assertTrue(html.contains("height: auto !important"), html);
+        Assert.assertEquals(html.split("id=\"shaft-overview-panel-style\"", -1).length - 1, 1, html);
+        Assert.assertTrue(html.indexOf("id=\"shaft-overview-panel-style\"") > html.indexOf("</head>"), html);
+        Assert.assertTrue(html.contains("id=\"shaft-overview-toggle\""), html);
+        Assert.assertTrue(html.contains("id=\"shaft-overview-backdrop\""), html);
+        Assert.assertTrue(html.contains("id=\"shaft-overview-panel\""), html);
+        Assert.assertTrue(html.contains("id=\"shaft-overview-close\""), html);
+        Assert.assertTrue(html.contains("id=\"shaft-overview-frame\""), html);
+        Assert.assertTrue(html.contains("id=\"shaft-overview-panel-script\""), html);
+        Assert.assertTrue(html.contains("overview-panel-injection-marker"), html);
     }
 
     @Test
@@ -311,6 +322,7 @@ public class AllureManagerCoverageUnitTest {
         Assert.assertTrue(scan.previewFixPresent());
         Assert.assertFalse(scan.previewScriptPresent());
         Assert.assertFalse(scan.themeColorsPresent());
+        Assert.assertFalse(scan.overviewPanelPresent());
         Assert.assertEquals(scan.headEndOffset(), headEndOffset);
         Assert.assertEquals(scan.bodyEndOffset(), lastBodyEndOffset);
     }

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/CheckpointCounterJsonUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/CheckpointCounterJsonUnitTest.java
@@ -166,6 +166,19 @@ public class CheckpointCounterJsonUnitTest {
         Assert.assertFalse(options.contains("value=\"\""), options);
     }
 
+    @Test(description = "overviewReportHtml renders the same checkpoint data published via attach() (issue #3534 P2 embedded panel)")
+    public void overviewReportHtmlRendersRecordedCheckpoints() {
+        String marker = "overview-report-html-marker";
+        CheckpointCounter.increment(CheckpointType.ASSERTION, marker, CheckpointStatus.PASS);
+
+        String html = CheckpointCounter.overviewReportHtml();
+
+        Assert.assertFalse(html.isEmpty(), "overviewReportHtml() must be non-empty once a checkpoint has been recorded");
+        Assert.assertTrue(html.contains("SHAFT Overview"), html);
+        Assert.assertTrue(html.contains(marker), html);
+        Assert.assertTrue(html.contains("<table>"), html);
+    }
+
     private static int countOccurrences(String haystack, String needle) {
         int count = 0;
         for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {


### PR DESCRIPTION
## Summary
- Extends the proven post-generate patch pattern (`AllureManager.patchGeneratedAllureReportIndex`, already used for the attachment-preview fix and theme-color overrides) to splice a floating "SHAFT Overview" toggle button + modal panel into the generated report's `index.html`.
- The panel renders `CheckpointCounter.overviewReportHtml()` (the exact same standalone document already published as the "SHAFT Overview" HTML attachment) via `<iframe srcdoc>`, so both surfaces share one data source instead of drifting apart.
- `CheckpointCounter.overviewReportHtml()` is a new extraction of the HTML-building logic previously inlined in `attach()` — no behavior change to the existing attachment.

## Why this approach, not an npm plugin
Issue #3534's P2 item asked for an "Allure-3 Awesome npm widget/tab... weigh against the ADR's post-generate patch approach." Before implementing, I verified against Allure 3's actual docs/source that its `awesome` plugin has **no documented third-party widget/tab extension API**, and its shipped report is an obfuscated, client-rendered Preact bundle with `<div id="app"></div>` as the only static markup — no stable DOM contract exists to hook a "native" tab into, regardless of whether it's built as an npm plugin or a patch. The toggle/panel here is deliberately isolated (lives entirely outside `#app`, only depends on the always-present `</body>` anchor), so it's immune to `allure3Version` bumps changing Allure's internal bundle.

## Test plan
- [x] `mvn -pl shaft-engine test -Dtest=AllureManagerCoverageUnitTest,CheckpointCounterJsonUnitTest,ReportThemeConsistencyTest -DheadlessExecution=true` — 27/27 passed (verified via surefire XML, not just exit code)
- [x] `mvn -pl shaft-engine package -DskipTests -DheadlessExecution=true` — BUILD SUCCESS
- [x] Live-verified in a real Chrome session against a real `npx allure@3.14.3 generate` report (not a mock): toggle opens the panel with correct live aggregate data, close button restores the exact original view (byte-identical screenshot). Escape/backdrop-click share the same reviewed `closePanel()` code path.

## Follow-up
Issue #3534 P3's "single data model → Allure widget AND offline HTML" convergence and the docs/screenshots item remain open, now partially unblocked by this change (the two surfaces already share the underlying HTML). Left as-is per YAGNI — larger convergence work, not required for this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbRC7ZV1WzJCoMqQ2iEYQH