### PR TITLE
shaft-mcp: fix McpMobileInitOptions schema wrongly requiring every nested field

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInitOptions.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInitOptions.java
@@ -1,5 +1,7 @@
 package com.shaft.mcp;
 
+import org.springframework.ai.tool.annotation.ToolParam;
+
 /**
  * Optional nested mobile-session request object accepted by {@code driver_initialize} when
  * {@code engine} selects {@link ActiveEngine#MOBILE_NATIVE} or {@link ActiveEngine#MOBILE_WEB}
@@ -29,23 +31,23 @@ package com.shaft.mcp;
  * @param bundleId        native only: optional iOS bundle identifier for installed apps
  */
 public record McpMobileInitOptions(
-        String targetUrl,
-        String browser,
-        String deviceName,
-        Integer width,
-        Integer height,
-        Double pixelRatio,
-        String userAgent,
-        Boolean headless,
-        String platformName,
-        String appiumServerUrl,
-        String automationName,
-        String platformVersion,
-        String udid,
-        String app,
-        String appPackage,
-        String appActivity,
-        String bundleId) {
+        @ToolParam(required = false) String targetUrl,
+        @ToolParam(required = false) String browser,
+        @ToolParam(required = false) String deviceName,
+        @ToolParam(required = false) Integer width,
+        @ToolParam(required = false) Integer height,
+        @ToolParam(required = false) Double pixelRatio,
+        @ToolParam(required = false) String userAgent,
+        @ToolParam(required = false) Boolean headless,
+        @ToolParam(required = false) String platformName,
+        @ToolParam(required = false) String appiumServerUrl,
+        @ToolParam(required = false) String automationName,
+        @ToolParam(required = false) String platformVersion,
+        @ToolParam(required = false) String udid,
+        @ToolParam(required = false) String app,
+        @ToolParam(required = false) String appPackage,
+        @ToolParam(required = false) String appActivity,
+        @ToolParam(required = false) String bundleId) {
 
     /** Every field unset; equivalent to omitting {@code mobileOptions} entirely. */
     static final McpMobileInitOptions EMPTY = new McpMobileInitOptions(

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
@@ -443,4 +443,33 @@ class ShaftMcpApplicationTests {
         assertEquals(List.of("NONE", "WEB", "MOBILE_NATIVE", "MOBILE_WEB", "PLAYWRIGHT"), allowed,
                 "driver_initialize's engine enum wire values: " + schema);
     }
+
+    /**
+     * Issue #3908 live-repro finding: {@code McpMobileInitOptions}'s javadoc says "Every field is
+     * optional" and every field is genuinely optional at the Java level (all boxed/nullable, each
+     * defaulted internally by {@code MobileService#initializeWebEmulation}/{@code #initializeNative}),
+     * but the live-served schema marked all 9 native-only fields required -- confirmed live by 3/3
+     * "Guided Workflows Live E2E" workflow_dispatch runs (29808732349, 29808737368, 29808742128)
+     * failing {@code mobileRecorderRecordsEmulatedActionsAndGeneratesShaftCode} with "JSON schema
+     * validation errors: [/mobileOptions: required property 'app' not found, ...]" the moment a
+     * MOBILE_WEB caller (which never sends the native-only fields) reached real schema validation --
+     * masked until #3906 fixed the plugin's flat-vs-nested shape bug that failed validation earlier
+     * for an unrelated reason. {@code McpMobileInitOptions} is the only record type used as a nested
+     * {@code @ToolParam} request object anywhere in shaft-mcp; the sibling pattern
+     * ({@code CaptureCodegenStartRequest}) is a plain mutable class, which Spring AI's schema
+     * generator treats as all-optional by default -- records don't get that default.
+     */
+    @Test
+    void driverInitializeMobileOptionsSchemaHasNoRequiredFieldsSoAnyEngineCanOmitTheOthers() throws Exception {
+        JsonNode schema = toolInputSchema("driver_initialize");
+        JsonNode mobileOptionsRequired = schema.path("properties").path("mobileOptions").path("required");
+
+        List<String> requiredNames = new java.util.ArrayList<>();
+        mobileOptionsRequired.forEach(node -> requiredNames.add(node.asText()));
+
+        assertTrue(requiredNames.isEmpty(),
+                "mobileOptions schema still requires: " + requiredNames
+                        + " -- a MOBILE_WEB caller that never sends native-only fields (or vice versa) "
+                        + "must still pass schema validation: " + schema);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #3910 — `driver_initialize`'s mobile dispatch (`engine=MOBILE_NATIVE`/`MOBILE_WEB`) was unusable: any real call fails live JSON schema validation before ever reaching Java code, because `McpMobileInitOptions` (the nested `mobileOptions` request record) had every one of its 17 fields marked `required` in the live-served schema, even though the record's own javadoc says "Every field is optional" and every field genuinely is at the Java level.

## Evidence

Found while live-repro'ing #3908 on a separate diagnostics branch. All 3 `workflow_dispatch` runs of "Guided Workflows Live E2E" failed identically at `GuidedWorkflowLiveE2ETest.mobileRecorderRecordsEmulatedActionsAndGeneratesShaftCode:117`:

```
Tool (driver_initialize) input validation failed: JSON schema validation errors:
[/mobileOptions: required property 'app' not found, .../appActivity'.../appPackage'.../
appiumServerUrl'.../automationName'.../bundleId'.../platformName'.../platformVersion'.../udid' not found]
```

Run links: https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29808732349, https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29808737368, https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29808742128

## Root cause

`McpMobileInitOptions` (`shaft-mcp/src/main/java/com/shaft/mcp/McpMobileInitOptions.java`) is the only `record` type used as a nested `@ToolParam` request object anywhere in shaft-mcp. Spring AI's JSON schema generator marks record canonical-constructor components required by default. The sibling pattern (`CaptureCodegenStartRequest`, used by `capture_start`'s `codegenOptions`) is a plain mutable class with public fields, which the generator treats as all-optional by default — so this defect class never surfaced there.

Introduced by #3881 (created `McpMobileInitOptions`). Masked until #3906 fixed a separate IntelliJ-plugin bug (flat-vs-nested argument shape) that failed schema validation earlier for an unrelated reason, so this "required" constraint was never actually evaluated by a real caller until now.

## Fix

`@ToolParam(required = false)` on every `McpMobileInitOptions` record component. `@ToolParam`'s own `@Target` (`PARAMETER`, `FIELD`, `ANNOTATION_TYPE`) both apply to a record component declaration per JLS 8.10.3, so the schema generator sees it exactly like it already does for scalar `@ToolParam` method parameters (e.g. `driver_initialize`'s own `targetBrowser`/`engine`).

## Test plan

- [x] New test `ShaftMcpApplicationTests#driverInitializeMobileOptionsSchemaHasNoRequiredFieldsSoAnyEngineCanOmitTheOthers` — watched RED against the unfixed record (schema dump in the failure message showed all 17 fields in `"required"`), watched GREEN after the fix.
- [x] `mvn -pl shaft-mcp test -Dtest='ShaftMcpApplicationTests,McpMobileInitOptionsTest,EngineServiceMobileInitBridgeTest,EngineServiceDriverInitializeTest' -DheadlessExecution=true -Dallure.automaticallyOpen=false` → 27/27 green.
- [x] `mvn -pl shaft-mcp test -DheadlessExecution=true -Dallure.automaticallyOpen=false` (full module) → 474/474 green, no regressions.

Closes #3910

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6zjrMRZpHqfeem4PkCkLn