### PR TITLE
IntelliJ plugin: onboarding/setup/Assistant trust polish (#3601 prioritized top 5)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
@@ -54,6 +53,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     private JBTextField mcpCommand;
     private JButton testMcp;
     private JLabel testStatus;
+    private JLabel testRecovery;
     private JLabel currentAgentConfigurationTitle;
     private JLabel currentAgentConfiguration;
     private JPanel currentAgentConfigurationRow;
@@ -147,6 +147,9 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         testMcp.addActionListener(event -> testMcpConnection());
         testStatus = statusLabel("Not tested");
         testStatus.getAccessibleContext().setAccessibleName("SHAFT MCP test status");
+        testRecovery = new JLabel();
+        testRecovery.getAccessibleContext().setAccessibleName("SHAFT MCP test recovery");
+        testRecovery.setVisible(false);
         mcpCommand.getDocument().addDocumentListener(new javax.swing.event.DocumentListener() {
             @Override
             public void insertUpdate(javax.swing.event.DocumentEvent event) {
@@ -259,10 +262,10 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         cloudModelLabel = label("Cloud model", 'W', cloudModel);
         defaultModeLabel = label("Default assistant mode", 'D', defaultMode);
         shaftAiSection = section("Advanced");
-        shaftAiProviderLabel = label("Provider", 'P', pilotAiProvider);
+        shaftAiProviderLabel = label("Provider for Doctor/Healer AI features", 'P', pilotAiProvider);
         shaftAiModelLabel = label("Model", 'L', pilotAiModel);
         providerKeysSection = section("Credentials");
-        shaftAiHelp = help("Provider settings apply only to MCP tools that explicitly request configured SHAFT AI assistance.");
+        shaftAiHelp = help("This provider powers only SHAFT MCP's own AI-assisted tools, such as Doctor/Healer diagnosis, separate and independent from the Assistant's cloud provider selection above.");
         providerKeysHelp = help("Passing keys exposes them only to the SHAFT MCP process. Disable to keep provider credentials local to IntelliJ only.");
         providerKeysStorageHelp = help("Provider keys are stored in IntelliJ Password Safe. Use 'Clear' only to remove a stored key.");
         openAiKeyLabel = label("OpenAI API key", 'O', openAiKey);
@@ -274,6 +277,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
                 .addComponent(section("Connection"))
                 .addLabeledComponent(label("MCP stdio command", 'M', mcpCommand), mcpCommand)
                 .addLabeledComponent(testMcp, testStatus)
+                .addComponent(testRecovery)
                 .addComponent(help("Visit the SHAFT MCP user guide, install the MCP integration, paste the stdio command, then test the connection."))
                 .addComponent(section("Execution"))
                 .addLabeledComponent(currentAgentConfigurationTitle, currentAgentConfigurationRow)
@@ -412,6 +416,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         mcpCommand = null;
         testMcp = null;
         testStatus = null;
+        testRecovery = null;
         currentAgentConfigurationTitle = null;
         currentAgentConfiguration = null;
         currentAgentConfigurationRow = null;
@@ -519,6 +524,9 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         if (testStatus != null) {
             testStatus.setText("Not tested");
             testStatus.setEnabled(false);
+        }
+        if (testRecovery != null) {
+            testRecovery.setVisible(false);
         }
     }
 
@@ -631,6 +639,9 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         statusLabel.setEnabled(true);
         statusLabel.setText("Testing...");
         statusLabel.setForeground(ShaftStatusPresentation.progress());
+        if (testRecovery != null) {
+            testRecovery.setVisible(false);
+        }
         // Race fix (issue #3551): a check is starting, so the persisted state must not read ready
         // for the whole in-flight window (mirrors ShaftMcpSetupPanel#testConnection()).
         settingsProvider.get().mcpSetupComplete = false;
@@ -652,7 +663,10 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
                         if (category.recoveryAction() != null) {
                             sb.append("\n\nRecovery: ").append(category.recoveryAction());
                         }
-                        Messages.showErrorDialog(host, sb.toString(), "SHAFT MCP");
+                        if (testRecovery != null) {
+                            testRecovery.setText(sb.toString());
+                            testRecovery.setVisible(true);
+                        }
                     } else {
                         showProbeResult(host, statusLabel, result);
                     }
@@ -683,6 +697,9 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         if (result != null && result.success()) {
             statusLabel.setText(ShaftStatusPresentation.SUCCESS_ICON + " Connected");
             statusLabel.setForeground(ShaftStatusPresentation.success());
+            if (testRecovery != null) {
+                testRecovery.setVisible(false);
+            }
             saveConnectedSettings();
             editingAgentConfiguration = false;
             updateAgentConfigurationControls();
@@ -690,7 +707,10 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
             statusLabel.setText(ShaftStatusPresentation.ERROR_ICON + " Failed");
             statusLabel.setForeground(ShaftStatusPresentation.error());
             String message = formatErrorMessage(result);
-            Messages.showErrorDialog(host, message, "SHAFT MCP");
+            if (testRecovery != null) {
+                testRecovery.setText(message);
+                testRecovery.setVisible(true);
+            }
         }
     }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -409,14 +409,14 @@ final class ShaftMcpSetupPanel extends JPanel {
         copyOutput = new JButton("Copy output");
         copyOutput.getAccessibleContext().setAccessibleName("Copy setup diagnostic output");
         copyOutput.setToolTipText("Copy the setup diagnostic output");
-        ShaftIconButtons.apply(copyOutput, ShaftIcons.COPY);
+        applyLabeledAction(copyOutput, ShaftIcons.COPY);
         copyOutput.setEnabled(false);
         copyOutput.addActionListener(event -> copyDiagnosticOutput());
         copyDocs = new JButton("Copy docs link");
         copyDocs.getAccessibleContext().setAccessibleName("Copy SHAFT MCP docs link");
         copyDocs.setToolTipText("Copy the SHAFT MCP setup docs link");
         copyDocs.setMnemonic(KeyEvent.VK_D);
-        ShaftIconButtons.apply(copyDocs, ShaftIcons.HELP);
+        applyLabeledAction(copyDocs, ShaftIcons.HELP);
         copyDocs.setEnabled(false);
         copyDocs.setVisible(false);
         copyDocs.addActionListener(event -> copyDocsLink());
@@ -426,7 +426,7 @@ final class ShaftMcpSetupPanel extends JPanel {
                 "Copy a command that stops any running sessions of the selected assistant CLI and "
                         + "re-checks its shaft-mcp access, so it picks up a fresh shaft-mcp install; "
                         + "also opens a terminal with it pre-typed");
-        ShaftIconButtons.apply(copyRestartCommand, ShaftIcons.RESET);
+        applyLabeledAction(copyRestartCommand, ShaftIcons.RESET);
         copyRestartCommand.setEnabled(false);
         copyRestartCommand.setVisible(false);
         copyRestartCommand.addActionListener(event -> copyCommandIntoTerminal(

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolApprovalPromptPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolApprovalPromptPanel.java
@@ -1,10 +1,13 @@
 package com.shaft.intellij.ui;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBUI;
 import com.shaft.intellij.approval.ToolApprovalDecision;
 
 import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -14,6 +17,7 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -73,15 +77,30 @@ final class ToolApprovalPromptPanel extends JPanel {
 
         JLabel summary = new JLabel("<html>SHAFT wants to run <b>" + escapeHtml(toolName) + "</b></html>");
         summary.getAccessibleContext().setAccessibleName("Tool approval summary");
+
+        WrappingArgumentsArea plainLanguageArea = new WrappingArgumentsArea(plainLanguageSummary(arguments));
+        plainLanguageArea.getAccessibleContext().setAccessibleName("Tool approval plain-language summary");
+        plainLanguageArea.getAccessibleContext().setAccessibleDescription(
+                "Plain-language description of the arguments for the " + toolName + " tool call awaiting approval: "
+                        + plainLanguageSummary(arguments));
+
         JTextArea argumentsLabel = new WrappingArgumentsArea(argumentsSummary(arguments));
+        argumentsLabel.setFont(argumentsLabel.getFont().deriveFont(Math.max(10f, argumentsLabel.getFont().getSize2D() - 1f)));
+        argumentsLabel.setForeground(JBColor.namedColor("Label.disabledForeground", JBColor.GRAY));
         argumentsLabel.getAccessibleContext().setAccessibleName("Tool approval arguments");
         argumentsLabel.getAccessibleContext().setAccessibleDescription(
                 "Arguments for the " + toolName + " tool call awaiting approval: " + argumentsSummary(arguments));
 
+        JPanel argumentsPanel = new JPanel();
+        argumentsPanel.setOpaque(false);
+        argumentsPanel.setLayout(new BoxLayout(argumentsPanel, BoxLayout.Y_AXIS));
+        argumentsPanel.add(plainLanguageArea);
+        argumentsPanel.add(argumentsLabel);
+
         JPanel header = new JPanel(new BorderLayout(2, 2));
         header.setOpaque(false);
         header.add(summary, BorderLayout.NORTH);
-        header.add(argumentsLabel, BorderLayout.CENTER);
+        header.add(argumentsPanel, BorderLayout.CENTER);
 
         JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         actions.setOpaque(false);
@@ -100,8 +119,21 @@ final class ToolApprovalPromptPanel extends JPanel {
         button.getAccessibleContext().setAccessibleDescription(buttonDescription(toolName, decision));
         button.setToolTipText(buttonDescription(toolName, decision));
         button.addActionListener(event -> decide(decision));
+        if (isBroadScope(decision)) {
+            button.setFont(button.getFont().deriveFont(Math.max(10f, button.getFont().getSize2D() - 1f)));
+            button.setForeground(JBColor.namedColor("Label.disabledForeground", JBColor.GRAY));
+        }
         decisionButtons.add(button);
         return button;
+    }
+
+    /**
+     * {@code APPROVE_TOOL_ALWAYS} and {@code APPROVE_ALL_TOOLS} grant broader, longer-lived
+     * trust than {@code APPROVE_ONCE} or {@code DENY}; they're rendered with a lighter visual
+     * weight so the narrowest/safest choices remain the default-looking path.
+     */
+    private static boolean isBroadScope(ToolApprovalDecision decision) {
+        return decision == ToolApprovalDecision.APPROVE_TOOL_ALWAYS || decision == ToolApprovalDecision.APPROVE_ALL_TOOLS;
     }
 
     private static String buttonDescription(String toolName, ToolApprovalDecision decision) {
@@ -142,6 +174,31 @@ final class ToolApprovalPromptPanel extends JPanel {
         String json = arguments.toString();
         int maxLength = 200;
         return json.length() > maxLength ? json.substring(0, maxLength) + "..." : json;
+    }
+
+    /**
+     * Renders the top-level entries of {@code arguments} as a plain-language sentence instead of
+     * raw JSON, e.g. {@code {"url":"https://example.com","headless":false}} becomes
+     * {@code "This will run with url: https://example.com, headless: false."}. SHAFT MCP tool
+     * arguments are effectively flat, so nested object/array values are rendered with their own
+     * {@code toString()} rather than recursively flattened; this is a one-level flattening, not a
+     * general JSON-to-English engine.
+     */
+    private static String plainLanguageSummary(JsonObject arguments) {
+        if (arguments == null || arguments.isEmpty()) {
+            return "No arguments.";
+        }
+        StringBuilder pairs = new StringBuilder();
+        for (Map.Entry<String, JsonElement> entry : arguments.entrySet()) {
+            if (pairs.length() > 0) {
+                pairs.append(", ");
+            }
+            JsonElement value = entry.getValue();
+            String plainValue = value == null || value.isJsonNull() ? "none"
+                    : value.isJsonPrimitive() ? value.getAsString() : value.toString();
+            pairs.append(entry.getKey()).append(": ").append(plainValue);
+        }
+        return "This will run with " + pairs + ".";
     }
 
     private static String escapeHtml(String value) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolApprovalPromptPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolApprovalPromptPanel.java
@@ -227,10 +227,18 @@ final class ToolApprovalPromptPanel extends JPanel {
 
         @Override
         public Dimension getPreferredSize() {
-            int cappedWidth = Math.min(super.getPreferredSize().width, JBUI.scale(MAX_WIDTH));
-            setSize(new Dimension(cappedWidth, Short.MAX_VALUE));
+            // Always wrap at a fixed width instead of deriving a cap from super.getPreferredSize()'s
+            // natural width: that query happens while this component's own size is still (0, 0) on
+            // its first layout pass, and a line-wrapped JTextArea measured at zero width collapses to
+            // near-zero preferred width too - wrapping every subsequent line one character at a time.
+            // That stayed invisible while this was the sole BorderLayout.CENTER child (which discards
+            // the child's preferred width and stretches it to the real available width regardless),
+            // but a second wrapping area stacked via BoxLayout honors the (broken) preferred width as
+            // the real allocated width, so the fixed-width component must actually be correct.
+            int width = JBUI.scale(MAX_WIDTH);
+            setSize(new Dimension(width, Short.MAX_VALUE));
             Dimension preferred = super.getPreferredSize();
-            preferred.width = cappedWidth;
+            preferred.width = width;
             return preferred;
         }
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
@@ -16,7 +16,6 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShaftSettingsConfigurableTest {
@@ -321,40 +319,29 @@ class ShaftSettingsConfigurableTest {
     }
 
     @Test
-    void showProbeResultAppliesErrorGlyphThroughRealCompletionPathBeforeReportingTheFailure() throws Exception {
+    void showProbeResultShowsInlineRecoveryTextOnFailure() throws Exception {
         ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
         settings.mcpSetupComplete = false;
         ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(settings, new InMemoryCredentials());
         JComponent panel = (JComponent) configurable.createComponent();
         JLabel statusLabel = findByAccessibleName(panel, "SHAFT MCP test status", JLabel.class);
+        JLabel recoveryLabel = findByAccessibleName(panel, "SHAFT MCP test recovery", JLabel.class);
         assertNotNull(statusLabel);
+        assertNotNull(recoveryLabel);
         statusLabel.setText("Testing...");
 
-        // showProbeResult's failure branch reports the outcome via Messages.showErrorDialog(host, ...).
-        // This module has no test-only seam (e.g. TestDialogManager.setTestDialog) wired up for that
-        // call - there is no existing precedent for stubbing Messages in this suite. The JUnit5 IntelliJ
-        // test framework attached to this module's test JVM enforces its own EDT-thread assertion
-        // before DialogWrapper ever reaches real AWT/Swing dialog code, so invoking this off the EDT (as
-        // any plain JUnit test body runs) surfaces as a real, deterministic IntelliJ threading exception
-        // instead of popping a blocking modal. We still invoke the real, private
-        // showProbeResult(JPanel, JLabel, ShaftMcpToolResult) method via reflection - not a hand-written
-        // stand-in - and the assertions below confirm the ERROR_ICON glyph the method sets on the label
-        // (which happens before the dialog call in production code) really came from that invocation.
-        InvocationTargetException wrapped = assertThrows(InvocationTargetException.class,
-                () -> invokeShowProbeResult(configurable, (JPanel) panel, statusLabel,
-                        ShaftMcpToolResult.failure("MCP server process exited.")));
+        // showProbeResult's failure branch now reports the outcome via an inline recovery JLabel
+        // (mirroring ShaftMcpSetupPanel's recoveryStatus pattern) instead of a blocking
+        // Messages.showErrorDialog(host, ...) call, so the method completes normally.
+        invokeShowProbeResult(configurable, (JPanel) panel, statusLabel,
+                ShaftMcpToolResult.failure("MCP server process exited."));
 
         assertAll(
-                () -> assertNotNull(wrapped.getCause()),
-                () -> assertTrue(wrapped.getCause() instanceof RuntimeException,
-                        "expected the real Messages.showErrorDialog call to fail with a runtime exception, got: "
-                                + wrapped.getCause()),
-                () -> assertTrue(wrapped.getCause().getMessage() != null
-                                && wrapped.getCause().getMessage().contains("Event Dispatch Thread"),
-                        "expected IntelliJ's EDT-only threading assertion inside Messages.showErrorDialog, got: "
-                                + wrapped.getCause()),
                 () -> assertEquals(ShaftStatusPresentation.ERROR_ICON + " Failed", statusLabel.getText()),
-                () -> assertFalse(settings.mcpSetupComplete));
+                () -> assertFalse(settings.mcpSetupComplete),
+                () -> assertTrue(recoveryLabel.isVisible(), "recovery label should be shown on failure"),
+                () -> assertTrue(recoveryLabel.getText().contains("MCP server process exited."),
+                        "recovery label should contain the failure detail, got: " + recoveryLabel.getText()));
     }
 
     private static void invokeShowProbeResult(

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2832,6 +2832,8 @@ class ShaftPanelSetupTest {
                 .filter(button -> !"Recheck prerequisites".equals(accessibleName(button)))
                 .filter(button -> !"Copy SHAFT Engine warm-up command".equals(accessibleName(button)))
                 .filter(button -> !"Copy assistant CLI restart command".equals(accessibleName(button)))
+                .filter(button -> !"Copy setup diagnostic output".equals(accessibleName(button)))
+                .filter(button -> !"Copy SHAFT MCP docs link".equals(accessibleName(button)))
                 .filter(button -> !String.valueOf(accessibleName(button)).matches("Copy .+ install command"))
                 // Empty-state suggestion chips (issue #3500 A6) are content affordances that name
                 // the exact request they pre-fill — an icon alone cannot convey that on first run.

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolApprovalPromptPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolApprovalPromptPanelTest.java
@@ -102,6 +102,80 @@ class ToolApprovalPromptPanelTest {
         assertEquals(ToolApprovalDecision.DENY, decided.get());
     }
 
+    @Test
+    void plainLanguageSummaryIsHumanReadableNotRawJson() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("url", "https://example.com");
+        arguments.addProperty("headless", false);
+        ToolApprovalPromptPanel panel = new ToolApprovalPromptPanel(
+                "capture_start", arguments, ToolApprovalPromptPanel.AgentApprovalCapability.STANDARD, decision -> { });
+
+        String plainLanguageText = plainLanguageAreaText(panel);
+
+        assertAll(
+                () -> assertFalse(plainLanguageText.contains("{"), "should not contain raw JSON punctuation"),
+                () -> assertFalse(plainLanguageText.contains("}"), "should not contain raw JSON punctuation"),
+                () -> assertFalse(plainLanguageText.contains("\":\""), "should not contain raw JSON punctuation"),
+                () -> assertTrue(plainLanguageText.contains("url: https://example.com"),
+                        "should contain the argument value in readable form"),
+                () -> assertTrue(plainLanguageText.contains("headless: false"),
+                        "should contain the argument value in readable form"));
+    }
+
+    @Test
+    void broadScopeButtonsAreVisuallyDeemphasizedComparedToOnceAndDeny() {
+        ToolApprovalPromptPanel panel = new ToolApprovalPromptPanel(
+                "capture_start", arguments(), ToolApprovalPromptPanel.AgentApprovalCapability.STANDARD, decision -> { });
+        List<JButton> buttons = panel.decisionButtonsForTest();
+
+        JButton approveOnce = findByLabel(buttons, "Approve once");
+        JButton deny = findByLabel(buttons, "Deny");
+        JButton approveToolAlways = findByLabel(buttons, "Approve tool always");
+        JButton approveAllTools = findByLabel(buttons, "Approve all tools");
+
+        assertAll(
+                () -> assertTrue(isVisuallyDeemphasized(approveOnce, approveToolAlways),
+                        "Approve tool always should be visually de-emphasized relative to Approve once"),
+                () -> assertTrue(isVisuallyDeemphasized(approveOnce, approveAllTools),
+                        "Approve all tools should be visually de-emphasized relative to Approve once"),
+                () -> assertTrue(isVisuallyDeemphasized(deny, approveToolAlways),
+                        "Approve tool always should be visually de-emphasized relative to Deny"),
+                () -> assertTrue(isVisuallyDeemphasized(deny, approveAllTools),
+                        "Approve all tools should be visually de-emphasized relative to Deny"));
+    }
+
+    private static boolean isVisuallyDeemphasized(JButton narrowScope, JButton broadScope) {
+        boolean smallerFont = broadScope.getFont().getSize2D() < narrowScope.getFont().getSize2D();
+        boolean differentForeground = !broadScope.getForeground().equals(narrowScope.getForeground());
+        return smallerFont || differentForeground;
+    }
+
+    private static JButton findByLabel(List<JButton> buttons, String label) {
+        return buttons.stream().filter(button -> label.equals(button.getText())).findFirst().orElseThrow();
+    }
+
+    private static String plainLanguageAreaText(ToolApprovalPromptPanel panel) {
+        List<javax.swing.JTextArea> textAreas = new java.util.ArrayList<>();
+        collectTextAreas(panel, textAreas);
+        return textAreas.stream()
+                .filter(area -> "Tool approval plain-language summary".equals(
+                        area.getAccessibleContext().getAccessibleName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("plain-language summary text area not found"))
+                .getText();
+    }
+
+    private static void collectTextAreas(java.awt.Container container, List<javax.swing.JTextArea> found) {
+        for (java.awt.Component component : container.getComponents()) {
+            if (component instanceof javax.swing.JTextArea textArea) {
+                found.add(textArea);
+            }
+            if (component instanceof java.awt.Container child) {
+                collectTextAreas(child, found);
+            }
+        }
+    }
+
     private static JsonObject arguments() {
         JsonObject arguments = new JsonObject();
         arguments.addProperty("targetUrl", "https://example.com");


### PR DESCRIPTION
## Summary

Implements the "Prioritized top 5" from #3601 (IntelliJ plugin onboarding/setup/Assistant trust & polish, no new features):

- **B3.1** — tool-approval prompt now shows a one-level plain-language summary of the arguments above the (still-available, visually demoted) raw JSON, instead of raw JSON being the only thing shown.
- **B1.1** — the three setup-wizard recovery buttons (Copy output / Copy docs link / Copy restart command), shown only on failure, keep visible text instead of being icon-only — narrow, scoped exception to the #3204 icon-only convention for failure-state diagnostic controls specifically.
- **B2.3** — Settings' "Test MCP" connection failure now reports via an inline recovery label (mirroring the setup wizard's existing `recoveryStatus` pattern) instead of a blocking modal dialog for the same event.
- **B3.2** — the two broad-scope approval buttons (Approve tool always / Approve all tools) are visually de-emphasized relative to Approve once / Deny, so visual weight tracks grant breadth.
- **B2.2** — the "SHAFT AI provider" label/help text under Settings → Advanced is now scoped ("Provider for Doctor/Healer AI features") and distinguishes itself from the Assistant's own cloud-provider selection, instead of circular help copy.

Plus a real bug fix found via visual verification: the B3.1 plain-language text was wrapping mid-word (one character per line) due to a pre-existing `WrappingArgumentsArea` sizing quirk that only surfaced once a second wrapping area was stacked via `BoxLayout` — fixed at the root (see commit `4d5fc71542`).

**Out of scope for this PR** (deferred, tracked by #3601 which stays open): S4 (safe re-enter setup — a new non-destructive affordance, larger/riskier than pure polish), Section A's remaining items (S2, A3, G3, O3, a11y pass), and B1.2-4/B2.1/B3.3-4.

## Verification

- `gradle compileJava compileTestJava` — clean.
- Scoped tests run together: `ShaftPanelSetupTest` (171), `ToolApprovalPromptPanelTest` (7), `ShaftSettingsConfigurableTest` (11) — 189/189 passing, 0 failures/errors/skips (verified via JUnit XML, not piped console output).
- `ShaftPluginScreenshotRendererTest` regenerated; visually reviewed the approval-prompt, setup-error, and settings screenshots — caught and fixed the mid-word-wrap bug this way.

## Test plan
- [x] Scoped unit tests green (189/189)
- [x] Full module compile clean
- [x] Screenshots regenerated and visually reviewed
- [ ] CI (security.yml, intellij-plugin.yml) green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuD9zNtcghu8MEN5eXCTTq