### PR TITLE
Sync stale API unit tests with the explicit-status and HEAD/OPTIONS refactors

### DIFF
--- a/shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/api/RestActionsCoverageUnitTest.java
@@ -389,14 +389,39 @@ public class RestActionsCoverageUnitTest {
         Mockito.when(ok.getStatusLine()).thenReturn("HTTP/1.1 200 OK");
         Validations.assertThat().object(actions.evaluateResponseStatusCode(ok, 0)).isTrue().perform();
 
+        // Test the new contract: evaluateResponseStatusCode returns false on mismatch and doesn't throw
         Response mismatch = Mockito.mock(Response.class);
         Mockito.when(mismatch.getStatusCode()).thenReturn(500);
         Mockito.when(mismatch.getStatusLine()).thenReturn("HTTP/1.1 500 Internal Server Error");
-        Assert.assertThrows(RuntimeException.class, () -> actions.evaluateResponseStatusCode(mismatch, 200));
+        boolean result = actions.evaluateResponseStatusCode(mismatch, 200);
+        Validations.assertThat().object(result).isFalse().perform();
 
         RestActions.passAction("covered-path");
         Assert.assertThrows(RuntimeException.class,
                 () -> RestActions.failAction("force-failure", new RuntimeException("boom")));
+    }
+
+    @Test
+    public void requestBuilderPublicPathThrowsAssertionErrorOnStatusMismatch() throws Exception {
+        // Regression: public path RequestBuilder.perform still throws AssertionError to users on status mismatch
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/test", exchange -> {
+            exchange.sendResponseHeaders(500, 0);
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            int port = server.getAddress().getPort();
+            String baseUrl = "http://127.0.0.1:" + port + "/";
+            RestActions actions = new RestActions(baseUrl);
+            Assert.assertThrows(AssertionError.class,
+                    () -> actions.buildNewRequest("test", RestActions.RequestType.GET)
+                            .setTargetStatusCode(200)
+                            .perform());
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/RestActionsComprehensiveTests.java
+++ b/shaft-engine/src/test/java/testPackage/CopilotGeneratedTests/RestActionsComprehensiveTests.java
@@ -525,14 +525,18 @@ public class RestActionsComprehensiveTests {
 
     @Test
     public void testRequestTypeEnum() {
+        // Assert named constants exist rather than brittle exact count
         Assert.assertNotNull(RequestType.GET);
         Assert.assertNotNull(RequestType.POST);
         Assert.assertNotNull(RequestType.PUT);
         Assert.assertNotNull(RequestType.PATCH);
         Assert.assertNotNull(RequestType.DELETE);
-        
+        Assert.assertNotNull(RequestType.HEAD);
+        Assert.assertNotNull(RequestType.OPTIONS);
+
+        // Assert all can be retrieved by name
         RequestType[] values = RequestType.values();
-        Assert.assertEquals(values.length, 5);
+        Assert.assertTrue(values.length >= 7, "RequestType must have at least GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS");
     }
 
     // ========== Edge Cases and Error Handling Tests ==========

--- a/shaft-engine/src/test/java/testPackage/unitTests/RestActionsUtilsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/RestActionsUtilsUnitTest.java
@@ -98,7 +98,7 @@ public class RestActionsUtilsUnitTest {
     // ─── RequestType enum ─────────────────────────────────────────────────────
 
     @Test(description = "RequestType enum has required HTTP method constants")
-    public void requestTypeEnumHasFiveConstants() {
+    public void requestTypeEnumHasRequiredHttpMethodConstants() {
         // Assert named constants exist rather than brittle exact count
         Assert.assertNotNull(RestActions.RequestType.valueOf("GET"), "RequestType must have GET");
         Assert.assertNotNull(RestActions.RequestType.valueOf("POST"), "RequestType must have POST");

--- a/shaft-engine/src/test/java/testPackage/unitTests/RestActionsUtilsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/RestActionsUtilsUnitTest.java
@@ -97,10 +97,20 @@ public class RestActionsUtilsUnitTest {
 
     // ─── RequestType enum ─────────────────────────────────────────────────────
 
-    @Test(description = "RequestType enum has all 5 expected constants")
+    @Test(description = "RequestType enum has required HTTP method constants")
     public void requestTypeEnumHasFiveConstants() {
-        Assert.assertEquals(RestActions.RequestType.values().length, 5,
-                "RequestType must have GET, POST, PATCH, DELETE, PUT");
+        // Assert named constants exist rather than brittle exact count
+        Assert.assertNotNull(RestActions.RequestType.valueOf("GET"), "RequestType must have GET");
+        Assert.assertNotNull(RestActions.RequestType.valueOf("POST"), "RequestType must have POST");
+        Assert.assertNotNull(RestActions.RequestType.valueOf("PATCH"), "RequestType must have PATCH");
+        Assert.assertNotNull(RestActions.RequestType.valueOf("DELETE"), "RequestType must have DELETE");
+        Assert.assertNotNull(RestActions.RequestType.valueOf("PUT"), "RequestType must have PUT");
+        Assert.assertNotNull(RestActions.RequestType.valueOf("HEAD"), "RequestType must have HEAD");
+        Assert.assertNotNull(RestActions.RequestType.valueOf("OPTIONS"), "RequestType must have OPTIONS");
+
+        // Assert length is at least 7 so additive verbs don't re-break this
+        Assert.assertTrue(RestActions.RequestType.values().length >= 7,
+                "RequestType must have at least GET, POST, PATCH, DELETE, PUT, HEAD, OPTIONS");
     }
 
     @Test(description = "RequestType.GET can be retrieved by name")

--- a/test-output.log
+++ b/test-output.log
@@ -1,0 +1,3208 @@
+[INFO] Scanning for projects...
+[INFO] Inspecting build with total of 1 modules
+[INFO] Installing Central Publishing features
+[INFO] 
+[INFO] -------------------< io.github.shafthq:shaft-engine >-------------------
+[INFO] Building io.github.shafthq:shaft-engine 10.3.20260719
+[INFO]   from pom.xml
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- enforcer:3.6.3:enforce (enforce-toolchain) @ shaft-engine ---
+[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
+[INFO] Rule 1: org.apache.maven.enforcer.rules.version.RequireMavenVersion passed
+[INFO] Rule 2: org.apache.maven.enforcer.rules.dependency.RequireReleaseDeps passed
+[INFO] Rule 3: org.apache.maven.enforcer.rules.RequirePluginVersions passed
+[INFO] Rule 4: org.apache.maven.enforcer.rules.dependency.BanDynamicVersions passed
+[INFO] Rule 5: org.apache.maven.enforcer.rules.BanDuplicatePomDependencyVersions passed
+[INFO] Rule 6: org.apache.maven.enforcer.rules.dependency.DependencyConvergence passed
+[INFO] Rule 7: org.apache.maven.enforcer.rules.dependency.RequireUpperBoundDeps passed
+[INFO] Rule 8: org.apache.maven.enforcer.rules.dependency.BannedDependencies passed
+[INFO] 
+[INFO] --- enforcer:3.6.3:enforce (enforce-engine-dependency-boundary) @ shaft-engine ---
+[INFO] Rule 0: org.apache.maven.enforcer.rules.dependency.BannedDependencies passed
+[INFO] 
+[INFO] --- jacoco:0.8.15:prepare-agent (default-prepare-agent) @ shaft-engine ---
+[INFO] argLine set to -javaagent:C:\\Users\\Mohab\\.m2\\repository\\org\\jacoco\\org.jacoco.agent\\0.8.15\\org.jacoco.agent-0.8.15-runtime.jar=destfile=C:\\Users\\Mohab\\IdeaProjects\\SHAFT_ENGINE\\.claude\\worktrees\\fix-3808\\shaft-engine\\target\\jacoco.exec,excludes=**/*Aspect:testDataFiles/**
+[INFO] 
+[INFO] --- resources:3.5.0:resources (default-resources) @ shaft-engine ---
+[INFO] Copying 7 resources from src\main\resources\properties\default to target\classes\resources\properties\default
+[INFO] Copying 7 resources from src\main\resources\META-INF to target\classes\META-INF
+[INFO] Copying 3 resources from src\main\resources to target\classes
+[INFO] 
+[INFO] --- compiler:3.15.0:compile (default-compile) @ shaft-engine ---
+[INFO] Recompiling the module because of changed source code.
+[INFO] Compiling 231 source files with javac [debug release 25] to target\classes
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java:[1013,48] dockerCommandTimeout() in com.shaft.properties.internal.Timeouts has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/main/java/com/shaft/cli/FileActions.java:[254,28] isDockerizedTerminal() in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/main/java/com/shaft/cli/FileActions.java:[297,28] isDockerizedTerminal() in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[INFO] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/main/java/com/shaft/tools/io/CSVFileManager.java: Some input files use or override a deprecated API.
+[INFO] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/main/java/com/shaft/tools/io/CSVFileManager.java: Recompile with -Xlint:deprecation for details.
+[INFO] 
+[INFO] --- resources:3.5.0:testResources (default-testResources) @ shaft-engine ---
+[INFO] Copying 53 resources from src\test\resources to target\test-classes
+[INFO] 
+[INFO] --- compiler:3.15.0:testCompile (default-testCompile) @ shaft-engine ---
+[INFO] Recompiling the module because of changed dependency.
+[INFO] Compiling 342 source files with javac [debug release 25] to target\test-classes
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java:[179,42] isDockerizedTerminal() in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/legacy/ChecksumTests.java:[64,43] TerminalActions(java.lang.String,int,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String) in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java:[53,57] dockerCommandTimeout() in com.shaft.properties.internal.Timeouts has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java:[83,40] dockerCommandTimeout(int) in com.shaft.properties.internal.Timeouts.SetProperty has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[50,36] isDockerizedTerminal() in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[59,36] isDockerizedTerminal() in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[66,36] TerminalActions(java.lang.String,java.lang.String) in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[69,35] isDockerizedTerminal() in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[83,36] isDockerizedTerminal() in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[100,36] TerminalActions(java.lang.String,int,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String) in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[105,35] isDockerizedTerminal() in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[120,36] isDockerizedTerminal() in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[252,36] TerminalActions(java.lang.String,int,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String) in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[288,46] TerminalActions(java.lang.String,int,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String) in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[337,36] isDockerizedTerminal() in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[489,36] TerminalActions(java.lang.String,java.lang.String) in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[WARNING] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java:[810,36] TerminalActions(java.lang.String,int,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String) in com.shaft.cli.TerminalActions has been deprecated and marked for removal
+[INFO] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java: Some input files use or override a deprecated API.
+[INFO] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/com/shaft/api/RequestBuilderTests.java: Recompile with -Xlint:deprecation for details.
+[INFO] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java: Some input files use unchecked or unsafe operations.
+[INFO] /C:/Users/Mohab/IdeaProjects/SHAFT_ENGINE/.claude/worktrees/fix-3808/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java: Recompile with -Xlint:unchecked for details.
+[INFO] 
+[INFO] --- surefire:3.5.6:test (default-test) @ shaft-engine ---
+[INFO] Using configured provider org.apache.maven.surefire.testng.TestNGProvider
+[INFO] 
+[INFO] -------------------------------------------------------
+[INFO]  T E S T S
+[INFO] -------------------------------------------------------
+[INFO] Running TestSuite
+[INFO] 01:20:29 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                           ⚡ Powered by SHAFT v.10.3.20260719                                           
+                                   Visit SHAFT's user guide https://shafthq.github.io/ to learn more                                   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:32 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting suite setup configuration                                                      
+                                          'com.shaft.listeners.internal.ConfigurationHelper.suiteSetup'                                          
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:33 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '1 of 140' test cases in the current suite                                        
+                  Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.apiConstructorShouldSeedCookiesFromStorageStateFile'                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:34 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+             ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.apiConstructorShouldSeedCookiesFromStorageStateFile'.             
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:34 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:34 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '2 of 140' test cases in the current suite                                        
+                 Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.apiConstructorWithStorageStatePathThrowsForMissingFile'                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:34 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+           ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.apiConstructorWithStorageStatePathThrowsForMissingFile'.           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:34 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:34 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '3 of 140' test cases in the current suite                                        
+         Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.apiExportCookiesToWithoutFiltersExportsAllSessionCookiesAndRejectsNull'         
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:40 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+   ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.apiExportCookiesToWithoutFiltersExportsAllSessionCookiesAndRejectsNull'.   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:40 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:40 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '4 of 140' test cases in the current suite                                        
+                 Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.apiShouldExportCookiesToBrowserWithDomainAndPathFilter'                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:40 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+           ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.apiShouldExportCookiesToBrowserWithDomainAndPathFilter'.           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:40 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:40 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '5 of 140' test cases in the current suite                                        
+                  Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.apiShouldImportBrowserCookiesWithDomainAndPathFilter'                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:40 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+            ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.apiShouldImportBrowserCookiesWithDomainAndPathFilter'.            
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:40 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:40 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '6 of 140' test cases in the current suite                                        
+                   Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.buildNewRequestCreatesBuildersForEveryRequestType'                   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:40 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ Assertion passed
+[INFO] 01:20:41 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+              ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.buildNewRequestCreatesBuildersForEveryRequestType'.              
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:41 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:41 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '7 of 140' test cases in the current suite                                        
+                Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.compareJsonCoversPositiveAndNegativeLocalFileStrategies'                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) 
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) 
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:42 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:42 │ You're using the latest engine version "10.3.20260719". 👍
+[INFO] 01:20:42 │ Assertion passed
+
+[INFO] 01:20:42 │ Assertion passed
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) 
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:42 │ Assertion passed
+[INFO] 01:20:43 │ Assertion passed
+[INFO] 01:20:43 │ Assertion passed
+[INFO] 01:20:43 │ Assertion passed
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:43 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+           ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.compareJsonCoversPositiveAndNegativeLocalFileStrategies'.           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:43 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:43 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '8 of 140' test cases in the current suite                                        
+                  Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.constructorWithDriverAndPrepareRequestUrlAreCovered'                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:43 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:43 │ Assertion passed
+[INFO] 01:20:43 │ Assertion passed
+[INFO] 01:20:43 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+             ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.constructorWithDriverAndPrepareRequestUrlAreCovered'.             
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:43 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:43 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '9 of 140' test cases in the current suite                                        
+               Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.evaluateResponseStatusCodeAndStaticActionHelpersAreCovered'               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:43 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[ERROR] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+         ✗ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.evaluateResponseStatusCodeAndStaticActionHelpersAreCovered'.         
+                                                                 Status: Failed                                                                 
+                     Root cause: "java.lang.AssertionError: Expected RuntimeException to be thrown, but nothing was thrown"                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) 
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '10 of 140' test cases in the current suite                                        
+                        Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.getResponseAsListMapsJsonArrayToRecords'                        
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:44 │ Assertion passed
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                   ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.getResponseAsListMapsJsonArrayToRecords'.                   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '11 of 140' test cases in the current suite                                        
+                    Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.getResponseAsMapsJsonBodyToGenericTypeReference'                    
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:44 │ Assertion passed
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+               ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.getResponseAsMapsJsonBodyToGenericTypeReference'.               
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '12 of 140' test cases in the current suite                                        
+                           Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.getResponseAsMapsJsonBodyToRecord'                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:44 │ Assertion passed
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                      ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.getResponseAsMapsJsonBodyToRecord'.                      
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '13 of 140' test cases in the current suite                                        
+                         Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.getResponseAsReportsClearMappingErrors'                         
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[ERROR] 01:20:44 │ Cannot map empty response body to com.shaft.api.RestActionsCoverageUnitTest$ApiUser.
+[ERROR] 01:20:44 │ Cannot map response body to com.shaft.api.RestActionsCoverageUnitTest$ApiUser because response Content-Type is not JSON: text/plain.
+[ERROR] 01:20:44 │ Failed to map response body to com.shaft.api.RestActionsCoverageUnitTest$ApiUser.
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                   ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.getResponseAsReportsClearMappingErrors'.                   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:44 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '14 of 140' test cases in the current suite                                        
+        Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.getResponseJsonValueSupportsStringsCollectionsFiltersAndMockedResponses'        
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:45 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:45 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:45 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:45 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:45 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:46 │ Assertion passed
+[INFO] 01:20:46 │ Assertion passed
+[INFO] 01:20:46 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+   ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.getResponseJsonValueSupportsStringsCollectionsFiltersAndMockedResponses'.   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:46 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:46 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '15 of 140' test cases in the current suite                                        
+                      Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.graphQlOverloadsAreCoveredAgainstLocalServer'                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:47 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:47 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:47 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:47 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) 
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:47 │ Assertion passed
+[INFO] 01:20:47 │ Assertion passed
+[INFO] 01:20:47 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.graphQlOverloadsAreCoveredAgainstLocalServer'.                
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:48 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:48 │ 
+
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '16 of 140' test cases in the current suite                                        
+       Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.parseBodyToJsonCoversStringsStreamsJacksonNodesMapsAndMockedResponseBodies'       
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+ ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.parseBodyToJsonCoversStringsStreamsJacksonNodesMapsAndMockedResponseBodies'. 
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:48 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:48 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '17 of 140' test cases in the current suite                                        
+                Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.prepareReportMessageExtractsCookiesHeadersAndBearerToken'                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.prepareReportMessageExtractsCookiesHeadersAndBearerToken'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:48 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:48 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '18 of 140' test cases in the current suite                                        
+                   Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.prepareReportMessageReturnsEmptyWhenResponseIsNull'                   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+             ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.prepareReportMessageReturnsEmptyWhenResponseIsNull'.             
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:48 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:48 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '19 of 140' test cases in the current suite                                        
+         Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.prepareRequestSpecsCoversBodyMapQueryFormAndMultipartParameterBranches'         
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:48 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+   ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.prepareRequestSpecsCoversBodyMapQueryFormAndMultipartParameterBranches'.   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '20 of 140' test cases in the current suite                                        
+             Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.prepareRequestSpecsShouldHonorJacksonNamingOnJsonRequestBodies'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.prepareRequestSpecsShouldHonorJacksonNamingOnJsonRequestBodies'.       
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '21 of 140' test cases in the current suite                                        
+            Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.requestBuilderHeaderCookieQueryAndFormHelpersMutateRequestState'            
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.requestBuilderHeaderCookieQueryAndFormHelpersMutateRequestState'.       
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '22 of 140' test cases in the current suite                                        
+                      Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.requestBuilderShouldSendQueryParametersOnce'                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) 
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                 ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.requestBuilderShouldSendQueryParametersOnce'.                 
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:49 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '23 of 140' test cases in the current suite                                        
+              Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.responseBodyEqualsIgnoringOrderShouldCompareJsonStructurally'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:49 │ Assertion passed
+[INFO] 01:20:49 │ Assertion passed
+[ERROR] 01:20:50 │ ❌ Assertion Failed at Line: 594
+🔍 Details: Assertion failed; expected {"name":"other","roles":["admin","tester"]}, but found {"roles":["tester","admin"],"name":"shaft"}
+📍 Navigate:
+at com.shaft.api.RestActionsCoverageUnitTest.lambda$responseBodyEqualsIgnoringOrderShouldCompareJsonStructurally$0(RestActionsCoverageUnitTest.java:594)
+[INFO] 01:20:50 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.responseBodyEqualsIgnoringOrderShouldCompareJsonStructurally'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:50 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:50 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '24 of 140' test cases in the current suite                                        
+                  Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.responseMetadataAndXmlHelpersUseLocalServerResponses'                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:50 │ Assertion passed
+[INFO] 01:20:50 │ Assertion passed
+[INFO] 01:20:50 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:51 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:51 │ Assertion passed
+[INFO] 01:20:51 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:51 │ Assertion passed
+[INFO] 01:20:51 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+            ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.responseMetadataAndXmlHelpersUseLocalServerResponses'.            
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:51 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:51 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '25 of 140' test cases in the current suite                                        
+                  Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.sendRequestSupportsAllHttpMethodsAgainstLocalServer'                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:51 │ Assertion passed
+[INFO] 01:20:51 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:51 │ Assertion passed
+[INFO] 01:20:51 │ Assertion passed
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:51 │ Assertion passed
+[WARN] 01:20:51 │ Jul 20, 2026 1:20:51 AM sun.net.httpserver.ExchangeImpl sendResponseHeaders
+[WARN] 01:20:51 │ WARNING: sendResponseHeaders: being invoked with a content length for a HEAD request
+[INFO] 01:20:51 │ Assertion passed
+[INFO] 01:20:51 │ Assertion passed
+[INFO] 01:20:51 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+             ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.sendRequestSupportsAllHttpMethodsAgainstLocalServer'.             
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:51 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:51 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '26 of 140' test cases in the current suite                                        
+                        Test Method: 'com.shaft.api.RestActionsCoverageUnitTest.shaftApiMapsLastResponseWithTypedHelpers'                        
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:51 │ Assertion passed
+[INFO] 01:20:51 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                  ✓ Finished test method 'com.shaft.api.RestActionsCoverageUnitTest.shaftApiMapsLastResponseWithTypedHelpers'.                  
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:51 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                        ⚙ Starting cleanup configuration                                                        
+                                               'com.shaft.api.RestActionsCoverageUnitTest.cleanup'                                               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:51 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '27 of 140' test cases in the current suite                                        
+                      Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddCookieVariable'                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                 ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddCookieVariable'.                 
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '28 of 140' test cases in the current suite                                        
+               Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddCookieVariableWithEmptyValues'               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+         ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddCookieVariableWithEmptyValues'.         
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '29 of 140' test cases in the current suite                                        
+               Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddCookieVariableWithNullValues'               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddCookieVariableWithNullValues'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '30 of 140' test cases in the current suite                                        
+                      Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddHeaderVariable'                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                 ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddHeaderVariable'.                 
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '31 of 140' test cases in the current suite                                        
+               Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddHeaderVariableWithEmptyValues'               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+         ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddHeaderVariableWithEmptyValues'.         
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '32 of 140' test cases in the current suite                                        
+               Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddHeaderVariableWithNullValues'               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testAddHeaderVariableWithNullValues'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '33 of 140' test cases in the current suite                                        
+                 Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testBuildNewRequestStaticMethod'                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+            ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testBuildNewRequestStaticMethod'.            
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '34 of 140' test cases in the current suite                                        
+           Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testBuildNewRequestWithDifferentRequestTypes'           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+     ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testBuildNewRequestWithDifferentRequestTypes'.     
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '35 of 140' test cases in the current suite                                        
+                Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testBuildNewRequestWithEmptyValues'                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testBuildNewRequestWithEmptyValues'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '36 of 140' test cases in the current suite                                        
+                Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testBuildNewRequestWithNullValues'                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+           ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testBuildNewRequestWithNullValues'.           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '37 of 140' test cases in the current suite                                        
+                   Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testChainedSessionVariables'                   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+              ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testChainedSessionVariables'.              
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '38 of 140' test cases in the current suite                                        
+                     Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONContains'                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONContains'.                
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+Asserting...   0% │░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│  0/10 (0:00:00) seconds
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '39 of 140' test cases in the current suite                                        
+         Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONContainsWithJsonPathToTargetArray'         
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+   ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONContainsWithJsonPathToTargetArray'.   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:52 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '40 of 140' test cases in the current suite                                        
+          Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONContainsWithSecondaryComparison'          
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+    ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONContainsWithSecondaryComparison'.    
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '41 of 140' test cases in the current suite                                        
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONContainsWithoutJsonPath'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONContainsWithoutJsonPath'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '42 of 140' test cases in the current suite                                        
+                      Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONEquals'                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                 ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONEquals'.                 
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '43 of 140' test cases in the current suite                                        
+                Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONEqualsIgnoringOrder'                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONEqualsIgnoringOrder'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '44 of 140' test cases in the current suite                                        
+           Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONEqualsIgnoringOrderWithArrays'           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+     ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONEqualsIgnoringOrderWithArrays'.     
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '45 of 140' test cases in the current suite                                        
+          Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONEqualsIgnoringOrderWithObjects'          
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+     ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONEqualsIgnoringOrderWithObjects'.     
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '46 of 140' test cases in the current suite                                        
+           Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONWithArrayExpectedArrayActual'           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+      ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONWithArrayExpectedArrayActual'.      
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '47 of 140' test cases in the current suite                                        
+                 Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONWithFileNotFound'                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+            ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONWithFileNotFound'.            
+                                                                 Status: Passed                                                                 
+ Root cause: "java.io.FileNotFoundException: src\test\resources\testDataFiles\nonexistent\file.json (The system cannot find the path specified)" 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '48 of 140' test cases in the current suite                                        
+                  Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONWithInvalidJson'                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+            ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONWithInvalidJson'.            
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '49 of 140' test cases in the current suite                                        
+                   Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONWithJsonPath'                   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[ERROR] 01:20:53 │ Failed to parse the JSON document
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+              ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONWithJsonPath'.              
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '50 of 140' test cases in the current suite                                        
+                Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONWithMismatchedTypes'                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompareJSONWithMismatchedTypes'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '51 of 140' test cases in the current suite                                        
+                      Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testComparisonTypeEnum'                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testComparisonTypeEnum'.                
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '52 of 140' test cases in the current suite                                        
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompleteApiWorkflowWithAllFeatures'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompleteApiWorkflowWithAllFeatures'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '53 of 140' test cases in the current suite                                        
+                       Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompleteWorkflow'                       
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                 ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testCompleteWorkflow'.                 
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '54 of 140' test cases in the current suite                                        
+                      Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithCDATA'                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithCDATA'.                
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '55 of 140' test cases in the current suite                                        
+                   Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithComplexXML'                   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+              ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithComplexXML'.              
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '56 of 140' test cases in the current suite                                        
+                   Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithEmptyString'                   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[WARN] 01:20:53 │ [Fatal Error] :1:1: Premature end of file.
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+             ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithEmptyString'.             
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '57 of 140' test cases in the current suite                                        
+                  Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithMalformedXML'                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[WARN] 01:20:53 │ [Fatal Error] :1:25: XML document structures must start and end within the same entity.
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+             ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithMalformedXML'.             
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:53 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '58 of 140' test cases in the current suite                                        
+                    Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithNullInput'                    
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+              ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithNullInput'.              
+                                                                 Status: Passed                                                                 
+                                                  Root cause: "java.lang.NullPointerException"                                                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '59 of 140' test cases in the current suite                                        
+                Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithSpecialCharacters'                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithSpecialCharacters'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '60 of 140' test cases in the current suite                                        
+                    Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithValidXML'                    
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+               ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testFormatXMLWithValidXML'.               
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '61 of 140' test cases in the current suite                                        
+                       Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseBody'                       
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                  ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseBody'.                  
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '62 of 140' test cases in the current suite                                        
+                  Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueAsList'                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+            ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueAsList'.            
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '63 of 140' test cases in the current suite                                        
+         Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueAsListWithComplexFilter'         
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+    ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueAsListWithComplexFilter'.    
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '64 of 140' test cases in the current suite                                        
+         Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueAsListWithComplexFilters'         
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+   ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueAsListWithComplexFilters'.   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '65 of 140' test cases in the current suite                                        
+         Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueAsListWithDifferentTypes'         
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+   ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueAsListWithDifferentTypes'.   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '66 of 140' test cases in the current suite                                        
+          Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueAsListWithEmptyResult'          
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+     ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueAsListWithEmptyResult'.     
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '67 of 140' test cases in the current suite                                        
+                 Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueFromList'                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+           ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueFromList'.           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '68 of 140' test cases in the current suite                                        
+             Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueFromListNotFound'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueFromListNotFound'.       
+                                                                 Status: Passed                                                                 
+Root cause: "java.lang.RuntimeException: Get response jsonvalue from list failed; Can't find the reference value [nonexistent] in the list with the [username] JSON Path."
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '69 of 140' test cases in the current suite                                        
+          Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueFromListWithEdgeCases'          
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+     ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueFromListWithEdgeCases'.     
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '70 of 140' test cases in the current suite                                        
+       Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueFromListWithMultipleMatches'       
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+  ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueFromListWithMultipleMatches'.  
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:54 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '71 of 140' test cases in the current suite                                        
+          Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueFromListWithNullValues'          
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+    ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueFromListWithNullValues'.    
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '72 of 140' test cases in the current suite                                        
+             Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithArrayIndices'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithArrayIndices'.       
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '73 of 140' test cases in the current suite                                        
+     Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithComplexPathNotFoundException'     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithComplexPathNotFoundException'.
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '74 of 140' test cases in the current suite                                        
+             Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithDeepNesting'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithDeepNesting'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '75 of 140' test cases in the current suite                                        
+           Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithInvalidJsonPath'           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[ERROR] 01:20:55 │ Failed to parse the JSON document
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+      ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithInvalidJsonPath'.      
+                                                                 Status: Passed                                                                 
+                         Root cause: "com.jayway.jsonpath.PathNotFoundException: Missing property in path $['invalid']"                         
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '76 of 140' test cases in the current suite                                        
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithJSONArray'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+         ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithJSONArray'.         
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '77 of 140' test cases in the current suite                                        
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithJSONObject'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithJSONObject'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '78 of 140' test cases in the current suite                                        
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithJsonArray'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+         ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithJsonArray'.         
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '79 of 140' test cases in the current suite                                        
+      Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithJsonPathContainingQuestion'      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithJsonPathContainingQuestion'.
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '80 of 140' test cases in the current suite                                        
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithListObject'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithListObject'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '81 of 140' test cases in the current suite                                        
+        Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithMalformedJsonResponse'        
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+   ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithMalformedJsonResponse'.   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '82 of 140' test cases in the current suite                                        
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithMapObject'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+         ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithMapObject'.         
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '83 of 140' test cases in the current suite                                        
+             Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithNestedArrays'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithNestedArrays'.       
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '84 of 140' test cases in the current suite                                        
+             Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithNullJsonPath'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithNullJsonPath'.       
+                                                                 Status: Passed                                                                 
+        Root cause: "java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "jsonPath" is null"        
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:55 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '85 of 140' test cases in the current suite                                        
+             Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithNullResponse'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithNullResponse'.       
+                                                                 Status: Passed                                                                 
+   Root cause: "java.lang.NullPointerException: Cannot invoke "io.restassured.response.Response.asPrettyString()" because "response" is null"   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '86 of 140' test cases in the current suite                                        
+             Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithObjectInput'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithObjectInput'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '87 of 140' test cases in the current suite                                        
+        Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithPathNotFoundException'        
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+   ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithPathNotFoundException'.   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '88 of 140' test cases in the current suite                                        
+            Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithValidJsonPath'            
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseJSONValueWithValidJsonPath'.       
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '89 of 140' test cases in the current suite                                        
+                    Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseStatusCode'                    
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+               ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseStatusCode'.               
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '90 of 140' test cases in the current suite                                        
+            Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseStatusCodeWithNullResponse'            
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseStatusCodeWithNullResponse'.       
+                                                                 Status: Passed                                                                 
+    Root cause: "java.lang.NullPointerException: Cannot invoke "io.restassured.response.Response.getStatusCode()" because "response" is null"    
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '91 of 140' test cases in the current suite                                        
+                       Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseTime'                       
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                  ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseTime'.                  
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '92 of 140' test cases in the current suite                                        
+               Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseTimeWithNullResponse'               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseTimeWithNullResponse'.          
+                                                                 Status: Passed                                                                 
+Root cause: "java.lang.NullPointerException: Cannot invoke "io.restassured.response.Response.timeIn(java.util.concurrent.TimeUnit)" because "response" is null"
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '93 of 140' test cases in the current suite                                        
+                  Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueAsList'                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+             ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueAsList'.             
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '94 of 140' test cases in the current suite                                        
+            Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueAsListWithEmptyList'            
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+      ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueAsListWithEmptyList'.      
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '95 of 140' test cases in the current suite                                        
+          Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueAsListWithNullResponse'          
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+     ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueAsListWithNullResponse'.     
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '96 of 140' test cases in the current suite                                        
+           Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueWithExceptionHandling'           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+     ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueWithExceptionHandling'.     
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '97 of 140' test cases in the current suite                                        
+            Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueWithInvalidXmlPath'            
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueWithInvalidXmlPath'.       
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '98 of 140' test cases in the current suite                                        
+                 Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueWithNode'                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+            ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueWithNode'.            
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                        ▶ Starting Execution: '99 of 140' test cases in the current suite                                        
+             Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueWithNodeChildren'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueWithNodeChildren'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '100 of 140' test cases in the current suite                                       
+               Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueWithResponse'               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGetResponseXMLValueWithResponse'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:56 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '101 of 140' test cases in the current suite                                       
+                Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGraphQlHelperMethodsStructure'                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+           ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testGraphQlHelperMethodsStructure'.           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '102 of 140' test cases in the current suite                                       
+             Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testInitializeSystemPropertiesIndirectly'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testInitializeSystemPropertiesIndirectly'.       
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '103 of 140' test cases in the current suite                                       
+                      Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParametersTypeEnum'                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParametersTypeEnum'.                
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '104 of 140' test cases in the current suite                                       
+               Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithComplexObject'               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+         ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithComplexObject'.         
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '105 of 140' test cases in the current suite                                       
+                Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithIOException'                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithIOException'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '106 of 140' test cases in the current suite                                       
+             Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithInvalidJsonObject'             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithInvalidJsonObject'.       
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '107 of 140' test cases in the current suite                                       
+                 Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithNullInput'                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+           ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithNullInput'.           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '108 of 140' test cases in the current suite                                       
+                 Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithResponse'                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+            ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithResponse'.            
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '109 of 140' test cases in the current suite                                       
+               Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithResponseBody'               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithResponseBody'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '110 of 140' test cases in the current suite                                       
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithValidJsonObject'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseBodyToJsonWithValidJsonObject'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '111 of 140' test cases in the current suite                                       
+            Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseJsonBodyWithDifferentObjectTypes'            
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+       ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testParseJsonBodyWithDifferentObjectTypes'.       
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '112 of 140' test cases in the current suite                                       
+                      Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testPassActionVariants'                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testPassActionVariants'.                
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '113 of 140' test cases in the current suite                                       
+                   Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testPrettyFormatXMLEdgeCases'                   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[WARN] 01:20:57 │ [Fatal Error] :1:26: XML document structures must start and end within the same entity.
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+             ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testPrettyFormatXMLEdgeCases'.             
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '114 of 140' test cases in the current suite                                       
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testReportActionResultWithLongTestData'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testReportActionResultWithLongTestData'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '115 of 140' test cases in the current suite                                       
+                       Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testRequestTypeEnum'                       
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[ERROR] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                  ✗ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testRequestTypeEnum'.                  
+                                                                 Status: Failed                                                                 
+                                       Root cause: "java.lang.AssertionError: expected [5] but found [7]"                                       
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '116 of 140' test cases in the current suite                                       
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testRestActionsConstructorWithEmptyURI'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testRestActionsConstructorWithEmptyURI'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '117 of 140' test cases in the current suite                                       
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testRestActionsConstructorWithNullURI'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+         ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testRestActionsConstructorWithNullURI'.         
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '118 of 140' test cases in the current suite                                       
+              Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testRestActionsConstructorWithValidURI'              
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+        ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testRestActionsConstructorWithValidURI'.        
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '119 of 140' test cases in the current suite                                       
+                   Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestBasic'                   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+              ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestBasic'.              
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '120 of 140' test cases in the current suite                                       
+                 Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestWithHeader'                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+           ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestWithHeader'.           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:57 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '121 of 140' test cases in the current suite                                       
+           Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestWithHeaderAndVariables'           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+     ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestWithHeaderAndVariables'.     
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '122 of 140' test cases in the current suite                                       
+       Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestWithHeaderVariablesAndFragment'       
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+ ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestWithHeaderVariablesAndFragment'. 
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '123 of 140' test cases in the current suite                                       
+               Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestWithVariables'               
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestWithVariables'.          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         ⚙ Starting set up configuration                                                         
+                                     'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.setUp'                                     
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '124 of 140' test cases in the current suite                                       
+          Test Method: 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestWithVariablesAndFragment'          
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+    ✓ Finished test method 'testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testSendGraphQlRequestWithVariablesAndFragment'.    
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '125 of 140' test cases in the current suite                                       
+                    Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.comparisonTypeContainsCanBeRetrievedByName'                    
+                                      Test Description: 'ComparisonType.CONTAINS can be retrieved by name'                                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+               ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.comparisonTypeContainsCanBeRetrievedByName'.               
+                                         Description: 'ComparisonType.CONTAINS can be retrieved by name'                                         
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '126 of 140' test cases in the current suite                                       
+                    Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.comparisonTypeEnumHasAtLeastThreeConstants'                    
+                                        Test Description: 'ComparisonType enum has at least 3 constants'                                        
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+               ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.comparisonTypeEnumHasAtLeastThreeConstants'.               
+                                           Description: 'ComparisonType enum has at least 3 constants'                                           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '127 of 140' test cases in the current suite                                       
+                     Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.comparisonTypeEqualsCanBeRetrievedByName'                     
+                                       Test Description: 'ComparisonType.EQUALS can be retrieved by name'                                       
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.comparisonTypeEqualsCanBeRetrievedByName'.                
+                                          Description: 'ComparisonType.EQUALS can be retrieved by name'                                          
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '128 of 140' test cases in the current suite                                       
+               Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.formatXmlMultiElementDocumentIsFormattedWithoutError'               
+                                Test Description: 'formatXML: multi-element document is formatted without error'                                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.formatXmlMultiElementDocumentIsFormattedWithoutError'.          
+                                   Description: 'formatXML: multi-element document is formatted without error'                                   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '129 of 140' test cases in the current suite                                       
+                    Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.formatXmlResultContainsOriginalElementNames'                    
+                                    Test Description: 'formatXML: result contains the original element names'                                    
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+              ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.formatXmlResultContainsOriginalElementNames'.              
+                                      Description: 'formatXML: result contains the original element names'                                      
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '130 of 140' test cases in the current suite                                       
+                        Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.formatXmlResultContainsTextContent'                        
+                                         Test Description: 'formatXML: result contains the text content'                                         
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                   ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.formatXmlResultContainsTextContent'.                   
+                                           Description: 'formatXML: result contains the text content'                                           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '131 of 140' test cases in the current suite                                       
+                   Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.formatXmlWellFormedInputReturnsNonNullString'                   
+                                Test Description: 'formatXML: well-formed XML returns non-null formatted string'                                
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+              ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.formatXmlWellFormedInputReturnsNonNullString'.              
+                                   Description: 'formatXML: well-formed XML returns non-null formatted string'                                   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '132 of 140' test cases in the current suite                                       
+                    Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.parametersTypeEnumHasFormAndQueryConstants'                    
+                                      Test Description: 'ParametersType enum has FORM and QUERY constants'                                      
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+               ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.parametersTypeEnumHasFormAndQueryConstants'.               
+                                         Description: 'ParametersType enum has FORM and QUERY constants'                                         
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '133 of 140' test cases in the current suite                                       
+                    Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.parseBodyToJsonByteArrayReturnsInputStream'                    
+                                    Test Description: 'parseBodyToJson: byte array body returns InputStream'                                    
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+               ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.parseBodyToJsonByteArrayReturnsInputStream'.               
+                                       Description: 'parseBodyToJson: byte array body returns InputStream'                                       
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '134 of 140' test cases in the current suite                                       
+                Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.parseBodyToJsonJsonStringReturnsParsableInputStream'                
+                           Test Description: 'parseBodyToJson: JSON string body returns InputStream with JSON content'                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+          ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.parseBodyToJsonJsonStringReturnsParsableInputStream'.          
+                             Description: 'parseBodyToJson: JSON string body returns InputStream with JSON content'                             
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '135 of 140' test cases in the current suite                                       
+                       Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.parseBodyToJsonMapReturnsInputStream'                       
+                                 Test Description: 'parseBodyToJson: Map body is serialized to JSON InputStream'                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                  ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.parseBodyToJsonMapReturnsInputStream'.                  
+                                   Description: 'parseBodyToJson: Map body is serialized to JSON InputStream'                                   
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '136 of 140' test cases in the current suite                                       
+                  Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.parseBodyToJsonStringReturnsNonNullInputStream'                  
+                                  Test Description: 'parseBodyToJson: String body returns non-null InputStream'                                  
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+             ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.parseBodyToJsonStringReturnsNonNullInputStream'.             
+                                    Description: 'parseBodyToJson: String body returns non-null InputStream'                                    
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '137 of 140' test cases in the current suite                                       
+                       Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.requestTypeDeleteCanBeRetrievedByName'                       
+                                         Test Description: 'RequestType.DELETE can be retrieved by name'                                         
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                 ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.requestTypeDeleteCanBeRetrievedByName'.                 
+                                           Description: 'RequestType.DELETE can be retrieved by name'                                           
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '138 of 140' test cases in the current suite                                       
+                          Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.requestTypeEnumHasFiveConstants'                          
+                                        Test Description: 'RequestType enum has all 5 expected constants'                                        
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[ERROR] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                    ✗ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.requestTypeEnumHasFiveConstants'.                    
+                                          Description: 'RequestType enum has all 5 expected constants'                                          
+                                                                 Status: Failed                                                                 
+             Root cause: "java.lang.AssertionError: RequestType must have GET, POST, PATCH, DELETE, PUT expected [5] but found [7]"             
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '139 of 140' test cases in the current suite                                       
+                        Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.requestTypeGetCanBeRetrievedByName'                        
+                                          Test Description: 'RequestType.GET can be retrieved by name'                                          
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                   ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.requestTypeGetCanBeRetrievedByName'.                   
+                                             Description: 'RequestType.GET can be retrieved by name'                                             
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                       ▶ Starting Execution: '140 of 140' test cases in the current suite                                       
+                        Test Method: 'testPackage.unitTests.RestActionsUtilsUnitTest.requestTypePostCanBeRetrievedByName'                        
+                                          Test Description: 'RequestType.POST can be retrieved by name'                                          
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                  ✓ Finished test method 'testPackage.unitTests.RestActionsUtilsUnitTest.requestTypePostCanBeRetrievedByName'.                  
+                                            Description: 'RequestType.POST can be retrieved by name'                                            
+                                                                 Status: Passed                                                                 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                      ⚙ Starting reset state configuration                                                      
+                                           'testPackage.unitTests.RestActionsUtilsUnitTest.resetState'                                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                    ⚙ Starting engine tear down configuration                                                    
+                                        'com.shaft.listeners.internal.ConfigurationHelper.engineTearDown'                                        
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:20:58 │ Issue Summary: Total Issues = 3, New issues for Failed Tests = 3, Open issues for Passed Tests = 0, Open issues for Failed Tests = 0. See the attached issue details.
+[INFO] 01:21:00 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                                         Test Execution Summary Results                                                         
+                           Total: 140  ·  ✓ Passed: 137  ·  ✗ Failed: 3  ·  ⊘ Skipped: 0                           
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:21:00 │ 
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+                                  ⚡ This test run was powered by SHAFT v.10.3.20260719                                  
+                               SHAFT is and will always be 100% FREE for commercial and private use                               
+                                                   in compliance with the MIT license                                                   
+                                   Visit SHAFT's user guide https://shafthq.github.io/ to learn more                                   
+════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
+
+[INFO] 01:21:00 │ Sending anonymous usage information...
+Note: the client IP is forwarded to Google Analytics for anonymous country-level reporting only.
+To disable telemetry, set `telemetry.enabled=false` in your custom.properties file.
+[ERROR] Tests run: 140, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 61.19 s <<< FAILURE! -- in TestSuite
+[ERROR] com.shaft.api.RestActionsCoverageUnitTest.evaluateResponseStatusCodeAndStaticActionHelpersAreCovered -- Time elapsed: 0.583 s <<< FAILURE!
+java.lang.AssertionError: Expected RuntimeException to be thrown, but nothing was thrown
+	at org.testng.Assert.expectThrows(Assert.java:2464)
+	at org.testng.Assert.expectThrows(Assert.java:2429)
+	at org.testng.Assert.assertThrows(Assert.java:2395)
+	at com.shaft.api.RestActionsCoverageUnitTest.evaluateResponseStatusCodeAndStaticActionHelpersAreCovered(RestActionsCoverageUnitTest.java:395)
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:141)
+	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:697)
+	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:230)
+	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:63)
+	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:1005)
+	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:203)
+	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:154)
+	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:134)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
+	at org.testng.TestRunner.privateRun(TestRunner.java:744)
+	at org.testng.TestRunner.run(TestRunner.java:616)
+	at org.testng.SuiteRunner.runTest(SuiteRunner.java:421)
+	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:413)
+	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:373)
+	at org.testng.SuiteRunner.run(SuiteRunner.java:312)
+	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
+	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
+	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1274)
+	at org.testng.TestNG.runSuitesLocally(TestNG.java:1208)
+	at org.testng.TestNG.runSuites(TestNG.java:1112)
+	at org.testng.TestNG.run(TestNG.java:1079)
+	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:155)
+	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeMulti(TestNGDirectoryTestSuite.java:169)
+	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:88)
+	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:137)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+
+[ERROR] testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testRequestTypeEnum -- Time elapsed: 0.140 s <<< FAILURE!
+java.lang.AssertionError: expected [5] but found [7]
+	at org.testng.Assert.fail(Assert.java:111)
+	at org.testng.Assert.failNotEquals(Assert.java:1590)
+	at org.testng.Assert.assertEqualsImpl(Assert.java:150)
+	at org.testng.Assert.assertEquals(Assert.java:132)
+	at org.testng.Assert.assertEquals(Assert.java:1431)
+	at org.testng.Assert.assertEquals(Assert.java:1395)
+	at org.testng.Assert.assertEquals(Assert.java:1441)
+	at testPackage.CopilotGeneratedTests.RestActionsComprehensiveTests.testRequestTypeEnum(RestActionsComprehensiveTests.java:535)
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:141)
+	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:697)
+	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:230)
+	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:63)
+	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:1005)
+	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:203)
+	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:154)
+	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:134)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
+	at org.testng.TestRunner.privateRun(TestRunner.java:744)
+	at org.testng.TestRunner.run(TestRunner.java:616)
+	at org.testng.SuiteRunner.runTest(SuiteRunner.java:421)
+	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:413)
+	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:373)
+	at org.testng.SuiteRunner.run(SuiteRunner.java:312)
+	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
+	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
+	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1274)
+	at org.testng.TestNG.runSuitesLocally(TestNG.java:1208)
+	at org.testng.TestNG.runSuites(TestNG.java:1112)
+	at org.testng.TestNG.run(TestNG.java:1079)
+	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:155)
+	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeMulti(TestNGDirectoryTestSuite.java:169)
+	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:88)
+	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:137)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+
+[ERROR] testPackage.unitTests.RestActionsUtilsUnitTest.requestTypeEnumHasFiveConstants -- Time elapsed: 0.052 s <<< FAILURE!
+java.lang.AssertionError: RequestType must have GET, POST, PATCH, DELETE, PUT expected [5] but found [7]
+	at org.testng.Assert.fail(Assert.java:111)
+	at org.testng.Assert.failNotEquals(Assert.java:1590)
+	at org.testng.Assert.assertEqualsImpl(Assert.java:150)
+	at org.testng.Assert.assertEquals(Assert.java:132)
+	at org.testng.Assert.assertEquals(Assert.java:1431)
+	at org.testng.Assert.assertEquals(Assert.java:1395)
+	at testPackage.unitTests.RestActionsUtilsUnitTest.requestTypeEnumHasFiveConstants(RestActionsUtilsUnitTest.java:102)
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:141)
+	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:697)
+	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:230)
+	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:63)
+	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:1005)
+	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:203)
+	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:154)
+	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:134)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
+	at org.testng.TestRunner.privateRun(TestRunner.java:744)
+	at org.testng.TestRunner.run(TestRunner.java:616)
+	at org.testng.SuiteRunner.runTest(SuiteRunner.java:421)
+	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:413)
+	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:373)
+	at org.testng.SuiteRunner.run(SuiteRunner.java:312)
+	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
+	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
+	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1274)
+	at org.testng.TestNG.runSuitesLocally(TestNG.java:1208)
+	at org.testng.TestNG.runSuites(TestNG.java:1112)
+	at org.testng.TestNG.run(TestNG.java:1079)
+	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:155)
+	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeMulti(TestNGDirectoryTestSuite.java:169)
+	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:88)
+	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:137)
+	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
+	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
+	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
+	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
+
+[INFO] 
+[INFO] Results:
+[INFO] 
+[ERROR] Failures: 
+[ERROR]   RestActionsCoverageUnitTest.evaluateResponseStatusCodeAndStaticActionHelpersAreCovered:395 Expected RuntimeException to be thrown, but nothing was thrown
+[ERROR]   RestActionsComprehensiveTests.testRequestTypeEnum:535 expected [5] but found [7]
+[ERROR]   RestActionsUtilsUnitTest.requestTypeEnumHasFiveConstants:102 RequestType must have GET, POST, PATCH, DELETE, PUT expected [5] but found [7]
+[INFO] 
+[ERROR] Tests run: 140, Failures: 3, Errors: 0, Skipped: 0
+[INFO] 
+[ERROR] There are test failures.
+
+See C:\Users\Mohab\IdeaProjects\SHAFT_ENGINE\.claude\worktrees\fix-3808\shaft-engine\target\surefire-reports for the individual test results.
+See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
+[INFO] 
+[INFO] --- jacoco:0.8.15:report (default-report) @ shaft-engine ---
+[INFO] Loading execution data file C:\Users\Mohab\IdeaProjects\SHAFT_ENGINE\.claude\worktrees\fix-3808\shaft-engine\target\jacoco.exec
+[INFO] Analyzed bundle 'io.github.shafthq:shaft-engine' with 397 classes
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  02:30 min
+[INFO] Finished at: 2026-07-20T01:21:21+03:00
+[INFO] ------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Three unit tests asserted pre-refactor contracts that have since changed:

1. **RestActionsCoverageUnitTest.java:395** — `evaluateResponseStatusCode` now returns boolean (false on mismatch) rather than throwing; test now asserts the new contract and includes regression test for RequestBuilder.perform to confirm it still throws AssertionError to users
2. **RestActionsComprehensiveTests.java:534-535** — RequestType grew from 5 to 7 constants (HEAD/OPTIONS added); test now asserts named constants exist rather than exact count 5
3. **RestActionsUtilsUnitTest.java:100-104** — Same RequestType growth; test now asserts named constants via valueOf and minimum length >= 7

## Evidence
**RED proof (before fix):**
- RestActionsCoverageUnitTest: Expected RuntimeException to be thrown, but nothing was thrown
- RestActionsComprehensiveTests: expected [5] but found [7]
- RestActionsUtilsUnitTest: expected [5] but found [7]

**GREEN proof (after fix):**
- All 141 tests pass (27 + 98 + 16)

Closes #3808

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk