### PR TITLE
Fix ArrayIndexOutOfBoundsException when DatabaseActions failAction is called without a root cause

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/db/DatabaseActions.java
+++ b/shaft-engine/src/main/java/com/shaft/db/DatabaseActions.java
@@ -128,8 +128,16 @@ public class DatabaseActions {
     }
 
     private static void failAction(String actionName, String testData, Exception... rootCauseException) {
-        String message = reportActionResult(actionName, testData, null, false, rootCauseException);
-        FailureReporter.fail(DatabaseActions.class, message, rootCauseException[0]);
+        Exception cause = getRootCauseException(testData, rootCauseException);
+        String message = reportActionResult(actionName, testData, null, false, cause);
+        FailureReporter.fail(DatabaseActions.class, message, cause);
+    }
+
+    private static Exception getRootCauseException(String testData, Exception... rootCauseException) {
+        if (rootCauseException != null && rootCauseException.length > 0 && rootCauseException[0] != null) {
+            return rootCauseException[0];
+        }
+        return new IllegalStateException(testData == null || testData.isBlank() ? "Database action failed." : testData);
     }
 
     /**

--- a/shaft-engine/src/test/java/testPackage/mockedTests/DatabaseActionsMockedTests.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/DatabaseActionsMockedTests.java
@@ -156,6 +156,17 @@ public class DatabaseActionsMockedTests {
     }
 
     @Test
+    public void testConstructorFailureWithoutRootCauseReportsDescriptiveError() {
+        try {
+            new DatabaseActions("");
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertFalse(e instanceof ArrayIndexOutOfBoundsException);
+            Assert.assertTrue(e.getMessage().contains("Custom Connection String"));
+        }
+    }
+
+    @Test
     public void testGetResultWithMockedResultSet() throws SQLException {
         String result = DatabaseActions.getResult(mockResultSet);
         Assert.assertEquals(result, "1\tMona\n2\tOctocat");

--- a/shaft-engine/src/test/java/testPackage/mockedTests/DatabaseActionsMockedTests.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/DatabaseActionsMockedTests.java
@@ -161,7 +161,7 @@ public class DatabaseActionsMockedTests {
             new DatabaseActions("");
             Assert.fail();
         } catch (ArrayIndexOutOfBoundsException e) {
-            Assert.fail("constructor failure should be reported instead of throwing ArrayIndexOutOfBoundsException");
+            Assert.fail("failAction should report the failure, not crash on empty root cause");
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Custom Connection String"));
         }

--- a/shaft-engine/src/test/java/testPackage/mockedTests/DatabaseActionsMockedTests.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/DatabaseActionsMockedTests.java
@@ -160,8 +160,9 @@ public class DatabaseActionsMockedTests {
         try {
             new DatabaseActions("");
             Assert.fail();
+        } catch (ArrayIndexOutOfBoundsException e) {
+            Assert.fail("constructor failure should be reported instead of throwing ArrayIndexOutOfBoundsException");
         } catch (Exception e) {
-            Assert.assertFalse(e instanceof ArrayIndexOutOfBoundsException);
             Assert.assertTrue(e.getMessage().contains("Custom Connection String"));
         }
     }


### PR DESCRIPTION
## Summary
- `DatabaseActions.failAction` dereferenced `rootCauseException[0]` without checking the varargs length, so failure paths that report a message only (constructor validation for empty connection fields) crashed with `ArrayIndexOutOfBoundsException` instead of reporting the actual failure
- Guard it with the same `getRootCauseException` fallback already used by `TerminalActions` and `FileActions`.
- Adds a focused regression test in `DatabaseActionsMockedTests`

## Tests
[2026-07-17_20-40-16-911_AllureReport.html](https://github.com/user-attachments/files/30133997/2026-07-17_20-40-16-911_AllureReport.html)  --> 14/14 passed