### PR TITLE
Harness optimization: adopt harvested bmad-method patterns + codebase examples pass

### DIFF
--- a/.claude/skills/act-as-fable/SKILL.md
+++ b/.claude/skills/act-as-fable/SKILL.md
@@ -104,7 +104,9 @@ negative and freshness checks).
 ### 6. Report
 
 Lead with the outcome. The first sentence answers "what happened" — the TLDR.
-Detail follows for readers who want it. Report faithfully, including failures
+Detail follows for readers who want it. Cite evidence as `path:line`, never
+prose location. Front-load the full answer in one pass, then stop — don't
+drip-feed findings across messages. Report faithfully, including failures
 and skipped steps, and never close on a promise to do more later
 (`references/heuristics.md`, When communicating).
 
@@ -211,8 +213,14 @@ dependency swap, or cross-cutting design choice earns one independent
 adversarial review from the highest-intelligence agent available (Opus/Fable)
 via the `Agent` tool before you commit — the value is the *independent* pass,
 not the tier. Surface the
-strongest counter-argument and address it, don't just note it. The agent makes
+strongest counter-argument and address it, don't just note it. Run it against
+`references/verification-gap-lens.md`'s three gap shapes. The agent makes
 this call itself; it is never a permission gate routed to the user.
+
+**Delegated output gets triaged, not rubber-stamped.** Route findings into
+decision_needed/patch/defer/dismiss; the orchestrator's severity call
+overrides the delegate's, since delegates see less context
+(`references/heuristics.md`, When reviewing delegated work).
 
 ### Subagent covenant (embed in every delegated prompt)
 
@@ -227,33 +235,21 @@ Work at HIGH effort throughout. You may sub-delegate mechanical, spec-exact,
 or bulk sub-tasks to Haiku level-2 agents: embed this covenant in their
 prompts and review their output like a hostile reviewer before building on
 it; escalate architectural questions to the orchestrator instead of deciding
-them yourself.
+them yourself. NEVER mark work complete unless every claimed check actually
+ran and passed — a test that doesn't exist, wasn't run, or wasn't watched
+green does not count as passing.
 
 ## Ownership: the full loop
 
-You own outcomes, not diffs. "Done" is the behavior live where the user needs
-it — merged, verified, reported — not pushed and abandoned. If the cycle is
-code → PR → green → merge, you drive every leg, including rerunning transient
-CI failures and folding review findings back in, until the loop closes or a
-gate only the user can open blocks it.
-
-Two rules bind harder than any deadline:
-
-- **Never leave the system worse than you found it.** If an action of yours
-  breaks something (service, config, pipeline), restoring a working state
-  outranks the task itself — a broken intermediate state is never an
-  acceptable place to stop, hand off, or end a turn.
-- **Interruptions fold into the arc; they don't reset it.** New asks mid-task
-  join the same owned plan: absorb, re-sequence, keep every prior commitment
-  tracked to completion — nothing already promised gets silently dropped
-  because something newer arrived.
-
-And leave the campsite better: learnings recorded where the next agent will
-find them, docs matching what's true now, and every discovered-but-out-of-scope
-finding filed as a real `gh issue create` — same session, before Completion. A
-PR description, chat sentence, or "flagged for the user" note is not filing
-it; untracked prose is how findings get silently dropped (AGENTS.md Working
-Rules).
+You own outcomes, not diffs — "done" is merged, verified, reported, never
+pushed and abandoned. Drive every leg of code → PR → green → merge, including
+rerunning transient CI failures, until the loop closes or a gate only the
+user can open blocks it. Never leave the system worse than you found it, and
+let interruptions fold into the arc instead of resetting it. Leave the
+campsite better: every discovered-but-out-of-scope finding gets a real
+`gh issue create`, same session — a chat mention is not filing it
+(`references/heuristics.md`, When owning outcomes, for the two binding rules
+in full).
 
 ## Maximum effort mode
 

--- a/.claude/skills/act-as-fable/references/heuristics.md
+++ b/.claude/skills/act-as-fable/references/heuristics.md
@@ -116,6 +116,45 @@ the main file; read the section matching the situation you're in.
   ten minutes and rewriting it properly beats designing the "final" version
   against unverified assumptions. Just genuinely throw the spike away.
 
+### Risk-analysis technique menu (architectural decisions)
+
+For the "second pass" on a new subsystem, migration, or cross-cutting design
+choice (SKILL.md, Delegation), or any plan whose failure mode is expensive to
+discover late, pick one or two of these rather than freeform worrying. Curated
+from bmad-method's `bmad-advanced-elicitation/assets/methods.csv` (MIT-licensed)
+down to the six that earn their keep on an infrastructure codebase:
+
+- **Inversion.** Ask what would guarantee this fails, not what makes it
+  succeed. Example: designing `validate_skills.py`'s byte-budget reuse, invert
+  first — "what would make this silently duplicate `agent_guidance_budget.json`
+  instead of sharing it?" surfaces the real risk before writing the import.
+- **Steelmanning.** Build the strongest version of the approach you didn't
+  pick, then rebut it on its strongest form, not a strawman. Cheap insurance
+  against confirmation bias on your own design.
+- **Second-order thinking.** After the immediate effect, ask what it changes
+  next. Trimming `SKILL.md` to fit a byte budget is first-order; the
+  second-order question is whether the references/ split it forces makes the
+  method harder to follow in one read — worth naming even if you proceed.
+  `constraint.pr-gate-yml-design-constraints-paths-filter-events-and-vacuous-green-traps`
+  is a second-order miss on record: GitHub's implicit `success()` on a
+  dependent job with no status function means a skipped `changes` job lets
+  every downstream leg report "skipped" and the summary go green having
+  tested nothing — the fix had to explicitly fail unless
+  `needs.changes.result == 'success'`.
+- **Red Team vs Blue Team.** One pass designs the change, a second
+  adversarial pass attacks it (security, correctness, or just "how does this
+  get merged broken"). The `Agent`-tool second-pass review below is this
+  technique running for real, not hypothetically.
+- **5 Whys.** Chain "why" past the first plausible cause. The
+  `CheckpointCounter` static-state leak (issue #3846) is a live example: the
+  proximate why was "a flaky Allure unit test"; the real why, five hops down,
+  was static process-wide counters with no test-scoped reset — three
+  independent test files had each patched the symptom with their own
+  reflection helper instead of asking why a fourth kept needing one.
+- **Pre-mortem.** Imagine the change has already failed in production; write
+  the postmortem before you ship, then work backwards to the mitigations that
+  postmortem would demand. Cheaper than an actual incident review.
+
 ## When writing and changing code
 
 - **Write code that reads like the surrounding code** — its naming, idiom,
@@ -141,6 +180,14 @@ the main file; read the section matching the situation you're in.
 - **Verify fresh.** Stale artifacts, cached builds, and locally-shadowed
   dependencies are a classic false confirmation. If a fix "works"
   suspiciously easily, confirm you're running the code you just wrote.
+  `gotcha.local-mvn-test-never-fails-the-build-read-surefire-xml-counts-for-verdicts`
+  is the canonical trap: `mvn test` prints `BUILD SUCCESS` even with
+  `failures=1` — read the `surefire-reports/TEST-*.xml` counts, don't trust
+  the exit banner. `gotcha.mvn-test-must-force-headlessexecution-true-and-never-invoke-allure-serve-report-open`
+  is the adjacent one: a scoped `mvn test` that can reach browser tests must
+  force `-DheadlessExecution=true` and must never trigger an Allure
+  report-open step, or "verifying fresh" launches a real browser on the
+  user's desktop instead of proving the fix.
 
 ## When communicating
 
@@ -162,6 +209,23 @@ the main file; read the section matching the situation you're in.
 - **Deliver bad news at full resolution.** A failing test's actual output, a
   regression's actual symptom. Softened or summarized failure reports force
   the user to re-discover what you already knew.
+- **Cite evidence as `path:line`, not prose location.** "the counter fields
+  in CheckpointCounter" makes the reader re-find what you already found; "the
+  static counters at `shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java:22-24`"
+  (issue #3846) doesn't. Adapted from bmad-method's `bmad-checkpoint-preview`
+  Global Step Rules (MIT-licensed): CWD-relative, no leading `/`, so it's
+  clickable in IDE-embedded terminals.
+- **Front-load, then stop.** Put the entire answer for the thing being
+  reported in one coherent pass — lead with the outcome, then the evidence,
+  then stop. Don't drip-feed findings across several short messages or pause
+  mid-report to ask a question the report itself could answer. PR #3815's
+  summary (fixing the #3803 loopback-sink race) is the pattern: root cause
+  and fix stated together in one block — "a single tab was reported under
+  two browsingContextId values... `CaptureGenerator` rejected the SWITCH...
+  blocking codegen" — not spread across a "found something, checking
+  further, one more thing" back-and-forth. The dedicated regression coverage
+  (PRs #3816, #3841) was correctly scoped as its own follow-up, not smuggled
+  into the same report.
 
 ## When judging risk
 
@@ -172,6 +236,56 @@ the main file; read the section matching the situation you're in.
   familiar* deserves one verification step first. Before any state-changing
   command, check the evidence supports *that specific action* — a signal
   resembling a known failure may have a different cause.
+
+## When owning outcomes
+
+You own outcomes, not diffs. "Done" is the behavior live where the user needs
+it — merged, verified, reported — not pushed and abandoned. If the cycle is
+code → PR → green → merge, you drive every leg, including rerunning transient
+CI failures and folding review findings back in, until the loop closes or a
+gate only the user can open blocks it.
+
+Two rules bind harder than any deadline:
+
+- **Never leave the system worse than you found it.** If an action of yours
+  breaks something (service, config, pipeline), restoring a working state
+  outranks the task itself — a broken intermediate state is never an
+  acceptable place to stop, hand off, or end a turn.
+- **Interruptions fold into the arc; they don't reset it.** New asks mid-task
+  join the same owned plan: absorb, re-sequence, keep every prior commitment
+  tracked to completion — nothing already promised gets silently dropped
+  because something newer arrived.
+
+And leave the campsite better: learnings recorded where the next agent will
+find them, docs matching what's true now, and every discovered-but-out-of-scope
+finding filed as a real `gh issue create` — same session, before Completion. A
+PR description, chat sentence, or "flagged for the user" note is not filing
+it; untracked prose is how findings get silently dropped (AGENTS.md Working
+Rules).
+
+## When reviewing delegated work
+
+Run the `references/verification-gap-lens.md` method for what to look for;
+this is what to do with what you find. Adapted from bmad-method's
+`bmad-code-review/steps/step-03-triage.md` (MIT-licensed).
+
+- **Route every finding into exactly one bucket**, never leave it unsorted:
+  - `decision_needed` — an ambiguous choice only the owner can make; the
+    finding is real but the fix depends on intent you don't have.
+  - `patch` — a real, unambiguous fix; make it before reporting done.
+  - `defer` — real, pre-existing, not caused by this change; file it
+    (`gh issue create`), don't silently drop it and don't block on it.
+  - `dismiss` — noise, false positive, or already handled elsewhere; drop it,
+    but only after checking, not by default.
+- **The orchestrator's severity call overrides the delegate's**, always, not
+  just on disagreement. A delegate reviewing one bounded diff has less
+  context than the thread that assigned it — information asymmetry, not a
+  competence gap — so a delegate-assigned "low" or "high" is an input to the
+  triage decision, never the output of it.
+- **Read the code before rating**, every time. A finding's real consequence
+  lives at the call site, not in the diff hunk — open the file, check
+  reachability, guards, and validation outside the hunk before assigning
+  severity or bucket.
 
 ## Maximum effort mode
 

--- a/.claude/skills/act-as-fable/references/verification-gap-lens.md
+++ b/.claude/skills/act-as-fable/references/verification-gap-lens.md
@@ -1,0 +1,75 @@
+# Verification-gap lens
+
+Worked method for the second-pass adversarial review (SKILL.md, Delegation)
+and for reviewing a subagent's diff before building on it. Adapted from
+bmad-method's `src/core-skills/bmad-review/references/lens-verification-gap.md`
+(MIT-licensed; trimmed and reworded to our scale — see PR notes for the
+adoption record).
+
+**Goal:** find changed behavior that could break without verification
+catching it. Ask one question: if the behavior this change is supposed to
+produce broke where it's actually used, would a test fail? Don't hunt for
+correctness bugs generally — that's the rest of the review; this lens is
+verification-coverage only.
+
+## The three gap shapes
+
+1. **Regression gap.** The changed code regresses where it's used, and no
+   test covering that use would fail.
+2. **Missing-adoption gap.** A place that should now use the new behavior
+   doesn't — it handles the same case its own way, or not at all — and no
+   test flags the omission. Qualifies only when there's a real supersession
+   signal (the change's intent, a replaced sibling site, a deleted duplicate)
+   *and* the local site shares the same observable contract; otherwise it's a
+   refactor suggestion, not a gap.
+3. **Broken-verification gap.** A test appears to cover the changed
+   behavior but wouldn't actually catch a regression — skipped, flaky, not
+   run in the normal path, or too weak to observe the change (mock-only,
+   snapshot-only, success/no-throw checks).
+
+## The Demonstration technique
+
+For each candidate site: name the smallest realistic regression a real
+consumer would observe — invert the branch, drop the default, omit the
+field, return the old error code, skip the call. If you can't name one,
+drop the path; untested downstream code that nothing would actually break
+is not a finding. Then find the relevant test and ask: would the
+Demonstration make an assertion fail? If yes, it's verified — no finding.
+
+## Evidence rules (non-negotiable)
+
+- Read a test before claiming what it covers, runs, asserts, or misses.
+- Before claiming no test exists, search the repo by symbol and import
+  reference — expected file locations alone aren't enough (`gotcha.local-mvn-test-never-fails-the-build-read-surefire-xml-counts-for-verdicts`
+  is the SHAFT-specific version of this: `BUILD SUCCESS` from `mvn test`
+  proves nothing — read `surefire-reports/TEST-*.xml` counts before calling
+  anything green).
+- Never assert what you didn't verify; an ungrounded finding gets dropped,
+  not softened.
+- Say what you actually checked ("none of the tests I read cover this") and
+  how far you looked. Only claim a test doesn't exist anywhere when the
+  symbol/import search actually shows that.
+- Don't assign severity, confidence, or priority — that's triage's job (see
+  the four-bucket taxonomy in SKILL.md's Delegation section).
+
+## Trimmed review sequence
+
+1. **Screen for behavioral change.** Non-behavioral (formatting, renames,
+   type-only) → zero findings, stop.
+2. **Find what changed** — output, side effect, branch, error path, schema
+   shape, default, contract.
+3. **Trace consumers** — direct callers, registered entry points, contract
+   consumers. Stop at the nearest boundary where a test would fail or the
+   next hop is guesswork.
+4. **Qualify each consumer with the Demonstration, then read its test.**
+5. **Re-open the specific test or search result before writing the finding.**
+   Don't report from memory of having glanced at it earlier in the review.
+
+## Findings shape
+
+Each finding: `location` (`file:line`), `trigger_condition` (the gap, one
+line), `potential_consequence` (what ships wrong and why the checked tests
+wouldn't catch it), `gap_shape` (one of the three above, or `other` for a
+genuine problem noticed in passing), `evidence` (what you actually read,
+with `file:line`). An empty list is a valid, complete result — say so
+plainly rather than padding with low-confidence noise.

--- a/.claude/skills/ponytail/SKILL.md
+++ b/.claude/skills/ponytail/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: ponytail
 description: >
-  Forces the laziest solution that actually works, simplest, shortest, most
-  minimal. Channels a senior dev who has seen everything: question whether the
-  task needs to exist at all (YAGNI), reach for the standard library before
-  custom code, native platform features before dependencies, one line before
-  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
+  Forces the simplest, shortest, laziest solution that works. Channels a
+  senior dev who has seen everything: question whether the task needs to
+  exist (YAGNI), reach for the standard library before custom code, native
+  features before dependencies, one line before fifty. Supports intensity
+  levels: lite, full (default), ultra. Use on ANY
   coding task: writing, adding, refactoring, fixing, reviewing, or designing
   code, and choosing libraries or dependencies. Also use whenever the user
-  says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
-  solution", "yagni", "do less", or "shortest path", or complains about
-  over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
-  use for non-coding requests (general knowledge, prose, translation,
-  summaries, recipes).
+  says "ponytail", "be lazy", "minimal solution", "yagni", or "do less", or
+  complains about over-engineering, bloat, boilerplate, or unnecessary
+  dependencies. Do NOT use for non-coding requests (general knowledge,
+  prose, translation, summaries, recipes).
 argument-hint: "[lite|full|ultra]"
 license: MIT
 ---

--- a/.claude/skills/work-github/references/playbook.md
+++ b/.claude/skills/work-github/references/playbook.md
@@ -54,6 +54,31 @@ genuine blocker (a decision only the user can make, not a step you could
 resolve by reading more code). The user asked for unattended execution —
 honor that by not manufacturing more checkpoints than the one they granted.
 
+### Mid-session realignment: named HALT conditions
+
+Per act-as-fable's Ownership, a new ask mid-run joins the same owned plan —
+absorb and keep going, in most cases. But absorbing on missing evidence is
+how a session drifts silently off the owner's actual intent. HALT and ask,
+by name, when any of these hold (adapted from bmad-method's
+`bmad-correct-course/checklist.md` halt-condition pattern, MIT-licensed —
+not its PRD/epic machinery, which doesn't apply here):
+
+- **HALT if the realignment changes the branch/PR/merge-authority shape
+  agreed in step 1.** A broad "keep going" for the original scope is not
+  authorization for a different shape — re-run `AskUserQuestion` for the
+  delta, don't silently reinterpret.
+- **HALT if you cannot ground the new ask in real code.** No matching
+  symptom, file, or prior art after an honest search means you'd be
+  building on a guess — say what you searched and ask, don't proceed on
+  inference.
+- **HALT if the new ask conflicts with work already in flight** (same file
+  scope, contradictory requirement, or it obsoletes a sub-item mid-commit).
+  Surface the conflict and the two options; don't quietly drop either side.
+- **HALT if merge authority for the newly-added scope was never granted.**
+  Authorization doesn't transfer (act-as-fable, When judging risk) — an
+  auto-merge mandate for the original item set doesn't extend to scope
+  added after the fact.
+
 ## 2. Branch and track
 
 - Fetch and prune, then branch fresh off `origin/main` (or the target repo's

--- a/scripts/ci/validate_agent_guidance.py
+++ b/scripts/ci/validate_agent_guidance.py
@@ -127,19 +127,56 @@ def validate_total_reduction(root: Path, budget: dict) -> list[dict[str, str]]:
     return []
 
 
+_BLOCK_SCALAR_HEADER = re.compile(r"^[|>][+-]?\d*$")
+
+
 def parse_frontmatter(content: str) -> dict[str, str] | None:
-    """Parse simple top-level YAML frontmatter without external dependencies."""
+    """Parse simple top-level YAML frontmatter without external dependencies.
+
+    Handles single-line scalars and multi-line block scalars (`>`, `>-`,
+    `|`, `|-`) -- several skill descriptions use folded style, and a value
+    of just the block-scalar marker (e.g. `description: >-`) is not the
+    real content. This stays a small proxy parser for flat frontmatter, not
+    a full YAML implementation: no nested mappings or sequences.
+    """
     if not content.startswith("---\n"):
         return None
     marker = content.find("\n---\n", 4)
     if marker < 0:
         return None
+    lines = content[4:marker].splitlines()
     values: dict[str, str] = {}
-    for raw_line in content[4:marker].splitlines():
+    index = 0
+    while index < len(lines):
+        raw_line = lines[index]
+        index += 1
         if ":" not in raw_line or raw_line[:1].isspace():
             continue
         key, value = raw_line.split(":", 1)
-        values[key.strip()] = value.strip().strip("\"'")
+        key = key.strip()
+        value = value.strip()
+        if _BLOCK_SCALAR_HEADER.match(value):
+            folded = value.startswith(">")
+            block_lines: list[str] = []
+            while index < len(lines) and (lines[index][:1].isspace() or not lines[index].strip()):
+                block_lines.append(lines[index].strip())
+                index += 1
+            if folded:
+                paragraphs: list[str] = []
+                current: list[str] = []
+                for block_line in block_lines:
+                    if block_line:
+                        current.append(block_line)
+                    elif current:
+                        paragraphs.append(" ".join(current))
+                        current = []
+                if current:
+                    paragraphs.append(" ".join(current))
+                values[key] = "\n\n".join(paragraphs)
+            else:
+                values[key] = "\n".join(block_lines).strip()
+        else:
+            values[key] = value.strip("\"'")
     return values
 
 

--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -25,6 +25,7 @@ from scripts.ci.validate_agent_guidance import (  # noqa: E402
 from scripts.ci.validate_documentation_boundaries import (  # noqa: E402
     validate_repository as validate_documentation,
 )
+from scripts.ci.validate_skills import validate_repository as validate_skill_hygiene  # noqa: E402
 
 MEMORY_PACKAGE = "@aictx/memory@0.1.55"
 MEMORY_TOOLS = {
@@ -257,6 +258,7 @@ def validate_repository(
             for message in validate_documentation(root)
         ],
         *validate_memory_setup(root),
+        *validate_skill_hygiene(root),
     ]
     if run_external:
         errors.extend(

--- a/scripts/ci/validate_skills.py
+++ b/scripts/ci/validate_skills.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Lint .claude/skills/*/SKILL.md for structural hygiene.
+
+Checks frontmatter presence/well-formedness, description quality (states
+what the skill does and when to use it), dead `references/*.md` links
+(resolved relative to each SKILL.md's own directory), and the per-skill byte
+budget. The byte budget is read from the same `agent_guidance_budget.json`
+`validate_agent_setup.py` already uses, not duplicated here — see
+`skill_budgets[".claude/skills"].max_skill_md_bytes`.
+
+Adapted (not copied) from bmad-method's `tools/skill-validator.md` rule
+catalog (MIT-licensed), trimmed to the rules that fit this repo's skill
+authoring conventions: no `bmad-`-prefixed name requirement, no step-file or
+workflow-variable rules (SHAFT skills are prose, not the bmad step-machine).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.ci.validate_agent_guidance import (  # noqa: E402
+    load_budget,
+    markdown_body,
+    parse_frontmatter,
+    relative,
+)
+
+SKILLS_ROOT = ".claude/skills"
+MIN_DESCRIPTION_CHARS = 20
+# Loose, deliberately broad signal set for "states when to use it" -- this is
+# a MEDIUM-severity hygiene nudge, not a grammar check; see bmad's own
+# SKILL-06 detection note ("absence of a trigger phrase suggests...").
+WHEN_TO_USE_SIGNALS = (
+    "use when",
+    "use for",
+    "use on",
+    "use if",
+    "use during",
+    "before ",
+    "trigger",
+    "invoke",
+    "load at",
+    "start of",
+    "when the",
+    "when working",
+    "when implementing",
+)
+REFERENCE_BACKTICK_PATTERN = re.compile(r"`(references/[^`]+\.md)`")
+REFERENCE_LINK_PATTERN = re.compile(r"\[[^\]]*\]\((references/[^)#]+\.md)")
+
+
+def issue(code: str, path: str, message: str) -> dict[str, str]:
+    """Create a stable skill-hygiene issue."""
+    return {"code": code, "path": path, "message": message}
+
+
+def referenced_markdown_paths(content: str) -> list[str]:
+    """Return every `references/*.md` path cited by backtick or Markdown link."""
+    found = REFERENCE_BACKTICK_PATTERN.findall(content)
+    found.extend(REFERENCE_LINK_PATTERN.findall(content))
+    return found
+
+
+def validate_skill(
+    root: Path, skill_dir: Path, max_skill_md_bytes: int
+) -> list[dict[str, str]]:
+    """Validate one skill directory's SKILL.md against the hygiene rules."""
+    skill_path = skill_dir / "SKILL.md"
+    skill_relative = relative(root, skill_path)
+    if not skill_path.is_file():
+        return [
+            issue("skill-missing", skill_relative, "skill directory must contain SKILL.md")
+        ]
+
+    content = skill_path.read_text(encoding="utf-8")
+    frontmatter = parse_frontmatter(content)
+    if frontmatter is None:
+        return [
+            issue(
+                "frontmatter-malformed",
+                skill_relative,
+                "SKILL.md must open with a well-formed --- frontmatter block",
+            )
+        ]
+
+    errors: list[dict[str, str]] = []
+
+    name = frontmatter.get("name")
+    if not name:
+        errors.append(issue("frontmatter-name", skill_relative, "frontmatter name is required"))
+    elif name != skill_dir.name:
+        errors.append(
+            issue(
+                "frontmatter-name",
+                skill_relative,
+                f"frontmatter name '{name}' must match directory '{skill_dir.name}'",
+            )
+        )
+
+    description = frontmatter.get("description", "")
+    if not description:
+        errors.append(
+            issue("frontmatter-description", skill_relative, "frontmatter description is required")
+        )
+    else:
+        if len(description) < MIN_DESCRIPTION_CHARS:
+            errors.append(
+                issue(
+                    "description-too-thin",
+                    skill_relative,
+                    f"description is only {len(description)} characters; state what the skill does",
+                )
+            )
+        lowered = description.lower()
+        if not any(signal in lowered for signal in WHEN_TO_USE_SIGNALS):
+            errors.append(
+                issue(
+                    "description-missing-trigger",
+                    skill_relative,
+                    "description must state when to use the skill "
+                    "(e.g. 'Use when ...', 'before ...', a named trigger word/phrase)",
+                )
+            )
+
+    if not markdown_body(content):
+        errors.append(
+            issue("body-empty", skill_relative, "SKILL.md must have body content after the frontmatter")
+        )
+
+    for raw_target in referenced_markdown_paths(content):
+        target = skill_dir / raw_target
+        if not target.is_file():
+            errors.append(
+                issue("dead-reference", skill_relative, f"references a missing file: {raw_target}")
+            )
+
+    actual_bytes = len(content.encode("utf-8"))
+    if actual_bytes > max_skill_md_bytes:
+        errors.append(
+            issue(
+                "byte-budget",
+                skill_relative,
+                f"{actual_bytes} bytes exceeds configured maximum {max_skill_md_bytes}",
+            )
+        )
+
+    return errors
+
+
+def validate_repository(
+    root: Path = ROOT, budget_path: Path | None = None
+) -> list[dict[str, str]]:
+    """Run every skill-hygiene check across .claude/skills and return sorted issues."""
+    budget = load_budget(budget_path or root / "scripts/ci/agent_guidance_budget.json")
+    max_skill_md_bytes = budget.get("skill_budgets", {}).get(SKILLS_ROOT, {}).get(
+        "max_skill_md_bytes"
+    )
+    if max_skill_md_bytes is None:
+        return [
+            issue(
+                "budget-config",
+                "scripts/ci/agent_guidance_budget.json",
+                f"skill_budgets[{SKILLS_ROOT!r}].max_skill_md_bytes is not configured",
+            )
+        ]
+
+    skills_root = root / SKILLS_ROOT
+    if not skills_root.is_dir():
+        return [issue("skill-root-missing", SKILLS_ROOT, "skills root is missing")]
+
+    errors: list[dict[str, str]] = []
+    for skill_dir in sorted(path for path in skills_root.iterdir() if path.is_dir()):
+        errors.extend(validate_skill(root, skill_dir, max_skill_md_bytes))
+
+    return sorted(errors, key=lambda item: (item["path"], item["code"], item["message"]))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root to validate.")
+    parser.add_argument(
+        "--budget",
+        type=Path,
+        help="Budget JSON path. Defaults to scripts/ci/agent_guidance_budget.json under --root.",
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser
+
+
+def main() -> int:
+    """Run the CLI."""
+    args = build_parser().parse_args()
+    root = args.root.resolve()
+    budget_path = args.budget.resolve() if args.budget else None
+    errors = validate_repository(root, budget_path)
+    if args.format == "json":
+        print(json.dumps({"valid": not errors, "errors": errors}, indent=2))
+    elif errors:
+        for error in errors:
+            print(f"{error['code']}: {error['path']}: {error['message']}", file=sys.stderr)
+    else:
+        print(
+            "Claude skill hygiene is valid: frontmatter, descriptions, "
+            "references, and byte budgets all pass."
+        )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_validate_agent_guidance.py
+++ b/tests/scripts/test_validate_agent_guidance.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.ci.validate_agent_guidance import validate_repository
+from scripts.ci.validate_agent_guidance import parse_frontmatter, validate_repository
 
 
 class ValidateAgentGuidanceTest(unittest.TestCase):
@@ -269,6 +269,31 @@ policy:
     def test_current_repository_configuration_is_valid(self):
         repository_root = Path(__file__).resolve().parents[2]
         self.assertEqual(validate_repository(repository_root), [])
+
+    def test_parse_frontmatter_reads_folded_block_scalar_description_in_full(self):
+        # Regression: the parser used to stop at the "description: >-" marker
+        # line itself, so every multi-line folded description in
+        # .claude/skills/*/SKILL.md was silently counted as its 2-character
+        # marker -- undercounting the "claude" host_context token estimate
+        # (validate_host_contexts) for every skill using folded style.
+        content = (
+            "---\n"
+            "name: example\n"
+            "description: >-\n"
+            "  First line of the description.\n"
+            "  Second line, still folded onto the first with a space.\n"
+            "---\n\nBody.\n"
+        )
+        frontmatter = parse_frontmatter(content)
+        self.assertEqual(
+            frontmatter["description"],
+            "First line of the description. Second line, still folded onto the first with a space.",
+        )
+
+    def test_parse_frontmatter_reads_literal_block_scalar_preserving_newlines(self):
+        content = "---\nname: example\ndescription: |-\n  Line one.\n  Line two.\n---\n\nBody.\n"
+        frontmatter = parse_frontmatter(content)
+        self.assertEqual(frontmatter["description"], "Line one.\nLine two.")
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_validate_skills.py
+++ b/tests/scripts/test_validate_skills.py
@@ -1,0 +1,125 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.ci.validate_skills import validate_repository
+
+
+class ValidateSkillsTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.budget_path = self.root / "scripts/ci/agent_guidance_budget.json"
+        self.budget = {"skill_budgets": {".claude/skills": {"max_skill_md_bytes": 400}}}
+        self.write_budget()
+        self.write(
+            ".claude/skills/example/SKILL.md",
+            "---\n"
+            "name: example\n"
+            "description: >-\n"
+            "  Do the example thing well. Use when the task looks like an\n"
+            "  example so future readers know when to reach for it.\n"
+            "---\n\n"
+            "# Example\n\nBody content that is non-empty.\n"
+            "See `references/detail.md` for more.\n",
+        )
+        self.write(".claude/skills/example/references/detail.md", "# Detail\n")
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write(self, relative_path, content):
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def write_budget(self):
+        self.budget_path.parent.mkdir(parents=True, exist_ok=True)
+        self.budget_path.write_text(json.dumps(self.budget), encoding="utf-8")
+
+    def codes(self):
+        return {error["code"] for error in validate_repository(self.root, self.budget_path)}
+
+    def test_valid_skill_passes(self):
+        self.assertEqual(validate_repository(self.root, self.budget_path), [])
+
+    def test_folded_block_scalar_description_is_read_in_full(self):
+        # Regression for the parse_frontmatter gap that used to truncate a
+        # `description: >-` value to its two-character marker: a thin/no-op
+        # description hiding behind a folded block scalar must still be
+        # caught, not silently treated as "long enough".
+        self.write(
+            ".claude/skills/example/SKILL.md",
+            "---\nname: example\ndescription: >-\n  x\n---\n\n# Example\n\nBody.\n",
+        )
+        self.assertIn("description-too-thin", self.codes())
+
+    def test_rejects_missing_skill_md(self):
+        (self.root / ".claude/skills/empty").mkdir(parents=True)
+        self.assertIn("skill-missing", self.codes())
+
+    def test_rejects_malformed_frontmatter(self):
+        self.write(".claude/skills/example/SKILL.md", "# No frontmatter at all\n")
+        self.assertIn("frontmatter-malformed", self.codes())
+
+    def test_rejects_name_mismatch(self):
+        self.write(
+            ".claude/skills/example/SKILL.md",
+            "---\nname: not-example\ndescription: Use when testing name mismatches.\n---\n\nBody.\n",
+        )
+        self.assertIn("frontmatter-name", self.codes())
+
+    def test_rejects_missing_description(self):
+        self.write(
+            ".claude/skills/example/SKILL.md",
+            "---\nname: example\n---\n\nBody.\n",
+        )
+        self.assertIn("frontmatter-description", self.codes())
+
+    def test_rejects_description_missing_trigger(self):
+        self.write(
+            ".claude/skills/example/SKILL.md",
+            "---\nname: example\ndescription: A skill that does example things nicely.\n---\n\nBody.\n",
+        )
+        self.assertIn("description-missing-trigger", self.codes())
+
+    def test_rejects_empty_body(self):
+        self.write(
+            ".claude/skills/example/SKILL.md",
+            "---\nname: example\ndescription: Use when the body is empty.\n---\n\n   \n",
+        )
+        self.assertIn("body-empty", self.codes())
+
+    def test_rejects_dead_backtick_reference(self):
+        self.write(
+            ".claude/skills/example/SKILL.md",
+            "---\nname: example\ndescription: Use when checking dead references.\n---\n\n"
+            "Body. See `references/missing.md`.\n",
+        )
+        self.assertIn("dead-reference", self.codes())
+
+    def test_rejects_dead_markdown_link_reference(self):
+        self.write(
+            ".claude/skills/example/SKILL.md",
+            "---\nname: example\ndescription: Use when checking dead references.\n---\n\n"
+            "Body. See [detail](references/missing.md) for more.\n",
+        )
+        self.assertIn("dead-reference", self.codes())
+
+    def test_rejects_oversized_skill_md(self):
+        self.budget["skill_budgets"][".claude/skills"]["max_skill_md_bytes"] = 10
+        self.write_budget()
+        self.assertIn("byte-budget", self.codes())
+
+    def test_reports_missing_budget_config(self):
+        self.budget_path.write_text(json.dumps({}), encoding="utf-8")
+        self.assertIn("budget-config", self.codes())
+
+    def test_current_repository_skills_are_valid(self):
+        repository_root = Path(__file__).resolve().parents[2]
+        self.assertEqual(validate_repository(repository_root), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #3842. Implements all 7 ranked bmad-method adoptions plus the codebase-specific-examples pass from the issue's deep scan. Source: [bmad-code-org/bmad-method](https://github.com/bmad-code-org/bmad-method), MIT-licensed (Copyright (c) 2025 BMad Code, LLC) — every port below is trimmed and reworded to our voice/scale, never copied wholesale.

1. **Verification-gap review lens** — ported from `src/core-skills/bmad-review/references/lens-verification-gap.md` into `.claude/skills/act-as-fable/references/verification-gap-lens.md` (three gap shapes, the Demonstration technique, hard evidence rules). Pointed to from the "Architectural decisions get a second pass" bullet in Delegation.
2. **Four-bucket triage taxonomy** — adapted from `src/bmm-skills/4-implementation/bmad-code-review/steps/step-03-triage.md`. New `decision_needed`/`patch`/`defer`/`dismiss` bucket + "orchestrator disregards delegate-assigned severity" rule, in a new "When reviewing delegated work" section in `references/heuristics.md`, pointed to from Delegation.
3. **`scripts/ci/validate_skills.py`** — a deterministic `.claude/skills/*/SKILL.md` linter (frontmatter presence/well-formedness, description states what+when-to-use, dead `references/*.md` links resolved relative to each SKILL.md, and the shared byte budget from `agent_guidance_budget.json`), adapted from bmad's `tools/skill-validator.md` 20-rule catalog trimmed to what fits our prose-style skills. Wired into `validate_agent_setup.py` rather than duplicated. Building it surfaced a real bug: `parse_frontmatter` truncated every YAML folded-style (`description: >-`) value to its 2-character marker, silently undercounting the `claude` host-context token budget for every `.claude/skills` description. Fixed the shared parser (with regression tests) and trimmed `ponytail`'s description to land back under the 2900-token cap with the honest number (2892, was falsely reporting well under budget at ~2850).
4. **Blunt completion-gate line** — added to the Subagent covenant (bmad-dev-story step 8 style): "NEVER mark work complete unless every claimed check actually ran and passed — a test that doesn't exist, wasn't run, or wasn't watched green does not count as passing."
5. **`path:line` citation + front-load-then-stop reporting conventions** — stated explicitly in act-as-fable's Report section (adapted from `bmad-checkpoint-preview`'s Global Step Rules), with the full convention and worked examples in `references/heuristics.md`.
6. **Risk-analysis technique menu** — curated 6 from bmad's `bmad-advanced-elicitation/assets/methods.csv` (73 techniques) down to Inversion, Steelmanning, Second-Order Thinking, Red Team vs Blue Team, 5 Whys, and Pre-mortem — the six that earn their keep on an infrastructure codebase. Added to `references/heuristics.md` for Plan-phase use on architectural decisions.
7. **Named HALT-on-missing-evidence conditions** — adopted the halt-condition *pattern* (not the PRD/epic machinery) from `bmad-correct-course/checklist.md` into `work-github`'s playbook, for mid-session owner realignments.

**Codebase-specific examples pass**: grounded abstract rules in real incidents, cited by id/number and verified against the actual `.memory/` records and issue/PR bodies before citing — `gotcha.local-mvn-test-never-fails-the-build-read-surefire-xml-counts-for-verdicts`, `gotcha.mvn-test-must-force-headlessexecution-true-and-never-invoke-allure-serve-report-open`, `constraint.pr-gate-yml-design-constraints-paths-filter-events-and-vacuous-green-traps`, the `CheckpointCounter` static-state leak from fresh issue #3846 (with real `file:line`), and the #3803 async-login loopback-sink race (PR #3815, with follow-up regression PRs #3816/#3841 correctly cited as separate scoped work, not folded into the same claim).

## Budget

`act-as-fable/SKILL.md`: **16234** LF-normalized bytes (hard cap 16384, 150 bytes headroom). Room was made by trimming the "Ownership: the full loop" section to a `references/heuristics.md` pointer — matching the file's own existing pattern (Debugging, Calibration already do this) — without touching the Delegation owner-rule paragraphs (Orchestrator role / Parallelism budget / Stall watch stayed untouched, only appended to).

`claude` host_context estimate: **2892** tokens (cap 2900) — now computed correctly after the `parse_frontmatter` fix.

## Test plan

- [x] `py -3 scripts/ci/validate_agent_setup.py` — exit 0 (full run, including `memory check` and `git diff --check`)
- [x] `py -3 scripts/ci/validate_skills.py` — exit 0
- [x] `py -3 -m unittest tests.scripts.test_validate_agent_guidance tests.scripts.test_validate_agent_setup tests.scripts.test_validate_skills` — 38 tests, all green (includes new regression tests for the block-scalar parser fix and 13 new tests for `validate_skills.py`)
- [x] No Java changes; Maven not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017P8noRGterU2wDhRbGhM8H