### PR TITLE
intellij: roll out button mnemonics to the API recording session panel (#3637)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ApiRecordingSessionPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ApiRecordingSessionPanel.java
@@ -46,6 +46,11 @@ import java.util.Set;
  * ({@link CaptureMode#PURE_API}, polling {@code mobile_api_record_transactions}/
  * {@code mobile_api_record_stop}) -- issue #3530 A2. {@code capture_api_generate} is shared by
  * both: it is already session-path-agnostic, taking only the persisted session JSON path.
+ *
+ * <p>Stop/Generate/Pin Fields/Copy CA Certificate keep visible text (unlike every other day-to-day
+ * panel, which is icon-only via {@code ShaftIconButtons.apply}) and carry Alt-reachable mnemonics
+ * (S/G/P/C respectively, non-conflicting within each button's visible row) per the setup panel's
+ * convention (issue #3637).
  */
 public final class ApiRecordingSessionPanel extends JPanel implements Disposable {
     private static final int POLL_INTERVAL_MILLIS = 2_000;
@@ -172,6 +177,7 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
         pinFieldsButton.getAccessibleContext().setAccessibleDescription(
                 "Pick volatile response fields to force-assert as business assertions");
         pinFieldsButton.addActionListener(event -> openPinFieldsDialog());
+        assignActionRowMnemonics(stopButton, pinFieldsButton, generateButton);
 
         JPanel header = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 2));
         JLabel titleLabel = new JLabel(headerText);
@@ -220,6 +226,9 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
                 CopyPasteManager.getInstance().setContents(new StringSelection(caCertificatePem));
             }
         });
+        // Own visible row (issue #3637): never shares a row with the actions above, so no
+        // cross-row conflict is possible -- still gets a real mnemonic for Alt-reachability.
+        copyCertificateButton.setMnemonic('C');
 
         JPanel pairingActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 2));
         pairingActions.add(copyCertificateButton);
@@ -269,6 +278,23 @@ public final class ApiRecordingSessionPanel extends JPanel implements Disposable
      */
     TransactionTableModel tableModel() {
         return tableModel;
+    }
+
+    /**
+     * Assigns non-conflicting mnemonics to the {@code actions} row's three buttons (issue #3637):
+     * extracted as a static, pure method (rather than inlined in the constructor) so
+     * {@code ApiRecordingSessionPanelTest} can verify the assignment has no duplicate mnemonic
+     * without needing a live {@link Project} to construct the full panel (this panel starts an
+     * {@link Alarm} and MCP polling in its constructor, so it is not itself headlessly testable).
+     *
+     * @param stop the Stop button
+     * @param pinFields the Pin Fields... button
+     * @param generate the Generate button
+     */
+    static void assignActionRowMnemonics(JButton stop, JButton pinFields, JButton generate) {
+        stop.setMnemonic('S');
+        pinFields.setMnemonic('P');
+        generate.setMnemonic('G');
     }
 
     JBTextField filterField() {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ApiRecordingSessionPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ApiRecordingSessionPanelTest.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Test;
 
+import javax.swing.JButton;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -55,6 +56,22 @@ class ApiRecordingSessionPanelTest {
     @Test
     void parseTransactionsReturnsEmptyForNonArrayOutput() {
         assertEquals(List.of(), ApiRecordingSessionPanel.parseTransactions(mcpArrayText("{\"state\": \"ACTIVE\"}")));
+    }
+
+    @Test
+    void actionRowMnemonicsAreNonConflictingAndAlReachable() {
+        // Issue #3637: Stop/Pin Fields/Generate render together in the "actions" row, so their
+        // mnemonics must be pairwise distinct. Exercised via the extracted static method rather
+        // than the full panel, which needs a live Project to construct (see class javadoc).
+        JButton stop = new JButton("Stop");
+        JButton pinFields = new JButton("Pin Fields...");
+        JButton generate = new JButton("Generate");
+
+        ApiRecordingSessionPanel.assignActionRowMnemonics(stop, pinFields, generate);
+
+        Set<Integer> mnemonics = Set.of(stop.getMnemonic(), pinFields.getMnemonic(), generate.getMnemonic());
+        assertEquals(3, mnemonics.size());
+        assertTrue(mnemonics.stream().noneMatch(mnemonic -> mnemonic == 0));
     }
 
     @Test


### PR DESCRIPTION
## Summary
Closes #3637 — part of the #3643 Phase 4/5 umbrella program.

The filed issue asked for mnemonics across 7 day-to-day panels
(ApiRecordingSessionPanel, ShaftFeaturePanel, VisualBaselinesPanel,
EvidenceTriagePanel, GuidedWorkflowPanel, ShaftTestsPanel, ShaftAssistantPanel).
A live audit found the other 6 have since been fully converted to icon-only
buttons via `ShaftIconButtons.apply` (a prior accessibility pass, e.g.
issues #3500/#3601/#3603/#3626) — `setMnemonic` on a button with no visible
text produces no underline, so applying it there wouldn't serve the issue's
own acceptance criterion ("screenshots regenerated, underlines visible").

**ApiRecordingSessionPanel is the only panel with buttons that still carry
visible text**, so this PR scopes the rollout there:
- `actions` row: Stop (**S**), Pin Fields... (**P**), Generate (**G**)
- pairing-info row (its own row, no cross-row conflict possible): Copy CA
  Certificate (**C**)

Mnemonic assignment is extracted into a static `assignActionRowMnemonics(...)`
method so it's directly unit-testable — the panel itself needs a live
`Project` and isn't headlessly constructable (documented in its test class).

## Test plan
- [x] New test `actionRowMnemonicsAreNonConflictingAndAlReachable` asserts
      the three actions-row mnemonics are pairwise distinct and all set
      (the issue's "no duplicate mnemonics" acceptance criterion)
- [x] `./gradlew test --tests "*ApiRecordingSessionPanelTest*"` → 12/12
- [x] `./gradlew check buildPlugin verifyPlugin` → BUILD SUCCESSFUL, both
      target IDEs compatible