### PR TITLE
shaft-intellij: drive element_type/element_click in live E2E after #3881 A1 tool unification

### DIFF
--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
@@ -119,9 +119,9 @@ class GuidedWorkflowLiveE2ETest {
             JsonObject recording = mcp.invoke(panel.click("Start recording"), TOOL_TIMEOUT);
             assertTrue(mobileStatus(recording).get("active").getAsBoolean(), recording.toString());
 
-            mcp.invoke(mobileAction("mobile_type", "ID", "search",
-                    Map.of("textValue", "SHAFT Engine")), TOOL_TIMEOUT);
-            mcp.invoke(mobileAction("mobile_tap", "ID", "go", Map.of()), TOOL_TIMEOUT);
+            mcp.invoke(mobileAction("element_type", "ID", "search",
+                    Map.of("text", "SHAFT Engine")), TOOL_TIMEOUT);
+            mcp.invoke(mobileAction("element_click", "ID", "go", Map.of()), TOOL_TIMEOUT);
 
             JsonObject stopped = mcp.invoke(panel.click("Stop recording"), TOOL_TIMEOUT);
             assertFalse(mobileStatus(stopped).get("active").getAsBoolean(), stopped.toString());
@@ -192,6 +192,12 @@ class GuidedWorkflowLiveE2ETest {
         return mobileStatus;
     }
 
+    /**
+     * Builds a locator-scoped invocation for the unified {@code element_type}/{@code element_click}
+     * tools. With the MOBILE_WEB session started above active, these dispatch through
+     * {@code MobileService.dispatchType}/{@code dispatchClick} and record the step exactly like the
+     * {@code mobile_type}/{@code mobile_tap} tools removed by design doc amendment A1 (#3881) did.
+     */
     private static Invocation mobileAction(
             String toolName, String strategy, String value, Map<String, String> extra) {
         JsonObject arguments = new JsonObject();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolTemplatesTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolTemplatesTest.java
@@ -186,7 +186,7 @@ class ToolTemplatesTest {
                       "contexts": ["browser", "browser-action"]
                     },
                     {
-                      "name": "mobile_tap",
+                      "name": "element_click",
                       "description": "Tap an element in a mobile app",
                       "context": "mobile,mobile-element-touch-action"
                     },
@@ -206,7 +206,7 @@ class ToolTemplatesTest {
 
         assertEquals(Set.of("all", "browser", "browser-action"), indexed.get("browser_take_screenshot").contextTypes());
         assertEquals(Set.of("all", "mobile", "mobile-element-touch-action"),
-                indexed.get("mobile_tap").contextTypes());
+                indexed.get("element_click").contextTypes());
         assertEquals(Set.of("all", "assistant", "diagnostics"), indexed.get("assist_only_tool").contextTypes());
     }
 


### PR DESCRIPTION
## Summary
- `GuidedWorkflowLiveE2ETest.mobileRecorderRecordsEmulatedActionsAndGeneratesShaftCode` invoked the now-removed `mobile_type`/`mobile_tap` MCP tools (design doc amendment A1, #3881); the live server returns `Tool not found` for both (proven by run 29813889559). Switched the two invocations to the live unified tools `element_type` (locator ID=search, arg `text`) and `element_click` (locator ID=go).
- `ElementService.type`/`click` dispatch through `MobileService.dispatchType`/`dispatchClick` when a mobile engine is active, reusing the same recording path as the removed direct tools (`MobileService.java:728`, `:699`), so the existing `actionCount >= 2` and generated-code (`driver.element()`, `"tap"`) assertions needed no changes.
- `ToolTemplatesTest.parseToolsListSupportsAlternativeContextKeysAndStringValues` used `"mobile_tap"` inside a fully self-contained JSON fixture (only referenced within that one test method, not checked against any live/manifest catalog) — renamed to the real live tool name `element_click` for hygiene.
- Audited the rest of `GuidedWorkflowLiveE2ETest` for other dead tool references: `capture_status` and `driver_quit` both still exist on origin/main shaft-mcp; no other issues found.

Closes #3914

## Test plan
- [x] `cd shaft-intellij && ./gradlew test --tests GuidedWorkflowLiveE2ETest --tests ToolTemplatesTest` (JDK 21 via `~/.jdks/ms-21.0.11`) — BUILD SUCCESSFUL; `GuidedWorkflowLiveE2ETest` 3/3 skipped (assumption abort, not error) since live config is unset locally; `ToolTemplatesTest` 16/16 passed.
- [ ] Live validation happens via a `guided-workflows-live` dispatch post-merge (this test only runs against a real SHAFT MCP server with `-Dshaft.intellij.liveWorkflows=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6zjrMRZpHqfeem4PkCkLn