### PR TITLE
Enable grid preflight fail-fast in nightly E2E; harden readiness and teardown

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -213,7 +213,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -249,7 +249,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -285,7 +285,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -624,7 +624,7 @@ jobs:
         run: docker ps
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DmaximumPerformanceMode=2" "-DgenerateAllureReportArchive=true" "-Dcucumber.features=src/test/resources/CucumberFeatures,src/test/resources/CustomCucumberFeatures" "-Dcucumber.glue=customCucumberSteps,com.shaft.cucumber" "-Dcucumber.plugin=pretty,json:allure-results/cucumber.json,html:allure-results/cucumberReport.html,com.shaft.listeners.CucumberTestRunnerListener" "-Dtest=%regex[.*(CucumberTests|CucumberFeatureListenerUnitTest|CucumberTestRunnerListenerUnitTest).*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DmaximumPerformanceMode=2" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dcucumber.features=src/test/resources/CucumberFeatures,src/test/resources/CustomCucumberFeatures" "-Dcucumber.glue=customCucumberSteps,com.shaft.cucumber" "-Dcucumber.plugin=pretty,json:allure-results/cucumber.json,html:allure-results/cucumberReport.html,com.shaft.listeners.CucumberTestRunnerListener" "-Dtest=%regex[.*(CucumberTests|CucumberFeatureListenerUnitTest|CucumberTestRunnerListenerUnitTest).*]"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -685,7 +685,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -789,6 +789,10 @@ jobs:
             "-DtargetBrowserName=chrome" \
             "-DheadlessExecution=true" \
             "-DremoteServerInstanceCreationTimeout=10" \
+            "-DremotePreflightEnabled=true" \
+            "-DremoteAdaptiveSessionThrottling=true" \
+            "-DremotePreflightFailFast=true" \
+            "-DremoteServerConnectionAttemptTimeout=15" \
             "-DgenerateAllureReportArchive=true" \
             "-Dallure.automaticallyOpen=false" \
             "-Dallure.open=false" \

--- a/shaft-engine/src/test/java/junitTestPackage/JunitParallelizationTests.java
+++ b/shaft-engine/src/test/java/junitTestPackage/JunitParallelizationTests.java
@@ -17,7 +17,9 @@ public class JunitParallelizationTests {
 
     @AfterEach
     void tearDown() {
-        driver.quit();
+        if (driver != null) {
+            driver.quit();
+        }
     }
 
     @RepeatedTest(20)

--- a/shaft-engine/src/test/java/junitTestPackage/JunitParallelizationTestsTearDownGuardTest.java
+++ b/shaft-engine/src/test/java/junitTestPackage/JunitParallelizationTestsTearDownGuardTest.java
@@ -1,0 +1,21 @@
+package junitTestPackage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Regression coverage for the tearDown() NPE masking bug described in issue #3812:
+ * when {@code setup()} never completes (e.g. the {@code SHAFT.GUI.WebDriver} constructor
+ * throws), {@code driver} stays null, and an unguarded {@code driver.quit()} in
+ * {@code tearDown()} throws a NullPointerException that hides the real setup failure.
+ */
+class JunitParallelizationTestsTearDownGuardTest {
+
+    @Test
+    void tearDownShouldNotThrowWhenSetupNeverCompleted() {
+        var testInstance = new JunitParallelizationTests();
+
+        assertDoesNotThrow(testInstance::tearDown);
+    }
+}

--- a/shaft-engine/src/test/java/junitTestPackage/JunitTest.java
+++ b/shaft-engine/src/test/java/junitTestPackage/JunitTest.java
@@ -68,6 +68,8 @@ public class JunitTest {
 
     @AfterEach
     void afterEach() {
-        driver.get().quit();
+        if (driver.get() != null) {
+            driver.get().quit();
+        }
     }
 }

--- a/shaft-engine/src/test/java/junitTestPackage/JunitTestTearDownGuardTest.java
+++ b/shaft-engine/src/test/java/junitTestPackage/JunitTestTearDownGuardTest.java
@@ -1,0 +1,23 @@
+package junitTestPackage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Sibling regression coverage for the same tearDown() NPE masking bug fixed in
+ * {@link JunitParallelizationTestsTearDownGuardTest} (issue #3812): {@link JunitTest}
+ * keeps its WebDriver in a {@code ThreadLocal} and calls {@code driver.get().quit()}
+ * unconditionally in {@code afterEach()}. When {@code beforeEach()} never completes,
+ * the ThreadLocal is never set, {@code driver.get()} returns null, and the resulting
+ * NullPointerException hides the real setup failure.
+ */
+class JunitTestTearDownGuardTest {
+
+    @Test
+    void afterEachShouldNotThrowWhenBeforeEachNeverCompleted() {
+        var testInstance = new JunitTest();
+
+        assertDoesNotThrow(testInstance::afterEach);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #3812 — the CI/test-hardening batch from the 07-19 stuck-grid nightly investigation (root regression fixed in #3793; session-leak amplifiers in #3825).

1. **Grid preflight enabled**: `RemoteGridPreflight` existed but was dormant (Platform.java defaults all three flags to false, no CI job set them). The five grid jobs (`Ubuntu_Firefox_Grid`, `Ubuntu_Chrome_Grid`, `Ubuntu_MicrosoftEdge_Grid`, `Ubuntu_Chrome_Cucumber_Grid`, `Ubuntu_JUnit_E2E`) now run with `remotePreflightEnabled` + `remoteAdaptiveSessionThrottling` + `remotePreflightFailFast`, plus `remoteServerConnectionAttemptTimeout=15` (from #3825, merged) for fail-fast attempts within the retry budget. BrowserStack/local jobs untouched (preflight probes `/status`+`/graphql`, grid-only). Live verification: the next nightly.
2. **Postgres readiness**: `--health-cmd pg_isready` → `pg_isready -U postgres` at both service definitions (lines 71 + 688 — the second instance was in the issue's list and had the identical bug).
3. **Teardown NPE guards (TDD)**: `JunitParallelizationTests.tearDown` NPE'd when setup never completed; guarded, with a regression test watched RED (exact NPE) then GREEN. Sibling `JunitTest.afterEach` had the identical unguarded `driver.get().quit()` — same cycle. `MoonTests`/`JunitWebGuiSmokeTest` already had the guard.

Surgical scope per the owner mandate: no E2E job renames, no trigger changes, flags and health-cmd only. YAML parse verified (21 jobs unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk