### PR TITLE
ci: roll out notify-nightly-failure to E2E Tests and Local E2E Tests

### DIFF
--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -347,3 +347,21 @@ jobs:
         with:
           job-name: Windows_Edge_Cucumber_Local
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  notify_local_e2e_tests_failure:
+    name: Notify on nightly failure
+    needs: [ Windows_Edge_Local, MacOSX_Safari_Local, Windows_Chrome_Local, Windows_SikuliX_Local, Windows_Appium_Desktop_Local, MacOSX_Chrome_Local, Windows_Edge_Cucumber_Local ]
+    if: always()
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: File or recover the nightly tracking issue
+        uses: ./.github/actions/notify-nightly-failure
+        with:
+          outcome: ${{ contains(needs.*.result, 'failure') && 'failure' || (contains(needs.*.result, 'cancelled') && 'skip' || 'success') }}
+          workflow-name: ${{ github.workflow }}
+          label: 'nightly-failure:local-e2e-tests'

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -835,3 +835,21 @@ jobs:
         with:
           job-name: Ubuntu_JUnit_E2E
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  notify_e2e_tests_failure:
+    name: Notify on nightly failure
+    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack, Ubuntu_JUnit_E2E ]
+    if: always()
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: File or recover the nightly tracking issue
+        uses: ./.github/actions/notify-nightly-failure
+        with:
+          outcome: ${{ contains(needs.*.result, 'failure') && 'failure' || (contains(needs.*.result, 'cancelled') && 'skip' || 'success') }}
+          workflow-name: ${{ github.workflow }}
+          label: 'nightly-failure:e2e-tests'


### PR DESCRIPTION
## Summary
- Adds `notify_e2e_tests_failure` to `e2eTests.yml` and `notify_local_e2e_tests_failure` to `e2eLocalTests.yml`, replicating the pattern already established by `mavenCentral_cd.yml`'s `notify_release_failure` job (and `shaft-mcp.yml`'s `notify` job).
- Each new job: `needs` covers every real test job in the workflow (verified against the actual job keys, not guessed), `if: always()`, `permissions: issues: write`, and calls `.github/actions/notify-nightly-failure` with a unique dedupe label (`nightly-failure:e2e-tests`, `nightly-failure:local-e2e-tests`).
- `shaft-mcp.yml` already had this wired in from a prior phase (#3855, label `nightly-failure:shaft-mcp`) — confirmed via `git log`/`git diff origin/main`, so no change was needed there.
- Did not touch `guided-workflows-live.yml`, `mavenCentral_cd.yml`, or `live-tools-nightly.yml` (out of scope / owned by other subtasks).

Closes #3931 (subtask of #3926)

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(...)"` confirms both edited workflow files parse as valid YAML.
- [x] Programmatically enumerated `jobs.keys()` and the new job's `needs` list for both files and diffed them against the real job names extracted straight from the files (not guessed) — exact match, nothing missing or extra.
- [x] `git diff --stat` / `git status --short` confirm only the two intended files changed.
- Cannot run GitHub Actions locally; this PR is scoped to careful static/structural validation as instructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz