### PR TITLE
memory: confirm merge authority extends to shafthq.github.io

### DIFF
--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -327,3 +327,4 @@
 {"actor":"agent","event":"memory.created","id":"gotcha.gbrain-serve-mcp-session-lock-another-live-claude-code-session-can-hold-it-not-just-autopilot-self","timestamp":"2026-07-17T15:52:32+03:00"}
 {"actor":"agent","event":"memory.created","id":"decision.gbrain-link-graph-confirmed-empty-for-shaft-engine-reconcile-links-root-cause-found-and-filed-2026-07-17","timestamp":"2026-07-17T16:02:38+03:00"}
 {"actor":"agent","event":"memory.created","id":"decision.intellij-plugin-ux-program-umbrella-3666-tracks-children-3659-3665","timestamp":"2026-07-17T16:50:31+03:00"}
+{"actor":"agent","event":"memory.created","id":"decision.autonomous-merge-authority-extends-to-shafthq-github-io-docs-repo","timestamp":"2026-07-17T17:29:30+03:00"}

--- a/.memory/memory/decisions/autonomous-merge-authority-extends-to-shafthq-github-io-docs-repo.json
+++ b/.memory/memory/decisions/autonomous-merge-authority-extends-to-shafthq-github-io-docs-repo.json
@@ -1,0 +1,29 @@
+{
+  "body_path": "memory/decisions/autonomous-merge-authority-extends-to-shafthq-github-io-docs-repo.md",
+  "content_hash": "sha256:48f661ce8063178c1e3eb80624bb04dafa230364fa0ac24712c2a270d3067f06",
+  "created_at": "2026-07-17T17:29:30+03:00",
+  "evidence": [],
+  "facets": {
+    "category": "decision-rationale"
+  },
+  "id": "decision.autonomous-merge-authority-extends-to-shafthq-github-io-docs-repo",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "extend autonomous PR-merge authority to shafthq.github.io docs repo"
+  },
+  "status": "active",
+  "tags": [
+    "merge-authority",
+    "docs-repo",
+    "github-issue"
+  ],
+  "title": "autonomous-merge-authority-extends-to-shafthq-github-io-docs-repo",
+  "type": "decision",
+  "updated_at": "2026-07-17T17:29:30+03:00"
+}

--- a/.memory/memory/decisions/autonomous-merge-authority-extends-to-shafthq-github-io-docs-repo.md
+++ b/.memory/memory/decisions/autonomous-merge-authority-extends-to-shafthq-github-io-docs-repo.md
@@ -1,0 +1,1 @@
+2026-07-17: user confirmed the existing SHAFT_ENGINE standing merge authorization also applies to the ShaftHQ slash shafthq dot github dot io docs repo, not just SHAFT_ENGINE. Confirmed during a session that closed out the 9 open tickets across both repos. Do not re-ask before merging a green docs-repo PR opened under this contract.


### PR DESCRIPTION
## Summary
- Confirms the standing autonomous-merge-once-green PR authorization also applies to the shafthq.github.io docs repo, not just SHAFT_ENGINE.

Memory-only change, no code touched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RuxETyrUcsemB2kJfSgzZb