### PR TITLE
maven-tools-mcp: bump to 3.2.0 and document the no-Docker fallback

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
     },
     "maven-tools-mcp": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "arvindand/maven-tools-mcp:3.1.1"]
+      "args": ["run", "-i", "--rm", "arvindand/maven-tools-mcp:3.2.0"]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ PowerShell: quote `'-Dname=value'`, `'stash@{0}'`, args with `{}`, `@`, `;`, `&`
 
 - Plugin Swing UI: `frontend-design` (net-new surfaces only) -> `jdtls-lsp` -> JetBrains MCP inspections (optional) -> plugin screenshot renderer review. Browser MCP tools cannot see Swing.
 - Docs/report web UI: `frontend-design` -> implement -> shaft-mcp browser evidence (screenshots + `browser_accessibility_audit`). Perf/network regressions: shaft-mcp `browser_network_requests`.
-- Deps/release: `release-dependency-guard` -> `maven-tools-mcp` for live Maven Central facts (in-tree facts: just `rg` the pom) -> `ci-failure-investigator` on breakage.
+- Deps/release: `release-dependency-guard` -> `maven-tools-mcp` for live Maven Central facts (in-tree facts: just `rg` the pom; Docker down -- never start it: `curl` search.maven.org) -> `ci-failure-investigator` on breakage.
 - `context7`: past-cutoff library APIs only, else repo exemplars.
 - Context/history/relationships: `mempalace`/`graphify` first, not grep; `rg` still for live code verification (mempalace/graphify can be stale).
 - Skip `jdtls-lsp` for one-liners; value scales with impact. `mcp-server-dev`: net-new tool schema only.


### PR DESCRIPTION
## What

`.mcp.json` launches maven-tools-mcp via `docker run`, but Docker Desktop is frequently not running on this dev machine and agents are forbidden from starting it — so the release/deps routing pointed at a dead transport with no documented alternative (#3736).

## Decision

Upstream ships **no prebuilt jar** (checked the v3.2.0 GitHub release — no assets; not on Maven Central; source build needs Java 25 and would pin an uncommittable machine-local path). So the transport stays Docker, and the fallback is documented instead:

- `AGENTS.md` deps/release routing line now names the no-Docker path: `rg` the pom for in-tree facts, `curl` search.maven.org for live facts.
- Docker image pin refreshed `3.1.1` → `3.2.0` (tag verified on Docker Hub, pushed 2026-07-13).

`scripts/ci/validate_agent_setup.py` exit 0 (guidance budgets respected).

Closes #3736

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2TirrqVJSrBb2XMqneScs