### PR TITLE
Doctor cleanup: guidance dedupe, unused-plugin disable, validator .memory/recovery ignore

### DIFF
--- a/.claude/user-harness/settings.json
+++ b/.claude/user-harness/settings.json
@@ -12,7 +12,7 @@
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
-    "mcp-server-dev@claude-plugins-official": true,
+    "mcp-server-dev@claude-plugins-official": false,
     "skill-creator@claude-plugins-official": true,
     "mempalace@mempalace": true
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Before forked Maven/Surefire/TestNG, load gotchas. If delete gotcha is active, a
 
 - Guidance/memory: `py -3`/`python3 scripts/ci/validate_agent_setup.py`
 - Local code: affected tests, then one compile/package.
-- IntelliJ plugin: Gradle 9+ + JDK 21; screenshots via `ShaftPluginScreenshotRendererTest -Dshaft.intellij.screenshotDir=...`.
+- IntelliJ plugin: build/verify facts live in the `shaft-mastery` intellij-plugin chapter; load it.
 - Shared API/build/release: targeted, then full compile/package.
 - Visual: relevant test + image/browser evidence.
 - UI/report PRs need screenshots; draft/report if blocked.

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -56,9 +56,10 @@ IGNORED_DIRECTORIES = {
     "node_modules",
     "target",
 }
-# Root-relative directories (concurrent agent worktrees hold full repo copies).
+# Root-relative directories (concurrent agent worktrees and memory recovery areas hold full repo copies).
 IGNORED_RELATIVE_DIRECTORIES = {
     ".claude/worktrees",
+    ".memory/recovery",
 }
 
 

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -72,6 +72,14 @@ class ValidateDocumentationBoundariesTest(unittest.TestCase):
 
         self.assertEqual(validate_repository(self.root), [])
 
+    def test_ignores_markdown_inside_memory_recovery(self):
+        self.write(
+            ".memory/recovery/2026-01-01T00-00-00/memory/gotchas/example.md",
+            "# Memory recovery gotcha\n",
+        )
+
+        self.assertEqual(validate_repository(self.root), [])
+
     def test_rejects_unapproved_nested_readme(self):
         self.write(".github/other/README.md", "# Other\n")
 


### PR DESCRIPTION
## What (Closes #3756)

Three small fixes from the user-approved /doctor cleanup bundle:

- **AGENTS.md**: the IntelliJ validation bullet duplicated build/verify facts canonical in `shaft-mastery/references/intellij-plugin.md:4-7`; replaced with a pointer so the facts can't drift. (Visual/E2E one-liners deliberately kept in AGENTS.md — universal etiquette, no matching chapter, migration would cost more resident tokens than it saves.)
- **.claude/user-harness/settings.json**: `mcp-server-dev@claude-plugins-official` → `false` (0 lifetime uses; already disabled locally for this repo). Deployed via `sync_user_harness.py --apply`.
- **validate_documentation_boundaries.py**: `.memory/recovery` joins `.claude/worktrees` in IGNORED_RELATIVE_DIRECTORIES — local gitignored recovery snapshots were making `validate_agent_setup.py` exit 1 on any machine with them. Red-green regression test added (mirrors the worktree-ignore test).

## Evidence

- New test watched fail, then pass; `unittest tests.scripts.test_validate_documentation_boundaries`: 9/9 OK.
- `py -3 scripts/ci/validate_agent_setup.py` exits 0 with recovery snapshots present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2TirrqVJSrBb2XMqneScs