### PR TITLE
Annotate retry-suppressed console lines as Failed (retried), not Skipped

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/internal/TestNGListenerHelper.java
@@ -496,7 +496,12 @@ public class TestNGListenerHelper {
                 } else if (iTestResult.getStatus() == ITestResult.FAILURE) {
                     methodStatus = "Failed";
                 } else if (iTestResult.getStatus() == ITestResult.SKIP) {
-                    methodStatus = "Skipped";
+                    // TestNG's TestInvoker forces the status to SKIP (and sets wasRetried=true) for every
+                    // failed attempt that RetryAnalyzer chooses to retry; only the terminal attempt keeps
+                    // its real FAILURE/SUCCESS status. Reporting one of these retry-suppressed attempts as
+                    // "Skipped" is factually wrong -- it actually failed and is being retried -- so the live
+                    // console line is annotated instead of parroting the misleading SKIP status.
+                    methodStatus = iTestResult.wasRetried() ? "Failed (retried)" : "Skipped";
                 }
                 ReportManagerHelper.logFinishedTestInformation(className, methodName, methodDescription, methodStatus, iTestResult.getThrowable());
             }

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -481,13 +481,13 @@ public class ReportManagerHelper {
 
         String statusIndicator = switch (testStatus.toUpperCase()) {
             case "PASSED" -> "✓";
-            case "FAILED" -> "✗";
+            case "FAILED", "FAILED (RETRIED)" -> "✗";
             case "SKIPPED" -> "⊘";
             default -> "●";
         };
 
         Level logLevel = switch (testStatus.toUpperCase()) {
-            case "FAILED" -> Level.ERROR;
+            case "FAILED", "FAILED (RETRIED)" -> Level.ERROR;
             case "SKIPPED" -> Level.WARN;
             default -> Level.INFO;
         };

--- a/shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
@@ -1,6 +1,7 @@
 package testPackage.unitTests;
 
 import com.shaft.driver.SHAFT;
+import com.shaft.listeners.internal.TestNGListenerHelper;
 import com.shaft.properties.internal.Properties;
 import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import com.shaft.tools.io.internal.AttachmentReporter;
@@ -11,6 +12,7 @@ import com.shaft.tools.io.internal.ReportContext;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import org.apache.logging.log4j.Level;
 import org.mockito.Mockito;
+import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -87,6 +89,31 @@ public class ReportManagerHelperUnitTests {
 
         SHAFT.Validations.assertThat().object(ReportManagerHelper.prepareIssuesLog()).isEqualTo("").perform();
         SHAFT.Validations.assertThat().object(ReportManagerHelper.getIssueCounter()).isEqualTo(0).perform();
+    }
+
+    @Test
+    public void logFinishedTestInformationShouldRenderRetriedFailureNotSkippedForWasRetriedResult() {
+        ITestNGMethod iTestNGMethod = Mockito.mock(ITestNGMethod.class);
+        Mockito.when(iTestNGMethod.getQualifiedName()).thenReturn("testPackage.unitTests.ReportManagerHelperUnitTests.sampleMethod");
+        Mockito.when(iTestNGMethod.isTest()).thenReturn(true);
+
+        // TestNG's TestInvoker forces the status to SKIP (and sets wasRetried=true) for every failed
+        // attempt that RetryAnalyzer chooses to retry; the live console line must not claim that
+        // attempt was "Skipped" -- it actually failed and is being retried.
+        ITestResult retrySuppressedAttempt = Mockito.mock(ITestResult.class);
+        Mockito.when(retrySuppressedAttempt.getMethod()).thenReturn(iTestNGMethod);
+        Mockito.when(retrySuppressedAttempt.getStatus()).thenReturn(ITestResult.SKIP);
+        Mockito.when(retrySuppressedAttempt.wasRetried()).thenReturn(true);
+        Mockito.when(retrySuppressedAttempt.getThrowable()).thenReturn(new AssertionError("boom"));
+
+        TestNGListenerHelper.logFinishedTestInformation(retrySuppressedAttempt);
+
+        List<String> output = ReportContext.snapshotOutput();
+        String renderedLine = output.get(output.size() - 1);
+
+        SHAFT.Validations.assertThat().object(renderedLine).contains("Status: Failed (retried)").perform();
+        SHAFT.Validations.assertThat().object(renderedLine).doesNotContain("Status: Skipped").perform();
+        SHAFT.Validations.assertThat().object(renderedLine).doesNotContain("⊘").perform();
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerHelperCoverageUnitTest.java
@@ -307,6 +307,30 @@ public class TestNGListenerHelperCoverageUnitTest {
         }
     }
 
+    @Test
+    public void logFinishedTestInformationShouldAnnotateRetriedFailedAttemptInsteadOfSkipped() {
+        // TestNG's TestInvoker forces the status to SKIP (and sets wasRetried=true) for every failed
+        // attempt that RetryAnalyzer chooses to retry; only the terminal attempt keeps its real
+        // FAILURE/SUCCESS status. The live console line must reflect that the attempt actually
+        // failed and is being retried, not parrot the misleading SKIP status (#3833).
+        ITestResult retrySuppressedAttempt = createResultForLogging("sampleMethod", ITestResult.SKIP);
+        Mockito.when(retrySuppressedAttempt.wasRetried()).thenReturn(true);
+
+        ITestResult terminalSkip = createResultForLogging("sampleMethod", ITestResult.SKIP);
+        Mockito.when(terminalSkip.wasRetried()).thenReturn(false);
+
+        try (MockedStatic<com.shaft.tools.io.internal.ReportManagerHelper> reportManagerHelper = Mockito.mockStatic(com.shaft.tools.io.internal.ReportManagerHelper.class)) {
+            reportManagerHelper.when(com.shaft.tools.io.internal.ReportManagerHelper::getTestClassName).thenReturn("sampleClass");
+            reportManagerHelper.when(com.shaft.tools.io.internal.ReportManagerHelper::getTestMethodName).thenReturn("sampleMethod");
+
+            TestNGListenerHelper.logFinishedTestInformation(retrySuppressedAttempt);
+            TestNGListenerHelper.logFinishedTestInformation(terminalSkip);
+
+            reportManagerHelper.verify(() -> com.shaft.tools.io.internal.ReportManagerHelper.logFinishedTestInformation(Mockito.eq("sampleClass"), Mockito.eq("sampleMethod"), Mockito.eq("sample description"), Mockito.eq("Failed (retried)"), Mockito.any()));
+            reportManagerHelper.verify(() -> com.shaft.tools.io.internal.ReportManagerHelper.logFinishedTestInformation(Mockito.eq("sampleClass"), Mockito.eq("sampleMethod"), Mockito.eq("sample description"), Mockito.eq("Skipped"), Mockito.any()));
+        }
+    }
+
     private static ITestResult createResultFromMethod(String methodName) {
         try {
             Method method = TestNGListenerHelperCoverageUnitTest.class.getDeclaredMethod(methodName);


### PR DESCRIPTION
## Summary
- TestNG coerces every attempt that `RetryAnalyzer` retries to `SKIP` with `wasRetried()==true` (the real throwable is preserved); only the terminal attempt keeps its true status. The live console therefore printed `⊘ Finished test method ... Status: Skipped` for attempts that actually failed and were being retried — the exact noise that misleads live-log triage.
- `TestNGListenerHelper.logFinishedTestInformation` now renders those attempts as `✗ ... Status: Failed (retried)` (failure icon + ERROR level via the status switch in `ReportManagerHelper`). Genuine skips and terminal attempts are untouched. Annotate-not-suppress: every attempt stays visible in the live log.
- Execution-summary rows were already retry-safe (#3810, PR #3832); this completes the console side.

## Verification
- RED: new `ReportManagerHelperUnitTests` end-to-end rendering test failed on unmodified code (`expected Status: Failed (retried) ... found ⊘ ... Status: Skipped`).
- GREEN: `TestNGListenerCoverageUnitTest` + `TestNGListenerHelperCoverageUnitTest` + `ReportManagerHelperUnitTests` — surefire 66/66, BUILD SUCCESS (independently re-run by the reviewer), including the #3832 regression suite.

Closes #3833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk