### PR TITLE
Add persistent User Guide + Star SHAFT header buttons to Allure 3 reports

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -91,6 +91,12 @@ public class AllureManager {
     private static final String ALLURE_ATTACHMENT_PREVIEW_SCRIPT_ID = "shaft-allure-attachment-preview-script";
     private static final String ALLURE_THEME_COLORS_ID = "shaft-allure-theme-colors";
     private static final String ALLURE_OVERVIEW_PANEL_ID = "shaft-overview-panel-style";
+    private static final String ALLURE_HEADER_BUTTONS_ID = "shaft-header-buttons";
+    /** Literal opening tag of the Allure "awesome" plugin's React/Preact mount point, present at a
+     *  fixed, stable location (the first element in {@code <body>}) across single-file and
+     *  multi-file Allure 3 output alike; verified against a real {@code allure generate} run
+     *  (issue #3802). Used purely as an insertion point, not a presence marker. */
+    private static final String ALLURE_APP_ROOT_TAG = "<div id=\"app\"";
     private static final String ALLURE_ATTACHMENT_PREVIEW_FIX_STYLE = """
             <style id="shaft-allure-attachment-preview-fix">
             .shaft-allure-image-modal {
@@ -497,6 +503,111 @@ public class AllureManager {
                 + "</div>"
                 + "</div>"
                 + ALLURE_OVERVIEW_PANEL_SCRIPT;
+    }
+
+    private static final String ALLURE_HEADER_BUTTONS_STYLE = """
+            <style id="shaft-header-buttons-style">
+            #shaft-header-buttons {
+              display: flex;
+              justify-content: flex-end;
+              align-items: center;
+              flex-wrap: wrap;
+              gap: 8px;
+              box-sizing: border-box;
+              padding: 10px 24px;
+              font-family: inherit;
+              background: var(--color-bg-canvas, #ffffff);
+              border-bottom: 1px solid var(--color-border-subtle, rgba(16, 42, 49, 0.10));
+            }
+
+            .shaft-header-btn {
+              display: inline-flex;
+              align-items: center;
+              gap: 6px;
+              padding: 6px 14px;
+              border-radius: 999px;
+              font-family: inherit;
+              font-size: 13px;
+              font-weight: 600;
+              line-height: 1.2;
+              white-space: nowrap;
+              text-decoration: none;
+              cursor: pointer;
+              transition: background-color 0.15s ease, border-color 0.15s ease;
+            }
+
+            .shaft-header-btn:focus-visible {
+              outline: 2px solid var(--color-focus-ring, #006ec0);
+              outline-offset: 2px;
+            }
+
+            .shaft-header-btn--primary {
+              background: var(--color-intent-primary-bg, #006ec0);
+              color: var(--color-intent-primary-on-bg, #ffffff);
+              border: 1px solid transparent;
+            }
+
+            .shaft-header-btn--primary:hover {
+              background: var(--color-intent-primary-bg-hover, #005da3);
+            }
+
+            .shaft-header-btn--primary:active {
+              background: var(--color-intent-primary-bg-active, #004d86);
+            }
+
+            .shaft-header-btn--secondary {
+              background: var(--color-control-bg, rgba(200, 214, 231, 0.55));
+              color: var(--color-text-primary, #102a31);
+              border: 1px solid var(--color-border-default, rgba(16, 42, 49, 0.18));
+            }
+
+            .shaft-header-btn--secondary:hover {
+              background: var(--color-control-bg-hover, rgba(200, 214, 231, 0.75));
+            }
+
+            .shaft-header-btn--secondary:active {
+              background: var(--color-control-bg-active, rgba(200, 214, 231, 0.92));
+            }
+
+            .shaft-header-btn-star {
+              font-size: 13px;
+              line-height: 1;
+            }
+
+            @media (max-width: 480px) {
+              #shaft-header-buttons {
+                padding: 8px 12px;
+                gap: 6px;
+              }
+
+              .shaft-header-btn {
+                padding: 5px 10px;
+                font-size: 12px;
+              }
+            }
+            </style>
+            """;
+
+    /**
+     * Builds the persistent "User Guide" / "Star SHAFT" header buttons bar (issue #3802) patched
+     * as a real sibling immediately before the Allure "awesome" plugin's {@code <div id="app">}
+     * mount point. Being outside {@code #app} means Preact/React never touches it, so it survives
+     * every client-side route change (Overview, Suites, Graphs, Timeline) without needing a
+     * {@code position: fixed} overlay or any brittle coupling to Allure's own (hashed, unstable)
+     * CSS module class names. Both links open in a new tab and carry no live star-count, so the
+     * static report keeps working fully offline (opened via {@code file://}).
+     *
+     * @return the HTML fragment to splice immediately before {@code <div id="app">}
+     */
+    private static String allureHeaderButtonsPatch() {
+        return ALLURE_HEADER_BUTTONS_STYLE
+                + "<div id=\"" + ALLURE_HEADER_BUTTONS_ID + "\">"
+                + "<a class=\"shaft-header-btn shaft-header-btn--primary\" href=\"https://shafthq.github.io\""
+                + " target=\"_blank\" rel=\"noopener\">User Guide</a>"
+                + "<a class=\"shaft-header-btn shaft-header-btn--secondary\" href=\"https://github.com/ShaftHQ/SHAFT_ENGINE\""
+                + " target=\"_blank\" rel=\"noopener\" aria-label=\"Star SHAFT on GitHub\">"
+                + "<span class=\"shaft-header-btn-star\" aria-hidden=\"true\">&#9733;</span> Star SHAFT</a>"
+                + "</div>";
     }
 
     // ─── Portable Node.js bootstrap ────────────────────────────────────────────
@@ -947,13 +1058,16 @@ public class AllureManager {
      * @param previewFixPresent    {@code true} when the attachment-preview-fix {@code <style>} id is present
      * @param previewScriptPresent {@code true} when the attachment-preview-fix {@code <script>} id is present
      * @param themeColorsPresent   {@code true} when the theme-colors {@code <style>} id is present
+     * @param headerButtonsPresent {@code true} when the header-buttons bar id is present
      * @param headEndOffset        absolute byte offset of the first {@code </head>}, or {@code -1} if absent
      * @param bodyEndOffset        absolute byte offset of the last {@code </body>}, or {@code -1} if absent
+     * @param appRootOffset        absolute byte offset of the first {@code <div id="app"}, or {@code -1} if absent
      */
     // package-private so unit tests can assert scan results without reflection
     record IndexMarkerScan(boolean previewFixPresent, boolean previewScriptPresent,
                            boolean themeColorsPresent, boolean overviewPanelPresent,
-                           long headEndOffset, long bodyEndOffset) {
+                           boolean headerButtonsPresent,
+                           long headEndOffset, long bodyEndOffset, long appRootOffset) {
     }
 
     /** A byte-range insertion to apply while streaming {@code index.html} to its patched copy. */
@@ -962,8 +1076,9 @@ public class AllureManager {
 
     /**
      * Patches the generated Allure single-file report's {@code index.html} to inject SHAFT's
-     * attachment-preview-fix styling/script and theme-color overrides, without ever holding the
-     * whole file in memory.
+     * attachment-preview-fix styling/script, theme-color overrides, the "SHAFT Overview" panel, and
+     * the persistent "User Guide" / "Star SHAFT" header buttons (issue #3802) — without ever holding
+     * the whole file in memory.
      *
      * <p>Single-file Allure reports inline every attachment as base64, so {@code index.html} can
      * grow far beyond the forked JVM's heap; the previous implementation read the whole file into a
@@ -993,10 +1108,11 @@ public class AllureManager {
             if (!scan.overviewPanelPresent()) {
                 bodyPatch += allureOverviewPanelPatch();
             }
-            if (headPatch.isEmpty() && bodyPatch.isEmpty()) {
+            String appRootPatch = scan.headerButtonsPresent() ? "" : allureHeaderButtonsPatch();
+            if (headPatch.isEmpty() && bodyPatch.isEmpty() && appRootPatch.isEmpty()) {
                 return;
             }
-            writePatchedIndex(indexPath, scan, headPatch, bodyPatch);
+            writePatchedIndex(indexPath, scan, headPatch, bodyPatch, appRootPatch);
         } catch (IOException e) {
             ReportManager.logDiscrete("Could not patch Allure report styling: " + e.getMessage());
         }
@@ -1012,6 +1128,8 @@ public class AllureManager {
         byte[] previewScriptMarker = ("id=\"" + ALLURE_ATTACHMENT_PREVIEW_SCRIPT_ID + "\"").getBytes(StandardCharsets.UTF_8);
         byte[] themeColorsMarker = ("id=\"" + ALLURE_THEME_COLORS_ID + "\"").getBytes(StandardCharsets.UTF_8);
         byte[] overviewPanelMarker = ("id=\"" + ALLURE_OVERVIEW_PANEL_ID + "\"").getBytes(StandardCharsets.UTF_8);
+        byte[] headerButtonsMarker = ("id=\"" + ALLURE_HEADER_BUTTONS_ID + "\"").getBytes(StandardCharsets.UTF_8);
+        byte[] appRootMarker = ALLURE_APP_ROOT_TAG.getBytes(StandardCharsets.UTF_8);
         byte[] headEndMarker = "</head>".getBytes(StandardCharsets.UTF_8);
         byte[] bodyEndMarker = "</body>".getBytes(StandardCharsets.UTF_8);
 
@@ -1019,15 +1137,20 @@ public class AllureManager {
         boolean previewScriptPresent = false;
         boolean themeColorsPresent = false;
         boolean overviewPanelPresent = false;
+        boolean headerButtonsPresent = false;
         boolean headFound = false;
+        boolean appRootFound = false;
         long headEndOffset = -1;
         long bodyEndOffset = -1;
+        long appRootOffset = -1;
 
         int maxMarkerLength = Math.max(previewFixMarker.length,
                 Math.max(previewScriptMarker.length,
                         Math.max(themeColorsMarker.length,
                                 Math.max(overviewPanelMarker.length,
-                                        Math.max(headEndMarker.length, bodyEndMarker.length)))));
+                                        Math.max(headerButtonsMarker.length,
+                                                Math.max(appRootMarker.length,
+                                                        Math.max(headEndMarker.length, bodyEndMarker.length)))))));
         int carryLength = maxMarkerLength - 1;
         byte[] window = new byte[carryLength + INDEX_PATCH_BUFFER_SIZE];
         int carried = 0;
@@ -1059,12 +1182,24 @@ public class AllureManager {
                 int minStart = Math.max(0, carried - overviewPanelMarker.length + 1);
                 overviewPanelPresent = indexOfMarker(window, windowLength, minStart, overviewPanelMarker, false) >= 0;
             }
+            if (!headerButtonsPresent) {
+                int minStart = Math.max(0, carried - headerButtonsMarker.length + 1);
+                headerButtonsPresent = indexOfMarker(window, windowLength, minStart, headerButtonsMarker, false) >= 0;
+            }
             if (!headFound) {
                 int minStart = Math.max(0, carried - headEndMarker.length + 1);
                 int matchIndex = indexOfMarker(window, windowLength, minStart, headEndMarker, false);
                 if (matchIndex >= 0) {
                     headEndOffset = windowStartOffset + matchIndex;
                     headFound = true;
+                }
+            }
+            if (!appRootFound) {
+                int minStart = Math.max(0, carried - appRootMarker.length + 1);
+                int matchIndex = indexOfMarker(window, windowLength, minStart, appRootMarker, false);
+                if (matchIndex >= 0) {
+                    appRootOffset = windowStartOffset + matchIndex;
+                    appRootFound = true;
                 }
             }
             int bodyMinStart = Math.max(0, carried - bodyEndMarker.length + 1);
@@ -1079,7 +1214,8 @@ public class AllureManager {
             carried = newCarry;
         }
 
-        return new IndexMarkerScan(previewFixPresent, previewScriptPresent, themeColorsPresent, overviewPanelPresent, headEndOffset, bodyEndOffset);
+        return new IndexMarkerScan(previewFixPresent, previewScriptPresent, themeColorsPresent, overviewPanelPresent,
+                headerButtonsPresent, headEndOffset, bodyEndOffset, appRootOffset);
     }
 
     /**
@@ -1110,17 +1246,25 @@ public class AllureManager {
 
     /**
      * Streams {@code indexPath} to a sibling temp file, inserting {@code headPatch} immediately
-     * before {@code scan.headEndOffset()} (or at offset 0 if absent) and {@code bodyPatch}
-     * immediately before {@code scan.bodyEndOffset()} (or at EOF if absent), then atomically
-     * replaces {@code indexPath}. Offsets are computed on the original (unpatched) file; since
-     * neither patch constant contains the literals {@code </head>} or {@code </body>}, this is
-     * equivalent to the old post-insertion string arithmetic.
+     * before {@code scan.headEndOffset()} (or at offset 0 if absent), {@code appRootPatch}
+     * immediately before {@code scan.appRootOffset()} (falling back to the {@code bodyPatch}
+     * insertion point when the app-root tag is absent, e.g. an unrecognised report layout), and
+     * {@code bodyPatch} immediately before {@code scan.bodyEndOffset()} (or at EOF if absent), then
+     * atomically replaces {@code indexPath}. Offsets are computed on the original (unpatched) file;
+     * since none of the patch constants contain the literals {@code </head>}, {@code </body>}, or
+     * {@code <div id="app"}, this is equivalent to the old post-insertion string arithmetic.
      */
-    private static void writePatchedIndex(Path indexPath, IndexMarkerScan scan, String headPatch, String bodyPatch) throws IOException {
-        List<IndexInsertion> insertions = new ArrayList<>(2);
+    private static void writePatchedIndex(Path indexPath, IndexMarkerScan scan, String headPatch, String bodyPatch,
+                                           String appRootPatch) throws IOException {
+        List<IndexInsertion> insertions = new ArrayList<>(3);
         if (!headPatch.isEmpty()) {
             long offset = scan.headEndOffset() >= 0 ? scan.headEndOffset() : 0L;
             insertions.add(new IndexInsertion(offset, headPatch.getBytes(StandardCharsets.UTF_8)));
+        }
+        if (!appRootPatch.isEmpty()) {
+            long offset = scan.appRootOffset() >= 0 ? scan.appRootOffset()
+                    : (scan.bodyEndOffset() >= 0 ? scan.bodyEndOffset() : Long.MAX_VALUE);
+            insertions.add(new IndexInsertion(offset, appRootPatch.getBytes(StandardCharsets.UTF_8)));
         }
         if (!bodyPatch.isEmpty()) {
             long offset = scan.bodyEndOffset() >= 0 ? scan.bodyEndOffset() : Long.MAX_VALUE;

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -1256,21 +1256,7 @@ public class AllureManager {
      */
     private static void writePatchedIndex(Path indexPath, IndexMarkerScan scan, String headPatch, String bodyPatch,
                                            String appRootPatch) throws IOException {
-        List<IndexInsertion> insertions = new ArrayList<>(3);
-        if (!headPatch.isEmpty()) {
-            long offset = scan.headEndOffset() >= 0 ? scan.headEndOffset() : 0L;
-            insertions.add(new IndexInsertion(offset, headPatch.getBytes(StandardCharsets.UTF_8)));
-        }
-        if (!appRootPatch.isEmpty()) {
-            long offset = scan.appRootOffset() >= 0 ? scan.appRootOffset()
-                    : (scan.bodyEndOffset() >= 0 ? scan.bodyEndOffset() : Long.MAX_VALUE);
-            insertions.add(new IndexInsertion(offset, appRootPatch.getBytes(StandardCharsets.UTF_8)));
-        }
-        if (!bodyPatch.isEmpty()) {
-            long offset = scan.bodyEndOffset() >= 0 ? scan.bodyEndOffset() : Long.MAX_VALUE;
-            insertions.add(new IndexInsertion(offset, bodyPatch.getBytes(StandardCharsets.UTF_8)));
-        }
-        insertions.sort(Comparator.comparingLong(IndexInsertion::offset));
+        List<IndexInsertion> insertions = buildIndexInsertions(scan, headPatch, bodyPatch, appRootPatch);
 
         Path tempPath = indexPath.resolveSibling(indexPath.getFileName() + ".shaft-patch.tmp");
         try {
@@ -1292,6 +1278,31 @@ public class AllureManager {
         } catch (AtomicMoveNotSupportedException e) {
             Files.move(tempPath, indexPath, StandardCopyOption.REPLACE_EXISTING);
         }
+    }
+
+    /**
+     * Assembles the offset-sorted insertion list for {@link #writePatchedIndex}: {@code headPatch}
+     * before {@code </head>} (or offset 0 if absent), {@code appRootPatch} before
+     * {@code <div id="app"} (falling back to the {@code bodyPatch} insertion point), and
+     * {@code bodyPatch} before {@code </body>} (or EOF if absent).
+     */
+    private static List<IndexInsertion> buildIndexInsertions(IndexMarkerScan scan, String headPatch, String bodyPatch,
+                                                             String appRootPatch) {
+        long bodyInsertionOffset = scan.bodyEndOffset() >= 0 ? scan.bodyEndOffset() : Long.MAX_VALUE;
+        List<IndexInsertion> insertions = new ArrayList<>(3);
+        if (!headPatch.isEmpty()) {
+            long offset = scan.headEndOffset() >= 0 ? scan.headEndOffset() : 0L;
+            insertions.add(new IndexInsertion(offset, headPatch.getBytes(StandardCharsets.UTF_8)));
+        }
+        if (!appRootPatch.isEmpty()) {
+            long offset = scan.appRootOffset() >= 0 ? scan.appRootOffset() : bodyInsertionOffset;
+            insertions.add(new IndexInsertion(offset, appRootPatch.getBytes(StandardCharsets.UTF_8)));
+        }
+        if (!bodyPatch.isEmpty()) {
+            insertions.add(new IndexInsertion(bodyInsertionOffset, bodyPatch.getBytes(StandardCharsets.UTF_8)));
+        }
+        insertions.sort(Comparator.comparingLong(IndexInsertion::offset));
+        return insertions;
     }
 
     /**

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
@@ -246,7 +246,14 @@ public class AllureManagerCoverageUnitTest {
         Assert.assertTrue(html.contains("--color-intent-primary-bg: #006ec0"), html);
         Assert.assertTrue(html.contains(":root[data-theme=\"dark\"]"), html);
         Assert.assertTrue(html.contains("--color-intent-primary-bg: #4cc2ff"), html);
-        Assert.assertFalse(html.contains("--color-bg-"), html);
+        // Scoped to the theme-colors block itself: it must use the "--color-intent-primary-bg"
+        // naming scheme, never the older/rejected "--color-bg-*" prefix. Scoping (rather than
+        // scanning the whole combined patched file) keeps this guard from tripping on unrelated
+        // patches elsewhere in the page that legitimately reference other real Allure variables
+        // (e.g. the header-buttons bar's "--color-bg-canvas", issue #3802).
+        String themeColorsBlock = html.substring(html.indexOf("id=\"shaft-allure-theme-colors\""),
+                html.indexOf("</style>", html.indexOf("id=\"shaft-allure-theme-colors\"")));
+        Assert.assertFalse(themeColorsBlock.contains("--color-bg-"), themeColorsBlock);
         Assert.assertTrue(html.contains("width: 100% !important"), html);
         Assert.assertTrue(html.contains("height: auto !important"), html);
         Assert.assertEquals(html.split("id=\"shaft-overview-panel-style\"", -1).length - 1, 1, html);
@@ -258,6 +265,35 @@ public class AllureManagerCoverageUnitTest {
         Assert.assertTrue(html.contains("id=\"shaft-overview-frame\""), html);
         Assert.assertTrue(html.contains("id=\"shaft-overview-panel-script\""), html);
         Assert.assertTrue(html.contains("overview-panel-injection-marker"), html);
+    }
+
+    @Test
+    public void patchGeneratedAllureReportIndexShouldInjectHeaderButtonsBeforeAppRootExactlyOnce() throws Exception {
+        Path reportDirectory = testDirectory.resolve("generated-report");
+        Files.createDirectories(reportDirectory);
+        Path index = reportDirectory.resolve("index.html");
+        Files.writeString(index,
+                "<html><head></head><body><div id=\"app\"></div></body></html>",
+                StandardCharsets.UTF_8);
+
+        invoke("patchGeneratedAllureReportIndex", new Class[]{Path.class}, reportDirectory);
+        invoke("patchGeneratedAllureReportIndex", new Class[]{Path.class}, reportDirectory);
+
+        String html = Files.readString(index, StandardCharsets.UTF_8);
+
+        Assert.assertEquals(html.split("id=\"shaft-header-buttons\"", -1).length - 1, 1, html);
+        Assert.assertEquals(html.split("id=\"shaft-header-buttons-style\"", -1).length - 1, 1, html);
+        Assert.assertEquals(html.split("href=\"https://shafthq.github.io\"", -1).length - 1, 1, html);
+        Assert.assertEquals(html.split("href=\"https://github.com/ShaftHQ/SHAFT_ENGINE\"", -1).length - 1, 1, html);
+        Assert.assertEquals(html.split("target=\"_blank\"", -1).length - 1, 2, html);
+        Assert.assertEquals(html.split("rel=\"noopener\"", -1).length - 1, 2, html);
+        Assert.assertTrue(html.contains("User Guide"), html);
+        Assert.assertTrue(html.contains("Star SHAFT"), html);
+        // The bar must be a real sibling BEFORE the app root, not inside it or after </body>,
+        // so it survives Allure's own client-side route switching (Overview/Suites/Graphs/Timeline).
+        Assert.assertTrue(html.indexOf("id=\"shaft-header-buttons-style\"") < html.indexOf("id=\"shaft-header-buttons\""), html);
+        Assert.assertTrue(html.indexOf("id=\"shaft-header-buttons\"") < html.indexOf("id=\"app\""), html);
+        Assert.assertTrue(html.indexOf("id=\"app\"") < html.indexOf("</body>"), html);
     }
 
     @Test
@@ -323,8 +359,10 @@ public class AllureManagerCoverageUnitTest {
         Assert.assertFalse(scan.previewScriptPresent());
         Assert.assertFalse(scan.themeColorsPresent());
         Assert.assertFalse(scan.overviewPanelPresent());
+        Assert.assertFalse(scan.headerButtonsPresent());
         Assert.assertEquals(scan.headEndOffset(), headEndOffset);
         Assert.assertEquals(scan.bodyEndOffset(), lastBodyEndOffset);
+        Assert.assertEquals(scan.appRootOffset(), -1L);
     }
 
     @Test


### PR DESCRIPTION
## Summary
Implements #3802 (Variant A): a persistent header button bar in every generated Allure 3 report — a primary **User Guide** button (https://shafthq.github.io) and a secondary **⭐ Star SHAFT** button (https://github.com/ShaftHQ/SHAFT_ENGINE), both opening in a new tab with `rel="noopener"`.

## How
- Injected by the existing streaming `patchGeneratedAllureReportIndex` pipeline in `AllureManager` as a document-flow sibling **immediately before Allure's `<div id="app">` mount point** — Preact never touches siblings of its root, so the bar persists across all client-side routes (Overview/Suites/Graphs/Timeline) with no `position:fixed` overlay and no coupling to Allure's hashed CSS-module class names.
- Idempotent: the `id="shaft-header-buttons"` marker short-circuits re-patching (byte-identity verified in tests).
- Graceful degradation: if a future Allure layout drops `<div id="app"`, insertion falls back to the `</body>` point.
- Styling uses real Allure CSS variables (`--color-bg-canvas`, `--color-intent-primary-bg`, …) with light-theme fallbacks; responsive at ≤480px; `:focus-visible` ring; `aria-label` on the star button.

## Evidence
- TDD: new test `patchGeneratedAllureReportIndexShouldInjectHeaderButtonsBeforeAppRootExactlyOnce` (watched red first) — patches twice, asserts single injection, ordering (style → bar → `#app` → `</body>`), and link attributes.
- `mvn -pl shaft-engine test -Dtest=AllureManagerCoverageUnitTest,AllureManagerUnitTest,ReportThemeConsistencyTest` → 62 passed, 0 failed, 1 pre-existing environment-conditional skip. Independently re-verified on the main thread: 20/20 for the coverage class.
- Probed a **real** Allure 3.14.3 single-file report (3.6 MB, generated via `npx allure@3.14.3 generate`): double-patched it, bar injected exactly once before `#app`; confirmed the literal `<body>\n    <div id="app">` byte sequence and that Allure's own header is a sibling-safe mount (verified against the published `@allurereport/web-awesome@3.14.3` TSX source).
- Screenshot note: headless Chrome/Edge capture is non-functional in this sandbox (processes spawn but never emit output — attempted and cleaned up). Visual design was pre-approved via the Variant A mockup (`allure-buttons-mockup.html`) earlier in this session; real-DOM source verification above substitutes for a live capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk