### PR TITLE
Quit leaked remote sessions on post-creation failure; decouple attempt timeout

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -519,11 +519,43 @@ public class DriverFactoryHelper {
     }
 
     private static ClientConfig createRemoteWebDriverClientConfig(URL targetExecutionUrl) {
-        var timeout = Duration.ofSeconds(remoteServerInstanceCreationTimeout);
+        // Read live (not cached in a static field like remoteServerInstanceCreationTimeout above) so the
+        // SHAFT.Properties.timeouts.set().remoteServerConnectionAttemptTimeout(...) override -- and the
+        // decoupling from remoteServerInstanceCreationTimeout itself (issue #3811) -- actually take
+        // effect: that property bounds only the overall retry budget; this bounds a single HTTP
+        // connect/read attempt so a hung/unreachable grid fails one attempt fast instead of silently
+        // consuming the whole retry budget.
+        var timeout = Duration.ofSeconds(SHAFT.Properties.timeouts.remoteServerConnectionAttemptTimeout());
         return ClientConfig.defaultConfig()
                 .baseUrl(targetExecutionUrl)
                 .connectionTimeout(timeout)
                 .readTimeout(timeout);
+    }
+
+    /**
+     * Best-effort teardown for a remote WebDriver session that was created successfully but whose
+     * post-creation setup then failed. Grid nodes otherwise pin a slot for the leaked session until
+     * SE_NODE_SESSION_TIMEOUT elapses (issue #3811), so it must be quit even though the caller never
+     * received the driver. Any exception raised while quitting is attached to the original failure via
+     * {@code addSuppressed} and swallowed here -- it must never replace or mask the original failure
+     * that triggered this cleanup (same pattern as the failure-screenshot path fixed in #3795).
+     *
+     * @param driver          the driver instance to quit; a no-op if {@code null}
+     * @param originalFailure the failure that triggered this cleanup; the quit failure (if any) is
+     *                        recorded on it via {@code addSuppressed}
+     */
+    private static void quitLeakedRemoteDriverBestEffort(WebDriver driver, Throwable originalFailure) {
+        if (driver == null) {
+            return;
+        }
+        try {
+            driver.quit();
+        } catch (Throwable quitFailure) {
+            if (originalFailure != null) {
+                originalFailure.addSuppressed(quitFailure);
+            }
+            ReportManagerHelper.logDiscrete(quitFailure, Level.DEBUG);
+        }
     }
 
     @SneakyThrows({InterruptedException.class, MalformedURLException.class})
@@ -632,8 +664,15 @@ public class DriverFactoryHelper {
             else if (isWindowsAppiumExecution(capabilities)) return new WindowsDriver(targetExecutionUrlObject, capabilities);
             else {
                 var driver = new RemoteWebDriver(targetExecutionUrlObject, capabilities, createRemoteWebDriverClientConfig(targetExecutionUrlObject));
-                driver.setFileDetector(new LocalFileDetector());
-                return augmentRemoteWebDriver(driver, SHAFT.Properties.web.targetBrowserName().toLowerCase(), SHAFT.Properties.platform.enableBiDi());
+                try {
+                    driver.setFileDetector(new LocalFileDetector());
+                    return augmentRemoteWebDriver(driver, SHAFT.Properties.web.targetBrowserName().toLowerCase(), SHAFT.Properties.platform.enableBiDi());
+                } catch (Throwable postCreationFailure) {
+                    // the live RemoteWebDriver session was already created against the grid; quit it
+                    // before rethrowing so a post-creation failure doesn't leak a pinned grid slot (#3811)
+                    quitLeakedRemoteDriverBestEffort(driver, postCreationFailure);
+                    throw postCreationFailure;
+                }
             }
         } catch (Throwable throwable) {
             ReportManagerHelper.logDiscrete(throwable, Level.DEBUG);
@@ -1153,6 +1192,14 @@ public class DriverFactoryHelper {
             ReportManager.logDiscrete("Remote WebDriver session was created.");
             ReportManager.logDiscrete("Remote WebDriver session creation completed in " + (System.currentTimeMillis() - remoteCreationStart) + "ms.");
         } catch (Throwable throwable) {
+            // the remote session may already have been created (setDriver(...) above succeeded) before
+            // this later post-creation setup step failed; quit it so the failure doesn't leak a pinned
+            // grid slot for up to SE_NODE_SESSION_TIMEOUT (#3811). No-op if creation itself never
+            // succeeded (driver is still null/unset at this point).
+            if (driver != null) {
+                quitLeakedRemoteDriverBestEffort(driver, throwable);
+                setDriver(null);
+            }
             //Root cause: "java.lang.NumberFormatException: Error at index 4 in: "4723wd""
             //this happens when the URL has an unsupported format
             Throwable throwable1 = throwable;

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java
@@ -149,9 +149,34 @@ public interface Timeouts extends EngineProperties<Timeouts> {
     @DefaultValue("1")
     int timeoutForRemoteServerToBeUp();
 
+    /**
+     * Timeout in minutes for the overall remote WebDriver session-creation retry budget: the total
+     * time {@code DriverFactoryHelper} keeps retrying failed connection attempts before giving up.
+     * Does <strong>not</strong> bound a single HTTP connect/read attempt against the grid -- see
+     * {@link #remoteServerConnectionAttemptTimeout()} for that. Prior to introducing that property,
+     * this single value simultaneously bounded the per-attempt HTTP client timeout, the outer retry
+     * budget, and the progress bar, so one hung attempt could silently consume the entire budget
+     * without the retry loop ever getting a chance to retry (issue #3811).
+     */
     @Key("remoteServerInstanceCreationTimeout")
     @DefaultValue("5")
     int remoteServerInstanceCreationTimeout();
+
+    /**
+     * Timeout in seconds for a single HTTP connect/read attempt made by the underlying HTTP client
+     * while creating a remote WebDriver session. Decoupled from
+     * {@link #remoteServerInstanceCreationTimeout()}, which bounds only the overall retry budget
+     * (in minutes) across all attempts: this property bounds one connection attempt, so an
+     * unreachable or saturated grid fails an attempt fast and the retry loop actually gets to retry
+     * within the overall budget, instead of one attempt burning the whole window (issue #3811).
+     * The default stays deliberately generous because a healthy-but-busy grid holds the new-session
+     * POST open while the request waits in its session queue; a timed-out attempt that gets retried
+     * enqueues a duplicate request. Lower this (e.g. to 10-30) only where fail-fast matters more
+     * than queue tolerance, such as CI with adaptive throttling.
+     */
+    @Key("remoteServerConnectionAttemptTimeout")
+    @DefaultValue("120")
+    int remoteServerConnectionAttemptTimeout();
 
     default SetProperty set() {
         return new SetProperty();
@@ -289,6 +314,11 @@ public interface Timeouts extends EngineProperties<Timeouts> {
 
         public SetProperty remoteServerInstanceCreationTimeout(int value) {
             setProperty("remoteServerInstanceCreationTimeout", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty remoteServerConnectionAttemptTimeout(int value) {
+            setProperty("remoteServerConnectionAttemptTimeout", String.valueOf(value));
             return this;
         }
 

--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java
@@ -3,6 +3,7 @@ package com.shaft.driver.internal.DriverFactory;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.DriverFactory.OptionsManager;
+import io.appium.java_client.Setting;
 import io.appium.java_client.android.AndroidDriver;
 import com.shaft.properties.internal.Properties;
 import com.shaft.properties.internal.ThreadLocalPropertiesManager;
@@ -558,9 +559,45 @@ public class DriverFactoryHelperCoverageUnitTest {
         }
 
         var clientConfig = (ClientConfig) constructionArguments.get(0).get(2);
-        var expectedTimeout = Duration.ofSeconds(TimeUnit.MINUTES.toSeconds(SHAFT.Properties.timeouts.remoteServerInstanceCreationTimeout()));
+        var expectedTimeout = Duration.ofSeconds(SHAFT.Properties.timeouts.remoteServerConnectionAttemptTimeout());
         SHAFT.Validations.assertThat().object(clientConfig.connectionTimeout()).isEqualTo(expectedTimeout).perform();
         SHAFT.Validations.assertThat().object(clientConfig.readTimeout()).isEqualTo(expectedTimeout).perform();
+    }
+
+    @Test
+    public void initializeDriverShouldDecoupleHttpClientTimeoutFromRetryBudget() {
+        // issue #3811: remoteServerInstanceCreationTimeout used to triple-bind the per-attempt HTTP
+        // client timeout, the outer retry budget, and the progress bar. Setting it to a large value
+        // must no longer inflate the per-attempt HTTP client timeout, which is now governed solely by
+        // the decoupled remoteServerConnectionAttemptTimeout property.
+        SHAFT.Properties.platform.set().targetPlatform("windows");
+        SHAFT.Properties.platform.set().executionAddress("http://localhost:4444");
+        SHAFT.Properties.web.set().targetBrowserName("chrome").headlessExecution(true);
+        SHAFT.Properties.flags.set().autoMaximizeBrowserWindow(false);
+        SHAFT.Properties.healenium.set().healEnabled(false);
+        SHAFT.Properties.timeouts.set().waitForRemoteServerToBeUp(false);
+        SHAFT.Properties.timeouts.set().remoteServerInstanceCreationTimeout(45);
+        SHAFT.Properties.timeouts.set().remoteServerConnectionAttemptTimeout(7);
+
+        var constructionArguments = new java.util.ArrayList<List<?>>();
+        DriverFactoryHelper helper = new DriverFactoryHelper();
+        try (MockedConstruction<RemoteWebDriver> ignored = org.mockito.Mockito.mockConstruction(RemoteWebDriver.class,
+                (mock, context) -> {
+                    constructionArguments.add(context.arguments());
+                    WebDriver.Options options = org.mockito.Mockito.mock(WebDriver.Options.class);
+                    WebDriver.Window window = org.mockito.Mockito.mock(WebDriver.Window.class);
+                    org.mockito.Mockito.when(mock.manage()).thenReturn(options);
+                    org.mockito.Mockito.when(options.window()).thenReturn(window);
+                    org.mockito.Mockito.when(mock.getCapabilities()).thenReturn(new ImmutableCapabilities());
+                })) {
+            helper.initializeDriver(com.shaft.driver.DriverFactory.DriverType.CHROME, null);
+        }
+
+        var clientConfig = (ClientConfig) constructionArguments.get(0).get(2);
+        // per-attempt HTTP timeout must reflect the new decoupled property (7s), not the 45-minute
+        // retry budget that the old triple-bound implementation would have used instead.
+        SHAFT.Validations.assertThat().object(clientConfig.connectionTimeout()).isEqualTo(Duration.ofSeconds(7)).perform();
+        SHAFT.Validations.assertThat().object(clientConfig.readTimeout()).isEqualTo(Duration.ofSeconds(7)).perform();
     }
 
     @Test
@@ -576,6 +613,71 @@ public class DriverFactoryHelperCoverageUnitTest {
             helper.initializeDriver(com.shaft.driver.DriverFactory.DriverType.APPIUM_MOBILE_NATIVE, null);
             SHAFT.Validations.assertThat().object(helper.getDriver()).isNotNull().perform();
         }
+    }
+
+    @Test
+    public void connectToRemoteServerShouldQuitCreatedDriverWhenPostCreationSetupThrows() {
+        // issue #3811: a live RemoteWebDriver session was created against the grid, but the
+        // post-creation setFileDetector/augmentRemoteWebDriver step then threw. Before the fix, the
+        // failure was rethrown without quitting the already-created session, leaking a grid slot for
+        // up to SE_NODE_SESSION_TIMEOUT. The created driver must be quit before the failure propagates.
+        SHAFT.Properties.platform.set().targetPlatform("windows");
+        SHAFT.Properties.platform.set().executionAddress("http://localhost:4444");
+        SHAFT.Properties.web.set().targetBrowserName("chrome").headlessExecution(true);
+        SHAFT.Properties.flags.set().autoMaximizeBrowserWindow(false);
+        SHAFT.Properties.healenium.set().healEnabled(false);
+        SHAFT.Properties.timeouts.set().waitForRemoteServerToBeUp(false);
+
+        DriverFactoryHelper helper = new DriverFactoryHelper();
+        java.util.concurrent.atomic.AtomicReference<RemoteWebDriver> createdDriver = new java.util.concurrent.atomic.AtomicReference<>();
+        try (MockedConstruction<RemoteWebDriver> ignored = org.mockito.Mockito.mockConstruction(RemoteWebDriver.class,
+                (mock, context) -> {
+                    createdDriver.set(mock);
+                    org.mockito.Mockito.doThrow(new RuntimeException("post-creation setup failure"))
+                            .when(mock).setFileDetector(org.mockito.Mockito.any());
+                })) {
+            try {
+                helper.initializeDriver(com.shaft.driver.DriverFactory.DriverType.CHROME, null);
+            } catch (Throwable expected) {
+                // expected: post-creation setup failure propagates
+            }
+        }
+
+        SHAFT.Validations.assertThat().object(createdDriver.get()).isNotNull().perform();
+        org.mockito.Mockito.verify(createdDriver.get()).quit();
+        SHAFT.Validations.assertThat().object(helper.getDriver()).isNull().perform();
+    }
+
+    @Test
+    public void setRemoteDriverInstanceShouldQuitCreatedDriverWhenPostCreationAppiumSetupThrows() {
+        // issue #3811: same leak as connectToRemoteServerShouldQuitCreatedDriverWhenPostCreationSetupThrows,
+        // but for the setRemoteDriverInstance-level post-creation setup (Appium settings applied after
+        // setDriver(...) already stored the created session) rather than the connectToRemoteServer-level
+        // setup that runs before the session is handed back.
+        SHAFT.Properties.platform.set().targetPlatform("android");
+        SHAFT.Properties.platform.set().executionAddress("http://localhost:4723");
+        SHAFT.Properties.mobile.set().browserName("").automationName("UIAutomator2");
+        SHAFT.Properties.healenium.set().healEnabled(false);
+        SHAFT.Properties.timeouts.set().waitForRemoteServerToBeUp(false);
+
+        DriverFactoryHelper helper = new DriverFactoryHelper();
+        java.util.concurrent.atomic.AtomicReference<AndroidDriver> createdDriver = new java.util.concurrent.atomic.AtomicReference<>();
+        try (MockedConstruction<AndroidDriver> ignored = org.mockito.Mockito.mockConstruction(AndroidDriver.class,
+                (mock, context) -> {
+                    createdDriver.set(mock);
+                    org.mockito.Mockito.doThrow(new RuntimeException("post-creation appium setting failure"))
+                            .when(mock).setSetting(Setting.WAIT_FOR_IDLE_TIMEOUT, 5000);
+                })) {
+            try {
+                helper.initializeDriver(com.shaft.driver.DriverFactory.DriverType.APPIUM_MOBILE_NATIVE, null);
+            } catch (Throwable expected) {
+                // expected: post-creation appium setting failure propagates
+            }
+        }
+
+        SHAFT.Validations.assertThat().object(createdDriver.get()).isNotNull().perform();
+        org.mockito.Mockito.verify(createdDriver.get()).quit();
+        SHAFT.Validations.assertThat().object(helper.getDriver()).isNull().perform();
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java
+++ b/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java
@@ -29,6 +29,7 @@ public class TimeoutsTests {
     Boolean waitForRemoteServerToBeUp;
     int timeoutForRemoteServerToBeUp;
     int remoteServerInstanceCreationTimeout;
+    int remoteServerConnectionAttemptTimeout;
 
 
     @BeforeClass
@@ -57,6 +58,7 @@ public class TimeoutsTests {
         waitForRemoteServerToBeUp = SHAFT.Properties.timeouts.waitForRemoteServerToBeUp();
         timeoutForRemoteServerToBeUp = SHAFT.Properties.timeouts.timeoutForRemoteServerToBeUp();
         remoteServerInstanceCreationTimeout = SHAFT.Properties.timeouts.remoteServerInstanceCreationTimeout();
+        remoteServerConnectionAttemptTimeout = SHAFT.Properties.timeouts.remoteServerConnectionAttemptTimeout();
 
     }
 
@@ -87,6 +89,7 @@ public class TimeoutsTests {
         SHAFT.Properties.timeouts.set().waitForRemoteServerToBeUp(waitForRemoteServerToBeUp);
         SHAFT.Properties.timeouts.set().timeoutForRemoteServerToBeUp(timeoutForRemoteServerToBeUp);
         SHAFT.Properties.timeouts.set().remoteServerInstanceCreationTimeout(remoteServerInstanceCreationTimeout);
+        SHAFT.Properties.timeouts.set().remoteServerConnectionAttemptTimeout(remoteServerConnectionAttemptTimeout);
 
     }
 


### PR DESCRIPTION
## Summary
Fixes #3811 (amplifiers of the 07-19 stuck-grid nightly incident).

**Leak fix** — two sites where a successfully created remote session survived a post-creation failure and pinned a grid node for up to `SE_NODE_SESSION_TIMEOUT` (7200s in the incident):
- `connectToRemoteServer`: `setFileDetector`/`augmentRemoteWebDriver` failures now quit the just-created `RemoteWebDriver` before rethrowing.
- `setRemoteDriverInstance`: post-creation Appium setup failures (e.g. `setSetting`) quit the session and clear the driver field.
- Both use a shared best-effort helper that attaches quit failures via `addSuppressed` — never masking the original exception (same pattern as #3795).

**Timeout decoupling** — `remoteServerInstanceCreationTimeout` (5 min) previously triple-bound the per-attempt HTTP connect/read timeout, the outer retry budget, and the progress bar, so one hung attempt burned the whole budget with zero retries. New `remoteServerConnectionAttemptTimeout` (seconds, **default 120**, read live so runtime `.set()` works) bounds a single attempt; the old property now bounds only the retry budget.

Default rationale (main-thread review adjustment from the delegate's 30s): a healthy-but-busy grid holds the new-session POST open in its session queue — a too-aggressive per-attempt timeout would retry and enqueue duplicate requests. 120s keeps 2+ retries inside the default budget while staying queue-tolerant; CI can opt into 10-30s where fail-fast matters (tracked with preflight enablement in #3812).

## Evidence (TDD)
- 4 tests watched RED against unfixed code, GREEN after: both leak scenarios (mocked construction, `quit()` asserted, driver field cleared) and both timeout assertions (client config uses the per-attempt value; 45-min budget with 7s attempt proves decoupling).
- `DriverFactoryHelperCoverageUnitTest` + `TimeoutsTests`: 40/40. Adjacent batch (`DriverFactoryHelperAugmentationUnitTest`, `DriverFactoryHelperStorageStateUnitTest`, `DriverFactoryCoverageUnitTest`, `DriverFactoryHelperAdditionalUnitTest`, `DriverFactoryHelperUnitTest`): 50/50.

## Adjacent finding (pre-existing, reported)
`remoteServerInstanceCreationTimeout`/`timeoutForRemoteServerToBeUp` are cached in `static final` fields, so runtime `.set()` overrides are ignored after class-load — untouched here, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk