### PR TITLE
Report BrowserActionsHelper failures under the correct class

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
@@ -2,7 +2,6 @@ package com.shaft.gui.browser.internal;
 
 import com.shaft.tools.io.internal.CheckpointStatus;
 import com.google.common.net.InternetDomainName;
-import com.shaft.db.DatabaseActions;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.SynchronizationManager;
 import com.shaft.gui.internal.image.ScreenshotManager;
@@ -170,7 +169,7 @@ public class BrowserActionsHelper {
                            Exception... rootCauseException) {
         String message = reportActionResult(driver, actionName, testData, false, rootCauseException);
         if (rootCauseException != null && rootCauseException.length > 0) {
-            FailureReporter.fail(DatabaseActions.class, message, rootCauseException[0]);
+            FailureReporter.fail(BrowserActionsHelper.class, message, rootCauseException[0]);
         } else {
             FailureReporter.fail(message);
         }

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java
@@ -3,6 +3,7 @@ package testPackage.unitTests;
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.browser.internal.BrowserActionsHelper;
 import com.shaft.tools.io.ReportManager;
+import com.shaft.tools.io.internal.FailureReporter;
 import com.shaft.properties.internal.Properties;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -18,11 +19,13 @@ import java.awt.HeadlessException;
 import java.io.File;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -89,6 +92,21 @@ public class BrowserActionsHelperCoverageUnitTest {
                 () -> helper.failAction(driver, "customAction", "forced"));
         Assert.assertThrows(RuntimeException.class,
                 () -> helper.failAction(driver, "customAction", "forced", new RuntimeException("forced")));
+    }
+
+    @Test
+    public void shouldReportBrowserActionsHelperClassOnFailAction() {
+        try (MockedStatic<FailureReporter> failureReporter = mockStatic(FailureReporter.class)) {
+            failureReporter.when(() -> FailureReporter.fail(any(), anyString(), any(Throwable.class)))
+                    .thenAnswer(invocation -> {
+                        throw new RuntimeException(invocation.getArgument(1), invocation.getArgument(2));
+                    });
+
+            Assert.assertThrows(RuntimeException.class,
+                    () -> helper.failAction(driver, "customAction", "forced", new RuntimeException("root")));
+
+            failureReporter.verify(() -> FailureReporter.fail(eq(BrowserActionsHelper.class), anyString(), any(Throwable.class)));
+        }
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsHelperCoverageUnitTest.java
@@ -97,13 +97,7 @@ public class BrowserActionsHelperCoverageUnitTest {
     @Test
     public void shouldReportBrowserActionsHelperClassOnFailAction() {
         try (MockedStatic<FailureReporter> failureReporter = mockStatic(FailureReporter.class)) {
-            failureReporter.when(() -> FailureReporter.fail(any(), anyString(), any(Throwable.class)))
-                    .thenAnswer(invocation -> {
-                        throw new RuntimeException(invocation.getArgument(1), invocation.getArgument(2));
-                    });
-
-            Assert.assertThrows(RuntimeException.class,
-                    () -> helper.failAction(driver, "customAction", "forced", new RuntimeException("root")));
+            helper.failAction(driver, "customAction", "forced", new RuntimeException("root"));
 
             failureReporter.verify(() -> FailureReporter.fail(eq(BrowserActionsHelper.class), anyString(), any(Throwable.class)));
         }


### PR DESCRIPTION
## Summary
- `BrowserActionsHelper.failAction` reported failures under `DatabaseActions.class`, so Allure attachment titles said "Database Actions" for browser failures
- Pass `BrowserActionsHelper.class` instead, matching every other helper, and drop the unused import
- Adds a focused regression test in `BrowserActionsHelperCoverageUnitTest`

## Tests
10/10 passed --> 
[2026-07-20_22-23-12-841_AllureReport.html](https://github.com/user-attachments/files/30201681/2026-07-20_22-23-12-841_AllureReport.html)
