### PR TITLE
#3902: explicit MIT license metadata across published modules

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -3,3 +3,32 @@
 # Healenium migrates or Jackson 2.x patched artifacts are available.
 allow-ghsas:
   - GHSA-5jmj-h7xm-6q6v
+
+# #3902: every io.github.shafthq reactor module carries an explicit MIT
+# <licenses> block (pom.xml:11-16 and each module pom), but the Dependency
+# Review action can't resolve a license for our own unpublished-release-version
+# inter-module dependencies via ClearlyDefined, so it flags them as "could not
+# detect a license". Exempt each own-group artifact explicitly: purl matching
+# in this action ignores the version segment entirely (actions/dependency-review-action
+# src/purl.ts purlsMatch compares only type+namespace+name), and there is no
+# namespace-wildcard form for allow-dependencies-licenses (only deny-groups
+# supports namespace-only purls, and only for denying) -- so each artifact must
+# be listed by name rather than as a single io.github.shafthq wildcard.
+allow-dependencies-licenses:
+  - pkg:maven/io.github.shafthq/shaft-parent
+  - pkg:maven/io.github.shafthq/shaft-engine
+  - pkg:maven/io.github.shafthq/shaft-pilot-core
+  - pkg:maven/io.github.shafthq/shaft-capture
+  - pkg:maven/io.github.shafthq/shaft-capture-proxy
+  - pkg:maven/io.github.shafthq/shaft-doctor
+  - pkg:maven/io.github.shafthq/shaft-ai
+  - pkg:maven/io.github.shafthq/shaft-heal
+  - pkg:maven/io.github.shafthq/shaft-mcp
+  - pkg:maven/io.github.shafthq/shaft-cli
+  - pkg:maven/io.github.shafthq/shaft-browserstack
+  - pkg:maven/io.github.shafthq/shaft-video
+  - pkg:maven/io.github.shafthq/shaft-visual
+  - pkg:maven/io.github.shafthq/shaft-sikulix
+  - pkg:maven/io.github.shafthq/report-aggregate
+  - pkg:maven/io.github.shafthq/shaft-bom
+  - pkg:maven/io.github.shafthq/SHAFT_ENGINE

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Mohab Mohie
+Copyright (c) 2018-2026 Mohab Mohie
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/legacy-shaft-engine/pom.xml
+++ b/legacy-shaft-engine/pom.xml
@@ -12,6 +12,12 @@
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Legacy SHAFT coordinate retained as a relocation POM.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <distributionManagement>
         <relocation>

--- a/scripts/ci/validate_maven_publication.py
+++ b/scripts/ci/validate_maven_publication.py
@@ -170,6 +170,8 @@ def validate_publication(root: Path = ROOT, check_build_outputs: bool = False,
         for field in ("m:name", "m:description"):
             if not _text(pom, field):
                 errors.append(f"{artifact} is missing {field.removeprefix('m:')}")
+        if _text(pom, "m:licenses/m:license/m:name") != "MIT License":
+            errors.append(f"{artifact} is missing explicit MIT License metadata")
         if packaging == "jar":
             plugins = {
                 _text(plugin, "m:artifactId")

--- a/shaft-ai/pom.xml
+++ b/shaft-ai/pom.xml
@@ -13,6 +13,12 @@
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Optional direct AI-provider adapters for SHAFT Pilot.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/shaft-bom/pom.xml
+++ b/shaft-bom/pom.xml
@@ -12,6 +12,12 @@
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Dependency management BOM for SHAFT consumer artifacts.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencyManagement>
         <dependencies>

--- a/shaft-browserstack/pom.xml
+++ b/shaft-browserstack/pom.xml
@@ -12,6 +12,12 @@
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Optional BrowserStack SDK integration for SHAFT Engine.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/shaft-capture-proxy/pom.xml
+++ b/shaft-capture-proxy/pom.xml
@@ -18,6 +18,12 @@
         module so the MITM/Netty/Bouncy Castle dependencies stay off the classpath of consumers
         that never enable mobile API capture.
     </description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/shaft-capture/pom.xml
+++ b/shaft-capture/pom.xml
@@ -13,6 +13,12 @@
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Deterministic SHAFT Capture recording, privacy, TestNG generation, and replay validation.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/shaft-cli/pom.xml
+++ b/shaft-cli/pom.xml
@@ -14,6 +14,12 @@
     <packaging>jar</packaging>
     <name>shaft-cli</name>
     <description>Command-line client over the shaft-mcp capability set (MCP client with a CLI surface).</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <properties>
         <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>

--- a/shaft-doctor/pom.xml
+++ b/shaft-doctor/pom.xml
@@ -13,6 +13,12 @@
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Offline, deterministic SHAFT evidence collection and failure diagnosis.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/shaft-heal/pom.xml
+++ b/shaft-heal/pom.xml
@@ -13,6 +13,12 @@
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Optional deterministic and explainable element recovery for SHAFT Engine.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/shaft-mcp/pom.xml
+++ b/shaft-mcp/pom.xml
@@ -14,6 +14,12 @@
     <packaging>jar</packaging>
     <name>shaft-mcp</name>
     <description>Model Context Protocol server for SHAFT browser automation.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <properties>
         <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>

--- a/shaft-pilot-core/pom.xml
+++ b/shaft-pilot-core/pom.xml
@@ -13,6 +13,12 @@
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Provider-neutral contracts, security controls, and deterministic fallback for SHAFT Pilot.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/shaft-sikulix/pom.xml
+++ b/shaft-sikulix/pom.xml
@@ -12,6 +12,12 @@
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Optional SikuliX desktop image automation for SHAFT Engine.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/shaft-video/pom.xml
+++ b/shaft-video/pom.xml
@@ -12,6 +12,12 @@
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Optional desktop video recording and FFmpeg integration for SHAFT Engine.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/shaft-visual/pom.xml
+++ b/shaft-visual/pom.xml
@@ -12,6 +12,12 @@
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Optional OpenCV, Applitools Eyes, and Shutterbug visual processing for SHAFT Engine.</description>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>

--- a/tests/scripts/test_validate_maven_publication.py
+++ b/tests/scripts/test_validate_maven_publication.py
@@ -97,6 +97,19 @@ class MavenPublicationValidationTest(unittest.TestCase):
             self.assertIn(sbom, names)
             self.assertIn(f"{sbom}.asc", names)
 
+    def test_rejects_missing_license_metadata(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._copy_contract(root)
+            pom = root / "shaft-engine" / "pom.xml"
+            document = ET.parse(pom)
+            licenses = document.getroot().find("m:licenses", MODULE.NS)
+            self.assertIsNotNone(licenses)
+            document.getroot().remove(licenses)
+            document.write(pom, encoding="utf-8", xml_declaration=True)
+            self.assertTrue(any("MIT License" in error and "shaft-engine" in error
+                                for error in MODULE.validate_publication(root)))
+
     def test_rejects_forbidden_source_jar_content(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Explicit `<licenses>` MIT block (matching the parent's at `pom.xml:11-16`) added to every published reactor module pom that lacked one — `shaft-pilot-core`, `shaft-capture`, `shaft-capture-proxy`, `shaft-doctor`, `shaft-ai`, `shaft-heal`, `shaft-browserstack`, `shaft-video`, `shaft-visual`, `shaft-sikulix`, `shaft-mcp`, `shaft-cli`, `shaft-bom`, plus `legacy-shaft-engine/pom.xml`. `shaft-engine/pom.xml` and the root `pom.xml` already had one and are untouched.
- `LICENSE` copyright line refreshed to `Copyright (c) 2018-2026 Mohab Mohie`; nothing else changed, still canonically GitHub-detectable as MIT.
- `shaft-intellij` (Gradle/JetBrains plugin) intentionally left untouched: verified against JetBrains docs that neither the `idea-plugin` `plugin.xml` schema nor the IntelliJ Platform Gradle Plugin's `pluginConfiguration` DSL expose a license slot — Marketplace license is set via the Marketplace listing UI, not the descriptor.
- `.github/dependency-review-config.yml`: added `allow-dependencies-licenses` exempting every `io.github.shafthq` reactor artifact (`shaft-parent`, `shaft-engine`, `shaft-pilot-core`, `shaft-capture`, `shaft-capture-proxy`, `shaft-doctor`, `shaft-ai`, `shaft-heal`, `shaft-mcp`, `shaft-cli`, `shaft-browserstack`, `shaft-video`, `shaft-visual`, `shaft-sikulix`, `report-aggregate`, `shaft-bom`, `SHAFT_ENGINE`) from the Dependency Review action's unknown-license flag. Verified against `actions/dependency-review-action@v5` source (`src/purl.ts` `purlsMatch`, `src/config.ts`): purl matching ignores the version segment entirely, and `allow-dependencies-licenses` has no namespace-wildcard form (only `deny-groups` supports namespace-only purls, and only for denying) — so each artifact is listed explicitly rather than as one `io.github.shafthq` wildcard.
- `scripts/ci/validate_maven_publication.py`: extended the publication contract to require every `PUBLIC_ARTIFACTS` pom to declare MIT `<licenses>` metadata, with a new regression test (`test_rejects_missing_license_metadata`) that strips `shaft-engine`'s license block from a copied contract and asserts the guard fires.

Closes #3902

## Test plan
- [x] `py -3 -m unittest tests.scripts.test_validate_maven_publication -v` — 8/8 green (new `test_rejects_missing_license_metadata` watched RED before the check was added, GREEN after; `test_repository_publication_contract_is_valid` watched RED against the real repo — 14 missing-license errors listed — then GREEN after the 14 poms were fixed)
- [x] `py -3 scripts/ci/validate_maven_publication.py` (default, no `--check-build-outputs`, needs no build artifacts) — "Maven Central publication configuration is valid."
- [x] XML well-formedness (`xml.etree.ElementTree.parse`) over all 16 touched/reference poms — all OK
- [x] YAML parse (`yaml.safe_load`) of `.github/dependency-review-config.yml` and `.github/workflows/pr-gate.yml` — both OK
- [x] Rebased onto latest `origin/main` immediately before push (no-op — PR #3901 not yet merged, no overlap materialized)
- No Maven builds run (not required by validation scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6zjrMRZpHqfeem4PkCkLn