### PR TITLE
Skip supplementary validation evidence when rich evidence is already attached

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/validation/PlaywrightValidationsExecutor.java
@@ -561,7 +561,7 @@ final class PlaywrightValidationsExecutor extends ValidationsExecutor {
 
     private void reportValidationState(Outcome outcome, long validationStartTime) {
         ValidationsHelper.reportValidationState(validationCategory, outcome.passed(), outcome.expected(),
-                outcome.actual(), attachments(outcome), validationStartTime);
+                outcome.actual(), attachments(outcome), validationStartTime, outcome.visualComparisonAttached());
     }
 
     private List<List<Object>> attachments(Outcome outcome) {

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
@@ -182,6 +182,36 @@ public class ValidationsHelper {
     }
 
     /**
+     * Same as {@link #reportValidationState(ValidationEnums.ValidationCategory, boolean, Object, Object, List, long)}
+     * for callers that already attached authoritative comparison evidence through a different channel
+     * before invoking this method (e.g. a Playwright visual-diff image attached directly via
+     * {@code Allure.addAttachment}). When {@code richEvidenceAlreadyAttached} is {@code true}, the
+     * generic "Validation Test Data" Expected/Actual text attachments and the "Assertion evidence"
+     * card are skipped, since they would otherwise redundantly restate a boolean/opaque comparison
+     * result that carries no information beyond what the rich evidence already shows (issue #3804).
+     *
+     * @param validationCategory        the validation category
+     * @param validationState           true when the validation passed
+     * @param expected                  the reported expected value
+     * @param actual                    the reported actual value
+     * @param attachments               report attachments prepared by the backend
+     * @param validationStartTime       epoch milliseconds at which the validation started
+     * @param richEvidenceAlreadyAttached true to skip the generic supplementary evidence attachments
+     */
+    public static void reportValidationState(ValidationEnums.ValidationCategory validationCategory,
+                                             boolean validationState,
+                                             Object expected,
+                                             Object actual,
+                                             List<List<Object>> attachments,
+                                             long validationStartTime,
+                                             boolean richEvidenceAlreadyAttached) {
+        var validationsHelper = new ValidationsHelper(validationCategory);
+        validationsHelper.validationStartTime = validationStartTime;
+        validationsHelper.reportValidationState(validationState, expected, actual, null, null, attachments,
+                false, richEvidenceAlreadyAttached);
+    }
+
+    /**
      * Automatically formats an AssertionError by detecting the package from the stack trace.
      * This method extracts the package from the first stack trace element that is not from
      * framework packages (org.testng, java, com.shaft.validation.internal, etc.)
@@ -1021,6 +1051,10 @@ public class ValidationsHelper {
     }
 
     private void reportValidationState(boolean validationState, Object expected, Object actual, WebDriver driver, By locator, List<List<Object>> attachments, boolean skipDefaultScreenshot) {
+        reportValidationState(validationState, expected, actual, driver, locator, attachments, skipDefaultScreenshot, false);
+    }
+
+    private void reportValidationState(boolean validationState, Object expected, Object actual, WebDriver driver, By locator, List<List<Object>> attachments, boolean skipDefaultScreenshot, boolean richEvidenceAlreadyAttached) {
         TraceEventRecorder.Event traceEvent = TraceEventRecorder.start(
                 "validation",
                 this.validationCategoryString,
@@ -1064,7 +1098,7 @@ public class ValidationsHelper {
                 List<Object> pageSourceAttachment = Arrays.asList(this.validationCategoryString, logMessage, pageSnapshot);
                 attachments.add(pageSourceAttachment);
             }
-        } else {
+        } else if (!richEvidenceAlreadyAttached) {
             // prepare testData attachments; always attach expected/actual so every checkpoint carries its evidence
             List<Object> expectedValueAttachment = Arrays.asList("Validation Test Data", "Expected Value",
                     String.valueOf(expected));
@@ -1077,11 +1111,15 @@ public class ValidationsHelper {
         // Single primary assertion-evidence card (issue #3502 A+B): one HTML block carrying the
         // redacted expected/actual plus a diff, placed first so it headlines the Allure step. The
         // existing Expected/Actual text attachments stay (dual-write) so consumers that scrape
-        // those names keep working.
-        String evidenceCard = AssertionEvidenceReporter.renderCard(
-                this.validationCategoryString, validationState, expected, actual);
-        if (!evidenceCard.isBlank()) {
-            attachments.add(0, Arrays.asList("Assertion evidence", "assertion-evidence.html", evidenceCard));
+        // those names keep working. Skipped when the caller already attached authoritative rich
+        // comparison evidence elsewhere (e.g. a Playwright visual-diff image) — issue #3804: the
+        // card would otherwise redundantly restate a boolean/opaque result.
+        if (!richEvidenceAlreadyAttached) {
+            String evidenceCard = AssertionEvidenceReporter.renderCard(
+                    this.validationCategoryString, validationState, expected, actual);
+            if (!evidenceCard.isBlank()) {
+                attachments.add(0, Arrays.asList("Assertion evidence", "assertion-evidence.html", evidenceCard));
+            }
         }
         // add attachments
         long profilerAttachmentStart = !attachments.isEmpty() && FlakeProfiler.isEnabled() ? System.nanoTime() : 0L;

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperCoverageUnitTest.java
@@ -171,4 +171,25 @@ public class ValidationsHelperCoverageUnitTest {
         Assert.assertTrue(captured.stream().anyMatch(attachment -> "Actual Value".equals(attachment.get(1))),
                 "Legacy Actual Value attachment must remain.");
     }
+
+    @Test(description = "reportValidationState must not attach redundant Expected/Actual text or an " +
+            "Assertion evidence card when the caller already attached rich comparison evidence " +
+            "(e.g. a Playwright visual-diff image) — issue #3804")
+    public void reportValidationStateSkipsSupplementaryEvidenceWhenRichEvidenceAlreadyAttached() {
+        List<List<Object>> captured = new ArrayList<>();
+        try (MockedStatic<ReportManagerHelper> reportMock = Mockito.mockStatic(ReportManagerHelper.class)) {
+            reportMock.when(() -> ReportManagerHelper.attach(any()))
+                    .thenAnswer(invocation -> {
+                        captured.addAll(invocation.getArgument(0));
+                        return null;
+                    });
+
+            ValidationsHelper.reportValidationState(ValidationCategory.HARD_ASSERT, true,
+                    true, true, new ArrayList<>(), System.currentTimeMillis(), true);
+        }
+
+        Assert.assertTrue(captured.isEmpty(),
+                "No Expected/Actual text or Assertion evidence card should be attached when the "
+                        + "caller already reported rich comparison evidence through another channel.");
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #3804. The investigation reframed the issue: of the 8 Local E2E failures lumped together, only `PlaywrightElementVisualValidationTest.matchesReferenceImageShouldAttachOnlyVisualComparisonWhenReferenceExists` is a genuine reporting regression. Its invariant — a passing visual comparison gets no attachments beyond the directly-attached diff image — was broken by the combination of 2bbf12cf31 (#3465, removed the 500-char threshold so Expected/Actual text always attaches) and a13637abcc2 (#3515, unconditional "Assertion evidence" card).

## Fix
New `richEvidenceAlreadyAttached` flag threaded through a new public `ValidationsHelper.reportValidationState` overload (existing signatures untouched); when true, both the "Validation Test Data" Expected/Actual attachments and the "Assertion evidence" card are skipped. `PlaywrightValidationsExecutor` passes `outcome.visualComparisonAttached()`.

## Evidence (TDD)
- RED: new coverage test called the not-yet-existing overload (compile failure watched), then asserted zero supplementary attachments.
- GREEN: `ValidationsHelperCoverageUnitTest` 7/7 (including the existing evidence-card non-regression test — default behavior unchanged), `PlaywrightElementVisualValidationTest` 3/3, negative-verification batch of 8 adjacent classes 102/103 (single unrelated flake, filed as #3821).

## The other 7 failures — root-caused, re-ticketed, not fixed here
- 4 alert/select failures reproduce byte-for-byte at the parent of both suspect commits — environmental Chromium headless behavior, filed as #3820.
- `AllAttachmentTypesTest.unknownAttachmentTypeFallsBackToTextPlain` — pre-existing `AttachmentReporter` substring self-match bug, filed as #3822.
- `AllureManagerCoverageUnitTest` — load-dependent streaming-patch flake (#3407 lineage), filed as #3821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk