### PR TITLE
Fix macOS nightly Local E2E heap OOM: cap surefireArgLine -Xmx1024m

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,15 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <surefireArgLine>--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
+        <!-- -Xmx: macos-latest GitHub-hosted runners have only 7GB RAM (vs 16GB on windows-latest/
+             ubuntu-latest), so the JVM's ergonomic default heap (unset otherwise) is smaller there,
+             and the single reused surefire fork (reuseForks=true) that runs the whole module's tests
+             sequentially under the JaCoCo agent accumulates garbage until it exceeds that smaller
+             ceiling, crashing with OutOfMemoryError: Java heap space (#3930). 1024m gives generous,
+             empirically verified headroom: locally reproduced a clean heap-space OOM at -Xmx80m, and
+             confirmed -Xmx128m comfortably clears 300+ sequential tests in the same fork, while
+             leaving about 6GB of the 7GB macOS runner for the browser and OS. -->
+        <surefireArgLine>--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8 -Xmx1024m</surefireArgLine>
         <mockito.version>5.23.0</mockito.version>
         <mockitoAgentArgLine>-javaagent:"${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"</mockitoAgentArgLine>
         <surefire.excludedGroups>allure3-visual-demo</surefire.excludedGroups>


### PR DESCRIPTION
## Summary

- `MacOSX_Chrome_Local` and `MacOSX_Safari_Local` in the nightly Local E2E Tests workflow have been red for ~3 weeks (last green 2026-06-30), both with `java.lang.OutOfMemoryError: Java heap space`, cascading across unrelated threads (main, HTTP-Dispatcher, surefire-forkedjvm-command-thread, even the JaCoCo agent's own SessionInfo write) - classic whole-fork heap exhaustion, not one oversized allocation. Confirmed genuine via `gh run view --job <id> --log` on run 29800769309 (job 88541246527 line 113567 / job 88541246528 lines 108233+).
- Root cause: no `-Xmx` was set anywhere (root `pom.xml`, `shaft-engine/pom.xml`, or the workflow YAML), so the single reused surefire fork (`reuseForks=true`) that runs the whole module's tests sequentially under the JaCoCo agent ran on the JVM's ergonomic default heap. `macos-latest` GitHub-hosted runners have only 7GB RAM vs 16GB on `windows-latest`/`ubuntu-latest`, so that default heap is smaller there and gets exhausted by accumulated garbage across ~213/77 sequential tests before Windows/Linux ever hit it.
- Fix: add an explicit `-Xmx1024m` to `surefireArgLine` in root `pom.xml:53`. It composes correctly with the existing `@{argLine} ${surefireArgLine} ${mockitoAgentArgLine}` pattern in both the TestNG and JUnit surefire profiles (`shaft-engine/pom.xml:811-815`, `:945-949`), which was already verified not to be clobbering the JaCoCo agent.

## What was verified locally vs the real acceptance signal

The two failing test classes (`ExcelFileManagerCoverageUnitTest`, `LambdaTestSetPropertyCoverageUnitTest`) don't allocate anything large in isolation, so isolating just those 2 classes never reproduced the CI failure shape at any heap size - the real CI failure needs the ~70-200 preceding tests' accumulated garbage in the same reused fork.

To get a real reproduction, I ran a 26-class/334-test slice of `shaft-engine`'s `unitTests` package (mock-based, no live browsers) in a single reused fork, including the two CI-failing classes, under a constrained `-Xmx` via `-DsurefireArgLine` overrides (never `-DargLine`, which would drop the JaCoCo agent):
- `-Xmx48m` -> JVM fork crashes ("terminated without properly saying goodbye") - too small, a boot/runtime crash, not a clean OOM.
- `-Xmx80m` -> clean `java.lang.OutOfMemoryError: Java heap space`, cascading across threads, hitting shortly after `ExcelFileManagerCoverageUnitTest` runs - the same failure shape as CI.
- `-Xmx128m` -> all 334 tests complete cleanly (1 unrelated pre-existing failure in `AndroidApkBadgingReaderUnitTest`, an Android-build-tools-version-dependent test unrelated to memory, present identically before and after this fix).
- With the fix applied (pom default now `-Xmx1024m`, no override): re-ran both the 2 originally-failing classes (7/7 pass) and the same 26-class/334-test slice (334 tests, same 1 pre-existing unrelated failure, no OOM).
- `mvn validate` confirms the full reactor POM still parses, and `mvn help:evaluate -Dexpression=surefireArgLine` confirms the resolved property now includes `-Xmx1024m`.

**Honest gap:** this is a local Windows repro at an artificially constrained heap on a slice of the suite, not the actual macOS CI environment or its full ~213/77-test workload across the broader (not just `unitTests`) test packages. It strongly validates the *mechanism* (fork garbage accumulation -> heap exhaustion, same clean-OOM shape as CI) and gives an evidence-based floor (fails at 80m, clears at 128m for a comparable slice), with `1024m` giving generous headroom above that floor while leaving about 6GB of the 7GB macOS runner for the browser and OS. The real "green" signal is the next macOS nightly run of `e2eLocalTests.yml`.

## Test plan

- [x] `mvn -pl shaft-engine test -Dtest=ExcelFileManagerCoverageUnitTest,LambdaTestSetPropertyCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` -> 7/7 pass with the fix.
- [x] 26-class/334-test slice of `testPackage.unitTests` reproduces clean heap OOM at `-Xmx80m`, clears at `-Xmx128m` and at the fix's `-Xmx1024m` default.
- [x] `mvn validate` (full reactor) and `mvn help:evaluate -Dexpression=surefireArgLine -DforceStdout` confirm the POM change resolves correctly.
- [ ] Real acceptance: next `Local E2E Tests` nightly run on `macos-latest` (both `MacOSX_Chrome_Local` and `MacOSX_Safari_Local`) goes green.

Not arming auto-merge - orchestrator reviews and arms it.

Closes #3930