### PR TITLE
docs(act-as-fable): bundle TDD implicitly, prefer graphify/gbrain before grep

### DIFF
--- a/.claude/skills/act-as-fable/SKILL.md
+++ b/.claude/skills/act-as-fable/SKILL.md
@@ -196,7 +196,9 @@ Evidence over inference: never claim what you did not observe — run it or
 read it first. Stay strictly inside the assigned scope; report adjacent
 findings, don't fix them. Return conclusions with file:line evidence, not
 file dumps. Report failures plainly — a blocked step honestly reported is a
-success; a polished guess is a defect.
+success; a polished guess is a defect. Production code in scope follows
+`test-driven-development` implicitly — failing test first, watched red, then
+minimal code, watched green — not a skill to separately decide invoking.
 
 ## Ownership: the full loop
 
@@ -255,9 +257,12 @@ decision you must state and justify.
 - **Session start** — `memory load "<task>"`; consult the graphify cache
   before broad exploration (`graphify` skill); `gbrain query` for any repo
   fact you'd otherwise assert from memory (retrieval-reflex).
-- **Production code, feature or bugfix** — `test-driven-development`: failing
-  test first, watched red, then code. The guard hook (R6) reminds you once;
-  don't wait for it.
+- **Finding files or relations** — try `graphify`/`gbrain` before a
+  traditional Grep/Glob sweep; fall back to grep when they don't have it.
+- **Production code, feature or bugfix** — `test-driven-development` is
+  implicit in act-as-fable itself, not a separate opt-in trigger: it applies
+  whether or not invoked by name. Failing test first, watched red, then code.
+  The guard hook (R6) reminds you once; don't wait for it.
 - **Shaping any diff** — the `ponytail` lens: does this need to exist, is it
   already in the codebase, stdlib before custom, one line before fifty. Load
   the full skill for code-heavy changes.

--- a/tools/agent-infra/gbrain-autosync.cmd
+++ b/tools/agent-infra/gbrain-autosync.cmd
@@ -5,5 +5,7 @@ REM --no-pull: never touch git state of working repos; sync what is on disk.
 REM --skip-failed: acknowledge parse failures (e.g. Docusaurus SLUG_MISMATCH,
 REM   ShaftHQ/SHAFT_ENGINE#3618) so one bad file never wedges the sync bookmark.
 REM Exits nonzero harmlessly while a gbrain serve MCP session holds the PGLite lock.
+REM --parallel 4 --workers 4: gbrain doctor's own sync_consolidation check recommends this
+REM   throughput setting; additive to the safety flags above, does not change their behavior.
 REM Logs stay machine-local (never in the repo).
-"%USERPROFILE%\.bun\bin\gbrain.exe" sync --all --no-pull --skip-failed --no-hard-deadline > "%USERPROFILE%\.gbrain\autopilot\autosync.log" 2>&1
+"%USERPROFILE%\.bun\bin\gbrain.exe" sync --all --no-pull --skip-failed --no-hard-deadline --parallel 4 --workers 4 > "%USERPROFILE%\.gbrain\autopilot\autosync.log" 2>&1


### PR DESCRIPTION
## Summary
Two explicit user instructions to persist as standing, source-controlled rules:

1. **TDD is now implicit in act-as-fable.** `test-driven-development` applies to any production code in scope whenever act-as-fable is loaded, whether or not the skill is invoked by name -- updated both the skill-routing table and the Subagent covenant (the text embedded in every delegated subagent prompt).
2. **Prefer graphify/gbrain over grep for file/relation lookups.** New routing bullet: try graphify/gbrain first, fall back to a traditional Grep/Glob sweep when they don't have it.

Also verified and tuned the graphify/gbrain nightly-update wiring per the user's request:
- Confirmed `gbrain-autosync` (every 30 min) and `gbrain-dream` (daily 05:00, also rebuilds `graphify-out/`) Scheduled Tasks are registered and Ready; `gbrain-dream`'s last run succeeded.
- `gbrain-autosync`'s intermittent nonzero exits are the already-documented PGLite single-writer lock contention with a live `gbrain serve` MCP session -- not a config defect (reproduced it live: a CLI sync attempt failed with the exact same message while this session's MCP connection was open).
- Added `--parallel 4 --workers 4` to `gbrain-autosync.cmd`, per `gbrain run_doctor`'s own `sync_consolidation` recommendation -- verified against `gbrain sync --help` as additive to the existing `--no-pull`/`--skip-failed`/`--no-hard-deadline` safety flags, not a replacement.
- `gbrain run_doctor` also surfaced two items outside this PR's scope, flagged for the user rather than silently fixed: a low brain-quality score (45/100, needs its own investigation) and 2 reranker auth failures (`ZEROENTROPY_API_KEY` -- a secret I won't touch).

Tightened the new routing-bullet wording to partially offset added bytes per the standing trim-on-instruction-update rule. The pre-existing `agent-guidance` size-budget overage (already over budget on `main` before this change) is unrelated and not addressed here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>