### PR TITLE
Phase 4 of #3814: notify-nightly-failure composite for the 3 nightly workflows

### DIFF
--- a/.github/actions/notify-nightly-failure/action.yml
+++ b/.github/actions/notify-nightly-failure/action.yml
@@ -1,0 +1,81 @@
+name: 'Notify Nightly Failure'
+description: >-
+  Surface a scheduled/nightly workflow failure as a single deduped GitHub issue,
+  and close that issue automatically when the workflow next succeeds (recovery).
+inputs:
+  outcome:
+    description: >-
+      Aggregated result of the workflow's real jobs, computed by the caller from
+      needs.*.result: 'failure' files/keeps the tracking issue, 'success' closes
+      it on recovery, and 'skip' (e.g. cancelled/skipped) is a no-op.
+    required: true
+  workflow-name:
+    description: 'Human-readable workflow name used in the issue title and body.'
+    required: true
+  label:
+    description: 'Unique label used to dedupe the tracking issue for this workflow.'
+    required: true
+  github-token:
+    description: 'Token with issues:write. Defaults to the job token.'
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: 'composite'
+  steps:
+    - name: File, keep, or close the nightly tracking issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        OUTCOME: ${{ inputs.outcome }}
+        WF_NAME: ${{ inputs.workflow-name }}
+        LABEL: ${{ inputs.label }}
+        REPO: ${{ github.repository }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+
+        # 'skip' (cancelled/superseded/skipped) must not file or close anything —
+        # a concurrency-cancelled run is not a real failure and not a recovery.
+        if [ "$OUTCOME" = "skip" ]; then
+          echo "Outcome is 'skip'; no issue action taken."
+          exit 0
+        fi
+
+        # Ensure the dedupe label exists (idempotent; --force updates in place).
+        gh label create "$LABEL" --repo "$REPO" --color B60205 \
+          --description "Auto-filed tracking issue for a failing nightly workflow" --force >/dev/null 2>&1 || true
+
+        # At most one open tracking issue per workflow, keyed on the dedupe label.
+        existing=$(gh issue list --repo "$REPO" --state open --label "$LABEL" \
+          --json number --jq '.[0].number // empty')
+
+        if [ "$OUTCOME" = "success" ]; then
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" \
+              --body "✅ Recovered: [\`$WF_NAME\`]($RUN_URL) passed on run \`$GITHUB_RUN_ID\`. Closing this auto-filed tracking issue."
+            gh issue close "$existing" --repo "$REPO" --reason completed
+            echo "Closed recovered tracking issue #$existing."
+          else
+            echo "Success with no open tracking issue; nothing to do."
+          fi
+          exit 0
+        fi
+
+        # OUTCOME == failure
+        if [ -n "$existing" ]; then
+          gh issue comment "$existing" --repo "$REPO" \
+            --body "❌ Still failing: [\`$WF_NAME\`]($RUN_URL) failed again on run \`$GITHUB_RUN_ID\`."
+          echo "Updated existing tracking issue #$existing."
+        else
+          BODY=$(printf '%s\n' \
+            "The scheduled workflow **$WF_NAME** failed." \
+            "" \
+            "- Run: $RUN_URL" \
+            "" \
+            "Filed automatically. Dedupes on the \`$LABEL\` label (one open issue per workflow) and closes automatically when \`$WF_NAME\` next succeeds.")
+          url=$(gh issue create --repo "$REPO" \
+            --title "Nightly failure: $WF_NAME" \
+            --label "$LABEL" \
+            --body "$BODY")
+          echo "Filed new tracking issue: $url"
+        fi

--- a/.github/workflows/guided-workflows-live.yml
+++ b/.github/workflows/guided-workflows-live.yml
@@ -76,3 +76,21 @@ jobs:
             build/live-workflows/target/shaft-doctor
           if-no-files-found: ignore
           retention-days: 14
+
+  notify:
+    name: Notify on nightly failure
+    needs: [live-guided-workflows]
+    if: always()
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: File or recover the nightly tracking issue
+        uses: ./.github/actions/notify-nightly-failure
+        with:
+          outcome: ${{ contains(needs.*.result, 'failure') && 'failure' || (contains(needs.*.result, 'cancelled') && 'skip' || 'success') }}
+          workflow-name: ${{ github.workflow }}
+          label: 'nightly-failure:guided-workflows-live'

--- a/.github/workflows/shaft-mcp.yml
+++ b/.github/workflows/shaft-mcp.yml
@@ -94,3 +94,21 @@ jobs:
         with:
           image-tag: shaft-mcp:test
           container-name: shaft-mcp-smoke
+
+  notify:
+    name: Notify on nightly failure
+    needs: [installer-script-tests, package-and-smoke]
+    if: always()
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: File or recover the nightly tracking issue
+        uses: ./.github/actions/notify-nightly-failure
+        with:
+          outcome: ${{ contains(needs.*.result, 'failure') && 'failure' || (contains(needs.*.result, 'cancelled') && 'skip' || 'success') }}
+          workflow-name: ${{ github.workflow }}
+          label: 'nightly-failure:shaft-mcp'

--- a/.github/workflows/update-selenium-grid-versions.yml
+++ b/.github/workflows/update-selenium-grid-versions.yml
@@ -179,3 +179,21 @@ jobs:
           labels: |
             dependencies
             automated
+
+  notify:
+    name: Notify on nightly failure
+    needs: [update-versions]
+    if: always()
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: File or recover the nightly tracking issue
+        uses: ./.github/actions/notify-nightly-failure
+        with:
+          outcome: ${{ contains(needs.*.result, 'failure') && 'failure' || (contains(needs.*.result, 'cancelled') && 'skip' || 'success') }}
+          workflow-name: ${{ github.workflow }}
+          label: 'nightly-failure:update-selenium-grid'


### PR DESCRIPTION
## What
Phase 4 of the #3814 CI-overhaul epic — **nightly failure visibility**. Scheduled workflows that fail silently now surface as a single deduped GitHub issue that auto-closes on recovery.

## Changes
- **New composite** `.github/actions/notify-nightly-failure` — given an aggregated `outcome` (`failure` | `success` | `skip`):
  - `failure` → files one tracking issue per workflow, deduped on a per-workflow label (`nightly-failure:<wf>`); a repeat failure comments on the existing issue instead of filing a duplicate.
  - `success` → closes the open tracking issue with a recovery note (close-on-recovery); no-op if none is open.
  - `skip` (cancelled/superseded/skipped) → no-op, so a concurrency-cancelled run is never mistaken for a failure or a recovery.
- **Wired a `notify` job** (`needs` all real jobs, `if: always()`) into `shaft-mcp`, `guided-workflows-live`, and `update-selenium-grid-versions`. Each notify job carries **job-level** `permissions: { contents: read, issues: write }`, so only the notify job gains issue access — the test jobs keep their original least-privilege scope.

## Verification
- All four YAML files parse; `notify` job + perms asserted via `yaml.safe_load`.
- Composite branch logic exercised locally against a **mock `gh`** across all five states (`skip`; `success` with/without an open issue; `failure` with/without an open issue) — dedupe, recovery-close, and no-op paths all behave as designed.

## Scope
No change to any workflow's actual test/build jobs. E2E / LambdaTest / release chains untouched (per #3814 non-goals). This closes the Phase 4 subticket; the #3814 epic remains open for Phase 3.

Closes #3854

🤖 Generated with [Claude Code](https://claude.com/claude-code)