### PR TITLE
fix(intellij): get ShaftPluginUpgradeActivity off the startup coroutine dispatcher (marketplace release blocker)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftPluginUpgradeActivity.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftPluginUpgradeActivity.java
@@ -1,6 +1,7 @@
 package com.shaft.intellij.settings;
 
 import com.intellij.ide.plugins.cl.PluginAwareClassLoader;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.ProjectActivity;
 import kotlin.Unit;
@@ -23,6 +24,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * version compare-and-reset must run exactly once per IDE session; {@link #CHECKED} guards that,
  * mirroring the process-wide {@code AtomicBoolean} pattern used by
  * {@link com.shaft.intellij.ui.ShaftRecordingActivity#active()}.
+ *
+ * <p>{@code execute} itself only schedules the check via {@code invokeLater} rather than running
+ * it inline: the platform invokes {@code ProjectActivity.execute} on its shared background
+ * coroutine dispatcher, and the actual work (settings I/O, credential/tool-approval reset) has no
+ * reason to hold that thread once scheduling is possible -- returning immediately keeps this
+ * activity's footprint on the platform's startup coroutine dispatcher as small as possible.
  */
 public final class ShaftPluginUpgradeActivity implements ProjectActivity {
     private static final AtomicBoolean CHECKED = new AtomicBoolean();
@@ -41,8 +48,9 @@ public final class ShaftPluginUpgradeActivity implements ProjectActivity {
     @Override
     public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
         if (CHECKED.compareAndSet(false, true)) {
-            checkForUpgrade(runningPluginVersion(), ShaftSettingsState.getInstance(),
-                    ShaftPluginResetService.getInstance());
+            ApplicationManager.getApplication().invokeLater(() ->
+                    checkForUpgrade(runningPluginVersion(), ShaftSettingsState.getInstance(),
+                            ShaftPluginResetService.getInstance()));
         }
         return Unit.INSTANCE;
     }


### PR DESCRIPTION
## Context

10.3.20260715 was **rejected by the JetBrains Marketplace verifier** with:

```
com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Read access is
allowed from inside read-action only (see Application.runReadAction()); ...
Current thread: Thread[#154,DefaultDispatcher-worker-74,6,main] ... (isDispatchThread()=false)
  at ThreadingAssertions.softAssertReadAccess
  at CodeInsightContextManagerImpl.getPreferredContext
  at EditorContextManagerImpl.getCurrentContextStateWithPreferredDefault$lambda$1
  ...
  at DaemonFusReporter.daemonCanceled/daemonStopped
  ...
  at DaemonCodeAnalyzerImpl.cancelAllUpdateProgresses / cancelIndicator
```

10.3.20260714 was the last accepted build. Every visible frame is IntelliJ
Platform-internal (`CodeInsightContext` "multiverse" subsystem, new in 2024.3) —
no `com.shaft.intellij` frame appears anywhere in the trace, so this is a real
platform-side threading bug, not a plugin logic bug.

## What changed between the accepted and rejected builds

Diffing `93dd9cb4ce..55db0f90ce` (last-accepted → rejected), the **only** newly
added code that runs on a `DefaultDispatcher-worker-*` thread — the exact
thread class in the crash — is `ShaftPluginUpgradeActivity` (#3587), a
`postStartupActivity` implementing `com.intellij.openapi.startup.ProjectActivity`.
That interface's `execute(Project, Continuation)` is a Kotlin suspend method;
the **platform** runs it on its own `Dispatchers.Default` coroutine pool even
though `shaft-intellij` itself has zero Kotlin/coroutines dependency — a
plain-Java implementor of a platform-provided suspend interface still executes
on the platform's dispatcher. (An earlier investigation pass, PR #3608,
incorrectly used "no coroutines dependency" to rule this out; corrected there.)

The full call stack above `cancelAllUpdateProgresses` wasn't included in the
verifier's report, so I can't prove this activity is the literal trigger —
only that it's the sole new coroutine-dispatcher entry point in the regressed
diff.

## Fix

`ShaftPluginUpgradeActivity.execute()` previously ran its full body (settings
reset, credential reset, tool-approval reset) inline, synchronously, on the
platform's shared startup coroutine dispatcher thread. It now only schedules
that work via `ApplicationManager.getApplication().invokeLater(...)` and
returns immediately — minimizing this activity's footprint on exactly the
thread class implicated in the crash. Behavior is unchanged (still runs once
per IDE session, still resets stale state before the user interacts with the
tool window); only the executing thread and scheduling timing change.

This is a safe, idiomatic hardening regardless of whether it's the literal
root cause — it just gets our code off a thread it never needed to hold. It
can only be confirmed as *the* fix by a marketplace re-submission, since
rejections happen in JetBrains' own automated verification stage, which our
CI cannot reproduce (no local pipeline launches a live IDE).

## Test plan

- [x] `ShaftPluginUpgradeActivityTest` (7/7 pass) and `ShaftPluginResetServiceTest`
      (11/11 pass) — both exercise `checkForUpgrade`/`shouldResetForUpgrade` via
      constructor injection, unaffected by the threading change.
- [x] `compileJava` / `compileTestJava` clean.
- [ ] Confirm on the next Marketplace submission that the rejection does not recur.

## Related

- Supersedes/corrects the "no plugin code needed changing" conclusion in #3608
  (memory record corrected there in a follow-up commit).