### PR TITLE
Fix Chromium alert auto-dismiss and invalid-select test on modern Chrome/Edge

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
@@ -444,11 +444,16 @@ public class OptionsManager {
             chromePreferences.put("profile.password_manager_enabled", false);
             chromePreferences.put("profile.password_manager_leak_detection", false);
             chromePreferences.put("profile.default_content_settings.popups", 0);
-            options.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE);
             options.setCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
-            options.setCapability(CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR, UnhandledPromptBehavior.IGNORE);
             options.setCapability(CapabilityType.ENABLE_DOWNLOADS, true);
         }
+        // Unconditionally match Firefox/Safari: without this, modern Chromium's default
+        // "dismiss and notify" unhandledPromptBehavior auto-dismisses JS alert/confirm/prompt
+        // dialogs as a side effect of the command that opened them (e.g. the click that calls
+        // window.alert()), so AlertActions' subsequent switchTo().alert() finds nothing and
+        // throws NoAlertPresentException (SHAFT_ENGINE#3820).
+        options.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.IGNORE);
+        options.setCapability(CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR, UnhandledPromptBehavior.IGNORE);
         options.setExperimentalOption("prefs", chromePreferences);
         // Timeouts and page load strategy
         if (DriverFactoryHelper.isNotMobileExecution())

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -1352,7 +1352,18 @@ public class Actions extends ElementActions {
 
     private byte[] takeAIHighlightedScreenshot(WebElement element, boolean isPass) {
         // getElementLocation
-        Rectangle elementLocation = element.getRect();
+        Rectangle elementLocation;
+        try {
+            elementLocation = element.getRect();
+        } catch (UnhandledAlertException unhandledAlertException) {
+            // The action being photographed opened a JS dialog (alert/confirm/prompt). A JS
+            // dialog blocks the renderer, so *every* WebDriver command except alert-handling
+            // ones -- including a plain, unhighlighted screenshot -- fails the same way until
+            // the dialog is handled. Evidence capture is best-effort: skip it rather than fail
+            // what was otherwise a successful action (SHAFT_ENGINE#3820).
+            ReportManagerHelper.logDiscrete(unhandledAlertException);
+            return null;
+        }
 
         //take screenshot
         byte[] src = takeScreenshot(element);

--- a/shaft-engine/src/test/java/testPackage/mockedTests/SelectMethodTests.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/SelectMethodTests.java
@@ -31,8 +31,12 @@ public class SelectMethodTests {
 
                 clickDropDownList("Div 1000");
 
-            } catch (AssertionError error){
-                
+            } catch (AssertionError | RuntimeException error){
+                // SHAFT.GUI.WebDriver#element().select() reports element-action failures via
+                // Actions.report(), which always wraps and throws RuntimeException (not
+                // AssertionError) -- see Actions.java's report()/reportBroken(). Catching only
+                // AssertionError never actually caught a failed select, so this test failed
+                // unconditionally whenever "Div 1000" was correctly rejected as not found.
             }
         }
     }


### PR DESCRIPTION
## Summary

The #3804 bisect flagged `CoverageTests.alerts_dismiss` / `alerts_getText_and_accept` / `alerts_type` (`NoAlertPresentException`) and `SelectMethodTests#testInvalidSelect` (`NoSuchElementException`) as reproducing byte-for-byte at `0817029a9f` — the **parent** of both suspect commits — so they were not a SHAFT regression from that PR. This investigates and fixes the actual root causes, both confirmed locally headless on Chrome 150.0.7871.129 and Edge 150.0.4078.83.

**Alerts (2 stacked defects, both in `shaft-engine/src/main/java`):**

1. `OptionsManager#setupChromiumOptions` only set `UnhandledPromptBehavior.IGNORE` when `automaticallyAddRecommendedChromeOptions` (default `false`) was enabled — unlike Firefox/Safari, which set it unconditionally. With Chromium's real default (`dismiss and notify`), a click that triggers `window.alert()` lets the dialog get silently auto-dismissed as a side effect of the very next WebDriver command, so `AlertActions`' `switchTo().alert()` finds nothing and throws `NoAlertPresentException`. Fix: set `IGNORE` unconditionally, matching Firefox/Safari.
2. Setting `IGNORE` unconditionally surfaced a second, previously-latent bug: `Actions#takeAIHighlightedScreenshot` called `element.getRect()` unguarded to build pass-evidence screenshots. A JS dialog blocks the renderer, so with `IGNORE` now keeping the dialog open (instead of Chromium silently closing it), that evidence-capture call itself throws `UnhandledAlertException` and fails the action that *correctly* opened the dialog. Fix: evidence capture is best-effort — skip it (return `null`) on `UnhandledAlertException` instead of failing the action. (Verified that even a plain, unhighlighted `driver.getScreenshotAs()` also throws while a JS dialog blocks the renderer — every command except alert-handling ones fails identically, so there's no other screenshot fallback to retry.)

**Select (unrelated to browser drift):** `SelectMethodTests#testInvalidSelect` caught only `AssertionError`, but `Actions#report` always throws `RuntimeException` on failure (`reportBroken`/`report`), matching the repo's own convention of catching both (`AssertionError | RuntimeException`) elsewhere (`AccessibilityTest`, `CookiesTests`, `LocatorBuilderTest`). The catch clause never actually caught a failed select — this test bug is independent of browser version and would fail on any Chrome/Edge build once `.select()` correctly rejects an invalid option.

**Environment audit:** `.github/workflows/e2eLocalTests.yml`'s `Windows_Chrome_Local` / `Windows_Edge_Local` jobs run unpinned against whatever Chrome/Edge `windows-latest` ships that day — there is no browser version gate. Given the alert issue is a genuine SHAFT defect affecting real users (not a CI-only artifact), adapting the alert-handling code is the correct fix over pinning or skipping; pinning the workflow's browser version was considered and rejected since it would only mask the defect in CI, not fix it for real users.

## Evidence

- Local repro before fix (Chrome 150.0.7871.129): `CoverageTests.alerts_dismiss/alerts_getText_and_accept/alerts_type` → 3 failures, `NoAlertPresentException`. `SelectMethodTests#testInvalidSelect` → 1 failure, uncaught `RuntimeException`.
- After fix, rebased onto latest `main` (`0d40dbffc6`), rerun headless/scoped:
  - `CoverageTests#alerts_dismiss+alerts_getText_and_accept+alerts_type`: surefire XML `tests="3" errors="0" skipped="0" failures="0"`
  - `SelectMethodTests` (`testValidSelect` + `testInvalidSelect`): surefire XML `tests="2" errors="0" skipped="0" failures="0"`
  - `AlertActionsCoverageUnitTest` regression check: `tests="4" failures="0" errors="0"`
  - Edge 150.0.4078.83 cross-browser confirmation of the 3 alert tests: `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`
  - `mvn -pl shaft-engine test-compile`: `BUILD SUCCESS`

## Test plan

- [x] Reproduced all 4 originally-reported failures locally, headless, scoped
- [x] `CoverageTests` alert tests green on Chrome and Edge (surefire XML)
- [x] `SelectMethodTests` green (surefire XML)
- [x] `AlertActionsCoverageUnitTest` regression check green
- [x] `mvn -pl shaft-engine test-compile` succeeds

Closes #3820

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017P8noRGterU2wDhRbGhM8H