### PR TITLE
memory: record Windows MAX_PATH supersede-shorthand gotcha (Closes #3790)

### DIFF
--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -390,3 +390,4 @@
 {"actor":"agent","event":"memory.created","id":"gotcha.shafthq-github-io-classic-heading-id-breaks-acorn-mdx-parse-on-md-files-use-heading-id-instead","timestamp":"2026-07-19T21:43:50+03:00"}
 {"actor":"agent","event":"memory.created","id":"gotcha.shaft-intellij-issue-3786-fixed-shafttestspaneltest-broke-under-full-suite-screenshotdir-because-a-second-screenshot-test-never-restored-its-installed-l-f","timestamp":"2026-07-19T21:43:50+03:00"}
 {"actor":"agent","event":"memory.updated","id":"gotcha.restoring-the-pre-test-lookandfeel-instance-does-not-un-stick-intellijs-defaulttreeui-sticky-latch","timestamp":"2026-07-19T21:54:55+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.memory-cli-supersede-shorthand-fails-on-windows-with-long-object-ids","timestamp":"2026-07-19T22:05:53+03:00"}

--- a/.memory/memory/gotchas/memory-cli-supersede-shorthand-fails-on-windows-with-long-object-ids.json
+++ b/.memory/memory/gotchas/memory-cli-supersede-shorthand-fails-on-windows-with-long-object-ids.json
@@ -1,0 +1,30 @@
+{
+  "body_path": "memory/gotchas/memory-cli-supersede-shorthand-fails-on-windows-with-long-object-ids.md",
+  "content_hash": "sha256:cbe5aa953e14d69095e7d78a9151949a7497edb9fe6f2cfdbf6eba58c04bb4ee",
+  "created_at": "2026-07-19T22:05:53+03:00",
+  "evidence": [],
+  "facets": {
+    "category": "gotcha"
+  },
+  "id": "gotcha.memory-cli-supersede-shorthand-fails-on-windows-with-long-object-ids",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "document Windows MAX_PATH issue with memory CLI supersede shorthand"
+  },
+  "status": "active",
+  "tags": [
+    "windows",
+    "memory-cli",
+    "max-path",
+    "upstream-bug"
+  ],
+  "title": "memory CLI: supersede shorthand fails on Windows with long object ids",
+  "type": "gotcha",
+  "updated_at": "2026-07-19T22:05:53+03:00"
+}

--- a/.memory/memory/gotchas/memory-cli-supersede-shorthand-fails-on-windows-with-long-object-ids.md
+++ b/.memory/memory/gotchas/memory-cli-supersede-shorthand-fails-on-windows-with-long-object-ids.md
@@ -1,0 +1,5 @@
+On Windows, `memory remember --stdin` with the `supersede` shorthand fails with `MemoryValidationFailed: File could not be written atomically` (underlying ENOENT on temp-file rename). Root cause: `supersede_object` auto-creates a `supersedes` relation file named by concatenating both full object ids (e.g., `gotcha-<long-id-A>-supersedes-gotcha-<long-id-B>.json`). With two long descriptive gotcha ids, this filename reached ~290 chars, exceeding Windows MAX_PATH when combined with the repo/worktree path prefix.
+
+Workaround: use `memory save --stdin` with a raw `update_object` patch setting `status: superseded`, `superseded_by`, and the corrected body. This writes only the object's own sidecar, no relation file.
+
+Upstream bug in @aictx/memory v0.1.55 (our READ access only); tracked locally as issue #3790. Successful workaround demonstrated in PR #3789 commit b88484867d.


### PR DESCRIPTION
## Summary

- Documented workaround for @aictx/memory v0.1.55 supersede-shorthand failure on Windows
- Root cause: relation filenames exceed MAX_PATH when two object ids are long
- Workaround: use `memory save --stdin` with raw `update_object` patch instead of shorthand
- Code fix belongs upstream in @aictx/memory (we hold READ access only)
- Successful workaround demonstrated in PR #3789 commit b88484867d

Closes #3790

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk