### PR TITLE
Tool sweep T4/#3870: index-fed IntelliJ deterministic tool selector

### DIFF
--- a/shaft-intellij/build.gradle.kts
+++ b/shaft-intellij/build.gradle.kts
@@ -145,6 +145,13 @@ tasks {
         filesMatching("messages/ShaftBundle.properties") {
             expand("pluginVersion" to project.version.toString())
         }
+        // Bundles a build-time copy of shaft-mcp's canonical tool catalog (design doc Decision 4/5;
+        // issue #3870/#3866 T4) so ToolCatalogIndex can read the surviving 89-tool list and any
+        // curated intentKeywords overlay entries from the plugin's own classpath at runtime, instead
+        // of hand-maintaining a second copy that can drift from the live @Tool registrations.
+        from(project.file("../shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index.json")) {
+            into("META-INF/shaft-mcp")
+        }
     }
 
     test {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ToolCatalogIndex.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/mcp/ToolCatalogIndex.java
@@ -1,0 +1,127 @@
+package com.shaft.intellij.mcp;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Lazy-holder reader for the bundled build-time copy of shaft-mcp's canonical
+ * {@code META-INF/shaft-mcp/tool-index.json} (design doc Decision 4/5, amendment A7): the
+ * single source of truth for the surviving tool catalog and any curated {@code intentKeywords}
+ * overlay entries, consumed by {@code com.shaft.intellij.ui.AssistantCommand}'s deterministic
+ * routing instead of a second hand-maintained keyword table (issue #3870/#3866 T4).
+ *
+ * <p>Loaded once, on first access, via the classic initialization-on-demand holder idiom (never
+ * eagerly at plugin/class-load time, per amendment A7) -- reading a several-thousand-line JSON
+ * resource on every IDE startup for a feature that may never be used would be wasteful. A missing,
+ * unreadable, or malformed resource degrades to an empty catalog rather than throwing:
+ * AssistantCommand's routing must keep working off its built-in fallback keyword lists even if the
+ * bundled copy is absent (for example a test classpath that only wires shaft-mcp's classes, not its
+ * resources).</p>
+ */
+public final class ToolCatalogIndex {
+    private static final String RESOURCE_PATH = "/META-INF/shaft-mcp/tool-index.json";
+
+    private ToolCatalogIndex() {
+    }
+
+    /**
+     * @return every surviving tool name in the bundled catalog, or empty when the resource is
+     *     missing/unreadable
+     */
+    public static Set<String> toolNames() {
+        return Holder.TOOL_NAMES;
+    }
+
+    /**
+     * @param toolName exact tool name (e.g. {@code "capture_start"})
+     * @return the curated {@code intentKeywords} for that tool, or an empty list when the tool is
+     *     unknown or has no curated keywords yet
+     */
+    public static List<String> intentKeywords(String toolName) {
+        return Holder.INTENT_KEYWORDS.getOrDefault(toolName, List.of());
+    }
+
+    /**
+     * Initialization-on-demand holder: the JSON resource is read only when a caller first touches
+     * {@link #toolNames()} or {@link #intentKeywords(String)}, not when {@link ToolCatalogIndex}
+     * itself is loaded.
+     */
+    private static final class Holder {
+        private static final Set<String> TOOL_NAMES;
+        private static final Map<String, List<String>> INTENT_KEYWORDS;
+
+        static {
+            Set<String> names = new LinkedHashSet<>();
+            Map<String, List<String>> keywords = new LinkedHashMap<>();
+            parse(names, keywords);
+            TOOL_NAMES = Collections.unmodifiableSet(names);
+            INTENT_KEYWORDS = Collections.unmodifiableMap(keywords);
+        }
+
+        private static void parse(Set<String> names, Map<String, List<String>> keywords) {
+            try (InputStream stream = ToolCatalogIndex.class.getResourceAsStream(RESOURCE_PATH)) {
+                if (stream == null) {
+                    return;
+                }
+                JsonElement root;
+                try (InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+                    root = JsonParser.parseReader(reader);
+                }
+                if (!root.isJsonObject()) {
+                    return;
+                }
+                JsonElement tools = root.getAsJsonObject().get("tools");
+                if (tools == null || !tools.isJsonArray()) {
+                    return;
+                }
+                for (JsonElement element : tools.getAsJsonArray()) {
+                    if (!element.isJsonObject()) {
+                        continue;
+                    }
+                    JsonObject tool = element.getAsJsonObject();
+                    JsonElement nameElement = tool.get("name");
+                    if (nameElement == null || !nameElement.isJsonPrimitive()) {
+                        continue;
+                    }
+                    String name = nameElement.getAsString();
+                    names.add(name);
+                    keywords.put(name, stringArray(tool.get("intentKeywords")));
+                }
+            } catch (IOException | RuntimeException ignored) {
+                // Best-effort catalog only: AssistantCommand's built-in keyword lists remain the
+                // fallback source of truth when the bundled resource is missing/malformed.
+            }
+        }
+
+        private static List<String> stringArray(JsonElement element) {
+            if (element == null || !element.isJsonArray()) {
+                return List.of();
+            }
+            JsonArray array = element.getAsJsonArray();
+            if (array.isEmpty()) {
+                return List.of();
+            }
+            List<String> values = new ArrayList<>(array.size());
+            for (JsonElement item : array) {
+                if (item.isJsonPrimitive()) {
+                    values.add(item.getAsString());
+                }
+            }
+            return List.copyOf(values);
+        }
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -6,8 +6,10 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.shaft.intellij.mcp.ShaftCommandLine;
+import com.shaft.intellij.mcp.ToolCatalogIndex;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -446,6 +448,35 @@ final class AssistantCommand {
                     "save storage state",
                     "load session",
                     "load storage state")));
+
+    /**
+     * Augments a built-in keyword list with any curated {@code intentKeywords} the bundled
+     * {@link ToolCatalogIndex} carries for the same tool (design doc Decision 5, amendment A7):
+     * closes the drift risk of two hand-maintained keyword sources (this file's INTENT_KEYWORDS map
+     * and the index's curated overlay) diverging, by making the index an additive, single growth
+     * path instead of a second copy that has to be kept in sync by hand.
+     *
+     * <p>Additive only, never subtractive: {@code toolName} keys that are internal
+     * INTENT_KEYWORDS lookup labels rather than real tool names (for example
+     * {@code "mobile_record_start"}, absorbed into {@code capture_start} by the W1 tool sweep) have
+     * no entry in the index and this is a no-op for them, returning {@code builtin} unchanged.</p>
+     *
+     * @param toolName exact tool name the keywords route to
+     * @param builtin  this file's hand-maintained fallback list for that tool, preserved verbatim as
+     *                 the first entries so existing behavior never regresses if the index is absent
+     * @return {@code builtin} followed by any index-curated entries not already present, in order,
+     *     with no duplicates
+     */
+    static List<String> keywordsFor(String toolName, List<String> builtin) {
+        List<String> fromIndex = ToolCatalogIndex.intentKeywords(toolName);
+        if (fromIndex.isEmpty()) {
+            return builtin;
+        }
+        Set<String> merged = new LinkedHashSet<>(builtin);
+        merged.addAll(fromIndex);
+        return List.copyOf(merged);
+    }
+
     // "start <mode> recording" phrasings match as a whole prefix (equal to the phrase, or the
     // phrase followed by more words) via matchesWholeWordPrefix, rather than the anywhere-in-text
     // keywords above -- kept out of the map above because they need different match semantics.
@@ -684,6 +715,19 @@ final class AssistantCommand {
             upgradeAgentRequest = true;
         } else if (text.startsWith("/")) {
             return slash(text, workingDirectory, openFileContext);
+        }
+        if (!liveCodegenRequest && !upgradeAgentRequest) {
+            // Deterministic-first routing (design doc Decision 5, issue #3870/#3866 T4 goal 3-4): an
+            // explicit tool-name mention is the single most unambiguous signal available and must
+            // win over every softer heuristic below it, including isCodeGenerationRequest's
+            // substring triggers -- a tool whose own name happens to contain a trigger word (for
+            // example capture_codegen_features, which contains "codegen") would otherwise be
+            // swallowed into the free-form code-generation/local-agent path before ever reaching
+            // this check.
+            String explicitTool = matchedExplicitToolName(text);
+            if (explicitTool != null) {
+                return explicitToolMention(text);
+            }
         }
         boolean codeGenerationRequest = !upgradeAgentRequest && isCodeGenerationRequest(text);
         // A code-generation request that already names a recording JSON converts deterministically:
@@ -1845,6 +1889,71 @@ final class AssistantCommand {
         return Invocation.sequence(calls);
     }
 
+    // Deterministic-first routing (design doc Decision 5, issue #3870/#3866 T4 goal 3-4): a call
+    // verb is optional -- "element_click ..." and "call element_click ..." both resolve -- so every
+    // one of the 89 surviving tools is directly addressable by name, not only the handful with a
+    // bespoke natural-language recognizer elsewhere in this file.
+    private static final List<String> EXPLICIT_TOOL_CALL_VERBS =
+            List.of("call ", "run ", "invoke ", "use ", "execute ");
+
+    /**
+     * Returns the exact tool name explicitly named at the start of {@code text} (optionally after
+     * one leading call verb, see {@link #EXPLICIT_TOOL_CALL_VERBS}), or {@code null} when the
+     * leading token isn't a known name from the bundled {@link ToolCatalogIndex}. Deliberately
+     * requires the mention to lead the prompt rather than merely appear anywhere in it: real tool
+     * names are long, unique snake_case identifiers a user is unlikely to type unless deliberately
+     * naming the tool, but requiring the lead keeps ordinary conversational mentions ("explain what
+     * element_click does") from being misread as a call.
+     */
+    private static String matchedExplicitToolName(String text) {
+        Set<String> toolNames = ToolCatalogIndex.toolNames();
+        if (toolNames.isEmpty()) {
+            return null;
+        }
+        String normalized = normalizeNaturalCommand(text);
+        for (String verb : EXPLICIT_TOOL_CALL_VERBS) {
+            if (normalized.startsWith(verb)) {
+                normalized = normalized.substring(verb.length());
+                break;
+            }
+        }
+        String firstToken = firstWord(normalized);
+        return toolNames.contains(firstToken) ? firstToken : null;
+    }
+
+    /**
+     * Builds a direct {@code Invocation.tool} for an explicitly-named tool mention. Any text after
+     * the mention (and its optional call verb) is tried as JSON tool arguments; anything that isn't
+     * a valid JSON object (a blank remainder, free-form prose, malformed JSON) falls back to empty
+     * arguments rather than guessing -- the same "no magic auto-fill" contract {@code rawMcp} uses
+     * for the {@code /mcp} slash command.
+     */
+    private static Invocation explicitToolMention(String text) {
+        String toolName = matchedExplicitToolName(text);
+        String rest = textAfterToolMention(text, toolName);
+        if (!rest.isBlank()) {
+            try {
+                JsonElement parsed = JsonParser.parseString(rest);
+                if (parsed.isJsonObject()) {
+                    return Invocation.tool(toolName, parsed.getAsJsonObject());
+                }
+            } catch (JsonParseException ignored) {
+                // Fall through to empty arguments.
+            }
+        }
+        return Invocation.tool(toolName, new JsonObject());
+    }
+
+    private static String textAfterToolMention(String text, String toolName) {
+        String trimmed = text(text);
+        String afterFirst = afterFirstWord(trimmed);
+        if (firstWord(trimmed).equalsIgnoreCase(toolName)) {
+            return afterFirst;
+        }
+        // A call verb led the mention ("call element_click ..."): skip its second word too.
+        return afterFirstWord(afterFirst);
+    }
+
     /**
      * Scores every natural-language intent that matches {@code text} and dispatches the
      * highest-weight match (see the {@code WEIGHT_*} constants above {@link #NATURAL_INTENTS}).
@@ -1881,7 +1990,7 @@ final class AssistantCommand {
 
     private static boolean isCodingPartnerIntent(String text) {
         String normalized = normalizeNaturalCommand(text);
-        return startsWithAny(normalized, INTENT_KEYWORDS.get("shaft_coding_partner_plan"))
+        return startsWithAny(normalized, keywordsFor("shaft_coding_partner_plan", INTENT_KEYWORDS.get("shaft_coding_partner_plan")))
                 && !naturalCodingPartnerIntent(text).isBlank();
     }
 
@@ -1904,19 +2013,19 @@ final class AssistantCommand {
 
     private static boolean isGuideSearchIntent(String text) {
         String normalized = normalizeNaturalCommand(text);
-        return startsWithAny(normalized, INTENT_KEYWORDS.get("shaft_guide_search"))
+        return startsWithAny(normalized, keywordsFor("shaft_guide_search", INTENT_KEYWORDS.get("shaft_guide_search")))
                 && !naturalQuery(text).isBlank();
     }
 
     private static boolean isScenarioSearchIntent(String text) {
         String normalized = normalizeNaturalCommand(text);
-        return startsWithAny(normalized, INTENT_KEYWORDS.get("test_automation_scenarios"))
+        return startsWithAny(normalized, keywordsFor("test_automation_scenarios", INTENT_KEYWORDS.get("test_automation_scenarios")))
                 && !naturalQuery(text).isBlank();
     }
 
     private static boolean isGuardrailsCheckIntent(String text) {
         String normalized = normalizeNaturalCommand(text);
-        return startsWithAny(normalized, INTENT_KEYWORDS.get("test_code_guardrails_check"))
+        return startsWithAny(normalized, keywordsFor("test_code_guardrails_check", INTENT_KEYWORDS.get("test_code_guardrails_check")))
                 && !naturalCode(text).isBlank();
     }
 
@@ -1933,11 +2042,13 @@ final class AssistantCommand {
      * are dead: {@code isNaturalUpgradeIntent} in {@code fromPrompt} intercepts that phrasing
      * before {@code directIntent} (and this predicate) is ever consulted, routing it to the
      * agent-performed upgrade instead (issue #3426 B6). Removed rather than left as unreachable
-     * branches.
+     * branches -- {@code keywordsFor}'s bundled-index contribution for this tool happens to include
+     * those same two dead phrasings (the curated overlay was seeded from a broader phrase set), so
+     * they stay unreachable here for the same reason, harmlessly.
      */
     private static boolean isProjectUpgradeIntent(String text) {
         String normalized = normalizeNaturalCommand(text);
-        return startsWithAny(normalized, INTENT_KEYWORDS.get("shaft_project_upgrade"));
+        return startsWithAny(normalized, keywordsFor("shaft_project_upgrade", INTENT_KEYWORDS.get("shaft_project_upgrade")));
     }
 
     private static boolean containsAny(String text, String... needles) {
@@ -2017,7 +2128,7 @@ final class AssistantCommand {
         if (!normalized.startsWith("record ")) {
             return false;
         }
-        return containsAny(normalized, INTENT_KEYWORDS.get("capture_start"));
+        return containsAny(normalized, keywordsFor("capture_start", INTENT_KEYWORDS.get("capture_start")));
     }
 
     /**
@@ -2042,7 +2153,7 @@ final class AssistantCommand {
     private static boolean isMobileControlIntent(String text) {
         String normalized = normalizeNaturalCommand(text);
         return normalized.contains("mobile")
-                && containsAny(normalized, INTENT_KEYWORDS.get("mobile_toolchain_status"));
+                && containsAny(normalized, keywordsFor("mobile_toolchain_status", INTENT_KEYWORDS.get("mobile_toolchain_status")));
     }
 
     private static String naturalMobileCommand(String text) {
@@ -2147,7 +2258,7 @@ final class AssistantCommand {
     // workspace.
     private static boolean isDoctorIntent(String text) {
         String normalized = normalizeNaturalCommand(text);
-        return startsWithAny(normalized, INTENT_KEYWORDS.get("doctor_analyze_failed_allure"));
+        return startsWithAny(normalized, keywordsFor("doctor_analyze_failed_allure", INTENT_KEYWORDS.get("doctor_analyze_failed_allure")));
     }
 
     private static String naturalQuery(String text) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -472,8 +472,23 @@ final class AssistantCommand {
         if (fromIndex.isEmpty()) {
             return builtin;
         }
-        Set<String> merged = new LinkedHashSet<>(builtin);
-        merged.addAll(fromIndex);
+        // Dedup on the trimmed value, not the raw string: several builtin phrases carry a
+        // deliberate trailing space as a word-boundary marker for matchesWholeWordPrefix/
+        // startsWithAny (for example "find reuse for "), and the curated overlay carries the same
+        // phrase WITHOUT it. A raw-string LinkedHashSet dedup let both survive as distinct entries,
+        // and the boundary-less overlay copy then matched unrelated text via plain String.startsWith
+        // (PR #3882 review: "find reuse format issues in this class" misrouted to
+        // shaft_coding_partner_plan). The builtin, with its boundary semantics, always wins.
+        List<String> merged = new ArrayList<>(builtin);
+        Set<String> trimmedSeen = new LinkedHashSet<>();
+        for (String keyword : builtin) {
+            trimmedSeen.add(keyword.trim());
+        }
+        for (String candidate : fromIndex) {
+            if (trimmedSeen.add(candidate.trim())) {
+                merged.add(candidate);
+            }
+        }
         return List.copyOf(merged);
     }
 
@@ -2128,7 +2143,14 @@ final class AssistantCommand {
         if (!normalized.startsWith("record ")) {
             return false;
         }
-        return containsAny(normalized, keywordsFor("capture_start", INTENT_KEYWORDS.get("capture_start")));
+        // Deliberately the raw builtin list here, NOT keywordsFor's index-merged one: the curated
+        // overlay for capture_start adds bare phrases ("start recording", "start a recording",
+        // "start recorder", "start capture") that isStartRecording/isRecordScenarioIntent already
+        // match deterministically as whole standalone commands. Feeding them into this containsAny
+        // check would let a "record ..." prompt that merely *contains* one of those phrases later on
+        // newly match (PR #3882 review), a reachable behavior change this drift-proofing merge must
+        // not introduce.
+        return containsAny(normalized, INTENT_KEYWORDS.get("capture_start"));
     }
 
     /**

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -713,6 +713,29 @@ final class ShaftAssistantPanel extends JPanel {
         refreshChatSelector();
         showPendingAgentGuidanceOptimizationPrompt();
         updateControlVisibility();
+        warmToolsCache();
+    }
+
+    /**
+     * Warms {@code ShaftMcpInvocationService}'s shared {@code tools/list} cache on first chat-panel
+     * construction (issue #3870/#3866 T4 goal 3): every {@code startTool} dispatch in this class
+     * routes through that service's unknown-tool fail-fast + did-you-mean guard, but the guard only
+     * activates once {@code knownToolNames()} has been populated by a successful
+     * {@code startListTools()} call -- and, before this change, nothing in this class ever made one
+     * (only the separate {@link ShaftFeaturePanel}'s {@code autoPopulateCatalog} did, via the same
+     * shared per-project service instance). Mirrors that method exactly: best-effort and silent, so
+     * an unconfigured MCP command, a disconnected server, or a test double project must never break
+     * panel construction or block ordinary chat usability.
+     */
+    private void warmToolsCache() {
+        if (project == null || !mcpConfigured()) {
+            return;
+        }
+        try {
+            ShaftMcpInvocationService.getInstance(project).startListTools();
+        } catch (RuntimeException ignored) {
+            // Best-effort warm-up only.
+        }
     }
 
     JComponent preferredFocusComponent() {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ToolCatalogIndexTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/mcp/ToolCatalogIndexTest.java
@@ -1,0 +1,66 @@
+package com.shaft.intellij.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers {@link ToolCatalogIndex}: the lazy-holder reader for the bundled build-time copy of
+ * shaft-mcp's canonical {@code META-INF/shaft-mcp/tool-index.json} (design doc Decision 4/5,
+ * amendment A7), which feeds {@link com.shaft.intellij.ui.AssistantCommand}'s deterministic
+ * routing (issue #3870/#3866 T4) instead of a second hand-maintained keyword source.
+ *
+ * <p>Asserted against the real bundled resource (not a fake), so this suite also proves the
+ * build actually copies the file where the plugin classloader can find it.</p>
+ */
+class ToolCatalogIndexTest {
+
+    @Test
+    void toolNamesIncludesRealSurvivingToolsAndExcludesDeletedOnes() {
+        Set<String> names = ToolCatalogIndex.toolNames();
+
+        assertTrue(names.contains("capture_start"), "a real, surviving tool must be present");
+        assertTrue(names.contains("browser_navigate"), "a real, surviving tool must be present");
+        assertTrue(names.contains("element_click"), "a real, surviving tool must be present");
+        assertTrue(names.contains("driver_initialize"), "a real, surviving tool must be present");
+        assertFalse(names.contains("natural_act"), "natural_act was deleted outright (owner mandate)");
+        assertFalse(names.contains("mobile_natural_act"), "mobile_natural_act was deleted outright");
+        assertFalse(names.contains("playwright_browser_navigate"),
+                "playwright_browser_navigate was absorbed into browser_navigate's engine dispatch");
+    }
+
+    @Test
+    void toolNamesMatchesTheCanonical89ToolCatalog() {
+        assertEquals(89, ToolCatalogIndex.toolNames().size(),
+                "the bundled index must track the canonical 89-tool catalog (#3868); a mismatch means "
+                        + "the build-time copy is stale or the resource wasn't regenerated");
+    }
+
+    @Test
+    void intentKeywordsReturnsCuratedOverlayEntriesForARealTool() {
+        // shaft_project_upgrade's curated overlay entries (tool-index-overlay.json) include two
+        // phrases not present in AssistantCommand's hand-maintained INTENT_KEYWORDS list -- real,
+        // observable proof the index contributes real data, not just an empty pass-through.
+        List<String> keywords = ToolCatalogIndex.intentKeywords("shaft_project_upgrade");
+
+        assertTrue(keywords.contains("upgrade shaft project"), keywords.toString());
+        assertTrue(keywords.contains("upgrade this shaft project"), keywords.toString());
+    }
+
+    @Test
+    void intentKeywordsReturnsEmptyForAnUnknownToolNameInsteadOfThrowing() {
+        assertEquals(List.of(), ToolCatalogIndex.intentKeywords("not_a_real_tool_xyz"));
+    }
+
+    @Test
+    void intentKeywordsReturnsEmptyForAToolWithNoCuratedKeywordsYet() {
+        // Most of the 89-tool catalog has no curated intentKeywords overlay entries yet (only 8/89
+        // are curated as of #3868/#3869) -- must degrade to an empty list, never null or an exception.
+        assertEquals(List.of(), ToolCatalogIndex.intentKeywords("element_click"));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandToolIndexRoutingTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandToolIndexRoutingTest.java
@@ -60,6 +60,80 @@ class AssistantCommandToolIndexRoutingTest {
         assertEquals(builtin, AssistantCommand.keywordsFor("mobile_record_start", builtin));
     }
 
+    @Test
+    void keywordsForDropsOverlayEntryThatOnlyDiffersFromABuiltinEntryByTrailingWhitespace() {
+        // PR #3882 review finding: shaft_coding_partner_plan's built-in list carries "find reuse
+        // for " with a deliberate trailing space (a word-boundary marker -- see
+        // matchesWholeWordPrefix's javadoc); the bundled overlay (tool-index.json) carries the same
+        // five phrases WITHOUT the trailing space. A plain LinkedHashSet string-dedup lets both the
+        // boundary-safe builtin and the boundary-less overlay copy survive, and startsWithAny's raw
+        // String.startsWith then matches the boundary-less copy against unrelated text (proven false
+        // positive: "find reuse format issues in this class"). The merge must dedupe on the trimmed
+        // value, keeping only the builtin's boundary-safe variant.
+        List<String> builtin = List.of(
+                "plan coding partner work for ",
+                "plan partner work for ",
+                "coding partner plan for ",
+                "partner plan for ",
+                "find reuse for ");
+
+        List<String> merged = AssistantCommand.keywordsFor("shaft_coding_partner_plan", builtin);
+
+        assertTrue(merged.containsAll(builtin), merged.toString());
+        assertFalse(merged.contains("find reuse for"),
+                "boundary-less overlay duplicate of 'find reuse for ' must be dropped: " + merged);
+        assertEquals(builtin.size(), merged.size(),
+                "every overlay entry here is a trim-duplicate of a builtin phrase and must not survive: " + merged);
+    }
+
+    @Test
+    void keywordsForStillAddsAGenuinelyNewOverlayEntryAlongsideATrimDuplicate() {
+        // The trimmed dedup must not become subtractive: a real overlay phrase that is NOT a
+        // trim-duplicate of any builtin entry (shaft_project_upgrade's "upgrade shaft project") is
+        // still additive, same as before this fix.
+        List<String> builtin = List.of("preview shaft upgrade", "preview upgrade", "dry run shaft upgrade");
+
+        List<String> merged = AssistantCommand.keywordsFor("shaft_project_upgrade", builtin);
+
+        assertTrue(merged.containsAll(builtin), merged.toString());
+        assertTrue(merged.contains("upgrade shaft project"), merged.toString());
+        assertTrue(merged.contains("upgrade this shaft project"), merged.toString());
+        assertEquals(5, merged.size(), "must not duplicate any entry: " + merged);
+    }
+
+    // ---- Proven false-positive routing (PR #3882 review) ----
+
+    @Test
+    void findReuseFormatIssuesDoesNotMisrouteToCodingPartnerPlan() {
+        assertFalse("shaft_coding_partner_plan".equals(command("find reuse format issues in this class").toolName()),
+                "must not misroute on the boundary-less overlay duplicate of 'find reuse for '");
+    }
+
+    @Test
+    void findReuseForgeDoesNotMisrouteToCodingPartnerPlan() {
+        assertFalse("shaft_coding_partner_plan".equals(command("find reuse forge").toolName()),
+                "must not misroute on the boundary-less overlay duplicate of 'find reuse for '");
+    }
+
+    @Test
+    void guardrailsChecklistDoesNotMisrouteToGuardrailsCheck() {
+        assertFalse("test_code_guardrails_check".equals(command("guardrails checklist for this PR").toolName()),
+                "must not misroute on the boundary-less overlay duplicate of 'guardrails check '");
+    }
+
+    @Test
+    void recordPrefixedPromptWithEmbeddedStartRecordingPhraseDoesNotMisrouteToCaptureStart() {
+        // PR #3882 review finding: capture_start's overlay adds "start recording"/"start a
+        // recording"/"start recorder"/"start capture" -- phrases already handled deterministically
+        // and exactly by isStartRecording/isRecordScenarioIntent as standalone commands. Merging them
+        // into isBrowserRecordingIntent's containsAny check (reached whenever the *whole* prompt
+        // starts with "record ") would let a "record ..." prompt that merely *contains* one of those
+        // phrases later newly match capture_start, which it did not pre-PR (no builtin capture_start
+        // keyword -- "browser", "web flow", "webdriver", etc. -- is present in this prompt).
+        assertFalse("capture_start".equals(command("record my start recording of the checkout demo").toolName()),
+                "must route the same as pre-PR: no builtin capture_start keyword is present");
+    }
+
     // ---- Deterministic-first: an explicit tool-name mention resolves directly ----
 
     @Test
@@ -122,29 +196,40 @@ class AssistantCommandToolIndexRoutingTest {
     // ---- Routing-accuracy suite (design doc Decision 5 last bullet): parameterized from the real
     // bundled index, not a hand-picked sample, across every surviving tool in the 89-tool catalog. ----
 
+    // Named exception allowlist for any future, deliberately-accepted exclusion from 100% explicit
+    // -tool-mention routing (PR #3882 review, Finding 2). Empty today: the full 89-tool catalog
+    // routes deterministically with no exceptions. Add a tool name here only with a comment
+    // explaining why it cannot route deterministically -- never to silence a real regression.
+    private static final Set<String> TOOL_MENTION_ROUTING_EXCEPTIONS = Set.of();
+
     @Test
-    void atLeast80PercentOfTheCatalogRoutesDeterministicallyViaAnExplicitToolMention() {
+    void everyToolInTheCatalogRoutesDeterministicallyViaAnExplicitToolMention() {
         Set<String> toolNames = ToolCatalogIndex.toolNames();
         assertFalse(toolNames.isEmpty(), "the bundled tool-index resource must be present for this suite to mean anything");
 
         List<String> misrouted = new ArrayList<>();
+        int checked = 0;
         for (String toolName : toolNames) {
+            if (TOOL_MENTION_ROUTING_EXCEPTIONS.contains(toolName)) {
+                continue;
+            }
+            checked++;
             String routed = command("call " + toolName).toolName();
             if (!toolName.equals(routed)) {
                 misrouted.add(toolName + " -> " + (routed.isBlank() ? "(local response)" : routed));
             }
         }
 
-        double passRate = 1.0 - ((double) misrouted.size() / toolNames.size());
         // Printed unconditionally (not just on failure) so CI logs and local runs both carry the
-        // measured percentage as evidence, not just a pass/fail bit -- design doc Decision 5's
+        // measured count as evidence, not just a pass/fail bit -- design doc Decision 5's
         // routing-accuracy suite is meant to be inspectable, not just green.
-        System.out.println("[routing-accuracy] " + (toolNames.size() - misrouted.size()) + "/" + toolNames.size()
-                + " tools (" + Math.round(passRate * 100) + "%) routed deterministically via an explicit "
-                + "tool mention; misrouted: " + misrouted);
-        assertTrue(passRate >= 0.80,
-                "expected >=80% deterministic routing across the " + toolNames.size() + "-tool catalog, got "
-                        + Math.round(passRate * 100) + "%; misrouted: " + misrouted);
+        System.out.println("[routing-accuracy] " + (checked - misrouted.size()) + "/" + checked
+                + " tools (100% required) routed deterministically via an explicit tool mention; "
+                + "allowlisted exceptions: " + TOOL_MENTION_ROUTING_EXCEPTIONS + "; misrouted: " + misrouted);
+        assertTrue(misrouted.isEmpty(),
+                "expected 100% deterministic routing across the " + checked + "-tool catalog (allowlisted "
+                        + "exceptions: " + TOOL_MENTION_ROUTING_EXCEPTIONS + "), got " + misrouted.size()
+                        + " misrouted: " + misrouted);
     }
 
     // ---- /codegen regression (design doc's explicit ask): must still resolve correctly ----

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandToolIndexRoutingTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandToolIndexRoutingTest.java
@@ -1,0 +1,167 @@
+package com.shaft.intellij.ui;
+
+import com.shaft.intellij.mcp.ToolCatalogIndex;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers issue #3870/#3866 T4: {@link AssistantCommand}'s routing wired to the canonical
+ * {@link ToolCatalogIndex} instead of a second hand-maintained keyword table (design doc
+ * Decision 5, amendment A7), plus the deterministic-first "explicit tool mention" routing this
+ * task adds so every one of the 89 surviving tools -- not just the handful with a bespoke
+ * natural-language recognizer -- is directly addressable without falling back to the local-AI
+ * agent (design doc Decision 5 / goal 3-4).
+ */
+class AssistantCommandToolIndexRoutingTest {
+
+    // ---- keywordsFor: index-fed augmentation of the built-in fallback lists ----
+
+    @Test
+    void keywordsForAugmentsBuiltinListWithRealCuratedIndexEntries() {
+        // shaft_project_upgrade's curated overlay (tool-index-overlay.json) carries two phrases
+        // that AssistantCommand's own built-in list does not -- real data, not a synthetic fixture.
+        List<String> builtin = List.of("preview shaft upgrade", "preview upgrade", "dry run shaft upgrade");
+
+        List<String> merged = AssistantCommand.keywordsFor("shaft_project_upgrade", builtin);
+
+        assertTrue(merged.containsAll(builtin), merged.toString());
+        assertTrue(merged.contains("upgrade shaft project"), merged.toString());
+        assertTrue(merged.contains("upgrade this shaft project"), merged.toString());
+        assertEquals(5, merged.size(), "must not duplicate any entry: " + merged);
+    }
+
+    @Test
+    void keywordsForDeduplicatesWhenIndexRepeatsABuiltinEntry() {
+        // mobile_toolchain_status's curated overlay entries ("toolchain", "appium", "adb", "sdk")
+        // are all already present in AssistantCommand's much larger built-in list -- the merge must
+        // not double them up.
+        List<String> builtin = List.of("toolchain", "appium", "adb", "sdk", "emulator");
+
+        List<String> merged = AssistantCommand.keywordsFor("mobile_toolchain_status", builtin);
+
+        assertEquals(builtin.size(), merged.size(), merged.toString());
+        assertEquals(builtin, merged);
+    }
+
+    @Test
+    void keywordsForReturnsBuiltinUnchangedWhenTheKeyIsNotARealIndexedTool() {
+        // "mobile_record_start" is an internal INTENT_KEYWORDS lookup key, not a live @Tool name
+        // (it was absorbed into capture_start by the W1 tool sweep) -- the index has nothing under
+        // that name, so the merge must be a no-op, never throw.
+        List<String> builtin = List.of("mobile", "android", "emulator");
+
+        assertEquals(builtin, AssistantCommand.keywordsFor("mobile_record_start", builtin));
+    }
+
+    // ---- Deterministic-first: an explicit tool-name mention resolves directly ----
+
+    @Test
+    void explicitToolMentionResolvesDeterministicallyForElementFamily() {
+        assertEquals("element_click", command("call element_click").toolName());
+        AssistantCommand.Invocation typed = command("element_type {\"text\": \"hello\"}");
+        assertEquals("element_type", typed.toolName());
+        assertEquals("hello", typed.arguments().get("text").getAsString());
+    }
+
+    @Test
+    void explicitToolMentionResolvesDeterministicallyForBrowserFamily() {
+        // No URL/verb context at all -- isBrowserControlIntent alone could never resolve this, so a
+        // pass here is real, new coverage, not an accidental double route to an existing recognizer.
+        assertEquals("browser_get_title", command("call browser_get_title").toolName());
+    }
+
+    @Test
+    void explicitToolMentionResolvesDeterministicallyForMobileFamily() {
+        assertEquals("mobile_swipe", command("run mobile_swipe").toolName());
+        assertEquals("mobile_toolchain_status", command("invoke mobile_toolchain_status").toolName());
+    }
+
+    @Test
+    void explicitToolMentionResolvesDeterministicallyForCaptureAndCodegenFamily() {
+        assertEquals("capture_generate_replay", command("call capture_generate_replay").toolName());
+        assertEquals("capture_pick_locator", command("use capture_pick_locator").toolName());
+    }
+
+    @Test
+    void explicitToolMentionWinsEvenWhenTheToolNameCoincidentallyContainsACodegenTriggerWord() {
+        // capture_codegen_features's name literally contains the substring "codegen", which is one
+        // of isCodeGenerationRequest's trigger words -- that earlier, higher-precedence gate in
+        // fromPrompt used to swallow the whole prompt into the free-form code-generation/local-agent
+        // path before directIntent (and this task's new explicit-tool-mention check inside it) was
+        // ever reached. An explicit tool-name mention must win regardless of what substrings happen
+        // to appear inside the tool's own name.
+        assertEquals("capture_codegen_features", command("call capture_codegen_features").toolName());
+    }
+
+    @Test
+    void explicitToolMentionResolvesDeterministicallyForDoctorAndHealerFamily() {
+        assertEquals("healer_run_failed_test", command("call healer_run_failed_test").toolName());
+        assertEquals("doctor_propose_healed_locator", command("call doctor_propose_healed_locator").toolName());
+    }
+
+    @Test
+    void explicitToolMentionResolvesDeterministicallyForProjectAndGuideFamily() {
+        assertEquals("shaft_project_init_agents", command("call shaft_project_init_agents").toolName());
+        assertEquals("test_plan_explore", command("call test_plan_explore").toolName());
+    }
+
+    @Test
+    void explicitToolMentionNeverFallsBackToTheLocalAgent() {
+        AssistantCommand.Invocation invocation = command("call element_click");
+        assertFalse("autobot_local_agent_run".equals(invocation.toolName())
+                || "autobot_provider_chat".equals(invocation.toolName()));
+    }
+
+    // ---- Routing-accuracy suite (design doc Decision 5 last bullet): parameterized from the real
+    // bundled index, not a hand-picked sample, across every surviving tool in the 89-tool catalog. ----
+
+    @Test
+    void atLeast80PercentOfTheCatalogRoutesDeterministicallyViaAnExplicitToolMention() {
+        Set<String> toolNames = ToolCatalogIndex.toolNames();
+        assertFalse(toolNames.isEmpty(), "the bundled tool-index resource must be present for this suite to mean anything");
+
+        List<String> misrouted = new ArrayList<>();
+        for (String toolName : toolNames) {
+            String routed = command("call " + toolName).toolName();
+            if (!toolName.equals(routed)) {
+                misrouted.add(toolName + " -> " + (routed.isBlank() ? "(local response)" : routed));
+            }
+        }
+
+        double passRate = 1.0 - ((double) misrouted.size() / toolNames.size());
+        // Printed unconditionally (not just on failure) so CI logs and local runs both carry the
+        // measured percentage as evidence, not just a pass/fail bit -- design doc Decision 5's
+        // routing-accuracy suite is meant to be inspectable, not just green.
+        System.out.println("[routing-accuracy] " + (toolNames.size() - misrouted.size()) + "/" + toolNames.size()
+                + " tools (" + Math.round(passRate * 100) + "%) routed deterministically via an explicit "
+                + "tool mention; misrouted: " + misrouted);
+        assertTrue(passRate >= 0.80,
+                "expected >=80% deterministic routing across the " + toolNames.size() + "-tool catalog, got "
+                        + Math.round(passRate * 100) + "%; misrouted: " + misrouted);
+    }
+
+    // ---- /codegen regression (design doc's explicit ask): must still resolve correctly ----
+
+    @Test
+    void codegenSlashCommandStillResolvesCorrectlyAfterIndexWiring() {
+        assertEquals("capture_generate_replay",
+                command("/codegen recordings/capture-session.json").toolName(),
+                "an explicit recording path must still deterministically drive the replay generator");
+        AssistantCommand.Invocation liveCodegen =
+                command("/codegen navigate to https://example.com and click login");
+        assertFalse(liveCodegen.toolName().equals("element_click"),
+                "a free-text /codegen flow description must not be hijacked by the new explicit-tool-mention "
+                        + "route just because it happens to describe an element action");
+    }
+
+    private static AssistantCommand.Invocation command(String prompt) {
+        return AssistantCommand.fromPrompt(prompt, "CODEX", "ASK", ".", "", false);
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelToolsCacheWarmupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelToolsCacheWarmupTest.java
@@ -1,0 +1,116 @@
+package com.shaft.intellij.ui;
+
+import com.intellij.openapi.project.Project;
+import com.shaft.intellij.settings.ShaftSettingsState;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers issue #3870/#3866 T4 goal 3 ("cache-warm"): {@code ShaftMcpInvocationService}'s
+ * {@code tools/list} cache used to be warmed only by {@link ShaftFeaturePanel} (see
+ * {@code ShaftFeaturePanelCatalogTest}), never by the chat panel itself -- confirmed by reading
+ * {@code ShaftAssistantPanel}'s source before this change: every {@code startTool} call site went
+ * straight to dispatch with no prior {@code startListTools()} anywhere in the class. That left
+ * {@code ShaftMcpInvocationService.startTool}'s unknown-tool fail-fast + did-you-mean guard
+ * (which reads {@code knownToolNames()}, populated only after a successful {@code startListTools})
+ * inert for every chat-panel dispatch unless a user happened to have also opened the separate
+ * Feature panel first in the same session.
+ *
+ * <p>Mirrors {@code ShaftFeaturePanelCatalogTest}'s "trap project" pattern: the real end-to-end
+ * path needs {@code ApplicationManager}, unavailable in this Gradle test JVM, so this suite instead
+ * pins the guard conditions -- warm-up is attempted exactly when a real project and configured MCP
+ * are both present, and never otherwise -- proven with a project stub that fails the test if the
+ * service is ever reached when it shouldn't be.</p>
+ */
+class ShaftAssistantPanelToolsCacheWarmupTest {
+
+    @Test
+    void constructionWarmsTheToolsCacheWhenMcpIsConfiguredAndAProjectExists() {
+        AtomicBoolean serviceReached = new AtomicBoolean();
+
+        new ShaftAssistantPanel(trapProject(serviceReached), connectedMcpSettings(),
+                ShaftAssistantChatState.getInstance(null));
+
+        assertTrue(serviceReached.get(),
+                "the chat panel must warm the shared tools/list cache on construction so the "
+                        + "unknown-tool fail-fast + did-you-mean guard is live for chat dispatches too");
+    }
+
+    @Test
+    void constructionNeverCallsTheServiceWithoutAProject() {
+        // Mirrors ShaftAssistantPanelLayoutTest's null-project construction; nothing to warm.
+        new ShaftAssistantPanel(null, connectedMcpSettings(), ShaftAssistantChatState.getInstance(null));
+        // No trap possible with a null project -- absence of a thrown exception is the assertion;
+        // the real guard-order proof is unconfiguredMcp below plus the positive case above.
+    }
+
+    @Test
+    void constructionNeverCallsTheServiceWhenMcpIsNotConfigured() {
+        AtomicBoolean serviceReached = new AtomicBoolean();
+
+        new ShaftAssistantPanel(trapProject(serviceReached), unverifiedMcpSettings(),
+                ShaftAssistantChatState.getInstance(null));
+
+        assertFalse(serviceReached.get(), "an unready MCP command must skip the warm-up entirely");
+    }
+
+    private static ShaftSettingsState.Settings connectedMcpSettings() {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        settings.mcpCommand = "\"java\" \"@target/shaft-mcp.args\"";
+        settings.mcpSetupComplete = true;
+        return settings;
+    }
+
+    private static ShaftSettingsState.Settings unverifiedMcpSettings() {
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.mcpSetupComplete = false;
+        return settings;
+    }
+
+    /**
+     * A {@link Project} stub whose {@code getService} flips the given flag before returning
+     * {@code null} (an unwired service) -- identical in spirit to
+     * {@code ShaftFeaturePanelCatalogTest}'s {@code trapProject}, scoped to
+     * {@code ShaftMcpInvocationService} lookups specifically so the panel's other legitimate
+     * {@code getService}/{@code PropertiesComponent} calls during construction are not mistaken for
+     * the warm-up being reached.
+     */
+    private static Project trapProject(AtomicBoolean serviceReached) {
+        return (Project) Proxy.newProxyInstance(Project.class.getClassLoader(), new Class<?>[]{Project.class},
+                (proxy, method, arguments) -> {
+                    switch (method.getName()) {
+                        case "equals":
+                            return proxy == (arguments == null || arguments.length == 0 ? null : arguments[0]);
+                        case "hashCode":
+                            return System.identityHashCode(proxy);
+                        case "getBasePath":
+                            return "";
+                        case "getName":
+                            return "shaft-assistant-panel-cache-warmup-test-project";
+                        case "getService":
+                            if (arguments != null && arguments.length > 0
+                                    && arguments[0] == com.shaft.intellij.mcp.ShaftMcpInvocationService.class) {
+                                serviceReached.set(true);
+                            }
+                            return null;
+                        default:
+                            return defaultValue(method.getReturnType());
+                    }
+                });
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
## Summary

Implements T4/#3870 (subtask of tracking issue #3866). Stacks on the
pending #3881 (T1/T2/T3/T5/T8 + regression fix) since this branch was
forked from `ChaosEngine/tool-architecture-sweep`'s tip -- the diff
below will shrink to just this PR's own commit once #3881 merges.

- **Verified the "inert cache" claim**: confirmed true by reading the
  code. `ShaftFeaturePanel.autoPopulateCatalog` was the only caller of
  `ShaftMcpInvocationService.startListTools()`; the chat panel
  (`ShaftAssistantPanel`) called `startTool` directly everywhere and
  never warmed the cache, so `startTool`'s unknown-tool fail-fast +
  did-you-mean guard (`knownToolNames()`) was always empty/inert for
  chat dispatches.
- **`ToolCatalogIndex`** (new, `com.shaft.intellij.mcp`): lazy-holder
  reader (amendment A7 -- initialization-on-demand holder idiom, never
  eager at class/plugin load) for a new build-time-bundled copy of
  shaft-mcp's canonical `tool-index.json`, wired via a one-line
  `processResources` `from(...)` in `build.gradle.kts`. Degrades to an
  empty catalog rather than throwing if the resource is ever missing.
- **`AssistantCommand.keywordsFor`**: merges each hand-maintained
  `INTENT_KEYWORDS` list with the index's curated `intentKeywords`
  overlay entries for the same tool name (union, de-duplicated,
  additive only). Internal lookup keys that aren't real tool names
  (`mobile_record_start`, `browser_session_action`, ...) are correctly
  left untouched (no matching index entry exists for them). Measured:
  only 8/89 tools have curated `intentKeywords` today, and even those
  are mostly a subset of what was already hand-coded -- so this wiring
  is currently a no-behavior-change, forward-looking single-source-of-
  truth fix (closes the two-source drift risk) rather than an
  immediate routing improvement, except for `shaft_project_upgrade`'s
  two new (but currently unreachable/dead, per existing code comments)
  phrases -- verified with real bundled data, not a synthetic fixture.
- **New "explicit tool mention" deterministic route**: a prompt that
  starts with (optionally after a call verb: "call"/"run"/"invoke"/
  "use"/"execute") an exact tool name from the index resolves directly
  to that tool via `Invocation.tool(name, args)`, trying any trailing
  text as JSON arguments. Checked *before* `isCodeGenerationRequest` in
  `fromPrompt` (not just inside `directIntent`'s `NATURAL_INTENTS`)
  after a RED test proved a real collision:
  `capture_codegen_features`'s own name contains the substring
  "codegen", which used to trip the codegen heuristic and swallow the
  whole prompt into the free-form local-agent path before the new
  route was ever reached.
- **Routing-accuracy suite**: `AssistantCommandToolIndexRoutingTest`
  measures **89/89 (100%)** of the real bundled 89-tool catalog routing
  deterministically via an explicit mention (`>=80%` required), plus a
  dedicated `/codegen` regression case (both the recording-path and
  free-text forms still resolve correctly).
- **Cache-warm fix**: `ShaftAssistantPanel`'s constructor now calls
  `ShaftMcpInvocationService.startListTools()` on construction
  (mirrors `ShaftFeaturePanel.autoPopulateCatalog` exactly: best-effort,
  silent, gated on a real project + configured MCP), so the fail-fast +
  did-you-mean guard is live for chat dispatches too.

Not implemented (in the GitHub issue body but not in the delegated task
list, flagged back rather than silently added or silently dropped):
`slashAlias`-driven `/mcp` autocomplete (the index has zero curated
`slashAlias` entries today -- nothing to consume yet) and
transcript-visible routing-decision/live-vs-bundled-index-diff labels.
Left for the orchestrator to decide whether to fold into this PR or a
follow-up.

## Test plan
- [x] `ToolCatalogIndexTest` (new): real bundled resource, TDD red/green
- [x] `AssistantCommandToolIndexRoutingTest` (new): merge behavior,
      explicit-mention routing per tool family, the codegen-name-
      collision regression, the 89-tool accuracy suite, `/codegen`
      regression -- all red before / green after
- [x] `ShaftAssistantPanelToolsCacheWarmupTest` (new): warm-up guard
      conditions, red before / green after
- [x] Full `shaft-intellij` module `gradlew test` green (includes
      pre-existing `AssistantCommandTest`, `AssistantCommandRoutingTest`,
      `GuidedWorkflowPanelTest`, `ShaftFeaturePanelCatalogTest`, all
      `com.shaft.intellij.mcp.*` suites -- no regressions)
- [x] `tests/scripts/test_mcp_tool_catalog_sync.py` (Gate 1e etc.) green

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01V6zjrMRZpHqfeem4PkCkLn

Closes #3870
