### PR TITLE
IntelliJ plugin UX polish: consistent label-column alignment in Recorder and MCP Setup forms

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/RecorderToolPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/RecorderToolPanel.java
@@ -28,6 +28,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridLayout;
@@ -114,11 +115,20 @@ final class RecorderToolPanel extends JPanel {
         JButton review = button("Review code", "Generate reviewed SHAFT code blocks from the recording",
                 ShaftIcons.CODE, this::reviewCode);
 
+        JPanel targetUrlRow = row("Target URL", 'U', targetUrl);
+        JPanel browserRow = row("Browser", 'B', browser);
+        JPanel headlessRow = row("Headless", 'H', headless);
+        JPanel outputPathRow = row("Output path", 'O', outputPath);
+        // Issue #3771: each row() panel packs its own label at that label's natural width, so
+        // without this the fields beside "Browser"/"Headless" land left of "Target URL"/"Output
+        // path" -- a ragged left edge next to a real aligned form.
+        alignLabelColumn(targetUrlRow, browserRow, headlessRow, outputPathRow);
+
         JPanel quickStartFields = new JPanel(new GridLayout(0, 1, 4, 4));
-        quickStartFields.add(row("Target URL", 'U', targetUrl));
-        quickStartFields.add(row("Browser", 'B', browser));
-        quickStartFields.add(row("Headless", 'H', headless));
-        quickStartFields.add(row("Output path", 'O', outputPath));
+        quickStartFields.add(targetUrlRow);
+        quickStartFields.add(browserRow);
+        quickStartFields.add(headlessRow);
+        quickStartFields.add(outputPathRow);
 
         JPanel actions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         actions.add(start);
@@ -509,6 +519,28 @@ final class RecorderToolPanel extends JPanel {
         row.add(label, BorderLayout.WEST);
         row.add(component, BorderLayout.CENTER);
         return row;
+    }
+
+    /**
+     * Equalizes the label column of a set of {@link #row} panels (issue #3771): each row is its own
+     * independent {@link BorderLayout}, so left to its own natural size a longer label (e.g.
+     * "Target URL") pushes its field further right than a shorter sibling label (e.g. "Browser"),
+     * producing a ragged left edge across the Quick Start section. Widening every label to the
+     * group's widest preferred size lines every field up in one column.
+     */
+    private static void alignLabelColumn(JPanel... rows) {
+        int columnWidth = 0;
+        for (JPanel row : rows) {
+            columnWidth = Math.max(columnWidth, rowLabel(row).getPreferredSize().width);
+        }
+        for (JPanel row : rows) {
+            JLabel label = rowLabel(row);
+            label.setPreferredSize(new Dimension(columnWidth, label.getPreferredSize().height));
+        }
+    }
+
+    private static JLabel rowLabel(JPanel row) {
+        return (JLabel) row.getComponent(0);
     }
 
     private static JButton button(String text, String description, Icon icon, Runnable action) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -534,7 +534,8 @@ final class ShaftMcpSetupPanel extends JPanel {
         JPanel agentControls = new JPanel();
         agentControls.setLayout(new javax.swing.BoxLayout(agentControls, javax.swing.BoxLayout.Y_AXIS));
         agentControls.setOpaque(false);
-        agentControls.add(labeledControl("Assistant family", family));
+        JPanel familyRow = labeledControl("Assistant family", family);
+        agentControls.add(familyRow);
         runtimeRow = labeledControl("Runtime", runtime);
         agentControls.add(runtimeRow);
         apiKeyRow = labeledControl("Gemini API key", geminiApiKey);
@@ -542,6 +543,10 @@ final class ShaftMcpSetupPanel extends JPanel {
         apiKeyRow.setVisible(false);
         agentControls.add(apiKeyRow);
         agentControls.add(recommendedAgent);
+        // Issue #3771: each labeledControl row above packs its own label at that label's natural
+        // width ("Assistant family" is longer than "Runtime"), so without this the dropdowns beside
+        // them land at different x-offsets -- a ragged left edge next to a real aligned form.
+        alignLabelColumn(familyRow, runtimeRow, apiKeyRow);
         JPanel checkActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         checkActions.setOpaque(false);
         checkActions.add(test);
@@ -2357,6 +2362,29 @@ final class ShaftMcpSetupPanel extends JPanel {
         row.add(label);
         row.add(control);
         return row;
+    }
+
+    /**
+     * Equalizes the label column of a set of {@link #labeledControl} rows (issue #3771): each row
+     * is its own independent {@link FlowLayout}, so left to its own natural size a longer label
+     * (e.g. "Assistant family") pushes its control further right than a shorter sibling label (e.g.
+     * "Runtime"), producing a ragged left edge across the group. Widening every label to the
+     * group's widest preferred size lines every control up in one column, matching the aligned
+     * look {@code stepRow}'s label/badge columns already have.
+     */
+    private static void alignLabelColumn(JPanel... rows) {
+        int columnWidth = 0;
+        for (JPanel row : rows) {
+            columnWidth = Math.max(columnWidth, rowLabel(row).getPreferredSize().width);
+        }
+        for (JPanel row : rows) {
+            JLabel label = rowLabel(row);
+            label.setPreferredSize(new Dimension(columnWidth, label.getPreferredSize().height));
+        }
+    }
+
+    private static JLabel rowLabel(JPanel row) {
+        return (JLabel) row.getComponent(0);
     }
 
     private static void styleStepRow(JPanel row, String state) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/RecorderToolPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/RecorderToolPanelTest.java
@@ -11,6 +11,7 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.text.JTextComponent;
 import java.awt.Component;
 import java.awt.Container;
@@ -54,6 +55,36 @@ class RecorderToolPanelTest {
                 () -> assertNotNull(outputPath),
                 () -> assertEquals("recordings/intellij-capture.json", outputPath.getText(),
                         "Must match ToolTemplates.recorder()'s capture_start template default"));
+    }
+
+    /**
+     * Issue #3771 (professional UX polish): each Quick Start row ("Target URL", "Browser",
+     * "Headless", "Output path") is built by {@code row()} as its own independent {@link
+     * java.awt.BorderLayout}, so a label's WEST slot naturally sizes to that label's own text --
+     * "Target URL"/"Output path" are longer than "Browser"/"Headless" -- and the fields beside them
+     * land at different x-offsets, a ragged left edge that reads as unpolished next to a real
+     * aligned form.
+     */
+    @Test
+    void quickStartRowLabelsShareAConsistentColumnWidthSoFieldsAlign() {
+        RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
+
+        JLabel targetUrlLabel = findByAccessibleName(panel, "Target URL", JLabel.class);
+        JLabel browserLabel = findByAccessibleName(panel, "Browser", JLabel.class);
+        JLabel headlessLabel = findByAccessibleName(panel, "Headless", JLabel.class);
+        JLabel outputPathLabel = findByAccessibleName(panel, "Output path", JLabel.class);
+
+        assertAll(
+                () -> assertNotNull(targetUrlLabel),
+                () -> assertNotNull(browserLabel),
+                () -> assertNotNull(headlessLabel),
+                () -> assertNotNull(outputPathLabel),
+                () -> assertEquals(targetUrlLabel.getPreferredSize().width, browserLabel.getPreferredSize().width,
+                        "Quick Start row labels must share a column width so fields align"),
+                () -> assertEquals(targetUrlLabel.getPreferredSize().width, headlessLabel.getPreferredSize().width,
+                        "Quick Start row labels must share a column width so fields align"),
+                () -> assertEquals(targetUrlLabel.getPreferredSize().width, outputPathLabel.getPreferredSize().width,
+                        "Quick Start row labels must share a column width so fields align"));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2360,6 +2360,40 @@ class ShaftPanelSetupTest {
         }
     }
 
+    /**
+     * Issue #3771 (professional UX polish): the "2 Pick agent" step stacks "Assistant family" and
+     * "Runtime" as two independently-packed {@code labeledControl} rows (each its own flow-layout
+     * row), so their labels naturally size to their own text ("Assistant family" is longer than
+     * "Runtime") and the dropdowns beside them land at different x-offsets -- a ragged left edge
+     * that reads as unpolished next to a real aligned form. The fix gives every label in the group
+     * the same preferred width (the widest label's), so every control in the column starts at the
+     * same x regardless of its own label's text length.
+     */
+    @Test
+    void pickAgentRowLabelsShareAConsistentColumnWidthSoControlsAlign() throws Exception {
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
+        });
+
+        JPanel chooseRow = (JPanel) getField(panel, "chooseRow");
+        AtomicReference<JLabel> familyLabel = new AtomicReference<>();
+        AtomicReference<JLabel> runtimeLabel = new AtomicReference<>();
+        walkComponents(chooseRow, comp -> {
+            if (comp instanceof JLabel lbl && "Assistant family".equals(lbl.getText())) {
+                familyLabel.set(lbl);
+            }
+            if (comp instanceof JLabel lbl && "Runtime".equals(lbl.getText())) {
+                runtimeLabel.set(lbl);
+            }
+        });
+
+        assertAll(
+                () -> assertNotNull(familyLabel.get(), "Should find 'Assistant family' label"),
+                () -> assertNotNull(runtimeLabel.get(), "Should find 'Runtime' label"),
+                () -> assertEquals(familyLabel.get().getPreferredSize().width, runtimeLabel.get().getPreferredSize().width,
+                        "\"Assistant family\" and \"Runtime\" labels must share a column width so their "
+                                + "dropdowns align at the same x"));
+    }
+
     @Test
     void doneStepRowCollapsesOnceLaterStepIsActiveAndReExpandsOnClick() throws Exception {
         ShaftSettingsState.Settings settings = connectedMcpSettings();


### PR DESCRIPTION
Phase 1 of tracking ticket #3751 (professional UX polish pass).

## What

Audit of all 37 renderer captures (every plugin surface, light + dark) against the issue's checklist — iconography, alignment, paddings, theme parity, affordances — surfaced two real spatial defects, both the same root cause (per-row BorderLayouts letting labels size independently):

- **Recorder → Quick Start**: Target URL / Browser / Headless / Output path fields sat at inconsistent x-offsets (~13px jitter). `RecorderToolPanel` now equalizes the label column across the four rows.
- **MCP Setup → Pick agent**: Assistant family / Runtime combos misaligned the same way; same `alignLabelColumn`/`rowLabel` fix in `ShaftMcpSetupPanel`.

The rest of the surfaces already meet the aligned-form standard (`GuidedWorkflowPanel`, `EvidenceTriagePanel` et al. use FormBuilder correctly); no taste-only churn was added.

## Evidence

- TDD: label-width regression tests watched RED then GREEN in both `RecorderToolPanelTest` and `ShaftPanelSetupTest`.
- Full plugin suite: `gradlew --offline test` → 1018 tests, 0 failures; the two touched classes re-verified green by the orchestrator.
- Before/after renders (37 each, both themes) archived in the session scratchpad; key captures shared with the owner.

## Adjacent finding (filed separately)

Every `JCheckBox` under light `IntelliJLaf` renders with no check glyph and a grey background band **in the headless screenshot renderer only** (dark `DarculaLaf` renders correctly; `setOpaque(false)` makes no difference). Suspected renderer/LAF icon-activation gap, needs live-IDE verification — tracked in a dedicated issue.

Closes #3771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk