### PR TITLE
Read the two legacy remote-server timeouts live instead of caching at class-load

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -103,9 +103,13 @@ public class DriverFactoryHelper {
     private static final Object LOCAL_DRIVER_INITIALIZATION_LOCK = new Object();
     @Getter(AccessLevel.PUBLIC)
     private static final Dimension TARGET_WINDOW_SIZE = new Dimension(1920, 1080);
-    private static final long appiumServerInitializationTimeout = TimeUnit.MINUTES.toSeconds(SHAFT.Properties.timeouts.timeoutForRemoteServerToBeUp()); // seconds
+    // appiumServerInitializationTimeout (backed by timeoutForRemoteServerToBeUp) and
+    // remoteServerInstanceCreationTimeout used to be cached in `static final` fields here, seeded once at
+    // class-load time, so a runtime SHAFT.Properties.timeouts.set().timeoutForRemoteServerToBeUp(...) /
+    // .remoteServerInstanceCreationTimeout(...) override had no effect (issue #3826). Both are now read
+    // live at each use site instead -- see the local variables of the same name in
+    // attemptRemoteServerPing(), attemptRemoteServerConnection(), and setRemoteDriverInstance().
     private static final int appiumServerInitializationPollingInterval = 1; // seconds
-    private static final long remoteServerInstanceCreationTimeout = TimeUnit.MINUTES.toSeconds(SHAFT.Properties.timeouts.remoteServerInstanceCreationTimeout()); // seconds
     private static final int appiumServerPreparationPollingInterval = 1; // seconds
     private static final long localDriverInitializationRetryDelayMs = TimeUnit.SECONDS.toMillis(1);
     private static final long localDriverBiDiTimeoutGraceMs = TimeUnit.SECONDS.toMillis(5);
@@ -419,6 +423,9 @@ public class DriverFactoryHelper {
 
     @SneakyThrows({InterruptedException.class, MalformedURLException.class})
     private static int attemptRemoteServerPing() {
+        // Read live (not cached in a static field, issue #3826) so
+        // SHAFT.Properties.timeouts.set().timeoutForRemoteServerToBeUp(...) actually takes effect.
+        long appiumServerInitializationTimeout = TimeUnit.MINUTES.toSeconds(SHAFT.Properties.timeouts.timeoutForRemoteServerToBeUp());
         boolean serverReady = false;
         var session = new SHAFT.API(normalizeRemoteServerPingBaseUrl(getTargetHubUrl()));
         var statusCode = 500;
@@ -519,10 +526,10 @@ public class DriverFactoryHelper {
     }
 
     private static ClientConfig createRemoteWebDriverClientConfig(URL targetExecutionUrl) {
-        // Read live (not cached in a static field like remoteServerInstanceCreationTimeout above) so the
-        // SHAFT.Properties.timeouts.set().remoteServerConnectionAttemptTimeout(...) override -- and the
-        // decoupling from remoteServerInstanceCreationTimeout itself (issue #3811) -- actually take
-        // effect: that property bounds only the overall retry budget; this bounds a single HTTP
+        // Read live (not cached in a static field, same as remoteServerInstanceCreationTimeout since issue
+        // #3826) so the SHAFT.Properties.timeouts.set().remoteServerConnectionAttemptTimeout(...) override
+        // -- and the decoupling from remoteServerInstanceCreationTimeout itself (issue #3811) -- actually
+        // take effect: that property bounds only the overall retry budget; this bounds a single HTTP
         // connect/read attempt so a hung/unreachable grid fails one attempt fast instead of silently
         // consuming the whole retry budget.
         var timeout = Duration.ofSeconds(SHAFT.Properties.timeouts.remoteServerConnectionAttemptTimeout());
@@ -560,6 +567,9 @@ public class DriverFactoryHelper {
 
     @SneakyThrows({InterruptedException.class, MalformedURLException.class})
     private static WebDriver attemptRemoteServerConnection(Capabilities capabilities) {
+        // Read live (not cached in a static field, issue #3826) so
+        // SHAFT.Properties.timeouts.set().remoteServerInstanceCreationTimeout(...) actually takes effect.
+        long remoteServerInstanceCreationTimeout = TimeUnit.MINUTES.toSeconds(SHAFT.Properties.timeouts.remoteServerInstanceCreationTimeout());
         WebDriver driver = null;
         boolean isRemoteConnectionEstablished = false;
         var startTime = System.currentTimeMillis();
@@ -1135,6 +1145,9 @@ public class DriverFactoryHelper {
     private void setRemoteDriverInstance(Capabilities capabilities) {
         // stage 1: ensure that the server is up and running
         if (SHAFT.Properties.timeouts.waitForRemoteServerToBeUp()) {
+            // Read live (not cached in a static field, issue #3826) so
+            // SHAFT.Properties.timeouts.set().timeoutForRemoteServerToBeUp(...) actually takes effect.
+            long appiumServerInitializationTimeout = TimeUnit.MINUTES.toSeconds(SHAFT.Properties.timeouts.timeoutForRemoteServerToBeUp());
             ReportManager.logDiscrete("Waiting up to " + TimeUnit.SECONDS.toMinutes(appiumServerInitializationTimeout) + " minute(s) for the remote server to become ready.");
             var remoteReadinessStart = System.currentTimeMillis();
             try {
@@ -1161,6 +1174,9 @@ public class DriverFactoryHelper {
         }
 
         // stage 2: create remote driver instance (requires some time with dockerized appium)
+        // Read live (not cached in a static field, issue #3826) so
+        // SHAFT.Properties.timeouts.set().remoteServerInstanceCreationTimeout(...) actually takes effect.
+        long remoteServerInstanceCreationTimeout = TimeUnit.MINUTES.toSeconds(SHAFT.Properties.timeouts.remoteServerInstanceCreationTimeout());
         ReportManager.logDiscrete("Creating the remote WebDriver session. Timeout: " + TimeUnit.SECONDS.toMinutes(remoteServerInstanceCreationTimeout) + " minute(s).");
         var remoteCreationStart = System.currentTimeMillis();
         var preflightPermit = RemoteGridPreflight.SessionPermit.noop();

--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java
@@ -1013,6 +1013,99 @@ public class DriverFactoryHelperCoverageUnitTest {
     }
 
     @Test
+    public void attemptRemoteServerPingShouldHonorRuntimeOverrideOfTimeoutForRemoteServerToBeUp() throws Exception {
+        // issue #3826: appiumServerInitializationTimeout (backed by timeoutForRemoteServerToBeUp) used to
+        // be cached in a `static final` field seeded once at class-load time, so a runtime
+        // SHAFT.Properties.timeouts.set().timeoutForRemoteServerToBeUp(...) override had no effect:
+        // attemptRemoteServerPing() kept retrying against whatever budget was in scope at class-load
+        // (default 1 minute) instead of the overridden one. An always-500 local server plus a tiny
+        // (0-minute) override proves the override is read live: a fixed implementation gives up almost
+        // immediately, a stale-cache implementation keeps retrying for the class-load-time default and
+        // blows past the bounded wait below.
+        //
+        // Both the hub URL (a ThreadLocal, see TARGET_HUB_URL) and the property override (also
+        // thread-scoped, see ThreadLocalPropertiesManager) must be set on the SAME thread that invokes
+        // attemptRemoteServerPing() -- so both the setup and the invocation run inside one task submitted
+        // to the bounding executor, and the test thread only waits on the Future.
+        com.sun.net.httpserver.HttpServer server = com.sun.net.httpserver.HttpServer.create(new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/wd/hub/status/", exchange -> {
+            byte[] response = "{\"value\":{\"ready\":false}}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(500, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Method attemptRemoteServerPing = DriverFactoryHelper.class.getDeclaredMethod("attemptRemoteServerPing");
+            attemptRemoteServerPing.setAccessible(true);
+
+            Future<Object> pingAttempt = executor.submit(() -> {
+                setTargetHubUrl("http://127.0.0.1:" + server.getAddress().getPort() + "/wd/hub");
+                SHAFT.Properties.timeouts.set().timeoutForRemoteServerToBeUp(0);
+                return attemptRemoteServerPing.invoke(null);
+            });
+            try {
+                pingAttempt.get(5, TimeUnit.SECONDS);
+                org.testng.Assert.fail("Expected attemptRemoteServerPing() to fail against the always-500 server.");
+            } catch (java.util.concurrent.ExecutionException expectedFailureOnceBudgetElapses) {
+                // expected: the server never reports ready, so the ping must fail once the (overridden,
+                // live-read) budget elapses -- proves the override was actually honored.
+            } catch (java.util.concurrent.TimeoutException stillRetrying) {
+                org.testng.Assert.fail("attemptRemoteServerPing() did not honor the runtime override of "
+                        + "timeoutForRemoteServerToBeUp(0): still retrying after 5s, which means it used a "
+                        + "stale class-load-time timeout instead of reading the property live.");
+            }
+        } finally {
+            executor.shutdownNow();
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void attemptRemoteServerConnectionShouldHonorRuntimeOverrideOfRemoteServerInstanceCreationTimeout() throws Exception {
+        // issue #3826: remoteServerInstanceCreationTimeout was cached in a `static final` field seeded once
+        // at class-load time (default 5 minutes), so a runtime
+        // SHAFT.Properties.timeouts.set().remoteServerInstanceCreationTimeout(...) override had no effect on
+        // the remote WebDriver session-creation retry budget. Forcing every RemoteWebDriver construction to
+        // fail with a retryable SessionNotCreatedException plus a tiny (0-minute) override proves the
+        // override is read live, the same way attemptRemoteServerPingShouldHonorRuntimeOverrideOf... proves
+        // it for timeoutForRemoteServerToBeUp above.
+        //
+        // As above: the hub URL, the target platform, and the property override are all thread-scoped, so
+        // they must be set on the same thread that calls attemptRemoteServerConnection().
+        Method attemptRemoteServerConnection = DriverFactoryHelper.class.getDeclaredMethod("attemptRemoteServerConnection", org.openqa.selenium.Capabilities.class);
+        attemptRemoteServerConnection.setAccessible(true);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (MockedConstruction<RemoteWebDriver> ignored = org.mockito.Mockito.mockConstruction(RemoteWebDriver.class,
+                (mock, context) -> {
+                    throw new org.openqa.selenium.SessionNotCreatedException("grid still initializing");
+                })) {
+            Future<Object> connectionAttempt = executor.submit(() -> {
+                SHAFT.Properties.platform.set().targetPlatform("windows");
+                setTargetHubUrl("http://127.0.0.1:4444/wd/hub");
+                SHAFT.Properties.timeouts.set().remoteServerInstanceCreationTimeout(0);
+                return attemptRemoteServerConnection.invoke(null, new ImmutableCapabilities());
+            });
+            try {
+                connectionAttempt.get(5, TimeUnit.SECONDS);
+                org.testng.Assert.fail("Expected attemptRemoteServerConnection() to fail against the always-failing constructor.");
+            } catch (java.util.concurrent.ExecutionException expectedFailureOnceBudgetElapses) {
+                // expected: the constructor always throws a retryable failure, so the connection attempt
+                // must fail once the (overridden, live-read) budget elapses -- proves the override was
+                // actually honored.
+            } catch (java.util.concurrent.TimeoutException stillRetrying) {
+                org.testng.Assert.fail("attemptRemoteServerConnection() did not honor the runtime override of "
+                        + "remoteServerInstanceCreationTimeout(0): still retrying after 5s, which means it "
+                        + "used a stale class-load-time timeout instead of reading the property live.");
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     public void configureRemoteDriverInstanceShouldCoverDesktopOptionRoutingBranches() throws Exception {
         SHAFT.Properties.timeouts.set().waitForRemoteServerToBeUp(false);
         SHAFT.Properties.platform.set().executionAddress("http://localhost:4444").targetPlatform("Linux");


### PR DESCRIPTION
## Summary
- `DriverFactoryHelper` cached `appiumServerInitializationTimeout` (backed by `timeoutForRemoteServerToBeUp`) and `remoteServerInstanceCreationTimeout` in `static final` fields seeded once at class-load, so `SHAFT.Properties.timeouts.set()...` runtime overrides were silently ignored (#3826, adjacent finding from #3811/PR #3825).
- Both are now local variables read live at each use site — `attemptRemoteServerPing()`, `attemptRemoteServerConnection()`, and both stages of `setRemoteDriverInstance()` — with identical units, defaults, and retry-budget math, matching the `remoteServerConnectionAttemptTimeout` pattern established in PR #3825. The stale cross-reference comment in `createRemoteWebDriverClientConfig()` was corrected to match.
- Audit of every file under `driver/internal/DriverFactory/` found **no other** static-cached `SHAFT.Properties` values — all ~245 other property call sites are already inline per-call; the only `static {}` block sets a JUL logger level.

## Verification
- RED: two new tests in `DriverFactoryHelperCoverageUnitTest` failed against unmodified code (override set to 0 minutes, yet the retry loop kept using the stale class-load value). Notably, the first RED design gave a false pass because `TARGET_HUB_URL` and the property overrides are ThreadLocal-scoped — the tests were redesigned so setup and invocation share one thread before the RED was trusted.
- GREEN: `DriverFactoryHelperCoverageUnitTest` 41/41; regression batch `DriverFactoryHelperAdditionalUnitTest, DriverFactoryCoverageUnitTest, LambdaTestHelperUnitTest, BrowserStackHelperUnitTest, TimeoutsTests` 50/50; reviewer independently re-ran `DriverFactoryHelperCoverageUnitTest + TimeoutsTests` — 42/42, BUILD SUCCESS.

Closes #3826

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHoYVC5KYCDMmGtwLsEHk