### PR TITLE
Mask basic-auth password in Playwright navigate URL logs

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/browser/BrowserActions.java
@@ -29,8 +29,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContract {
+    // Matches embedded credentials in URLs (e.g. protocol://user:password@host); compiled once for reuse
+    private static final Pattern EMBEDDED_PASSWORD_PATTERN = Pattern.compile(":\\/\\/.*:(.*)@");
+
     private final PlaywrightSession session;
 
     public BrowserActions(PlaywrightSession session) {
@@ -102,9 +107,10 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
 
     @Override
     public BrowserActions navigateToURL(String targetUrl) {
-        return timedPageLoad("playwright.browser.navigateToURL", targetUrl, () -> {
+        String loggedUrl = obfuscateEmbeddedPassword(targetUrl);
+        return timedPageLoad("playwright.browser.navigateToURL", loggedUrl, () -> {
             page().navigate(targetUrl);
-            ReportManager.log("Navigate to url \"" + targetUrl + "\".");
+            ReportManager.log("Navigate to url \"" + loggedUrl + "\".");
         });
     }
 
@@ -595,6 +601,14 @@ public class BrowserActions implements com.shaft.gui.driver.BrowserActionsContra
             BrowserPerformanceExecutionReport.recordBrowserAction(actionName, durationNanos);
             BrowserPerformanceExecutionReport.recordPageLoad(pageName, durationNanos);
         }
+    }
+
+    private String obfuscateEmbeddedPassword(String targetUrl) {
+        Matcher matcher = EMBEDDED_PASSWORD_PATTERN.matcher(targetUrl);
+        if (matcher.find()) {
+            return targetUrl.replaceAll(matcher.group(1), "•".repeat(matcher.group(1).length()));
+        }
+        return targetUrl;
     }
 
     private org.openqa.selenium.Cookie toSeleniumCookie(Cookie cookie) {

--- a/shaft-engine/src/test/java/com/shaft/gui/playwright/browser/PlaywrightBrowserActionsUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/playwright/browser/PlaywrightBrowserActionsUnitTest.java
@@ -5,7 +5,9 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Route;
 import com.shaft.gui.browser.internal.PlaywrightNetworkInterceptor;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
+import com.shaft.tools.io.ReportManager;
 import com.shaft.validation.accessibility.AccessibilityActions;
+import org.mockito.MockedStatic;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -13,13 +15,17 @@ import org.testng.annotations.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -120,5 +126,29 @@ public class PlaywrightBrowserActionsUnitTest {
 
         Assert.assertSame(actions.routeFromHar(harFile.toString()), actions);
         Assert.assertNotNull(handler.get());
+    }
+
+    @Test
+    public void shouldMaskPasswordWhenLoggingBasicAuthenticationUrl() {
+        PlaywrightSession session = mock(PlaywrightSession.class);
+        Page page = mock(Page.class);
+        when(session.page()).thenReturn(page);
+        BrowserActions actions = new BrowserActions(session);
+
+        List<String> loggedMessages = new ArrayList<>();
+        try (MockedStatic<ReportManager> reportManager = mockStatic(ReportManager.class)) {
+            reportManager.when(() -> ReportManager.log(anyString())).thenAnswer(invocation -> {
+                loggedMessages.add(invocation.getArgument(0));
+                return null;
+            });
+
+            actions.navigateToURLWithBasicAuthentication(
+                    "https://example.com/secure", "user", "secretPass", null);
+        }
+
+        verify(page).navigate("https://user:secretPass@example.com/secure");
+        String logged = String.join("\n", loggedMessages);
+        Assert.assertFalse(logged.contains("secretPass"));
+        Assert.assertTrue(logged.contains("••••••••••"));
     }
 }


### PR DESCRIPTION
## Summary
- Playwright's `navigateToURL` logged the full URL, so `navigateToURLWithBasicAuthentication` leaked the raw password into Allure/console (`https://user:password@host`).
- Mask the embedded password before logging, reusing the same `EMBEDDED_PASSWORD_PATTERN` convention already used by the Selenium `BrowserActions`. Navigation still uses the real credentials.
- Adds a focused regression test in `PlaywrightBrowserActionsUnitTest`.

## Tests
Tests --> 4/4 passed
[2026-07-18_22-43-48-885_AllureReport.html](https://github.com/user-attachments/files/30156296/2026-07-18_22-43-48-885_AllureReport.html)
