### PR TITLE
Coverage pass: sweep new/changed classes to 80-90% (JaCoCo-measured)

### DIFF
--- a/shaft-cli/src/test/java/com/shaft/commandline/ShaftCliTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/ShaftCliTest.java
@@ -1,0 +1,56 @@
+package com.shaft.commandline;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.PrintWriter;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@code ShaftCli.main} is not exercised here: it unconditionally calls {@code System.exit},
+ * which would terminate the test JVM if invoked in-process (JDK 25 has no SecurityManager hook to
+ * intercept it). That entry point is covered out-of-process instead, by
+ * {@code ShaftCliEndToEndStdioIT} launching the real packaged CLI. This class covers the two
+ * pieces of {@link ShaftCli} that ARE safely unit-testable in-process: the {@code --version}
+ * provider and the UTF-8 writer factory {@code main} builds its streams from.
+ */
+class ShaftCliTest {
+
+    @Test
+    void manifestVersionProviderFallsBackToDevelopmentWhenNoImplementationVersion() {
+        // Running from the test classpath (not a packaged jar), the package has no
+        // Implementation-Version manifest entry, so the provider must fall back to "(development)".
+        String[] version = new ShaftCli.ManifestVersionProvider().getVersion();
+
+        assertArrayEquals(new String[]{"shaft-cli (development)"}, version);
+    }
+
+    @Test
+    void utf8WriterEncodesNonAsciiTextAsUtf8(@TempDir Path temp) throws Exception {
+        Path file = temp.resolve("utf8-writer-output.txt");
+        Method utf8Writer = ShaftCli.class.getDeclaredMethod("utf8Writer", FileDescriptor.class);
+        utf8Writer.setAccessible(true);
+
+        try (FileOutputStream fileOutputStream = new FileOutputStream(file.toFile())) {
+            PrintWriter writer = (PrintWriter) utf8Writer.invoke(null, fileOutputStream.getFD());
+            writer.print("héllo wörld 日本語");
+            writer.flush();
+        }
+
+        String written;
+        try (FileInputStream in = new FileInputStream(file.toFile())) {
+            written = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        assertEquals("héllo wörld 日本語", written);
+        assertArrayEquals(Files.readAllBytes(file), "héllo wörld 日本語".getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/CaptureCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/CaptureCommandTest.java
@@ -59,6 +59,9 @@ class CaptureCommandTest {
     void defaultConstructorUsesRealConnectionFactoryWithoutConnecting() {
         CaptureCommand command = new CaptureCommand();
 
-        assertTrue(true, "constructed without throwing: " + command);
+        CommandLine.Model.CommandSpec spec = new CommandLine(command).getCommandSpec();
+        assertEquals("capture", spec.name());
+        assertEquals(2, spec.positionalParameters().size());
+        assertEquals("ACTION", spec.positionalParameters().get(0).paramLabel());
     }
 }

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/CaptureCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/CaptureCommandTest.java
@@ -43,4 +43,22 @@ class CaptureCommandTest {
         assertTrue(out.toString().contains("called capture_step_reorder"),
                 "step-reorder should dispatch to capture_step_reorder");
     }
+
+    @Test
+    void unknownActionReturnsExitCodeTwoWithoutDispatching() {
+        StringWriter err = new StringWriter();
+        int exit = new CommandLine(new CaptureCommand(connector))
+                .setErr(new PrintWriter(err, true))
+                .execute("not-a-real-action");
+
+        assertEquals(2, exit);
+        assertTrue(err.toString().contains("Unknown capture action"), err.toString());
+    }
+
+    @Test
+    void defaultConstructorUsesRealConnectionFactoryWithoutConnecting() {
+        CaptureCommand command = new CaptureCommand();
+
+        assertTrue(true, "constructed without throwing: " + command);
+    }
 }

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/ToolsCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/ToolsCommandTest.java
@@ -34,7 +34,10 @@ class ToolsCommandTest {
         // (the one Picocli uses) doesn't blow up before any command actually runs.
         ToolsCommand command = new ToolsCommand();
 
-        assertTrue(true, "constructed without throwing: " + command);
+        CommandLine.Model.CommandSpec spec = new CommandLine(command).getCommandSpec();
+        assertEquals("tools", spec.name());
+        assertTrue(spec.findOption("--json") != null, "must declare --json");
+        assertTrue(spec.findOption("--cached") != null, "must declare --cached");
     }
 
     @Test

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/ToolsCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/ToolsCommandTest.java
@@ -1,0 +1,144 @@
+package com.shaft.commandline.command;
+
+import com.shaft.commandline.mcp.CallToolResult;
+import com.shaft.commandline.mcp.InitializeResult;
+import com.shaft.commandline.mcp.McpClient;
+import com.shaft.commandline.mcp.Tool;
+import com.shaft.commandline.runtime.McpConnector;
+import com.shaft.commandline.util.Json;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers {@link ToolsCommand}'s real (non-{@code --cached}) connection path, its default
+ * constructor, and {@code firstSentence}'s branches -- none of which {@code ToolsCommandCachedTest}
+ * exercises, since that class only drives {@code --cached}.
+ */
+class ToolsCommandTest {
+
+    @Test
+    void defaultConstructorUsesRealConnectionFactoryWithoutConnecting() {
+        // Constructing the real ConnectionFactory must not itself attempt any MCP connection;
+        // only calling the command would. This just proves wiring the production constructor
+        // (the one Picocli uses) doesn't blow up before any command actually runs.
+        ToolsCommand command = new ToolsCommand();
+
+        assertTrue(true, "constructed without throwing: " + command);
+    }
+
+    @Test
+    void nonCachedJsonPrintsRawToolsListFromTheLiveConnection() {
+        ObjectNode raw = Json.newObject();
+        raw.put("marker", "raw-tools-list");
+        FakeMcpClient client = new FakeMcpClient(List.of(), raw);
+        StringWriter out = new StringWriter();
+
+        int exit = new CommandLine(new ToolsCommand((requiresSession, stdioOk) -> client))
+                .setOut(new PrintWriter(out, true))
+                .execute("--json");
+
+        assertEquals(0, exit);
+        assertTrue(out.toString().contains("raw-tools-list"), out.toString());
+        assertTrue(client.closed, "client must be closed after use");
+    }
+
+    @Test
+    void nonCachedListsToolsUsingFirstSentenceOfDescription() {
+        FakeMcpClient client = new FakeMcpClient(List.of(
+                new Tool("browser_navigate", "Navigates to a URL. Extra detail that must be trimmed.", null)
+        ), Json.newObject());
+        StringWriter out = new StringWriter();
+
+        int exit = new CommandLine(new ToolsCommand((requiresSession, stdioOk) -> client))
+                .setOut(new PrintWriter(out, true))
+                .execute();
+
+        assertEquals(0, exit);
+        assertTrue(out.toString().contains("browser_navigate — Navigates to a URL."), out.toString());
+        assertFalse(out.toString().contains("Extra detail"), out.toString());
+        assertTrue(client.closed, "client must be closed after use");
+    }
+
+    @Test
+    void firstSentenceReturnsEmptyForNullDescription() throws Exception {
+        assertEquals("", invokeFirstSentence(null));
+    }
+
+    @Test
+    void firstSentenceReturnsEmptyForBlankDescription() throws Exception {
+        assertEquals("", invokeFirstSentence("   "));
+    }
+
+    @Test
+    void firstSentenceCutsAtTheFirstPeriodSpace() throws Exception {
+        assertEquals("First sentence.", invokeFirstSentence("First sentence. Second sentence."));
+    }
+
+    @Test
+    void firstSentenceCutsAtANewlineWhenItComesBeforeAnyPeriod() throws Exception {
+        assertEquals("First line", invokeFirstSentence("First line\nSecond line. Third."));
+    }
+
+    @Test
+    void firstSentenceReturnsTheWholeStrippedDescriptionWhenNoTerminatorExists() throws Exception {
+        assertEquals("No terminator here", invokeFirstSentence("  No terminator here  "));
+    }
+
+    private static String invokeFirstSentence(String description) throws Exception {
+        Method method = ToolsCommand.class.getDeclaredMethod("firstSentence", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, (Object) description);
+    }
+
+    private static final class FakeMcpClient implements McpClient {
+        private final List<Tool> tools;
+        private final JsonNode raw;
+        private boolean closed;
+
+        private FakeMcpClient(List<Tool> tools, JsonNode raw) {
+            this.tools = tools;
+            this.raw = raw;
+        }
+
+        @Override
+        public InitializeResult initialize() {
+            throw new UnsupportedOperationException("not used by `tools`");
+        }
+
+        @Override
+        public List<Tool> listTools() {
+            return tools;
+        }
+
+        @Override
+        public CallToolResult callTool(String name, ObjectNode arguments) {
+            throw new UnsupportedOperationException("not used by `tools`");
+        }
+
+        @Override
+        public JsonNode listToolsRaw() {
+            return raw;
+        }
+
+        @Override
+        public JsonNode callToolRaw(String name, ObjectNode arguments) {
+            throw new UnsupportedOperationException("not used by `tools`");
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/EngineService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/EngineService.java
@@ -228,7 +228,12 @@ public class EngineService {
             SHAFT.Properties.web.set().targetBrowserName(targetBrowser.name());
             initializeConfiguredDriver(targetBrowser.name(), ActiveEngine.WEB);
         } catch (Exception e) {
-            logger.error("Failed to initialize driver for browser: {}", targetBrowser.name(), e);
+            // Logs `targetBrowser` itself (SLF4J's `{}` placeholder null-safely stringifies it),
+            // not `targetBrowser.name()`: re-deriving the name here previously threw a second,
+            // masking NullPointerException whenever `targetBrowser` was null -- the exact case this
+            // catch block exists to report -- silently skipping the log line and replacing the
+            // original failure with this unrelated one.
+            logger.error("Failed to initialize driver for browser: {}", targetBrowser, e);
             throw e;
         }
     }

--- a/shaft-mcp/src/test/java/com/shaft/mcp/BrowserServiceRouteTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/BrowserServiceRouteTest.java
@@ -77,4 +77,47 @@ class BrowserServiceRouteTest {
         assertEquals(503, response.getStatus());
         assertNull(response.getHeader("X-Test"));
     }
+
+    @Test
+    void buildMockResponsePopulatesMultipleHeaders() {
+        Map<String, String> headers = Map.of("X-Test", "value1", "Content-Type", "application/json");
+        HttpResponse response = BrowserService.buildMockResponse(201, "{}", headers);
+
+        assertEquals(201, response.getStatus());
+        assertEquals("value1", response.getHeader("X-Test"));
+        assertEquals("application/json", response.getHeader("Content-Type"));
+    }
+
+    @Test
+    void buildMockResponseHandlesNullHeaders() {
+        HttpResponse response = BrowserService.buildMockResponse(200, "body", null);
+
+        assertEquals(200, response.getStatus());
+        assertTrue(response.getStatus() > 0);
+    }
+
+    @Test
+    void routePredicateHandlesCaseInsensitiveHttpMethod() {
+        Predicate<HttpRequest> predicateLower = BrowserService.routePredicate("get", "**/api/**", "");
+        Predicate<HttpRequest> predicateUpper = BrowserService.routePredicate("GET", "**/api/**", "");
+
+        assertTrue(predicateLower.test(new HttpRequest(HttpMethod.GET, "https://example.test/api/users")));
+        assertTrue(predicateUpper.test(new HttpRequest(HttpMethod.GET, "https://example.test/api/users")));
+    }
+
+    @Test
+    void routePredicateHandlesWhitespaceInBlankInputs() {
+        Predicate<HttpRequest> predicate = BrowserService.routePredicate("  ", "  ", "https://example.test");
+
+        assertTrue(predicate.test(new HttpRequest(HttpMethod.GET, "https://example.test")));
+    }
+
+    @Test
+    void routePredicateMatchesAllHttpMethodsWhenNull() {
+        Predicate<HttpRequest> predicate = BrowserService.routePredicate(null, "**/api/**", "");
+
+        assertTrue(predicate.test(new HttpRequest(HttpMethod.GET, "https://example.test/api/users")));
+        assertTrue(predicate.test(new HttpRequest(HttpMethod.POST, "https://example.test/api/users")));
+        assertTrue(predicate.test(new HttpRequest(HttpMethod.DELETE, "https://example.test/api/users")));
+    }
 }

--- a/shaft-mcp/src/test/java/com/shaft/mcp/BrowserServiceRouteTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/BrowserServiceRouteTest.java
@@ -93,7 +93,9 @@ class BrowserServiceRouteTest {
         HttpResponse response = BrowserService.buildMockResponse(200, "body", null);
 
         assertEquals(200, response.getStatus());
-        assertTrue(response.getStatus() > 0);
+        assertFalse(response.getHeaderNames().iterator().hasNext(),
+                "no headers should be set when responseHeaders is null");
+        assertNull(response.getHeader("X-Test"));
     }
 
     @Test

--- a/shaft-mcp/src/test/java/com/shaft/mcp/BrowserServiceWebEngineTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/BrowserServiceWebEngineTest.java
@@ -1,0 +1,318 @@
+package com.shaft.mcp;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.browser.BrowserActions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.OutputType;
+
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Tests for WEB engine-specific paths and utility methods in BrowserService that are not
+ * covered by the dispatch matrix tests (which focus on web vs. Playwright engine selection).
+ * These tests verify the actual WEB engine implementations and helper methods without
+ * requiring a real browser.
+ */
+class BrowserServiceWebEngineTest {
+    @TempDir
+    Path temp;
+
+    @AfterEach
+    void resetActiveEngine() {
+        EngineService.setActiveEngine(null);
+    }
+
+    @Test
+    void navigateWithBasicAuthCallsWebDriverBrowserActions() {
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            service.navigateWithBasicAuth("https://example.test", "user", "pass", "https://example.test/after");
+
+            verify(webBrowser).navigateToURLWithBasicAuthentication("https://example.test", "user", "pass",
+                    "https://example.test/after");
+        }
+    }
+
+    @Test
+    void addCookieCallsWebDriverBrowserActions() {
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            service.addCookie("sid", "session123");
+
+            verify(webBrowser).addCookie("sid", "session123");
+        }
+    }
+
+    @Test
+    void getCookieReturnsValueFromWebDriver() {
+        Cookie mockCookie = mock(Cookie.class);
+        when(mockCookie.getValue()).thenReturn("session123");
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        when(webBrowser.getCookie("sid")).thenReturn(mockCookie);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            String cookieValue = service.getCookie("sid");
+
+            assertEquals("session123", cookieValue);
+        }
+    }
+
+    @Test
+    void getAllCookiesReturnsStringRepresentation() {
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        Set<Cookie> cookies = Set.of(mock(Cookie.class), mock(Cookie.class));
+        when(webBrowser.getAllCookies()).thenReturn(cookies);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            String allCookies = service.getAllCookies();
+
+            assertNotNull(allCookies);
+            assertTrue(allCookies.length() > 0);
+        }
+    }
+
+    @Test
+    void getPageDomOnWebEngineReturnsPageSourceSnapshot() {
+        WebDriver seleniumDriver = mock(WebDriver.class);
+        when(seleniumDriver.getPageSource()).thenReturn("<html><body><p>Test</p></body></html>");
+        when(seleniumDriver.getCurrentUrl()).thenReturn("https://example.test");
+        when(seleniumDriver.getTitle()).thenReturn("Test Page");
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.getDriver()).thenReturn(seleniumDriver);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            McpPageDomSnapshot snapshot = service.getPageDom(1000);
+
+            assertEquals("https://example.test", snapshot.currentUrl());
+            assertEquals("Test Page", snapshot.title());
+            assertTrue(snapshot.dom().contains("Test"));
+            assertFalse(snapshot.truncated());
+        }
+    }
+
+    @Test
+    void getPageDomOnWebEngineTruncatesDomWhenExceedsLimit() {
+        String largeDom = "<html><body>" + "x".repeat(200) + "</body></html>";
+        WebDriver seleniumDriver = mock(WebDriver.class);
+        when(seleniumDriver.getPageSource()).thenReturn(largeDom);
+        when(seleniumDriver.getCurrentUrl()).thenReturn("https://example.test");
+        when(seleniumDriver.getTitle()).thenReturn("Test Page");
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.getDriver()).thenReturn(seleniumDriver);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            McpPageDomSnapshot snapshot = service.getPageDom(100);
+
+            assertTrue(snapshot.truncated(), "DOM should be truncated when exceeding limit");
+            assertEquals(100, snapshot.dom().length());
+            assertTrue(snapshot.characterCount() > 100, "characterCount should reflect original DOM size");
+            assertFalse(snapshot.warnings().isEmpty(), "warnings should not be empty when truncated");
+            assertTrue(snapshot.warnings().stream().anyMatch(w -> w.contains("DOM was truncated")));
+        }
+    }
+
+    @Test
+    void getPageDomOnWebEngineHandlesNullPageSource() {
+        WebDriver seleniumDriver = mock(WebDriver.class);
+        when(seleniumDriver.getPageSource()).thenReturn(null);
+        when(seleniumDriver.getCurrentUrl()).thenReturn("https://example.test");
+        when(seleniumDriver.getTitle()).thenReturn("Test Page");
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.getDriver()).thenReturn(seleniumDriver);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            McpPageDomSnapshot snapshot = service.getPageDom(1000);
+
+            assertEquals("", snapshot.dom());
+            assertEquals(0, snapshot.characterCount());
+            assertFalse(snapshot.truncated());
+        }
+    }
+
+    @Test
+    void takeScreenshotOnWebEngineReturnsPngBytesAndPath() throws Exception {
+        byte[] pngBytes = new byte[]{(byte) 0x89, (byte) 0x50, (byte) 0x4E, (byte) 0x47};
+        WebDriver seleniumDriver = mock(WebDriver.class, withSettings().extraInterfaces(TakesScreenshot.class));
+        TakesScreenshot takesScreenshot = (TakesScreenshot) seleniumDriver;
+        when(takesScreenshot.getScreenshotAs(OutputType.BYTES)).thenReturn(pngBytes);
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.getDriver()).thenReturn(seleniumDriver);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            McpScreenshotResult result = service.takeScreenshot("screenshot.png", true);
+
+            assertEquals("image/png", result.mediaType());
+            assertEquals(4, result.byteLength());
+            assertNotNull(result.base64(), "base64 should be included when includeBase64=true");
+            assertTrue(result.warnings().isEmpty(), "warnings should be empty when includeBase64=true");
+        }
+    }
+
+    @Test
+    void takeScreenshotOnWebEngineOmitsBase64WhenNotRequested() throws Exception {
+        byte[] pngBytes = new byte[]{(byte) 0x89, (byte) 0x50, (byte) 0x4E, (byte) 0x47};
+        WebDriver seleniumDriver = mock(WebDriver.class, withSettings().extraInterfaces(TakesScreenshot.class));
+        TakesScreenshot takesScreenshot = (TakesScreenshot) seleniumDriver;
+        when(takesScreenshot.getScreenshotAs(OutputType.BYTES)).thenReturn(pngBytes);
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.getDriver()).thenReturn(seleniumDriver);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            McpScreenshotResult result = service.takeScreenshot("screenshot.png", false);
+
+            assertNull(result.base64(), "base64 should be null when includeBase64=false");
+            assertFalse(result.warnings().isEmpty(), "warnings should not be empty when includeBase64=false");
+            assertTrue(result.warnings().stream().anyMatch(w -> w.contains("Base64 omitted")));
+        }
+    }
+
+    @Test
+    void takeScreenshotOnWebEngineThrowsWhenDriverDoesNotSupportScreenshots() {
+        WebDriver seleniumDriver = mock(WebDriver.class);
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.getDriver()).thenReturn(seleniumDriver);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            assertThrows(IllegalStateException.class, () -> service.takeScreenshot("screenshot.png", true));
+        }
+    }
+
+    @Test
+    void saveStorageStateOnWebEngineWritesAndReturnsPath() {
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            String path = service.saveStorageState("storage.json");
+
+            assertNotNull(path);
+            assertTrue(path.endsWith("storage.json"));
+            verify(webBrowser).saveStorageState(path);
+        }
+    }
+
+    @Test
+    void loadStorageStateOnWebEngineLoadsAndReturnsCookieCount() {
+        Cookie cookie1 = mock(Cookie.class);
+        Cookie cookie2 = mock(Cookie.class);
+        BrowserActions webBrowser = mock(BrowserActions.class);
+        when(webBrowser.getAllCookies()).thenReturn(Set.of(cookie1, cookie2));
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.browser()).thenReturn(webBrowser);
+        Path storageFile = temp.resolve("storage.json");
+
+        try {
+            Files.write(storageFile, "{}".getBytes());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        BrowserService service = new BrowserService(McpWorkspacePolicy.of(temp), mock(PlaywrightService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            String result = service.loadStorageState("storage.json");
+
+            assertTrue(result.contains("Loaded browser storage state"));
+            assertTrue(result.contains("cookies restored: 2"));
+            verify(webBrowser).loadStorageState(anyString());
+        }
+    }
+
+    // AriaSnapshot on WEB engine is tested implicitly through ariaSnapshot on PLAYWRIGHT engine dispatch test
+    // The WEB engine path requires complex mocking of SHAFT's internal element actions which is already
+    // verified through integration with real drivers in acceptance tests
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/BrowserServiceWebEngineTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/BrowserServiceWebEngineTest.java
@@ -104,7 +104,7 @@ class BrowserServiceWebEngineTest {
     @Test
     void getAllCookiesReturnsStringRepresentation() {
         BrowserActions webBrowser = mock(BrowserActions.class);
-        Set<Cookie> cookies = Set.of(mock(Cookie.class), mock(Cookie.class));
+        Set<Cookie> cookies = Set.of(new Cookie("sid", "abc123"), new Cookie("theme", "dark"));
         when(webBrowser.getAllCookies()).thenReturn(cookies);
         SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
         when(shaftDriver.browser()).thenReturn(webBrowser);
@@ -116,8 +116,8 @@ class BrowserServiceWebEngineTest {
 
             String allCookies = service.getAllCookies();
 
-            assertNotNull(allCookies);
-            assertTrue(allCookies.length() > 0);
+            assertTrue(allCookies.contains("sid=abc123"), allCookies);
+            assertTrue(allCookies.contains("theme=dark"), allCookies);
         }
     }
 

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ElementServiceJavaCallerConvenienceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ElementServiceJavaCallerConvenienceTest.java
@@ -1,0 +1,174 @@
+package com.shaft.mcp;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.element.internal.Actions;
+import com.shaft.gui.element.TouchActions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openqa.selenium.By;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link ElementService}'s Java-caller-only convenience surface (not exposed as MCP tools)
+ * that {@link ElementServiceDispatchTest} doesn't reach: the 2-arg {@code click} overload, the
+ * semantic-locator aliases, the WEB branch of {@code clear}, the 4-arg {@code dragAndDrop} overload,
+ * the DOM/CSS value getters, and the Playwright branch of {@code isEnabled}. Reuses the same
+ * {@code mockStatic(EngineService.class, CALLS_REAL_METHODS)} fake-driver pattern as
+ * {@link ElementServiceDispatchTest} -- no real browser is launched.
+ */
+class ElementServiceJavaCallerConvenienceTest {
+
+    @AfterEach
+    void resetActiveEngine() {
+        EngineService.setActiveEngine(null);
+    }
+
+    @Test
+    void twoArgClickDefaultsToSingleClickMode() {
+        Actions element = mock(Actions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mockShaftDriver(element);
+        ElementService service = new ElementService(mock(PlaywrightService.class), mock(MobileService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            ElementActionResult result = service.click(locatorStrategy.ID, "submit");
+
+            verify(element).click(any(By.class));
+            assertEquals("WEB", result.activeEngine());
+        }
+    }
+
+    @Test
+    void clickSemanticAndItsDeprecatedAliasDelegateToTheRealDriver() {
+        Actions element = mock(Actions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mockShaftDriver(element);
+        ElementService service = new ElementService(mock(PlaywrightService.class), mock(MobileService.class));
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            service.clickSemantic("Submit button");
+            service.clickUsingAI("Submit button");
+
+            verify(element, org.mockito.Mockito.times(2)).click("Submit button");
+        }
+    }
+
+    @Test
+    void typeSemanticAndItsDeprecatedAliasDelegateToTheRealDriver() {
+        Actions element = mock(Actions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mockShaftDriver(element);
+        ElementService service = new ElementService(mock(PlaywrightService.class), mock(MobileService.class));
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            service.typeSemantic("Email field", "alice@example.com");
+            service.typeUsingAI("Email field", "alice@example.com");
+
+            verify(element, org.mockito.Mockito.times(2)).type("Email field", "alice@example.com");
+        }
+    }
+
+    @Test
+    void typeSemanticToleratesANullVarargsArray() {
+        Actions element = mock(Actions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mockShaftDriver(element);
+        ElementService service = new ElementService(mock(PlaywrightService.class), mock(MobileService.class));
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            service.typeSemantic("Email field", (CharSequence[]) null);
+
+            verify(element).type("Email field", (CharSequence[]) null);
+        }
+    }
+
+    @Test
+    void webEngineClearDispatchesToElementClear() {
+        Actions element = mock(Actions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mockShaftDriver(element);
+        ElementService service = new ElementService(mock(PlaywrightService.class), mock(MobileService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            ElementActionResult result = service.clear(locatorStrategy.ID, "email");
+
+            verify(element).clear(any(By.class));
+            assertEquals("WEB", result.activeEngine());
+        }
+    }
+
+    @Test
+    void fourArgDragAndDropOverloadForwardsToTheSixArgVersionWithoutAnOffset() {
+        Actions element = mock(Actions.class);
+        SHAFT.GUI.WebDriver shaftDriver = mockShaftDriver(element);
+        ElementService service = new ElementService(mock(PlaywrightService.class), mock(MobileService.class));
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            service.dragAndDrop(locatorStrategy.ID, "source", locatorStrategy.ID, "target");
+
+            verify(element).dragAndDrop(any(By.class), any(By.class));
+        }
+    }
+
+    @Test
+    void domAndCssValueGettersReturnValuesFromTheRealDriver() {
+        Actions element = mock(Actions.class);
+        Actions.GetElementInformation info = mock(Actions.GetElementInformation.class);
+        when(element.get()).thenReturn(info);
+        when(info.domAttribute(any(By.class), anyString())).thenReturn("attr-value");
+        when(info.domProperty(any(By.class), anyString())).thenReturn("prop-value");
+        when(info.cssValue(any(By.class), anyString())).thenReturn("12px");
+        when(info.text(any(By.class))).thenReturn("Hello");
+        SHAFT.GUI.WebDriver shaftDriver = mockShaftDriver(element);
+        ElementService service = new ElementService(mock(PlaywrightService.class), mock(MobileService.class));
+
+        try (MockedStatic<EngineService> mocked = mockStatic(EngineService.class, CALLS_REAL_METHODS)) {
+            mocked.when(EngineService::getDriver).thenReturn(shaftDriver);
+
+            assertEquals("Hello", service.getText(locatorStrategy.ID, "greeting"));
+            assertEquals("attr-value", service.getDomAttribute(locatorStrategy.ID, "el", "data-x"));
+            assertEquals("prop-value", service.getDomProperty(locatorStrategy.ID, "el", "value"));
+            assertEquals("12px", service.getCssValue(locatorStrategy.ID, "el", "font-size"));
+        }
+    }
+
+    @Test
+    void playwrightEngineIsEnabledDispatchesToPlaywrightService() {
+        PlaywrightService playwrightService = mock(PlaywrightService.class);
+        when(playwrightService.isEnabled(locatorStrategy.ID, "banner")).thenReturn(false);
+        ElementService service = new ElementService(playwrightService, mock(MobileService.class));
+        EngineService.setActiveEngine(ActiveEngine.PLAYWRIGHT);
+
+        ElementQueryResult result = service.isEnabled(locatorStrategy.ID, "banner");
+
+        assertEquals("PLAYWRIGHT", result.activeEngine());
+        assertEquals(false, result.value());
+    }
+
+    private static SHAFT.GUI.WebDriver mockShaftDriver(Actions element) {
+        SHAFT.GUI.WebDriver shaftDriver = mock(SHAFT.GUI.WebDriver.class);
+        when(shaftDriver.element()).thenReturn(element);
+        when(shaftDriver.touch()).thenReturn(mock(TouchActions.class));
+        return shaftDriver;
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceDriverInitializeTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceDriverInitializeTest.java
@@ -1,0 +1,110 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * {@code driver_initialize}/{@code driver_quit}'s PLAYWRIGHT-engine dispatch and error paths --
+ * covered here without any real browser, since {@link EngineService}'s package-private constructor
+ * accepts an injectable {@link PlaywrightService} (mirroring the bridge-based pattern in
+ * {@link EngineServiceCaptureBridgeTest}/{@link EngineServiceMobileInitBridgeTest}). The WEB-engine
+ * happy path itself (a real WebDriver launch) is out of scope for a unit test and stays covered by
+ * the {@code external-e2e}-tagged {@link EngineServiceTest}.
+ */
+class EngineServiceDriverInitializeTest {
+
+    @AfterEach
+    void resetActiveEngine() {
+        EngineService.setActiveEngine(null);
+    }
+
+    @Test
+    void initializeDriverDispatchesToPlaywrightServiceWhenEnginePlaywright() {
+        PlaywrightService playwrightService = mock(PlaywrightService.class);
+        EngineService engineService = new EngineService(playwrightService);
+
+        engineService.initializeDriver(BrowserType.CHROME, ActiveEngine.PLAYWRIGHT, null);
+
+        verify(playwrightService).initialize("CHROME", com.shaft.driver.SHAFT.Properties.web.headlessExecution());
+    }
+
+    @Test
+    void initializeDriverPassesNullBrowserNameToPlaywrightServiceWhenTargetBrowserOmitted() {
+        PlaywrightService playwrightService = mock(PlaywrightService.class);
+        EngineService engineService = new EngineService(playwrightService);
+
+        engineService.initializeDriver(null, ActiveEngine.PLAYWRIGHT, null);
+
+        verify(playwrightService).initialize(null, com.shaft.driver.SHAFT.Properties.web.headlessExecution());
+    }
+
+    @Test
+    void initializeDriverThrowsAndLogsWhenTargetBrowserIsNullForTheDefaultWebEngine() {
+        EngineService engineService = new EngineService();
+
+        // engine omitted (null) defaults to WEB; a null targetBrowser fails fast on
+        // `targetBrowser.name()` before any real driver is touched, exercising the catch-log-rethrow
+        // branch without launching a browser.
+        assertThrows(NullPointerException.class, () -> engineService.initializeDriver(null, null, null));
+    }
+
+    /**
+     * Regression for a masking bug found while writing the test above: the catch block's own
+     * diagnostic log line re-evaluated {@code targetBrowser.name()} on the very value already known
+     * to be null, throwing a second NPE from inside the {@code catch} that silently replaced
+     * whatever the try block actually failed with and skipped the log line entirely. The fix logs
+     * {@code targetBrowser} directly (SLF4J's {@code {}} placeholder null-safely stringifies it)
+     * instead of re-deriving its name.
+     */
+    @Test
+    void initializeDriverPropagatesTheOriginalFailureInsteadOfAMaskingNpeFromItsOwnLogging() {
+        EngineService engineService = new EngineService();
+
+        NullPointerException failure = assertThrows(NullPointerException.class,
+                () -> engineService.initializeDriver(null, null, null));
+
+        StackTraceElement topFrame = failure.getStackTrace()[0];
+        assertEquals("com.shaft.mcp.EngineService", topFrame.getClassName());
+        assertEquals("initializeDriver", topFrame.getMethodName());
+        // The masking bug always surfaced at the catch block's own logger.error call; asserting the
+        // failure is NOT attributed there proves it's the original try-block failure propagating.
+        org.junit.jupiter.api.Assertions.assertNotEquals(231, topFrame.getLineNumber(),
+                "exception must propagate from the try block, not get replaced by the catch block's "
+                        + "own logging re-dereferencing the already-null targetBrowser: " + failure);
+    }
+
+    @Test
+    void quitDriverDispatchesToPlaywrightServiceWhenActiveEngineIsPlaywright() {
+        PlaywrightService playwrightService = mock(PlaywrightService.class);
+        EngineService engineService = new EngineService(playwrightService);
+        EngineService.setActiveEngine(ActiveEngine.PLAYWRIGHT);
+
+        engineService.quitDriver();
+
+        verify(playwrightService).quit();
+    }
+
+    @Test
+    void quitDriverResetsActiveEngineToNoneWhenNoDriverIsActive() {
+        EngineService engineService = new EngineService();
+        EngineService.setActiveEngine(ActiveEngine.WEB);
+
+        // No `driver` was ever initialized in this unit test JVM, so this exercises the
+        // `driver == null` branch instead of attempting to quit a real WebDriver.
+        engineService.quitDriver();
+
+        assertThrows(IllegalStateException.class, EngineService::getDriver);
+    }
+
+    @Test
+    void getPageSourceThrowsIllegalStateWhenNoSessionIsActive() {
+        EngineService engineService = new EngineService();
+
+        assertThrows(IllegalStateException.class, engineService::getPageSource);
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceLocatorTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceLocatorTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EngineServiceLocatorTest {
 
@@ -11,5 +12,73 @@ class EngineServiceLocatorTest {
     void idStrategyUsesNativeWebDriverIdLocator() {
         assertEquals(By.id("com.example:id/list").toString(),
                 EngineService.getLocator(locatorStrategy.ID, "com.example:id/list").toString());
+    }
+
+    @Test
+    void cssSelectorStrategyUsesNativeWebDriverCssLocator() {
+        assertEquals(By.cssSelector(".list-item").toString(),
+                EngineService.getLocator(locatorStrategy.CSSSELECTOR, ".list-item").toString());
+    }
+
+    @Test
+    void cssAliasStrategyUsesNativeWebDriverCssLocator() {
+        assertEquals(By.cssSelector(".list-item").toString(),
+                EngineService.getLocator(locatorStrategy.CSS, ".list-item").toString());
+    }
+
+    @Test
+    void selectorAliasStrategyUsesNativeWebDriverCssLocator() {
+        assertEquals(By.cssSelector(".list-item").toString(),
+                EngineService.getLocator(locatorStrategy.SELECTOR, ".list-item").toString());
+    }
+
+    @Test
+    void xpathStrategyUsesNativeWebDriverXpathLocator() {
+        assertEquals(By.xpath("//div").toString(),
+                EngineService.getLocator(locatorStrategy.XPATH, "//div").toString());
+    }
+
+    @Test
+    void androidUiAutomatorStrategyUsesAppiumLocator() {
+        assertEquals(io.appium.java_client.AppiumBy.androidUIAutomator("new UiSelector().text(\"OK\")").toString(),
+                EngineService.getLocator(locatorStrategy.ANDROID_UIAUTOMATOR, "new UiSelector().text(\"OK\")")
+                        .toString());
+    }
+
+    @Test
+    void iosPredicateStrategyUsesAppiumLocator() {
+        assertEquals(io.appium.java_client.AppiumBy.iOSNsPredicateString("type == 'XCUIElementTypeButton'")
+                        .toString(),
+                EngineService.getLocator(locatorStrategy.IOS_PREDICATE, "type == 'XCUIElementTypeButton'")
+                        .toString());
+    }
+
+    @Test
+    void iosClassChainStrategyUsesAppiumLocator() {
+        assertEquals(io.appium.java_client.AppiumBy.iOSClassChain("**/XCUIElementTypeButton").toString(),
+                EngineService.getLocator(locatorStrategy.IOS_CLASS_CHAIN, "**/XCUIElementTypeButton").toString());
+    }
+
+    @Test
+    void nameStrategyBuildsANameAttributeLocator() {
+        By locator = EngineService.getLocator(locatorStrategy.NAME, "email");
+
+        assertTrue(locator.toString().contains("name"), locator.toString());
+        assertTrue(locator.toString().contains("email"), locator.toString());
+    }
+
+    @Test
+    void tagNameStrategyBuildsATagNameLocator() {
+        By locator = EngineService.getLocator(locatorStrategy.TAGNAME, "button");
+
+        assertTrue(locator.toString().contains("button"), locator.toString());
+    }
+
+    @Test
+    void classNameStrategyBuildsAClassAttributeLocator() {
+        By locator = EngineService.getLocator(locatorStrategy.CLASSNAME, "primary-button");
+
+        assertTrue(locator.toString().contains("class"), locator.toString());
+        assertTrue(locator.toString().contains("primary-button"), locator.toString());
     }
 }

--- a/shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceRuntimePathTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/EngineServiceRuntimePathTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EngineServiceRuntimePathTest {
@@ -95,5 +96,21 @@ class EngineServiceRuntimePathTest {
                 System.getProperty("servicesFolderPath"));
         assertTrue(Files.isDirectory(absoluteResults));
         assertTrue(Files.isDirectory(absoluteServices));
+    }
+
+    @Test
+    void configureRuntimePathsWrapsIoExceptionWhenAPathPropertyCollidesWithARegularFile() throws Exception {
+        Path runtimeRoot = temp.resolve("runtime-root");
+        // "downloads" must resolve to a directory, but a same-named regular file already occupies
+        // that path -- Files.createDirectories() then fails with FileAlreadyExistsException, which
+        // configureRuntimePaths wraps into an IllegalStateException naming the offending property.
+        Files.createDirectories(runtimeRoot);
+        Files.writeString(runtimeRoot.resolve("downloads"), "not a directory");
+        System.setProperty("downloadsFolderPath", "downloads");
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class,
+                () -> EngineService.configureRuntimePaths(runtimeRoot));
+
+        assertTrue(failure.getMessage().contains("downloadsFolderPath"), failure.getMessage());
     }
 }

--- a/shaft-mcp/src/test/java/com/shaft/mcp/HealerServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/HealerServiceTest.java
@@ -251,33 +251,27 @@ class HealerServiceTest {
     @Test
     void usesDefaultOutputDirectoryWhenBlank(@TempDir Path tempDir) throws Exception {
         Path repository = fakeRepository(tempDir);
-        var capturedCommand = new Object() { List<String> cmd; };
-        HealerService service = new HealerService(McpWorkspacePolicy.of(tempDir),
-                (command, directory, timeout) -> {
-                    capturedCommand.cmd = command;
-                    writeAllure(directory, "passed", "");
-                    return new HealerService.ProcessResult(0, false, "");
-                });
+        HealerService service = service(tempDir, 1, "failed", "TimeoutException: still waiting");
 
-        service.runFailedTest(repository.toString(), List.of("mvn", "test"),
+        McpHealerRunResult result = service.runFailedTest(repository.toString(), List.of("mvn", "test"),
                 "", 1, false, false, List.of(), false, false, false, false, "driver", null);
-        // Assertion: the test passed (verifying blank outputDirectory was handled)
+
+        Path expectedReport = tempDir.toRealPath().resolve("target/shaft-healer/attempt-1/doctor-report.json");
+        assertEquals(McpHealerRunResult.Status.FAILED_WITH_SUGGESTIONS, result.status());
+        assertEquals(expectedReport.toString(), result.analysis().jsonReportPath());
     }
 
     @Test
     void usesDefaultOutputDirectoryWhenNull(@TempDir Path tempDir) throws Exception {
         Path repository = fakeRepository(tempDir);
-        var capturedCommand = new Object() { List<String> cmd; };
-        HealerService service = new HealerService(McpWorkspacePolicy.of(tempDir),
-                (command, directory, timeout) -> {
-                    capturedCommand.cmd = command;
-                    writeAllure(directory, "passed", "");
-                    return new HealerService.ProcessResult(0, false, "");
-                });
+        HealerService service = service(tempDir, 1, "failed", "TimeoutException: still waiting");
 
-        service.runFailedTest(repository.toString(), List.of("mvn", "test"),
+        McpHealerRunResult result = service.runFailedTest(repository.toString(), List.of("mvn", "test"),
                 null, 1, false, false, List.of(), false, false, false, false, "driver", null);
-        // Assertion: the test passed (verifying null outputDirectory was handled)
+
+        Path expectedReport = tempDir.toRealPath().resolve("target/shaft-healer/attempt-1/doctor-report.json");
+        assertEquals(McpHealerRunResult.Status.FAILED_WITH_SUGGESTIONS, result.status());
+        assertEquals(expectedReport.toString(), result.analysis().jsonReportPath());
     }
 
     @Test

--- a/shaft-mcp/src/test/java/com/shaft/mcp/HealerServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/HealerServiceTest.java
@@ -238,6 +238,336 @@ class HealerServiceTest {
         assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("timed out")));
     }
 
+    @Test
+    void rejectsRepositoryRootAsFile(@TempDir Path tempDir) throws Exception {
+        Path file = Files.createFile(tempDir.resolve("fake-repo"));
+        HealerService service = service();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(file.toString(), List.of("mvn", "test"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void usesDefaultOutputDirectoryWhenBlank(@TempDir Path tempDir) throws Exception {
+        Path repository = fakeRepository(tempDir);
+        var capturedCommand = new Object() { List<String> cmd; };
+        HealerService service = new HealerService(McpWorkspacePolicy.of(tempDir),
+                (command, directory, timeout) -> {
+                    capturedCommand.cmd = command;
+                    writeAllure(directory, "passed", "");
+                    return new HealerService.ProcessResult(0, false, "");
+                });
+
+        service.runFailedTest(repository.toString(), List.of("mvn", "test"),
+                "", 1, false, false, List.of(), false, false, false, false, "driver", null);
+        // Assertion: the test passed (verifying blank outputDirectory was handled)
+    }
+
+    @Test
+    void usesDefaultOutputDirectoryWhenNull(@TempDir Path tempDir) throws Exception {
+        Path repository = fakeRepository(tempDir);
+        var capturedCommand = new Object() { List<String> cmd; };
+        HealerService service = new HealerService(McpWorkspacePolicy.of(tempDir),
+                (command, directory, timeout) -> {
+                    capturedCommand.cmd = command;
+                    writeAllure(directory, "passed", "");
+                    return new HealerService.ProcessResult(0, false, "");
+                });
+
+        service.runFailedTest(repository.toString(), List.of("mvn", "test"),
+                null, 1, false, false, List.of(), false, false, false, false, "driver", null);
+        // Assertion: the test passed (verifying null outputDirectory was handled)
+    }
+
+    @Test
+    void verifyFocusedUsesWorkspaceRootWhenBlank(@TempDir Path tempDir) throws Exception {
+        Path repository = fakeRepository(tempDir);
+        HealerService service = new HealerService(McpWorkspacePolicy.of(tempDir),
+                (command, directory, timeout) -> new HealerService.ProcessResult(0, false, "ok"));
+
+        McpVerificationResult result = service.verifyFocused("", List.of("mvn", "test-compile"), false);
+
+        assertEquals("PASSED", result.status());
+    }
+
+    @Test
+    void verifyFocusedUsesWorkspaceRootWhenNull(@TempDir Path tempDir) throws Exception {
+        Path repository = fakeRepository(tempDir);
+        HealerService service = new HealerService(McpWorkspacePolicy.of(tempDir),
+                (command, directory, timeout) -> new HealerService.ProcessResult(0, false, "ok"));
+
+        McpVerificationResult result = service.verifyFocused(null, List.of("mvn", "test-compile"), false);
+
+        assertEquals("PASSED", result.status());
+    }
+
+    @Test
+    void rejectsEmptyCommand() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of(),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsNullCommand() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), null,
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsNonMavenExecutable() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("gradle", "test"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsAbsolutePathMavenExecutable() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        // Absolute Maven paths (not wrapper) are rejected
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("/usr/bin/mvn", "test"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsLongArguments() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+        String longArg = "x".repeat(2001);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", longArg),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsNullArgumentInCommand() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        // Null in command list causes NPE in validationCommand when accessing string methods
+        assertThrows(Exception.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", null),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsBlankArgument() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", "   "),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsMavenFileSettingsOption() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", "-s", "settings.xml"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsMavenGlobalSettingsOption() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", "-gs", "settings.xml"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsMavenToolchainsOption() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", "-t", "toolchains.xml"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsMavenExtensionClassPathOption() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", "-Dmaven.ext.class.path=/ext"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsMavenMultiModuleProjectDirectoryOption() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", "-Dmaven.multiModuleProjectDirectory=/root"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsReleaseProfile() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", "-Prelease"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsDeployGoal() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "deploy"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsReleaseGoal() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "release:perform"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsScmGoal() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "scm:commit"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsVersionsGoal() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "versions:set"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsHeadlessExecutionNotTrue() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", "-DheadlessExecution=false"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsUnknownMavenGoal() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "unknown:goal"),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void rejectsParentTraversalInProjectSelection() throws Exception {
+        HealerService service = service();
+        Path repository = Files.createDirectories(temp.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.runFailedTest(repository.toString(), List.of("mvn", "test", "-pl", ".."),
+                        "", 1, false, false, List.of(), false, false, false, false, "driver", null));
+    }
+
+    @Test
+    void acceptsProfileArgumentValue(@TempDir Path tempDir) throws Exception {
+        // "-p" takes a profile-name value (previousOptionTakesValue); "myprofile" must NOT be
+        // rejected as an unknown/unallowlisted Maven goal just because it doesn't start with "-".
+        // Uses a real SHAFT-project fixture (not a bare directory) so command/path validation is
+        // the only thing under test -- a bare directory would short-circuit at the earlier
+        // non-SHAFT-project guardrail (a normal GUARDRAIL_STOPPED result, not a validation failure).
+        Path repository = fakeRepository(tempDir);
+        java.util.concurrent.atomic.AtomicReference<List<String>> capturedCommand = new java.util.concurrent.atomic.AtomicReference<>();
+        HealerService service = new HealerService(McpWorkspacePolicy.of(tempDir),
+                (command, directory, timeout) -> {
+                    capturedCommand.set(command);
+                    return new HealerService.ProcessResult(0, false, "no allure evidence");
+                });
+
+        McpHealerRunResult result = service.runFailedTest(
+                repository.toString(), List.of("mvn", "test", "-p", "myprofile"),
+                tempDir.resolve("target/healer").toString(),
+                1, false, false, List.of(), false, false, false, false, "driver", null);
+
+        assertEquals(McpHealerRunResult.Status.GUARDRAIL_STOPPED, result.status());
+        assertTrue(capturedCommand.get().contains("-p"), capturedCommand.get().toString());
+        assertTrue(capturedCommand.get().contains("myprofile"), capturedCommand.get().toString());
+    }
+
+    @Test
+    void addsMissingHeadlessExecutionForTestGoals(@TempDir Path tempDir) throws Exception {
+        Path repository = fakeRepository(tempDir);
+        var capturedCommand = new Object() { List<String> cmd; };
+        HealerService service = new HealerService(McpWorkspacePolicy.of(tempDir),
+                (command, directory, timeout) -> {
+                    capturedCommand.cmd = command;
+                    writeAllure(directory, "passed", "");
+                    return new HealerService.ProcessResult(0, false, "");
+                });
+
+        service.runFailedTest(repository.toString(), List.of("mvn", "test"),
+                tempDir.resolve("target/healer").toString(), 1, false, false, List.of(),
+                false, false, false, false, "driver", null);
+
+        assertTrue(capturedCommand.cmd.contains("-DheadlessExecution=true"),
+                "Headless flag should be added for test goal");
+    }
+
+    @Test
+    void addsOfflineModeWhenNetworkNotApproved(@TempDir Path tempDir) throws Exception {
+        Path repository = fakeRepository(tempDir);
+        var capturedCommand = new Object() { List<String> cmd; };
+        HealerService service = new HealerService(McpWorkspacePolicy.of(tempDir),
+                (command, directory, timeout) -> {
+                    capturedCommand.cmd = command;
+                    writeAllure(directory, "passed", "");
+                    return new HealerService.ProcessResult(0, false, "");
+                });
+
+        service.runFailedTest(repository.toString(), List.of("mvn", "test"),
+                tempDir.resolve("target/healer").toString(), 1, false, false, List.of(),
+                false, false, false, false, "driver", null);
+
+        assertTrue(capturedCommand.cmd.contains("--offline"),
+                "Offline flag should be added when network not approved");
+    }
+
     private HealerService service() {
         return new HealerService(McpWorkspacePolicy.of(temp));
     }

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpDoctorRemediationServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpDoctorRemediationServiceTest.java
@@ -73,6 +73,28 @@ class McpDoctorRemediationServiceTest {
         assertTrue(blocks.stream().noneMatch(block -> block.id().startsWith("fix-prompt-")), blocks.toString());
     }
 
+    @Test
+    void twoArgDeterministicBlocksOverloadDefaultsToWebdriverBackend() {
+        Diagnosis diagnosis = diagnosis(List.of(rankedCause(CauseCategory.LOCATOR, 88, "Locator fix prompt body.")));
+
+        List<McpCodeBlock> viaTwoArgOverload = service.deterministicBlocks(diagnosis, "driver");
+        List<McpCodeBlock> viaExplicitWebdriver =
+                service.deterministicBlocks(diagnosis, "driver", CodegenBackend.WEBDRIVER);
+
+        assertEquals(viaExplicitWebdriver, viaTwoArgOverload);
+    }
+
+    @Test
+    void nullBackendDefaultsToWebdriverInTheThreeArgOverload() {
+        Diagnosis diagnosis = diagnosis(List.of(rankedCause(CauseCategory.LOCATOR, 88, "Locator fix prompt body.")));
+
+        List<McpCodeBlock> viaNullBackend = service.deterministicBlocks(diagnosis, "driver", null);
+        List<McpCodeBlock> viaExplicitWebdriver =
+                service.deterministicBlocks(diagnosis, "driver", CodegenBackend.WEBDRIVER);
+
+        assertEquals(viaExplicitWebdriver, viaNullBackend);
+    }
+
     private static RankedCause rankedCause(CauseCategory category, int trust, String fixPrompt) {
         return new RankedCause(
                 category,

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileInitOptionsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpMobileInitOptionsTest.java
@@ -1,0 +1,176 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * {@link McpMobileInitOptions} coerces every optional field to a safe default (blank string, zero,
+ * {@code false}) before forwarding to {@link MobileService}'s real initializers (design doc
+ * amendment A9). {@link MobileService#initializeWebEmulation}/{@code initializeNative} themselves
+ * launch a real WebDriver/Appium session, so this test overrides them on a subclass instead of
+ * calling the real ones -- proving only the coercion/forwarding this class is responsible for,
+ * without needing a live browser or device.
+ */
+class McpMobileInitOptionsTest {
+
+    @AfterEach
+    void unregisterBridge() {
+        EngineService.registerMobileInitBridge(null);
+    }
+
+    @Test
+    void initializeWebEmulationCoercesAllNullOrUnsetFieldsToSafeDefaults() {
+        RecordingMobileService mobileService = new RecordingMobileService();
+        McpMobileInitOptions allUnset = new McpMobileInitOptions(
+                null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null);
+
+        allUnset.initializeWebEmulation(mobileService);
+
+        assertEquals("", mobileService.targetUrl);
+        assertEquals("", mobileService.browser);
+        assertEquals("", mobileService.deviceName);
+        assertEquals(0, mobileService.width);
+        assertEquals(0, mobileService.height);
+        assertEquals(0.0, mobileService.pixelRatio);
+        assertEquals("", mobileService.userAgent);
+        assertFalse(mobileService.headless);
+    }
+
+    @Test
+    void initializeWebEmulationForwardsExplicitValuesUnchanged() {
+        RecordingMobileService mobileService = new RecordingMobileService();
+        McpMobileInitOptions explicit = new McpMobileInitOptions(
+                "https://example.com", "EDGE", "Galaxy S22", 400, 800, 2.5, "custom-agent", true,
+                null, null, null, null, null, null, null, null, null);
+
+        explicit.initializeWebEmulation(mobileService);
+
+        assertEquals("https://example.com", mobileService.targetUrl);
+        assertEquals("EDGE", mobileService.browser);
+        assertEquals("Galaxy S22", mobileService.deviceName);
+        assertEquals(400, mobileService.width);
+        assertEquals(800, mobileService.height);
+        assertEquals(2.5, mobileService.pixelRatio);
+        assertEquals("custom-agent", mobileService.userAgent);
+        assertEquals(true, mobileService.headless);
+    }
+
+    @Test
+    void initializeNativeCoercesAllNullFieldsToSafeDefaults() {
+        RecordingMobileService mobileService = new RecordingMobileService();
+        McpMobileInitOptions allUnset = new McpMobileInitOptions(
+                null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null);
+
+        allUnset.initializeNative(mobileService);
+
+        assertEquals("", mobileService.platformName);
+        assertEquals("", mobileService.deviceName);
+        assertEquals("", mobileService.appiumServerUrl);
+        assertEquals("", mobileService.automationName);
+        assertEquals("", mobileService.platformVersion);
+        assertEquals("", mobileService.udid);
+        assertEquals("", mobileService.app);
+        assertEquals("", mobileService.appPackage);
+        assertEquals("", mobileService.appActivity);
+        assertEquals("", mobileService.bundleId);
+    }
+
+    @Test
+    void initializeNativeForwardsExplicitValuesUnchanged() {
+        RecordingMobileService mobileService = new RecordingMobileService();
+        McpMobileInitOptions explicit = new McpMobileInitOptions(
+                null, null, "Pixel 7", null, null, null, null, null,
+                "Android", "http://localhost:4723", "UiAutomator2", "14", "udid-1",
+                "/path/app.apk", "com.example", ".MainActivity", null);
+
+        explicit.initializeNative(mobileService);
+
+        assertEquals("Android", mobileService.platformName);
+        assertEquals("Pixel 7", mobileService.deviceName);
+        assertEquals("http://localhost:4723", mobileService.appiumServerUrl);
+        assertEquals("UiAutomator2", mobileService.automationName);
+        assertEquals("14", mobileService.platformVersion);
+        assertEquals("udid-1", mobileService.udid);
+        assertEquals("/path/app.apk", mobileService.app);
+        assertEquals("com.example", mobileService.appPackage);
+        assertEquals(".MainActivity", mobileService.appActivity);
+        assertEquals("", mobileService.bundleId);
+    }
+
+    @Test
+    void emptyConstantHasEveryFieldUnset() {
+        assertEquals(null, McpMobileInitOptions.EMPTY.targetUrl());
+        assertEquals(null, McpMobileInitOptions.EMPTY.browser());
+        assertEquals(null, McpMobileInitOptions.EMPTY.platformName());
+        assertEquals(null, McpMobileInitOptions.EMPTY.headless());
+    }
+
+    /**
+     * Overrides the two package-private initializers so no real WebDriver/Appium session is ever
+     * launched; just captures the coerced arguments {@link McpMobileInitOptions} forwarded.
+     */
+    private static final class RecordingMobileService extends MobileService {
+        String targetUrl;
+        String browser;
+        String deviceName;
+        int width;
+        int height;
+        double pixelRatio;
+        String userAgent;
+        boolean headless;
+        String platformName;
+        String appiumServerUrl;
+        String automationName;
+        String platformVersion;
+        String udid;
+        String app;
+        String appPackage;
+        String appActivity;
+        String bundleId;
+
+        RecordingMobileService() {
+            super(new EngineService());
+        }
+
+        @Override
+        McpMobileSessionResult initializeWebEmulation(
+                String targetUrl, String browser, String deviceName, int width, int height,
+                double pixelRatio, String userAgent, boolean headless) {
+            this.targetUrl = targetUrl;
+            this.browser = browser;
+            this.deviceName = deviceName;
+            this.width = width;
+            this.height = height;
+            this.pixelRatio = pixelRatio;
+            this.userAgent = userAgent;
+            this.headless = headless;
+            return new McpMobileSessionResult("web-emulation", "", deviceName, browser, true, List.of(), List.of());
+        }
+
+        @Override
+        McpMobileSessionResult initializeNative(
+                String platformName, String deviceName, String appiumServerUrl, String automationName,
+                String platformVersion, String udid, String app, String appPackage, String appActivity,
+                String bundleId) {
+            this.platformName = platformName;
+            this.deviceName = deviceName;
+            this.appiumServerUrl = appiumServerUrl;
+            this.automationName = automationName;
+            this.platformVersion = platformVersion;
+            this.udid = udid;
+            this.app = app;
+            this.appPackage = appPackage;
+            this.appActivity = appActivity;
+            this.bundleId = bundleId;
+            return new McpMobileSessionResult("native", platformName, deviceName, "", true, List.of(), List.of());
+        }
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpResultRecordsTest.java
@@ -99,6 +99,24 @@ class McpResultRecordsTest {
     }
 
     @Test
+    void captureUnionStatusNormalizesNullEngineToWebButKeepsExplicitEngine() {
+        McpCaptureUnionStatus defaulted = new McpCaptureUnionStatus(null, null, null, null);
+        McpCaptureUnionStatus explicit = new McpCaptureUnionStatus(ActiveEngine.PLAYWRIGHT, null, null, null);
+
+        assertEquals(ActiveEngine.WEB, defaulted.engine());
+        assertEquals(ActiveEngine.PLAYWRIGHT, explicit.engine());
+    }
+
+    @Test
+    void captureApiUnionStatusNormalizesNullEngineToWebButKeepsExplicitEngine() {
+        McpCaptureApiUnionStatus defaulted = new McpCaptureApiUnionStatus(null, null, null);
+        McpCaptureApiUnionStatus explicit = new McpCaptureApiUnionStatus(ActiveEngine.MOBILE_NATIVE, null, null);
+
+        assertEquals(ActiveEngine.WEB, defaulted.engine());
+        assertEquals(ActiveEngine.MOBILE_NATIVE, explicit.engine());
+    }
+
+    @Test
     void workspacePolicyResolvesOutputsListsAndSourceAllowlist() throws Exception {
         Path root = Files.createDirectories(temp.resolve("workspace"));
         Path repository = Files.createDirectories(root.resolve("repo"));

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
@@ -229,6 +229,47 @@ class ShaftMcpApplicationTests {
         assertTrue(argsFileContent.contains(com.shaft.capture.cli.CaptureCli.class.getName()));
     }
 
+    /**
+     * When the current process was itself launched with {@code -jar some.jar}, the relaunch prefix
+     * reuses that exact jar instead of falling through to the classpath-based branches -- this is
+     * the branch a real {@code -jar}-launched JVM (a packaged shaft-mcp release) takes, which
+     * {@link #captureLaunchPrefixBuildsRunnableCaptureCommand} cannot reliably exercise since
+     * {@code ProcessHandle.info().arguments()} often comes back empty on this OS/JDK.
+     */
+    @Test
+    void captureLaunchPrefixReusesTheDashJarArgumentWhenThisProcessWasJarLaunched() throws Exception {
+        Method method = ShaftMcpApplication.class.getDeclaredMethod(
+                "captureLaunchPrefix", String[].class, String.class);
+        method.setAccessible(true);
+
+        String[] processArguments = {"-Xmx512m", "-jar", "shaft-mcp-launcher.jar", "--server"};
+
+        @SuppressWarnings("unchecked")
+        List<String> prefix = (List<String>) method.invoke(null, processArguments, "ignored-classpath.jar");
+
+        assertEquals(List.of(prefix.get(0), "-jar", "shaft-mcp-launcher.jar", "capture"), prefix);
+    }
+
+    /**
+     * When this JVM's own classpath is a single {@code .jar} file (the shape Surefire's
+     * manifest-only booter jar can also produce), the relaunch prefix reuses that jar directly
+     * instead of falling through to the {@code @argfile} branch.
+     */
+    @Test
+    void captureLaunchPrefixReusesASingleJarClasspathEntry(@org.junit.jupiter.api.io.TempDir Path tempDir)
+            throws Exception {
+        Method method = ShaftMcpApplication.class.getDeclaredMethod(
+                "captureLaunchPrefix", String[].class, String.class);
+        method.setAccessible(true);
+
+        Path jar = Files.createFile(tempDir.resolve("single-entry.jar"));
+
+        @SuppressWarnings("unchecked")
+        List<String> prefix = (List<String>) method.invoke(null, new String[0], jar.toString());
+
+        assertEquals(List.of(prefix.get(0), "-jar", jar.toString(), "capture"), prefix);
+    }
+
     @Test
     void absoluteClassPathNormalizesRelativeEntries() throws Exception {
         Method method = ShaftMcpApplication.class.getDeclaredMethod("absoluteClassPath", String.class);

--- a/shaft-mcp/src/test/java/com/shaft/mcp/TraceServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/TraceServiceTest.java
@@ -493,7 +493,11 @@ class TraceServiceTest {
         var analysis = service(temp).doctorAnalyzeTrace(relative(temp, index), "webdriver");
 
         assertFalse(analysis.diagnosis().summary().isBlank(), "Diagnosis summary should be populated");
-        assertTrue(analysis.primaryCause() != null, "Should return a detected cause category");
+        // The fixture's locator value ("custom-locator") itself contains the substring "locator",
+        // which TraceService#cause matches before it ever inspects the TimeoutException, so the
+        // deterministic cause is LOCATOR rather than TIMING_SYNCHRONIZATION.
+        assertEquals(CauseCategory.LOCATOR, analysis.primaryCause(),
+                "custom-locator's locator value should deterministically classify as LOCATOR");
     }
 
     @Test

--- a/shaft-mcp/src/test/java/com/shaft/mcp/TraceServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/TraceServiceTest.java
@@ -218,6 +218,452 @@ class TraceServiceTest {
         assertTrue(result.warnings().stream().anyMatch(w -> w.contains("does not contain")));
     }
 
+    @Test
+    void traceLatestHandlesZeroMaxResultsWithDefault(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "test-one", traceJson("\"actions\": [], \"network\": [], \"console\": []"));
+        Path index2 = writeTrace(temp, "test-two", traceJson("\"actions\": [], \"network\": [], \"console\": []"));
+        Path index3 = writeTrace(temp, "test-three", traceJson("\"actions\": [], \"network\": [], \"console\": []"));
+
+        var latest = service(temp).traceLatest(0);
+
+        assertEquals(3, latest.traces().size(), "Zero maxResults should use DEFAULT_LATEST_LIMIT and still return all");
+    }
+
+    @Test
+    void traceLatestCapedAtMaxLimit(@TempDir Path temp) throws Exception {
+        for (int i = 0; i < 60; i++) {
+            writeTrace(temp, "test-" + i, traceJson("\"actions\": [], \"network\": [], \"console\": []"));
+        }
+
+        var latest = service(temp).traceLatest(100);
+
+        assertTrue(latest.traces().size() <= 50, "Should cap at MAX_LATEST_LIMIT of 50");
+    }
+
+    @Test
+    void traceReadDefaultsMaxCharactersWhenZero(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "test-chars", traceJson(
+                "\"actions\": [], \"network\": [], \"console\": [], " +
+                "\"padding\": \"" + "x".repeat(25_000) + "\""));
+
+        var result = service(temp).traceRead(relative(temp, index), 0);
+
+        assertTrue(result.content().length() <= 20_000, "Zero maxCharacters should use DEFAULT_MAX_CHARACTERS");
+    }
+
+    @Test
+    void traceReadCapedAtMaxCharacters(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "test-max", traceJson(
+                "\"actions\": [], \"network\": [], \"console\": [], " +
+                "\"padding\": \"" + "x".repeat(150_000) + "\""));
+
+        var result = service(temp).traceRead(relative(temp, index), 150_000);
+
+        assertTrue(result.content().length() <= 100_000, "Should cap at MAX_CHARACTERS");
+        assertTrue(result.truncated());
+    }
+
+    @Test
+    void traceReadNoTruncationWhenContentShorterThanLimit(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "test-short", traceJson("\"actions\": [], \"network\": [], \"console\": []"));
+
+        var result = service(temp).traceRead(relative(temp, index), 50_000);
+
+        assertFalse(result.truncated());
+    }
+
+    @Test
+    void traceOpenViewerHandlesZipWithoutShaftTraceJson(@TempDir Path temp) throws Exception {
+        Path directory = Files.createDirectories(temp.resolve("target/shaft-traces/no-trace"));
+        Path archive = directory.resolve("shaft-trace.zip");
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(archive))) {
+            zip.putNextEntry(new ZipEntry("other.txt"));
+            zip.write("content".getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
+        Path index = directory.resolve("index.json");
+        Files.writeString(index, """
+                {
+                  "testId": "no-trace",
+                  "generatedAt": "2026-06-26T10:00:00Z",
+                  "archive": "%s",
+                  "entries": {}
+                }
+                """.formatted(relative(temp, archive)), StandardCharsets.UTF_8);
+
+        var result = service(temp).traceOpenViewer(relative(temp, index));
+
+        assertTrue(result.viewerPath().isBlank());
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("does not contain")));
+    }
+
+    @Test
+    void traceFromDirectoryFailsWhenNoValidTraceFound(@TempDir Path temp) throws Exception {
+        Path directory = Files.createDirectories(temp.resolve("target/shaft-traces/empty"));
+
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> service(temp).traceSummarize(relative(temp, directory)));
+
+        assertTrue(failure.getMessage().contains("does not contain"));
+    }
+
+    @Test
+    void failedActionReturnsFirstWhenAllActionsPassed(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "all-passed", traceJson("""
+                "actions": [
+                  {"id": "action-1", "category": "browser", "name": "NAVIGATE", "status": "passed",
+                   "locator": "", "url": "https://example.com", "message": "Opened",
+                   "exception": {"type": "", "message": ""}, "attachments": [], "metadata": {}, "durationMs": 10},
+                  {"id": "action-2", "category": "element", "name": "CLICK", "status": "passed",
+                   "locator": "By.id: submit", "url": "https://example.com", "message": "Clicked",
+                   "exception": {"type": "", "message": ""}, "attachments": [], "metadata": {}, "durationMs": 20}
+                ]
+                """));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertEquals("NAVIGATE", summary.failedAction().name(), "Should return first action when all passed");
+    }
+
+    @Test
+    void failedActionReturnsEmptyObjectWhenNoActionsArray(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "no-actions-array", traceJson("""
+                "actions": "not-an-array"
+                """));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertTrue(summary.failedAction().id().isBlank(), "Should return empty action when actions is not an array");
+    }
+
+    @Test
+    void failedActionReturnsEmptyObjectWhenActionsEmpty(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "empty-actions", traceJson("""
+                "actions": []
+                """));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertTrue(summary.failedAction().id().isBlank(), "Should return empty action when actions array is empty");
+    }
+
+    @Test
+    void networkFindingsFiltersStatusCodesAndFailureReasons(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "network-test", traceJson("""
+                "actions": [],
+                "network": [
+                  {"url": "https://example.com/ok", "status": 200, "method": "GET"},
+                  {"url": "https://example.com/bad", "status": 404, "method": "GET"},
+                  {"url": "https://example.com/error", "status": 500, "method": "POST"},
+                  {"url": "https://example.com/failed", "status": 0, "method": "GET", "failureReason": "net::ERR_FAILED"},
+                  {"url": "https://example.com/timeout", "status": -1, "method": "GET"}
+                ],
+                "console": []
+                """));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertEquals(4, summary.networkFindings().size(), "Should include status codes >= 400, <= 0, and any with failureReason");
+        assertTrue(summary.networkFindings().stream().anyMatch(f -> f.contains("404")));
+        assertTrue(summary.networkFindings().stream().anyMatch(f -> f.contains("500")));
+        assertTrue(summary.networkFindings().stream().anyMatch(f -> f.contains("net::ERR_FAILED")));
+    }
+
+    @Test
+    void networkFindingsTruncatesAtMaxFindings(@TempDir Path temp) throws Exception {
+        StringBuilder network = new StringBuilder("\"actions\": [], \"network\": [");
+        for (int i = 0; i < 15; i++) {
+            if (i > 0) network.append(",");
+            network.append("{\"url\": \"https://example.com/").append(i).append("\", \"status\": 500, \"method\": \"GET\"}");
+        }
+        network.append("], \"console\": []");
+
+        Path index = writeTrace(temp, "network-max", traceJson(network.toString()));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertEquals(10, summary.networkFindings().size(), "Should truncate at MAX_FINDINGS (10)");
+    }
+
+    @Test
+    void consoleFindingsTruncatesAtMaxFindings(@TempDir Path temp) throws Exception {
+        StringBuilder console = new StringBuilder("\"actions\": [], \"network\": [], \"console\": [");
+        for (int i = 0; i < 15; i++) {
+            if (i > 0) console.append(",");
+            console.append("{\"level\": \"ERROR\", \"message\": \"Error ").append(i).append("\"}");
+        }
+        console.append("]");
+
+        Path index = writeTrace(temp, "console-max", traceJson(console.toString()));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertEquals(10, summary.consoleFindings().size(), "Should truncate at MAX_FINDINGS (10)");
+    }
+
+    @Test
+    void redactionRemovesAuthorizationHeaders(@TempDir Path temp) throws Exception {
+        String authContent = "Authorization: Bearer secret-token-123";
+        Path index = writeTrace(temp, "auth-test", traceJson(
+                "\"actions\": [], \"network\": [], \"console\": [], \"timeline\": [\"" + authContent + "\"]"));
+
+        var result = service(temp).traceRead(relative(temp, index), 100_000);
+
+        assertFalse(result.content().contains("secret-token-123"), "Authorization tokens should be redacted");
+        assertTrue(result.content().contains("********"), "Redacted content should show mask");
+    }
+
+    @Test
+    void redactionRemovesCookies(@TempDir Path temp) throws Exception {
+        String cookieContent = "Set-Cookie: sessionid=abc123xyz789";
+        Path index = writeTrace(temp, "cookie-test", traceJson(
+                "\"actions\": [], \"network\": [], \"console\": [], \"timeline\": [\"" + cookieContent + "\"]"));
+
+        var result = service(temp).traceRead(relative(temp, index), 100_000);
+
+        assertFalse(result.content().contains("abc123xyz789"), "Cookie values should be redacted");
+        assertTrue(result.content().contains("********"), "Redacted content should show mask");
+    }
+
+    @Test
+    void redactionRemovesAssignmentSecrets(@TempDir Path temp) throws Exception {
+        String secretContent = "password=super-secret-123 api_key=key-456 token=tok-789";
+        Path index = writeTrace(temp, "assignment-secret-test", traceJson(
+                "\"actions\": [], \"network\": [], \"console\": [], \"timeline\": [\"" + secretContent + "\"]"));
+
+        var result = service(temp).traceRead(relative(temp, index), 100_000);
+
+        assertFalse(result.content().contains("super-secret-123"), "Assignment secrets should be redacted");
+        assertFalse(result.content().contains("key-456"), "Assignment API keys should be redacted");
+        assertFalse(result.content().contains("tok-789"), "Assignment tokens should be redacted");
+    }
+
+    @Test
+    void mergeSharesWithEmptyOutputDirectory(@TempDir Path temp) throws Exception {
+        Path shard = Files.createDirectories(temp.resolve("test-shard/allure-results"));
+        Files.writeString(shard.resolve("result.json"),
+                "{\"fullName\":\"com.test.Test.sample\",\"status\":\"passed\",\"start\":0,\"stop\":100}",
+                StandardCharsets.UTF_8);
+
+        var result = service(temp).reportMergeShards(java.util.List.of("test-shard"), "");
+
+        assertTrue(result.mergedAllureResultsDirectory().contains("shaft-merged-report"),
+                "Empty outputDirectory should default to target/shaft-merged-report");
+    }
+
+    @Test
+    void traceSummarizeHandlesMissingNetworkAndConsoleArrays(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "missing-arrays", traceJson("""
+                "actions": [],
+                "network": "not-an-array",
+                "console": null
+                """));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertTrue(summary.networkFindings().isEmpty(), "Should handle non-array network");
+        assertTrue(summary.consoleFindings().isEmpty(), "Should handle null console");
+    }
+
+    @Test
+    void traceReadRedactsCredentialsInUrls(@TempDir Path temp) throws Exception {
+        String urlWithCreds = "https://user:password@example.com/api";
+        Path index = writeTrace(temp, "url-creds", traceJson(
+                "\"actions\": [], \"network\": [], \"console\": [], \"timeline\": [\"" + urlWithCreds + "\"]"));
+
+        var result = service(temp).traceRead(relative(temp, index), 100_000);
+
+        assertFalse(result.content().contains(":password@"), "URL credentials should be redacted");
+        assertTrue(result.content().contains("********"), "Credentials should show mask");
+    }
+
+    @Test
+    void doctorAnalyzeTraceReturnsAnalysisWithValidCause(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "timeout-fail", traceJson("""
+                "actions": [
+                  {"id": "action-1", "category": "element", "name": "CLICK", "status": "failed",
+                   "locator": "custom-locator", "url": "https://example.com", "message": "Click timed out",
+                   "exception": {"type": "org.openqa.selenium.TimeoutException", "message": "Timed out waiting"},
+                   "attachments": [], "metadata": {}, "durationMs": 5000}
+                ],
+                "network": [],
+                "console": []
+                """));
+
+        var analysis = service(temp).doctorAnalyzeTrace(relative(temp, index), "webdriver");
+
+        assertFalse(analysis.diagnosis().summary().isBlank(), "Diagnosis summary should be populated");
+        assertTrue(analysis.primaryCause() != null, "Should return a detected cause category");
+    }
+
+    @Test
+    void doctorAnalyzeTraceDetectsUnknownIssues(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "unknown-fail", traceJson("""
+                "actions": [
+                  {"id": "action-1", "category": "custom", "name": "CUSTOM_ACTION", "status": "failed",
+                   "locator": "", "url": "https://example.com", "message": "Unknown error occurred",
+                   "exception": {"type": "java.lang.RuntimeException", "message": "Something unexpected"},
+                   "attachments": [], "metadata": {}, "durationMs": 100}
+                ],
+                "network": [],
+                "console": []
+                """));
+
+        var analysis = service(temp).doctorAnalyzeTrace(relative(temp, index), null);
+
+        assertEquals(CauseCategory.UNKNOWN, analysis.primaryCause(),
+                "Should default to UNKNOWN for unrecognized patterns");
+    }
+
+    @Test
+    void doctorAnalyzeTraceDetectsAssertionIssues(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "assert-fail", traceJson("""
+                "actions": [
+                  {"id": "action-1", "category": "assertion", "name": "ASSERT", "status": "failed",
+                   "locator": "", "url": "https://example.com", "message": "Assertion failed",
+                   "exception": {"type": "java.lang.AssertionError", "message": "Expected true but was false"},
+                   "attachments": [], "metadata": {}, "durationMs": 50}
+                ],
+                "network": [],
+                "console": []
+                """));
+
+        var analysis = service(temp).doctorAnalyzeTrace(relative(temp, index), null);
+
+        assertEquals(CauseCategory.TEST, analysis.primaryCause(),
+                "Should detect test/assertion failures");
+    }
+
+    @Test
+    void traceFromDirectoryFallbackThroughArchiveAndIndex(@TempDir Path temp) throws Exception {
+        Path directory = Files.createDirectories(temp.resolve("target/shaft-traces/fallback"));
+        Path archive = directory.resolve("shaft-trace.zip");
+        writeZip(archive, traceJson("\"actions\": [], \"network\": [], \"console\": []"));
+        // No index.json, no shaft-trace.json, only archive exists
+        // Should find and use shaft-trace.zip via fallback
+
+        var summary = service(temp).traceSummarize(relative(temp, directory));
+
+        assertEquals("CheckoutTest", summary.testClass(), "Should load from archive fallback");
+    }
+
+    @Test
+    void traceLatestSkipsUnreadableIndexes(@TempDir Path temp) throws Exception {
+        Path tracesDir = Files.createDirectories(temp.resolve("target/shaft-traces"));
+        Path validIndex = writeTrace(temp, "valid", traceJson("\"actions\": [], \"network\": [], \"console\": []"));
+
+        Path badDir = Files.createDirectories(tracesDir.resolve("bad-index"));
+        Path badIndex = badDir.resolve("index.json");
+        Files.writeString(badIndex, "{ invalid json content", StandardCharsets.UTF_8);
+
+        var latest = service(temp).traceLatest(10);
+
+        assertEquals(1, latest.traces().size(), "Should skip unreadable indexes and return only valid ones");
+        assertTrue(latest.warnings().stream().anyMatch(w -> w.contains("Could not read")),
+                "Should warn about unreadable index");
+    }
+
+    @Test
+    void openViewerDoesNotExtractWhenHtmlAlreadyExists(@TempDir Path temp) throws Exception {
+        Path index = writeTraceWithHtml(temp, "already-extracted",
+                traceJson("\"actions\": [], \"network\": [], \"console\": []"),
+                "<html><body>Original</body></html>");
+        Path directory = index.getParent();
+        Path htmlPath = directory.resolve("SHAFT Trace Report.html");
+
+        var result1 = service(temp).traceOpenViewer(relative(temp, index));
+        assertTrue(result1.extracted(), "First call should extract");
+
+        // Verify it exists and update it
+        assertTrue(Files.isRegularFile(htmlPath));
+        Files.writeString(htmlPath, "<html><body>Modified</body></html>", StandardCharsets.UTF_8);
+
+        // Second call should not re-extract
+        var result2 = service(temp).traceOpenViewer(relative(temp, index));
+        assertFalse(result2.extracted(), "Second call should reuse existing");
+        assertTrue(Files.readString(temp.resolve(result2.viewerPath())).contains("Modified"),
+                "Should keep the modified HTML");
+    }
+
+    @Test
+    void traceSummarizeExtractsEmptyExceptionFromAction(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "no-exception", traceJson("""
+                "actions": [
+                  {"id": "a1", "category": "browser", "name": "NAVIGATE", "status": "passed",
+                   "locator": "", "url": "https://example.com", "message": "OK",
+                   "exception": {"type": "", "message": ""}, "attachments": [], "metadata": {}, "durationMs": 10}
+                ]
+                """));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertTrue(summary.failedAction().exceptionType().isBlank(), "Should handle empty exception type");
+        assertTrue(summary.failedAction().exceptionMessage().isBlank(), "Should handle empty exception message");
+    }
+
+    @Test
+    void traceSummarizeExtractsDurationMs(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "duration-test", traceJson("""
+                "actions": [
+                  {"id": "a1", "category": "element", "name": "CLICK", "status": "failed",
+                   "locator": "By.id: button", "url": "https://example.com", "message": "Fail",
+                   "exception": {"type": "Exception", "message": "Error"}, "attachments": [], "metadata": {}, "durationMs": 3500}
+                ]
+                """));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertEquals(3500L, summary.failedAction().durationMs(), "Should extract duration correctly");
+    }
+
+    @Test
+    void networkFindingsIncludesFailureReason(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "network-reason", traceJson("""
+                "actions": [],
+                "network": [
+                  {"url": "https://api.example.com/data", "status": 0, "method": "GET", "failureReason": "net::ERR_BLOCKED_BY_CLIENT"}
+                ],
+                "console": []
+                """));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertEquals(1, summary.networkFindings().size());
+        assertTrue(summary.networkFindings().getFirst().contains("net::ERR_BLOCKED_BY_CLIENT"),
+                "Should include network failure reason in findings");
+    }
+
+    @Test
+    void consoleFindingsIncludesLevelAndMessage(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "console-detail", traceJson("""
+                "actions": [],
+                "network": [],
+                "console": [
+                  {"level": "WARNING", "message": "Deprecation warning"}
+                ]
+                """));
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertEquals(1, summary.consoleFindings().size());
+        assertTrue(summary.consoleFindings().getFirst().contains("WARNING"));
+        assertTrue(summary.consoleFindings().getFirst().contains("Deprecation warning"),
+                "Should include both level and message");
+    }
+
+    @Test
+    void traceReadIncludesWarningsWhenTruncated(@TempDir Path temp) throws Exception {
+        Path index = writeTrace(temp, "test-truncated", traceJson(
+                "\"actions\": [], \"network\": [], \"console\": [], " +
+                "\"padding\": \"" + "x".repeat(25_000) + "\""));
+
+        var result = service(temp).traceRead(relative(temp, index), 1000);
+
+        assertTrue(result.truncated());
+        assertTrue(result.warnings().stream().anyMatch(w -> w.contains("truncated")),
+                "Should include truncation warning");
+    }
+
     private static TraceService service(Path root) {
         return new TraceService(McpWorkspacePolicy.of(root), new McpDoctorRemediationService());
     }


### PR DESCRIPTION
## Summary

Owner-owed coverage pass on the tool-architecture sweep merged as PR #3881 (squash commit `d0fcaf9662`). Measured a **real JaCoCo baseline** (never estimated) for every new/changed production class under `shaft-mcp/src/main/java` and `shaft-cli/src/main/java`, then added focused, behavior-asserting tests for everything below 80% line coverage that was safely testable without a live browser/device/subprocess. `shaft-intellij` is out of scope (tracked separately in PR #3882).

## Measurement note

`shaft-cli`'s JaCoCo agent was **silently never attaching** during `mvn test`: the module's own `<argLine>${surefireArgLine}</argLine>` surefire override disconnects it from the parent pom's `jacoco:prepare-agent`, which writes to the (different) `argLine` property. Measured via a CLI-only `-DsurefireArgLine=...` override embedding the javaagent directly — no pom changes. Filed as #3885 with the real fix suggested (`@{argLine} ${surefireArgLine}`).

## Coverage table (JaCoCo-measured, before → after)

### shaft-mcp

| Class | Before (lines) | After (lines) | Notes |
|---|---|---|---|
| ActiveEngine | 100.0% | 100.0% | enum, already full |
| BrowserService | 78.8% | **88.5%** | WEB-engine cookie/DOM/screenshot/storage-state paths |
| CaptureService | 87.0% | 87.0% | already ≥80% |
| ClickMode | 100.0% | 100.0% | already full |
| CodingPartnerService | 88.5% | 88.5% | already ≥80% |
| DoctorService | 82.1% | 82.1% | already ≥80% |
| ElementActionResult | 100.0% | 100.0% | already full |
| ElementQueryResult | 100.0% | 100.0% | already full |
| ElementService | 79.6% | **100.0%** | convenience overloads, semantic aliases, WEB clear/drag-drop, DOM/CSS getters, Playwright isEnabled |
| EngineService | 56.0% | **70.1%** | raised to practical ceiling — see Exclusions |
| HealerService | 77.6% | **86.0%** | validationCommand rejection branches, verifyFocused paths |
| McpCaptureApiUnionStatus | 100.0% (branch 50%) | 100.0% (branch **100%**) | null-engine normalization |
| McpCaptureUnionStatus | 100.0% (branch 50%) | 100.0% (branch **100%**) | null-engine normalization |
| McpDoctorRemediationService | 79.8% | **81.6%** | 2-arg overload + null-backend default |
| McpMobileInitOptions | 15.4% | **100.0%** | all coercion helpers + initializer forwarding |
| McpMobileRecordingStatus | 100.0% | 100.0% | already full |
| McpNetworkTransaction(Detail/List) | 100.0% | 100.0% | already full |
| MobileService | 95.5% | 95.5% | already ≥80% |
| PlaywrightService | 86.3% | 86.3% | already ≥80% |
| ShaftMcpApplication | 72.4% | **78.9%** | raised to practical ceiling — see Exclusions |
| TestAutomationService | 96.4% | 96.4% | already ≥80% |
| TraceService | 78.5% | **87.5%** | edge cases, redaction, network/console findings, doctor analysis |
| WindowSizeMode | 100.0% | 100.0% | already full |

### shaft-cli

| Class | Before (lines) | After (lines) | Notes |
|---|---|---|---|
| ShaftCli | 0.0% | 14.3% (class) / **100%** (nested `ManifestVersionProvider`) | raised to practical ceiling — see Exclusions |
| CaptureCommand | 75.0% | **100.0%** | unknown-action exit-2 path + default constructor |
| CodegenCommand | 81.8% | 81.8% | already ≥80% |
| ToolsCommand | 64.8% | **79.6%** | raised to practical ceiling — see Exclusions |
| CaptureDelegate | N/A (0 lines) | N/A | pure `@FunctionalInterface`, no executable lines |

Full-module test results: `shaft-mcp` 471/471 passed, `shaft-cli` 64/64 passed (both headless, `-DheadlessExecution=true -Dallure.automaticallyOpen=false`).

## Exclusions (documented, not faked)

- **EngineService** (70.1%, ceiling): remaining lines require a real `SHAFT.GUI.WebDriver` browser session (`initializeConfiguredDriver`, `getDriver()`'s non-null path, `quitDriver`'s non-null-driver path), a real `REMOTE_DRIVER_ADDRESS` OS environment variable, the one-time-only `engineInitialized` global bootstrap flag (order-dependent across the whole test JVM), or `generateTestReport()`'s `AllureManager.openAllureReportAfterExecution()` — which can open a browser/GUI report viewer, explicitly unsafe to invoke from an automated test per repo safety rules. The `external-e2e`-tagged `EngineServiceTest` already covers the real-browser happy path.
- **ShaftMcpApplication** (78.9%, ceiling): remaining lines are exactly `main()` (unconditional `System.exit`, would terminate the test JVM; JDK 25 has no SecurityManager hook to intercept it) and the jar-vs-classes `ProtectionDomain` code-source branch (only reachable when the class loads from a packaged jar, never from the test classpath).
- **ShaftCli** outer class (14.3%): identical `main()`/`System.exit` situation; covered out-of-process by `ShaftCliEndToEndStdioIT`. The nested `ManifestVersionProvider` (the actually-testable part) is now 100%.
- **ToolsCommand** (79.6%, 1 line short of 80%): the three remaining branches in `callCached()` (classpath resource not found / IOException / malformed-JSON) all read a single hardcoded classpath resource (`/tool-index-cache.json`); triggering them would require corrupting that shared resource, which would break the two existing passing `--cached` tests that read the same file. No production seam exists to fake it without a code change, which is out of scope here.
- **CaptureDelegate**: a bare `@FunctionalInterface` with zero executable lines — nothing to cover.

## Bug found and fixed while testing

`EngineService.initializeDriver`'s catch block re-evaluated `targetBrowser.name()` (already known to be the null value that caused the original failure) inside its own diagnostic `logger.error(...)` call, throwing a **second, masking `NullPointerException`** that replaced the original failure and skipped the log line entirely. Fixed minimally: log `targetBrowser` itself (SLF4J's `{}` null-safely stringifies it) instead of re-deriving `.name()`. Regression test: `EngineServiceDriverInitializeTest#initializeDriverPropagatesTheOriginalFailureInsteadOfAMaskingNpeFromItsOwnLogging` (watched red against the bug, green after the fix).

## Test plan

- [x] `mvn -pl shaft-mcp test -DheadlessExecution=true -Dallure.automaticallyOpen=false` — 471/471 passed
- [x] `mvn -pl shaft-cli test` (with the JaCoCo argLine workaround) — 64/64 passed
- [x] Every new/changed test asserts real, observable behavior (return values, exception types/messages, mock-verified delegate calls) — no bare "doesn't throw"
- [x] JaCoCo CSV re-parsed after each run for real per-class numbers, never estimated

Closes #3884
Refs #3866, #3881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6zjrMRZpHqfeem4PkCkLn