### PR TITLE
Tee the Allure failure list into the job log, not only the step summary

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -205,11 +205,14 @@ runs:
                 ALLURE_FAILURE_SOURCE="${{ inputs.module-directory }}/allure-report"
               fi
               if [ -n "$ALLURE_FAILURE_SOURCE" ]; then
+                # tee instead of a bare redirect so the failure list also lands in the
+                # raw job log, where gh run view --log and log-download forensics can
+                # see it -- previously it was visible only in the step summary (#3807)
                 {
                   echo ""
                   echo "### ❌ Failed and broken test methods"
                   python3 scripts/ci/extract_allure_failures.py "$ALLURE_FAILURE_SOURCE" || true
-                } >> "$GITHUB_STEP_SUMMARY"
+                } | tee -a "$GITHUB_STEP_SUMMARY"
               fi
             fi
             echo "::error::Allure report shows $FAILED failed and $BROKEN broken test(s) out of $TOTAL total. Check the Allure report artifact for details."


### PR DESCRIPTION
## Summary
Part 2 of #3807. The forensics gap wasn't in `extract_allure_failures.py` (it already prints to stdout) — `post-test-report/action.yml` redirected the whole output group into `$GITHUB_STEP_SUMMARY`, so the failure list was invisible in the raw job log and to `gh run view --log` tooling. One-line fix: `tee -a` instead of `>>`, so the list lands in both sinks with no double-write.

The delegate's initial approach (in-script summary write) was reverted during main-thread review: with the workflow-level redirect in place it would have double-posted the summary while stdout still never reached the log — the redirect itself was the bug.

## Validation
- `yaml.safe_load` on the action: OK.
- `pytest tests/scripts/test_extract_allure_failures.py`: green (script unchanged, existing suite).
- Live verification: the next nightly's failing job (if any) shows the failure list in its raw log.

## Remaining scope of #3807 (open)
Part 1 — locating and fixing the null-byte source in Local E2E job logs — was blocked mid-investigation by a GitHub API outage; the issue stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk