### PR TITLE
Grid YML verified against docker-selenium guide: CDP/Augmenter contract documented

### DIFF
--- a/shaft-engine/src/main/resources/docker-compose/selenium4.yml
+++ b/shaft-engine/src/main/resources/docker-compose/selenium4.yml
@@ -15,9 +15,13 @@
 # `-DenableBiDi=true`/`SHAFT.Properties.platform.set().enableBiDi(true)` (the default). If your
 # test client instead runs as its own container on this compose network, or the grid is reachable
 # only via a different host/IP, SE_NODE_GRID_URL must be changed to match that reachable address on
-# every node -- a mismatch here breaks only BiDi (webSocketUrl points somewhere the client can't
-# open a websocket to); classic WebDriver HTTP commands keep working because they only ever talk to
-# the Hub's published port. See https://github.com/SeleniumHQ/docker-selenium#grid-url-and-session-timeout
+# every node -- a mismatch here breaks every websocket-backed feature: BiDi (webSocketUrl) AND
+# CDP/Augmenter access (se:cdp -- what HasAuthentication-based remote basic auth and DevTools
+# features ride on; upstream names SE_NODE_GRID_URL as the requirement for RemoteWebDriver
+# builder/Augmenter in Selenium 4). Classic WebDriver HTTP commands keep working because they only
+# ever talk to the Hub's published port. Note: CDP-backed features (e.g. basic auth via
+# HasAuthentication) are Chromium-only (chrome/edge nodes); firefox is BiDi-only.
+# See https://github.com/SeleniumHQ/docker-selenium#grid-url-and-session-timeout
 services:
   chrome:
     image: selenium/node-chrome:4.45.0-20260606


### PR DESCRIPTION
## What (Closes #3746)

Verification of `selenium4.yml` against the current docker-selenium README (Grid Url and Session Timeout): every knob the guide names is already correctly set — `SE_NODE_GRID_URL` on all three nodes, `SE_NODE_CONNECTION_LIMIT_PER_SESSION=1000` (websocket exhaustion), explicit `SE_NODE_SESSION_TIMEOUT=7200`, hub healthcheck gating. The one gap was documentation: the in-file comment claimed a Grid-URL mismatch "breaks only BiDi", but upstream explicitly ties `SE_NODE_GRID_URL` to CDP/Augmenter access as well — which is what #3744's remote `HasAuthentication` basic auth rides on. The comment now covers both websocket-backed protocols and notes CDP-backed features are Chromium-only (firefox is BiDi-only).

`docker compose config` parses clean post-edit. No functional changes required — configuration confirmed fully BiDi+CDP capable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwokRv8sPdDTdy4UcPxcW4