### PR TITLE
shaft-intellij: add Record API entry point to GuidedWorkflowPanel

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
@@ -53,6 +53,7 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     static final String BACKEND_WEBDRIVER = "WebDriver";
     static final String BACKEND_PLAYWRIGHT = "Playwright";
     static final String BACKEND_MOBILE = "Mobile (web emulation)";
+    static final String BACKEND_API = "API";
     private static final int STATUS_POLL_INTERVAL_MILLIS = 2_000;
     /** Stop idle polling after ~5 minutes if the prepared recording request is never run. */
     private static final int MAX_POLLS_BEFORE_ACTIVE = 150;
@@ -98,6 +99,9 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     private boolean recorderSeenActive;
     private int pollsWithoutActivity;
     private String statusToolName = "";
+    // capture_api_start ignores its outputPath argument on the WEB engine and only reports the
+    // persisted session path back in its response (issue #3939); read via readApiOutputPath().
+    private String apiSessionPath = "";
 
     GuidedWorkflowPanel(Project project, ToolPrefill prefill) {
         this(project, prefill, resolveSettings());
@@ -110,7 +114,7 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
         this.settings = settings == null ? new ShaftSettingsState.Settings() : settings;
         setBorder(JBUI.Borders.empty(8));
 
-        backend = new JComboBox<>(new String[]{BACKEND_WEBDRIVER, BACKEND_PLAYWRIGHT, BACKEND_MOBILE});
+        backend = new JComboBox<>(new String[]{BACKEND_WEBDRIVER, BACKEND_PLAYWRIGHT, BACKEND_MOBILE, BACKEND_API});
         backend.getAccessibleContext().setAccessibleName("Guided workflow backend");
         templateSelector = new JComboBox<>(WorkflowTemplate.values());
         templateSelector.setPrototypeDisplayValue(WorkflowTemplate.CREATE_NEW_SHAFT_PROJECT);
@@ -433,7 +437,16 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
         recorderBrowser.setToolTipText(playwrightBackend
                 ? "The Playwright recorder start request does not take a browser parameter."
                 : "Browser used for the WebDriver capture recorder and the Mobile web-emulation session.");
-        sessionPath.setToolTipText(mobile()
+        // capture_api_start's WEB branch ignores its outputPath argument entirely -- the persisted
+        // session path is only known once the server reports it back on start (CaptureService#apiStart) --
+        // so unlike the other backends this field has nothing to send and is disabled rather than
+        // silently ignored.
+        boolean apiBackend = api();
+        sessionPath.setEnabled(!apiBackend);
+        sessionPath.setToolTipText(apiBackend
+                ? "Not used for API recording: capture_api_start ignores outputPath and reports the "
+                + "persisted session path back once the recording starts."
+                : mobile()
                 ? "Mobile recording JSON output path (capture_start outputPath)."
                 : playwrightBackend
                 ? "Playwright recording JSON output path (capture_start outputPath)."
@@ -634,6 +647,10 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     }
 
     private void startRecording() {
+        if (api()) {
+            startApiRecording();
+            return;
+        }
         if (mobile()) {
             startMobileRecording();
             return;
@@ -732,6 +749,71 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
                 }));
     }
 
+    /**
+     * Starts an API/network-traffic recording (issue #3939): {@code capture_api_start} launches its
+     * own SHAFT-managed browser on the WEB engine (CaptureService#apiStart), so this mirrors {@link
+     * #startRecording()}'s WebDriver branch rather than chaining a separate session like {@link
+     * #startMobileRecording()} does. The started recording's server-reported {@code outputPath} is
+     * captured for {@link #generateToolArguments()} since, unlike the other backends,
+     * {@code capture_api_start} ignores the Session path field entirely.
+     */
+    private void startApiRecording() {
+        String startTool = "capture_api_start";
+        JsonObject arguments = apiCaptureStartArguments();
+        ShaftMcpInvocationService invocationService = invocationService();
+        if (invocationService == null) {
+            prefill.prefill(startTool, arguments);
+            startStatusPolling("capture_api_status");
+            return;
+        }
+        setRecorderStatus("Starting the API recording...");
+        invocationService.startTool(startTool, arguments)
+                .future()
+                .whenComplete((result, error) -> onEdt(() -> {
+                    if (failed(result, error)) {
+                        setRecorderStatus("API recording failed to start: " + failureText(result, error));
+                        return;
+                    }
+                    apiSessionPath = readApiOutputPath(result);
+                    setRecorderStatus("API recording started. Interact with the browser, then press Stop recording.");
+                    startStatusPolling("capture_api_status");
+                }));
+    }
+
+    /**
+     * Arguments for {@code capture_api_start}'s WEB dispatch (CaptureService#apiStart), matching the
+     * proven-working shape {@code GuidedWorkflowLiveE2ETest#apiStart} sends: request/response body
+     * capture defaults to what {@code capture_api_generate}'s SCHEMA validation depth needs (response
+     * bodies to derive a schema from; request bodies are not rendered into the generated code).
+     */
+    private JsonObject apiCaptureStartArguments() {
+        JsonObject networkOptions = new JsonObject();
+        networkOptions.addProperty("enabled", true);
+        networkOptions.addProperty("captureRequestBodies", false);
+        networkOptions.addProperty("captureResponseBodies", true);
+
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("targetUrl", targetUrl.getText().trim());
+        arguments.addProperty("browser", (String) recorderBrowser.getSelectedItem());
+        arguments.addProperty("headless", headlessBrowser.isSelected());
+        arguments.add("networkOptions", networkOptions);
+        return arguments;
+    }
+
+    /**
+     * Unwraps {@code capture_api_start}'s {@code McpCaptureApiUnionStatus} response down to the
+     * WEB-engine {@code webStatus.outputPath} (mirrors {@code GuidedWorkflowLiveE2ETest#webStatus}):
+     * the persisted session path capture_api_generate needs, since capture_api_start never echoes
+     * back the (ignored) requested path.
+     */
+    private static String readApiOutputPath(ShaftMcpToolResult result) {
+        JsonObject raw = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
+        if (raw == null || !raw.has("webStatus") || !raw.get("webStatus").isJsonObject()) {
+            return "";
+        }
+        return jsonString(raw.getAsJsonObject("webStatus"), "outputPath");
+    }
+
     private void planPartnerWork() {
         JsonObject arguments = new JsonObject();
         arguments.addProperty("repositoryPath", ".");
@@ -754,7 +836,7 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     private void stopRecording() {
         JsonObject arguments = new JsonObject();
         arguments.addProperty("discard", false);
-        String stopTool = "capture_stop";
+        String stopTool = api() ? "capture_api_stop" : "capture_stop";
         ShaftMcpInvocationService invocationService = invocationService();
         if (invocationService == null) {
             prefill.prefill(stopTool, arguments);
@@ -773,7 +855,23 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     }
 
     private void generateCode() {
-        prefill.prefill(codeBlocksToolName(), codeBlocksArguments());
+        prefill.prefill(generateToolName(), generateToolArguments());
+    }
+
+    /**
+     * Returns the codegen MCP tool for the selected backend, shared by "Review code", "Insert at
+     * caret", and "Create test class" so the three actions always generate from the same recording.
+     * API recording (issue #3939) uses the dedicated {@code capture_api_generate} tool rather than
+     * {@code capture_code_blocks}: that tool's {@code backend} parameter only recognizes
+     * web/playwright/mobile and would silently misread an API-network recording as a WebDriver UI
+     * capture (GuidedWorkflowLiveE2ETest#apiRecorderCapturesNetworkTrafficAndGeneratesShaftApiCode).
+     */
+    private String generateToolName() {
+        return api() ? "capture_api_generate" : codeBlocksToolName();
+    }
+
+    private JsonObject generateToolArguments() {
+        return api() ? apiGenerateArguments() : codeBlocksArguments();
     }
 
     /**
@@ -782,6 +880,29 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
      */
     private String codeBlocksToolName() {
         return "capture_code_blocks";
+    }
+
+    /**
+     * Arguments for {@code capture_api_generate} (CaptureService#generateApi), matching the
+     * proven-working shape {@code GuidedWorkflowLiveE2ETest#apiGenerate} sends. {@code sessionPath}
+     * prefers the path {@code capture_api_start} actually reported ({@link #apiSessionPath}) over the
+     * disabled Session path field, since capture_api_start ignores that field's value.
+     */
+    private JsonObject apiGenerateArguments() {
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("sessionPath",
+                apiSessionPath.isBlank() ? sessionPath.getText().trim() : apiSessionPath);
+        arguments.addProperty("outputDirectory", ".");
+        arguments.addProperty("packageName", "tests.generated");
+        arguments.addProperty("className", "GeneratedApiCaptureTest");
+        arguments.addProperty("style", "SCENARIO");
+        arguments.addProperty("validationDepth", "SCHEMA");
+        arguments.addProperty("overwrite", false);
+        arguments.addProperty("replay", false);
+        arguments.addProperty("openApiSpecPath", "");
+        arguments.add("excludedTransactionIds", new JsonArray());
+        arguments.add("pinnedJsonPaths", new JsonArray());
+        return arguments;
     }
 
     private JsonObject codeBlocksArguments() {
@@ -820,7 +941,7 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     private void insertCodeAtCaret() {
         ShaftMcpInvocationService invocationService = invocationService();
         if (invocationService == null) {
-            prefill.prefill(codeBlocksToolName(), codeBlocksArguments());
+            prefill.prefill(generateToolName(), generateToolArguments());
             return;
         }
         if (selectedJavaEditor() == null) {
@@ -828,7 +949,7 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
             return;
         }
         setRecorderStatus("Generating code to insert at caret...");
-        invocationService.startTool(codeBlocksToolName(), codeBlocksArguments())
+        invocationService.startTool(generateToolName(), generateToolArguments())
                 .future()
                 .whenComplete((result, error) -> onEdt(() -> applyInsertAtCaret(result, error)));
     }
@@ -873,7 +994,7 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     private void createTestClassFromRecording() {
         ShaftMcpInvocationService invocationService = invocationService();
         if (invocationService == null) {
-            prefill.prefill(codeBlocksToolName(), codeBlocksArguments());
+            prefill.prefill(generateToolName(), generateToolArguments());
             return;
         }
         if (project == null || project.getBasePath() == null) {
@@ -881,7 +1002,7 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
             return;
         }
         setRecorderStatus("Generating test class...");
-        invocationService.startTool(codeBlocksToolName(), codeBlocksArguments())
+        invocationService.startTool(generateToolName(), generateToolArguments())
                 .future()
                 .whenComplete((result, error) -> onEdt(() -> applyCreateTestClass(result, error)));
     }
@@ -1384,6 +1505,10 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
 
     private boolean mobile() {
         return BACKEND_MOBILE.equals(backend.getSelectedItem());
+    }
+
+    private boolean api() {
+        return BACKEND_API.equals(backend.getSelectedItem());
     }
 
     private String currentSourcePath() {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
@@ -195,6 +195,87 @@ class GuidedWorkflowPanelTest {
     }
 
     @Test
+    void apiRecorderButtonsWireCaptureApiToolsMirroringWebDriverAndMobile() {
+        // Issue #3939: GuidedWorkflowPanel had zero UI entry points for API recording even though
+        // capture_api_start/capture_api_status/capture_api_stop/capture_api_generate (CaptureService,
+        // shaft-mcp) already work and are proven by GuidedWorkflowLiveE2ETest
+        // #apiRecorderCapturesNetworkTrafficAndGeneratesShaftApiCode. Start/Stop/Review code must route
+        // to those tools for the new API backend, exactly like the existing backends route to
+        // capture_start/capture_stop/capture_code_blocks.
+        List<CapturedInvocation> invocations = new ArrayList<>();
+        GuidedWorkflowPanel panel = new GuidedWorkflowPanel(null,
+                (toolName, arguments) -> invocations.add(new CapturedInvocation(toolName, arguments)));
+        expandAdvanced(panel);
+        JComboBox<?> backend = findByAccessibleName(panel, "Guided workflow backend", JComboBox.class);
+        JButton start = findButton(panel, "Start recording");
+        JButton stop = findButton(panel, "Stop recording");
+        JButton review = findButton(panel, "Review code");
+        assertNotNull(backend);
+
+        select(backend, "API");
+        start.doClick();
+        CapturedInvocation apiStart = last(invocations);
+        JsonObject networkOptions = apiStart.arguments().getAsJsonObject("networkOptions");
+        assertAll(
+                () -> assertEquals("capture_api_start", apiStart.toolName()),
+                () -> assertFalse(apiStart.arguments().get("headless").getAsBoolean()),
+                () -> assertNotNull(networkOptions, "capture_api_start requires networkOptions: "
+                        + apiStart.arguments()),
+                () -> assertTrue(networkOptions.get("enabled").getAsBoolean()),
+                () -> assertTrue(networkOptions.get("captureResponseBodies").getAsBoolean()),
+                () -> assertFalse(networkOptions.get("captureRequestBodies").getAsBoolean()));
+
+        stop.doClick();
+        CapturedInvocation apiStop = last(invocations);
+        assertAll(
+                () -> assertEquals("capture_api_stop", apiStop.toolName()),
+                () -> assertFalse(apiStop.arguments().get("discard").getAsBoolean()));
+
+        review.doClick();
+        CapturedInvocation apiGenerate = last(invocations);
+        assertAll(
+                // capture_code_blocks' backend parameter only recognizes web/playwright/mobile and would
+                // silently misread an API-network recording as a WebDriver UI capture (GuidedWorkflowLiveE2ETest
+                // javadoc); the dedicated capture_api_generate tool is the real API codegen entry point.
+                () -> assertEquals("capture_api_generate", apiGenerate.toolName()),
+                () -> assertEquals("recordings/intellij-capture.json",
+                        apiGenerate.arguments().get("sessionPath").getAsString()),
+                () -> assertFalse(apiGenerate.arguments().get("overwrite").getAsBoolean()),
+                () -> assertFalse(apiGenerate.arguments().get("replay").getAsBoolean()),
+                () -> assertTrue(apiGenerate.arguments().has("style")),
+                () -> assertTrue(apiGenerate.arguments().has("validationDepth")),
+                () -> assertTrue(apiGenerate.arguments().has("excludedTransactionIds")),
+                () -> assertTrue(apiGenerate.arguments().has("pinnedJsonPaths")));
+    }
+
+    @Test
+    void apiBackendEnablesTargetFieldsAndDisablesTheUnusedSessionPathField() {
+        // capture_api_start's WEB branch ignores its outputPath argument entirely (the session path
+        // is only known once the server reports it back), so unlike the other backends the Session
+        // path field has nothing to send for API recording and must be disabled rather than silently
+        // ignored.
+        GuidedWorkflowPanel panel = new GuidedWorkflowPanel(null, (tool, arguments) -> {
+        });
+        expandAdvanced(panel);
+        JComboBox<?> backend = findByAccessibleName(panel, "Guided workflow backend", JComboBox.class);
+        javax.swing.JCheckBox headless = findByAccessibleName(panel, "Headless browser", javax.swing.JCheckBox.class);
+        javax.swing.text.JTextComponent targetUrl =
+                findByAccessibleName(panel, "Target URL", javax.swing.text.JTextComponent.class);
+        JComboBox<?> recorderBrowser = findByAccessibleName(panel, "Recorder browser", JComboBox.class);
+        javax.swing.text.JTextComponent sessionPath =
+                findByAccessibleName(panel, "Session path", javax.swing.text.JTextComponent.class);
+        assertNotNull(backend);
+
+        select(backend, "API");
+        assertAll(
+                () -> assertTrue(targetUrl.isEnabled()),
+                () -> assertTrue(headless.isEnabled()),
+                () -> assertTrue(recorderBrowser.isEnabled()),
+                () -> assertFalse(sessionPath.isEnabled(),
+                        "capture_api_start ignores outputPath; the field has nothing to send"));
+    }
+
+    @Test
     void recorderBrowserPickerIsVisibleByDefaultAndDrivesBothStartToolArguments() {
         // Issue #3660: a real browser picker (not a hardcoded literal) replaces the old
         // "Chrome"/"CHROME" constants in both webdriverCaptureStartArguments() and


### PR DESCRIPTION
## Summary
- `GuidedWorkflowPanel` had real Start/Stop/Review-code UI for WebDriver, Playwright, and Mobile recording, but zero UI for API recording (issue #3939) even though `capture_api_start`/`capture_api_status`/`capture_api_stop`/`capture_api_generate` (`CaptureService`, shaft-mcp) already work and are proven by `GuidedWorkflowLiveE2ETest#apiRecorderCapturesNetworkTrafficAndGeneratesShaftApiCode` (merged this session).
- Adds a `BACKEND_API` option to the backend selector, wired through the existing Start recording/Stop recording/Review code buttons (`GuidedWorkflowPanel.java`):
  - Start routes to `capture_api_start` with `targetUrl`/`browser`/`headless`/`networkOptions` (response-body capture on, matching what `capture_api_generate`'s SCHEMA validation depth needs) — the same argument shape the live E2E test proved works.
  - Since `capture_api_start`'s WEB branch ignores its `outputPath` argument, the Session path field is disabled for this backend and the server-reported `outputPath` is captured from the start response instead (`readApiOutputPath`).
  - Stop routes to `capture_api_stop`.
  - Review code / Insert at caret / Create test class now share a `generateToolName()`/`generateToolArguments()` choke point that routes API recordings to the dedicated `capture_api_generate` tool instead of `capture_code_blocks` (whose `backend` parameter only recognizes web/playwright/mobile and would silently misread an API-network recording as a WebDriver capture).

## Verified
- TDD: added `apiRecorderButtonsWireCaptureApiToolsMirroringWebDriverAndMobile` and `apiBackendEnablesTargetFieldsAndDisablesTheUnusedSessionPathField` to `GuidedWorkflowPanelTest` first, watched both fail (`select(backend, "API")` — item didn't exist yet), then implemented and watched green.
- `gradlew test --tests com.shaft.intellij.ui.GuidedWorkflowPanelTest` — 21/21 pass.
- `gradlew compileJava compileTestJava` — clean.
- `gradlew test --tests ShaftToolWindowPanelTest --tests ShaftPanelSetupTest --tests InsertionAnchorTest --tests GuidedWorkflowLiveE2ETest` — all pass (the live E2E class correctly skips its 4 gated tests without live infra, 0 failures); this file was not modified.
- Manually cross-checked every new tool call's argument shape against `CaptureService#apiStart/apiStatus/apiStop/generateApi` (shaft-mcp) and against `GuidedWorkflowLiveE2ETest`'s proven-working `apiStart()`/`apiStop()`/`apiGenerate()` helper methods.

## Not verified (needs human/live review)
- Actual visual UX/layout of the new "API" backend option was not screenshot-checked: `GuidedWorkflowPanel` is not currently wired into `ShaftPluginScreenshotRendererTest`'s rendered-panel set, so no before/after screenshot evidence exists for this panel at all (pre-existing gap, not introduced by this change).
- The background status-polling display (`applyStatusPoll`) is reused as-is for the new backend for consistency with the existing WebDriver/Mobile/Playwright polling code; a plain code-reading pass suggests this polling path may not correctly unwrap the `webStatus`/`mobileStatus` union shape that `capture_status`/`capture_api_status` actually return (it reads `active`/`state`/`actionCount` at the top level), but this is pre-existing behavior shared by all backends, untested by both the unit tests and the live E2E test (neither ever asserts on `recorderStatusLabel()`'s live text), and out of scope for this UI-wiring task. Flagging for a follow-up issue.

Closes #3939