### PR TITLE
Escape raw control bytes reaching the console/job log sink

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -754,7 +754,38 @@ public class ReportManagerHelper {
     }
 
     private static String normalizeLogText(String logText) {
-        return logText == null ? "null" : logText.trim();
+        return logText == null ? "null" : sanitizeControlCharacters(logText.trim());
+    }
+
+    /**
+     * Escapes raw ASCII control bytes (NUL and friends) that occasionally leak into log
+     * text from JDK exception messages -- e.g. {@link java.nio.file.InvalidPathException}
+     * echoes an offending path verbatim, embedded NUL byte and all (#3807). A literal NUL
+     * reaching the console/log file flips log-scraping tools like ripgrep into binary mode
+     * and silently truncates every search past that point, so control bytes are replaced
+     * with a visible {@code \xNN} escape here -- the single sink every console/log-file log
+     * line passes through -- rather than at each call site. Tab, newline, and carriage
+     * return are real formatting and are left untouched.
+     *
+     * @param text the trimmed log text to sanitize
+     * @return the same text with unsafe control bytes replaced by visible escapes
+     */
+    private static String sanitizeControlCharacters(String text) {
+        StringBuilder sanitized = null;
+        for (int i = 0; i < text.length(); i++) {
+            char character = text.charAt(i);
+            boolean isUnsafeControlCharacter = character < 0x20 && character != '\t' && character != '\n' && character != '\r'
+                    || character == 0x7F;
+            if (isUnsafeControlCharacter) {
+                if (sanitized == null) {
+                    sanitized = new StringBuilder(text.length() + 16).append(text, 0, i);
+                }
+                sanitized.append(String.format("\\x%02X", (int) character));
+            } else if (sanitized != null) {
+                sanitized.append(character);
+            }
+        }
+        return sanitized == null ? text : sanitized.toString();
     }
 
     public static void createLogEntry(String logText, Level loglevel) {

--- a/shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ReportManagerHelperUnitTests.java
@@ -582,6 +582,27 @@ public class ReportManagerHelperUnitTests {
     }
 
     @Test
+    public void createLogEntryShouldEscapeRawControlBytesInsteadOfEmittingThemVerbatim() {
+        // Regression for #3807: java.nio.file.InvalidPathException echoes the offending
+        // path verbatim (e.g. "bad\0path"), so a NUL byte can reach this sink straight
+        // from JDK exception messages -- not just from attachment/screenshot bytes.
+        // Emitting it raw makes ripgrep flip the CI job log to binary mode and silently
+        // truncate post-mortem searches past that point. Tabs and newlines are real
+        // formatting and must survive untouched.
+        ReportManagerHelper.createLogEntry("bad\0path with \u0007 bell,\ttab, and\nnewline", Level.INFO);
+
+        List<String> output = ReportContext.snapshotOutput();
+        String renderedLine = output.get(output.size() - 1);
+
+        SHAFT.Validations.assertThat().object(renderedLine).doesNotContain("\0").perform();
+        SHAFT.Validations.assertThat().object(renderedLine).doesNotContain("\u0007").perform();
+        SHAFT.Validations.assertThat().object(renderedLine).contains("bad\\x00path").perform();
+        SHAFT.Validations.assertThat().object(renderedLine).contains("\\x07 bell").perform();
+        SHAFT.Validations.assertThat().object(renderedLine).contains("\ttab").perform();
+        SHAFT.Validations.assertThat().object(renderedLine).contains("\nnewline").perform();
+    }
+
+    @Test
     public void privateHelpersShouldReturnExpectedValues() throws Exception {
         Method createSeparatorMethod = ReportManagerHelper.class.getDeclaredMethod("createSeparator", char.class);
         createSeparatorMethod.setAccessible(true);


### PR DESCRIPTION
## Summary

Closes #3807

- **Root cause found and fixed (item 1):** local E2E job logs from run `29673202709` (jobs `88155817093`, `88155817104`, `88155817171`) contain embedded NUL bytes that flip ripgrep into binary mode and silently truncate post-mortem searches past that offset.
- **Item 2 was already fixed by #3829** — verified current, no change needed. Evidence below.

## Root-cause evidence (item 1)

Downloaded all three job logs via `gh api repos/ShaftHQ/SHAFT_ENGINE/actions/jobs/<id>/logs` and located the first NUL byte in each:

| Job | First NUL offset | Total NUL bytes |
|---|---|---|
| 88155817093 | byte 7,618,520 of 13,177,417 | 12 |
| 88155817104 | byte 7,524,673 of 13,158,739 | 12 |
| 88155817171 | byte 97,490 of 9,842,247 | 8 |

The bytes immediately surrounding every offset are the same log line, e.g. (job 88155817093, `2026-07-19T04:44:59.0619070Z`):

```
[INFO] 04:44:59 │ File action "ListFiles" failed. Input: "Could not list files in directory "bad<NUL>path".". Root cause: "java.nio.file.InvalidPathException: Illegal char <NUL> at index 3: bad<NUL>path"
```

Traced the emitting path:

1. `shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java:353-355,366` deliberately passes a Java string literal `"bad\0path"` (a real embedded NUL char) into `FileActions.listFilesInDirectory`/`getFileList`/`writeToFile` to exercise `java.nio.file.InvalidPathException` handling.
2. The JDK's `InvalidPathException` embeds the offending path **verbatim** (NUL byte included) in its own message (`"Illegal char <\0> at index 3: bad\0path"` on Windows/Linux, `"Nul character not allowed: bad\0path"` on macOS — confirmed from job 88155817171, which runs on `macos`).
3. `shaft-engine/src/main/java/com/shaft/cli/FileActions.java:163` builds `testData = "Could not list files in directory \"" + targetDirectory + "\"."` (also NUL-laden) and calls `failAction(testData, rootCauseException)`.
4. `FileActions.java:773-802` (`reportActionResult`) appends `testData` unmodified into the log `message` (line 801: `message = message + " Input: \"" + testData + "\"."`).
5. `shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureReporter.java:29,52-58` (`fail`/`getRootCause`) appends the exception's raw `getLocalizedMessage()` (NUL-laden) and calls `ReportManagerHelper.log(message + rootCause, attachments, CheckpointStatus.FAIL)`.
6. `shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java:756-758` (`normalizeLogText`, the single choke point every console/log-file line passes through before `logger.log(...)` and `ReportContext.append(...)`) previously only called `.trim()` — no control-character sanitization — so the raw NUL byte reached both the log4j2 console appender (the job's stdout, i.e. the CI log) and the execution log file untouched.

## Fix

`ReportManagerHelper.normalizeLogText()` now routes text through a new `sanitizeControlCharacters()` that replaces unsafe ASCII control bytes (NUL and friends, excluding tab/newline/CR which are legitimate formatting) with a visible `\xNN` escape, before the text ever reaches the console/log sink. Fixed at this one choke point rather than at each call site (`FileActions`, `FailureReporter`, or every future caller that might forward a raw exception message).

Confirmed end-to-end: re-ran `FileActionsCoverageUnitTest` after the fix and captured the full console output — **0 NUL bytes** in 66KB of captured stdout, and the same log line now reads:

```
[INFO] 09:21:18 │ File action "ListFiles" failed. Input: "Could not list files in directory "bad\x00path".". Root cause: "java.nio.file.InvalidPathException: Illegal char <\x00> at index 3: bad\x00path"
```

## Item 2 status — already fixed by #3829

`scripts/ci/extract_allure_failures.py` itself already prints to stdout via `print(output)` in `main()`. The actual gap the issue described was in the workflow step that invokes it. `.github/actions/post-test-report/action.yml:207-216` already tees the failure list into both the job log and `$GITHUB_STEP_SUMMARY`:

```yaml
# tee instead of a bare redirect so the failure list also lands in the
# raw job log, where gh run view --log and log-download forensics can
# see it -- previously it was visible only in the step summary (#3807)
{
  echo ""
  echo "### ❌ Failed and broken test methods"
  python3 scripts/ci/extract_allure_failures.py "$ALLURE_FAILURE_SOURCE" || true
} | tee -a "$GITHUB_STEP_SUMMARY"
```

This was landed by PR #3829 ("Tee the Allure failure list into the job log, not only the step summary", merged 2026-07-19) and directly cites #3807. No further change needed for item 2 — the issue closes on item 1 alone.

## Test plan

- [x] TDD: added `createLogEntryShouldEscapeRawControlBytesInsteadOfEmittingThemVerbatim` to `ReportManagerHelperUnitTests`, watched it fail RED against the exact reproduction bytes (raw NUL/BEL in the rendered line) before the fix
- [x] `mvn -pl shaft-engine -Dtest=ReportManagerHelperUnitTests test` — 33/33 passed (surefire XML: `tests="33" errors="0" failures="0"`)
- [x] `mvn -pl shaft-engine -Dtest=FileActionsCoverageUnitTest test` — 9/9 passed, and captured console output verified to contain 0 NUL bytes
- [x] `mvn -pl shaft-engine test-compile` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017P8noRGterU2wDhRbGhM8H