### PR TITLE
Remote BiDi-enabled sessions get real HasAuthentication basic auth instead of silent URL-credential fallback

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -633,18 +633,29 @@ public class DriverFactoryHelper {
             else {
                 var driver = new RemoteWebDriver(targetExecutionUrlObject, capabilities, createRemoteWebDriverClientConfig(targetExecutionUrlObject));
                 driver.setFileDetector(new LocalFileDetector());
+                // Note: org.openqa.selenium.remote.Augmenter#addDriverAugmentation returns a NEW
+                // Augmenter (immutable builder) rather than mutating `this`; every call below must
+                // reassign `augmenter`, otherwise the added augmentation is silently discarded.
                 var augmenter = new Augmenter();
                 var targetBrowser = SHAFT.Properties.web.targetBrowserName().toLowerCase();
-                if (Arrays.asList("chrome", "edge").contains(targetBrowser)) {
-                    augmenter.addDriverAugmentation(new AddHasCdp() {
+                var isChromiumBrowser = Arrays.asList("chrome", "edge").contains(targetBrowser);
+                if (isChromiumBrowser) {
+                    augmenter = augmenter.addDriverAugmentation(new AddHasCdp() {
                         @Override
                         public Map<String, CommandInfo> getAdditionalCommands() {
                             return Map.of();
                         }
                     });
                 }
-                if (SHAFT.Properties.platform.enableBiDi())
-                    augmenter.addDriverAugmentation(new BiDiProvider());
+                if (SHAFT.Properties.platform.enableBiDi()) {
+                    augmenter = augmenter.addDriverAugmentation(new BiDiProvider());
+                    if (isChromiumBrowser) {
+                        // Selenium's HasAuthentication is CDP-backed (org.openqa.selenium.remote.AddHasAuthentication),
+                        // not auto-discovered via ServiceLoader for RemoteWebDriver, so navigateToURLWithBasicAuthentication
+                        // would otherwise always fall back to URL-embedded credentials on remote executions (issue #3732).
+                        augmenter = augmenter.addDriverAugmentation(new AddHasAuthentication());
+                    }
+                }
                 return augmenter.augment(driver);
             }
         } catch (Throwable throwable) {

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -490,10 +490,15 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
     public BrowserActions navigateToURLWithBasicAuthentication(String targetUrl, String username, String password, String targetUrlAfterAuthentication) {
         try {
             String domainName = browserActionsHelper.getDomainNameFromUrl(targetUrl);
-            if (SHAFT.Properties.platform.executionAddress().equals("local")) {
+            var strategy = browserActionsHelper.determineBasicAuthenticationStrategy(
+                    SHAFT.Properties.platform.executionAddress(), SHAFT.Properties.platform.enableBiDi());
+            if (strategy == BrowserActionsHelper.BasicAuthenticationStrategy.NATIVE_HAS_AUTHENTICATION) {
                 Predicate<URI> uriPredicate = uri -> uri.getHost().contains(domainName);
                 ((HasAuthentication) driverFactoryHelper.getDriver()).register(uriPredicate, UsernameAndPassword.of(username, password));
             } else {
+                ReportManagerHelper.logDiscrete("Basic authentication downgraded to URL-embedded credentials: execution is remote and "
+                        + "SHAFT.Properties.platform.enableBiDi() is disabled, so no native HasAuthentication handler can be provisioned "
+                        + "on the remote driver. Enable BiDi to use the native handler for remote executions.", Level.WARN);
                 targetUrl = browserActionsHelper.formatUrlForBasicAuthentication(username, password, targetUrl);
             }
         } catch (Exception e) {

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
@@ -576,4 +576,44 @@ public class BrowserActionsHelper {
         InternetDomainName internetDomainName = InternetDomainName.from(host).topPrivateDomain();
         return internetDomainName.toString();
     }
+
+    /**
+     * The basic-authentication mechanism selected by {@link #determineBasicAuthenticationStrategy}.
+     */
+    public enum BasicAuthenticationStrategy {
+        /**
+         * Register a {@link org.openqa.selenium.HasAuthentication} handler on the driver instance
+         * (CDP-backed for Chromium browsers, augmented for remote sessions when BiDi is enabled).
+         */
+        NATIVE_HAS_AUTHENTICATION,
+        /**
+         * Embed the credentials directly in the target URL as a fallback for drivers/executions
+         * that cannot provide a native authentication handler.
+         */
+        URL_EMBEDDED_CREDENTIALS
+    }
+
+    /**
+     * Decides which basic-authentication mechanism {@link com.shaft.gui.browser.BrowserActions#navigateToURLWithBasicAuthentication}
+     * should use, given the current execution address and whether BiDi is enabled.
+     *
+     * <p>Local executions always get a real, directly-implemented {@code HasAuthentication} driver
+     * (ChromeDriver/EdgeDriver implement it natively via CDP), so they always use the native path.
+     * Remote executions only get a real {@code HasAuthentication} handler when BiDi is enabled,
+     * because that is the flag SHAFT.Properties.platform.enableBiDi() gates the remote driver's
+     * {@code Augmenter} wiring on (see {@code DriverFactoryHelper.connectToRemoteServer}); when BiDi
+     * is disabled remotely there is no augmented handler to register against, so credentials must be
+     * embedded in the URL instead (issue #3732).
+     *
+     * @param executionAddress the current {@code SHAFT.Properties.platform.executionAddress()} value
+     * @param biDiEnabled       the current {@code SHAFT.Properties.platform.enableBiDi()} value
+     * @return {@link BasicAuthenticationStrategy#NATIVE_HAS_AUTHENTICATION} when a real authentication
+     * handler can be provisioned, otherwise {@link BasicAuthenticationStrategy#URL_EMBEDDED_CREDENTIALS}
+     */
+    public BasicAuthenticationStrategy determineBasicAuthenticationStrategy(String executionAddress, boolean biDiEnabled) {
+        boolean isLocalExecution = "local".equalsIgnoreCase(executionAddress);
+        return (isLocalExecution || biDiEnabled)
+                ? BasicAuthenticationStrategy.NATIVE_HAS_AUTHENTICATION
+                : BasicAuthenticationStrategy.URL_EMBEDDED_CREDENTIALS;
+    }
 }

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
@@ -220,8 +220,12 @@ public class BrowserActionsCoverageUnitTest {
     }
 
     @Test
-    public void navigateWithBasicAuthenticationShouldEmbedCredentialsForRemoteExecution() {
+    public void navigateWithBasicAuthenticationShouldEmbedCredentialsForRemoteExecutionWhenBiDiIsDisabled() {
+        // Regression for issue #3732: remote execution is genuinely incapable of the native
+        // HasAuthentication handler only when BiDi is disabled; that is the case this URL-embedded
+        // fallback exists for.
         SHAFT.Properties.platform.set().executionAddress("remote-grid");
+        SHAFT.Properties.platform.set().enableBiDi(false);
         when(driver.getCurrentUrl()).thenReturn("https://example.com/start");
 
         browserActions.navigateToURLWithBasicAuthentication(
@@ -231,6 +235,26 @@ public class BrowserActionsCoverageUnitTest {
                 "https://example.com/secure");
 
         Mockito.verify(navigation).to("https://user:pass@example.com/secure");
+    }
+
+    @Test
+    public void navigateWithBasicAuthenticationShouldUseNativeHandlerForRemoteExecutionWhenBiDiIsEnabled() {
+        // Regression for issue #3732: remote execution with BiDi enabled (the default) must use the
+        // real HasAuthentication.register() handler instead of silently downgrading to URL-embedded
+        // credentials, so BasicAuthenticationTests#basicAuthenticationWebdriverBidi actually exercises
+        // the BiDi-augmented path remotely.
+        SHAFT.Properties.platform.set().executionAddress("remote-grid");
+        SHAFT.Properties.platform.set().enableBiDi(true);
+        when(driver.getCurrentUrl()).thenReturn("https://example.com/start");
+
+        browserActions.navigateToURLWithBasicAuthentication(
+                "https://example.com/secure",
+                "user",
+                "pass",
+                "https://example.com/secure");
+
+        Mockito.verify((HasAuthentication) driver).register(any(), any());
+        Mockito.verify(navigation).to("https://example.com/secure");
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java
@@ -145,4 +145,28 @@ public class BrowserActionsHelperCoverageUnitTest {
                     "Navigate to url \"https://example.com/path\".", null, com.shaft.tools.io.internal.CheckpointStatus.PASS));
         }
     }
+
+    // Regression for issue #3732: navigateToURLWithBasicAuthentication used to gate the native
+    // HasAuthentication path solely on `executionAddress == "local"`, so remote executions always
+    // silently fell back to URL-embedded credentials even when BiDi was enabled. The decision is
+    // extracted here so local/remote x bidi-on/off -> expected strategy is unit-testable headlessly.
+    @Test
+    public void shouldSelectNativeAuthenticationForLocalExecutionRegardlessOfBiDi() {
+        Assert.assertEquals(helper.determineBasicAuthenticationStrategy("local", false),
+                BrowserActionsHelper.BasicAuthenticationStrategy.NATIVE_HAS_AUTHENTICATION);
+        Assert.assertEquals(helper.determineBasicAuthenticationStrategy("local", true),
+                BrowserActionsHelper.BasicAuthenticationStrategy.NATIVE_HAS_AUTHENTICATION);
+    }
+
+    @Test
+    public void shouldSelectNativeAuthenticationForRemoteExecutionWhenBiDiIsEnabled() {
+        Assert.assertEquals(helper.determineBasicAuthenticationStrategy("http://grid:4444/wd/hub", true),
+                BrowserActionsHelper.BasicAuthenticationStrategy.NATIVE_HAS_AUTHENTICATION);
+    }
+
+    @Test
+    public void shouldFallBackToUrlEmbeddedCredentialsForRemoteExecutionWhenBiDiIsDisabled() {
+        Assert.assertEquals(helper.determineBasicAuthenticationStrategy("http://grid:4444/wd/hub", false),
+                BrowserActionsHelper.BasicAuthenticationStrategy.URL_EMBEDDED_CREDENTIALS);
+    }
 }


### PR DESCRIPTION
## What (Closes #3732)

`navigateToURLWithBasicAuthentication` gated native `HasAuthentication` on `executionAddress == "local"`, silently downgrading every remote run to URL-embedded credentials even with BiDi enabled (the default). Two-layer root cause, both fixed:

1. **The gate** — replaced with an extracted, unit-tested `BasicAuthenticationStrategy` decision (local → native; remote → native iff BiDi enabled, else loud WARN + fallback).
2. **Missing remote wiring + a latent discard bug** — `RemoteWebDriver` only gets `HasAuthentication` via an explicit `AddHasAuthentication` augmentation (not ServiceLoader-discovered; verified via javap on Selenium 4.46.0), which SHAFT never added. Worse, `Augmenter#addDriverAugmentation` returns a new immutable instance, and the existing calls discarded the return value — so `AddHasCdp` was silently a no-op for every remote Chrome/Edge session. Now reassigned and extended with `AddHasAuthentication` for remote Chromium + BiDi.

Also fact-checked: `HasAuthentication` is CDP-backed (Chromium-only), not BiDi-backed, despite the test naming — recorded in memory.

## Verification (TDD)

- Watched red: 3 new strategy tests fail compile (`cannot find symbol`) before implementation; green after — 9/9.
- The regression sweep exposed a pre-existing test asserting the buggy behavior (`...ShouldEmbedCredentialsForRemoteExecution` with BiDi defaulted on) — split into BiDi-disabled (fallback preserved) and BiDi-enabled (asserts `HasAuthentication.register()` called, URL untouched): 19/19.
- Full `executionAddress` sweep across all modules: table of every site with verdicts — the basic-auth site was the only silent BiDi downgrade.
- Harvest rerun on this branch: BrowserActions + helper + DriverFactoryHelper coverage suites, exit 0. Honest caveat: no live grid run (no Docker daemon); grounded in verified Selenium bytecode behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwokRv8sPdDTdy4UcPxcW4