### PR TITLE
Add CheckpointCounter.resetForTesting() and route test resetters through it (#3846)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/CheckpointCounter.java
@@ -86,6 +86,27 @@ public class CheckpointCounter {
     }
 
     /**
+     * Testing-support hook only &mdash; <strong>not for production use</strong>. Resets the
+     * process-wide, static checkpoint accumulation back to its initial empty/zero state: it clears
+     * the {@link #checkpoints} list, zeroes the {@link #passedCheckpoints}/{@link #failedCheckpoints}
+     * counters, and resets the monotonic {@link #checkpointSequence} id source so the next captured
+     * checkpoint restarts at id {@code 1}.
+     *
+     * <p>Because this static state is shared by every test in the same forked JVM (any SHAFT
+     * Validation/Verification records a checkpoint via {@code ValidationsHelper}), tests that must
+     * isolate themselves from checkpoints left behind by earlier-run tests call this between methods.
+     * It exists as a single, {@code public} entry point so those tests no longer each reflect into
+     * these private fields to clear them (issue #3846); it is {@code public} rather than
+     * package-private because consumer tests live outside this package.
+     */
+    public static void resetForTesting() {
+        checkpoints.clear();
+        passedCheckpoints.set(0);
+        failedCheckpoints.set(0);
+        checkpointSequence.set(0);
+    }
+
+    /**
      * Resolves the current test class from the per-thread report context, best-effort. Identity
      * lookup must never prevent a checkpoint from being recorded, so any failure yields {@code ""}.
      *

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
@@ -22,10 +22,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.Comparator;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @Test(singleThreaded = true)
 public class AllureManagerCoverageUnitTest {
@@ -609,19 +607,12 @@ public class AllureManagerCoverageUnitTest {
      * theme-colors-only patch, making the outcome depend on execution order within the fork rather
      * than on this test's own setup. Mirrors the reflection pattern {@code CheckpointAndReportingTest}
      * and {@code PlaywrightActionsE2ETestBase} already use to reach the same private fields.
+     *
+     * <p>Delegates to {@link CheckpointCounter#resetForTesting()} (issue #3846) so the reset logic
+     * lives in one testing-support hook instead of being duplicated as field reflection here.
      */
-    private static void resetCheckpointCounterState() throws Exception {
-        Field checkpointsField = CheckpointCounter.class.getDeclaredField("checkpoints");
-        checkpointsField.setAccessible(true);
-        ((List<?>) checkpointsField.get(null)).clear();
-
-        Field passedField = CheckpointCounter.class.getDeclaredField("passedCheckpoints");
-        passedField.setAccessible(true);
-        ((AtomicInteger) passedField.get(null)).set(0);
-
-        Field failedField = CheckpointCounter.class.getDeclaredField("failedCheckpoints");
-        failedField.setAccessible(true);
-        ((AtomicInteger) failedField.get(null)).set(0);
+    private static void resetCheckpointCounterState() {
+        CheckpointCounter.resetForTesting();
     }
 
     private static String quote(String value) {

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/CheckpointCounterJsonUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/CheckpointCounterJsonUnitTest.java
@@ -179,6 +179,28 @@ public class CheckpointCounterJsonUnitTest {
         Assert.assertTrue(html.contains("<table>"), html);
     }
 
+    @Test(description = "resetForTesting() clears cumulative totals and restarts the id sequence (#3846)")
+    public void resetForTestingClearsStateAndRestartsSequence() {
+        // Accumulate some process-wide state first.
+        CheckpointCounter.increment(CheckpointType.ASSERTION, "reset-marker-pass", CheckpointStatus.PASS);
+        CheckpointCounter.increment(CheckpointType.VERIFICATION, "reset-marker-fail", CheckpointStatus.FAIL);
+
+        CheckpointCounter.resetForTesting();
+
+        // Every accumulated total must be back to zero and the checkpoint list emptied.
+        JsonObject afterReset = JsonParser.parseString(CheckpointCounter.checkpointsJson()).getAsJsonObject();
+        Assert.assertEquals(afterReset.get("total").getAsInt(), 0, "total must reset to zero");
+        Assert.assertEquals(afterReset.get("passed").getAsInt(), 0, "passed must reset to zero");
+        Assert.assertEquals(afterReset.get("failed").getAsInt(), 0, "failed must reset to zero");
+        Assert.assertTrue(afterReset.getAsJsonArray("checkpoints").isEmpty(), "checkpoint rows must be cleared");
+
+        // The next checkpoint restarts the id sequence from 1 (checkpointSequence was reset too).
+        String firstAfterReset = "reset-marker-first-after-reset";
+        CheckpointCounter.increment(CheckpointType.ASSERTION, firstAfterReset, CheckpointStatus.PASS);
+        Assert.assertEquals(idForMessage(CheckpointCounter.checkpointsJson(), firstAfterReset), 1,
+                "checkpointSequence must restart so the first post-reset id is 1");
+    }
+
     private static int countOccurrences(String haystack, String needle) {
         int count = 0;
         for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {

--- a/shaft-engine/src/test/java/testPackage/unitTests/CheckpointAndReportingTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/CheckpointAndReportingTest.java
@@ -37,10 +37,8 @@ public class CheckpointAndReportingTest {
         }
     }
 
-    private void resetCheckpointCounter() throws Exception {
-        ((List<?>) CHECKPOINTS_FIELD.get(null)).clear();
-        ((AtomicInteger) PASSED_FIELD.get(null)).set(0);
-        ((AtomicInteger) FAILED_FIELD.get(null)).set(0);
+    private void resetCheckpointCounter() {
+        CheckpointCounter.resetForTesting();
     }
 
     private int getCheckpointsSize() throws Exception {


### PR DESCRIPTION
## What

`CheckpointCounter` holds process-wide mutable static state (`checkpoints`, `passedCheckpoints`, `failedCheckpoints`, `checkpointSequence`). Multiple test files independently reflected into these private fields to clear them between test methods — fragile duplication (issue #3846).

This adds a single public testing-support hook, `CheckpointCounter.resetForTesting()`, and routes the reflection-based resetters through it.

## Changes

- **`CheckpointCounter.java`** — new `public static void resetForTesting()` that clears `checkpoints`, zeroes `passedCheckpoints`/`failedCheckpoints`, and resets `checkpointSequence` to 0. Javadoc marks it testing-support only, not for production. Public because two consumer test files live outside the `internal` package (`testPackage.*`).
- **`CheckpointAndReportingTest.java`** — `resetCheckpointCounter()` now delegates to the hook. The field handles are kept because they are still read for assertions (`getCheckpointsSize`/`getPassedCount`/`getFailedCount`).
- **`AllureManagerCoverageUnitTest.java`** — `resetCheckpointCounterState()` delegates to the hook; now-unused `List`/`AtomicInteger` imports removed.
- **`CheckpointCounterJsonUnitTest.java`** — new regression test asserting totals reset to zero and the id sequence restarts at 1 after `resetForTesting()`.

`PlaywrightActionsE2ETestBase` only *reads* the `checkpoints` field (no reset write), so its read-reflection is preserved unchanged. `CucumberTestsHelperCoverageUnitTest` uses `Mockito.mockStatic` (not field reflection) and needed no change.

## Note

`resetForTesting()` now also resets `checkpointSequence` between methods, where the old reflection resetters did not. Verified no existing test asserts an absolute id that depends on the sequence *not* resetting — the JSON test uses relative `first < second` comparisons.

## Verification

Scoped unit tests (Playwright/browser E2E excluded), verdict read from `testng-results.xml`: `total=38, passed=38, failed=0`. Module `test-compile` clean, including the Playwright base.

Closes #3846