### PR TITLE
fix(intellij): notification redesign, honest completion summaries, POM/stage-announcement guidance

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/java/CaptureReadinessNotifier.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/java/CaptureReadinessNotifier.java
@@ -1,0 +1,139 @@
+package com.shaft.intellij.java;
+
+import com.google.gson.JsonObject;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.FileEditorManagerListener;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.shaft.intellij.notifications.ShaftNotifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Surfaces the SHAFT Capture generation report's readiness findings as a single, dismissable IDE
+ * notification when the generated test class is actually opened (issue #3705), replacing {@link
+ * CaptureReportAnnotator}'s previous per-finding file-level banners -- those stacked, truncated
+ * with no expand affordance, and could never be dismissed because the {@code Annotator} SPI simply
+ * re-created them on every highlighting pass.
+ *
+ * <p>Registered as a project-wide {@link FileEditorManagerListener} (see plugin.xml's {@code
+ * <projectListeners>}, matching {@code FailedRunDoctorNotifier}'s wiring style) instead of an {@code
+ * Annotator}, so this fires once per real file-open action rather than continuously. {@link
+ * CaptureReportAnnotator#findings(JsonObject)} and {@link CaptureReportAnnotator#reportFor(Path)}
+ * continue to do all the report-loading and finding-flattening work unchanged.</p>
+ *
+ * <p>{@code <projectListeners>} registration gives every project its own instance for the life of
+ * that project (same reasoning as {@code FailedRunDoctorNotifier}'s {@code lastNotifiedAt}), so the
+ * {@link #gate} instance field scopes dedup correctly without a static map leaking across
+ * projects.</p>
+ */
+public final class CaptureReadinessNotifier implements FileEditorManagerListener {
+    private final NotificationGate gate = new NotificationGate();
+
+    @Override
+    public void fileOpened(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
+        if (!file.getName().endsWith(".java")) {
+            return;
+        }
+        Path sourcePath;
+        try {
+            sourcePath = Path.of(file.getPath());
+        } catch (RuntimeException invalidPath) {
+            return;
+        }
+        JsonObject report = CaptureReportAnnotator.reportFor(sourcePath);
+        if (report == null) {
+            return;
+        }
+        gate.evaluate(sourcePath.toString(), report).ifPresent(plan -> fire(source.getProject(), plan));
+    }
+
+    @Override
+    public void fileClosed(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
+        gate.forget(file.getPath());
+    }
+
+    private static void fire(@Nullable Project project, NotificationPlan plan) {
+        if (project == null) {
+            return;
+        }
+        if (plan.warning()) {
+            ShaftNotifier.warn(project, plan.title(), plan.content());
+        } else {
+            ShaftNotifier.info(project, plan.title(), plan.content());
+        }
+    }
+
+    /**
+     * A ready-to-fire notification: title, the full un-truncated findings content, and whether it
+     * should be shown as a warning (BLOCKED readiness or any {@code readinessWarnings}/{@code
+     * warnings}) or as plain info.
+     */
+    record NotificationPlan(String title, String content, boolean warning) {
+    }
+
+    /**
+     * Decides whether a report is worth surfacing and, if so, what to show -- pure and fully unit
+     * testable without any IntelliJ platform types (mirrors {@link CaptureReportAnnotator#findings}'s
+     * PSI-free style). Returns {@link Optional#empty()} for a report with no actionable findings at
+     * all, matching the previous annotator's behavior of creating zero annotations in that case.
+     *
+     * @param report parsed generation report
+     * @return the notification to fire, or empty when there is nothing to say
+     */
+    static Optional<NotificationPlan> plan(JsonObject report) {
+        List<String> findings = CaptureReportAnnotator.findings(report);
+        if (findings.isEmpty()) {
+            return Optional.empty();
+        }
+        String title = "SHAFT Capture readiness: " + findings.size()
+                + (findings.size() == 1 ? " finding" : " findings");
+        String content = findings.stream()
+                .map(finding -> "&#8226; " + finding)
+                .collect(Collectors.joining("<br>"));
+        return Optional.of(new NotificationPlan(title, content, isWarning(report)));
+    }
+
+    private static boolean isWarning(JsonObject report) {
+        return isBlocked(report) || hasEntries(report, "readinessWarnings") || hasEntries(report, "warnings");
+    }
+
+    private static boolean isBlocked(JsonObject report) {
+        return report.has("readiness") && report.get("readiness").isJsonPrimitive()
+                && "BLOCKED".equals(report.get("readiness").getAsString());
+    }
+
+    private static boolean hasEntries(JsonObject report, String key) {
+        return report.has(key) && report.get(key).isJsonArray() && !report.getAsJsonArray(key).isEmpty();
+    }
+
+    /**
+     * Fire-once, refire-on-reopen dedup: remembers the last report content notified per source-file
+     * key so a still-open, unchanged file is not re-notified, while a changed report or a fresh
+     * {@link #forget} (the file being closed, see {@link #fileClosed}) always notifies again.
+     */
+    static final class NotificationGate {
+        private final Map<String, JsonObject> lastNotified = new HashMap<>();
+
+        Optional<NotificationPlan> evaluate(String key, JsonObject report) {
+            JsonObject previous = lastNotified.get(key);
+            if (previous != null && previous.equals(report)) {
+                return Optional.empty();
+            }
+            Optional<NotificationPlan> notificationPlan = plan(report);
+            notificationPlan.ifPresent(ignored -> lastNotified.put(key, report));
+            return notificationPlan;
+        }
+
+        void forget(String key) {
+            lastNotified.remove(key);
+        }
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/java/CaptureReportAnnotator.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/java/CaptureReportAnnotator.java
@@ -3,12 +3,6 @@ package com.shaft.intellij.java;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.intellij.lang.annotation.AnnotationHolder;
-import com.intellij.lang.annotation.Annotator;
-import com.intellij.lang.annotation.HighlightSeverity;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiFile;
-import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,50 +12,33 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Surfaces the SHAFT Capture generation report's readiness findings as file-level IDE
- * annotations on the generated test class (issue #3425 B3): blockers, warnings, flaky steps,
- * unsupported events, and required inputs show up where the developer actually reads the code,
- * instead of only inside a JSON report nobody opens.
+ * Loads and flattens the SHAFT Capture generation report's readiness findings for a generated test
+ * class (issue #3425 B3): blockers, warnings, flaky steps, unsupported events, and required inputs,
+ * so they can be surfaced to the developer instead of sitting only inside a JSON report nobody
+ * opens. The actual surfacing is {@link CaptureReadinessNotifier}'s job (issue #3705) -- this class
+ * is purely the report-loading/parsing/flattening logic it reuses, with no delivery mechanism of
+ * its own.
  *
  * <p>The generated source lives under the generation output root, whose report is written to
- * {@code <outputRoot>/target/shaft-capture/generation-report.json}; this annotator walks up from
- * the file to find that report and only annotates when the report's {@code sourcePath} names the
- * annotated file.</p>
+ * {@code <outputRoot>/target/shaft-capture/generation-report.json}; {@link #reportFor} walks up
+ * from the file to find that report and only returns it when the report's {@code sourcePath} names
+ * the given file.</p>
  */
-public final class CaptureReportAnnotator implements Annotator {
+public final class CaptureReportAnnotator {
     private static final String REPORT_RELATIVE_PATH = "target/shaft-capture/generation-report.json";
     private static final int MAX_PARENT_HOPS = 12;
     private static final int MAX_FINDINGS = 12;
     /** Per-report parse cache keyed by path, invalidated by last-modified time. */
     private static final Map<String, CachedReport> REPORT_CACHE = new ConcurrentHashMap<>();
 
+    private CaptureReportAnnotator() {
+        throw new IllegalStateException("Utility class");
+    }
+
     private record CachedReport(long lastModified, JsonObject report) {
     }
 
-    @Override
-    public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
-        if (!(element instanceof PsiFile file) || file.getVirtualFile() == null
-                || !file.getName().endsWith(".java")) {
-            return;
-        }
-        Path sourcePath;
-        try {
-            sourcePath = Path.of(file.getVirtualFile().getPath());
-        } catch (RuntimeException invalidPath) {
-            return;
-        }
-        JsonObject report = reportFor(sourcePath);
-        if (report == null) {
-            return;
-        }
-        for (String finding : findings(report)) {
-            holder.newAnnotation(HighlightSeverity.WEAK_WARNING, "SHAFT Capture readiness: " + finding)
-                    .fileLevel()
-                    .create();
-        }
-    }
-
-    private static JsonObject reportFor(Path sourcePath) {
+    static JsonObject reportFor(Path sourcePath) {
         Path current = sourcePath.getParent();
         for (int hop = 0; hop < MAX_PARENT_HOPS && current != null; hop++, current = current.getParent()) {
             Path reportFile = current.resolve(REPORT_RELATIVE_PATH);

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -102,7 +102,8 @@ final class AssistantCommand {
                     - If the user described the scenario without a recording, do not stall and do not return unverified locator guesses: start a fresh session with capture_start_codegen, perform the described actions live (element_type, element_click, natural_act), call capture_stop, then pass the persisted recording to capture_generate_replay (replay true, useAi false) so the returned code ships with replay-proven locators.
                     - Choose the recording surface that matches the description: capture_start_codegen for a WebDriver browser flow, or the mobile_record_start / mobile_tap / mobile_type / mobile_record_stop sequence for a native or hybrid mobile flow.
                     - If capture_generate_replay (or its mobile/Playwright equivalents) reports a broken or unhealed locator, call healer_run_failed_test (or playwright_healer_run_failed_test) to self-heal it before returning code, instead of returning a known-broken locator.
-                    - Keep the returned code minimal and project-structure-compliant: one Page Object Model class per described flow, matching this project's existing package/module layout and SHAFT syntax; do not repeat this guidance text back to the user or paste unrelated boilerplate.
+                    - MUST follow the Page Object Model: one Page Object Model class per described flow, holding all locators and action methods, matching this project's existing package/module layout and SHAFT syntax; do not put driver.element()/locator calls directly in a @Test method body -- extract them into a page class. Keep the returned code minimal and project-structure-compliant; do not repeat this guidance text back to the user or paste unrelated boilerplate.
+                    - Write in SHAFT's fluent design and action chaining style: chain calls on the same element/actions object (for example driver.element().click(locator).type(otherLocator, "value")) instead of a separate statement per action; only break the chain when the next step needs a different receiver.
                     - If the user names a site, product, or environment without an explicit URL, ask the user to confirm the exact target URL before navigating or writing code. Do not infer canonical URLs.
                     - For any requested site/action, preserve the user's requested target. Never substitute a different URL, domain, or example page in code or screenshot evidence.
                     - If the user asks for code only, a draft, or says not to run/open a browser, do not call live browser tools.
@@ -2411,11 +2412,15 @@ final class AssistantCommand {
      * excluded so the narrow, deliberately exact-match deterministic triggers they own (issue
      * #3673) are unaffected.
      *
+     * <p>Package-private (not {@code private}) so {@code ShaftAssistantPanel} can reuse this exact
+     * detection as the trigger for its pre-run orchestration-stage announcement (issue #3704),
+     * without reimplementing it.
+     *
      * @param text the natural-language prompt
      * @return whether the text describes a scenario to record and turn into code, not just a bare
      *         recording trigger
      */
-    private static boolean isScenarioDescriptionIntent(String text) {
+    static boolean isScenarioDescriptionIntent(String text) {
         if (isStartRecording(text) || isRecordScenarioIntent(text) || isReRecord(text)) {
             return false;
         }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
@@ -85,6 +85,37 @@ final class AssistantMarkdown {
         return joinSections(sections);
     }
 
+    /**
+     * Renders a failed local-agent CLI run (Claude Code/Codex/etc., not an MCP tool call) with the
+     * same short-headline + details + one-next-action shape {@link #toolFailureMarkdown} uses for
+     * MCP tool failures (issue #3703) -- but with wording that actually fits a local CLI run instead
+     * of the generic "check the SHAFT MCP connection" hint, which makes no sense for a subprocess
+     * timeout or an unauthenticated CLI. A body that already leads with its own bold headline (e.g.
+     * the native-Selenium-rejection narrative) is returned unchanged, matching {@link
+     * #toolFailureMarkdown}'s same guard.
+     *
+     * @param reason the already-humanized failure reason/output (may be blank)
+     * @return the failure markdown
+     */
+    static String localAgentFailureMarkdown(String reason) {
+        String trimmed = reason == null ? "" : reason.strip();
+        if (trimmed.startsWith("**")) {
+            return trimmed;
+        }
+        List<String> sections = new ArrayList<>();
+        sections.add("**" + ShaftStatusPresentation.ERROR_ICON + " The local agent run couldn't finish**");
+        if (!trimmed.isBlank()) {
+            sections.add(trimmed);
+        }
+        boolean timedOut = trimmed.toLowerCase(Locale.ROOT).contains("timed out");
+        sections.add(timedOut
+                ? "_Next: try increasing the timeout, simplifying the request, or confirming your local "
+                + "CLI is authenticated, then resend._"
+                : "_Next: review the details above, or confirm your local CLI is installed and "
+                + "authenticated, then try again._");
+        return joinSections(sections);
+    }
+
     private static Throwable rootCause(Throwable error) {
         Throwable current = error;
         while ((current instanceof CompletionException || current instanceof ExecutionException)

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -2017,6 +2017,13 @@ final class ShaftAssistantPanel extends JPanel {
         if (rejectedGeneratedJava) {
             setStatus("Rejected generated code");
         }
+        // #3703: a local-agent CLI failure (a CLI timeout, a nonzero exit, ...) renders with the same
+        // short-headline + details + one-next-action shape showFinalToolResult already gives MCP tool
+        // failures, instead of leaving the user with only a bare "Failed" milestone bubble. The
+        // rejected-generated-code narrative already carries its own headline, so it is left alone.
+        if (!success && !rejectedGeneratedJava) {
+            response = AssistantMarkdown.localAgentFailureMarkdown(response);
+        }
         showAgentResponse(streamToken, currentStream, response, rejectedGeneratedJava ? "" : output);
         // Milestone appended AFTER the response in both branches, not before: for a live stream
         // (currentStream), showAgentResponse() replaces the transcript's last message (see
@@ -2090,7 +2097,11 @@ final class ShaftAssistantPanel extends JPanel {
         if (currentStream) {
             finishLocalAgentResponse(streamToken, response, output);
         } else {
-            showResponse(response, output);
+            // Not showResponse(): that applies the generic withTokenUsage, which stays silent when no
+            // usage metadata is found. Every local-agent terminal response -- this is the "stale/not
+            // the active stream" branch, still a local-agent run -- must say so explicitly instead
+            // (issue #3703), which withLocalAgentTokenUsage does.
+            persistAndAppendResponse(withLocalAgentTokenUsage(response, output), output);
         }
     }
 
@@ -2202,7 +2213,7 @@ final class ShaftAssistantPanel extends JPanel {
         if (streamToken != activeLocalAgentStreamToken && activeLocalAgentStreamToken != -1) {
             return;
         }
-        String displayResponse = withTokenUsage(response, rawResponse);
+        String displayResponse = withLocalAgentTokenUsage(response, rawResponse);
         AssistantQuestion question = AssistantQuestion.detect(displayResponse);
         String toPersist = question == null ? displayResponse : question.promptMarkdown();
         replaceLocalAgentStreamPlaceholder("assistant", toPersist);
@@ -2401,7 +2412,10 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void showResponse(String response, String rawResponse) {
-        String displayResponse = withTokenUsage(response, rawResponse);
+        persistAndAppendResponse(withTokenUsage(response, rawResponse), rawResponse);
+    }
+
+    private void persistAndAppendResponse(String displayResponse, String rawResponse) {
         AssistantQuestion question = AssistantQuestion.detect(displayResponse);
         String toPersist = question == null ? displayResponse : question.promptMarkdown();
         lastResponse = toPersist;
@@ -2430,6 +2444,26 @@ final class ShaftAssistantPanel extends JPanel {
         }
         return markdown + "\n\n**Tokens consumed:** `" + reported.totalTokens() + "` (input: "
                 + reported.inputTokens() + ", output: " + reported.outputTokens() + ")";
+    }
+
+    /**
+     * Every terminal local-agent run (Completed, Failed, Cancelled, or Killed) must say whether
+     * token usage is known, not just show it when it happens to be parseable (issue #3703): a user
+     * who never sees a token count has no way to tell "this run reported no usage metadata" apart
+     * from "this feature doesn't exist here". {@link #withTokenUsage} already appends the real
+     * numbers when {@code parseTokenUsage} finds them; this adds the explicit "not available"
+     * fallback line on top for local-agent responses only -- unlike {@link #withTokenUsage} itself,
+     * which stays silent by design for every other {@link #showResponse} caller (MCP tool calls,
+     * canned local replies, ...) that never carries token metadata in the first place.
+     */
+    private String withLocalAgentTokenUsage(String response, String rawResponse) {
+        String withUsage = withTokenUsage(response, rawResponse);
+        if (withUsage.isBlank()
+                || LOCAL_AGENT_STREAMING_HEADER.equals(withUsage)
+                || withUsage.toLowerCase(Locale.ROOT).contains("tokens consumed:")) {
+            return withUsage;
+        }
+        return withUsage + "\n\n**Token usage:** not available for this run.";
     }
 
     private void append(String role, String text, String rawResponse) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -1339,6 +1339,7 @@ final class ShaftAssistantPanel extends JPanel {
         }
         if (AssistantLocalAgentRunner.supports(invocation)) {
             captureIntegrationRunning = approvingCaptureReview;
+            maybeAnnounceOrchestrationStages(text);
             int streamToken = ++localAgentStreamToken;
             appendAgentMilestone("Tool selected: local assistant");
             appendAgentMilestone("Running");
@@ -2464,6 +2465,31 @@ final class ShaftAssistantPanel extends JPanel {
             return withUsage;
         }
         return withUsage + "\n\n**Token usage:** not available for this run.";
+    }
+
+    // Issue #3704 (scoped slice): a scenario-description prompt routes to a multi-step orchestrated
+    // local-agent run (record -> act -> save -> codegen -> self-heal, per
+    // AssistantCommand.SHAFT_CODEGEN_TOOL_GUIDANCE). The agent decides its own actual steps, so this
+    // is phrased as an anticipated preview, not a guarantee -- and it is purely informational: it
+    // never blocks or delays the run that follows it.
+    private static final String ORCHESTRATION_STAGE_ANNOUNCEMENT =
+            """
+                    This will likely: 1) record your actions in a browser session, 2) save the recording, \
+                    3) generate SHAFT test code from it, and 4) verify and self-heal any broken locators. \
+                    The agent decides its own actual steps, so treat this as an anticipated plan, not a guarantee.
+                    """.stripIndent().trim();
+
+    /**
+     * Posts a plain informational preview of the anticipated stages before a local-agent run that
+     * is plausibly a multi-step orchestrated flow starts. Reuses {@link
+     * AssistantCommand#isScenarioDescriptionIntent} exactly rather than reinventing detection --
+     * that predicate already recognizes the record -&gt; act -&gt; save -&gt; codegen -&gt;
+     * self-heal orchestration intent (issue #3692). Not a gate: it never blocks or delays the run.
+     */
+    private void maybeAnnounceOrchestrationStages(String text) {
+        if (AssistantCommand.isScenarioDescriptionIntent(text)) {
+            append("assistant", ORCHESTRATION_STAGE_ANNOUNCEMENT, "");
+        }
     }
 
     private void append(String role, String text, String rawResponse) {

--- a/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml
+++ b/shaft-intellij/src/main/resources/META-INF/io.github.shafthq.shaft-withJava.xml
@@ -1,9 +1,5 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
-        <!-- Capture generation-report readiness findings as file-level annotations on the
-             generated test class (issue #3425 B3). -->
-        <annotator language="JAVA"
-                   implementationClass="com.shaft.intellij.java.CaptureReportAnnotator"/>
         <!-- Only needs Java PSI (method annotations); the JUnit/TestNG run-configuration producers
              that actually create run configurations live in their own optional-dependency files
              below because JUnitConfiguration/TestNGConfiguration classes belong to the separate

--- a/shaft-intellij/src/main/resources/META-INF/plugin.xml
+++ b/shaft-intellij/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,13 @@
                   topic="com.intellij.execution.ExecutionListener"/>
         <listener class="com.shaft.intellij.testindex.ShaftTestIndexListener"
                   topic="com.intellij.execution.ExecutionListener"/>
+        <!-- Replaces CaptureReportAnnotator's old per-finding file-level annotator banners (issue
+             #3705): a single dismissable notification, fired once when the generated test class is
+             actually opened rather than on every continuous highlighting pass. Needs only VirtualFile
+             (no PSI), so it is registered here rather than behind the optional com.intellij.java
+             dependency that the old Annotator-based registration required. -->
+        <listener class="com.shaft.intellij.java.CaptureReadinessNotifier"
+                  topic="com.intellij.openapi.fileEditor.FileEditorManagerListener"/>
         <!-- Live pass/fail progression for the "SHAFT Tests" panel (issue #3688): a project-wide
              subscription to every SM Test Runner-driven test run, mirroring the two listeners
              above rather than attaching per-process-handler; see ShaftSmTestRunnerBridge's

--- a/shaft-intellij/src/test/java/com/shaft/intellij/java/CaptureReadinessNotifierTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/java/CaptureReadinessNotifierTest.java
@@ -1,0 +1,158 @@
+package com.shaft.intellij.java;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code fileOpened}/{@code fileClosed} themselves drive {@code FileEditorManager}/{@code Project},
+ * which need a live IntelliJ platform and are not exercised by this lightweight Gradle unit test JVM
+ * (same documented gap as {@code FailedRunDoctorNotifierTest}). This class instead covers every pure
+ * piece those callbacks delegate to: the notification-content decision ({@link
+ * CaptureReadinessNotifier#plan(JsonObject)}) and the fire-once/refire-on-reopen dedup ({@link
+ * CaptureReadinessNotifier.NotificationGate}), both plain Java with no platform types involved.
+ */
+class CaptureReadinessNotifierTest {
+    private static JsonObject json(String text) {
+        return JsonParser.parseString(text).getAsJsonObject();
+    }
+
+    @Test
+    void planProducesExactlyOneNotificationWithTheFullUntruncatedFindingsText() {
+        JsonObject report = json("""
+                {
+                  "readiness": "READY",
+                  "readinessWarnings": ["Step 8 needs a follow-up assertion after navigation."],
+                  "warnings": ["Recording used a positional locator."],
+                  "flakySteps": ["step-3"],
+                  "unsupportedEvents": ["drag-and-drop on canvas"],
+                  "requiredUserInputs": ["data.searchbox-input-4"],
+                  "fallbackLocators": ["#searchbox_input"]
+                }
+                """);
+
+        Optional<CaptureReadinessNotifier.NotificationPlan> plan = CaptureReadinessNotifier.plan(report);
+
+        assertTrue(plan.isPresent());
+        String content = plan.get().content();
+        assertTrue(content.contains("Step 8 needs a follow-up assertion after navigation."));
+        assertTrue(content.contains("Recording used a positional locator."));
+        assertTrue(content.contains("potentially flaky — step-3"));
+        assertTrue(content.contains("not converted to code — drag-and-drop on canvas"));
+        assertTrue(content.contains("input required before running — data.searchbox-input-4"));
+        assertTrue(content.contains("fallback locator — #searchbox_input"));
+        assertFalse(content.contains("..."), "the full findings text must never be clipped with an ellipsis");
+        assertEquals("SHAFT Capture readiness: 6 findings", plan.get().title());
+    }
+
+    @Test
+    void planIsEmptyWhenTheReportHasNoFindingsAtAll() {
+        Optional<CaptureReadinessNotifier.NotificationPlan> plan = CaptureReadinessNotifier.plan(json("{}"));
+
+        assertTrue(plan.isEmpty());
+    }
+
+    @Test
+    void planIsAWarningWhenReadinessIsBlocked() {
+        JsonObject report = json("""
+                {
+                  "readiness": "BLOCKED",
+                  "unsupportedEvents": ["drag-and-drop on canvas"]
+                }
+                """);
+
+        Optional<CaptureReadinessNotifier.NotificationPlan> plan = CaptureReadinessNotifier.plan(report);
+
+        assertTrue(plan.isPresent());
+        assertTrue(plan.get().warning());
+    }
+
+    @Test
+    void planIsAWarningWhenReadinessWarningsArePresentEvenIfNotBlocked() {
+        JsonObject report = json("""
+                {
+                  "readiness": "RISKY",
+                  "readinessWarnings": ["Step 8 needs a follow-up assertion after navigation."]
+                }
+                """);
+
+        Optional<CaptureReadinessNotifier.NotificationPlan> plan = CaptureReadinessNotifier.plan(report);
+
+        assertTrue(plan.isPresent());
+        assertTrue(plan.get().warning());
+    }
+
+    @Test
+    void planIsAWarningWhenWarningsArePresentEvenIfReady() {
+        JsonObject report = json("""
+                {
+                  "readiness": "READY",
+                  "warnings": ["Recording used a positional locator."]
+                }
+                """);
+
+        Optional<CaptureReadinessNotifier.NotificationPlan> plan = CaptureReadinessNotifier.plan(report);
+
+        assertTrue(plan.isPresent());
+        assertTrue(plan.get().warning());
+    }
+
+    @Test
+    void planIsInfoWhenFindingsExistButNoneAreBlockingOrWarnings() {
+        JsonObject report = json("""
+                {
+                  "readiness": "READY",
+                  "flakySteps": ["step-3"]
+                }
+                """);
+
+        Optional<CaptureReadinessNotifier.NotificationPlan> plan = CaptureReadinessNotifier.plan(report);
+
+        assertTrue(plan.isPresent());
+        assertFalse(plan.get().warning());
+    }
+
+    @Test
+    void gateFiresOnceThenSuppressesTheSameUnchangedReport() {
+        CaptureReadinessNotifier.NotificationGate gate = new CaptureReadinessNotifier.NotificationGate();
+        JsonObject report = json("{\"warnings\": [\"Recording used a positional locator.\"]}");
+
+        assertTrue(gate.evaluate("path/A.java", report).isPresent());
+        assertTrue(gate.evaluate("path/A.java", report).isEmpty());
+    }
+
+    @Test
+    void gateFiresAgainWhenTheReportChanges() {
+        CaptureReadinessNotifier.NotificationGate gate = new CaptureReadinessNotifier.NotificationGate();
+        JsonObject original = json("{\"warnings\": [\"Recording used a positional locator.\"]}");
+        JsonObject changed = json("{\"warnings\": [\"Recording used a positional locator.\", \"a new one\"]}");
+
+        assertTrue(gate.evaluate("path/A.java", original).isPresent());
+        assertTrue(gate.evaluate("path/A.java", changed).isPresent());
+    }
+
+    @Test
+    void gateFiresAgainAfterForgetEvenWithTheSameUnchangedReport() {
+        CaptureReadinessNotifier.NotificationGate gate = new CaptureReadinessNotifier.NotificationGate();
+        JsonObject report = json("{\"warnings\": [\"Recording used a positional locator.\"]}");
+
+        assertTrue(gate.evaluate("path/A.java", report).isPresent());
+        gate.forget("path/A.java");
+        assertTrue(gate.evaluate("path/A.java", report).isPresent(),
+                "re-opening the file must notify again even when the report has not changed");
+    }
+
+    @Test
+    void gateNeverRecordsStateForAReportWithNoFindings() {
+        CaptureReadinessNotifier.NotificationGate gate = new CaptureReadinessNotifier.NotificationGate();
+
+        assertTrue(gate.evaluate("path/A.java", json("{}")).isEmpty());
+        assertTrue(gate.evaluate("path/A.java", json("{}")).isEmpty());
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -228,6 +228,11 @@ class AssistantCommandTest {
                 () -> assertTrue(generatedPrompt.contains("Call test_automation_scenarios"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("call shaft_coding_partner_plan"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("Reuse existing tests, page objects"), generatedPrompt),
+                () -> assertTrue(generatedPrompt.contains("MUST follow the Page Object Model"), generatedPrompt),
+                () -> assertTrue(generatedPrompt.contains(
+                        "do not put driver.element()/locator calls directly in a @Test method body"),
+                        generatedPrompt),
+                () -> assertTrue(generatedPrompt.contains("fluent design and action chaining"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("start a fresh session with capture_start_codegen"), generatedPrompt),
                 () -> assertTrue(generatedPrompt.contains("ask the user to confirm the exact target URL"),
                         generatedPrompt),

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
@@ -543,6 +543,41 @@ class AssistantMarkdownTest {
     }
 
     @Test
+    void localAgentFailureMarkdownGivesATimeoutHeadlineAndTimeoutSpecificNextAction() {
+        // Issue #3703: a local-agent CLI timeout must render with the same short-headline +
+        // details + one-next-action shape as an MCP tool failure (toolFailureMarkdown), but with
+        // wording that actually fits a local CLI run instead of the generic MCP-connection hint.
+        String rendered = AssistantMarkdown.localAgentFailureMarkdown("Timed out after 300 seconds.");
+
+        assertAll(
+                () -> assertTrue(rendered.contains("couldn't finish"), rendered),
+                () -> assertTrue(rendered.contains("Timed out after 300 seconds."), rendered),
+                () -> assertTrue(rendered.contains("_Next:"), rendered),
+                () -> assertTrue(rendered.contains("timeout"), rendered));
+    }
+
+    @Test
+    void localAgentFailureMarkdownGivesAGenericFailureAGenericNextAction() {
+        String rendered = AssistantMarkdown.localAgentFailureMarkdown("Claude Code CLI exited with code 1.");
+
+        assertAll(
+                () -> assertTrue(rendered.contains("couldn't finish"), rendered),
+                () -> assertTrue(rendered.contains("Claude Code CLI exited with code 1."), rendered),
+                () -> assertTrue(rendered.contains("_Next:"), rendered),
+                () -> assertFalse(rendered.contains("timeout"), rendered));
+    }
+
+    @Test
+    void localAgentFailureMarkdownLeavesAnAlreadyHeadlinedNarrativeUntouched() {
+        String structured = "**⚠ Rejected generated code — details below**\n\nbody";
+        String rendered = AssistantMarkdown.localAgentFailureMarkdown(structured);
+
+        assertAll(
+                () -> assertEquals(structured, rendered),
+                () -> assertFalse(rendered.contains("couldn't finish"), rendered));
+    }
+
+    @Test
     void formatsDoctorAnalysisReportWithActionsSnippetsAndReportPaths() {
         String markdown = AssistantMarkdown.fromMcpOutput("doctor_analyze_failed_allure", mcpText("""
                 {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2307,6 +2307,67 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantLocalAgentTimeoutShowsFailureReasonBeforeMilestoneAndTokenNote() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        appendStreamingLocalAgentBubble(panel, 9);
+        showAgentResult(panel, 9, ShaftMcpToolResult.failure("Timed out after 300 seconds."));
+
+        String markdown = transcriptMarkdown(panel);
+        int reasonIndex = markdown.indexOf("Timed out after 300 seconds.");
+        int milestoneIndex = markdown.indexOf("Failed (");
+        assertAll(
+                () -> assertTrue(reasonIndex >= 0, "Failure reason must appear in the transcript: " + markdown),
+                () -> assertTrue(milestoneIndex >= 0, "Terminal milestone must appear in the transcript: " + markdown),
+                () -> assertTrue(reasonIndex < milestoneIndex,
+                        "Failure reason should render before the terminal milestone bubble: " + markdown),
+                () -> assertTrue(markdown.toLowerCase(java.util.Locale.ROOT).contains("token"),
+                        "A terminal failure must say whether token usage is available: " + markdown));
+    }
+
+    @Test
+    void assistantLocalAgentFailureUsesConsistentHeadlineAndNextStepCta() throws Exception {
+        // Issue #3703: a local-agent CLI failure must render with the same short-headline +
+        // details + one-next-action shape as an MCP tool failure, not a bare error string.
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        appendStreamingLocalAgentBubble(panel, 10);
+        showAgentResult(panel, 10, ShaftMcpToolResult.failure("Timed out after 300 seconds."));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("couldn't finish"), markdown),
+                () -> assertTrue(markdown.contains("_Next:"), markdown));
+    }
+
+    @Test
+    void assistantLocalAgentCompletedWithoutUsageMetadataStatesTokenUsageNotAvailable() throws Exception {
+        // Issue #3703: silence must never stand in for "no data" -- the user must be able to tell
+        // "no data" apart from "the feature doesn't exist here".
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        appendStreamingLocalAgentBubble(panel, 11);
+        showAgentResult(panel, 11, ShaftMcpToolResult.success("Final answer with no usage metadata."));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.toLowerCase(java.util.Locale.ROOT).contains("token usage"), markdown),
+                () -> assertFalse(markdown.contains("Tokens consumed:"), markdown));
+    }
+
+    @Test
+    void assistantLocalAgentCancelledWithoutUsageMetadataStatesTokenUsageNotAvailable() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        appendStreamingLocalAgentBubble(panel, 12);
+        appendLocalAgentOutput(panel, 12, "partial answer before cancel");
+        showAgentResult(panel, 12, null, new CancellationException("cancelled"));
+
+        String markdown = transcriptMarkdown(panel);
+        assertTrue(markdown.toLowerCase(java.util.Locale.ROOT).contains("token usage"), markdown);
+    }
+
+    @Test
     void assistantLocalAgentStaleCompletionClearsThinkingState() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
         panel.setRunning(true, "Thinking...");

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2541,6 +2541,54 @@ class ShaftPanelSetupTest {
                 () -> assertNull(transcriptWidget(panel), "the card must clear once the user has chosen"));
     }
 
+    /**
+     * Issue #3704 (scoped slice): before a local-agent run that is plausibly a multi-step
+     * orchestrated flow (record -> act -> save -> codegen -> self-heal) starts, the user should see
+     * a plain informational preview of the anticipated stages. The trigger reuses {@code
+     * AssistantCommand#isScenarioDescriptionIntent} exactly (issue #3692) rather than reinventing
+     * detection.
+     *
+     * <p>The announcement helper is invoked directly via reflection rather than through a full
+     * {@code send()} click: {@code send()} for a prompt this detector matches ultimately reaches
+     * {@code AssistantLocalAgentRunner#startWithOptionalCompact}, which spawns a real OS process
+     * (see the javadoc on {@code prepareAgentModeForProposedPlanSwitchesModeAndGrantsSourceEditsAndClearsTheCard}
+     * above for the same constraint) -- unsafe and undesired in a headless unit test.
+     */
+    @Test
+    void scenarioDescriptionPromptTriggersStageAnnouncementBeforeLocalAgentRunStarts() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        String scenarioPrompt =
+                "Record a sample web flow on a practice page, add one assertion, and generate a reviewed test.";
+        assertTrue(AssistantCommand.isScenarioDescriptionIntent(scenarioPrompt), "test precondition");
+
+        Method announce = ShaftAssistantPanel.class.getDeclaredMethod(
+                "maybeAnnounceOrchestrationStages", String.class);
+        announce.setAccessible(true);
+        announce.invoke(panel, scenarioPrompt);
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("This will likely"), markdown),
+                () -> assertTrue(markdown.contains("record"), markdown),
+                () -> assertTrue(markdown.contains("save"), markdown),
+                () -> assertTrue(markdown.contains("generate"), markdown),
+                () -> assertTrue(markdown.contains("self-heal"), markdown));
+    }
+
+    @Test
+    void plainNonOrchestrationPromptDoesNotTriggerStageAnnouncement() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        String plainPrompt = "what does this method do?";
+        assertFalse(AssistantCommand.isScenarioDescriptionIntent(plainPrompt), "test precondition");
+
+        Method announce = ShaftAssistantPanel.class.getDeclaredMethod(
+                "maybeAnnounceOrchestrationStages", String.class);
+        announce.setAccessible(true);
+        announce.invoke(panel, plainPrompt);
+
+        assertFalse(transcriptMarkdown(panel).contains("This will likely"));
+    }
+
     @Test
     void assistantRejectsNativeSeleniumMcpCodeBlocksBeforeApproval() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());


### PR DESCRIPTION
## Summary

Consolidates three independently-scoped fixes for the SHAFT IntelliJ Assistant panel, each addressing one of the user's three critical bug reports. Implemented by three parallel Sonnet agents (worktree-isolated, TDD throughout), merged here into one branch after independent verification.

### Closes #3705 — un-dismissable, un-expandable, truncated readiness banners

Replaced `CaptureReportAnnotator`'s per-finding `Annotator` file-level annotations (persistent, non-dismissable, capped at 12 findings, re-fired every highlighting pass) with a single grouped, dismissable `ShaftNotifier` balloon notification fired once when the generated test file is opened. New `CaptureReadinessNotifier` (`FileEditorManagerListener`, registered in `plugin.xml`'s `<projectListeners>`) with an instance-scoped dedup gate so re-opening an unchanged file doesn't refire. Real IntelliJ Platform SDK shape (no `FILE_OPENED_AND_LOADED` topic in this platform version) was verified against the actual installed jar via `javap`, not assumed from memory.

### Closes #3703 — FAIL messages with no elapsed time / token count, and inconsistent failure formatting

Every terminal local-agent run now explicitly states whether token usage is known (`"**Token usage:** not available for this run."` fallback) instead of silently omitting the line when nothing was parseable — a user can no longer confuse "this run reported nothing" with "this feature doesn't exist." Local-agent CLI failures now get the same headline + body + `_Next: ..._` call-to-action shape as the sibling MCP-tool-call failure path, instead of a bare humanized string.

### Closes #3704 (scoped slice) — no pre-execution stage announcement; codegen not enforcing Page Object Model / fluent chaining

A scenario-description prompt now posts a plain informational preview of the anticipated orchestration stages (record → save → codegen → self-heal) before the local-agent run starts — non-blocking, purely informational, reuses `AssistantCommand.isScenarioDescriptionIntent` exactly rather than reimplementing detection. `SHAFT_CODEGEN_TOOL_GUIDANCE` strengthened: POM is now a MUST (no locator/action calls directly in `@Test` bodies — extract to a page class), plus new explicit guidance for SHAFT's fluent/action-chaining style.

**Not in this PR** — deliberately out of scope: the deeper `CaptureGenerator` architecture change (the deterministic capture→code path doesn't yet emit POM classes at all; the scenario-description/local-agent path already did via the strengthened guidance above). Tracked separately under #3704 for the larger piece.

## Verification (independently rerun by me, not just agent self-report)

```
CaptureReadinessNotifierTest:                     10/10, 0 failures
CaptureReportAnnotatorTest:                        2/2,  0 failures
ShaftPanelSetupTest:                             205/205, 0 failures
AssistantCommandTest:                             71/71, 0 failures
AssistantMarkdownTest:                            38/38, 0 failures
AssistantLocalAgentRunnerVerboseStreamTest:       29/29, 0 failures
ToolApprovalPromptPanelTest:                       8/8,  0 failures
```

Full module suite: 958 tests, 1 failure (`AssistantLocalAgentRunnerCancellationTest.forceCancelCallsDestroyForciblyNotDestroyAndClearsTheProcessReference`) — reran in isolation and it passes; the file isn't touched by any commit in this PR. Pre-existing flaky test, unrelated.

## Merge mechanics

Three agents worked in isolated worktrees against slightly different base commits. Committed each worktree's uncommitted diff, then cherry-picked all three onto a fresh branch off `main`. One real conflict (both #3703 and #3704 added a new private method immediately after `withTokenUsage` in `ShaftAssistantPanel.java`) — resolved by keeping both methods; `ShaftPanelSetupTest.java` auto-merged cleanly. No `.memory/` conflicts.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>