### PR TITLE
Capture the Appium server's own log in the Windows desktop nightly job

### DIFF
--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -219,9 +219,19 @@ jobs:
       - name: Start Appium server
         shell: powershell
         run: |
+          # Write the server's own stdout/stderr to a file via Appium's native --log flag
+          # rather than relying solely on PowerShell job-stream buffering. Start-Job +
+          # Receive-Job at cleanup was found to surface zero lines of server output across
+          # a full ~12-minute run in CI (#3806) even though the same pattern captures
+          # output reliably in isolated local testing on the same OS/PowerShell version.
+          # A log file survives regardless of that buffering behavior and lets us inspect
+          # what the "windows" driver actually did while creating the session, including
+          # for runs that hang for the full 300s timeout.
+          $appiumLog = Join-Path $env:RUNNER_TEMP 'appium-server.log'
           Start-Job -Name shaft-appium -ScriptBlock {
-            appium --address 127.0.0.1 --port 4723 --log-level info
-          } | Out-Null
+            param($logPath)
+            appium --address 127.0.0.1 --port 4723 --log-level info --log $logPath
+          } -ArgumentList $appiumLog | Out-Null
           $ready = $false
           for ($i = 0; $i -lt 60; $i++) {
             try {
@@ -234,6 +244,9 @@ jobs:
           }
           if (-not $ready) {
             Receive-Job -Name shaft-appium -Keep
+            if (Test-Path $appiumLog) {
+              Get-Content $appiumLog
+            }
             throw "Appium server did not become ready."
           }
       - name: Run Appium Windows desktop flow
@@ -243,8 +256,23 @@ jobs:
         if: always()
         shell: powershell
         run: |
+          $appiumLog = Join-Path $env:RUNNER_TEMP 'appium-server.log'
+          Write-Output "=== Appium server log ($appiumLog) ==="
+          if (Test-Path $appiumLog) {
+            Get-Content $appiumLog
+          } else {
+            Write-Output "(log file was not created)"
+          }
+          Write-Output "=== Receive-Job (PowerShell job stream, for comparison) ==="
           Receive-Job -Name shaft-appium -ErrorAction SilentlyContinue
           Get-Job -Name shaft-appium -ErrorAction SilentlyContinue | Stop-Job
+      - name: Upload Appium server log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: Windows_Appium_Desktop_Local_server_log
+          path: ${{ runner.temp }}\appium-server.log
+          if-no-files-found: ignore
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()


### PR DESCRIPTION
## Summary
Diagnostics step for #3806 (does NOT close it). The `Windows_Appium_Desktop_Local` job hangs 300s at session creation, and the only server-side capture point (`Receive-Job` at cleanup) produced **zero** lines across a 12-minute run — the exact window where the `windows` driver's behavior would explain the hang is a blind spot. Verified locally that the same Start-Job/Receive-Job pattern DOES capture output in isolation, so the CI behavior is environment-specific buffering; a native `appium --log <file>` sidesteps it entirely.

## Changes (`Windows_Appium_Desktop_Local` only, no job renames/trigger changes)
- Appium server writes its own log file via the native `--log` flag (flag verified against `appium@3.5.2 server --help` + live local run).
- Readiness-failure path and the cleanup step print the file (job stream kept for comparison).
- New `if: always()` artifact upload of the server log.

## Next (recorded on #3806)
The next nightly's server log discriminates three paths: (1) driver visibly stalls on something fixable (Developer Mode, WinAppDriver spawn, UIA error) → fix it; (2) the session request never reaches the server → transport bug, different class; (3) genuine silent in-driver hang → matches upstream's own posture (appium-windows-driver's CI **skips real session creation on windows-latest**), and the honest call becomes re-scope/allow-failure/drop — owner decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk