### PR TITLE
fix #3905: generate the missing Role import for ROLE-strategy locators

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -886,6 +886,9 @@ public final class CaptureGenerator {
         if (needsByImport(targets, fallbackReplay)) {
             line(source, "import org.openqa.selenium.By;");
         }
+        if (needsRoleImport(targets)) {
+            line(source, "import com.shaft.gui.internal.locator.Role;");
+        }
         line(source, "import org.testng.annotations.AfterMethod;");
         line(source, "import org.testng.annotations.BeforeMethod;");
         line(source, "import org.testng.annotations.Test;");
@@ -1315,6 +1318,17 @@ public final class CaptureGenerator {
 
     private static boolean needsByImport(List<TargetPlan> targets, boolean fallbackReplay) {
         return fallbackReplay || targets.stream().anyMatch(CaptureGenerator::usesNativeBy);
+    }
+
+    /**
+     * True when {@link #semanticLocator} will render at least one {@code Role.<NAME>} literal
+     * (issue #3905): mirrors the exact condition under which {@code semanticLocator} takes its ROLE
+     * branch, so the emitted {@code import com.shaft.gui.internal.locator.Role;} appears if and only
+     * if the generated source actually references {@link Role}.
+     */
+    private static boolean needsRoleImport(List<TargetPlan> targets) {
+        return targets.stream().anyMatch(plan -> plan.selection().selected().candidate().strategy()
+                == LocatorCandidate.LocatorStrategy.ROLE && ariaRole(plan.target().role()) != null);
     }
 
     private static boolean usesNativeBy(TargetPlan plan) {

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -706,6 +706,66 @@ class CaptureGeneratorTest {
                 .anyMatch(fallback -> fallback.contains("username-input")));
     }
 
+    /**
+     * Issue #3905: a ROLE-strategy locator (the highest-scoring {@link LocatorCandidate.LocatorStrategy},
+     * always preferred when present -- see the nightly "Guided Workflows Live E2E" login fixture, where
+     * every field resolves to ROLE) renders {@code Role.BUTTON}/{@code Role.TEXTBOX} literals into the
+     * generated source ({@code semanticLocator}) without ever adding the matching
+     * {@code import com.shaft.gui.internal.locator.Role;} -- so real compilation fails with
+     * "cannot find symbol: variable Role" every time a ROLE locator is chosen and generation reaches
+     * the compile step. Reproduced deterministically here (no live browser needed): a session with a
+     * single ROLE-only-candidate button, real javac compilation requested via {@link #request}.
+     */
+    @Test
+    void roleStrategyLocatorGeneratesAnImportForTheRoleEnumSoCompilationSucceeds() throws Exception {
+        Path session = session(roleLocatorSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result = new CaptureGenerator().generate(request(session, temp.resolve("role")));
+
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("import com.shaft.gui.internal.locator.Role;"),
+                "generated source uses Role.BUTTON but never imports Role: " + source);
+        assertTrue(source.contains("Role.BUTTON"), source);
+        assertTrue(result.successful(),
+                "generation must compile a ROLE-strategy locator: " + result.report().compilation());
+        assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                result.report().compilation().status(),
+                result.report().compilation().diagnostics().toString());
+    }
+
+    private static CaptureSession roleLocatorSession() {
+        ElementSnapshot loginButton = new ElementSnapshot(
+                "login-button",
+                "button",
+                "button",
+                "Log in",
+                "",
+                Map.of(),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
+                        "button:Log in", 1, true, true,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE))),
+                true,
+                true,
+                false);
+        return new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "role-locator-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(3),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), loginButton,
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+    }
+
     @Test
     void controlFlowPreviewReportsSuggestionsWithoutChangingLinearReplay() throws Exception {
         Path preview = temp.resolve("control-flow-preview.json");


### PR DESCRIPTION
## Summary

Root-causes and fixes the recurring pre-#3881 "Guided Workflows Live E2E" nightly failure at `GuidedWorkflowLiveE2ETest.java:78` (`successful == false`), tracked by #3905.

Evidence: downloaded the Gradle HTML test reports for the 3 nightlies whose artifacts hadn't yet expired (07-18, 07-19, 07-20; 07-14→07-17 evidence is gone — 4-day artifact retention). All 3 show `readiness:"BLOCKED"` / `successful:false` at the "Review code" step, via **two different proximate mechanisms**:

1. **07-18 and 07-19**: `unsupportedEvents: ["event-3: logical window window-2 was not opened earlier in the session."]` — an intermittent phantom-second-logical-window bug in `CaptureEventPipeline`'s BiDi context tracking. This short-circuits generation before compilation is even attempted. **Filed separately** — see the follow-up issue linked below — not touched in this PR.
2. **07-20**: no phantom-window issue that night, so generation reached the compile step and hit a real, deterministic bug fixed here: `CaptureGenerator.semanticLocator()` (`shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java:1378-1381`) emits a `Role.<NAME>` literal for ROLE-strategy locators — `LocatorCandidate.LocatorStrategy.ROLE` has the highest base score (100) of any strategy, so it wins whenever present; all three login-form fields picked it every single night per the captured `locatorDecisions`. But `renderSource()`'s import block never added `import com.shaft.gui.internal.locator.Role;`. Real javac then fails with `cannot find symbol: variable Role` — exactly the diagnostic captured in the 07-20 report.

Explicitly ruled out the `CaptureEventPipeline` pendingInputs/committed-`change`-event gotcha: `eventCount` reached the awaited minimum every night (5-7 events captured, username/password/login all resolved via real locator decisions), and the fixture already dispatches both `input` and `change`. Not a match for this failure.

## Fix

`CaptureGenerator` gains `needsRoleImport(targets)`, mirroring the existing `needsByImport(targets, fallbackReplay)` pattern — true exactly when `semanticLocator()` will render at least one `Role.<NAME>` literal (same condition: `candidate.strategy() == ROLE && ariaRole(target.role()) != null`) — and `renderSource()` emits the import when it's true.

## Test plan

- [x] New test `CaptureGeneratorTest#roleStrategyLocatorGeneratesAnImportForTheRoleEnumSoCompilationSucceeds` — a minimal session with a single ROLE-only-candidate button, real javac compilation requested. Watched RED against the unfixed generator (assertion failed: generated source used `Role.BUTTON` but never imported `Role`); watched GREEN after the fix.
- [x] `mvn -pl shaft-capture test -Dtest=CaptureGeneratorTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` → 32/32 green, no regressions (including the golden-fixture compilation test, which doesn't use a ROLE locator and is unaffected by this change).
- [ ] Live E2E itself (`GuidedWorkflowLiveE2ETest`, `-Dshaft.intellij.liveWorkflows=true`) needs a live MCP subprocess + real headless browser + IntelliJ test sandbox — out of scope for a local run; will be proven by the next scheduled/rerun of the workflow (note: the phantom-window-2 issue can still independently fail the run on nights it occurs, until that follow-up issue is also fixed).

Closes #3905

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6zjrMRZpHqfeem4PkCkLn