### PR TITLE
shaft-intellij: fix GuidedWorkflowPanel stale capture_start mode/includeSensitiveValues args

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
@@ -643,10 +643,12 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
         String statusTool = "capture_status";
         JsonObject arguments;
         if (playwrightBackend) {
+            // capture_start's flat mode/includeSensitiveValues parameters were absorbed into
+            // sessionGoal (design doc amendment A3, #3881); includeSensitiveValues is no longer a
+            // tool argument at all (CaptureService always passes false for it on PLAYWRIGHT/mobile).
             arguments = new JsonObject();
             arguments.addProperty("outputPath", sessionPath.getText().trim());
-            arguments.addProperty("mode", "default");
-            arguments.addProperty("includeSensitiveValues", false);
+            arguments.addProperty("sessionGoal", intent.getText().trim());
         } else {
             arguments = webdriverCaptureStartArguments();
         }
@@ -683,10 +685,12 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     }
 
     private JsonObject mobileRecordStartArguments() {
+        // See the matching comment in startRecording(): mode/includeSensitiveValues are stale
+        // pre-#3881 capture_start arguments; sessionGoal replaces mode, and includeSensitiveValues
+        // is no longer an exposed tool argument.
         JsonObject arguments = new JsonObject();
         arguments.addProperty("outputPath", sessionPath.getText().trim());
-        arguments.addProperty("mode", "default");
-        arguments.addProperty("includeSensitiveValues", false);
+        arguments.addProperty("sessionGoal", intent.getText().trim());
         return arguments;
     }
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
@@ -146,7 +146,13 @@ class GuidedWorkflowPanelTest {
         CapturedInvocation mobileStart = last(invocations);
         assertAll(
                 () -> assertEquals("capture_start", mobileStart.toolName()),
-                () -> assertFalse(mobileStart.arguments().get("includeSensitiveValues").getAsBoolean()));
+                // Issue #3908 live-repro finding: capture_start has no mode/includeSensitiveValues
+                // arguments (absorbed into sessionGoal / dropped, #3881) -- the stale flat shape this
+                // used to send fails live schema validation ("property 'mode' is not defined in the
+                // schema").
+                () -> assertFalse(mobileStart.arguments().has("mode")),
+                () -> assertFalse(mobileStart.arguments().has("includeSensitiveValues")),
+                () -> assertTrue(mobileStart.arguments().has("sessionGoal")));
 
         stop.doClick();
         CapturedInvocation mobileStop = last(invocations);
@@ -161,6 +167,13 @@ class GuidedWorkflowPanelTest {
                 () -> assertEquals("driver", mobileReview.arguments().get("driverVariableName").getAsString()));
 
         select(backend, "Playwright");
+        start.doClick();
+        CapturedInvocation playwrightStart = last(invocations);
+        assertAll(
+                () -> assertEquals("capture_start", playwrightStart.toolName()),
+                () -> assertFalse(playwrightStart.arguments().has("mode")),
+                () -> assertFalse(playwrightStart.arguments().has("includeSensitiveValues")),
+                () -> assertTrue(playwrightStart.arguments().has("sessionGoal")));
         stop.doClick();
         assertEquals("capture_stop", last(invocations).toolName());
         review.doClick();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -5688,7 +5688,12 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertEquals("capture_start", playwright.toolName()),
                 () -> assertTrue(playwright.arguments().has("outputPath")),
-                () -> assertTrue(playwright.arguments().has("includeSensitiveValues")),
+                // Issue #3912: mode/includeSensitiveValues are stale pre-#3881 capture_start
+                // arguments (absorbed into sessionGoal / dropped) -- the live-served schema rejects
+                // them outright, and this assertion previously encoded the stale contract.
+                () -> assertTrue(playwright.arguments().has("sessionGoal")),
+                () -> assertFalse(playwright.arguments().has("mode")),
+                () -> assertFalse(playwright.arguments().has("includeSensitiveValues")),
                 () -> assertFalse(playwright.arguments().has("targetUrl")));
     }
 


### PR DESCRIPTION
## Summary

Fixes #3912 — `capture_start` calls from the Playwright and Mobile guided-workflow backends fail live JSON schema validation: a real plugin bug (not just the live E2E test), found while live-repro'ing #3908, second wave (after #3910's fix let mobile driver_initialize succeed and the test reached one step further).

## Evidence

All 3 `workflow_dispatch` runs failed identically at `GuidedWorkflowLiveE2ETest.mobileRecorderRecordsEmulatedActionsAndGeneratesShaftCode:119`:

```
Tool (capture_start) input validation failed: JSON schema validation errors:
[: property 'mode' is not defined in the schema and the schema does not allow additional properties,
 : property 'includeSensitiveValues' is not defined in the schema and the schema does not allow additional properties]
```

Run links: https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29809717829, https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29809723132, https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29809728492

## Root cause

`capture_start`'s only parameters are `targetUrl`/`browser`/`outputPath`/`headless`/`sessionGoal`/`codegenOptions` (`shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java:145-160`). `mode` and `includeSensitiveValues` are stale pre-#3881 flat arguments from the former separate `mobile_record_start`/`playwright_record_start` tools, absorbed into the unified `capture_start`. `sessionGoal` replaces `mode`'s role; `includeSensitiveValues` is no longer exposed at all.

Two call sites in `GuidedWorkflowPanel.java` still sent the stale shape: `startRecording()`'s Playwright branch, and `mobileRecordStartArguments()` (used by both the mobile "Start recording" button and the one-click mobile chain).

## Fix

Both now send `sessionGoal` from the existing "Intent" field (`intent.getText().trim()`), matching `webdriverCaptureStartArguments()`'s already-correct pattern.

## Test plan

- [x] `GuidedWorkflowPanelTest#recorderButtonsRouteByBackendAndRespectHeadlessToggle` — updated the (previously stale, never-caught-the-drift) mobile assertion, and added a new assertion block for the Playwright Start-recording call, which previously had zero coverage. `gradlew test --tests GuidedWorkflowPanelTest` (JDK 21) → green, watched.
- [ ] Live E2E itself — 6/6 `workflow_dispatch` budget already spent on this investigation; next dispatch needs owner sign-off.

Closes #3912

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6zjrMRZpHqfeem4PkCkLn