### PR TITLE
Match the binary attachment route on whole tokens, not raw substrings

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AttachmentReporter.java
@@ -15,6 +15,7 @@ import java.util.Calendar;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 
 /**
  * Internal utility class responsible for attaching test artifacts (screenshots, recordings,
@@ -359,7 +360,7 @@ public class AttachmentReporter {
         if (containsAny(combined, "link", "uri", "text/uri-list")) return "link";
         if (containsAny(combined, "engine logs")) return "engine logs";
         if (containsAny(combined, "zip", "trace", "diagnostics", "application/zip")) return "zip";
-        if (containsAny(combined, "octet-stream", "binary")) return "binary";
+        if (containsWord(combined, "octet-stream", "binary")) return "binary";
         if (containsAny(combined, "properties")) return "properties";
         return "default";
     }
@@ -390,6 +391,21 @@ public class AttachmentReporter {
     private static boolean containsAny(String value, String... tokens) {
         for (String token : tokens) {
             if (value.contains(token)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Like {@link #containsAny}, but requires each token to appear as a whole word/segment
+     * (word-boundary match) rather than as a raw substring, so a user-supplied type/name that
+     * merely contains the token inside a larger word (e.g. {@code "unknownBinaryType"} containing
+     * {@code "binary"}) does not self-match.
+     */
+    private static boolean containsWord(String value, String... tokens) {
+        for (String token : tokens) {
+            if (Pattern.compile("\\b" + Pattern.quote(token) + "\\b").matcher(value).find()) {
                 return true;
             }
         }


### PR DESCRIPTION
## Summary
- `AttachmentReporter.getAttachmentCase` routes on a lowercased `type + " " + name` string via raw `String.contains`; an unknown type such as `unknownBinaryType` contains the substring `binary`, so it self-matched the binary route and returned `application/octet-stream` instead of the documented `text/plain` fallback.
- The binary route now matches on whole tokens (`\btoken\b` with quoted tokens) via a new `containsWord` helper; `octet-stream` and standalone `binary` still match (delimiters like `/`, space, and string edges are word boundaries), while substrings inside larger identifiers no longer do.
- Only the binary route was changed. The same raw-substring risk exists on the other 19 routes (e.g. `link` inside `backlink.csv`, `zip` inside `unzippedLogs`) but none has a failing regression today — tracked in #3822's discussion rather than blanket-changed here.

## Verification
- RED: `AllAttachmentTypesTest#unknownAttachmentTypeFallsBackToTextPlain` failed on unmodified code (`expected text/plain, but found application/octet-stream`).
- GREEN: `AllAttachmentTypesTest` + `AttachmentReporterUnitTest` scoped run — 34/34 pass, including the dedicated `{"octet-stream", "payload.bin"}` case proving legitimate binary routing still works.

Closes #3822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk