### PR TITLE
Fix grid-CI test-isolation and portability bugs (S2)

### DIFF
--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -70,6 +70,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Test(singleThreaded = true)
 public class ActionsCoverageUnitTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final By LOCATOR = By.id("target");

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsScreenshotBaselineUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsScreenshotBaselineUnitTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
  * the {@code matchesScreenshot()} baseline auto-create-on-first-run, {@code -Dshaft.updateSnapshots} lifecycle,
  * and the per-browser/OS baseline naming scheme with legacy fallback.
  */
+@Test(singleThreaded = true)
 public class ImageProcessingActionsScreenshotBaselineUnitTest {
     private static final FileActions FILE_ACTIONS = FileActions.getInstance(true);
     private static final Path TEMP_ROOT = Path.of("target", "temp", "imageProcessingActionsScreenshotBaselineUnitTest");

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AssertionEvidenceReporterTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AssertionEvidenceReporterTest.java
@@ -200,8 +200,7 @@ public class AssertionEvidenceReporterTest {
 
         String html = AssertionEvidenceReporter.renderAccessibilityCard(false, baselineYaml, actualYaml);
 
-        Path outputFile = Path.of(System.getProperty("shaft.accessibilityEvidence.sampleOutput",
-                "C:\\Users\\Mohab\\AppData\\Local\\Temp\\claude\\C--Users-Mohab-IdeaProjects-SHAFT-ENGINE\\a0966654-661a-46d0-8c81-75ecf6570c15\\scratchpad\\accessibility-card-sample.html"));
+        Path outputFile = sampleOutputPath("shaft.accessibilityEvidence.sampleOutput", "accessibility-card-sample.html");
         Files.createDirectories(outputFile.getParent());
         Files.writeString(outputFile, html, StandardCharsets.UTF_8);
 
@@ -241,8 +240,7 @@ public class AssertionEvidenceReporterTest {
     public void writeSampleVisualCardForManualReview() throws Exception {
         String html = AssertionEvidenceReporter.renderVisualCard(false, 4821L, 500, 0.0231d, 0.01d);
 
-        Path outputFile = Path.of(System.getProperty("shaft.visualEvidence.sampleOutput",
-                "C:\\Users\\Mohab\\AppData\\Local\\Temp\\claude\\C--Users-Mohab-IdeaProjects-SHAFT-ENGINE\\a0966654-661a-46d0-8c81-75ecf6570c15\\scratchpad\\visual-card-sample.html"));
+        Path outputFile = sampleOutputPath("shaft.visualEvidence.sampleOutput", "visual-card-sample.html");
         Files.createDirectories(outputFile.getParent());
         Files.writeString(outputFile, html, StandardCharsets.UTF_8);
 
@@ -258,8 +256,7 @@ public class AssertionEvidenceReporterTest {
 
         String html = AssertionEvidenceReporter.renderCard("Assert", false, expectedJson, actualJson);
 
-        Path outputFile = Path.of(System.getProperty("shaft.assertionEvidence.sampleOutput",
-                "C:\\Users\\Mohab\\AppData\\Local\\Temp\\claude\\C--Users-Mohab-IdeaProjects-SHAFT-ENGINE\\f31b7827-7767-4eff-9dfa-7c3f79d2df84\\scratchpad\\assertion-card-sample.html"));
+        Path outputFile = sampleOutputPath("shaft.assertionEvidence.sampleOutput", "assertion-card-sample.html");
         Files.createDirectories(outputFile.getParent());
         Files.writeString(outputFile, html, StandardCharsets.UTF_8);
 
@@ -267,5 +264,16 @@ public class AssertionEvidenceReporterTest {
         Assert.assertTrue(html.contains("FAILED"), html);
         Assert.assertTrue(html.contains(">JSON<"), html);
         Assert.assertFalse(html.contains("abcdef123456"), html);
+    }
+
+    /**
+     * Default sample-output location is the JVM temp directory so these manual-review fixtures
+     * are portable across OSes (never a hardcoded developer-machine path). Overridable per-run
+     * via the given system property, e.g. for pointing a manual review at a specific folder.
+     */
+    private static Path sampleOutputPath(String systemProperty, String fileName) {
+        Path defaultPath = Path.of(System.getProperty("java.io.tmpdir"), "shaft-evidence-samples", fileName);
+        String override = System.getProperty(systemProperty);
+        return override != null ? Path.of(override) : defaultPath;
     }
 }

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipFile;
 
+@Test(singleThreaded = true)
 public class FailureTraceReporterTest {
 
     @Test(description = "Failure mode should attach trace artifacts only for failed tests")

--- a/shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryHelperAdditionalUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/DriverFactoryHelperAdditionalUnitTest.java
@@ -402,6 +402,12 @@ public class DriverFactoryHelperAdditionalUnitTest {
         SHAFT.Properties.flags.set().autoMaximizeBrowserWindow(false);
         SHAFT.Properties.healenium.set().healEnabled(false);
         SHAFT.Properties.timeouts.set().waitForRemoteServerToBeUp(false);
+        // This test proves the mocked-construction success path only; it must not depend on
+        // whatever real Selenium Grid (if any) happens to be listening on :4444 in the current
+        // environment. Disable the live preflight explicitly instead of inheriting an ambient
+        // -DremotePreflightEnabled=true from the caller (e.g. the nightly grid CI jobs, which run
+        // a real Linux-only grid on this exact port and have no "chrome/windows" slot to match).
+        SHAFT.Properties.platform.set().remotePreflightEnabled(false);
 
         DriverFactoryHelper helper = new DriverFactoryHelper();
         try (MockedConstruction<RemoteWebDriver> ignored = org.mockito.Mockito.mockConstruction(RemoteWebDriver.class,


### PR DESCRIPTION
## Summary
- Fix intra-class TestNG method-parallelism races in 3 unit-test classes (`ActionsCoverageUnitTest`, `ImageProcessingActionsScreenshotBaselineUnitTest`, `FailureTraceReporterTest`) that share mutable state / JVM-global `SHAFT.Properties.flags` — the nightly grid jobs run `-DsetParallel=METHODS`, exposing races that don't show up in a serial local run. Fixed with `@Test(singleThreaded = true)`, a pattern already used in 52 other classes in this repo.
- Fix `DriverFactoryHelperAdditionalUnitTest`'s mocked-construction test, which hardcoded `localhost:4444` and inherited ambient `-DremotePreflightEnabled=true` from the CI environment — it was making a real network call against the nightly's real grid and failing with "No Selenium Grid slot matches chrome/windows". Now explicitly disables preflight.
- Fix `AssertionEvidenceReporterTest`'s 3 "write sample ... for manual review" tests, which defaulted their output path to a hardcoded Windows-only absolute path — on POSIX CI runners `Path.of(...)` treats the whole backslash string as one segment, so `.getParent()` is null and `Files.createDirectories(null)` throws the exact NPE seen in CI logs. Now defaults portably to `java.io.tmpdir`.

All 5 were confirmed as the deterministic cross-browser (Chrome + Edge) failure cluster in the 2026-07-21 nightly E2E Tests run (29800667354), part of an 11-night red streak.

Closes #3928

## Test plan
- [x] `mvn -pl shaft-engine test -DheadlessExecution=true -Dallure.automaticallyOpen=false -DsetParallelMode=DYNAMIC -DsetParallel=METHODS "-Dtest=AssertionEvidenceReporterTest,ActionsCoverageUnitTest,ImageProcessingActionsScreenshotBaselineUnitTest,DriverFactoryHelperAdditionalUnitTest,FailureTraceReporterTest"` → 119/119 green, reproducing the exact CI-style parallel scheduling
- [x] `mvn -pl shaft-engine test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false` → clean
- [x] Each class also verified in isolation (39/39, 8/8, 27/27, 23/23, 22/22)