### PR TITLE
Grid YML: BiDi documentation + hub healthcheck gating; selenium3.yml BiDi warning

### DIFF
--- a/shaft-engine/src/main/resources/docker-compose/selenium3.yml
+++ b/shaft-engine/src/main/resources/docker-compose/selenium3.yml
@@ -4,6 +4,13 @@
 # add '-d' option for detached execution
 # docker-compose -f selenium3.yml down --remove-orphans
 # http://localhost:4444/grid/console
+#
+# WARNING - NO WebDriver BiDi SUPPORT: the Selenium 3.141.59 hub/node protocol predates the
+# WebDriver BiDi specification entirely (BiDi and the `webSocketUrl` opt-in capability were
+# introduced in Selenium 4.6, see https://github.com/SeleniumHQ/selenium/issues/9817). Running
+# through THIS grid, the recorder, network capture, preload scripts, and any other BiDi-backed
+# SHAFT feature cannot work under any client-side configuration -- there is no BiDi endpoint to
+# connect to. Use selenium4.yml for BiDi-capable remote execution.
 version: '3.7'
 services:
    selenium-hub:

--- a/shaft-engine/src/main/resources/docker-compose/selenium4.yml
+++ b/shaft-engine/src/main/resources/docker-compose/selenium4.yml
@@ -3,12 +3,28 @@
 # Add the `-d` flag at the end for detached execution
 # http://localhost:4444/grid/console
 # To stop the execution, hit Ctrl+C, and then `docker compose -f selenium4.yml down --remove-orphans`
+#
+# WebDriver BiDi (recorder / network capture / preload scripts): this is the BiDi-capable grid
+# (selenium3.yml has NO BiDi support at all, see its header). SE_NODE_GRID_URL below is what each
+# node embeds as the externally-reachable base URL for the `webSocketUrl` the Grid Router returns
+# on session creation (Selenium NodeOptions#getPublicGridUri, consumed by LocalNodeFactory) -- it
+# MUST be the exact host:port your SHAFT test client actually reaches this grid on. It is set to
+# `http://localhost:4444` for the documented same-host case (dev machine or CI runner driving
+# Maven directly against `docker compose up` on that same host) -- pair it with
+# `-DexecutionAddress=localhost:4444` (or `http://localhost:4444`) and leave
+# `-DenableBiDi=true`/`SHAFT.Properties.platform.set().enableBiDi(true)` (the default). If your
+# test client instead runs as its own container on this compose network, or the grid is reachable
+# only via a different host/IP, SE_NODE_GRID_URL must be changed to match that reachable address on
+# every node -- a mismatch here breaks only BiDi (webSocketUrl points somewhere the client can't
+# open a websocket to); classic WebDriver HTTP commands keep working because they only ever talk to
+# the Hub's published port. See https://github.com/SeleniumHQ/docker-selenium#grid-url-and-session-timeout
 services:
   chrome:
     image: selenium/node-chrome:4.45.0-20260606
     shm_size: 2gb
     depends_on:
-      - selenium-hub
+      selenium-hub:
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -22,7 +38,8 @@ services:
     image: selenium/node-edge:4.45.0-20260606
     shm_size: 2gb
     depends_on:
-      - selenium-hub
+      selenium-hub:
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -36,7 +53,8 @@ services:
     image: selenium/node-firefox:4.45.0-20260606
     shm_size: 2gb
     depends_on:
-      - selenium-hub
+      selenium-hub:
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -53,3 +71,14 @@ services:
       - "4442:4442"
       - "4443:4443"
       - "4444:4444"
+    # Nodes register over the event bus as soon as their container starts; a plain `depends_on`
+    # (service_started) only waits for the Hub container to exist, not for its Router/EventBus to
+    # actually be listening, which is a documented cold-start race in docker-selenium. Gate node
+    # startup on the Hub's HTTP port actually answering (not on `.value.ready`, which requires
+    # nodes to already be registered and would deadlock the two `service_healthy` waits against
+    # each other). See https://github.com/SeleniumHQ/docker-selenium#adding-a-healthcheck-to-the-grid
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -sf http://localhost:4444/wd/hub/status >/dev/null || exit 1" ]
+      interval: 5s
+      timeout: 10s
+      retries: 20


### PR DESCRIPTION
## What (Closes #3723)

Investigation outcome: `selenium4.yml`'s BiDi-relevant knobs (`SE_NODE_GRID_URL`, `SE_NODE_CONNECTION_LIMIT_PER_SESSION=1000`) were already correct per current docker-selenium/Selenium sources; the engine's remote BiDi wiring (OptionsManager `webSocketUrl:true` → DriverFactoryHelper BiDi augmentation) is structurally sound. The reproducible failure modes were:

1. **Wrong file**: `selenium3.yml` ships beside `selenium4.yml` with no in-file distinction, and Selenium 3 predates WebDriver BiDi entirely — picking it yields exactly "no BiDi works, classic commands fine". It now carries an explicit header warning.
2. **Cold-start race**: nodes register over the event bus before the hub's Router is listening (documented docker-selenium race). The hub now has a `/wd/hub/status` healthcheck and all nodes gate on `service_healthy` (deliberately not `.value.ready`, which would deadlock — see in-file comment).
3. **Undocumented `SE_NODE_GRID_URL` contract**: a mismatch with the client-reachable address breaks only BiDi (the returned `webSocketUrl` points somewhere unreachable) while classic HTTP keeps working. Now documented in-file with the pairing to SHAFT's `executionAddress`.

## Verification

- Every knob verified against current upstream sources (docker-selenium README, SeleniumHQ/selenium#15610, #17089, #9817, NodeOptions#getPublicGridUri source), not memory.
- `docker compose -f selenium4.yml config` / `-f selenium3.yml config` parse cleanly post-edit.
- **Honest caveat**: no live grid run was possible — the Docker daemon is not running on this machine and starting Docker Desktop (GUI) is disallowed for agents. Engine-side findings that gate BiDi features to local execution are filed separately with implementation follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwokRv8sPdDTdy4UcPxcW4