### PR TITLE
fix(intellij): stop truncating Assistant chat-bubble and tool-approval messages

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -1034,7 +1034,7 @@ final class AssistantLocalAgentRunner {
                 String toolName = toolNamesByUseId.get(stringField(block, "tool_use_id"));
                 String label = toolName == null ? "tool" : toolName;
                 String text = toolResultText(block.get("content"));
-                String summary = text == null || text.isBlank() ? "(no output)" : truncate(firstLine(text.strip()), 160);
+                String summary = text == null || text.isBlank() ? "(no output)" : text.strip();
                 lines.add((booleanField(block, "is_error") ? "Tool failed (" : "Tool result (") + label + "): " + summary);
             }
             return lines.isEmpty() ? null : String.join("\n", lines);
@@ -1063,7 +1063,7 @@ final class AssistantLocalAgentRunner {
                                 stringField(item, "aggregated_output"), stringField(item, "output"), stringField(item, "result"));
                         if (output != null && !output.isBlank()) {
                             Integer exitCode = intField(item, "exit_code");
-                            String outputSummary = truncate(firstLine(output.strip()), 160);
+                            String outputSummary = output.strip();
                             lines.add(exitCode != null && exitCode != 0
                                     ? "Tool failed (" + label + ", exit " + exitCode + "): " + outputSummary
                                     : "Tool result (" + label + "): " + outputSummary);
@@ -1161,8 +1161,8 @@ final class AssistantLocalAgentRunner {
         /**
          * Picks the first present, non-blank value among the input keys most likely to tell the user
          * what a tool call is actually doing (the command run, the file touched, the pattern searched
-         * for, ...), collapsed to a single line and truncated so a large payload never floods the
-         * transcript. Returns {@code null} when none of the known keys are present rather than
+         * for, ...), collapsed to a single line (but not otherwise truncated -- the user asked to see
+         * full messages). Returns {@code null} when none of the known keys are present rather than
          * guessing at unfamiliar tool schemas.
          */
         private static String toolInputSummary(JsonObject input) {
@@ -1173,7 +1173,7 @@ final class AssistantLocalAgentRunner {
                     "command", "file_path", "path", "pattern", "url", "query", "description", "prompt")) {
                 String value = stringField(input, key);
                 if (value != null && !value.isBlank()) {
-                    return truncate(value.strip().replaceAll("\\s+", " "), 80);
+                    return value.strip().replaceAll("\\s+", " ");
                 }
             }
             return null;
@@ -1205,15 +1205,6 @@ final class AssistantLocalAgentRunner {
                 return parts.isEmpty() ? null : String.join("\n", parts);
             }
             return null;
-        }
-
-        private static String firstLine(String text) {
-            int newlineIndex = text.indexOf('\n');
-            return newlineIndex < 0 ? text : text.substring(0, newlineIndex);
-        }
-
-        private static String truncate(String value, int maxLength) {
-            return value.length() > maxLength ? value.substring(0, maxLength) + "..." : value;
         }
     }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -2171,10 +2171,12 @@ final class ShaftAssistantPanel extends JPanel {
         if (trimmed.isEmpty() || trimmed.startsWith("{") || trimmed.startsWith("[")) {
             return;
         }
-        // A milestone bubble is a single-line-per-entry heartbeat, not a full transcript message, so
-        // long milestone text (a full answer paragraph, a tool call with long arguments) is kept
-        // skimmable.
-        appendAgentMilestone(trimmed.length() > 80 ? trimmed.substring(0, 77) + "..." : trimmed);
+        // Since the #3695 redesign, a milestone renders as its own full chat bubble in the main
+        // transcript (see appendAgentMilestone), not a compact single-line heartbeat entry in a
+        // separate timeline -- so it must show the complete text, unlike the old "Run timeline" list
+        // this fed before #3695. Cutting it short here would silently drop content the user asked to
+        // see in full (e.g. a long tool result or command), so the whole trimmed string is kept as-is.
+        appendAgentMilestone(trimmed);
     }
 
     /** True for a "Calling tool X..." (or "...X (args)...") sub-line naming a denylisted meta-tool. */

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolApprovalPromptPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolApprovalPromptPanel.java
@@ -211,9 +211,7 @@ final class ToolApprovalPromptPanel extends JPanel {
         if (arguments == null || arguments.isEmpty()) {
             return "No arguments.";
         }
-        String json = arguments.toString();
-        int maxLength = 200;
-        return json.length() > maxLength ? json.substring(0, maxLength) + "..." : json;
+        return arguments.toString();
     }
 
     /**

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
@@ -130,7 +130,9 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
     }
 
     @Test
-    void claudeToolResultsTruncateToTheFirstLine() throws Exception {
+    void claudeToolResultsIncludeAllLinesNotJustTheFirst() throws Exception {
+        // Regression: a multi-line tool result used to be silently cut to its first line only, e.g.
+        // hiding the rest of a Bash command's output. The user asked for full messages, no trimming.
         String toolUseEvent = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\","
                 + "\"id\":\"tool-1\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}]}}";
         String toolResultEvent = "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\","
@@ -139,8 +141,35 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
         List<String> lines = run(claudeInvocation(),
                 toolUseEvent + "\n" + toolResultEvent + "\n" + claudeResultEvent("done") + "\n");
 
-        assertTrue(lines.contains("Tool result (Bash): first line"), lines.toString());
-        assertTrue(lines.stream().noneMatch(line -> line.contains("second line")), lines.toString());
+        assertTrue(lines.contains("Tool result (Bash): first line\nsecond line"), lines.toString());
+    }
+
+    @Test
+    void codexToolResultsIncludeAllLinesNotJustTheFirst() throws Exception {
+        // Same fix, Codex side: describeCodexEvent must not cut a multi-line aggregated_output down
+        // to its first line either.
+        String toolEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\","
+                + "\"name\":\"shell\",\"command\":\"ls\",\"aggregated_output\":\"first line\\nsecond line\","
+                + "\"exit_code\":0}}";
+
+        List<String> lines = run(codexInvocation(), toolEvent + "\n" + codexTurnCompletedEvent() + "\n");
+
+        assertTrue(lines.contains("Calling tool shell (ls)...\nTool result (shell): first line\nsecond line"),
+                lines.toString());
+    }
+
+    @Test
+    void claudeToolUseArgumentSummaryIsNotTruncatedForLongCommands() throws Exception {
+        // Regression: toolInputSummary used to cap the "Calling tool X (...)" argument preview to 80
+        // chars, cutting a long Bash command mid-word. The user asked for full messages, no trimming.
+        String longCommand = "npm run build && npm run test && npm run lint && npm run typecheck "
+                + "&& echo build pipeline finished successfully";
+        String toolUseEvent = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\","
+                + "\"id\":\"tool-1\",\"name\":\"Bash\",\"input\":{\"command\":\"" + longCommand + "\"}}]}}";
+
+        List<String> lines = run(claudeInvocation(), toolUseEvent + "\n" + claudeResultEvent("done") + "\n");
+
+        assertTrue(lines.contains("Calling tool Bash (" + longCommand + ")..."), lines.toString());
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2822,6 +2822,24 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantAgentMilestoneBubbleShowsFullLongLineWithoutMidWordTruncation() throws Exception {
+        // Regression: a non-verbose milestone line over 80 chars used to be hard-cut to 77 chars +
+        // "...", producing a mid-word cutoff like "...sun.misc.Unsaf..." (user report with screenshot).
+        // Milestones are full transcript bubbles since #3695, so long content must render in full,
+        // matching Verbose mode's fidelity -- the user asked for full messages, no trimming.
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        String longLine = "Tool result (Bash): WARNING: A terminally deprecated method in "
+                + "sun.misc.Unsafe::allocateInstance has been called";
+
+        appendStreamingLocalAgentBubble(panel, 201);
+        appendLocalAgentOutput(panel, 201, longLine);
+
+        String transcript = transcriptMarkdown(panel);
+        assertTrue(transcript.contains(longLine),
+                "Expected the full milestone line with no truncation, got: " + transcript);
+    }
+
+    @Test
     void assistantVerboseModeShowsLiveAgentOutput() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         JCheckBox verbose = findByAccessibleName(panel, "Show verbose agent output", JCheckBox.class);

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolApprovalPromptPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolApprovalPromptPanelTest.java
@@ -123,6 +123,23 @@ class ToolApprovalPromptPanelTest {
                         "should contain the argument value in readable form"));
     }
 
+    @Test
+    void argumentsSummaryRendersFullJsonWithoutTruncation() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("longValue", "x".repeat(300));
+        ToolApprovalPromptPanel panel = new ToolApprovalPromptPanel(
+                "capture_start", arguments, ToolApprovalPromptPanel.AgentApprovalCapability.STANDARD, decision -> { });
+
+        String argumentsText = argumentsAreaText(panel);
+        String expectedFullJson = arguments.toString();
+
+        assertAll(
+                () -> assertEquals(expectedFullJson, argumentsText,
+                        "arguments JSON must render in full, not truncated"),
+                () -> assertFalse(argumentsText.endsWith("..."),
+                        "arguments JSON must not be truncated with a trailing ellipsis"));
+    }
+
     /**
      * Issue #3696: previously {@code APPROVE_TOOL_ALWAYS} and {@code APPROVE_ALL_TOOLS} rendered
      * with a smaller, gray, unbordered "de-emphasized" look while {@code APPROVE_ONCE} kept full
@@ -186,6 +203,17 @@ class ToolApprovalPromptPanelTest {
                         area.getAccessibleContext().getAccessibleName()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("plain-language summary text area not found"))
+                .getText();
+    }
+
+    private static String argumentsAreaText(ToolApprovalPromptPanel panel) {
+        List<javax.swing.JTextArea> textAreas = new java.util.ArrayList<>();
+        collectTextAreas(panel, textAreas);
+        return textAreas.stream()
+                .filter(area -> "Tool approval arguments".equals(
+                        area.getAccessibleContext().getAccessibleName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("arguments text area not found"))
                 .getText();
     }
 


### PR DESCRIPTION
## Summary
- Removes 4 message-truncation sites in the SHAFT IntelliJ Assistant panel that cut agent/tool messages off mid-word with a trailing "..." (milestone chat bubbles, tool-result narration, tool-call argument previews, and tool-approval argument JSON).
- The chat-bubble truncation was stale behavior left over from before #3695 removed the separate "Run timeline" list — milestones are full chat bubbles now, not a compact heartbeat.
- The tool-approval truncation is more than cosmetic: users need the full arguments to safely approve/deny a tool call.

Closes #3701

## Test plan
- [x] TDD throughout — 4 new/updated tests watched RED then GREEN
- [x] `AssistantLocalAgentRunnerVerboseStreamTest`: 29/29
- [x] `ShaftPanelSetupTest`: 199/199
- [x] `ToolApprovalPromptPanelTest`: 8/8
- [x] All independently re-run and verified, zero failures

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>