### PR TITLE
Restore automaticallyAssertResponseStatusCode after Test_LTMobAPKRelativePath

### DIFF
--- a/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKRelativePath.java
+++ b/shaft-engine/src/test/java/testPackage/LambdaTest/Test_LTMobAPKRelativePath.java
@@ -15,6 +15,7 @@ public class Test_LTMobAPKRelativePath {
     private final By displayOptions = AppiumBy.accessibilityId("Display Options");
     private final By displayShowCustom = AppiumBy.accessibilityId("DISPLAY_SHOW_CUSTOM");
     private final By app = AppiumBy.accessibilityId("App");
+    private boolean originalAutomaticallyAssertResponseStatusCode;
 
     @Test
     public void wizard_scrollInExpandableLists_verticalScrolling_insideScreen() {
@@ -39,6 +40,8 @@ public class Test_LTMobAPKRelativePath {
         SHAFT.Properties.lambdaTest.set().isRealMobile(true);
         SHAFT.Properties.lambdaTest.set().appRelativeFilePath("src/test/resources/testDataFiles/apps/ApiDemos-debug.apk");
         LambdaTestCredentials.apply();
+        // Save original value before changing to avoid property leak into subsequent tests
+        originalAutomaticallyAssertResponseStatusCode = SHAFT.Properties.flags.automaticallyAssertResponseStatusCode();
         SHAFT.Properties.flags.set().automaticallyAssertResponseStatusCode(false);
         driver.set(new SHAFT.GUI.WebDriver());
     }
@@ -49,5 +52,7 @@ public class Test_LTMobAPKRelativePath {
             driver.get().quit();
         }
         driver.remove();
+        // Restore original value to avoid property leak into subsequent tests
+        SHAFT.Properties.flags.set().automaticallyAssertResponseStatusCode(originalAutomaticallyAssertResponseStatusCode);
     }
 }


### PR DESCRIPTION
## Summary
Fixes #3809. `Test_LTMobAPKRelativePath` set `automaticallyAssertResponseStatusCode(false)` in `@BeforeMethod` and never restored it, leaking the flag into every test that runs after it in the LambdaTest suite. Standard save/restore applied (exemplar: `PropertiesUnitTest`), symmetric in `@AfterMethod`.

## Validation
`mvn -pl shaft-engine test-compile` clean. The class itself is cloud-gated (LambdaTest credentials), so the leak fix is exercised by the LambdaTest suite run; the change is pure test-hygiene with no product-code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk