### PR TITLE
Deterministic record-stop-generate loop for chat-side API recording

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -2241,6 +2241,38 @@ final class AssistantCommand {
         return Invocation.tool("playwright_record_stop", stopRecording());
     }
 
+    /**
+     * Reroutes a natural "stop recording" phrase to {@code capture_api_stop} (issue #3739) when
+     * the API backend is the active recorder -- {@link #recording} itself is stateless and always
+     * resolves a bare stop phrase to {@code capture_stop}, so {@code ShaftAssistantPanel} calls
+     * this from {@code routeNaturalStopToActiveRecorder} once it knows the active backend.
+     */
+    static Invocation stopApiRecording() {
+        return Invocation.tool("capture_api_stop", stopRecording());
+    }
+
+    /**
+     * Builds the {@code capture_api_generate} argument shape for the chat-driven record -> stop ->
+     * generate loop (issue #3739), matching {@code ApiRecordingSessionPanel.generateCode()}'s
+     * Advanced-UI defaults exactly: no excluded transactions, no pinned response fields, and the
+     * same output directory/package/style/validation-depth defaults.
+     */
+    static JsonObject apiCaptureGenerate(String sessionPath) {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("sessionPath", sessionPath == null ? "" : sessionPath);
+        arguments.addProperty("outputDirectory", "generated-tests");
+        arguments.addProperty("packageName", "tests.generated");
+        arguments.addProperty("className", "");
+        arguments.addProperty("style", "SCENARIO");
+        arguments.addProperty("validationDepth", "SCHEMA");
+        arguments.addProperty("overwrite", false);
+        arguments.addProperty("replay", false);
+        arguments.addProperty("openApiSpecPath", "");
+        arguments.add("excludedTransactionIds", new JsonArray());
+        arguments.add("pinnedJsonPaths", new JsonArray());
+        return arguments;
+    }
+
     private static String defaultCaptureRecordingPath() {
         return DEFAULT_CAPTURE_RECORDING_PATH_PREFIX + System.currentTimeMillis() + ".json";
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -247,6 +247,14 @@ final class ShaftAssistantPanel extends JPanel {
     private final List<ToolEvidence> toolEvidence = new ArrayList<>();
     private String activeCaptureRecordingPath = AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH;
     private String activePlaywrightRecordingPath = AssistantCommand.DEFAULT_PLAYWRIGHT_RECORDING_PATH;
+    /**
+     * Session JSON path for the active {@code capture_api_*} recording (issue #3739). Unlike
+     * {@link #activeCaptureRecordingPath}/{@link #activePlaywrightRecordingPath}, {@code
+     * capture_api_start} returns no start-time output path -- the persisted session path only
+     * arrives in the {@code capture_api_stop} result's {@code CaptureStatus.outputPath}, extracted
+     * in {@link #showCaptureStopDiagnosticIfPending}.
+     */
+    private String activeApiRecordingPath = "";
     private RecordingBackend activeRecordingBackend = RecordingBackend.WEBDRIVER;
     private javax.swing.JPanel emptyStateChips;
     /**
@@ -1885,14 +1893,41 @@ final class ShaftAssistantPanel extends JPanel {
 
     private boolean showCaptureStopDiagnosticIfPending(
             String toolName, boolean success, String markdown, String output) {
-        boolean isCaptureStopTool = "capture_stop".equals(toolName) || "playwright_record_stop".equals(toolName);
+        boolean isCaptureStopTool = "capture_stop".equals(toolName)
+                || "playwright_record_stop".equals(toolName)
+                || "capture_api_stop".equals(toolName);
         if (!success || !generateCaptureReviewAfterStop || !isCaptureStopTool) {
             return false;
         }
         stopCaptureStartDiagnostic();
+        if ("capture_api_stop".equals(toolName)) {
+            String sessionPath = apiSessionPathFromStopOutput(output);
+            if (sessionPath.isBlank()) {
+                // Issue #3739: capture_api_generate needs a persisted session path that this stop
+                // result did not report -- skip the generate call rather than send it a blank
+                // sessionPath, and clear the armed flag so a later unrelated stop can't misfire it.
+                generateCaptureReviewAfterStop = false;
+                showResponse("**SHAFT Assistant (" + toolName + " OK)**\n\n" + markdown
+                        + "\n\n_No session path was returned by the stop result, so no code could be "
+                        + "generated automatically. Try stopping the recording again._", output);
+                return true;
+            }
+            activeApiRecordingPath = sessionPath;
+        }
         showResponse("**SHAFT Assistant (" + toolName + " OK)**\n\n" + markdown, output);
         startCaptureCodeReview();
         return true;
+    }
+
+    /**
+     * Extracts the persisted session JSON path from a {@code capture_api_stop} result's {@code
+     * CaptureStatus} payload (issue #3739) -- the same parse {@link ApiRecordingSessionPanel} uses
+     * to feed its own Generate button, so the chat-driven record -> stop -> generate loop hands
+     * {@code capture_api_generate} the same sessionPath the Advanced-UI panel would.
+     */
+    private static String apiSessionPathFromStopOutput(String output) {
+        JsonObject status = AssistantMarkdown.jsonObjectFromMcpOutput(output);
+        return status != null && status.has("outputPath") ? status.get("outputPath").getAsString() : "";
     }
 
     private void showFinalToolResult(String toolName, boolean success, String markdown, String output) {
@@ -3429,10 +3464,14 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private AssistantCommand.Invocation routeNaturalStopToActiveRecorder(String promptText, AssistantCommand.Invocation invocation) {
-        if (activeRecordingBackend == RecordingBackend.PLAYWRIGHT
-                && "capture_stop".equals(invocation.toolName())
-                && AssistantCommand.isStopRecording(promptText)) {
+        if (!"capture_stop".equals(invocation.toolName()) || !AssistantCommand.isStopRecording(promptText)) {
+            return invocation;
+        }
+        if (activeRecordingBackend == RecordingBackend.PLAYWRIGHT) {
             return AssistantCommand.stopPlaywrightRecording();
+        }
+        if (activeRecordingBackend == RecordingBackend.API) {
+            return AssistantCommand.stopApiRecording();
         }
         return invocation;
     }
@@ -3457,10 +3496,24 @@ final class ShaftAssistantPanel extends JPanel {
             captureReviewGenerationRunning = false;
             return;
         }
-        if (("capture_stop".equals(invocation.toolName()) || "playwright_record_stop".equals(invocation.toolName()))
+        if ("capture_api_start".equals(invocation.toolName())) {
+            // Issue #3739: capture_api_start has no start-time output path (it arrives only in the
+            // capture_api_stop result), and -- like playwright_record_start -- it never schedules
+            // capture_start's WebDriver-specific startup diagnostic.
+            activeRecordingBackend = RecordingBackend.API;
+            activeApiRecordingPath = "";
+            clearPendingCaptureReview();
+            generateCaptureReviewAfterStop = false;
+            captureReviewGenerationRunning = false;
+            return;
+        }
+        if (("capture_stop".equals(invocation.toolName()) || "playwright_record_stop".equals(invocation.toolName())
+                || "capture_api_stop".equals(invocation.toolName()))
                 && AssistantCommand.isStopRecording(promptText)) {
             if ("playwright_record_stop".equals(invocation.toolName())) {
                 activeRecordingBackend = RecordingBackend.PLAYWRIGHT;
+            } else if ("capture_api_stop".equals(invocation.toolName())) {
+                activeRecordingBackend = RecordingBackend.API;
             }
             stopCaptureStartDiagnostic();
             generateCaptureReviewAfterStop = true;
@@ -3472,9 +3525,13 @@ final class ShaftAssistantPanel extends JPanel {
         captureReviewGenerationRunning = true;
         setRunning(true, "Generating review code...");
         RecordingBackend reviewBackend = activeRecordingBackend;
-        lastReviewSessionPath = reviewBackend == RecordingBackend.PLAYWRIGHT
-                ? activePlaywrightRecordingPath
-                : activeCaptureRecordingPath;
+        if (reviewBackend == RecordingBackend.PLAYWRIGHT) {
+            lastReviewSessionPath = activePlaywrightRecordingPath;
+        } else if (reviewBackend == RecordingBackend.API) {
+            lastReviewSessionPath = activeApiRecordingPath;
+        } else {
+            lastReviewSessionPath = activeCaptureRecordingPath;
+        }
         AssistantCommand.Invocation invocation = recordingCodeReviewInvocation(reviewBackend);
         activeRecordingBackend = RecordingBackend.WEBDRIVER;
         currentInvocation = ShaftMcpInvocationService.getInstance(project).startTool(invocation.toolName(), invocation.arguments());
@@ -3483,6 +3540,10 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private AssistantCommand.Invocation recordingCodeReviewInvocation(RecordingBackend backend) {
+        if (backend == RecordingBackend.API) {
+            return AssistantCommand.Invocation.tool(
+                    "capture_api_generate", AssistantCommand.apiCaptureGenerate(activeApiRecordingPath));
+        }
         boolean playwright = backend == RecordingBackend.PLAYWRIGHT;
         return AssistantCommand.Invocation.tool(
                 playwright ? "playwright_recording_code_blocks" : "capture_code_blocks",
@@ -3495,7 +3556,8 @@ final class ShaftAssistantPanel extends JPanel {
         return "capture_code_blocks".equals(toolName)
                 || "playwright_recording_code_blocks".equals(toolName)
                 || "capture_generate_replay".equals(toolName)
-                || "playwright_capture_generate_replay".equals(toolName);
+                || "playwright_capture_generate_replay".equals(toolName)
+                || "capture_api_generate".equals(toolName);
     }
 
     private void showPendingCaptureReview() {
@@ -4283,7 +4345,8 @@ final class ShaftAssistantPanel extends JPanel {
 
     private enum RecordingBackend {
         WEBDRIVER,
-        PLAYWRIGHT
+        PLAYWRIGHT,
+        API
     }
 
     private record ToolEvidence(String toolName, String payload, String createdAt) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -226,6 +226,103 @@ class ShaftPanelSetupTest {
                         invocation.arguments().get("recordingPath").getAsString()));
     }
 
+    // ---- Issue #3739: chat-side capture_api_* recording gets the same deterministic
+    // record -> stop -> generate loop as the WebDriver/Playwright recorders. ----
+
+    @Test
+    void assistantTracksApiRecordingStartAndReroutesNaturalStopToApiStop() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        AssistantCommand.Invocation apiStart =
+                AssistantCommand.Invocation.tool("capture_api_start", new JsonObject());
+
+        rememberCaptureInvocation(panel, "/mcp capture_api_start {}", apiStart);
+
+        assertEquals(recordingBackend("API"), getField(panel, "activeRecordingBackend"));
+
+        AssistantCommand.Invocation naturalStop = AssistantCommand.fromPrompt(
+                "stop recording", "CODEX", "ASK", ".", "", false);
+        Method route = ShaftAssistantPanel.class.getDeclaredMethod(
+                "routeNaturalStopToActiveRecorder", String.class, AssistantCommand.Invocation.class);
+        route.setAccessible(true);
+        AssistantCommand.Invocation routedStop = (AssistantCommand.Invocation) route.invoke(
+                panel, "stop recording", naturalStop);
+
+        assertAll(
+                () -> assertEquals("capture_stop", naturalStop.toolName()),
+                () -> assertEquals("capture_api_stop", routedStop.toolName()),
+                () -> assertFalse(routedStop.arguments().get("discard").getAsBoolean()));
+    }
+
+    @Test
+    void armedApiStopExtractsSessionPathAndBuildsGenerateInvocationWithPanelDefaults() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        setField(panel, "activeRecordingBackend", recordingBackend("API"));
+        setField(panel, "generateCaptureReviewAfterStop", true);
+
+        String output = mcpText("""
+                {
+                  "state": "STOPPED",
+                  "outputPath": "recordings/intellij-api-capture.json"
+                }
+                """);
+        Method showDiagnostic = ShaftAssistantPanel.class.getDeclaredMethod(
+                "showCaptureStopDiagnosticIfPending", String.class, boolean.class, String.class, String.class);
+        showDiagnostic.setAccessible(true);
+        // Extracting the session path happens before startCaptureCodeReview()'s real MCP dispatch,
+        // which NPEs against the null test project -- mirrors
+        // directCodegenToolDispatchArmsSameStickyReviewGateAsRecordFlow's null-project pattern, so
+        // the state assertions below still hold even though the invoke() itself throws.
+        assertThrows(InvocationTargetException.class,
+                () -> showDiagnostic.invoke(panel, "capture_api_stop", true, "Stopped.", output));
+
+        assertEquals("recordings/intellij-api-capture.json", getField(panel, "activeApiRecordingPath"));
+
+        Method review = ShaftAssistantPanel.class.getDeclaredMethod(
+                "recordingCodeReviewInvocation", Class.forName("com.shaft.intellij.ui.ShaftAssistantPanel$RecordingBackend"));
+        review.setAccessible(true);
+        AssistantCommand.Invocation invocation =
+                (AssistantCommand.Invocation) review.invoke(panel, recordingBackend("API"));
+        JsonObject arguments = invocation.arguments();
+
+        assertAll(
+                () -> assertEquals("capture_api_generate", invocation.toolName()),
+                () -> assertEquals("recordings/intellij-api-capture.json", arguments.get("sessionPath").getAsString()),
+                () -> assertEquals("generated-tests", arguments.get("outputDirectory").getAsString()),
+                () -> assertEquals("tests.generated", arguments.get("packageName").getAsString()),
+                () -> assertEquals("", arguments.get("className").getAsString()),
+                () -> assertEquals("SCENARIO", arguments.get("style").getAsString()),
+                () -> assertEquals("SCHEMA", arguments.get("validationDepth").getAsString()),
+                () -> assertFalse(arguments.get("overwrite").getAsBoolean()),
+                () -> assertFalse(arguments.get("replay").getAsBoolean()),
+                () -> assertEquals("", arguments.get("openApiSpecPath").getAsString()),
+                () -> assertEquals(0, arguments.getAsJsonArray("excludedTransactionIds").size()),
+                () -> assertEquals(0, arguments.getAsJsonArray("pinnedJsonPaths").size()));
+    }
+
+    @Test
+    void armedApiStopWithBlankSessionPathSkipsGenerateAndExplains() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        setField(panel, "activeRecordingBackend", recordingBackend("API"));
+        setField(panel, "generateCaptureReviewAfterStop", true);
+
+        String output = mcpText("""
+                {
+                  "state": "STOPPED",
+                  "outputPath": ""
+                }
+                """);
+        Method showDiagnostic = ShaftAssistantPanel.class.getDeclaredMethod(
+                "showCaptureStopDiagnosticIfPending", String.class, boolean.class, String.class, String.class);
+        showDiagnostic.setAccessible(true);
+        boolean handled = (Boolean) showDiagnostic.invoke(panel, "capture_api_stop", true, "Stopped.", output);
+
+        assertAll(
+                () -> assertTrue(handled),
+                () -> assertFalse((Boolean) getField(panel, "generateCaptureReviewAfterStop")),
+                () -> assertFalse((Boolean) getField(panel, "captureReviewGenerationRunning")),
+                () -> assertTrue(containsText(panel, "session path")));
+    }
+
     // ---- Attach-to-prompt affordances (issue #3727): current file / all open files / a disk file /
     // an image, rendered as removable chips near the composer and folded into the outbound prompt
     // text sent to the local-agent or cloud-provider MCP tool. ----


### PR DESCRIPTION
## What

Chat-side API recording had a deterministic start (`/record-api` → `capture_api_start`, #3740) but no deterministic finish: stopping never offered code generation, so users had to switch to the Advanced-UI panel or trust LLM guidance (#3739).

## How

The chat panel now runs the same record → stop → generate loop UI recordings get:

- `RecordingBackend.API` third variant; `capture_api_start` tracked in `rememberCaptureInvocation`.
- Natural "stop recording" reroutes `capture_stop` → `capture_api_stop` while the API backend is active (mirrors the Playwright reroute).
- The stop-result choke point (`showCaptureStopDiagnosticIfPending`) extracts the persisted session JSON path from `capture_api_stop`'s CaptureStatus `outputPath` (same parse the Advanced-UI panel uses) and auto-invokes `capture_api_generate` with exactly the panel's default argument shape; a missing/blank path skips generation with a plain explanation instead of a broken call.
- `capture_api_generate` renders like the other review tools.

TDD: three new tests watched red (`RecordingBackend.API` didn't exist), then green — `ShaftPanelSetupTest` 231/231.

Closes #3739

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2TirrqVJSrBb2XMqneScs