### PR TITLE
fix #3899: driver_initialize mobile args + stale union-status test assertions

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
@@ -545,15 +545,22 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     }
 
     private JsonObject mobileWebEmulation() {
+        // driver_initialize absorbed mobile_initialize_web_emulation (design doc amendment A9):
+        // these fields now nest under mobileOptions, and engine must select MOBILE_WEB explicitly
+        // (issue #3899 -- the flat top-level shape this used to send fails schema validation).
+        JsonObject mobileOptions = new JsonObject();
+        mobileOptions.addProperty("targetUrl", targetUrl.getText().trim());
+        mobileOptions.addProperty("browser", (String) recorderBrowser.getSelectedItem());
+        mobileOptions.addProperty("deviceName", "Pixel 5");
+        mobileOptions.addProperty("width", 0);
+        mobileOptions.addProperty("height", 0);
+        mobileOptions.addProperty("pixelRatio", 0);
+        mobileOptions.addProperty("userAgent", "");
+        mobileOptions.addProperty("headless", headlessBrowser.isSelected());
+
         JsonObject arguments = new JsonObject();
-        arguments.addProperty("targetUrl", targetUrl.getText().trim());
-        arguments.addProperty("browser", (String) recorderBrowser.getSelectedItem());
-        arguments.addProperty("deviceName", "Pixel 5");
-        arguments.addProperty("width", 0);
-        arguments.addProperty("height", 0);
-        arguments.addProperty("pixelRatio", 0);
-        arguments.addProperty("userAgent", "");
-        arguments.addProperty("headless", headlessBrowser.isSelected());
+        arguments.addProperty("engine", "MOBILE_WEB");
+        arguments.add("mobileOptions", mobileOptions);
         return arguments;
     }
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
@@ -64,13 +64,13 @@ class GuidedWorkflowLiveE2ETest {
 
         try (LiveMcp mcp = context.connect()) {
             JsonObject started = mcp.invoke(panel.click("Start recording"), SESSION_START_TIMEOUT);
-            assertEquals("ACTIVE", started.get("state").getAsString(), started.toString());
+            assertEquals("ACTIVE", webStatus(started).get("state").getAsString(), started.toString());
 
             JsonObject status = awaitEvents(mcp, 4, Duration.ofSeconds(90));
             assertTrue(status.get("eventCount").getAsInt() >= 4, status.toString());
 
             JsonObject stopped = mcp.invoke(panel.click("Stop recording"), TOOL_TIMEOUT);
-            assertEquals("COMPLETED", stopped.get("state").getAsString(), stopped.toString());
+            assertEquals("COMPLETED", webStatus(stopped).get("state").getAsString(), stopped.toString());
             assertTrue(context.workspaceFile("recordings/web-live.json"), "capture JSON missing");
 
             JsonObject generated = mcp.invoke(panel.click("Review code"), TOOL_TIMEOUT);
@@ -110,21 +110,22 @@ class GuidedWorkflowLiveE2ETest {
         panel.selectBackend(GuidedWorkflowPanel.BACKEND_MOBILE);
 
         try (LiveMcp mcp = context.connect()) {
-            JsonObject session = mcp.invoke(
-                    panel.useTemplate("Start mobile emulation session for recording"), SESSION_START_TIMEOUT);
-            assertEquals("web-emulation", session.get("mode").getAsString(), session.toString());
-            assertTrue(session.get("active").getAsBoolean(), session.toString());
+            // driver_initialize's mobile dispatch (design doc amendment A9) returns no structured
+            // status -- the former mobile_initialize_web_emulation session summary is absorbed but not
+            // surfaced back through the union response family, so success here is proven by invoke()
+            // itself (it fails the test on isError) and by the recording/actions that follow.
+            mcp.invoke(panel.useTemplate("Start mobile emulation session for recording"), SESSION_START_TIMEOUT);
 
             JsonObject recording = mcp.invoke(panel.click("Start recording"), TOOL_TIMEOUT);
-            assertTrue(recording.get("active").getAsBoolean(), recording.toString());
+            assertTrue(mobileStatus(recording).get("active").getAsBoolean(), recording.toString());
 
             mcp.invoke(mobileAction("mobile_type", "ID", "search",
                     Map.of("textValue", "SHAFT Engine")), TOOL_TIMEOUT);
             mcp.invoke(mobileAction("mobile_tap", "ID", "go", Map.of()), TOOL_TIMEOUT);
 
             JsonObject stopped = mcp.invoke(panel.click("Stop recording"), TOOL_TIMEOUT);
-            assertFalse(stopped.get("active").getAsBoolean(), stopped.toString());
-            assertTrue(stopped.get("actionCount").getAsInt() >= 2, stopped.toString());
+            assertFalse(mobileStatus(stopped).get("active").getAsBoolean(), stopped.toString());
+            assertTrue(mobileStatus(stopped).get("actionCount").getAsInt() >= 2, stopped.toString());
             assertTrue(context.workspaceFile("recordings/mobile-live.json"), "mobile recording missing");
 
             JsonObject generated = mcp.invoke(panel.click("Review code"), TOOL_TIMEOUT);
@@ -158,15 +159,37 @@ class GuidedWorkflowLiveE2ETest {
 
     private static JsonObject awaitEvents(LiveMcp mcp, int minimumEvents, Duration limit) throws Exception {
         long deadline = System.nanoTime() + limit.toNanos();
-        JsonObject status = null;
+        JsonObject status = new JsonObject();
         while (System.nanoTime() < deadline) {
-            status = mcp.invoke(new Invocation("capture_status", new JsonObject()), TOOL_TIMEOUT);
+            status = webStatus(mcp.invoke(new Invocation("capture_status", new JsonObject()), TOOL_TIMEOUT));
             if (status.has("eventCount") && status.get("eventCount").getAsInt() >= minimumEvents) {
                 return status;
             }
             Thread.sleep(2000);
         }
-        return status == null ? new JsonObject() : status;
+        return status;
+    }
+
+    /**
+     * Unwraps {@code capture_start}/{@code capture_status}/{@code capture_stop}'s
+     * {@code McpCaptureUnionStatus} response down to its WEB-engine {@code webStatus} section
+     * (design doc amendment A3, landed by #3881): the union's {@code state}/{@code eventCount}
+     * fields moved off the top level into this nested object.
+     */
+    private static JsonObject webStatus(JsonObject union) {
+        JsonObject webStatus = union.getAsJsonObject("webStatus");
+        assertNotNull(webStatus, "Expected a populated webStatus section: " + union);
+        return webStatus;
+    }
+
+    /**
+     * Unwraps the same union response's {@code mobileStatus} section, populated instead of
+     * {@code webStatus} when the active engine is MOBILE_NATIVE/MOBILE_WEB.
+     */
+    private static JsonObject mobileStatus(JsonObject union) {
+        JsonObject mobileStatus = union.getAsJsonObject("mobileStatus");
+        assertNotNull(mobileStatus, "Expected a populated mobileStatus section: " + union);
+        return mobileStatus;
     }
 
     private static Invocation mobileAction(

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
@@ -63,13 +63,19 @@ class GuidedWorkflowPanelTest {
         select(templates, "Start mobile emulation session for recording");
         useTemplate.doClick();
         CapturedInvocation mobileEmulation = last(invocations);
+        JsonObject mobileOptions = mobileEmulation.arguments().getAsJsonObject("mobileOptions");
         assertAll(
                 () -> assertEquals("driver_initialize", mobileEmulation.toolName()),
+                // driver_initialize's engine selector (issue #3899: the plugin must send the schema's
+                // uppercase Java-enum-name wire casing, e.g. MOBILE_WEB, not a lowercase variant).
+                () -> assertEquals("MOBILE_WEB", mobileEmulation.arguments().get("engine").getAsString()),
+                () -> assertNotNull(mobileOptions, "mobile fields must nest under mobileOptions: "
+                        + mobileEmulation.arguments()),
                 // Default combo selection is "Chrome" (matches CaptureBrowser#parse and
                 // MobileService#browserType, both case-insensitive) -- not the old hardcoded "CHROME".
-                () -> assertEquals("Chrome", mobileEmulation.arguments().get("browser").getAsString()),
-                () -> assertEquals("Pixel 5", mobileEmulation.arguments().get("deviceName").getAsString()),
-                () -> assertFalse(mobileEmulation.arguments().get("headless").getAsBoolean()));
+                () -> assertEquals("Chrome", mobileOptions.get("browser").getAsString()),
+                () -> assertEquals("Pixel 5", mobileOptions.get("deviceName").getAsString()),
+                () -> assertFalse(mobileOptions.get("headless").getAsBoolean()));
 
         select(templates, "Analyze failed Allure results");
         useTemplate.doClick();
@@ -198,7 +204,8 @@ class GuidedWorkflowPanelTest {
         CapturedInvocation mobileEmulation = last(invocations);
         assertAll(
                 () -> assertEquals("driver_initialize", mobileEmulation.toolName()),
-                () -> assertEquals("Edge", mobileEmulation.arguments().get("browser").getAsString(),
+                () -> assertEquals("Edge",
+                        mobileEmulation.arguments().getAsJsonObject("mobileOptions").get("browser").getAsString(),
                         "mobileWebEmulation() must read the same selected combo item"));
     }
 

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
@@ -396,4 +396,51 @@ class ShaftMcpApplicationTests {
         }
         return false;
     }
+
+    /**
+     * Issue #3899 regression: {@code driver_initialize}'s mobile fields (former
+     * {@code mobile_initialize_web_emulation}/{@code mobile_initialize_native} parameters) moved
+     * under a nested {@code mobileOptions} object when commit 22bc611ec7 absorbed those tools
+     * (design doc amendment A9). The IntelliJ plugin's {@code GuidedWorkflowPanel.mobileWebEmulation()}
+     * kept sending them flat at the top level, which the live-served schema rejects
+     * ("property 'targetUrl' is not defined in the schema and the schema does not allow additional
+     * properties", ...): this asserts the served schema shape directly so that drift is caught by a
+     * fast in-repo test instead of only the nightly live E2E run.
+     */
+    @Test
+    void driverInitializeSchemaNestsMobileFieldsUnderMobileOptionsNotAtTheTopLevel() throws Exception {
+        JsonNode schema = toolInputSchema("driver_initialize");
+        JsonNode properties = schema.path("properties");
+
+        assertTrue(properties.has("mobileOptions"),
+                "driver_initialize schema must expose a nested mobileOptions object: " + schema);
+        assertFalse(properties.has("targetUrl"),
+                "targetUrl must live under mobileOptions, not top-level: " + schema);
+        assertFalse(properties.has("browser") && properties.path("browser").path("type").asText().equals("string")
+                        && properties.has("deviceName"),
+                "web-emulation fields must live under mobileOptions, not top-level: " + schema);
+
+        JsonNode mobileOptionsProperties = properties.path("mobileOptions").path("properties");
+        assertTrue(mobileOptionsProperties.has("targetUrl"), "mobileOptions must expose targetUrl: " + schema);
+        assertTrue(mobileOptionsProperties.has("deviceName"), "mobileOptions must expose deviceName: " + schema);
+        assertTrue(mobileOptionsProperties.has("headless"), "mobileOptions must expose headless: " + schema);
+    }
+
+    /**
+     * Issue #3899: confirms the wire-format casing {@code driver_initialize}'s {@code engine}
+     * selector actually validates against, so plugin/tool callers don't have to guess between the
+     * Java enum constant name ({@code MOBILE_WEB}) and the lowercase form used in prose elsewhere
+     * (for example {@link ActiveEngine}'s own javadoc says {@code engine=mobile_web}).
+     */
+    @Test
+    void driverInitializeEngineEnumWireCasingMatchesJavaConstantNames() throws Exception {
+        JsonNode schema = toolInputSchema("driver_initialize");
+        JsonNode engineEnum = schema.path("properties").path("engine").path("enum");
+
+        List<String> allowed = new java.util.ArrayList<>();
+        engineEnum.forEach(node -> allowed.add(node.asText()));
+
+        assertEquals(List.of("NONE", "WEB", "MOBILE_NATIVE", "MOBILE_WEB", "PLAYWRIGHT"), allowed,
+                "driver_initialize's engine enum wire values: " + schema);
+    }
 }


### PR DESCRIPTION
## Summary

Root-causes and fixes the "Guided Workflows Live E2E" nightly failure ([run 29804413744](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29804413744)). Both failing tests trace back to yesterday's `#3881` tool-architecture sweep changing two MCP tool response/request shapes without updating the IntelliJ plugin and its live E2E test to match.

Evidence source: downloaded the run's `guided-workflows-live-evidence` artifact and read the actual Gradle HTML test report (`shaft-intellij/build/reports/tests/test/classes/com.shaft.intellij.ui.GuidedWorkflowLiveE2ETest.html`), which has the full stack traces the console log summary doesn't show.

### Root cause 1 — `mobileRecorderRecordsEmulatedActionsAndGeneratesShaftCode()` — real plugin bug

Actual server error from the report (not guessed):
```
Tool (driver_initialize) input validation failed: ... property 'targetUrl' is not defined in the schema and the schema does not allow additional properties, property 'browser' ... 'deviceName' ... 'width' ... 'height' ... 'pixelRatio' ... 'userAgent' ... 'headless' [same]
```
Commit `22bc611ec7` ("Tool sweep W1 commit 4a", part of #3881) absorbed `mobile_initialize_web_emulation` into `driver_initialize`, moving those fields under a nested `mobileOptions` object plus a required top-level `engine` selector. `GuidedWorkflowPanel.mobileWebEmulation()` (`shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java:547`) still built the old flat shape and never set `engine`. **This breaks the real plugin for real users**, not just the test — confirmed by the sibling `AssistantCommand.driverInitializeMobile()` (`shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java:1273-1278`) already using the correct nested shape.

### Root cause 2 — `webRecorderCapturesSelfDrivingLoginAndGeneratesShaftCode()` — stale test assertion

```
java.lang.NullPointerException: Cannot invoke "com.google.gson.JsonElement.getAsString()" because the return value of "com.google.gson.JsonObject.get(String)" is null
	at GuidedWorkflowLiveE2ETest.java:67
```
Commit `ebff36af50` ("unify capture recording/status/stop onto ActiveEngine dispatch", also #3881) wraps `capture_start`/`capture_status`/`capture_stop` responses in a new `McpCaptureUnionStatus {engine, webStatus, playwrightStatus, mobileStatus}`, moving `state`/`eventCount` off the top level into `webStatus`. `GuidedWorkflowLiveE2ETest.java` was last touched in #3421 (2026-07-10), well before this refactor, and still read the old flat shape.

### Classification: in-repo regression (not transient/flake)

Confirmed via `gh run list --workflow "Guided Workflows Live E2E" --limit 10`: this workflow has been failing nightly since 2026-07-14, but with a *different* failure signature each time (`AssertionFailedError at :78`, unrelated to today's `:67`/`:113`). Today's specific NPE-at-67 / AssertionFailedError-at-113 pair is new, and lines up exactly with yesterday's #3881 merge. The orchestrator is separately filing the pre-existing `:78` signature as its own issue — out of scope for this PR.

## Changes

- `GuidedWorkflowPanel.mobileWebEmulation()`: nest fields under `mobileOptions`, set `engine="MOBILE_WEB"`.
- `GuidedWorkflowLiveE2ETest`: unwrap `webStatus`/`mobileStatus` sections from the union response; drop the two mobile-session assertions `driver_initialize` no longer returns data for (its mobile dispatch is `void` — success is already proven by `LiveMcp.invoke()`'s `isError` guard plus the recording/action assertions that follow).
- `ShaftMcpApplicationTests`: two new regression tests asserting `driver_initialize`'s live-served JSON schema shape (`mobileOptions` nesting, `engine` enum wire-casing) so this exact class of plugin/schema drift is caught by a fast in-repo test instead of only the live nightly run — also used to empirically confirm the enum's wire casing (uppercase Java constant names, e.g. `MOBILE_WEB`) instead of guessing from `ActiveEngine`'s casual lowercase javadoc prose.

## Test plan

- [x] `mvn -pl shaft-mcp test -Dtest=ShaftMcpApplicationTests -DheadlessExecution=true -Dallure.automaticallyOpen=false` → 11/11 green (2 new schema tests confirm the wire-format hypothesis against already-correct production code).
- [x] `shaft-intellij`: `gradlew test --tests GuidedWorkflowPanelTest` (JDK 21) → watched RED against the pre-fix flat-args code (`NullPointerException` at the new `mobileOptions` assertions), then GREEN after the fix; 19/19 green.
- [x] `shaft-intellij`: `gradlew compileTestJava` → `GuidedWorkflowLiveE2ETest` edits compile clean.
- [ ] Live E2E itself (`GuidedWorkflowLiveE2ETest`, `-Dshaft.intellij.liveWorkflows=true`) needs a live MCP subprocess + real headless browser + IntelliJ test sandbox — out of scope for a local run per repo policy; will be proven by the next scheduled/rerun of the "Guided Workflows Live E2E" workflow.

Fixes #3899

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6zjrMRZpHqfeem4PkCkLn