### PR TITLE
Wire the six live E2E test classes into CI (#3932)

### DIFF
--- a/.github/actions/build-shaft-mcp-live-jar/action.yml
+++ b/.github/actions/build-shaft-mcp-live-jar/action.yml
@@ -1,0 +1,39 @@
+name: 'Build shaft-mcp Live Launcher Jar'
+description: >-
+  Sets up JDK 25, builds a runnable shaft-mcp jar plus its runtime
+  dependencies, and writes a `java @argsfile` launcher for it (same recipe as
+  guided-workflows-live.yml, with -DheadlessExecution=true added to the
+  argsfile so the spawned MCP server process runs headless -- Web.java's
+  "system:properties" @Sources entry wins inside that process). Exports
+  MCP_JAVA (java executable) and MCP_ARGS (path to the argsfile) as job
+  environment variables so callers pass
+  "-D<gate>.liveMcpCommand=${MCP_JAVA} @${MCP_ARGS}" to a live test run.
+  Callers needing other reactor modules built (e.g. shaft-cli) must install
+  them separately -- this action only builds shaft-mcp.
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up JDK 25 (shaft-mcp runtime)
+      uses: actions/setup-java@v5
+      with:
+        java-version: '25'
+        distribution: 'zulu'
+        check-latest: true
+    - name: Build shaft-mcp with dependencies
+      shell: bash
+      run: |
+        mvn --batch-mode -pl shaft-mcp -am install -DskipTests -Dgpg.skip
+        mvn --batch-mode -pl shaft-mcp dependency:copy-dependencies -DincludeScope=runtime '-DoutputDirectory=${maven.multiModuleProjectDirectory}/shaft-mcp/target/dependency' -DskipTests -Dgpg.skip
+    - name: Write shaft-mcp launcher argfile
+      shell: bash
+      run: |
+        JAR=$(ls shaft-mcp/target/shaft-mcp-*.jar | grep -v -e sources -e javadoc -e original | head -1)
+        CLASSPATH="$(realpath "$JAR"):$(realpath shaft-mcp/target/dependency)/*"
+        {
+          printf '"-cp"\n'
+          printf '"%s"\n' "$CLASSPATH"
+          printf '"-DheadlessExecution=true"\n'
+          printf 'com.shaft.mcp.ShaftMcpApplication\n'
+        } > shaft-mcp/target/shaft-mcp-live.args
+        echo "MCP_JAVA=$JAVA_HOME/bin/java" >> "$GITHUB_ENV"
+        echo "MCP_ARGS=$PWD/shaft-mcp/target/shaft-mcp-live.args" >> "$GITHUB_ENV"

--- a/.github/workflows/live-tools-nightly.yml
+++ b/.github/workflows/live-tools-nightly.yml
@@ -1,0 +1,294 @@
+name: Live Tools Nightly E2E
+
+# Issue #3932 (subtask of tracker #3926): six live E2E test classes existed
+# with ZERO workflow wiring before this file. pr-gate.yml's `cli` leg now
+# runs ShaftCliLiveE2ETest's 3 OFFLINE methods on every PR (no
+# liveMcpCommand configured there, so its 3 live-server methods self-skip
+# via Assumptions.assumeTrue -- ShaftCliLiveE2ETest.java:144-160); this
+# workflow is the only place the LIVE-server methods across all six classes
+# ever run:
+#   - shaft-cli: ShaftCliLiveE2ETest's live trio (tools/call/doctor analyze)
+#   - shaft-intellij: the four ShaftAssistantPanelLive*ToolE2ETest classes
+#     plus AssistantGeminiLiveE2ETest
+#
+# Every job here builds its own shaft-mcp launcher jar (via the
+# build-shaft-mcp-live-jar composite action, based on
+# guided-workflows-live.yml:29-49) and, where Maven live-server tests run,
+# does so BEFORE any JDK 17/Gradle switch -- the root pom's enforcer plugin
+# (pom.xml:589-590, range [25,26)) hard-fails any Maven invocation under
+# JDK 17.
+
+on:
+  schedule:
+    # 03:30 UTC: after e2eTests.yml/e2eLocalTests.yml/shaft-mcp.yml (01:00)
+    # and guided-workflows-live.yml (02:30), before none -- no collision.
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-tools-nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  cli-live:
+    name: shaft-cli live E2E (Maven)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Build shaft-mcp live launcher jar
+        uses: ./.github/actions/build-shaft-mcp-live-jar
+      - name: Install shaft-cli reactor dependencies
+        run: mvn --batch-mode -pl shaft-cli -am install -DskipTests -q '-DheadlessExecution=true' '-Dgpg.skip' '-Dcyclonedx.skip'
+      - name: Run shaft-cli live E2E suite
+        run: >-
+          mvn --batch-mode -pl shaft-cli test
+          -Dtest=ShaftCliLiveE2ETest
+          -Dshaft.intellij.liveToolE2E=true
+          "-Dshaft.intellij.liveMcpCommand=${MCP_JAVA} @${MCP_ARGS}"
+          '-DheadlessExecution=true' '-Dallure.automaticallyOpen=false' -Dgpg.skip
+      - name: Verify shaft-cli live tests actually executed
+        run: >-
+          python3 scripts/ci/assert_tests_executed.py
+          shaft-cli/target/surefire-reports/TEST-com.shaft.commandline.ShaftCliLiveE2ETest.xml
+          --min-executed 6
+      - name: Upload shaft-cli live evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shaft-cli-live-evidence
+          path: |
+            shaft-cli/target/surefire-reports
+            shaft-cli/build/live-tool-e2e-examples
+          if-no-files-found: ignore
+          retention-days: 14
+
+  intellij-tools-core:
+    name: IntelliJ live tools (Tool + Capture)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Build shaft-mcp live launcher jar
+        uses: ./.github/actions/build-shaft-mcp-live-jar
+      - name: Set up JDK 17 (Gradle)
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          check-latest: true
+      - name: Set up Gradle 9
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: '9.0.0'
+      - name: Run live IntelliJ chat-panel tool tests (Tool + Capture)
+        run: >-
+          gradle -p shaft-intellij test
+          --tests com.shaft.intellij.ui.ShaftAssistantPanelLiveToolE2ETest
+          --tests com.shaft.intellij.ui.ShaftAssistantPanelLiveCaptureToolE2ETest
+          -Dshaft.intellij.liveToolE2E=true
+          "-Dshaft.intellij.liveMcpCommand=${MCP_JAVA} @${MCP_ARGS}"
+          "-Dshaft.intellij.workspaceRoot=${GITHUB_WORKSPACE}/build/live-tools/core"
+      - name: Verify live tool tests actually executed
+        run: >-
+          python3 scripts/ci/assert_tests_executed.py
+          shaft-intellij/build/test-results/test/TEST-com.shaft.intellij.ui.ShaftAssistantPanelLiveToolE2ETest.xml
+          shaft-intellij/build/test-results/test/TEST-com.shaft.intellij.ui.ShaftAssistantPanelLiveCaptureToolE2ETest.xml
+          --min-executed 4
+      - name: Upload live tool evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: intellij-live-tools-core-evidence
+          path: |
+            shaft-intellij/build/reports/tests/test
+            build/live-tools/core
+          if-no-files-found: ignore
+          retention-days: 14
+
+  intellij-tools-diagnostics:
+    name: IntelliJ live tools (Diagnostics)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Build shaft-mcp live launcher jar
+        uses: ./.github/actions/build-shaft-mcp-live-jar
+      - name: Set up JDK 17 (Gradle)
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          check-latest: true
+      - name: Set up Gradle 9
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: '9.0.0'
+      - name: Run live IntelliJ chat-panel tool tests (Diagnostics)
+        run: >-
+          gradle -p shaft-intellij test
+          --tests com.shaft.intellij.ui.ShaftAssistantPanelLiveDiagnosticsToolE2ETest
+          -Dshaft.intellij.liveToolE2E=true
+          "-Dshaft.intellij.liveMcpCommand=${MCP_JAVA} @${MCP_ARGS}"
+          "-Dshaft.intellij.workspaceRoot=${GITHUB_WORKSPACE}/build/live-tools/diagnostics"
+      - name: Verify live tool tests actually executed
+        run: >-
+          python3 scripts/ci/assert_tests_executed.py
+          shaft-intellij/build/test-results/test/TEST-com.shaft.intellij.ui.ShaftAssistantPanelLiveDiagnosticsToolE2ETest.xml
+          --min-executed 5
+      - name: Upload live tool evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: intellij-live-tools-diagnostics-evidence
+          path: |
+            shaft-intellij/build/reports/tests/test
+            build/live-tools/diagnostics
+          if-no-files-found: ignore
+          retention-days: 14
+
+  intellij-tools-authoring:
+    name: IntelliJ live tools (Authoring)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Build shaft-mcp live launcher jar
+        uses: ./.github/actions/build-shaft-mcp-live-jar
+      - name: Set up JDK 17 (Gradle)
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          check-latest: true
+      - name: Set up Gradle 9
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: '9.0.0'
+      # ShaftAssistantPanelLiveAuthoringToolE2ETest's two other methods
+      # (shaft_guide_search -> shafthq.github.io, test_plan_explore ->
+      # example.com) reach third-party hosts; run them in the separate,
+      # continue-on-error step below so their flakiness never fails this
+      # job -- and, by extension, never flips the notify job's outcome.
+      - name: Run authoring live tests (gating)
+        run: >-
+          gradle -p shaft-intellij test
+          --tests "com.shaft.intellij.ui.ShaftAssistantPanelLiveAuthoringToolE2ETest.shaftProjectServiceCreatesAndInitializesAgentsThroughTheRealChatPanel"
+          --tests "com.shaft.intellij.ui.ShaftAssistantPanelLiveAuthoringToolE2ETest.testAutomationServiceLooksUpScenariosAndChecksGuardrailsThroughTheRealChatPanel"
+          --tests "com.shaft.intellij.ui.ShaftAssistantPanelLiveAuthoringToolE2ETest.codingPartnerServicePlansAndDiffsThroughTheRealChatPanel"
+          -Dshaft.intellij.liveToolE2E=true
+          "-Dshaft.intellij.liveMcpCommand=${MCP_JAVA} @${MCP_ARGS}"
+          "-Dshaft.intellij.workspaceRoot=${GITHUB_WORKSPACE}/build/live-tools/authoring"
+      - name: Verify authoring gating tests actually executed
+        run: >-
+          python3 scripts/ci/assert_tests_executed.py
+          shaft-intellij/build/test-results/test/TEST-com.shaft.intellij.ui.ShaftAssistantPanelLiveAuthoringToolE2ETest.xml
+          --min-executed 3
+      - name: Run authoring externally-networked tests (non-gating)
+        continue-on-error: true
+        run: >-
+          gradle -p shaft-intellij test
+          --tests "com.shaft.intellij.ui.ShaftAssistantPanelLiveAuthoringToolE2ETest.guideServiceSearchesTheLiveUserGuideThroughTheRealChatPanel"
+          --tests "com.shaft.intellij.ui.ShaftAssistantPanelLiveAuthoringToolE2ETest.plannerServiceExploresARealHeadlessSessionThroughTheRealChatPanel"
+          -Dshaft.intellij.liveToolE2E=true
+          "-Dshaft.intellij.liveMcpCommand=${MCP_JAVA} @${MCP_ARGS}"
+          "-Dshaft.intellij.workspaceRoot=${GITHUB_WORKSPACE}/build/live-tools/authoring"
+      - name: Upload live tool evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: intellij-live-tools-authoring-evidence
+          path: |
+            shaft-intellij/build/reports/tests/test
+            build/live-tools/authoring
+          if-no-files-found: ignore
+          retention-days: 14
+
+  gemini-live:
+    name: IntelliJ live Gemini E2E
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    # Skip-if-absent, not fail-if-absent (unlike lambdatestTests.yml:63-70's
+    # LambdaTest credential check): a nightly run with no GEMINI_API_KEY
+    # configured yet should report "skipped", not "failure". No existing
+    # precedent for this in the repo -- job-level `if:` cannot read this
+    # job's own `env:` block and `if:` should not reference `secrets.`
+    # directly, so the secret is read once into the GEMINI_API_KEY job env
+    # var here, and every downstream step gates on `env.GEMINI_API_KEY != ''`.
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Build shaft-mcp live launcher jar
+        if: env.GEMINI_API_KEY != ''
+        uses: ./.github/actions/build-shaft-mcp-live-jar
+      - name: Set up JDK 17 (Gradle)
+        if: env.GEMINI_API_KEY != ''
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+          check-latest: true
+      - name: Set up Gradle 9
+        if: env.GEMINI_API_KEY != ''
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: '9.0.0'
+      - name: Run live Gemini E2E test
+        if: env.GEMINI_API_KEY != ''
+        run: >-
+          gradle -p shaft-intellij test
+          --tests com.shaft.intellij.ui.AssistantGeminiLiveE2ETest
+          -Dshaft.intellij.liveGemini=true
+          "-Dshaft.intellij.liveMcpCommand=${MCP_JAVA} @${MCP_ARGS}"
+          "-Dshaft.intellij.workspaceRoot=${GITHUB_WORKSPACE}/build/live-tools/gemini"
+      - name: Verify live Gemini test actually executed
+        if: env.GEMINI_API_KEY != ''
+        run: >-
+          python3 scripts/ci/assert_tests_executed.py
+          shaft-intellij/build/test-results/test/TEST-com.shaft.intellij.ui.AssistantGeminiLiveE2ETest.xml
+          --min-executed 1
+      - name: Skip notice (GEMINI_API_KEY not configured)
+        if: env.GEMINI_API_KEY == ''
+        run: echo "::notice::GEMINI_API_KEY is not configured; skipping the live Gemini E2E job."
+      - name: Upload live Gemini evidence
+        if: always() && env.GEMINI_API_KEY != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: intellij-live-gemini-evidence
+          path: |
+            shaft-intellij/build/reports/tests/test
+            build/live-tools/gemini
+          if-no-files-found: ignore
+          retention-days: 14
+
+  notify:
+    name: Notify on nightly failure
+    needs:
+      - cli-live
+      - intellij-tools-core
+      - intellij-tools-diagnostics
+      - intellij-tools-authoring
+      - gemini-live
+    if: always()
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: File or recover the nightly tracking issue
+        uses: ./.github/actions/notify-nightly-failure
+        with:
+          outcome: ${{ contains(needs.*.result, 'failure') && 'failure' || (contains(needs.*.result, 'cancelled') && 'skip' || 'success') }}
+          workflow-name: ${{ github.workflow }}
+          label: 'nightly-failure:live-tools'

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -199,8 +199,13 @@ jobs:
           cache: 'maven'
       - name: Install shaft-cli reactor dependencies
         run: mvn --batch-mode -pl shaft-cli -am -DskipTests install -q '-DheadlessExecution=true' '-Dgpg.skip' '-Dcyclonedx.skip'
+      # -Dshaft.intellij.liveToolE2E=true with no liveMcpCommand set (issue #3932a):
+      # exercises ShaftCliLiveE2ETest's 3 offline methods (tools --cached, codegen,
+      # session status) for real on every PR; its 3 live-server methods still
+      # self-skip via Assumptions.assumeTrue (ShaftCliLiveE2ETest.java:144-160) --
+      # the live-server trio only runs in live-tools-nightly.yml.
       - name: Test shaft-cli
-        run: mvn --batch-mode -pl shaft-cli test '-DheadlessExecution=true'
+        run: mvn --batch-mode -pl shaft-cli test '-DheadlessExecution=true' '-Dshaft.intellij.liveToolE2E=true'
       - name: Package shaft-cli and run the binary
         shell: bash
         run: |

--- a/scripts/ci/assert_tests_executed.py
+++ b/scripts/ci/assert_tests_executed.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Fail the build when a JUnit-style test report shows nothing actually ran.
+
+Guards live-test workflows (issue #3932) against a silent false-green: a typo
+in the gate system property (e.g. -Dshaft.intellij.liveToolE2E) makes every
+test self-skip via Assumptions, and the job still exits 0. Parses the same
+JUnit XML schema Maven Surefire and Gradle's Test task both emit
+(<testsuite tests="" failures="" errors="" skipped="">), following the
+xml.etree.ElementTree precedent at .github/workflows/pr-gate.yml:291-305.
+"""
+
+from __future__ import annotations
+
+import argparse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def summarize(xml_path: Path) -> tuple[int, int, int, int]:
+    """Returns (tests, failures, errors, skipped) from one JUnit-style report."""
+    root = ET.parse(xml_path).getroot()
+    tests = int(root.get("tests", "0"))
+    failures = int(root.get("failures", "0"))
+    errors = int(root.get("errors", "0"))
+    skipped = int(root.get("skipped", "0"))
+    return tests, failures, errors, skipped
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("reports", nargs="+", type=Path, help="JUnit-style TEST-*.xml report(s)")
+    parser.add_argument("--min-executed", type=int, default=1,
+                         help="Minimum non-skipped tests required across all reports (default: 1)")
+    args = parser.parse_args(argv)
+
+    total_tests = total_failures = total_errors = total_skipped = 0
+    for report in args.reports:
+        tests, failures, errors, skipped = summarize(report)
+        executed = tests - skipped
+        print(f"{report}: tests={tests} failures={failures} errors={errors} skipped={skipped} executed={executed}")
+        total_tests += tests
+        total_failures += failures
+        total_errors += errors
+        total_skipped += skipped
+
+    total_executed = total_tests - total_skipped
+    print(f"TOTAL: tests={total_tests} failures={total_failures} errors={total_errors} "
+          f"skipped={total_skipped} executed={total_executed}")
+
+    if total_failures or total_errors:
+        print(f"::error::{total_failures} failure(s) / {total_errors} error(s) across the reports")
+        return 1
+    if total_executed < args.min_executed:
+        print(f"::error::only {total_executed} test(s) actually executed (need >= {args.min_executed}); "
+              "every test self-skipped -- check the live-gate system property")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shaft-cli/.gitignore
+++ b/shaft-cli/.gitignore
@@ -1,0 +1,5 @@
+# ShaftCliLiveE2ETest.recordExample() writes real request/response evidence here
+# (shaft-cli/build/live-tool-e2e-examples/*.json) whenever the live-tool-E2E gate
+# is enabled (issue #3932a activates it in pr-gate.yml's cli leg) -- generated,
+# not source, same as shaft-intellij's own /build/ (shaft-intellij/.gitignore).
+/build/

--- a/shaft-cli/src/test/java/com/shaft/commandline/ShaftCliLiveE2ETest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/ShaftCliLiveE2ETest.java
@@ -3,6 +3,7 @@ package com.shaft.commandline;
 import com.shaft.commandline.util.Json;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import tools.jackson.databind.node.ObjectNode;
 
@@ -57,6 +58,7 @@ class ShaftCliLiveE2ETest {
     }
 
     @Test
+    @Timeout(90)
     void toolsLiveConnectsToTheCurrentBuildServer(@TempDir Path tempDir) throws IOException {
         Map<String, String> serverEnv = assumeLiveServerConfigured();
 
@@ -71,6 +73,7 @@ class ShaftCliLiveE2ETest {
     }
 
     @Test
+    @Timeout(90)
     void callInvokesAToolAgainstTheLiveServer(@TempDir Path tempDir) throws IOException {
         Map<String, String> serverEnv = assumeLiveServerConfigured();
 
@@ -85,6 +88,7 @@ class ShaftCliLiveE2ETest {
     }
 
     @Test
+    @Timeout(90)
     void doctorAnalyzeWithNoTraceFileReportsAnHonestFailure(@TempDir Path tempDir) throws IOException {
         Map<String, String> serverEnv = assumeLiveServerConfigured();
 

--- a/tests/scripts/test_assert_tests_executed.py
+++ b/tests/scripts/test_assert_tests_executed.py
@@ -1,0 +1,76 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.ci.assert_tests_executed import main, summarize
+
+
+JUNIT_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="{name}" tests="{tests}" failures="{failures}" errors="{errors}" skipped="{skipped}">
+</testsuite>
+"""
+
+
+class AssertTestsExecutedTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+    def write_report(self, filename, **counts):
+        defaults = {"name": "com.example.Test", "tests": 0, "failures": 0, "errors": 0, "skipped": 0}
+        defaults.update(counts)
+        path = Path(self.temp_dir.name) / filename
+        path.write_text(JUNIT_XML.format(**defaults), encoding="utf-8")
+        return path
+
+    def test_summarize_reads_junit_style_counts(self):
+        # Real shape confirmed against shaft-cli/target/surefire-reports/TEST-*.xml
+        # (Maven Surefire) and Gradle's Test task, which both emit this schema.
+        report = self.write_report("all-skipped.xml", tests=6, failures=0, errors=0, skipped=6)
+
+        tests, failures, errors, skipped = summarize(report)
+
+        self.assertEqual((tests, failures, errors, skipped), (6, 0, 0, 6))
+
+    def test_all_tests_skipped_fails_the_gate(self):
+        # Guards against a gate-property typo silently producing a false-green nightly.
+        report = self.write_report("all-skipped.xml", tests=6, failures=0, errors=0, skipped=6)
+
+        exit_code = main([str(report)])
+
+        self.assertEqual(exit_code, 1)
+
+    def test_some_tests_executed_passes_the_gate(self):
+        report = self.write_report("partial.xml", tests=6, failures=0, errors=0, skipped=3)
+
+        exit_code = main([str(report)])
+
+        self.assertEqual(exit_code, 0)
+
+    def test_real_failure_still_fails_the_gate_even_if_executed(self):
+        report = self.write_report("failed.xml", tests=6, failures=1, errors=0, skipped=0)
+
+        exit_code = main([str(report)])
+
+        self.assertEqual(exit_code, 1)
+
+    def test_aggregates_multiple_report_files(self):
+        # Nightly jobs pass one XML per test class; a typo affecting only one class
+        # must still fail the gate even though the other classes executed fine.
+        executed = self.write_report("executed.xml", tests=3, failures=0, errors=0, skipped=0)
+        all_skipped = self.write_report("skipped.xml", tests=3, failures=0, errors=0, skipped=3)
+
+        exit_code = main([str(executed), str(all_skipped), "--min-executed", "4"])
+
+        self.assertEqual(exit_code, 1)
+
+    def test_min_executed_threshold_is_configurable(self):
+        report = self.write_report("partial.xml", tests=6, failures=0, errors=0, skipped=5)
+
+        exit_code = main([str(report), "--min-executed", "1"])
+
+        self.assertEqual(exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Issue #3932 (subtask of tracker #3926): six live E2E test classes existed with **zero** workflow wiring. Implements the amended design posted on the issue (adversarial review complete) -- parts (a) and (b) only; (c) release-gate wiring is explicitly dropped per that review.

**(a) PR gate** -- `.github/workflows/pr-gate.yml`'s `cli` leg now passes `-Dshaft.intellij.liveToolE2E=true` (no `liveMcpCommand`) to its existing `mvn test` step, so `ShaftCliLiveE2ETest`'s 3 offline methods (`tools --cached`, `codegen`, `session status`) run for real on every PR. Its 3 live-server methods keep self-skipping via `Assumptions.assumeTrue` (`ShaftCliLiveE2ETest.java:144-160`) -- confirmed locally: `tests=6 skipped=3 failures=0`, Maven exit 0.

**(b) New nightly `.github/workflows/live-tools-nightly.yml`** (03:30 UTC, no collision with the 01:00/02:30 slots) runs the live-server methods across all six classes, split into 5 jobs:
- `cli-live` -- Maven `ShaftCliLiveE2ETest` live trio, run **before** any JDK 17/Gradle switch (root `pom.xml:589-590`'s enforcer hard-fails Maven under JDK 17).
- `intellij-tools-core` -- `ShaftAssistantPanelLiveToolE2ETest` + `ShaftAssistantPanelLiveCaptureToolE2ETest` (Gradle).
- `intellij-tools-diagnostics` -- `ShaftAssistantPanelLiveDiagnosticsToolE2ETest`.
- `intellij-tools-authoring` -- `ShaftAssistantPanelLiveAuthoringToolE2ETest`'s 3 non-networked methods gate the job; its 2 externally-networked methods (`shaft_guide_search` -> shafthq.github.io, `test_plan_explore` -> example.com) run in a separate `continue-on-error: true` step so third-party flakiness can't flip the tracking issue.
- `gemini-live` -- `AssistantGeminiLiveE2ETest`, own gate (`-Dshaft.intellij.liveGemini=true` + `GEMINI_API_KEY`), skips cleanly (not fail-closed) when the secret is absent via env-indirection (new pattern in this repo -- commented inline).
- `notify` -- includes all 5 jobs in `needs:` (Gemini included, per the review's explicit callout) and files/recovers a tracking issue via the existing `notify-nightly-failure` composite action, label `nightly-failure:live-tools`.

A new composite action `.github/actions/build-shaft-mcp-live-jar` factors out the shared jar+argfile recipe (based on `guided-workflows-live.yml:29-49`), with `-DheadlessExecution=true` added to the argfile (confirmed sufficient -- `Web.java`'s `system:properties` `@Sources` entry wins inside the spawned MCP server process).

**Other changes in scope:**
- `scripts/ci/assert_tests_executed.py` (+ `tests/scripts/test_assert_tests_executed.py`, TDD'd) parses JUnit-style Surefire/Gradle XML reports and fails the job when everything self-skipped -- guards against a gate-property typo producing a silent false-green, following the existing pattern at `pr-gate.yml:291-305`.
- Added `@Timeout(90)` to `ShaftCliLiveE2ETest`'s 3 live-server methods, which previously had none.
- Added `shaft-cli/.gitignore` (`/build/`) -- `ShaftCliLiveE2ETest.recordExample()` writes real evidence there, a path that was unreachable until the pr-gate change above actually exercises those methods.

## Validation

- YAML syntax: every `.github/workflows/*.yml` and `.github/actions/*/action.yml`, including the two touched/added here, parses cleanly via `yaml.safe_load`.
- `scripts/ci/assert_tests_executed.py`: TDD'd (red then green), then cross-checked against a **real** Maven Surefire XML generated locally (`mvn -pl shaft-cli test -Dtest=ShaftCliLiveE2ETest`) in both the all-skipped shape (`tests=6 skipped=6`) and the pr-gate shape (`tests=6 skipped=3`, gate on, no live server) -- both produced the expected pass/fail verdict.
- The exact new `mvn` command in pr-gate.yml's cli leg was run locally end-to-end (full `shaft-cli` module, matching the YAML verbatim): 70 tests, 3 self-skip (the live trio), Maven exits 0.
- Every `gradle -p shaft-intellij test --tests ...` command written into the nightly workflow (all 4 tool classes including the split authoring method-level filters, and the Gemini class) was dry-run locally (`--dry-run`) and resolved cleanly -- full live execution was intentionally **not** run locally (no `liveMcpCommand` configured on this box; would hang/fail meaninglessly per the task's hard constraint).
- Gradle's JUnit XML report schema (`<testsuite tests= failures= errors= skipped=>`) was **not** independently confirmed against a real Gradle-generated report in this session (only dry-run, per the same constraint) -- it's asserted from documented Gradle behavior and is schema-identical to the real Maven Surefire XML I did generate and validate the parser against. This is the main residual gap; the first real nightly run is the true validation for the Gradle side.
- `python3 scripts/ci/validate_agent_setup.py` passes.

**This PR cannot be fully validated locally** (six live-server test classes need a real running MCP server + IntelliJ Gradle test harness this box isn't set up to exercise for real). The first real scheduled/`workflow_dispatch` run of `live-tools-nightly.yml` is the true end-to-end validation -- please don't treat a green PR-gate run alone as proof the nightly jobs work.

## Tradeoffs

- Authoring-class network isolation uses two Gradle invocations (method-level `--tests` filters) rather than one combined run + exclude-filter, since Gradle's `--tests` is inclusion-only; the second step is `continue-on-error: true` and non-gating.
- Each of the 5 test jobs in the nightly workflow independently builds the shaft-mcp jar (via the shared composite action) rather than building once and sharing via artifacts across jobs -- simpler, avoids cross-job artifact/path wiring, costs a bit of duplicate CI time on a nightly (not latency-sensitive) workflow.

Closes #3932
