### PR TITLE
intellij: one-click fix buttons for MCP-mode and source-edit pre-flight gates

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
@@ -844,15 +844,19 @@ final class AssistantTranscriptView extends JPanel {
 
     /**
      * Renders an assistant-styled bubble containing {@code markdown} plus a trailing
-     * {@code actions} row (for example a "Got it" dismiss button), sharing the exact bubble chrome
-     * and word-wrap-safe {@link WidthAwareHtmlPane} rendering that persisted transcript messages
-     * use via {@link #fallbackMessage}. Intended for {@link #showWidget(String, JComponent)}
-     * callers (namely the first-run welcome) that need an assistant bubble look without adding
-     * anything to the persisted {@link #messages}/{@link #markdown} model. The returned component
-     * is plain content, not a pre-aligned row: {@link #showWidget(String, JComponent)} applies the
-     * same West/East alignment {@link #fallbackMessage} applies directly.
+     * {@code actions} row (for example a "Got it" dismiss button, or a gate's one-click fix
+     * button), sharing the exact bubble chrome and word-wrap-safe {@link WidthAwareHtmlPane}
+     * rendering that persisted transcript messages use via {@link #fallbackMessage}. Intended for
+     * {@link #showWidget(String, JComponent)} callers (the first-run welcome, and SHAFT's own
+     * deterministic pre-flight gates -- issue #3681) that need an assistant bubble look without
+     * adding anything to the persisted {@link #messages}/{@link #markdown} model. The returned
+     * component is plain content, not a pre-aligned row: {@link #showWidget(String, JComponent)}
+     * applies the same West/East alignment {@link #fallbackMessage} applies directly.
+     *
+     * @param accessibleName distinguishes each caller's bubble for accessibility tools and tests
+     *                       (e.g. "Assistant welcome message bubble" vs. a gate-specific name)
      */
-    JComponent assistantBubbleWithActions(String markdown, JComponent actions) {
+    JComponent assistantBubbleWithActions(String markdown, JComponent actions, String accessibleName) {
         Color background = resolvedColor("Panel.background", new Color(0xF6F8FA));
         Color foreground = resolvedColor("TextArea.foreground", new Color(0x202020));
         Color stroke = resolvedColor("Component.borderColor", new Color(0xD0D7DE));
@@ -862,7 +866,7 @@ final class AssistantTranscriptView extends JPanel {
         bubble.setBackground(background);
         bubble.setForeground(foreground);
         bubble.putClientProperty(TRANSCRIPT_BUBBLE_PROPERTY, UNKNOWN_ROLE);
-        bubble.getAccessibleContext().setAccessibleName("Assistant welcome message bubble");
+        bubble.getAccessibleContext().setAccessibleName(accessibleName);
         JEditorPane htmlPane = fallbackHtmlPane(convertMarkdown(markdown), foreground, background);
         // JEditorPane under-reports the preferred height of a trailing HTML list by roughly its last
         // item's bottom margin, which cropped the final "Review code into a test" step against the

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -1260,10 +1260,14 @@ final class ShaftAssistantPanel extends JPanel {
         }
         append("user", AssistantMarkdown.normalizeMarkdown(text), "");
         if (!approvingCaptureReview && AssistantCommand.requiresAgentModeForMcp(text, selectedMode, invocation)) {
-            showResponse("This request needs MCP tool access. Switch to **Agent** mode, then send it again.",
-                    "");
             addTerminalTimeline("Failed");
             setRunning(false, "Switch to Agent mode");
+            showGateConfirmation(
+                    project,
+                    "This request needs MCP tool access.",
+                    "MCP tool access gate",
+                    "Switch to Agent mode and resend",
+                    () -> mode.setSelectedItem("AGENT"));
             return;
         }
         if (agentMode
@@ -1275,10 +1279,14 @@ final class ShaftAssistantPanel extends JPanel {
                         customCommand.getText(),
                         text,
                         conversationContext)) {
-            showResponse("To let the agent make source edits, please enable **Allow source edits** before sending.",
-                    "");
             addTerminalTimeline("Failed");
             setRunning(false, "Approve source edits");
+            showGateConfirmation(
+                    project,
+                    "To let the agent make source edits, enable **Allow source edits**.",
+                    "Source edit approval gate",
+                    "Allow source edits and resend",
+                    () -> allowSourceMutation.setSelected(true));
             return;
         }
         prompt.setText("");
@@ -1312,6 +1320,41 @@ final class ShaftAssistantPanel extends JPanel {
         }
         rememberCaptureInvocation(text, invocation);
         startMcpInvocation(invocation);
+    }
+
+    /**
+     * Shows a one-click confirmation bubble for a SHAFT pre-flight gate (issue #3681): SHAFT's own
+     * command layer already knows exactly which control resolves the gate and that the choice is a
+     * deterministic yes/no, so this renders {@code markdown} plus a single button that flips that
+     * control and resends {@link #lastPrompt} -- instead of the plain-text prose the panel used to
+     * hand the user via {@link #showResponse}, which left finding and flipping the control as a
+     * manual, out-of-band step. Reuses the same ephemeral {@link AssistantTranscriptView#showWidget}
+     * slot as {@link ToolApprovalPromptPanel} and the first-run welcome, so the bubble is cleared
+     * automatically by the next {@link #append} call -- including the one at the very top of the
+     * {@link #send} triggered by clicking the button itself.
+     *
+     * @param project current project, forwarded to {@link #rerun(Project)} for the resend
+     * @param markdown gate explanation shown above the fix button
+     * @param accessibleBubbleName distinguishes this gate's bubble from other {@code showWidget} bubbles
+     * @param buttonLabel visible and accessible name of the one-click fix button
+     * @param applyFix flips the exact control this gate needs (e.g. the mode combo box or the
+     *                 source-mutation checkbox) before the prompt is resent
+     */
+    private void showGateConfirmation(
+            Project project,
+            String markdown,
+            String accessibleBubbleName,
+            String buttonLabel,
+            Runnable applyFix) {
+        JButton fix = new JButton(buttonLabel);
+        fix.getAccessibleContext().setAccessibleName(buttonLabel);
+        fix.addActionListener(event -> {
+            transcript.clearWidget();
+            applyFix.run();
+            rerun(project);
+        });
+        transcript.showWidget("assistant", transcript.assistantBubbleWithActions(markdown, fix, accessibleBubbleName));
+        runOnEdt(fix::requestFocusInWindow);
     }
 
     private void startMcpInvocation(AssistantCommand.Invocation invocation) {
@@ -2510,7 +2553,8 @@ final class ShaftAssistantPanel extends JPanel {
             settings.firstRunCoachDismissed = true;
             transcript.clearWidget();
         });
-        transcript.showWidget("assistant", transcript.assistantBubbleWithActions(FIRST_RUN_WELCOME_MARKDOWN, gotIt));
+        transcript.showWidget("assistant", transcript.assistantBubbleWithActions(
+                FIRST_RUN_WELCOME_MARKDOWN, gotIt, "Assistant welcome message bubble"));
     }
 
     /**

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -4070,16 +4070,32 @@ class ShaftPanelSetupTest {
     }
 
     @Test
-    void assistantAskOrPlanMcpPromptTellsUserToSwitchToAgentMode() {
+    void assistantAskOrPlanMcpPromptOffersOneClickSwitchToAgentMode() {
+        // Issue #3681: SHAFT already knows exactly which binary confirmation and control this gate
+        // needs, so it must offer a one-click fix instead of plain chat text the user has to act on
+        // by finding the mode combo box themselves.
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
         assertNotNull(assistantMode);
         assistantMode.setSelectedItem("PLAN");
 
-        assistantPrompt(panel).setText("open duckduckgo and search for SHAFT Engine");
+        String promptText = "open duckduckgo and search for SHAFT Engine";
+        assistantPrompt(panel).setText(promptText);
         clickAccessible(panel, "Send assistant prompt");
 
-        assertTrue(transcriptMarkdown(panel).contains("Switch to **Agent** mode"));
+        JButton fix = findByAccessibleName(panel, "Switch to Agent mode and resend", JButton.class);
+        assertNotNull(fix, "The MCP-mode gate must offer a one-click fix button, not just prose.");
+        assertEquals("PLAN", assistantMode.getSelectedItem(), "Mode must not flip until the button is clicked.");
+
+        fix.doClick();
+
+        assertAll(
+                () -> assertEquals("AGENT", assistantMode.getSelectedItem(),
+                        "Clicking the fix must switch the mode selector to Agent."),
+                () -> assertEquals(2, countOccurrences(transcriptMarkdown(panel), promptText),
+                        "Clicking the fix must resend the original prompt."),
+                () -> assertNull(findByAccessibleName(panel, "Switch to Agent mode and resend", JButton.class),
+                        "The gate bubble must clear itself once the fix is applied."));
     }
 
     @Test
@@ -4101,6 +4117,42 @@ class ShaftPanelSetupTest {
         clickAccessible(panel, "Send assistant prompt");
 
         assertFalse(transcriptMarkdown(panel).contains("enable **Allow source edits**"));
+    }
+
+    @Test
+    void assistantSourceEditGateOffersOneClickAllowAndResend() {
+        // Issue #3681: same one-click-fix treatment as the MCP-mode gate above, for the source-edit
+        // approval gate -- ticks the checkbox and resends instead of leaving prose for the user to
+        // act on.
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
+        JCheckBox allowEdits = findByAccessibleName(panel, "Approve source mutation for Agent mode", JCheckBox.class);
+        JTextComponent customCommand = textComponent(panel, "Optional local agent command");
+        assertAll(
+                () -> assertNotNull(assistantMode),
+                () -> assertNotNull(allowEdits),
+                () -> assertNotNull(customCommand));
+        assistantMode.setSelectedItem("AGENT");
+        allowEdits.setSelected(false);
+        customCommand.setText("custom-agent --unsafe");
+
+        String promptText = "fix this Java test";
+        assistantPrompt(panel).setText(promptText);
+        clickAccessible(panel, "Send assistant prompt");
+
+        JButton fix = findByAccessibleName(panel, "Allow source edits and resend", JButton.class);
+        assertNotNull(fix, "The source-edit gate must offer a one-click fix button, not just prose.");
+        assertFalse(allowEdits.isSelected(), "The checkbox must not flip until the button is clicked.");
+
+        fix.doClick();
+
+        assertAll(
+                () -> assertTrue(allowEdits.isSelected(),
+                        "Clicking the fix must tick the Allow source edits checkbox."),
+                () -> assertEquals(2, countOccurrences(transcriptMarkdown(panel), promptText),
+                        "Clicking the fix must resend the original prompt."),
+                () -> assertNull(findByAccessibleName(panel, "Allow source edits and resend", JButton.class),
+                        "The gate bubble must clear itself once the fix is applied."));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `ShaftAssistantPanel.sendPrompt(...)`'s two deterministic pre-flight gates -- "needs Agent mode for MCP tools" and "needs Allow source edits enabled" -- used to render `showResponse(...)` plain chat text the user had to act on by finding the right control elsewhere in the panel.
- Both now render a one-click confirmation bubble in the transcript: a single button that flips the exact control the gate needs (the `mode` combo box, or the `allowSourceMutation` checkbox) and resends the preserved prompt.
- Reused `AssistantTranscriptView.assistantBubbleWithActions(markdown, actions)` (previously only used by the first-run welcome), generalized with a caller-supplied `accessibleName` parameter instead of a hardcoded one, rather than introducing a new bubble component.
- New `ShaftAssistantPanel.showGateConfirmation(...)` helper renders the bubble via the existing ephemeral `transcript.showWidget(...)` slot (same family as `ToolApprovalPromptPanel`) and resends via the existing `rerun(project)` path, which reuses `lastPrompt`.

## Test plan
- [x] `ShaftPanelSetupTest.assistantAskOrPlanMcpPromptOffersOneClickSwitchToAgentMode` (renamed/rewritten from `assistantAskOrPlanMcpPromptTellsUserToSwitchToAgentMode`) -- written first, watched red, now green: verifies the fix button appears, the mode combo doesn't flip until clicked, and clicking it switches to Agent mode and resends the prompt.
- [x] `ShaftPanelSetupTest.assistantSourceEditGateOffersOneClickAllowAndResend` -- new test, same red/green cycle, for the source-edit approval gate.
- [x] Full `ShaftPanelSetupTest` (187 tests), `AssistantCommandTest` (62), `ShaftAssistantPanelTest` (2), `ShaftAssistantPanelToolCardTest` (4), `ToolApprovalPromptPanelTest` -- all pass, no regressions.
- [x] `./gradlew.bat compileJava compileTestJava` -- clean.

Closes #3681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrmYLoUUVnwXyxrQgEyv3s