### PR TITLE
Route context lookups through mempalace/graphify; refine followup-issue rule

### DIFF
--- a/.claude/user-harness/CLAUDE.md
+++ b/.claude/user-harness/CLAUDE.md
@@ -11,5 +11,12 @@ Outside SHAFT_ENGINE:
 - `/graphify` -> read and follow
   `C:\Users\Mohab\IdeaProjects\SHAFT_ENGINE\.claude\skills\graphify\references\full-pipeline.md`.
 
+Any project: for past context/history/relationships (what was decided, why,
+who/what's connected), check mempalace (`mempalace_search`/`mempalace_kg_query`,
+or `/mempalace:search`) and graphify first, before grepping around for it
+yourself. Still use `rg`/grep for current file contents and live-code
+verification -- mempalace/graphify reflect what was mined, not necessarily
+the current working tree.
+
 Drift check / deploy:
 `py -3 C:\Users\Mohab\IdeaProjects\SHAFT_ENGINE\scripts\agents\sync_user_harness.py [--apply]`

--- a/.claude/user-harness/settings.json
+++ b/.claude/user-harness/settings.json
@@ -5,7 +5,7 @@
   "permissions": {
     "defaultMode": "bypassPermissions"
   },
-  "model": "claude-fable-5[1m]",
+  "model": "sonnet",
   "statusLine": {
     "type": "command",
     "command": "bash C:/Users/Mohab/.claude/statusline-command.sh"
@@ -13,12 +13,22 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "mcp-server-dev@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "mempalace@mempalace": true
+  },
+  "extraKnownMarketplaces": {
+    "mempalace": {
+      "source": {
+        "source": "github",
+        "repo": "MemPalace/mempalace"
+      }
+    }
   },
   "effortLevel": "high",
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
   "skipWorkflowUsageWarning": true,
+  "theme": "dark",
   "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": false
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ At session start fetch/prune, branch/worktree fresh `ChaosEngine/*` from `origin
 - Docs repo `C:\Users\Mohab\IdeaProjects\shafthq.github.io`; targeted `rg`. Function changes need guide + docs PR.
 - Never expose secrets or run deploy/publish/rewrites/cleanup/cloud suites unless asked.
 - No generated reports, binaries, or `target/`; browser tests headless unless headed approved.
-- Blockers/small issues in path: fix inline. Anything else out-of-scope (enhancement, missing feature, degraded health metric) -- never silently drop: `gh issue create` same session (search first, consolidate). A PR/chat mention alone doesn't count. Don't hunt for extras.
+- Blockers/small issues in path: fix inline. Anything else out-of-scope (enhancement, missing feature, degraded health metric, followup) -- never silently drop or just chat it: interactive -> ask now-vs-issue; noninteractive -> always `gh issue create` same session (search first, consolidate). Don't hunt for extras.
 
 ## Windows/Codex Safety
 
@@ -57,6 +57,7 @@ PowerShell: quote `'-Dname=value'`, `'stash@{0}'`, args with `{}`, `@`, `;`, `&`
 - Docs/report web UI: `frontend-design` -> implement -> shaft-mcp browser evidence (screenshots + `browser_accessibility_audit`). Perf/network regressions: shaft-mcp `browser_network_requests`.
 - Deps/release: `release-dependency-guard` -> `maven-tools-mcp` for live Maven Central facts (in-tree facts: just `rg` the pom) -> `ci-failure-investigator` on breakage.
 - `context7`: past-cutoff library APIs only, else repo exemplars.
+- Context/history/relationships: `mempalace`/`graphify` first, not grep; `rg` still for live code verification (mempalace/graphify can be stale).
 - Skip `jdtls-lsp` for one-liners; value scales with impact. `mcp-server-dev`: net-new tool schema only.
 - Repo `.claude/skills/`: `act-as-fable` methodology (binding: always, every model, every subagent; owns skill-routing triggers + delegation tiers); `shaft-mastery`/`ponytail`/`caveman`/`test-driven-development`/`graphify`/`work-github`.
 


### PR DESCRIPTION
## Summary
- Guidance addition: check mempalace/graphify first for past context, history, and relationships before grepping around for it; `rg` remains the tool for current file state and live-code verification (mempalace/graphify reflect what was mined, not necessarily the live tree). Mirrored in both `AGENTS.md` (repo) and `.claude/user-harness/CLAUDE.md` (deployed globally to `~/.claude/CLAUDE.md`).
- Refined the existing "never silently drop out-of-scope items" rule: in an interactive session, ask the user whether to address a followup/suggestion now or file it as a GitHub issue; in a noninteractive session (loop/automated), always file the issue — a chat mention alone never counts.
- Reconciled `.claude/user-harness/settings.json` (canonical) with the live `~/.claude/settings.json`, which had drifted: `mempalace@mempalace` plugin + its marketplace entry, `theme: dark`, `model: sonnet`.

## Test plan
- [x] `py -3 scripts/ci/validate_agent_setup.py` — passes (copilot host-token budget was pushed over by the initial wording; trimmed AGENTS.md phrasing to fit back under the 2900-token cap; remaining reported failure is on gitignored `.memory/recovery/` local files, unrelated to this change)
- [x] `py -3 scripts/agents/sync_user_harness.py --check` — all three manifest files report IN-SYNC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwokRv8sPdDTdy4UcPxcW4