### PR TITLE
Fix Maven Central release: extend publish poll timeout + add failure alerting

### DIFF
--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -326,3 +326,25 @@ jobs:
             --header 'Content-type: application/json' \
             --data @/tmp/slack_release_payload.json \
             "$SLACK_WEBHOOK_URL"
+
+  notify_release_failure:
+    name: Notify on release failure
+    needs: [ check_release_needed, build_release_and_deliver, verify_public_shaft_mcp_installer, announce_release ]
+    # Runs regardless of upstream outcome so a failure anywhere in the pipeline is caught.
+    # Most pushes to main land between releases with nothing new to deliver (see top-of-file
+    # comment): build_release_and_deliver/verify_public_shaft_mcp_installer/announce_release
+    # are then cleanly 'skipped', not failed - the outcome expression below must not alert on that.
+    if: always()
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: File or recover the release failure tracking issue
+        uses: ./.github/actions/notify-nightly-failure
+        with:
+          outcome: ${{ contains(needs.*.result, 'failure') && 'failure' || (contains(needs.*.result, 'cancelled') && 'skip' || 'success') }}
+          workflow-name: ${{ github.workflow }}
+          label: 'release-failure:maven-central-cd'

--- a/pom.xml
+++ b/pom.xml
@@ -845,10 +845,9 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <centralBaseUrl>https://central.sonatype.com</centralBaseUrl>
-                    <tokenAuth>true</tokenAuth>
                     <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil>
-                    <waitMaxTime>3600</waitMaxTime> <!-- one hour -->
+                    <waitMaxTime>7200</waitMaxTime> <!-- two hours -->
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Root cause (independently confirmed)

`gh run view 29820726153 --log-failed` for the failed [Maven Central Continuous Delivery run](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29820726153) shows:

```
[INFO] Uploaded bundle successfully, ... deploymentId: 1f8e79c6-80a8-4c49-9a66-93881f87789b. Deployment will publish automatically
[INFO] Waiting until Deployment 1f8e79c6-80a8-4c49-9a66-93881f87789b is published
```
at `10:26:51.93`, then the next log line is the Reactor Summary at `11:26:52.5684367` — exactly one hour later:
```
[INFO] io.github.shafthq:SHAFT_ENGINE ..................... FAILURE [ 01:00 h]
...
[ERROR] ... Polling for 1f8e79c6-80a8-4c49-9a66-93881f87789b timed out before the deployment completed.
```

No validation-rejection or "FAILED validation" message anywhere in the log — the deployment simply never reached a terminal state inside the poll window. `pom.xml:851` set `<waitMaxTime>3600</waitMaxTime> <!-- one hour -->`, an exact match for the observed stall. The reactor has grown to ~20 modules; checksums for every module generated cleanly at the start of the run, so this reads as the polling budget being outgrown as the reactor grew, not a real validation failure.

`10.3.20260721` is confirmed **not** live on Maven Central (`https://repo.maven.apache.org/maven2/io/github/shafthq/shaft-engine/10.3.20260721/` 404s), so this release genuinely still needs to complete.

## Fix 1 — extend the poll timeout

`pom.xml`: `waitMaxTime` `3600` → `7200` (2h), comfortably under `build_release_and_deliver`'s unset `timeout-minutes` (GH Actions default 360 min).

## Fix 2 — remove stale `tokenAuth` (verified dead, not just a guess)

The same failed run logs `[WARNING] Parameter 'tokenAuth' is unknown for plugin 'central-publishing-maven-plugin:0.11.0:publish'`. Unzipped the cached `central-publishing-maven-plugin-0.11.0.jar`'s `META-INF/maven/plugin.xml` and confirmed `tokenAuth` is not a parameter of the `publish` mojo — or any mojo — in this plugin version (full parameter list checked programmatically). It's dead config left over from the legacy OSSRH-staging-plugin migration (`72eacea1e3`, `git log -S"tokenAuth"`). Removed it.

## Fix 3 — failure notification (owner directive: never fail silently)

`mavenCentral_cd.yml` had zero failure notification — on any failure the workflow just went red on the Actions tab with nobody alerted (`verify_public_shaft_mcp_installer` and `announce_release` are both gated `if: needs.build_release_and_deliver.result == 'success'`, so a failure produces no downstream signal at all).

Added `notify_release_failure`, following the exact pattern already used by `guided-workflows-live.yml:80-97`'s `notify` job — same `needs.*.result` → `outcome` expression, same reusable `./.github/actions/notify-nightly-failure` composite action (auto-files/dedupes a labeled GH issue on failure, auto-closes it on recovery). `needs: [check_release_needed, build_release_and_deliver, verify_public_shaft_mcp_installer, announce_release]` so a failure anywhere in the pipeline is caught, including in `announce_release` itself. `permissions: issues: write` added on the new job.

Traced both scenarios by hand:
- **Normal "nothing to release" push** (the common case per this workflow's own top-of-file comment): `build_release_and_deliver`/`verify_public_shaft_mcp_installer`/`announce_release` are all cleanly `skipped` (not `failure`, not `cancelled`) → `outcome = 'success'` → no alert.
- **Real failure** (this incident): `build_release_and_deliver` → `failure` → `contains(needs.*.result, 'failure')` is true → `outcome = 'failure'` → tracking issue filed/updated.
- Manual cancel mid-run → `outcome = 'skip'` → no-op, matching the reference pattern's treatment of concurrency-cancelled runs.

## Validated locally

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/mavenCentral_cd.yml'))"` → parses cleanly.
- Re-read the full modified workflow file end to end; `if:`/`needs:` on the new job match `guided-workflows-live.yml:80-97`'s syntax exactly.
- `mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout` → `10.3.20260721` (pom still parses/evaluates). No `deploy`/`install`/`test` goals run, no GPG/OSSRH secrets touched.

## Out of scope / not touched

- No other workflow file modified.
- No real Maven deploy/install/test run against Maven Central or GPG/OSSRH secrets.
- The currently-open S2/#3936 PR and other in-flight branches untouched.

Not arming auto-merge — fast-tracking review/merge manually given the urgency, and will trigger + monitor the next real release run myself.