### PR TITLE
Document the interactive recorder's local-only execution as a design constraint

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
@@ -403,6 +403,10 @@ class ManagedCaptureRecorder {
     private void configureShaft() {
         SHAFT.Properties.clearForCurrentThread();
         SHAFT.Properties.platform.set()
+                // Deliberately pinned to local execution (issue #3733): interactive recording
+                // requires the launched browser on the user's own screen -- a remote-grid browser
+                // renders on the grid node where the user cannot see or click it. Any configured
+                // executionAddress applies when generated tests run, never at recording time.
                 .executionAddress("local")
                 .enableBiDi(true);
         SHAFT.Properties.web.set()


### PR DESCRIPTION
## Decision (#3733)

`ManagedCaptureRecorder.configureShaft()` pins `executionAddress("local")` **on purpose**, and this PR documents that instead of adding remote-grid recording: an interactive recording needs the launched browser on the user's own screen to click through — a remote-grid browser renders on the grid node where the user cannot see or interact with it. Generated tests still honor the configured `executionAddress` at replay time; the constraint is recording-time only.

- Code comment at the pin site (`ManagedCaptureRecorder.java`, `configureShaft()`), so the next grid investigation doesn't re-flag it.
- Companion user-docs PR: shafthq/shafthq.github.io (capture.md, "Managed browser recording").

`mvn -pl shaft-capture compile` exit 0 (comment-only change).

Closes #3733

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2TirrqVJSrBb2XMqneScs