### PR TITLE
Fix stale javadoc @link references in shaft-mcp

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -886,7 +886,7 @@ public class CaptureService {
      *
      * <p>Plain Java overload with no progress reporting, preserved for direct callers (for example,
      * white-box tests); the MCP-exposed tool is {@link #generateReplay(String, String, String, String,
-     * boolean, boolean, boolean, boolean, boolean, String, String, McpSyncServerExchange)}.
+     * boolean, boolean, boolean, boolean, boolean, String, String, String, McpSyncServerExchange)}.
      *
      * @param sessionPath persisted Capture JSON path inside the MCP workspace
      * @param outputDirectory generated project root inside the MCP workspace

--- a/shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/ShaftMcpApplication.java
@@ -48,7 +48,7 @@ public class ShaftMcpApplication {
 
     /**
      * Registers the ShaftService tool callbacks. {@link PlaywrightService} and
-     * {@link NaturalActionService}'s former {@code natural_act}/{@code mobile_natural_act} tools are
+     * {@code NaturalActionService}'s former {@code natural_act}/{@code mobile_natural_act} tools are
      * deliberately absent: since commit 4 of the tool architecture sweep (design doc Decision 2),
      * every {@code playwright_*} tool is absorbed into the unified {@code element_*}/{@code browser_*}/
      * {@code capture_*}/{@code doctor_*}/{@code healer_*} tools (PlaywrightService is still a Spring


### PR DESCRIPTION
## Summary
- `CaptureService.java:888` linked the 12-arg `generateReplay` overload; the MCP-exposed overload actually takes 13 args (a `backend` parameter was added without updating the `@link`). Fixed the reference to match the real signature.
- `ShaftMcpApplication.java:51` linked `NaturalActionService`, a class deleted during the tool-architecture sweep the same comment describes. Downgraded `{@link NaturalActionService}` to `{@code NaturalActionService}` since it no longer resolves to a type.

## Root cause investigation
Pulled javadoc-step logs from 5 recent `guided-workflows-live.yml` runs (3 failing conclusion, 2 passing, plus 2 more failing runs checked for a total of 5 failing + 1 passing sampled). In **every single run**, pass or fail, the identical `CaptureService.java:888` / `ShaftMcpApplication.java:51: reference not found` error appears in the `javadoc:jar` step, immediately followed by `[INFO] Building jar:` / `[INFO] BUILD SUCCESS` — `pom.xml:671`'s `failOnError=false` suppresses it **deterministically** in 100% of samples checked, not flakily.

The workflow's actual pass/fail split traces to a separate, unrelated flake: `GuidedWorkflowLiveE2ETest.mobileRecorderRecordsEmulatedActionsAndGeneratesShaftCode()` failing an assertion in the later "Run live guided workflows through the plugin panel" Gradle step. That is a different bug, out of scope here — not touched by this PR.

This PR fixes the two genuinely broken javadoc references so the noisy, always-suppressed `reference not found` error stops appearing in CI logs and misleading future triage (which is exactly what happened here: issue #3943 was filed against the javadoc error as if it were the flaky cause).

## Test plan
- [x] `mvn -pl shaft-mcp javadoc:javadoc -DheadlessExecution=true -Dallure.automaticallyOpen=false` run locally against a clean `target/reports/apidocs` — completes with `BUILD SUCCESS` and zero `error`/`warning` lines (previously logged a suppressed `MavenReportException` with the two "reference not found" errors).
- [x] Confirmed `CaptureService.html` and `ShaftMcpApplication.html` regenerated cleanly in the fresh output.

Closes #3943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz