### PR TITLE
Apply waitForLazyLoading after navigateToURL even when initialURL is null

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -427,10 +427,10 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
                 else
                     // already on the same page
                     driverFactoryHelper.getDriver().navigate().refresh();
-                JavaScriptWaitManager.waitForLazyLoading(driverFactoryHelper.getDriver());
             } else
                 // navigate to new url
                 browserActionsHelper.navigateToNewUrl(driverFactoryHelper.getDriver(), null, modifiedTargetUrl, targetUrlAfterRedirection);
+            JavaScriptWaitManager.waitForLazyLoading(driverFactoryHelper.getDriver());
 
             // validate successful navigation
             if (!targetUrl.contains("\n")) {

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
@@ -3,11 +3,13 @@ package testPackage.unitTests;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.gui.browser.BrowserActions;
+import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.internal.BrowserObservabilityRecorder;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.openqa.selenium.*;
 import org.openqa.selenium.devtools.Command;
@@ -158,6 +160,21 @@ public class BrowserActionsCoverageUnitTest {
 
         Assert.assertThrows(RuntimeException.class,
                 () -> browserActions.navigateToURL("https://example.com/down", "https://example.com/down"));
+    }
+
+    @Test(description = "Regression for issue #3774: navigateToURL(String,String) must still apply the " +
+            "post-navigation waitForLazyLoading wait when initialURL is null (e.g. getCurrentUrl() throws " +
+            "UnsupportedCommandException), matching the non-null branch's behavior.")
+    public void navigateToURLShouldWaitForLazyLoadingWhenInitialUrlIsNull() {
+        when(driver.getCurrentUrl()).thenThrow(new UnsupportedCommandException("current URL is not available"));
+
+        try (MockedStatic<JavaScriptWaitManager> javaScriptWaitManagerMocked = Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            browserActions.navigateToURL("https://example.com/target", "https://example.com/target");
+
+            // Once from forceStopCurrentNavigation() (pre-navigation), and once more after the
+            // null-initialURL navigation completes -- matching the non-null branch's post-navigation wait.
+            javaScriptWaitManagerMocked.verify(() -> JavaScriptWaitManager.waitForLazyLoading(driver), Mockito.times(2));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fixes issue #3774: `BrowserActions.navigateToURL(String, String)` skipped `JavaScriptWaitManager.waitForLazyLoading()` whenever `initialURL` stayed `null` (i.e. `driver.getCurrentUrl()` threw `UnsupportedCommandException`), because the wait call lived only inside the `initialURL != null` branch.
- The fix moves the `waitForLazyLoading` call out of the `if/else` so it runs after navigation regardless of which branch was taken, matching the existing non-null-branch behavior. No other logic in `navigateToURL` was touched.

## Root cause

`shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java` (around line 430, pre-fix): the post-navigation `JavaScriptWaitManager.waitForLazyLoading(...)` call was nested inside `if (initialURL != null) { ... }`, so the `else` branch (`initialURL == null`) called `browserActionsHelper.navigateToNewUrl(...)` and returned without ever waiting for lazy loading to settle.

## Test plan

- [x] Added a regression test, `navigateToURLShouldWaitForLazyLoadingWhenInitialUrlIsNull`, to `BrowserActionsCoverageUnitTest` (Mockito `mockStatic(JavaScriptWaitManager.class)`, forcing `driver.getCurrentUrl()` to throw `UnsupportedCommandException`, then asserting `waitForLazyLoading` is invoked twice: once from `forceStopCurrentNavigation()` pre-navigation and once post-navigation).
  - Watched it fail RED for the correct reason first: `TooFewActualInvocations` — only 1 call observed (the pre-navigation one), proving the post-navigation wait was skipped.
  - After the minimal fix, reran and it passes GREEN.
- [x] `mvn -pl shaft-engine test -Dtest=testPackage.unitTests.BrowserActionsCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` → 20/20 passed.
- [x] `mvn -pl shaft-engine test -Dtest=testPackage.mockedTests.LazyLoadingFixtureLiveTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` (headless Chrome, local `TestPageServer` + `lazyLoadingFixture.html`) → 3/3 passed.
- [x] `mvn -pl shaft-engine test-compile` → BUILD SUCCESS (no new warnings introduced).

Closes #3774

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk