### PR TITLE
Resolve loopback-sink sentinel to the tab's real BiDi browsing context

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/BrowserEventSink.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/BrowserEventSink.java
@@ -29,6 +29,14 @@ import java.util.function.Supplier;
  */
 final class BrowserEventSink implements AutoCloseable {
     private static final int MAX_REQUEST_BYTES = 131_072;
+    /**
+     * Sentinel browsing-context id stamped on every signal this sink delivers: page JS posting to
+     * this loopback endpoint has no visibility into its own BiDi browsing-context id, so it can
+     * never report the tab's real one. {@link CaptureEventPipeline} correlates this sentinel back
+     * to the tab most recently confirmed by a genuine BiDi signal (issue #3803) instead of treating
+     * it as a distinct context.
+     */
+    static final String LOOPBACK_BROWSING_CONTEXT_ID = "loopback";
 
     private final Consumer<BrowserSignal> signalConsumer;
     private final Consumer<String> warningConsumer;
@@ -227,7 +235,8 @@ final class BrowserEventSink implements AutoCloseable {
             if (!payload.isObject()) {
                 return;
             }
-            signalConsumer.accept(BrowserSignal.fromJson(mapper.writeValueAsString(payload), "loopback"));
+            signalConsumer.accept(BrowserSignal.fromJson(
+                    mapper.writeValueAsString(payload), LOOPBACK_BROWSING_CONTEXT_ID));
         } catch (JacksonException exception) {
             warningConsumer.accept("A malformed browser interaction signal was ignored.");
         }

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -103,6 +103,15 @@ final class CaptureEventPipeline implements AutoCloseable {
     private Instant lastAppendedNavigationAt = Instant.EPOCH;
     private String lastWindow = "";
     private List<String> lastFramePath = List.of();
+    // The tab most recently confirmed by a genuine BiDi signal (window-open, navigation-committed,
+    // or an interaction delivered over the BiDi script channel). BrowserEventSink's loopback HTTP
+    // channel -- a redundant delivery path for the same preload-script signals, added by #3495 so
+    // bfcache-restored pages that lost their BiDi channel still get delivered -- cannot report a
+    // real browsing-context id (page JS has no visibility into it) and stamps every signal it
+    // carries with the literal sentinel "loopback" instead. Resolving that sentinel to this tracked
+    // id keeps a single tab's signals under one logical window regardless of which channel wins the
+    // delivery race; see resolveBrowsingContextId().
+    private String currentRealBrowsingContextId = "";
     private boolean closed;
 
     CaptureEventPipeline(
@@ -302,10 +311,10 @@ final class CaptureEventPipeline implements AutoCloseable {
             case "step_delete" -> deleteStep(signal);
             case "step_reorder" -> reorderStep(signal);
             case "window_open" -> append(new CaptureEvent.WindowEvent(
-                    context(signal), CaptureEvent.WindowAction.OPEN_TAB, logicalWindow(signal.browsingContextId())),
+                    context(signal), CaptureEvent.WindowAction.OPEN_TAB, logicalWindow(resolveBrowsingContextId(signal))),
                     RedactionSummary.empty(), List.of());
             case "window_close" -> append(new CaptureEvent.WindowEvent(
-                    context(signal), CaptureEvent.WindowAction.CLOSE, logicalWindow(signal.browsingContextId())),
+                    context(signal), CaptureEvent.WindowAction.CLOSE, logicalWindow(resolveBrowsingContextId(signal))),
                     RedactionSummary.empty(), List.of());
             case "alert" -> emitAlert(signal);
             default -> {
@@ -705,7 +714,7 @@ final class CaptureEventPipeline implements AutoCloseable {
         PageContext page = new PageContext(
                 safeUrl.value(),
                 safeTitle.value(),
-                logicalWindow(signal.browsingContextId()),
+                logicalWindow(resolveBrowsingContextId(signal)),
                 frames,
                 integer(signal.page().get("width"), 0),
                 integer(signal.page().get("height"), 0));
@@ -994,6 +1003,28 @@ final class CaptureEventPipeline implements AutoCloseable {
     private String logicalWindow(String contextId) {
         String key = contextId == null || contextId.isBlank() ? "default" : contextId;
         return logicalWindows.computeIfAbsent(key, ignored -> "window-" + (logicalWindows.size() + 1));
+    }
+
+    /**
+     * Resolves the effective browsing-context id used to look up a signal's logical window,
+     * correlating {@link BrowserEventSink}'s loopback-sink sentinel ({@code "loopback"}) back to
+     * the tab most recently confirmed by a genuine BiDi signal. Without this correlation, a
+     * loopback delivery winning its redundant-channel race against the BiDi channel carried a
+     * different raw id than the rest of the session and {@link #logicalWindow(String)} minted a
+     * phantom second logical window for a tab that never actually changed (issue #3803).
+     *
+     * @param signal the signal being normalized
+     * @return the real browsing-context id this signal's tab is known by
+     */
+    private String resolveBrowsingContextId(BrowserSignal signal) {
+        String contextId = signal.browsingContextId();
+        if (BrowserEventSink.LOOPBACK_BROWSING_CONTEXT_ID.equals(contextId)) {
+            return currentRealBrowsingContextId.isBlank() ? contextId : currentRealBrowsingContextId;
+        }
+        if (!contextId.isBlank()) {
+            currentRealBrowsingContextId = contextId;
+        }
+        return contextId;
     }
 
     private static String targetKey(BrowserSignal signal) {

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -1,6 +1,9 @@
 package com.shaft.capture.runtime;
 
 import com.shaft.capture.collector.BrowserSignal;
+import com.shaft.capture.generate.CaptureGenerationRequest;
+import com.shaft.capture.generate.CaptureGenerationResult;
+import com.shaft.capture.generate.CaptureGenerator;
 import com.shaft.capture.model.BrowserMetadata;
 import com.shaft.capture.model.CaptureEvent;
 import com.shaft.capture.model.CaptureSession;
@@ -8,12 +11,14 @@ import com.shaft.capture.model.ExternalTestDataReference;
 import com.shaft.capture.model.LocatorCandidate;
 import com.shaft.capture.privacy.CapturePrivacyPolicy;
 import com.shaft.capture.storage.CaptureSessionStore;
+import com.shaft.pilot.ai.ApprovalPolicy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +76,57 @@ class CaptureEventPipelineTest {
         assertFalse(sessionJson.contains(SECRET_CANARY));
         assertFalse(dataJson.contains(SECRET_CANARY));
         assertTrue(dataJson.contains("alice"));
+    }
+
+    @Test
+    void asyncTypedInteractionDeliveredThroughLoopbackSinkStaysInTheSameLogicalWindow(
+            @TempDir Path temp) throws Exception {
+        // Issue #3803: BrowserEventSink -- the loopback HTTP channel wired as a second delivery
+        // path for BiDi preload signals by #3495 -- tags every signal it carries with the literal
+        // browsing-context id "loopback" (BrowserEventSink.java:230), never the tab's real BiDi
+        // context id. An async-typed interaction (e.g. a self-driving demo login that types via
+        // setTimeout, arriving ~2.5s after the page opened) can race across that channel and win:
+        // when it does, logicalWindow() saw a contextId it had never seen before and minted a
+        // phantom second logical window for a session that only ever had one tab, emitting a
+        // WindowEvent.SWITCH that CaptureGenerator then rejects as a window never opened.
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        String realContextId = "context-tab-1";
+        // BiDi's own BrowsingContextInspector reports the tab's real context id for window-open
+        // and navigation-committed signals: those never go through the loopback sink.
+        pipeline.accept(signalFromContext(
+                "window_open", START, realContextId, Map.of(), Map.of(), Map.of()));
+        pipeline.accept(signalFromContext(
+                "navigation", START.plusMillis(50), realContextId, Map.of(),
+                Map.of("action", "OPEN"), Map.of("url", "https://example.test/login")));
+        pipeline.accept(signalFromContext(
+                "input", START.plusSeconds(3), "loopback", usernameTarget(),
+                Map.of("value", "shaft.user", "committed", true), Map.of()));
+        pipeline.close();
+
+        List<CaptureEvent> events = store.read().events();
+        assertFalse(events.stream().anyMatch(event -> event instanceof CaptureEvent.WindowEvent windowEvent
+                        && windowEvent.action() == CaptureEvent.WindowAction.SWITCH),
+                "A single tab that never opened another window must never emit a WindowEvent.SWITCH: "
+                        + events);
+        CaptureEvent.TypeEvent typed = assertInstanceOf(CaptureEvent.TypeEvent.class, events.getLast());
+        assertEquals("window-1", typed.context().page().logicalWindowId(),
+                "The loopback-delivered interaction must resolve to the same logical window as the "
+                        + "tab's real BiDi context, not mint a second one.");
+
+        CaptureGenerationResult generated = new CaptureGenerator().generate(new CaptureGenerationRequest(
+                output, temp.resolve("generated"), "generated.capture", "", false,
+                false, false, Duration.ofMinutes(1),
+                CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                ApprovalPolicy.denyAll()));
+        assertTrue(generated.successful(),
+                "Codegen must succeed for a single-tab async-typed session: "
+                        + generated.report().unsupportedEvents());
     }
 
     @Test
@@ -788,6 +844,23 @@ class CaptureEventPipelineTest {
                 "framePath", List.of()));
         page.putAll(pageOverrides);
         return new BrowserSignal(kind, timestamp, "context-1", page, target, data);
+    }
+
+    private static BrowserSignal signalFromContext(
+            String kind,
+            Instant timestamp,
+            String browsingContextId,
+            Map<String, Object> target,
+            Map<String, Object> data,
+            Map<String, Object> pageOverrides) {
+        Map<String, Object> page = new java.util.LinkedHashMap<>(Map.of(
+                "url", "https://example.test/login",
+                "title", "Login",
+                "width", 1280,
+                "height", 720,
+                "framePath", List.of()));
+        page.putAll(pageOverrides);
+        return new BrowserSignal(kind, timestamp, browsingContextId, page, target, data);
     }
 
     private static Map<String, Object> usernameTarget() {


### PR DESCRIPTION
## Summary
Fixes #3803: a single tab was reported under two browsingContextId values — the real BiDi id (window-open/navigation channel) and the literal `"loopback"` sentinel stamped by `BrowserEventSink`'s HTTP loopback channel (the redundant preload-signal delivery path added by #3495). When the loopback delivery won the race for an async-typed interaction, `CaptureEventPipeline.logicalWindow()` minted a phantom `window-2`, emitted a `WindowEvent.SWITCH`, and `CaptureGenerator` rejected the SWITCH to a never-opened window — blocking codegen for the Guided Workflows Live E2E login scenario.

## Fix
- `BrowserEventSink`: the bare `"loopback"` literal becomes a documented package-visible sentinel constant.
- `CaptureEventPipeline`: tracks the most recently confirmed real browsing-context id and resolves the loopback sentinel to it at all three `logicalWindow(...)` call sites. Genuine multi-window SWITCH validation in `CaptureGenerator` is untouched.

## Evidence (TDD)
- New regression `asyncTypedInteractionDeliveredThroughLoopbackSinkStaysInTheSameLogicalWindow` — watched RED pre-fix (reproduced the exact `window-1 → window-2` phantom SWITCH), GREEN post-fix; drives the full pipeline through store persistence **and** real `CaptureGenerator` codegen.
- `CaptureEventPipelineTest` 25/25, `CaptureGeneratorTest` 31/31 — multi-channel-race, navigation-debounce, and window-validation cases all unaffected.

## Deferred (filed separately)
Promoting the async-login scenario into the PR-gated capture E2E suite and tightening `ManagedCaptureRecorderBrowserTest`'s window-event assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk