### PR TITLE
Trim the dead rich-evidence flag from ValidationsHelper's driver paths

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsHelper.java
@@ -207,8 +207,8 @@ public class ValidationsHelper {
                                              boolean richEvidenceAlreadyAttached) {
         var validationsHelper = new ValidationsHelper(validationCategory);
         validationsHelper.validationStartTime = validationStartTime;
-        validationsHelper.reportValidationState(validationState, expected, actual, null, null, attachments,
-                false, richEvidenceAlreadyAttached);
+        validationsHelper.reportValidationStateWithRichEvidence(validationState, expected, actual, attachments,
+                richEvidenceAlreadyAttached);
     }
 
     /**
@@ -1050,11 +1050,15 @@ public class ValidationsHelper {
         reportValidationState(validationState, expected, actual, driver, locator, attachments, false);
     }
 
+    /**
+     * Terminal implementation for every WebDriver-affiliated (and driver-less-but-not-rich-evidence)
+     * validation path. This path never carries pre-attached rich evidence — only the driver-less
+     * Playwright entry point does, via {@link #reportValidationStateWithRichEvidence} — so it always
+     * attaches the standard testData/screenshot evidence and the assertion-evidence card (issue
+     * #3840: the rich-evidence flag is intentionally not accepted/forwarded here since it would
+     * always be {@code false} on this path).
+     */
     private void reportValidationState(boolean validationState, Object expected, Object actual, WebDriver driver, By locator, List<List<Object>> attachments, boolean skipDefaultScreenshot) {
-        reportValidationState(validationState, expected, actual, driver, locator, attachments, skipDefaultScreenshot, false);
-    }
-
-    private void reportValidationState(boolean validationState, Object expected, Object actual, WebDriver driver, By locator, List<List<Object>> attachments, boolean skipDefaultScreenshot, boolean richEvidenceAlreadyAttached) {
         TraceEventRecorder.Event traceEvent = TraceEventRecorder.start(
                 "validation",
                 this.validationCategoryString,
@@ -1064,9 +1068,42 @@ public class ValidationsHelper {
         //initialize attachments object if no attachments were already prepared
         attachments = attachments == null ? new ArrayList<>() : attachments;
 
-        prepareEvidenceAttachments(validationState, expected, actual, driver, locator, skipDefaultScreenshot,
-                richEvidenceAlreadyAttached, attachments);
-        attachEvidenceCardIfNeeded(richEvidenceAlreadyAttached, validationState, expected, actual, attachments);
+        prepareEvidenceAttachments(validationState, expected, actual, driver, locator, skipDefaultScreenshot, attachments);
+        attachEvidenceCard(validationState, expected, actual, attachments);
+
+        finishReportingValidationState(validationState, expected, actual, locator, attachments, traceEvent);
+    }
+
+    /**
+     * Terminal implementation for the driver-less Playwright visual-evidence entry point (issue
+     * #3804 / PR #3823). Unlike the WebDriver-affiliated overload above, this path can be told that
+     * the caller already attached authoritative rich comparison evidence elsewhere (e.g. a
+     * Playwright visual-diff image via {@code Allure.addAttachment}); when {@code
+     * richEvidenceAlreadyAttached} is {@code true}, the generic "Validation Test Data" text and the
+     * "Assertion evidence" card are skipped since they would otherwise redundantly restate an
+     * opaque boolean result. There is no WebDriver on this path, which is why the flag lives here
+     * instead of being threaded through the driver-affiliated overloads (issue #3840).
+     */
+    private void reportValidationStateWithRichEvidence(boolean validationState, Object expected, Object actual,
+                                                        List<List<Object>> attachments, boolean richEvidenceAlreadyAttached) {
+        TraceEventRecorder.Event traceEvent = TraceEventRecorder.start(
+                "validation",
+                this.validationCategoryString,
+                (By) null,
+                null);
+        recordProfiledValidationState(validationState);
+        attachments = attachments == null ? new ArrayList<>() : attachments;
+
+        if (!richEvidenceAlreadyAttached) {
+            prepareTestDataAttachments(expected, actual, attachments);
+            attachEvidenceCard(validationState, expected, actual, attachments);
+        }
+
+        finishReportingValidationState(validationState, expected, actual, null, attachments, traceEvent);
+    }
+
+    private void finishReportingValidationState(boolean validationState, Object expected, Object actual, By locator,
+                                                 List<List<Object>> attachments, TraceEventRecorder.Event traceEvent) {
         attachEvidenceWithProfiling(attachments);
 
         // determine checkpoint type
@@ -1078,17 +1115,16 @@ public class ValidationsHelper {
     }
 
     /**
-     * Prepares the reportable evidence attachments, mutating {@code attachments} in place. When a
-     * WebDriver is present the driver-derived evidence (screenshot/page-snapshot) is always
-     * considered; {@code richEvidenceAlreadyAttached} only gates the plain testData attachments
-     * prepared below when no driver is available.
+     * Prepares the reportable evidence attachments, mutating {@code attachments} in place: the
+     * driver-derived evidence (screenshot/page-snapshot) when a WebDriver is present, otherwise the
+     * plain testData attachments. This overload is only reached from the WebDriver-affiliated
+     * terminal above, which never carries pre-attached rich evidence.
      */
     private void prepareEvidenceAttachments(boolean validationState, Object expected, Object actual, WebDriver driver,
-                                            By locator, boolean skipDefaultScreenshot, boolean richEvidenceAlreadyAttached,
-                                            List<List<Object>> attachments) {
+                                            By locator, boolean skipDefaultScreenshot, List<List<Object>> attachments) {
         if (driver != null) {
             prepareWebDriverAttachments(driver, locator, validationState, skipDefaultScreenshot, attachments);
-        } else if (!richEvidenceAlreadyAttached) {
+        } else {
             prepareTestDataAttachments(expected, actual, attachments);
         }
     }
@@ -1155,14 +1191,12 @@ public class ValidationsHelper {
     // Single primary assertion-evidence card (issue #3502 A+B): one HTML block carrying the
     // redacted expected/actual plus a diff, placed first so it headlines the Allure step. The
     // existing Expected/Actual text attachments stay (dual-write) so consumers that scrape
-    // those names keep working. Skipped when the caller already attached authoritative rich
-    // comparison evidence elsewhere (e.g. a Playwright visual-diff image) — issue #3804: the
-    // card would otherwise redundantly restate a boolean/opaque result.
-    private void attachEvidenceCardIfNeeded(boolean richEvidenceAlreadyAttached, boolean validationState,
-                                            Object expected, Object actual, List<List<Object>> attachments) {
-        if (richEvidenceAlreadyAttached) {
-            return;
-        }
+    // those names keep working. The rich-evidence path (#3804 / #3823) skips calling this
+    // altogether rather than passing a flag in, since it's the only path that can have
+    // authoritative comparison evidence attached elsewhere already — see
+    // reportValidationStateWithRichEvidence.
+    private void attachEvidenceCard(boolean validationState, Object expected, Object actual,
+                                    List<List<Object>> attachments) {
         String evidenceCard = AssertionEvidenceReporter.renderCard(
                 this.validationCategoryString, validationState, expected, actual);
         if (!evidenceCard.isBlank()) {

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperNewPatternCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/ValidationsHelperNewPatternCoverageUnitTest.java
@@ -302,7 +302,7 @@ public class ValidationsHelperNewPatternCoverageUnitTest {
         preAttached.add(List.of("Expected Aria Snapshot", "sample.yaml", "expectedYaml"));
 
         Method reportValidationState = ValidationsHelper.class.getDeclaredMethod("reportValidationState",
-                boolean.class, Object.class, Object.class, WebDriver.class, By.class, List.class, boolean.class, boolean.class);
+                boolean.class, Object.class, Object.class, WebDriver.class, By.class, List.class, boolean.class);
         reportValidationState.setAccessible(true);
 
         try (MockedStatic<ReportManagerHelper> reportManagerHelperMocked = Mockito.mockStatic(ReportManagerHelper.class);
@@ -310,7 +310,7 @@ public class ValidationsHelperNewPatternCoverageUnitTest {
             @SuppressWarnings({"rawtypes", "unchecked"})
             ArgumentCaptor<List<List<Object>>> attachmentsCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
 
-            reportValidationState.invoke(helper, true, "expected", "actual", driver, locator, preAttached, false, false);
+            reportValidationState.invoke(helper, true, "expected", "actual", driver, locator, preAttached, false);
 
             reportManagerHelperMocked.verify(() -> ReportManagerHelper.attach(attachmentsCaptor.capture()));
             List<List<Object>> attachments = attachmentsCaptor.getValue();
@@ -335,7 +335,7 @@ public class ValidationsHelperNewPatternCoverageUnitTest {
         SHAFT.Properties.reporting.set().flakeProfilerEnabled(true);
 
         Method reportValidationState = ValidationsHelper.class.getDeclaredMethod("reportValidationState",
-                boolean.class, Object.class, Object.class, WebDriver.class, By.class, List.class, boolean.class, boolean.class);
+                boolean.class, Object.class, Object.class, WebDriver.class, By.class, List.class, boolean.class);
         reportValidationState.setAccessible(true);
 
         try (MockedStatic<ReportManagerHelper> reportManagerHelperMocked = Mockito.mockStatic(ReportManagerHelper.class);
@@ -347,7 +347,7 @@ public class ValidationsHelperNewPatternCoverageUnitTest {
             @SuppressWarnings({"rawtypes", "unchecked"})
             ArgumentCaptor<List<List<Object>>> attachmentsCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
 
-            reportValidationState.invoke(helper, true, "expected", "actual", driver, locator, new ArrayList<>(), false, false);
+            reportValidationState.invoke(helper, true, "expected", "actual", driver, locator, new ArrayList<>(), false);
 
             reportManagerHelperMocked.verify(() -> ReportManagerHelper.attach(attachmentsCaptor.capture()));
             List<List<Object>> attachments = attachmentsCaptor.getValue();


### PR DESCRIPTION
## Summary

`ValidationsHelper.reportValidationState`'s `richEvidenceAlreadyAttached` flag can only ever be `true` via the driver-less 8-arg... actually 7-arg public static entry point added by #3823 for the Playwright visual-evidence path (`PlaywrightValidationsExecutor`). Every WebDriver-affiliated call site routes through the 6/7-arg instance overloads that always forward `false`, so `driver != null && richEvidenceAlreadyAttached` was permanently dead headroom — a combination the private terminal method's signature allowed but no caller could ever exercise, inviting exactly the confusion #3840 documents.

**Decision (option B, per the issue): trim the parameter from the driver paths** rather than asserting/documenting the impossible combination. Rationale — YAGNI: no Selenium-side rich-evidence caller exists or is planned; a dead parameter threaded through driver-carrying overloads invites confusion; a future caller can reintroduce it with a real use.

## What changed

Split the single shared 8-arg private terminal (`reportValidationState(state, expected, actual, driver, locator, attachments, skipDefaultScreenshot, richEvidenceAlreadyAttached)`) into two terminals so the flag no longer rides along the driver-affiliated chain:

- `reportValidationState(state, expected, actual, driver, locator, attachments, skipDefaultScreenshot)` — now the **WebDriver-affiliated terminal** (used by every `validate*` method that carries, or may carry, a driver). It no longer accepts or forwards the flag at all; it always attaches the standard testData/screenshot evidence and the assertion-evidence card.
- `reportValidationStateWithRichEvidence(state, expected, actual, attachments, richEvidenceAlreadyAttached)` — new **driver-less terminal**, reached only from the Playwright rich-evidence public entry point. It owns the skip-supplementary-evidence gating (issue #3804 behavior, unchanged).
- `prepareEvidenceAttachments` and `attachEvidenceCardIfNeeded` → `attachEvidenceCard` drop the flag accordingly.
- Shared tail logic (trace event finish, checkpoint type, report line, outcome routing) is factored into `finishReportingValidationState` so the two terminals don't duplicate it.

**No public API changed.** `ValidationsHelper`'s three public static `reportValidationState` overloads (including the 7-arg one with `richEvidenceAlreadyAttached` that `PlaywrightValidationsExecutor` calls) are untouched — only the private instance-level helper chain was reshaped. Verified `ValidationsHelper` is `public` but every changed helper method is `private`, and searched the whole repo for reflection-based access to the renamed/removed private methods — only the two test files below reference them.

## Verification evidence

- `mvn --batch-mode -pl shaft-engine test-compile` → `BUILD SUCCESS` (231 main + 344 test source files compiled clean).
- `mvn --batch-mode -pl shaft-engine test -Dtest=ValidationsHelperNewPatternCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` → surefire XML: `tests="8" errors="0" skipped="0" failures="0"`. Updated the two reflection-based tests in this class (which invoked the now-7-arg private terminal via `getDeclaredMethod`) to drop the trailing `richEvidenceAlreadyAttached` argument.
- `mvn --batch-mode -pl shaft-engine test -Dtest=ValidationsHelperCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` → surefire XML: `tests="7" errors="0" skipped="0" failures="0"`. This includes `reportValidationStateSkipsSupplementaryEvidenceWhenRichEvidenceAlreadyAttached`, which pins the Playwright-path (#3804) contract unchanged, and `reportValidationStateAttachesPrimaryEvidenceCard`, which pins the default (non-rich) contract unchanged.
- Repo-wide `rg` confirmed `PlaywrightValidationsExecutor` is the only production caller of the rich-evidence public overload, and it is structurally driver-less (that overload has no `WebDriver` parameter at all).

Closes #3840

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017P8noRGterU2wDhRbGhM8H