### PR TITLE
Route the no-browser API prefill to mobile_api_record_start

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -272,11 +272,16 @@ final class AssistantCommand {
     //    api ..." phrase that happens to also satisfy the browser/mobile recognizers' broad keyword
     //    lists still starts the API-capture recorder (issue #3726). isApiRecordingIntent excludes
     //    "without a browser" phrasing up front so RecordApiMobileAction's no-browser proxy prefill
-    //    (mobile_api_record_start) is left to isMobileRecordingStartIntent, uncontested.
+    //    is left to isMobileApiRecordingIntent instead (issue #3738): WEIGHT_MOBILE_API_RECORDING
+    //    sits between WEIGHT_API_RECORDING and WEIGHT_MOBILE_RECORDING so that prefill starts
+    //    mobile_api_record_start deterministically, outscoring both isMobileRecordingStartIntent's
+    //    broad "android"/"mobile" keywords and isBrowserRecordingIntent's "browser" keyword (which
+    //    the literal words "without a browser" also happen to satisfy).
     private static final int WEIGHT_COMMAND_HELP = 100;
     private static final int WEIGHT_NAMED_TOOL_REQUEST = 90;
     private static final int WEIGHT_PROJECT_UPGRADE = 80;
     private static final int WEIGHT_API_RECORDING = 70;
+    private static final int WEIGHT_MOBILE_API_RECORDING = 68;
     private static final int WEIGHT_MOBILE_RECORDING = 65;
     private static final int WEIGHT_BROWSER_RECORDING = 60;
     private static final int WEIGHT_TOPIC_CONTROL = 55;
@@ -303,6 +308,8 @@ final class AssistantCommand {
                     (text, workingDirectory) -> browser(text)),
             new NaturalIntent(WEIGHT_API_RECORDING, AssistantCommand::isApiRecordingIntent,
                     (text, workingDirectory) -> recordApi(text)),
+            new NaturalIntent(WEIGHT_MOBILE_API_RECORDING, AssistantCommand::isMobileApiRecordingIntent,
+                    (text, workingDirectory) -> recordApiMobile(text)),
             new NaturalIntent(WEIGHT_BROWSER_RECORDING, AssistantCommand::isBrowserRecordingIntent,
                     (text, workingDirectory) -> record(text)),
             new NaturalIntent(WEIGHT_MOBILE_RECORDING, AssistantCommand::isMobileRecordingStartIntent,
@@ -1670,6 +1677,36 @@ final class AssistantCommand {
         return Invocation.tool("capture_api_start", apiCaptureStart(rest));
     }
 
+    /**
+     * Starts RecordApiMobileAction's no-browser API/network-traffic recording (issue #3738) via
+     * {@code mobile_api_record_start}, the loopback MITM proxy that captures native mobile API
+     * traffic without launching a browser. Mirrors the argument shape RecordApiMobileAction's
+     * Advanced-UI path builds directly: platform, plus blank deviceLabel/outputPath left for the
+     * user to fill in via the API Recording tab.
+     */
+    private static Invocation recordApiMobile(String text) {
+        return Invocation.tool("mobile_api_record_start", mobileApiRecordStart(text));
+    }
+
+    private static JsonObject mobileApiRecordStart(String text) {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("platform", platformName(mobileApiRecordingPlatform(text)));
+        arguments.addProperty("deviceLabel", "");
+        arguments.addProperty("outputPath", "");
+        return arguments;
+    }
+
+    /**
+     * Extracts the platform word following " on " in RecordApiMobileAction's prefill (for example
+     * "Record API traffic without a browser on Android"). Returns blank when no such trailing
+     * platform is present, letting {@link #platformName(String)} default it to Android.
+     */
+    private static String mobileApiRecordingPlatform(String text) {
+        String trimmed = text(text);
+        int index = trimmed.toLowerCase(Locale.ROOT).lastIndexOf(" on ");
+        return index < 0 ? "" : firstWord(trimmed.substring(index + 4));
+    }
+
     private static JsonObject apiCaptureStart(String rest) {
         JsonObject arguments = new JsonObject();
         String targetUrl = parseLeadingUrl(rest);
@@ -1932,7 +1969,7 @@ final class AssistantCommand {
      * for example RecordApiWebAction's exact Assistant prefill ("Record API traffic on
      * https://..."). Deliberately excludes "without a browser" phrasing up front: that marks
      * RecordApiMobileAction's no-browser proxy prefill, which drives a different MCP tool
-     * ({@code mobile_api_record_start}, via {@link #isMobileRecordingStartIntent}) that this
+     * ({@code mobile_api_record_start}, via {@link #isMobileApiRecordingIntent}) that this
      * command does not.
      */
     private static boolean isApiRecordingIntent(String text) {
@@ -2004,6 +2041,22 @@ final class AssistantCommand {
             }
         }
         return "";
+    }
+
+    /**
+     * True for RecordApiMobileAction's no-browser proxy prefill (issue #3738), for example
+     * "Record API traffic without a browser on Android" -- the loopback MITM proxy captures
+     * native mobile API traffic directly, so this must resolve to {@code mobile_api_record_start}
+     * rather than {@code isApiRecordingIntent}'s browser-driven {@code capture_api_start} or
+     * {@code isMobileRecordingStartIntent}'s UI-driven {@code mobile_record_start}. Requires both
+     * "without a browser" and "api" wording so plain browser-API phrases (no "without a browser")
+     * and plain mobile-recording phrases (no "api") still resolve to their own intents.
+     */
+    private static boolean isMobileApiRecordingIntent(String text) {
+        String normalized = normalizeNaturalCommand(text);
+        return normalized.startsWith("record ")
+                && normalized.contains("api")
+                && normalized.contains("without a browser");
     }
 
     private static boolean isMobileRecordingStartIntent(String text) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandRoutingTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandRoutingTest.java
@@ -89,12 +89,41 @@ class AssistantCommandRoutingTest {
     @Test
     void recordApiNaturalLanguageDoesNotStealTheNoBrowserMobileApiRecordingPrompt() {
         // RecordApiMobileAction's "without a browser" prefill drives a different MCP tool
-        // (mobile_api_record_start, a no-browser MITM proxy) -- it must keep routing to the mobile
-        // recorder, not the browser-launching capture_api_start this command adds.
+        // (mobile_api_record_start, a no-browser MITM proxy) -- it now has its own deterministic
+        // route (issue #3738); capture_api_start (this command) must still not steal it.
         AssistantCommand.Invocation mobileApiPrefill =
                 command("Record API traffic without a browser on Android");
 
-        assertEquals("mobile_record_start", mobileApiPrefill.toolName());
+        assertEquals("mobile_api_record_start", mobileApiPrefill.toolName());
+    }
+
+    @Test
+    void noBrowserApiRecordingPrefillRoutesToMobileApiRecordStart() {
+        // Issue #3738: RecordApiMobileAction's no-browser proxy prefill ("Record API traffic
+        // without a browser on <platform>") was being swallowed by isMobileRecordingStartIntent's
+        // broad "android"/"mobile" keyword list and routed to mobile_record_start (the UI-driven
+        // mobile recorder) instead of the intended mobile_api_record_start proxy tool. It must
+        // resolve deterministically to mobile_api_record_start with the same argument shape
+        // RecordApiMobileAction's Advanced-UI path builds (platform, blank deviceLabel/outputPath).
+        AssistantCommand.Invocation androidPrefill =
+                command("Record API traffic without a browser on Android");
+        AssistantCommand.Invocation iosPrefill =
+                command("Record API traffic without a browser on iOS");
+        // Plain mobile-recording phrasing (no "without a browser"/API wording) must keep starting
+        // the UI-driven mobile recorder -- no regression on the existing route.
+        AssistantCommand.Invocation plainMobileRecording =
+                command("Record my mobile actions on the Android emulator");
+
+        assertAll(
+                () -> assertEquals("mobile_api_record_start", androidPrefill.toolName()),
+                () -> assertEquals("Android", androidPrefill.arguments().get("platform").getAsString()),
+                () -> assertEquals("", androidPrefill.arguments().get("deviceLabel").getAsString()),
+                () -> assertEquals("", androidPrefill.arguments().get("outputPath").getAsString()),
+                () -> assertEquals("mobile_api_record_start", iosPrefill.toolName()),
+                () -> assertEquals("iOS", iosPrefill.arguments().get("platform").getAsString()),
+                () -> assertEquals("", iosPrefill.arguments().get("deviceLabel").getAsString()),
+                () -> assertEquals("", iosPrefill.arguments().get("outputPath").getAsString()),
+                () -> assertEquals("mobile_record_start", plainMobileRecording.toolName()));
     }
 
     @Test


### PR DESCRIPTION
## What

`RecordApiMobileAction`'s prefill ("Record API traffic without a browser on <platform>") never reached the intended no-browser MITM proxy tool `mobile_api_record_start` (#3738). Worse than filed: the misroute was platform-inconsistent — the Android variant landed on `mobile_record_start` (UI-driven recorder), while the **iOS variant landed on `capture_start` and launched a browser**, because the literal words "without a *browser*" satisfy the browser-recorder keyword and the iOS text carries no android/mobile/emulator token.

## How

- New `isMobileApiRecordingIntent` recognizer (requires `record` + `api` + `without a browser`) at `WEIGHT_MOBILE_API_RECORDING = 68` — deterministically outscores both the broad mobile keywords and the browser keyword, without stealing plain browser-API or plain mobile-recording phrases.
- Dispatches `mobile_api_record_start` with exactly `RecordApiMobileAction`'s Advanced-UI argument shape (`platform` via the existing `platformName` helper, blank `deviceLabel`/`outputPath`).
- Weight-ordering comment block and `isApiRecordingIntent` javadoc updated to describe the real routing.
- TDD: watched red (both misroutes quoted in the test), then green — `AssistantCommandRoutingTest` 43/43, `AssistantCommandTest` 22/22.

Closes #3738

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2TirrqVJSrBb2XMqneScs