### PR TITLE
Fix failure-screenshot exception masking the real action failure

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -910,29 +910,37 @@ public class Actions extends ElementActions {
                     ? ElementActionabilityDiagnostics.collect(
                             locator, driverFactoryHelper.getDriver(), foundElements.get(), exception)
                     : Map.of();
+            // take failure screenshot - a failure here (e.g. the element went stale between the
+            // original failure and this screenshot attempt) must never mask the original exception
             try {
-                // take failure screenshot
                 if (foundElements.get() == null || foundElements.get().size() != 1) {
                     screenshot.set(0, takeFailureScreenshot(null));
                 } else {
                     screenshot.set(0, takeFailureScreenshot(foundElements.get().getFirst()));
                 }
-                recordFlakeProfile(flakeProfile, false);
-                // report broken
+            } catch (RuntimeException screenshotException) {
+                // fall back to a viewport-only screenshot instead of failing the screenshot step
+                try {
+                    screenshot.set(0, takeFailureScreenshot(null));
+                } catch (RuntimeException viewportScreenshotException) {
+                    screenshotException.addSuppressed(viewportScreenshotException);
+                    screenshot.set(0, null);
+                }
+                exception.addSuppressed(screenshotException);
+            }
+            recordFlakeProfile(flakeProfile, false);
+            try {
+                // report broken - always reported against the ORIGINAL exception
                 reportBroken(traceEvent, action.name(), accessibleName.get(), reportContext.get(), screenshot.get(0),
                         exception, actionability);
-            } catch (RuntimeException exception2) {
-                if (exception2.getCause() == null || !exception2.getCause().equals(exception)) {
-                    // in case a new exception was thrown while attempting to take a screenshot
-                    exception2.addSuppressed(exception);
-                    recordFlakeProfile(flakeProfile, false);
-                    // report broken
-                    reportBroken(traceEvent, action.name(), accessibleName.get(), reportContext.get(), screenshot.get(0),
-                            exception2, actionability);
-                } else {
-                    // in case no new exceptions where thrown, just the one created by SHAFT for the main issue
-                    throw exception2;
+            } catch (RuntimeException reportedException) {
+                if (reportedException.getCause() == exception) {
+                    // expected: SHAFT's designed wrapper carrying the original exception as its cause
+                    throw reportedException;
                 }
+                // the reporting pipeline itself failed unexpectedly; the original failure must still win
+                exception.addSuppressed(reportedException);
+                throw exception;
             }
         }
         //report pass

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -934,7 +935,7 @@ public class Actions extends ElementActions {
                 reportBroken(traceEvent, action.name(), accessibleName.get(), reportContext.get(), screenshot.get(0),
                         exception, actionability);
             } catch (RuntimeException reportedException) {
-                if (reportedException.getCause() == exception) {
+                if (Objects.equals(reportedException.getCause(), exception)) {
                     // expected: SHAFT's designed wrapper carrying the original exception as its cause
                     throw reportedException;
                 }

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Rectangle;
 import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
@@ -748,6 +749,48 @@ public class ActionsCoverageUnitTest {
             RuntimeException exception = Assert.expectThrows(RuntimeException.class, () -> new Actions(helper).click(LOCATOR));
             Assert.assertTrue(hasCause(exception, InvalidElementStateException.class));
             verify((JavascriptExecutor) driver, org.mockito.Mockito.never()).executeScript(eq("arguments[0].click();"), eq(element));
+        }
+    }
+
+    @Test
+    public void performActionShouldReportOriginalExceptionAsRootCauseWhenFailureScreenshotThrows() {
+        // Reproduces #3795: an action fails, and while SHAFT is capturing the failure screenshot
+        // the element has already gone stale (e.g. ENTER navigated away). The reported root cause
+        // must remain the ORIGINAL action failure, never the screenshot-capture failure.
+        // A plain WebDriverException is neither one of FluentWait's ignored/retried exceptions
+        // (unlike StaleElementReferenceException) nor InvalidElementStateException (which triggers
+        // a JavaScript-click fallback instead of failing) - so it propagates to the failure handler
+        // deterministically on the first attempt.
+        WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class, TakesScreenshot.class));
+        WebElement element = standardElement();
+        RuntimeException originalFailure = new WebDriverException(
+                "element became unusable after ENTER navigated away");
+        doThrow(originalFailure).when(element).click();
+        // Default highlight method is "AI": takeFailureScreenshot -> captureScreenshot ->
+        // takeAIHighlightedScreenshot calls element.getRect() first, which is now stale too.
+        when(element.getRect()).thenThrow(new StaleElementReferenceException(
+                "stale element reference: element is not attached to the page document"));
+        // The viewport fallback screenshot also fails here, so the outer safety net has to win.
+        when(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES))
+                .thenThrow(new WebDriverException("session deleted because of page crash"));
+        when(driver.findElements(LOCATOR)).thenReturn(List.of(element));
+        DriverFactoryHelper helper = helperFor(driver);
+
+        try (var ignored = org.mockito.Mockito.mockStatic(JavaScriptWaitManager.class)) {
+            RuntimeException exception = Assert.expectThrows(RuntimeException.class,
+                    () -> new Actions(helper).click(LOCATOR));
+
+            Throwable rootCause = exception;
+            while (rootCause.getCause() != null) {
+                rootCause = rootCause.getCause();
+            }
+            Assert.assertSame(rootCause, originalFailure,
+                    "Expected the original action failure to remain the reported root cause, not the screenshot failure.");
+            boolean screenshotFailureWasSuppressed = java.util.Arrays.stream(rootCause.getSuppressed())
+                    .anyMatch(suppressed -> suppressed.getMessage() != null
+                            && suppressed.getMessage().contains("element is not attached to the page document"));
+            Assert.assertTrue(screenshotFailureWasSuppressed,
+                    "Expected the screenshot-capture failure to be attached as suppressed, not to replace the root cause.");
         }
     }
 


### PR DESCRIPTION
## Summary

- `Actions.performAction`'s failure handler (`shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java`, around lines 913-940) took a failure screenshot and reported it unconditionally. When the failure-screenshot attempt itself threw (e.g. the target element went stale between the original failure and the screenshot, so `takeFailureScreenshot -> captureScreenshot -> takeAIHighlightedScreenshot -> element.getRect()` threw `StaleElementReferenceException`), the old `addSuppressed` branch reported that screenshot exception as the "Root cause" and only attached the real original exception as suppressed - burying the actual triggering failure.
- Evidence: a live grid run surfaced a test failure as `StaleElementReferenceException` from `Actions.takeFailureScreenshot -> getRect()`, reported as the Root cause, while the true cause (element went stale after ENTER navigated away) was demoted to a suppressed exception.
- Fix:
  - The failure-screenshot step now falls back to a viewport-only screenshot (`takeFailureScreenshot(null)`, which does not depend on the element's rect) when the highlighted/element screenshot throws, instead of failing the screenshot step outright.
  - If screenshot capture still fails entirely, or the reporting pipeline (`reportBroken`/`report`) itself fails unexpectedly, the **original** exception is always what gets reported and thrown, with the screenshot/report failure attached via `addSuppressed` - never the reverse.

## Test plan

- [x] Added `ActionsCoverageUnitTest#performActionShouldReportOriginalExceptionAsRootCauseWhenFailureScreenshotThrows`, simulating a click failure where the element is also stale by the time the failure screenshot is captured (`getRect()` throws) and the viewport fallback screenshot also fails. Asserts the reported root cause is the original exception, with the screenshot failure attached as suppressed.
- [x] Verified the test fails red on the pre-fix code (root cause was the screenshot exception) and passes green after the fix.
- [x] `mvn -pl shaft-engine test -Dtest=ActionsCoverageUnitTest,ActionsExceptionDetailsUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` - all 48 tests pass, no regressions in the adjacent Actions test suites.

Closes #3795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk