### PR TITLE
Pre-stage the classpath OpenCV native into SikuliX's libs folder

### DIFF
--- a/shaft-sikulix/src/main/java/com/shaft/gui/element/SikuliActions.java
+++ b/shaft-sikulix/src/main/java/com/shaft/gui/element/SikuliActions.java
@@ -1,6 +1,7 @@
 package com.shaft.gui.element;
 
 import com.shaft.driver.SHAFT;
+import com.shaft.sikulix.internal.SikuliNativeLibraryStager;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import org.sikuli.basics.Settings;
@@ -356,6 +357,7 @@ public class SikuliActions {
     }
 
     private void initializeSikuliEngineForCurrentScreen() {
+        SikuliNativeLibraryStager.ensureOpenCvNativeStaged();
         Settings.setShowActions(false);
         Settings.ActionLogs = true;
         Settings.InfoLogs = true;

--- a/shaft-sikulix/src/main/java/com/shaft/sikulix/internal/SikuliNativeLibraryStager.java
+++ b/shaft-sikulix/src/main/java/com/shaft/sikulix/internal/SikuliNativeLibraryStager.java
@@ -1,0 +1,118 @@
+package com.shaft.sikulix.internal;
+
+import com.shaft.tools.io.internal.ReportManagerHelper;
+import org.opencv.core.Core;
+import org.sikuli.script.support.Commons;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/**
+ * Stages the native OpenCV matcher library into SikuliX's own "libs folder"
+ * ({@code %APPDATA%/Sikulix/SikulixLibs} on Windows, {@code ~/Library/Application
+ * Support/Sikulix/SikulixLibs} on macOS, {@code ~/.Sikulix/SikulixLibs} on Linux -- see
+ * {@link Commons#getAppDataPath()}) before any SikuliX class touches native loading.
+ * <p>
+ * SikuliX 2.0.5 resolves its native OpenCV binary via
+ * {@code org.sikuli.script.support.RunTime#libsLoad}, which only ever looks inside that
+ * folder for a file named after the OpenCV build actually on the classpath
+ * ({@link Core#NATIVE_LIBRARY_NAME} plus the platform extension). SikuliX populates the
+ * folder itself, on first use, from a manifest bundled in its own jar
+ * ({@code sikulixlibs/<os>/libs64/sikulixcontent}) -- but that manifest still names
+ * {@code opencv_java430.dll} (OpenCV 4.3.0), stale since shaft-sikulix/pom.xml pinned
+ * {@code org.openpnp:opencv:4.9.0-0} directly (PR #3408) to fix an unrelated
+ * {@code NoClassDefFoundError}. That jar only contains {@code opencv_java490.dll}, so
+ * SikuliX's own extraction step always fails, deletes the whole folder it just created,
+ * and every later native-lib lookup throws
+ * {@code SikuliXception: loadlib: opencv_java490.dll not in any libs folder} (issue
+ * #3805; confirmed via {@code RunTime:libsExport: opencv_java430.dll: failed} in the
+ * Windows_SikuliX_Local nightly log).
+ * <p>
+ * Rather than relying on SikuliX's stale manifest, this pre-stages the native that is
+ * actually on the classpath (bundled as a resource inside {@code org.openpnp:opencv})
+ * directly under the exact file name SikuliX's loader will ask for, and marks the
+ * folder as already prepared via {@link Commons#makeVersionFile(File)} so SikuliX's own
+ * (otherwise-failing) extraction step is skipped rather than re-run on top of it.
+ */
+public final class SikuliNativeLibraryStager {
+
+    private SikuliNativeLibraryStager() {
+    }
+
+    /**
+     * Ensures the OpenCV native SikuliX will look for is present in its libs folder.
+     * Safe to call repeatedly -- a no-op once already staged for the running SikuliX
+     * build -- and a best-effort no-op if the target location cannot be determined or
+     * written, in which case SikuliX's own loader still surfaces its usual
+     * {@code SikuliXception}, unchanged from today's behavior.
+     */
+    public static synchronized void ensureOpenCvNativeStaged() {
+        try {
+            File libsFolder = new File(Commons.getAppDataPath(), "SikulixLibs");
+            if (libsFolder.isDirectory() && Commons.hasVersionFile(libsFolder)) {
+                return; // already staged for this exact SikuliX build
+            }
+            if (libsFolder.exists()) {
+                deleteRecursively(libsFolder.toPath());
+            }
+            String nativeLibFileName = platformLibraryFileName(Core.NATIVE_LIBRARY_NAME);
+            String openCvResourcePath = openCvResourcePath(nativeLibFileName);
+            try (InputStream nativeLibStream = nu.pattern.OpenCV.class.getResourceAsStream(openCvResourcePath)) {
+                if (nativeLibStream == null) {
+                    return; // unsupported OS/arch combination for org.openpnp:opencv; nothing we can stage
+                }
+                Files.createDirectories(libsFolder.toPath());
+                Files.copy(nativeLibStream, new File(libsFolder, nativeLibFileName).toPath(),
+                        StandardCopyOption.REPLACE_EXISTING);
+            }
+            Commons.makeVersionFile(libsFolder);
+        } catch (Exception rootCauseException) {
+            ReportManagerHelper.logDiscrete(rootCauseException);
+        }
+    }
+
+    private static String platformLibraryFileName(String libraryName) {
+        if (Commons.runningWindows()) {
+            return libraryName + ".dll";
+        }
+        if (Commons.runningMac()) {
+            return "lib" + libraryName + ".dylib";
+        }
+        return "lib" + libraryName + ".so";
+    }
+
+    private static String openCvResourcePath(String nativeLibFileName) {
+        String osArch = System.getProperty("os.arch", "").toLowerCase();
+        if (Commons.runningWindows()) {
+            String archSegment = osArch.contains("64") ? "x86_64" : "x86_32";
+            return "/nu/pattern/opencv/windows/" + archSegment + "/" + nativeLibFileName;
+        }
+        if (Commons.runningMac()) {
+            String archSegment = osArch.contains("aarch64") ? "ARMv8" : "x86_64";
+            return "/nu/pattern/opencv/osx/" + archSegment + "/" + nativeLibFileName;
+        }
+        String archSegment = osArch.contains("aarch64") ? "ARMv8" : osArch.contains("arm") ? "ARMv7" : "x86_64";
+        return "/nu/pattern/opencv/linux/" + archSegment + "/" + nativeLibFileName;
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(path)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(entry -> {
+                try {
+                    Files.deleteIfExists(entry);
+                } catch (IOException ignored) {
+                    // best-effort cleanup of a previous, stale libs folder
+                }
+            });
+        }
+    }
+}

--- a/shaft-sikulix/src/test/java/com/shaft/sikulix/SikuliOpenCvNativeLoadTest.java
+++ b/shaft-sikulix/src/test/java/com/shaft/sikulix/SikuliOpenCvNativeLoadTest.java
@@ -1,0 +1,36 @@
+package com.shaft.sikulix;
+
+import com.shaft.gui.element.SikuliActions;
+import org.sikuli.script.Pattern;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Headless regression coverage for issue #3805: SikuliX's native OpenCV loader
+ * ({@code org.sikuli.script.support.RunTime#libsLoad}) must be able to resolve
+ * {@code opencv_java490.dll} (the native matching the {@code org.openpnp:opencv:4.9.0-0}
+ * dependency pinned in shaft-sikulix/pom.xml) from its "libs folder"
+ * ({@code %APPDATA%/Sikulix/SikulixLibs} on Windows). SikuliX 2.0.5's own bundled
+ * manifest still references the older {@code opencv_java430.dll}, so without SHAFT
+ * staging the correct native first, the very first {@link Pattern} construction throws
+ * {@code ExceptionInInitializerError} wrapping
+ * {@code SikuliXception: loadlib: opencv_java490.dll not in any libs folder} --
+ * exactly the Windows_SikuliX_Local nightly failure (run 29673202709, job 88155817101).
+ * <p>
+ * This does not open any window, capture the desktop, or otherwise touch the GUI --
+ * {@link Pattern}'s constructor only triggers the {@code Finder$Finder2} static
+ * initializer that loads the native OpenCV matcher backend.
+ */
+public class SikuliOpenCvNativeLoadTest {
+
+    @Test
+    public void patternConstructionLoadsOpenCvNativeLibrary() {
+        // Mirrors SikuliActions' constructor-time bootstrap, the same entry point
+        // com.shaft.gui.element.SikuliActions#prepareElementPattern uses in the
+        // failing CI flow (SikuliActions.java:353 -> Pattern.java:128 -> Finder2.<clinit>).
+        new SikuliActions();
+        Pattern pattern = new Pattern();
+        assertNotNull(pattern);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #3805 — the Windows_SikuliX_Local nightly job has never passed because of a version skew inside SikuliX itself: its bundled extraction manifest (`sikulixlibs/windows/libs64/sikulixcontent`) still lists `opencv_java430.dll`, while the OpenCV pinned by `shaft-sikulix/pom.xml` (`org.openpnp:opencv:4.9.0-0`, added by #3408) only ships `opencv_java490.dll`. SikuliX's `libsExport()` fails the copy, deletes the entire libs folder, marks itself done, and every subsequent `loadLibrary` throws `SikuliXception: loadlib: opencv_java490.dll not in any libs folder` (exact CI log lines cited in the issue).

## Fix
New `SikuliNativeLibraryStager` (shaft-sikulix internal): before SikuliX touches native loading, extract the OpenCV native **actually on the classpath** (from the openpnp jar's own resource) into `SikulixLibs` under the exact filename SikuliX's loader resolves (`Core.NATIVE_LIBRARY_NAME` + platform extension), then stamp SikuliX's version marker via `Commons.makeVersionFile` so its broken extraction is skipped rather than re-run. Idempotent (marker fast-path), cross-platform, and best-effort — if staging can't happen, today's error path is unchanged. Hooked with one call in `SikuliActions.initializeSikuliEngineForCurrentScreen()`, reached by every SikuliX entry point; zero impact outside the optional shaft-sikulix module.

## Evidence (TDD, reproduced locally on Windows, headless)
- RED: new `SikuliOpenCvNativeLoadTest` reproduced the exact CI failure locally (`ExceptionInInitializerError` → `SikuliXception: loadlib: opencv_java490.dll`), and `%APPDATA%\Sikulix\SikulixLibs` confirmed wiped by SikuliX's own failed extraction.
- GREEN: same test passes; on-disk verification: `opencv_java490.dll` staged (52,015,616 bytes, byte-size match with the jar resource) + version marker. Second run green (idempotent fast path).
- Module regression: full `shaft-sikulix` suite green; the gated real-desktop E2E stays skipped (GUI interaction intentionally not run locally).

## Remaining verification
The full image-match/click flow is proven by the next `Windows_SikuliX_Local` nightly run — this PR fixes the documented native-load failure point that blocked the job before any test logic ran.

## Adjacent note
SikuliX's manifest also lists `JIntellitype.dll` (hotkeys) — never successfully staged before either, nothing in shaft-sikulix uses it, not staged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk