### PR TITLE
Fix #3794: restore UnsupportedCommandException fallback for remote CDP screenshots

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java
@@ -163,7 +163,7 @@ public class ScreenshotHelper {
             var result = cdpDriver.executeCdpCommand("Page.captureScreenshot", screenshot_config);
             String base64EncodedPng = (String) ((Map<String, ?>) result).get("data");
             return OutputType.BYTES.convertFromBase64Png(base64EncodedPng);
-        } catch (org.openqa.selenium.TimeoutException exception) {
+        } catch (org.openqa.selenium.TimeoutException | UnsupportedCommandException exception) {
                 /* Error:  org.openqa.selenium.TimeoutException: java.net.http.HttpTimeoutException: request timed out
                     Build info: version: '4.16.1', revision: '9b4c83354e'
                     System info: os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '12.7.1', java.version: '21.0.1'
@@ -171,6 +171,13 @@ public class ScreenshotHelper {
                     Command: [xxx, executeCdpCommand {cmd=Page.captureScreenshot, params={fromSurface=true, optimizeForSpeed=true, captureBeyondViewport=true, clip={width=1905, x=0, y=0, scale=1, height=2555}}}]
                  */
             // in some cases it was noticed that the full page screenshot Cdp command can cause a timeout, and therefore a workaround should be implemented
+
+            // Issue #3794: on a remote MicrosoftEdge grid session, Selenium's AdditionalHttpCommands
+            // ServiceLoader merge has no per-browser isApplicable() concept -- both selenium-chrome-driver
+            // and selenium-edge-driver register "executeCdpCommand" with different URL templates, and
+            // chrome's (/goog/cdp/execute) wins even for an Edge session, so the Edge node 404s it:
+            // org.openqa.selenium.UnsupportedCommandException: unknown command: unknown command: session/xxx/goog/cdp/execute
+            // (this catch was present for #2841 but was accidentally dropped by the #2895 refactor)
             return takeFullPageScreenshotManually(driver);
         }
     }

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java
@@ -185,6 +185,43 @@ public class ScreenshotHelperCoverageUnitTest {
                 .executeScript("window.scrollTo(0, arguments[0]);", 0);
     }
 
+    @Test
+    public void makeFullScreenshotShouldFallBackToManualStitchingWhenCdpCommandIsUnsupported() throws Exception {
+        // Reproduces issue #3794: on a remote MicrosoftEdge grid session, Selenium's
+        // AdditionalHttpCommands ServiceLoader merge has no per-browser isApplicable() concept, so
+        // with both selenium-chrome-driver and selenium-edge-driver on the classpath, executeCdpCommand
+        // resolves to chrome's HTTP path (/goog/cdp/execute) even for an Edge session. The Edge grid
+        // node rejects that path, and Selenium's ErrorCodec decodes the W3C "unknown command" response
+        // into UnsupportedCommandException (see org.openqa.selenium.remote.ErrorCodec), e.g.:
+        // org.openqa.selenium.UnsupportedCommandException: unknown command: unknown command: session/xxx/goog/cdp/execute
+        SHAFT.Properties.platform.set().targetPlatform("LINUX");
+        SHAFT.Properties.web.set().targetBrowserName("MicrosoftEdge");
+        SHAFT.Properties.mobile.set().browserName("");
+
+        WebDriver remoteEdgeDriver = Mockito.mock(WebDriver.class,
+                Mockito.withSettings().extraInterfaces(HasCdp.class, JavascriptExecutor.class));
+        HasCdp cdpDriver = (HasCdp) remoteEdgeDriver;
+        when(cdpDriver.executeCdpCommand(anyString(), any()))
+                .thenThrow(new org.openqa.selenium.UnsupportedCommandException(
+                        "unknown command: unknown command: session/deadbeef/goog/cdp/execute"));
+
+        when(((JavascriptExecutor) remoteEdgeDriver).executeScript(Mockito.contains("Math.max("))).thenReturn(50L);
+        when(((JavascriptExecutor) remoteEdgeDriver).executeScript(Mockito.contains("window.devicePixelRatio"))).thenReturn(1.0);
+        when(((JavascriptExecutor) remoteEdgeDriver).executeScript(Mockito.contains("window.pageYOffset"))).thenReturn(0L);
+        when(((JavascriptExecutor) remoteEdgeDriver).executeScript(Mockito.contains("window.scrollTo"), any())).thenReturn(null);
+        when(((JavascriptExecutor) remoteEdgeDriver).executeScript(Mockito.contains("document.documentElement.style.overflow = 'hidden';"))).thenReturn(null);
+        when(((JavascriptExecutor) remoteEdgeDriver).executeScript(Mockito.contains("document.documentElement.style.overflow = 'visible';"))).thenReturn(null);
+
+        byte[] viewport = createPngBytes(80, 50, Color.MAGENTA);
+        try (MockedConstruction<ScreenshotManager> mocked = Mockito.mockConstruction(ScreenshotManager.class,
+                (mock, context) -> when(mock.takeScreenshot(any(), any(), any())).thenReturn(viewport))) {
+            byte[] result = ScreenshotHelper.makeFullScreenshot(remoteEdgeDriver);
+            Assert.assertNotNull(result, "Full-page screenshot should fall back to manual stitching instead of "
+                    + "propagating UnsupportedCommandException from the mis-routed remote CDP call.");
+        }
+        Mockito.verify(cdpDriver).executeCdpCommand(anyString(), any());
+    }
+
     private static void setStaticField(String fieldName, Object value) throws Exception {
         Field field = ScreenshotHelper.class.getDeclaredField(fieldName);
         field.setAccessible(true);


### PR DESCRIPTION
## Summary

Closes #3794

On a remote MicrosoftEdge grid session, a CDP screenshot call hit `session/.../goog/cdp/execute` (chrome's HTTP path) instead of `.../ms/cdp/execute`, and the Edge node rejected it with `UnsupportedCommandException: unknown command`.

**Root cause (verified in Selenium sources):** Selenium's `AdditionalHttpCommands` `ServiceLoader` merge has no per-browser `isApplicable()` concept — both `selenium-chrome-driver` and `selenium-edge-driver` register the `executeCdpCommand` command name with different URL templates, and with both jars on the classpath (always true for SHAFT) chrome's path wins even for an Edge session. The `Augmenter` side is correctly scoped (fixed separately in #3788) — this is the separate HTTP-command registry, which the engine cannot cheaply re-scope per browser.

**Prior art / actual root cause of the regression:** `ScreenshotHelper.takeFullPageScreenshotUsingCDP` already had exactly this fallback — it was added in #2841/#2847 as `catch (TimeoutException | UnsupportedCommandException exception)`. It was silently dropped by the unrelated "optimize full page screenshot with cdp" refactor in #2895, which rewrote the method and only kept the `TimeoutException` catch, deleting the `UnsupportedCommandException` case along with its explanatory comment. This PR restores that catch.

## Changes

- `shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java`: `takeFullPageScreenshotUsingCDP` now catches `UnsupportedCommandException` (in addition to `TimeoutException`) and falls back to the manual viewport-stitching screenshot path, instead of letting the exception propagate. `UnsupportedCommandException` is `org.openqa.selenium.UnsupportedCommandException`, already covered by the existing `org.openqa.selenium.*` wildcard import.
- `shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java`: added `makeFullScreenshotShouldFallBackToManualStitchingWhenCdpCommandIsUnsupported`, simulating a remote Edge session (`HasCdp` mock) where `executeCdpCommand` throws `UnsupportedCommandException("unknown command: ... /goog/cdp/execute")`, asserting the full-page screenshot still succeeds via the manual fallback.

## Scope note

Investigated all three engine call sites reaching `executeCdpCommand`/CDP-backed screenshots:
- `ScreenshotHelper.takeFullPageScreenshotUsingCDP` — fixed here (was missing the fallback after #2895 regressed it).
- `BrowserActionsHelper.capturePageSnapshot` — already catches `WebDriverException` broadly and retries via plain `getPageSource()`, which already covers `UnsupportedCommandException` (it's a `WebDriverException` subtype). No change needed.
- `DriverFactoryHelper` — only wires up the `Augmenter`/`HasCdp` capability, does not itself invoke `executeCdpCommand`. No change needed.

Reflection-based patching of Selenium's command registry was considered and rejected as unnecessarily invasive for this fix — the existing catch-and-fallback pattern (already proven for #2841) is the smallest maintainable remedy and simply needed to be restored.

## Test plan

- [x] `mvn -pl shaft-engine test -Dtest=ScreenshotHelperCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` — new test fails red (uncaught `UnsupportedCommandException`) before the fix, passes green after.
- [x] `mvn -pl shaft-engine test -Dtest=ScreenshotHelperCoverageUnitTest,ScreenshotManagerCoverageUnitTest,AnimatedGifManagerCoverageUnitTest,ImageProcessingActionsScreenshotBaselineUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` — 27/27 passed, no regressions in adjacent image-package tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk