### PR TITLE
intellij: correlate watch-mode reruns with the changed test file (#3641)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/testindex/ShaftTestWatchService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testindex/ShaftTestWatchService.java
@@ -11,8 +11,8 @@ import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
@@ -166,7 +166,7 @@ public final class ShaftTestWatchService implements Disposable {
         if (file == null) {
             return null;
         }
-        return ReadAction.compute(() -> {
+        return ApplicationManager.getApplication().runReadAction((Computable<String>) () -> {
             if (project.isDisposed() || !file.isValid()) {
                 return null;
             }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/testindex/ShaftTestWatchService.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/testindex/ShaftTestWatchService.java
@@ -1,20 +1,29 @@
 package com.shaft.intellij.testindex;
 
 import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.executors.DefaultRunExecutor;
+import com.intellij.execution.junit.JUnitConfiguration;
 import com.intellij.execution.runners.ExecutionUtil;
 import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationAction;
 import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiJavaFile;
+import com.intellij.psi.PsiManager;
 import com.intellij.util.Alarm;
 import com.intellij.util.messages.MessageBusConnection;
 import com.shaft.intellij.settings.ShaftSettingsState;
+import com.theoryinpractice.testng.configuration.TestNGConfiguration;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,7 +32,13 @@ import java.util.List;
 /**
  * Bounded, opt-in "watch mode": when {@link ShaftSettingsState.Settings#watchModeEnabled} is on,
  * saving a file under {@code src/test/} debounces then reruns the last SHAFT test run
- * configuration (captured by {@link ShaftTestIndexListener}).
+ * configuration (captured by {@link ShaftTestIndexListener}) -- but only when that changed file's
+ * class actually matches what the last run targeted ({@link #correlate}). A save to an unrelated
+ * test class instead surfaces a notification offering to run the class that was actually changed
+ * (via {@link ShaftRunConfigurationResolver#run}), rather than silently replaying a stale result.
+ * When either side of that comparison can't be determined (a non-Java file, or an unrecognized
+ * run-configuration type), watch mode falls back to today's unconditional rerun rather than
+ * blocking on an inability to introspect.
  * <p>
  * Bounded scheduling (a 750ms debounce plus {@link WatchRerunThrottle}'s rolling-window cap)
  * exists because unbounded Maven-fork reruns on rapid saves are a known repo risk on Windows: each
@@ -38,6 +53,7 @@ public final class ShaftTestWatchService implements Disposable {
     private final WatchRerunThrottle throttle;
     private final Alarm debounceAlarm;
     private volatile RunnerAndConfigurationSettings lastRunSettings;
+    private volatile VFileEvent pendingCorrelationEvent;
 
     public ShaftTestWatchService(@NotNull Project project) {
         this(project, new WatchRerunThrottle());
@@ -84,10 +100,18 @@ public final class ShaftTestWatchService implements Disposable {
         if (basePath == null) {
             return;
         }
-        boolean relevant = events.stream().anyMatch(event -> isTestSourceChange(event.getPath(), basePath));
-        if (!relevant) {
+        VFileEvent relevantEvent = null;
+        for (VFileEvent event : events) {
+            if (isTestSourceChange(event.getPath(), basePath)) {
+                // Last relevant event in the batch wins: correlation only needs "the file that
+                // changed" for the common single-save case this feature targets (see class javadoc).
+                relevantEvent = event;
+            }
+        }
+        if (relevantEvent == null) {
             return;
         }
+        pendingCorrelationEvent = relevantEvent;
         debounceAlarm.cancelAllRequests();
         debounceAlarm.addRequest(this::onDebounceFired, (int) DEBOUNCE_MILLIS);
     }
@@ -111,11 +135,125 @@ public final class ShaftTestWatchService implements Disposable {
             // meaningful to replay).
             return;
         }
+        String changedClassFqn = resolveChangedClassFqn(pendingCorrelationEvent);
+        String lastRunClassName = extractTargetClassName(settings.getConfiguration());
+        if (correlate(changedClassFqn, lastRunClassName) == CorrelationResult.MISMATCH) {
+            // Both sides are known and clearly different classes: rerunning lastRunSettings here
+            // would silently replay a test unrelated to what was just saved (see class javadoc).
+            notifyScopeMismatch(changedClassFqn, lastRunClassName);
+            return;
+        }
         ApplicationManager.getApplication().invokeLater(() -> {
             if (!project.isDisposed()) {
                 ExecutionUtil.runConfiguration(settings, DefaultRunExecutor.getRunExecutorInstance());
             }
         });
+    }
+
+    /**
+     * Resolves the top-level class FQN of the file a {@link VFileEvent} touched, so
+     * {@link #rerunLastTest()} can correlate it against the last run's target class.
+     * Runs the PSI lookup in a read action, per platform threading rules.
+     *
+     * @param event the triggering VFS event, or {@code null}
+     * @return the changed file's top-level class FQN, or {@code null} when the event, its
+     *         {@link VirtualFile}, or a resolvable {@link PsiJavaFile} top-level class is unavailable
+     *         (e.g. a test resource save) -- meaning there is nothing to correlate against
+     */
+    @Nullable
+    private String resolveChangedClassFqn(@Nullable VFileEvent event) {
+        VirtualFile file = event == null ? null : event.getFile();
+        if (file == null) {
+            return null;
+        }
+        return ReadAction.compute(() -> {
+            if (project.isDisposed() || !file.isValid()) {
+                return null;
+            }
+            if (!(PsiManager.getInstance(project).findFile(file) instanceof PsiJavaFile javaFile)) {
+                return null;
+            }
+            PsiClass[] classes = javaFile.getClasses();
+            return classes.length > 0 ? classes[0].getQualifiedName() : null;
+        });
+    }
+
+    /**
+     * Extracts the class a run configuration targets, for the two configuration types
+     * {@link ShaftRunConfigurationResolver} creates (see that class's javadoc).
+     * <p>
+     * Confirmed against the decompiled platform classes: {@code TestNGConfiguration.getPersistantData()}
+     * (sic -- the platform's own spelling) and {@code JUnitConfiguration.getPersistentData()} each
+     * return a data holder whose {@code getMainClassName()} never returns {@code null}, only
+     * {@code ""} when unset.
+     *
+     * @param configuration the last run's configuration
+     * @return the target class name ({@code null} or blank when unset or an unrecognized configuration
+     *         type -- both treated as "cannot determine" by {@link #correlate}
+     */
+    @Nullable
+    static String extractTargetClassName(RunConfiguration configuration) {
+        if (configuration instanceof TestNGConfiguration testNg) {
+            return testNg.getPersistantData().getMainClassName();
+        }
+        if (configuration instanceof JUnitConfiguration jUnit) {
+            return jUnit.getPersistentData().getMainClassName();
+        }
+        return null;
+    }
+
+    /**
+     * Compares the changed file's class against the last run's target class.
+     *
+     * @param changedClassFqn  the changed file's resolved class FQN, or {@code null}/blank when
+     *                         unresolvable (non-Java file, no top-level class)
+     * @param lastRunClassName the last run's target class name, or {@code null}/blank when it could
+     *                         not be determined
+     * @return {@link CorrelationResult#INDETERMINATE} when either side is unknown -- falls back to
+     *         today's unconditional rerun rather than blocking on an inability to introspect;
+     *         otherwise {@link CorrelationResult#MATCH} (exact FQN match, else simple-name match, per
+     *         {@link ShaftRunConfigurationResolver}'s own short-name-ambiguity precedent) or
+     *         {@link CorrelationResult#MISMATCH}
+     */
+    static CorrelationResult correlate(@Nullable String changedClassFqn, @Nullable String lastRunClassName) {
+        if (changedClassFqn == null || changedClassFqn.isBlank()
+                || lastRunClassName == null || lastRunClassName.isBlank()) {
+            return CorrelationResult.INDETERMINATE;
+        }
+        if (changedClassFqn.equals(lastRunClassName)) {
+            return CorrelationResult.MATCH;
+        }
+        return simpleName(changedClassFqn).equals(simpleName(lastRunClassName))
+                ? CorrelationResult.MATCH : CorrelationResult.MISMATCH;
+    }
+
+    /**
+     * Returns the simple (unqualified) class name from a possibly fully-qualified name.
+     *
+     * @param className a simple or fully-qualified class name
+     * @return the part after the last {@code .}, or the whole string if there is none
+     */
+    static String simpleName(String className) {
+        int lastDot = className.lastIndexOf('.');
+        return lastDot >= 0 ? className.substring(lastDot + 1) : className;
+    }
+
+    /** Outcome of {@link #correlate(String, String)}. */
+    enum CorrelationResult {
+        MATCH, MISMATCH, INDETERMINATE
+    }
+
+    private void notifyScopeMismatch(String changedClassFqn, String lastRunClassName) {
+        String changedSimpleName = simpleName(changedClassFqn);
+        String lastRunSimpleName = simpleName(lastRunClassName);
+        Notification notification = NotificationGroupManager.getInstance()
+                .getNotificationGroup(NOTIFICATION_GROUP_ID)
+                .createNotification("SHAFT watch mode skipped a stale rerun",
+                        "Changed `" + changedSimpleName + "` is not covered by the last run (`"
+                                + lastRunSimpleName + "`)", NotificationType.INFORMATION);
+        notification.addAction(NotificationAction.createSimple("Run " + changedSimpleName,
+                () -> ShaftRunConfigurationResolver.run(project, changedClassFqn)));
+        notification.notify(project);
     }
 
     private void notifyThrottled() {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/testindex/ShaftTestWatchServiceTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/testindex/ShaftTestWatchServiceTest.java
@@ -1,12 +1,36 @@
 package com.shaft.intellij.testindex;
 
+import com.intellij.execution.configurations.RunConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Covers {@link ShaftTestWatchService}'s directly-testable pure logic: the {@code src/test/} path
+ * heuristic ({@code isTestSourceChange}), and the #3641 changed-file-vs-last-run-scope correlation
+ * ({@code correlate}, {@code simpleName}, {@code extractTargetClassName}).
+ * <p>
+ * The PSI-facing wiring around that correlation ({@code resolveChangedClassFqn}, which needs a real
+ * {@code VirtualFile}/{@code PsiJavaFile}) and the notification/rerun glue in {@code rerunLastTest}
+ * (which needs a live {@code NotificationGroupManager}/{@code Application}) are not covered here:
+ * like {@code ShaftRunConfigurationResolverTest}'s own disclaimer, this module has no
+ * {@code BasePlatformTestCase} fixture and adding one is a build-dependency change outside this
+ * class's scope. {@code extractTargetClassName}'s unrecognized-configuration-type branch is
+ * reachable with a plain dynamic proxy (below) since it never invokes a method on the configuration
+ * -- only its two {@code instanceof} checks -- but the real {@code TestNGConfiguration}/
+ * {@code JUnitConfiguration} branches need real platform objects and are not reachable this way.
+ */
 class ShaftTestWatchServiceTest {
     private static final String PROJECT_ROOT = "C:/dev/shop-tests";
+
+    // ------------------------------------------------------------------
+    // isTestSourceChange (unchanged by #3641; still covered here)
+    // ------------------------------------------------------------------
 
     @Test
     void recognizesTestSourceFileUnderProject() {
@@ -43,5 +67,97 @@ class ShaftTestWatchServiceTest {
     void ignoresTargetOrBuildOutputEvenIfPathContainsTestSubstring() {
         assertFalse(ShaftTestWatchService.isTestSourceChange(
                 "C:/dev/shop-tests/target/test-classes/SignInTest.class", PROJECT_ROOT));
+    }
+
+    // ------------------------------------------------------------------
+    // simpleName
+    // ------------------------------------------------------------------
+
+    @Test
+    void simpleNameStripsThePackagePrefix() {
+        assertEquals("SignInTest", ShaftTestWatchService.simpleName("com.example.SignInTest"));
+    }
+
+    @Test
+    void simpleNameReturnsTheWholeStringWhenThereIsNoPackage() {
+        assertEquals("SignInTest", ShaftTestWatchService.simpleName("SignInTest"));
+    }
+
+    // ------------------------------------------------------------------
+    // correlate -- the #3641 changed-file-vs-last-run-scope decision
+    // ------------------------------------------------------------------
+
+    @Test
+    void correlateMatchesOnAnExactFqn() {
+        // (a) changed file matches the last run's scope exactly: proceed with the rerun.
+        assertEquals(ShaftTestWatchService.CorrelationResult.MATCH,
+                ShaftTestWatchService.correlate("com.example.SignInTest", "com.example.SignInTest"));
+    }
+
+    @Test
+    void correlateMatchesOnSimpleNameWhenFqnsDifferButSimpleNamesMatch() {
+        // Mirrors ShaftRunConfigurationResolver's own short-name-ambiguity precedent: an FQN mismatch
+        // still counts as a match when the simple names agree.
+        assertEquals(ShaftTestWatchService.CorrelationResult.MATCH,
+                ShaftTestWatchService.correlate("com.example.a.SignInTest", "com.example.b.SignInTest"));
+    }
+
+    @Test
+    void correlateMismatchesWhenSimpleNamesClearlyDiffer() {
+        // (b) changed file does NOT match the last run's scope: do not rerun.
+        assertEquals(ShaftTestWatchService.CorrelationResult.MISMATCH,
+                ShaftTestWatchService.correlate("com.example.CheckoutTest", "com.example.SignInTest"));
+    }
+
+    @Test
+    void correlateIsIndeterminateWhenTheChangedClassIsUnresolvable() {
+        // (c) changed file is a non-class test resource (no resolvable PSI class): fall back to
+        // today's unconditional-rerun behavior rather than blocking on it.
+        assertEquals(ShaftTestWatchService.CorrelationResult.INDETERMINATE,
+                ShaftTestWatchService.correlate(null, "com.example.SignInTest"));
+    }
+
+    @Test
+    void correlateIsIndeterminateWhenTheChangedClassIsBlank() {
+        assertEquals(ShaftTestWatchService.CorrelationResult.INDETERMINATE,
+                ShaftTestWatchService.correlate("   ", "com.example.SignInTest"));
+    }
+
+    @Test
+    void correlateIsIndeterminateWhenTheLastRunClassCannotBeDetermined() {
+        // The last run's target class could not be introspected (unrecognized configuration type, or
+        // an empty getMainClassName()): fall back rather than invent a new failure mode.
+        assertEquals(ShaftTestWatchService.CorrelationResult.INDETERMINATE,
+                ShaftTestWatchService.correlate("com.example.SignInTest", null));
+        assertEquals(ShaftTestWatchService.CorrelationResult.INDETERMINATE,
+                ShaftTestWatchService.correlate("com.example.SignInTest", ""));
+    }
+
+    // ------------------------------------------------------------------
+    // extractTargetClassName -- only its unrecognized-configuration-type branch is reachable
+    // without a real TestNGConfiguration/JUnitConfiguration (see class javadoc)
+    // ------------------------------------------------------------------
+
+    @Test
+    void extractTargetClassNameReturnsNullForAnUnrecognizedConfigurationType() {
+        RunConfiguration configuration = fakeUnrecognizedConfiguration();
+
+        assertNull(ShaftTestWatchService.extractTargetClassName(configuration));
+    }
+
+    /**
+     * A {@link RunConfiguration} that is neither a {@code TestNGConfiguration} nor a
+     * {@code JUnitConfiguration}. {@code extractTargetClassName} only ever performs {@code instanceof}
+     * checks against it, never invoking a method, so the proxy's handler is never reached.
+     */
+    private static RunConfiguration fakeUnrecognizedConfiguration() {
+        return (RunConfiguration) Proxy.newProxyInstance(
+                ShaftTestWatchServiceTest.class.getClassLoader(),
+                new Class<?>[]{RunConfiguration.class},
+                (proxy, method, args) -> {
+                    throw new UnsupportedOperationException(
+                            "fakeUnrecognizedConfiguration should never have a method invoked on it, "
+                                    + "only instanceof-checked; got " + method.getName());
+                });
     }
 }


### PR DESCRIPTION
## Summary
Closes #3641 — part of the #3643 Phase 4/5 umbrella program.

Watch mode (opt-in, saves under `src/test/` debounce-rerun the last SHAFT
test run configuration) used to blindly replay the last run regardless of
which test file was actually saved. Now:

- Resolves the changed file's top-level class via PSI (`PsiJavaFile.getClasses()[0]`).
- Compares it against the last run configuration's target class
  (`TestNGConfiguration.getPersistantData().getMainClassName()` /
  `JUnitConfiguration.getPersistentData().getMainClassName()` — confirmed via
  decompiled platform jars, never null).
- On a mismatch, surfaces a notification with a "Run `<Class>`" action
  (wired to `ShaftRunConfigurationResolver.run`, #3640) instead of silently
  rerunning a stale result.
- Falls back to today's unconditional rerun when either side can't be
  determined (non-Java file, unrecognized run-configuration type).

Cut as its own branch off updated `origin/main` (post #3654 merge) since this
depends on #3640's `ShaftRunConfigurationResolver`, per the file-dependent
sequential-branch process now in AGENTS.md.

## Test plan
- [x] `./gradlew test --tests "*ShaftTestWatchService*"` → 15/15
- [x] Full decision-table coverage added: exact-FQN match, simple-name-fallback
      match, mismatch, and all indeterminate/blank/null variants