### PR TITLE
shaft-intellij: send sessionPath/backend to unified capture_code_blocks from the guided workflow panel

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
@@ -786,16 +786,19 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
 
     private JsonObject codeBlocksArguments() {
         JsonObject arguments = new JsonObject();
-        if (mobile() || playwright()) {
-            arguments.addProperty("recordingPath", sessionPath.getText().trim());
-            arguments.addProperty("driverVariableName", "driver");
-        } else {
-            arguments.addProperty("sessionPath", sessionPath.getText().trim());
-            arguments.addProperty("outputDirectory", ".");
-            arguments.addProperty("packageName", "tests.generated");
-            arguments.addProperty("className", "GeneratedShaftTest");
-            arguments.addProperty("overwrite", false);
-            arguments.addProperty("driverVariableName", "driver");
+        arguments.addProperty("sessionPath", sessionPath.getText().trim());
+        arguments.addProperty("outputDirectory", ".");
+        arguments.addProperty("packageName", "tests.generated");
+        arguments.addProperty("className", "GeneratedShaftTest");
+        arguments.addProperty("overwrite", false);
+        arguments.addProperty("driverVariableName", "driver");
+        // Issue #3916: the unified capture_code_blocks tool (post-#3881) has no recordingPath
+        // argument and rejects unknown properties -- mobile/Playwright must pass sessionPath plus
+        // an explicit backend rather than the retired flat recordingPath shape.
+        if (mobile()) {
+            arguments.addProperty("backend", "mobile");
+        } else if (playwright()) {
+            arguments.addProperty("backend", "playwright");
         }
         return arguments;
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
@@ -164,7 +164,15 @@ class GuidedWorkflowPanelTest {
         CapturedInvocation mobileReview = last(invocations);
         assertAll(
                 () -> assertEquals("capture_code_blocks", mobileReview.toolName()),
-                () -> assertEquals("driver", mobileReview.arguments().get("driverVariableName").getAsString()));
+                () -> assertEquals("driver", mobileReview.arguments().get("driverVariableName").getAsString()),
+                // Issue #3916 live-repro finding: the unified capture_code_blocks tool (post-#3881)
+                // has no recordingPath argument -- it fails live schema validation ("property
+                // 'recordingPath' is not defined in the schema"). Mobile/Playwright must send
+                // sessionPath plus an explicit backend, exactly like the WebDriver branch below.
+                () -> assertFalse(mobileReview.arguments().has("recordingPath")),
+                () -> assertEquals("recordings/intellij-capture.json",
+                        mobileReview.arguments().get("sessionPath").getAsString()),
+                () -> assertEquals("mobile", mobileReview.arguments().get("backend").getAsString()));
 
         select(backend, "Playwright");
         start.doClick();
@@ -177,7 +185,13 @@ class GuidedWorkflowPanelTest {
         stop.doClick();
         assertEquals("capture_stop", last(invocations).toolName());
         review.doClick();
-        assertEquals("capture_code_blocks", last(invocations).toolName());
+        CapturedInvocation playwrightReview = last(invocations);
+        assertAll(
+                () -> assertEquals("capture_code_blocks", playwrightReview.toolName()),
+                () -> assertFalse(playwrightReview.arguments().has("recordingPath")),
+                () -> assertEquals("recordings/intellij-capture.json",
+                        playwrightReview.arguments().get("sessionPath").getAsString()),
+                () -> assertEquals("playwright", playwrightReview.arguments().get("backend").getAsString()));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `GuidedWorkflowPanel.codeBlocksArguments()`'s mobile/Playwright branch still sent the retired `recordingPath` argument to `capture_code_blocks`. Post-#3881 the unified tool's schema has `additionalProperties=false` and rejects it outright ("property 'recordingPath' is not defined in the schema"), proven live on run 29816909851.
- Collapses the branch split into shared codegen args (`sessionPath`, `outputDirectory`, `packageName`, `className`, `overwrite`, `driverVariableName`) plus an explicit `backend` ("mobile"/"playwright") when the panel's backend selector isn't the default WebDriver — matching the reference shape already used by `AssistantCommand.mobileCodeBlocks` (`AssistantCommand.java:1499-1509`).
- The web branch was already correct and is unchanged in shape (only de-duplicated).

Closes #3916

## Sweep for other stale `recordingPath` sites (shaft-intellij main + test)
Grepped the whole `shaft-intellij` module (main + test) for `recordingPath`. Only one stale JSON-schema-key site existed (the one fixed here). All other hits are legitimate:
- `AssistantCommand.java` (several sites, e.g. line 1897, 2399, 2447, 2623, 2642): `recordingPath` is only a local variable/parameter name; every one of these already builds its JSON with `arguments.addProperty("sessionPath", recordingPath)` — verified at `AssistantCommand.java:2625`. Not stale.
- `ShaftPanelSetupTest.java` / `GuidedWorkflowLiveE2ETest.java`: no `recordingPath` literal present; `ShaftPanelSetupTest.assistantBuildsPlaywrightReviewFromActiveRecordingPath` (line 224) already asserts the correct `sessionPath`/`backend` contract for the (separate) `ShaftAssistantPanel` class.
- Verified against `shaft-mcp/CaptureService.java`: both `capture_code_blocks` (`CaptureService.java:1027-1053`) and `capture_generate_replay` (`CaptureService.java:939-945`) declare `sessionPath`, never `recordingPath`, in their `@Tool`/`@ToolParam` schema. No legacy `playwright_capture_code_blocks`/`mobile_recording_code_blocks` tool names remain in shaft-mcp main — confirmed absorbed per #3881.
- Confirmed mobile/Playwright codegen args don't need to differ from web: `CaptureService.codeBlocks` (line 1055-1064) routes mobile/Playwright-step-recording targets straight to `mobileService.recordingCodeBlocks(sessionPath, driverVariableName)`/`playwrightService.recordingCodeBlocks(...)`, ignoring `outputDirectory`/`packageName`/`className`/`overwrite` for those targets — but the schema still declares them, and the reference caller (`AssistantCommand.mobileCodeBlocks`) sends them anyway, which this fix now matches.

**Adjacent finding, out of scope (not fixed here):** `modular-era-feature-catalog.md:500` still documents the retired `mobile_recording_code_blocks(recordingPath=...)` tool call shape from before the #3881 unification. Flagging for a follow-up doc fix.

## Test plan
- [x] TDD: extended `GuidedWorkflowPanelTest.recorderButtonsRouteByBackendAndRespectHeadlessToggle` to pin `sessionPath` + explicit `backend`, and assert `recordingPath` is absent, for both the mobile and Playwright "Review code" click — watched RED (failed at line 165 against the old code) then GREEN after the fix.
- [x] `gradlew test --tests GuidedWorkflowPanelTest --tests ShaftPanelSetupTest --tests GuidedWorkflowLiveE2ETest` (JDK `ms-21.0.11`): BUILD SUCCESSFUL — `GuidedWorkflowPanelTest` 19/19 passed, `ShaftPanelSetupTest` 241/241 passed, `GuidedWorkflowLiveE2ETest` 3/3 skipped (live E2E requires `-DincludeMcpBrowserE2E=true` + real infra, correctly skips locally).
- [ ] Post-merge: live validation via the `guided-workflows-live` dispatch workflow against a real shaft-mcp server, to confirm the fixed mobile/Playwright "Review code"/"Insert at caret"/"Create test class" actions no longer hit the schema-validation error from run 29816909851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6zjrMRZpHqfeem4PkCkLn