### PR TITLE
Gitignore runtime-regenerated properties/ in shaft-ai/shaft-doctor/shaft-pilot-core (#3856)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@
 /shaft-visual/generate_allure_report.bat
 /shaft-visual/src/main/resources/properties/
 /shaft-visual/src/test/resources/META-INF/services/
+# SHAFT regenerates the default property set into each module's resources at
+# runtime; only the hand-authored custom.properties (already tracked) belongs
+# in git, same as shaft-engine/shaft-heal/shaft-visual above (#3856).
+/shaft-ai/src/main/resources/properties/
+/shaft-doctor/src/main/resources/properties/
+/shaft-pilot-core/src/main/resources/properties/
 /allure-report/
 /allure-report-check/
 /allurerc.yaml


### PR DESCRIPTION
Closes #3856.

## What
SHAFT regenerates the full default property set into each module's `src/main/resources/properties/default/` at runtime. `shaft-engine`, `shaft-heal`, and `shaft-visual` already gitignore their module `properties/` dir (the hand-authored `custom.properties`, committed before the ignore, stays tracked because git-ignore never untracks). The three newer modules — `shaft-ai`, `shaft-doctor`, `shaft-pilot-core` — were missing that entry, so a stray `git add -A` would sweep ~21 generated files into the tree (nearly happened during the #3854 Phase-4 commit).

## Change
Three `.gitignore` lines, matching the existing per-module pattern.

## Verification
- `git check-ignore`: each module's generated `properties/default/` is now ignored.
- `git ls-files`: each module's tracked `properties/custom.properties` remains tracked.

`.gitignore`-only change → path-skips every pr-gate leg; PR Gate Summary passes on the fail-closed summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)