### PR TITLE
Fix Firefox-grid WWW-Authenticate/ClosedChannelException cluster: isolate LambdaTestHelperUnitTest (#3929)

### DIFF
--- a/shaft-engine/src/test/java/testPackage/unitTests/LambdaTestHelperUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/LambdaTestHelperUnitTest.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 
+@Test(singleThreaded = true)
 public class LambdaTestHelperUnitTest {
     @AfterMethod(alwaysRun = true)
     public void cleanup() {


### PR DESCRIPTION
## Summary

Investigated the remaining Firefox-grid-specific failure mode from issue #3929 (subtask of #3926): `ClosedChannelException` during `setRemoteDriverInstance` and `WWW-Authenticate header missing for response code 401`, seen as 20 broken tests on the 2026-07-21 nightly run ([29800667354](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29800667354)).

**This is not genuine Selenium Grid infrastructure instability.** Full CI stack traces for all 20 broken tests show the same root cause: `LambdaTestHelperUnitTest`'s real (non-mocked) invocations of `LambdaTestHelper.setupDesktopWebExecution()` / `setupMobileWebExecution()` / `setLambdaTestProperties()` mutate the thread-scoped `SHAFT.Properties.platform.executionAddress` override to a real `user:key@hub.lambdatest.com/wd/hub` value as an intentional side effect of exercising that production code path (`LambdaTestHelper.java:208`, `:160`, `:244`).

Every affected test's stack trace routes through `DriverFactory.getHelper()` → `LambdaTestHelper.getLambdaTestDriver()` with `Target: ***hub.lambdatest.com/wd/hub` — never the job's real grid at `http://localhost:4444`. This CI job never configures LambdaTest credentials, so the accidental route there burns the full 5-minute retry budget (`remoteServerInstanceCreationTimeout=5min`) and fails with either:
- `ClosedChannelException` — connection reset against `mobile-hub.lambdatest.com`
- `WWW-Authenticate header missing for response code 401` — malformed auth challenge against `hub.lambdatest.com`, both symptoms of the same unauthenticated request to a real external host.

**Why Firefox only:** the Chrome and Edge grid jobs on the identical run show **zero** occurrences of this pattern (`grep -c "hub.lambdatest\|ClosedChannelException\|WWW-Authenticate"` = 0 on both job logs), ruling out shared docker-selenium/network infra. Firefox's grid-session establishment is measurably slower than chromedriver's (industry-documented), which increases pooled-thread congestion/reuse pressure under `-DsetParallelMode=DYNAMIC -DsetParallel=METHODS`, raising the odds that `LambdaTestHelperUnitTest`'s side-effecting methods share a worker thread with a driver-instantiating victim test around its cleanup boundary.

## Fix

This is the same test-isolation bug class S2 (#3928) already fixed for four other unit-test classes racing on shared state under `DYNAMIC`/`METHODS` parallel mode — using the repo's established `@Test(singleThreaded = true)` pattern (52 existing precedents). `LambdaTestHelperUnitTest` was missed by that audit because its side effect is a network-routing property, not the `SHAFT.Properties.flags`/instance-field state S2's audit targeted.

`shaft-engine/src/test/java/testPackage/unitTests/LambdaTestHelperUnitTest.java`: added `@Test(singleThreaded = true)` at the class level, capping this class to one worker thread instead of several concurrently-scheduled ones (confirmed via interleaved sub-millisecond `Test Method:` timestamps in the CI log — multiple of this class's methods were dispatched to different threads within the same run).

## What's verified vs. what isn't

- Verified: `mvn -pl shaft-engine -am test -Dtest=LambdaTestHelperUnitTest -DheadlessExecution=true` — 9/9 pass, before and after the change.
- Verified: `mvn -pl shaft-engine -am test-compile` — clean compile.
- Verified: root-cause chain via full CI log analysis across the 2026-07-21 run (stack traces, timing, cross-job diff against Chrome/Edge on the same run).
- **Not verified locally**: the actual concurrent-thread race under full suite load — reproducing it requires the full 1129-test `GLOBAL_TESTING_SCOPE` suite under `-DsetParallelMode=DYNAMIC -DsetParallel=METHODS` against a live 10-node Firefox grid, which isn't feasible in this sandboxed Windows environment (matches how S2's own precedent commit validated this exact bug class — empirically against real parallel execution, not a hermetic unit test).
- **Real acceptance signal**: the next nightly `E2E Tests` run's `Ubuntu_Firefox_Grid` job should show zero `ClosedChannelException`/`WWW-Authenticate` broken tests. Multiple prior nights (07-19, 07-18, 07-17, 07-09) show this job passing cleanly even without this fix, so the failure is probabilistic (consistent with a race), not deterministic — a single clean run afterward is suggestive but not conclusive; a few clean nights would be the stronger signal.

## Also investigated, ruled out / out of scope

- Docker Selenium Grid image versions/config (`shaft-engine/src/main/resources/docker-compose/selenium4.yml`): Firefox, Chrome, and Edge nodes use the identical pinned image tag (`4.46.0-20260707`), same `shm_size`, connection limits, and session timeout — no Firefox-specific drift.
- `update-selenium-grid-versions.yml` / recent auto-bump PRs: not implicated: the polluted-routing root cause is independent of Grid image version.
- Existing retry/resilience infra (`DriverFactoryHelper.attemptRemoteServerConnection`, `RemoteGridPreflight` session throttling/preflight) is already present and working as designed — it retried for the full configured budget against the (wrong) LambdaTest endpoint before giving up, which is why failures took the full ~5 minutes rather than failing fast.
- The already-known `AssertionEvidenceReporterTest` NPE and `DriverFactoryHelperAdditionalUnitTest` chrome/windows `SessionNotCreatedException` also appeared in this run's broken list — those are S2 (#3928), already merged; this run predates that merge landing.
- S9 (#3935, moving tests between suites): not touched; out of scope per the parent task.

Closes #3929

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz
