### PR TITLE
IntelliJ: attach files, open editors, and screenshots to the assistant prompt context

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantAttachment.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantAttachment.java
@@ -1,0 +1,37 @@
+package com.shaft.intellij.ui;
+
+/**
+ * One file or image attached to an Assistant prompt via the attach affordances (issue #3727):
+ * current-file / all-open-files / pick-file-from-disk / screenshot. Immutable value held by the
+ * removable chip row in {@link ShaftAssistantPanel} and folded into the outbound prompt text by
+ * {@link AssistantAttachments#outboundBlock}.
+ *
+ * <p>{@code content} is always empty for an image: the outbound transport is text-only (see
+ * {@code AssistantCommand.java}'s {@code arguments.addProperty("prompt", ...)} call sites), so an
+ * image attachment carries only its absolute path -- {@link AssistantAttachments#outboundBlock}
+ * turns that into an explicit note telling a filesystem-capable agent to read the file itself.
+ */
+record AssistantAttachment(String path, String content, boolean image, boolean truncated) {
+    /**
+     * Embedded text-file content longer than this is truncated with a visible note (issue #3727
+     * guard rail), mirroring {@link ShaftAssistantPanel}'s own MAX_AGENT_CONTEXT_CHARACTERS cap on
+     * conversation history.
+     */
+    static final int MAX_CONTENT_CHARACTERS = 16_000;
+
+    static AssistantAttachment forText(String path, String content) {
+        String safe = content == null ? "" : content;
+        boolean overLimit = safe.length() > MAX_CONTENT_CHARACTERS;
+        return new AssistantAttachment(path, overLimit ? safe.substring(0, MAX_CONTENT_CHARACTERS) : safe,
+                false, overLimit);
+    }
+
+    static AssistantAttachment forImage(String path) {
+        return new AssistantAttachment(path, "", true, false);
+    }
+
+    /** Chip label: the file name only, never the full path. */
+    String displayName() {
+        return ShaftAssistantPanel.fileName(path);
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantAttachments.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantAttachments.java
@@ -1,0 +1,74 @@
+package com.shaft.intellij.ui;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Dedupe and outbound-text-formatting helpers for the attach-to-prompt affordances (issue #3727).
+ * Kept separate from {@link ShaftAssistantPanel} so the list bookkeeping and the outbound text
+ * assembly are unit-testable without Swing.
+ */
+final class AssistantAttachments {
+    private AssistantAttachments() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Adds {@code attachment} to {@code attachments}, replacing any existing entry with the same
+     * path instead of appending a duplicate chip (guard rail: dedupe by path). Preserves the order
+     * attachments were first added in; re-adding an existing path keeps its original position.
+     */
+    static List<AssistantAttachment> withAttachment(List<AssistantAttachment> attachments, AssistantAttachment attachment) {
+        Map<String, AssistantAttachment> byPath = new LinkedHashMap<>();
+        for (AssistantAttachment existing : attachments) {
+            byPath.put(existing.path(), existing);
+        }
+        byPath.put(attachment.path(), attachment);
+        return new ArrayList<>(byPath.values());
+    }
+
+    /** Removes the attachment at {@code path}, if present. */
+    static List<AssistantAttachment> withoutAttachment(List<AssistantAttachment> attachments, String path) {
+        List<AssistantAttachment> next = new ArrayList<>();
+        for (AssistantAttachment existing : attachments) {
+            if (!existing.path().equals(path)) {
+                next.add(existing);
+            }
+        }
+        return next;
+    }
+
+    /**
+     * Renders the attachment list as the block folded into the outbound prompt text by {@code
+     * AssistantCommand} (localAgentPrompt/cloudPrompt): a fenced code block per text file with its
+     * path header, and an explicit path note for images -- the outbound transport is text-only
+     * (both {@code autobot_local_agent_run} and {@code autobot_provider_chat} send a single JSON
+     * {@code "prompt"} string property; see AssistantCommand.java's two
+     * {@code arguments.addProperty("prompt", ...)} call sites), so an image's bytes are never
+     * embedded, only its absolute path for a filesystem-capable agent to read.
+     */
+    static String outboundBlock(List<AssistantAttachment> attachments) {
+        if (attachments == null || attachments.isEmpty()) {
+            return "";
+        }
+        StringBuilder block = new StringBuilder("Attached context:");
+        for (AssistantAttachment attachment : attachments) {
+            block.append("\n\n");
+            if (attachment.image()) {
+                block.append("Image attached at: ").append(attachment.path())
+                        .append("\nThis message is text-only: read the file at that absolute path to view "
+                                + "the screenshot; its bytes are not embedded here.");
+            } else {
+                block.append("File: ").append(attachment.path());
+                if (attachment.truncated()) {
+                    block.append(" (truncated to ").append(AssistantAttachment.MAX_CONTENT_CHARACTERS)
+                            .append(" characters)");
+                }
+                block.append("\n```\n").append(attachment.content()).append("\n```");
+            }
+        }
+        return block.toString();
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -623,6 +623,30 @@ final class AssistantCommand {
             boolean allowSourceMutation,
             OpenFileContext openFileContext,
             String conversationContext) {
+        return fromPrompt(prompt, selection, mode, workingDirectory, customCommand, allowSourceMutation,
+                openFileContext, conversationContext, "");
+    }
+
+    /**
+     * Real entry point for building an Assistant invocation from prompt text (issue #3727 adds
+     * {@code attachmentsContext}: the pre-formatted {@link AssistantAttachments#outboundBlock} for
+     * whatever the user attached via the panel's attach affordances -- current file, all open
+     * files, a picked file, or an image path note). Folded into the outbound prompt text alongside
+     * {@code conversationContext} by {@link #localAgentPrompt} and {@link #cloudPrompt}, the only
+     * two call sites that carry a free-text "prompt" argument; direct MCP tool invocations (slash
+     * commands, natural-language tool routing) carry no such field and attachments are not applied
+     * to them (see {@link AssistantAttachments#outboundBlock} javadoc for the transport evidence).
+     */
+    static Invocation fromPrompt(
+            String prompt,
+            Selection selection,
+            String mode,
+            String workingDirectory,
+            String customCommand,
+            boolean allowSourceMutation,
+            OpenFileContext openFileContext,
+            String conversationContext,
+            String attachmentsContext) {
         String text = prompt == null ? "" : prompt.trim();
         if (text.isEmpty()) {
             return Invocation.local("Describe what you need in plain language — record a journey, "
@@ -674,7 +698,8 @@ final class AssistantCommand {
             }
         }
         if (selection.cloud()) {
-            return cloud(text, selection, mode, workingDirectory, openFileContext, conversationContext);
+            return cloud(text, selection, mode, workingDirectory, openFileContext, conversationContext,
+                    attachmentsContext);
         }
         if (!"CLI".equals(selection.runtime())) {
             return Invocation.local("SHAFT is configured for " + selection.displayName()
@@ -688,7 +713,7 @@ final class AssistantCommand {
         // Codex receives the effort as a real CLI config flag in AssistantLocalAgentRunner; the
         // other CLIs have no effort flag, so their prompt carries the preference instead.
         String localPrompt = localAgentPrompt(text, mode, allowSourceMutation, openFileContext,
-                conversationContext);
+                conversationContext, attachmentsContext);
         arguments.addProperty("prompt", "CODEX".equals(selection.family())
                 ? localPrompt
                 : withEffortHint(localPrompt, selection.effort()));
@@ -706,17 +731,24 @@ final class AssistantCommand {
             String mode,
             String workingDirectory,
             OpenFileContext openFileContext,
-            String conversationContext) {
+            String conversationContext,
+            String attachmentsContext) {
         JsonObject arguments = new JsonObject();
         arguments.addProperty("provider", selection.cloudProvider());
         arguments.addProperty("model", selection.cloudModel());
         arguments.addProperty("mode", mode);
         arguments.addProperty("prompt",
-                withEffortHint(cloudPrompt(text, mode, openFileContext, conversationContext), selection.effort()));
+                withEffortHint(cloudPrompt(text, mode, openFileContext, conversationContext, attachmentsContext),
+                        selection.effort()));
         arguments.addProperty("workingDirectory", workingDirectory == null ? "" : workingDirectory);
         arguments.addProperty("timeoutSeconds", DEFAULT_TIMEOUT_SECONDS);
         arguments.addProperty("allowSourceMutation", false);
         return Invocation.tool("autobot_provider_chat", arguments);
+    }
+
+    private static String cloudPrompt(String text, String mode, OpenFileContext openFileContext,
+                                      String conversationContext, String attachmentsContext) {
+        return withAttachments(cloudPrompt(text, mode, openFileContext, conversationContext), attachmentsContext);
     }
 
     private static String cloudPrompt(String text, String mode, OpenFileContext openFileContext,
@@ -2370,7 +2402,8 @@ final class AssistantCommand {
             String mode,
             boolean allowSourceMutation,
             OpenFileContext openFileContext,
-            String conversationContext) {
+            String conversationContext,
+            String attachmentsContext) {
         String lower = text.toLowerCase(Locale.ROOT);
         String normalizedMode = Selection.normalize(mode, "ASK");
         boolean agentMode = "AGENT".equals(normalizedMode);
@@ -2390,6 +2423,7 @@ final class AssistantCommand {
                 : SHAFT_OPTIONS_HINT + "\n\n" + text)
                 : hint + "\n\n" + text;
         withHint = withConversationContext(withHint, conversationContext);
+        withHint = withAttachments(withHint, attachmentsContext);
         if (!agentMode) {
             return withHint;
         }
@@ -2450,6 +2484,19 @@ final class AssistantCommand {
                 Current request:
                 %s
                 """.formatted(context, prompt).stripIndent().trim();
+    }
+
+    /**
+     * Appends the {@link AssistantAttachments#outboundBlock} (issue #3727) to an already-assembled
+     * prompt, mirroring {@link #withConversationContext}'s no-op-when-blank shape. Applied after
+     * conversation context so attachment content always reads as the most recent addition.
+     */
+    private static String withAttachments(String prompt, String attachmentsContext) {
+        String block = text(attachmentsContext);
+        if (block.isBlank()) {
+            return prompt;
+        }
+        return prompt + "\n\n" + block;
     }
 
     private static String codeRequestScope(String mode, OpenFileContext openFileContext) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -180,6 +180,7 @@ final class ShaftAssistantPanel extends JPanel {
     private final JBTextArea prompt;
     private final AssistantTranscriptView transcript;
     private final JButton send;
+    private final JButton attach;
     private final JButton cancel;
     private final JButton copyLastResponse;
     private final JButton copyRawResponse;
@@ -248,6 +249,30 @@ final class ShaftAssistantPanel extends JPanel {
     private String activePlaywrightRecordingPath = AssistantCommand.DEFAULT_PLAYWRIGHT_RECORDING_PATH;
     private RecordingBackend activeRecordingBackend = RecordingBackend.WEBDRIVER;
     private javax.swing.JPanel emptyStateChips;
+    /**
+     * Files/images attached to the next prompt (issue #3727): removable chips rendered by {@link
+     * #refreshAttachmentsChipRow()}, folded into the outbound prompt text via {@link
+     * AssistantAttachments#outboundBlock} from {@link #send(Project)}. Cleared alongside the prompt
+     * text itself once a send actually goes through (mirrors the existing {@code prompt.setText("")}
+     * reset point), but preserved across a pre-flight gate bounce so a resend keeps them.
+     */
+    private List<AssistantAttachment> attachments = new ArrayList<>();
+    private javax.swing.JPanel attachmentsChipRow;
+    /**
+     * Resolves the current editor's content for "Add current file" (issue #3727). Defaults to the
+     * existing {@link #openFileContext(Project)} static helper so production behavior is unchanged;
+     * overridden via reflection in headless tests (no real {@code FileEditorManager} without a live
+     * IDE project) to simulate an open editor, per the "current-file... actions with simulated
+     * editors" TDD requirement.
+     */
+    private java.util.function.Function<Project, AssistantCommand.OpenFileContext> currentEditorFileProvider =
+            ShaftAssistantPanel::openFileContext;
+    /**
+     * Resolves every open editor's content for "Add all open files" (issue #3727). Same
+     * test-injection rationale as {@link #currentEditorFileProvider}.
+     */
+    private java.util.function.Function<Project, List<AssistantCommand.OpenFileContext>> openEditorFilesProvider =
+            ShaftAssistantPanel::realOpenEditorFiles;
     private CaptureReview pendingCaptureReview;
     private boolean generateCaptureReviewAfterStop;
     private boolean captureReviewGenerationRunning;
@@ -479,6 +504,8 @@ final class ShaftAssistantPanel extends JPanel {
         ShaftIconButtons.widen(send, 64);
         send.setToolTipText(SEND_TOOLTIP);
         bindSendHover();
+        attach = button("Attach", "Attach files or images to the prompt", event -> showAttachMenu());
+        ShaftIconButtons.apply(attach, ShaftIcons.ATTACH);
         cancel = button("Cancel", "Cancel assistant request", event -> cancelOrKillCurrent());
         ShaftIconButtons.apply(cancel, ShaftIcons.CANCEL);
         cancel.setEnabled(false);
@@ -608,7 +635,8 @@ final class ShaftAssistantPanel extends JPanel {
         routeRow.add(verboseAgentOutput);
         routeRow.add(autoCompact);
 
-        JPanel sendActions = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
+        JPanel sendActions = new JPanel(new FlowLayout(FlowLayout.RIGHT, 4, 0));
+        sendActions.add(attach);
         sendActions.add(send);
         JPanel promptActions = new JPanel(new BorderLayout(6, 0));
         promptActions.add(sendActions, BorderLayout.EAST);
@@ -631,7 +659,14 @@ final class ShaftAssistantPanel extends JPanel {
         JBScrollPane promptScroll = new JBScrollPane(prompt);
         promptScroll.setMinimumSize(JBUI.size(320, 108));
         promptScroll.setPreferredSize(JBUI.size(560, 120));
-        composer.add(buildEmptyStateChips(), BorderLayout.NORTH);
+        // BoxLayout (not a plain BorderLayout NORTH slot), matching the {@code notices} panel
+        // precedent above: the attachments chip row is hidden by default (no attachments yet) and
+        // must collapse to zero height rather than reserve blank space (issue #3727).
+        JPanel composerTop = new JPanel();
+        composerTop.setLayout(new BoxLayout(composerTop, BoxLayout.Y_AXIS));
+        composerTop.add(buildAttachmentsChipRow());
+        composerTop.add(buildEmptyStateChips());
+        composer.add(composerTop, BorderLayout.NORTH);
         composer.add(promptScroll, BorderLayout.CENTER);
         composer.add(cloudKeyPanel, BorderLayout.WEST);
         composer.add(composerFooter, BorderLayout.SOUTH);
@@ -1217,7 +1252,9 @@ final class ShaftAssistantPanel extends JPanel {
         }
     }
 
-    private static String fileName(String path) {
+    /** Package-private (not private): reused by {@link AssistantAttachment#displayName()} so an
+     * attachment chip's label uses the same file-name-only convention as the rest of the panel. */
+    static String fileName(String path) {
         if (path == null || path.isBlank()) {
             return "current";
         }
@@ -1245,6 +1282,10 @@ final class ShaftAssistantPanel extends JPanel {
         String selectedMode = String.valueOf(mode.getSelectedItem());
         String workingDirectory = project == null || project.getBasePath() == null ? "" : project.getBasePath();
         String conversationContext = conversationContextForPrompt();
+        // Issue #3727: attachments fold into the outbound prompt text only (never into the
+        // display bubble appended below, and never into the capture-review approval path, which
+        // carries no free-text prompt for attachments to join).
+        String attachmentsContext = AssistantAttachments.outboundBlock(attachments);
         boolean approvingCaptureReview = pendingCaptureReview != null && AssistantCommand.isCaptureApproval(text);
         AssistantCommand.Invocation invocation = approvingCaptureReview
                 ? AssistantCommand.approvedCaptureIntegration(
@@ -1261,7 +1302,8 @@ final class ShaftAssistantPanel extends JPanel {
                 customCommand.getText(),
                 allowSourceMutation.isSelected(),
                 openFileContext(project),
-                conversationContext);
+                conversationContext,
+                attachmentsContext);
         invocation = routeNaturalStopToActiveRecorder(text, invocation);
         if (!approvingCaptureReview
                 && !ShaftProjectDetector.isShaftProject(project)
@@ -1304,6 +1346,10 @@ final class ShaftAssistantPanel extends JPanel {
             return;
         }
         prompt.setText("");
+        if (!attachments.isEmpty()) {
+            attachments = List.of();
+            refreshAttachmentsChipRow();
+        }
         if (invocation.isLocal()) {
             appendTerminalAgentMilestone("Completed");
             showLocalResponse(invocation.localResponse());
@@ -2869,6 +2915,180 @@ final class ShaftAssistantPanel extends JPanel {
             prompt.requestFocusInWindow();
         });
         return chip;
+    }
+
+    /**
+     * Removable-chip row for prompt attachments (issue #3727): current file / all open files / a
+     * picked file / a picked image, added via {@link #showAttachMenu()}. Hidden (zero height, via
+     * the {@code composerTop} BoxLayout) whenever {@link #attachments} is empty.
+     */
+    private javax.swing.JPanel buildAttachmentsChipRow() {
+        attachmentsChipRow = new javax.swing.JPanel(new WrapLayout(java.awt.FlowLayout.LEFT, 6, 0));
+        attachmentsChipRow.getAccessibleContext().setAccessibleName("Prompt attachments");
+        attachmentsChipRow.setOpaque(false);
+        attachmentsChipRow.setVisible(false);
+        return attachmentsChipRow;
+    }
+
+    private void refreshAttachmentsChipRow() {
+        attachmentsChipRow.removeAll();
+        for (AssistantAttachment attachment : attachments) {
+            attachmentsChipRow.add(attachmentChip(attachment));
+        }
+        attachmentsChipRow.setVisible(!attachments.isEmpty());
+        attachmentsChipRow.revalidate();
+        attachmentsChipRow.repaint();
+        Container parent = attachmentsChipRow.getParent();
+        if (parent != null) {
+            parent.revalidate();
+            parent.repaint();
+        }
+    }
+
+    /** One removable attachment chip: name plus a trailing "×", the whole chip is the remove control. */
+    private JButton attachmentChip(AssistantAttachment attachment) {
+        JButton chip = new JButton(attachment.displayName() + "  ×");
+        chip.getAccessibleContext().setAccessibleName("Remove attachment " + attachment.displayName());
+        String note = attachment.truncated()
+                ? " (truncated to " + AssistantAttachment.MAX_CONTENT_CHARACTERS + " characters)"
+                : "";
+        chip.setToolTipText((attachment.image() ? "Attached image: " : "Attached file: ")
+                + attachment.path() + note + " — click to remove");
+        chip.setMargin(JBUI.insets(1, 8));
+        chip.addActionListener(event -> removeAttachment(attachment.path()));
+        return chip;
+    }
+
+    private void addAttachment(AssistantAttachment attachment) {
+        attachments = AssistantAttachments.withAttachment(attachments, attachment);
+        refreshAttachmentsChipRow();
+    }
+
+    private void removeAttachment(String path) {
+        attachments = AssistantAttachments.withoutAttachment(attachments, path);
+        refreshAttachmentsChipRow();
+    }
+
+    /** Popup menu behind the {@link #attach} toolbar button: the four attach affordances from
+     * issue #3727 -- current file, all open files, a picked file, a picked image. */
+    private void showAttachMenu() {
+        JPopupMenu menu = new JPopupMenu("Attach to prompt");
+        JMenuItem currentFile = new JMenuItem("Add current file");
+        currentFile.addActionListener(event -> addCurrentFileAttachment());
+        JMenuItem allOpenFiles = new JMenuItem("Add all open files");
+        allOpenFiles.addActionListener(event -> addAllOpenFilesAttachments());
+        JMenuItem pickFile = new JMenuItem("Attach file from disk…");
+        pickFile.addActionListener(event -> attachFileFromDisk());
+        JMenuItem pickImage = new JMenuItem("Attach screenshot or image…");
+        pickImage.addActionListener(event -> attachImageFromDisk());
+        menu.add(currentFile);
+        menu.add(allOpenFiles);
+        menu.addSeparator();
+        menu.add(pickFile);
+        menu.add(pickImage);
+        menu.show(attach, 0, attach.getHeight());
+    }
+
+    private void addCurrentFileAttachment() {
+        AssistantCommand.OpenFileContext current = currentEditorFileProvider.apply(project);
+        if (current == null || !current.present()) {
+            setStatus("No file is open to attach");
+            return;
+        }
+        addAttachment(AssistantAttachment.forText(current.path(), current.text()));
+        setStatus("Attached " + fileName(current.path()));
+    }
+
+    private void addAllOpenFilesAttachments() {
+        List<AssistantCommand.OpenFileContext> openFiles = openEditorFilesProvider.apply(project);
+        List<AssistantCommand.OpenFileContext> present = openFiles == null ? List.of() : openFiles.stream()
+                .filter(AssistantCommand.OpenFileContext::present)
+                .toList();
+        if (present.isEmpty()) {
+            setStatus("No open editor files to attach");
+            return;
+        }
+        for (AssistantCommand.OpenFileContext file : present) {
+            addAttachment(AssistantAttachment.forText(file.path(), file.text()));
+        }
+        setStatus("Attached " + present.size() + " open file" + (present.size() == 1 ? "" : "s"));
+    }
+
+    private void attachFileFromDisk() {
+        File selected = chooseFile("Attach File", null);
+        if (selected != null) {
+            attachFileAtPath(selected.toPath());
+        }
+    }
+
+    private void attachImageFromDisk() {
+        File selected = chooseFile("Attach Screenshot or Image",
+                new FileNameExtensionFilter("Images", "png", "jpg", "jpeg", "gif", "bmp"));
+        if (selected != null) {
+            attachImageAtPath(selected.toPath());
+        }
+    }
+
+    /**
+     * Reads {@code path} and adds it as a text attachment. Package-private (not private): factored
+     * out of {@link #attachFileFromDisk()} so headless tests can exercise the real read/attach logic
+     * without driving a {@link JFileChooser} dialog.
+     */
+    void attachFileAtPath(Path path) {
+        try {
+            String content = Files.readString(path);
+            addAttachment(AssistantAttachment.forText(path.toAbsolutePath().toString(), content));
+            setStatus("Attached " + path.getFileName());
+        } catch (IOException | RuntimeException unreadable) {
+            setStatus("Could not read " + path.getFileName());
+        }
+    }
+
+    /** Same test-seam rationale as {@link #attachFileAtPath}, for the image-attach affordance. */
+    void attachImageAtPath(Path path) {
+        addAttachment(AssistantAttachment.forImage(path.toAbsolutePath().toString()));
+        setStatus("Attached image " + path.getFileName());
+    }
+
+    private File chooseFile(String title, FileNameExtensionFilter filter) {
+        JFileChooser chooser = new JFileChooser(lastSaveDirectory().toFile());
+        chooser.setDialogTitle(title);
+        if (filter != null) {
+            chooser.setFileFilter(filter);
+        }
+        if (chooser.showOpenDialog(this) != JFileChooser.APPROVE_OPTION) {
+            return null;
+        }
+        return chooser.getSelectedFile();
+    }
+
+    /** Default {@link #openEditorFilesProvider}: every open editor's path and text, via the real
+     * {@link FileEditorManager} (production path; headless tests inject a fake provider instead). */
+    private static List<AssistantCommand.OpenFileContext> realOpenEditorFiles(Project project) {
+        if (project == null) {
+            return List.of();
+        }
+        try {
+            FileEditorManager manager = FileEditorManager.getInstance(project);
+            List<AssistantCommand.OpenFileContext> files = new ArrayList<>();
+            for (VirtualFile virtualFile : manager.getOpenFiles()) {
+                String text = readVirtualFileText(virtualFile);
+                if (!text.isEmpty()) {
+                    files.add(new AssistantCommand.OpenFileContext(virtualFile.getPath(), text));
+                }
+            }
+            return files;
+        } catch (RuntimeException | Error headlessTestEnvironment) {
+            return List.of();
+        }
+    }
+
+    private static String readVirtualFileText(VirtualFile virtualFile) {
+        try {
+            return com.intellij.openapi.vfs.VfsUtilCore.loadText(virtualFile);
+        } catch (IOException | RuntimeException unreadable) {
+            return "";
+        }
     }
 
     private void updateActionChrome() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftIcons.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftIcons.java
@@ -9,6 +9,7 @@ import java.awt.Graphics;
 
 public final class ShaftIcons {
     public static final Icon ADD = load("add");
+    public static final Icon ATTACH = load("attach");
     public static final Icon CANCEL = load("cancel");
     public static final Icon CHECK = load("check");
     public static final Icon CLEAR = load("clear");

--- a/shaft-intellij/src/main/resources/icons/actions/attach.svg
+++ b/shaft-intellij/src/main/resources/icons/actions/attach.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10.6 3.9 5.8 8.7a2.1 2.1 0 0 0 3 3l4.6-4.6a3.6 3.6 0 0 0-5.1-5.1L3.6 6.7a5.1 5.1 0 0 0 7.2 7.2"
+        fill="none" stroke="#6C707E" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/shaft-intellij/src/main/resources/icons/actions/attach_dark.svg
+++ b/shaft-intellij/src/main/resources/icons/actions/attach_dark.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10.6 3.9 5.8 8.7a2.1 2.1 0 0 0 3 3l4.6-4.6a3.6 3.6 0 0 0-5.1-5.1L3.6 6.7a5.1 5.1 0 0 0 7.2 7.2"
+        fill="none" stroke="#CED0D6" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -72,6 +72,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import javax.swing.text.JTextComponent;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -223,6 +224,307 @@ class ShaftPanelSetupTest {
                 () -> assertEquals("playwright_recording_code_blocks", invocation.toolName()),
                 () -> assertEquals("recordings/custom-playwright.json",
                         invocation.arguments().get("recordingPath").getAsString()));
+    }
+
+    // ---- Attach-to-prompt affordances (issue #3727): current file / all open files / a disk file /
+    // an image, rendered as removable chips near the composer and folded into the outbound prompt
+    // text sent to the local-agent or cloud-provider MCP tool. ----
+
+    @Test
+    void fromPromptFoldsAttachmentsBlockIntoLocalAgentPromptText() {
+        String attachmentsBlock = AssistantAttachments.outboundBlock(List.of(
+                AssistantAttachment.forText("src/main/java/Foo.java", "class Foo {}")));
+
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Explain this class",
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "ASK",
+                ".",
+                "",
+                false,
+                AssistantCommand.OpenFileContext.empty(),
+                "",
+                attachmentsBlock);
+
+        String promptText = invocation.arguments().get("prompt").getAsString();
+        assertAll(
+                () -> assertTrue(promptText.contains("Attached context:"), promptText),
+                () -> assertTrue(promptText.contains("File: src/main/java/Foo.java"), promptText),
+                () -> assertTrue(promptText.contains("class Foo {}"), promptText));
+    }
+
+    @Test
+    void fromPromptFoldsAttachmentsBlockIntoCloudPromptText() {
+        String attachmentsBlock = AssistantAttachments.outboundBlock(List.of(
+                AssistantAttachment.forText("Notes.txt", "remember to check locators")));
+
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Summarize this",
+                AssistantCommand.Selection.cloud("openai", "gpt-4.1"),
+                "ASK",
+                ".",
+                "",
+                false,
+                AssistantCommand.OpenFileContext.empty(),
+                "",
+                attachmentsBlock);
+
+        String promptText = invocation.arguments().get("prompt").getAsString();
+        assertAll(
+                () -> assertEquals("autobot_provider_chat", invocation.toolName()),
+                () -> assertTrue(promptText.contains("Notes.txt"), promptText),
+                () -> assertTrue(promptText.contains("remember to check locators"), promptText));
+    }
+
+    @Test
+    void fromPromptWithoutAttachmentsContextBuildsPromptUnchanged() {
+        AssistantCommand.Invocation withoutAttachments = AssistantCommand.fromPrompt(
+                "Explain this class", "CODEX", "ASK", ".", "", false);
+
+        assertFalse(withoutAttachments.arguments().get("prompt").getAsString().contains("Attached context:"));
+    }
+
+    @Test
+    void outboundBlockTruncatesOversizedTextAttachmentWithVisibleNote() {
+        String huge = "x".repeat(AssistantAttachment.MAX_CONTENT_CHARACTERS + 500);
+        AssistantAttachment attachment = AssistantAttachment.forText("Big.java", huge);
+        String block = AssistantAttachments.outboundBlock(List.of(attachment));
+
+        assertAll(
+                () -> assertTrue(attachment.truncated()),
+                () -> assertEquals(AssistantAttachment.MAX_CONTENT_CHARACTERS, attachment.content().length()),
+                () -> assertTrue(block.contains("truncated to " + AssistantAttachment.MAX_CONTENT_CHARACTERS
+                        + " characters"), block));
+    }
+
+    @Test
+    void outboundBlockNotesImagePathInsteadOfEmbeddingBytes() {
+        AssistantAttachment image = AssistantAttachment.forImage("C:\\shots\\bug.png");
+        String block = AssistantAttachments.outboundBlock(List.of(image));
+
+        assertAll(
+                () -> assertTrue(block.contains("C:\\shots\\bug.png"), block),
+                () -> assertTrue(block.contains("text-only"), block),
+                () -> assertEquals("", image.content()));
+    }
+
+    @Test
+    void withAttachmentDedupesByPathReplacingEarlierEntry() {
+        List<AssistantAttachment> firstAdd = AssistantAttachments.withAttachment(
+                List.of(), AssistantAttachment.forText("Foo.java", "first"));
+        List<AssistantAttachment> secondAdd = AssistantAttachments.withAttachment(
+                firstAdd, AssistantAttachment.forText("Foo.java", "second"));
+
+        assertAll(
+                () -> assertEquals(1, secondAdd.size()),
+                () -> assertEquals("second", secondAdd.get(0).content()));
+    }
+
+    @Test
+    void addCurrentFileAttachmentUsesInjectedProviderAndShowsRemovableChip() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        setField(panel, "currentEditorFileProvider",
+                (Function<Project, AssistantCommand.OpenFileContext>)
+                        p -> new AssistantCommand.OpenFileContext("SignInTest.java", "class SignInTest {}"));
+
+        invokePrivate(panel, "addCurrentFileAttachment");
+
+        @SuppressWarnings("unchecked")
+        List<AssistantAttachment> attachments = (List<AssistantAttachment>) getField(panel, "attachments");
+        JPanel chipRow = (JPanel) getField(panel, "attachmentsChipRow");
+        assertAll(
+                () -> assertEquals(1, attachments.size()),
+                () -> assertEquals("SignInTest.java", attachments.get(0).path()),
+                () -> assertTrue(chipRow.isVisible()),
+                () -> assertEquals(1, chipRow.getComponentCount()),
+                () -> assertTrue(((JButton) chipRow.getComponent(0)).getText().contains("SignInTest.java")));
+    }
+
+    @Test
+    void addCurrentFileAttachmentWithNoOpenFileShowsStatusAndAddsNothing() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        setField(panel, "currentEditorFileProvider",
+                (Function<Project, AssistantCommand.OpenFileContext>) p -> AssistantCommand.OpenFileContext.empty());
+
+        invokePrivate(panel, "addCurrentFileAttachment");
+
+        assertAll(
+                () -> assertTrue(((List<?>) getField(panel, "attachments")).isEmpty()),
+                () -> assertTrue(containsText(panel, "No file is open to attach")));
+    }
+
+    @Test
+    void addAllOpenFilesAttachmentsUsesInjectedProviderForEverySimulatedEditor() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        setField(panel, "openEditorFilesProvider",
+                (Function<Project, List<AssistantCommand.OpenFileContext>>) p -> List.of(
+                        new AssistantCommand.OpenFileContext("Foo.java", "class Foo {}"),
+                        new AssistantCommand.OpenFileContext("Bar.java", "class Bar {}")));
+
+        invokePrivate(panel, "addAllOpenFilesAttachments");
+
+        @SuppressWarnings("unchecked")
+        List<AssistantAttachment> attachments = (List<AssistantAttachment>) getField(panel, "attachments");
+        assertAll(
+                () -> assertEquals(2, attachments.size()),
+                () -> assertTrue(attachments.stream().anyMatch(a -> a.path().equals("Foo.java"))),
+                () -> assertTrue(attachments.stream().anyMatch(a -> a.path().equals("Bar.java"))));
+    }
+
+    @Test
+    void addAllOpenFilesAttachmentsWithNoOpenEditorsShowsStatusAndAddsNothing() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        setField(panel, "openEditorFilesProvider",
+                (Function<Project, List<AssistantCommand.OpenFileContext>>) p -> List.of());
+
+        invokePrivate(panel, "addAllOpenFilesAttachments");
+
+        assertAll(
+                () -> assertTrue(((List<?>) getField(panel, "attachments")).isEmpty()),
+                () -> assertTrue(containsText(panel, "No open editor files to attach")));
+    }
+
+    @Test
+    void attachFileAtPathReadsRealFileFromDiskAndAddsAttachment(@TempDir Path tempDir) throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        Path file = tempDir.resolve("notes.txt");
+        Files.writeString(file, "attach me");
+
+        panel.attachFileAtPath(file);
+
+        @SuppressWarnings("unchecked")
+        List<AssistantAttachment> attachments = (List<AssistantAttachment>) getField(panel, "attachments");
+        assertAll(
+                () -> assertEquals(1, attachments.size()),
+                () -> assertEquals("attach me", attachments.get(0).content()),
+                () -> assertFalse(attachments.get(0).image()));
+    }
+
+    @Test
+    void attachFileAtPathTruncatesOversizedFileWithVisibleChipNote(@TempDir Path tempDir) throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        Path file = tempDir.resolve("big.txt");
+        Files.writeString(file, "y".repeat(AssistantAttachment.MAX_CONTENT_CHARACTERS + 1000));
+
+        panel.attachFileAtPath(file);
+
+        @SuppressWarnings("unchecked")
+        List<AssistantAttachment> attachments = (List<AssistantAttachment>) getField(panel, "attachments");
+        JPanel chipRow = (JPanel) getField(panel, "attachmentsChipRow");
+        JButton chip = (JButton) chipRow.getComponent(0);
+        assertAll(
+                () -> assertTrue(attachments.get(0).truncated()),
+                () -> assertTrue(chip.getToolTipText().contains("truncated"), chip.getToolTipText()));
+    }
+
+    @Test
+    void attachImageAtPathAddsImageAttachmentWithoutReadingBytes(@TempDir Path tempDir) throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        Path image = tempDir.resolve("screenshot.png");
+        Files.write(image, new byte[]{(byte) 0x89, 'P', 'N', 'G'});
+
+        panel.attachImageAtPath(image);
+
+        @SuppressWarnings("unchecked")
+        List<AssistantAttachment> attachments = (List<AssistantAttachment>) getField(panel, "attachments");
+        assertAll(
+                () -> assertEquals(1, attachments.size()),
+                () -> assertTrue(attachments.get(0).image()),
+                () -> assertEquals("", attachments.get(0).content()),
+                () -> assertEquals(image.toAbsolutePath().toString(), attachments.get(0).path()));
+    }
+
+    @Test
+    void attachingSamePathTwiceDedupesInsteadOfDuplicatingChip(@TempDir Path tempDir) throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        Path file = tempDir.resolve("dup.txt");
+        Files.writeString(file, "v1");
+        panel.attachFileAtPath(file);
+        Files.writeString(file, "v2");
+        panel.attachFileAtPath(file);
+
+        @SuppressWarnings("unchecked")
+        List<AssistantAttachment> attachments = (List<AssistantAttachment>) getField(panel, "attachments");
+        JPanel chipRow = (JPanel) getField(panel, "attachmentsChipRow");
+        assertAll(
+                () -> assertEquals(1, attachments.size()),
+                () -> assertEquals("v2", attachments.get(0).content()),
+                () -> assertEquals(1, chipRow.getComponentCount()));
+    }
+
+    @Test
+    void clickingAttachmentChipRemovesItAndHidesRowWhenEmpty(@TempDir Path tempDir) throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        Path file = tempDir.resolve("removable.txt");
+        Files.writeString(file, "content");
+        panel.attachFileAtPath(file);
+
+        JPanel chipRow = (JPanel) getField(panel, "attachmentsChipRow");
+        JButton chip = (JButton) chipRow.getComponent(0);
+        chip.doClick();
+
+        assertAll(
+                () -> assertTrue(((List<?>) getField(panel, "attachments")).isEmpty()),
+                () -> assertFalse(chipRow.isVisible()),
+                () -> assertEquals(0, chipRow.getComponentCount()));
+    }
+
+    @Test
+    void sendClearsAttachmentsOnceThePromptActuallyGoesThrough(@TempDir Path tempDir) throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        Path file = tempDir.resolve("clearMe.txt");
+        Files.writeString(file, "content");
+        panel.attachFileAtPath(file);
+        assertEquals(1, ((List<?>) getField(panel, "attachments")).size());
+
+        JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
+        assistantMode.setSelectedItem("ASK");
+        JTextComponent prompt = assistantPrompt(panel);
+        prompt.setText("/help");
+
+        Method send = ShaftAssistantPanel.class.getDeclaredMethod("send", Project.class);
+        send.setAccessible(true);
+        send.invoke(panel, (Project) null);
+
+        assertAll(
+                () -> assertEquals("", prompt.getText()),
+                () -> assertTrue(((List<?>) getField(panel, "attachments")).isEmpty()),
+                () -> assertFalse(((JPanel) getField(panel, "attachmentsChipRow")).isVisible()));
+    }
+
+    /**
+     * A pre-flight gate bounce (e.g. "switch to Agent mode and resend") must not silently drop
+     * attachments the user already picked -- it returns before the {@code prompt.setText("")} reset
+     * point that also clears attachments, mirroring how it preserves the typed prompt text for the
+     * same resend.
+     */
+    @Test
+    void sendPreservesAttachmentsWhenBlockedByAPreflightGate(@TempDir Path tempDir) throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        Path file = tempDir.resolve("keepMe.txt");
+        Files.writeString(file, "content");
+        panel.attachFileAtPath(file);
+
+        // Same known-good MCP-access-gate trigger as
+        // assistantAskOrPlanMcpPromptOffersOneClickSwitchToAgentMode: PLAN mode plus a prompt that
+        // needs shaft-mcp browser tool access trips the "Switch to Agent mode" gate in send()
+        // before the prompt/attachments reset point.
+        JComboBox<?> assistantMode = findByAccessibleName(panel, "Assistant mode", JComboBox.class);
+        assistantMode.setSelectedItem("PLAN");
+        assistantPrompt(panel).setText("open duckduckgo and search for SHAFT Engine");
+        clickAccessible(panel, "Send assistant prompt");
+
+        assertAll(
+                () -> assertNotNull(findByAccessibleName(panel, "Switch to Agent mode and resend", JButton.class),
+                        "Precondition: the gate must actually have fired"),
+                () -> assertEquals(1, ((List<?>) getField(panel, "attachments")).size(),
+                        "A gate bounce must preserve attachments for the resend, just like it preserves the prompt text"));
+    }
+
+    private static void invokePrivate(Object target, String methodName) throws Exception {
+        Method method = target.getClass().getDeclaredMethod(methodName);
+        method.setAccessible(true);
+        method.invoke(target);
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -127,6 +127,7 @@ class ShaftPluginScreenshotRendererTest {
 
         Path assistantLightScreenshot = outputPath.resolve("intellij-plugin-assistant.png");
         Path assistantEmptyScreenshot = outputPath.resolve("intellij-plugin-assistant-empty.png");
+        Path assistantAttachmentsScreenshot = outputPath.resolve("intellij-plugin-assistant-attachments.png");
         Path assistantEmptyNarrowScreenshot = outputPath.resolve("intellij-plugin-assistant-empty-narrow.png");
         Path assistantDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-dark.png");
         Path assistantNarrowDarkScreenshot = outputPath.resolve("intellij-plugin-assistant-narrow-dark.png");
@@ -165,6 +166,7 @@ class ShaftPluginScreenshotRendererTest {
 
         write(assistantLightScreenshot, renderToolWindow(0, "", LIGHT_THEME, false));
         write(assistantEmptyScreenshot, renderAssistantEmpty(LIGHT_THEME, false));
+        write(assistantAttachmentsScreenshot, renderAssistantWithAttachments(LIGHT_THEME, false));
         write(assistantEmptyNarrowScreenshot, renderAssistantEmpty(DARK_THEME, true, NARROW_WIDTH, HEIGHT));
         write(assistantDarkScreenshot, renderToolWindow(0, "", DARK_THEME, true));
         write(assistantNarrowDarkScreenshot, renderToolWindow(0, "", DARK_THEME, true, NARROW_WIDTH, HEIGHT));
@@ -203,6 +205,7 @@ class ShaftPluginScreenshotRendererTest {
         assertAll(
                 () -> assertTrue(Files.size(assistantLightScreenshot) > 0, assistantLightScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantEmptyScreenshot) > 0, assistantEmptyScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantAttachmentsScreenshot) > 0, assistantAttachmentsScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantEmptyNarrowScreenshot) > 0, assistantEmptyNarrowScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantDarkScreenshot) > 0, assistantDarkScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantNarrowDarkScreenshot) > 0, assistantNarrowDarkScreenshot + " should be non-empty"),
@@ -241,6 +244,7 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(Files.size(mcpGuideScreenshot) > 0, mcpGuideScreenshot + " should be non-empty"),
                 () -> assertDimensions(assistantLightScreenshot),
                 () -> assertDimensions(assistantEmptyScreenshot),
+                () -> assertDimensions(assistantAttachmentsScreenshot),
                 () -> assertDimensions(assistantEmptyNarrowScreenshot, NARROW_WIDTH, HEIGHT),
                 () -> assertDimensions(assistantDarkScreenshot),
                 () -> assertDimensions(assistantNarrowDarkScreenshot, NARROW_WIDTH, HEIGHT),
@@ -462,6 +466,44 @@ class ShaftPluginScreenshotRendererTest {
             image.set(render(component, width, height));
         });
         return image.get();
+    }
+
+    /**
+     * Renders the composer with the attach affordances populated (issue #3727): the "Attach" toolbar
+     * button beside Send, and a removable chip per attachment above the prompt -- a picked file, a
+     * large file truncated with a visible note, and a picked image. Attaches through the same
+     * package-private {@code attachFileAtPath}/{@code attachImageAtPath} seams {@code
+     * ShaftPanelSetupTest} drives directly (real temp files on disk, not reflection), so this shot
+     * documents the exact production code path a real "Attach file from disk…" pick would run.
+     */
+    private static BufferedImage renderAssistantWithAttachments(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException, IOException {
+        Path fixtureDirectory = Files.createTempDirectory("shaft-assistant-attachments");
+        Path smallFile = fixtureDirectory.resolve("SignInTest.java");
+        Files.writeString(smallFile, ASSISTANT_SHAFT_CODE_SAMPLE);
+        Path largeFile = fixtureDirectory.resolve("huge-log.txt");
+        Files.writeString(largeFile, "x".repeat(20_000));
+        Path image = fixtureDirectory.resolve("failure-screenshot.png");
+        Files.write(image, new byte[]{(byte) 0x89, 'P', 'N', 'G'});
+
+        AtomicReference<BufferedImage> screenshot = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftSettingsState.Settings settings = defaultSettings();
+            ShaftAssistantPanel component = new ShaftAssistantPanel(screenshotProject(), settings,
+                    new ShaftAssistantChatState(), () -> {
+                    });
+            component.attachFileAtPath(smallFile);
+            component.attachFileAtPath(largeFile);
+            component.attachImageAtPath(image);
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+            screenshot.set(render(component, WIDTH, HEIGHT));
+        });
+        return screenshot.get();
     }
 
     private static BufferedImage renderAssistantLiveOutput(String lookAndFeelClassName, boolean dark)


### PR DESCRIPTION
## What (Closes #3727)

The assistant composer gains a paperclip attach button with quick actions — current editor file, all open files, pick a file from disk, attach a screenshot/image — rendered as removable chips above the prompt. Attached content is folded into the outbound prompt: text files as fenced blocks with path headers; images as an explicit absolute-path note (the outbound MCP transport is text-only — both call sites send a single JSON `prompt` string, `AssistantCommand.java` `autobot_local_agent_run`/`autobot_provider_chat` — so a filesystem-capable agent reads the image from the noted path; documented in `AssistantAttachments.outboundBlock`'s javadoc).

Guard rails: path-dedupe (re-add replaces), 16k-char size cap with a visible truncation note in both the outbound block and chip tooltip, attachments cleared at the same reset point as the prompt text and preserved across a pre-flight gate bounce.

## Verification (draft-first + TDD)

- Draft check: rendered the composed UI against the unmodified baseline via the screenshot renderer before finalizing — chip row collapses to zero height when empty (no layout regression); renders shared with the owner. A pre-existing unlabeled icon button spotted in both renders is filed as #3741.
- Watched red: with the implementation stashed and new classes moved aside, `compileTestJava` fails with 41 `cannot find symbol` errors for exactly the missing feature surface; restored → green.
- `ShaftPanelSetupTest`: 225/225 (17 new tests: chip add/remove, current-file/all-open-files with simulated editors, outbound content, size cap, gate-bounce preservation). Full module: 972 tests, 1 pre-existing flaky failure in an untouched process-timing test (passes in isolation).
- Rebased onto main after #3740 (both touch `AssistantCommand.java`); combined `ShaftPanelSetupTest` + `AssistantCommandTest` rerun on the rebased branch: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwokRv8sPdDTdy4UcPxcW4