### PR TITLE
shaft-intellij: unwrap capture_status/capture_api_status union before reading fields

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
@@ -94,7 +94,10 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
     private final String recordingKey = "guided#" + Integer.toHexString(System.identityHashCode(this));
     // Created lazily on the first poll so headless panel tests never touch platform executors.
     private Alarm statusPollAlarm;
-    private volatile boolean pollingActive;
+    // Package-private (not private) for GuidedWorkflowPanelTest, matching the applyStatusPoll()
+    // test seam below: exercises the real poll-response handling path against a status fixture
+    // without needing a live polling MCP connection to flip this on via startStatusPolling().
+    volatile boolean pollingActive;
     private boolean headlessLockedByPolicy;
     private boolean recorderSeenActive;
     private int pollsWithoutActivity;
@@ -1210,7 +1213,10 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
                 .whenComplete((result, error) -> onEdt(() -> applyStatusPoll(result, error)));
     }
 
-    private void applyStatusPoll(ShaftMcpToolResult result, Throwable error) {
+    // Package-private (not private) for GuidedWorkflowPanelTest (mirrors renderStepsFromStatus()
+    // below): exercises the real poll-response handling path against a status fixture directly,
+    // without needing a live polling MCP connection.
+    void applyStatusPoll(ShaftMcpToolResult result, Throwable error) {
         if (!pollingActive) {
             return;
         }
@@ -1219,7 +1225,7 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
             scheduleNextStatusPoll();
             return;
         }
-        JsonObject status = AssistantMarkdown.jsonObjectFromMcpOutput(result.output());
+        JsonObject status = unwrapCaptureStatus(AssistantMarkdown.jsonObjectFromMcpOutput(result.output()));
         // Issue #3639: the steps list is a pure projection of this same polled status, refreshed on
         // every poll (active or the final post-stop poll) -- there is no separate client-side state
         // store. A capture_status payload (WebDriver) has no "steps" key, so this naturally renders
@@ -1396,6 +1402,34 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
             }
             return text.toString();
         }
+    }
+
+    /**
+     * Unwraps a {@code capture_status}/{@code capture_api_status} union response ({@code
+     * McpCaptureUnionStatus}/{@code McpCaptureApiUnionStatus}, design doc amendment A3, landed by
+     * #3881) down to whichever of {@code webStatus}/{@code playwrightStatus}/{@code mobileStatus}
+     * the active engine populated -- mirrors {@code GuidedWorkflowLiveE2ETest}'s {@code
+     * webStatus()}/{@code mobileStatus()} helpers, which confirmed this wire shape against a live
+     * server (issue #3949): {@code state}/{@code active}/{@code actionCount}/{@code steps} live on
+     * that nested section, not at the union's top level. The union guarantees exactly one section is
+     * populated, so returning the first populated section is equivalent to dispatching on the
+     * union's {@code engine} field. A payload with none of these keys (already unwrapped, or a
+     * non-union shape) is returned unchanged.
+     *
+     * @param status the raw parsed tool output, or null
+     * @return the unwrapped engine-specific status section, or {@code status} itself when it has no
+     *         union section to unwrap
+     */
+    private static JsonObject unwrapCaptureStatus(JsonObject status) {
+        if (status == null) {
+            return null;
+        }
+        for (String section : new String[]{"webStatus", "playwrightStatus", "mobileStatus"}) {
+            if (status.has(section) && status.get(section).isJsonObject()) {
+                return status.getAsJsonObject(section);
+            }
+        }
+        return status;
     }
 
     private static boolean isRecorderActive(JsonObject status) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowPanelTest.java
@@ -1,8 +1,10 @@
 package com.shaft.intellij.ui;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
+import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.intellij.ui.components.JBList;
 import org.junit.jupiter.api.Test;
 
@@ -481,6 +483,44 @@ class GuidedWorkflowPanelTest {
         captureStatusShape.addProperty("eventCount", 3);
         assertTrue(GuidedWorkflowPanel.parseSteps(captureStatusShape).isEmpty());
         assertTrue(GuidedWorkflowPanel.parseSteps(null).isEmpty());
+    }
+
+    @Test
+    void applyStatusPollUnwrapsTheActiveEngineSectionFromTheUnionResponse() {
+        // Issue #3949: capture_status/capture_api_status return a union (McpCaptureUnionStatus /
+        // McpCaptureApiUnionStatus, design doc amendment A3, landed by #3881) with the real recorder
+        // status nested under webStatus/playwrightStatus/mobileStatus -- GuidedWorkflowLiveE2ETest's
+        // webStatus()/mobileStatus() helpers (confirmed against a live server) prove this is the
+        // actual wire shape, not the flat pre-#3881 shape. applyStatusPoll must unwrap the matching
+        // section before reading state/eventCount, or an active recording never renders as active.
+        GuidedWorkflowPanel panel = new GuidedWorkflowPanel(null, (tool, arguments) -> {
+        });
+        panel.pollingActive = true;
+
+        JsonObject webStatus = new JsonObject();
+        webStatus.addProperty("state", "ACTIVE");
+        webStatus.addProperty("eventCount", 2);
+        webStatus.addProperty("readiness", "READY");
+        webStatus.addProperty("currentUrl", "https://example.com/cart");
+
+        JsonObject union = new JsonObject();
+        union.addProperty("engine", "WEB");
+        union.add("webStatus", webStatus);
+        union.add("playwrightStatus", JsonNull.INSTANCE);
+        union.add("mobileStatus", JsonNull.INSTANCE);
+
+        try {
+            panel.applyStatusPoll(new ShaftMcpToolResult(true, union.toString(), null, null), null);
+
+            String statusText = panel.recorderStatusLabel().getText();
+            assertAll(
+                    () -> assertTrue(statusText.contains("Recording"),
+                            "Expected the WEB engine's nested webStatus to render as active: " + statusText),
+                    () -> assertTrue(statusText.contains("2 steps"),
+                            "Expected the unwrapped webStatus eventCount to render: " + statusText));
+        } finally {
+            panel.dispose();
+        }
     }
 
     private static JsonObject recordedStepsStatus(String stepId) {


### PR DESCRIPTION
## Summary
- `GuidedWorkflowPanel`'s background status poller (`applyStatusPoll`, `isRecorderActive`, `activeStatusText`, `countText`, `renderStepsFromStatus`/`parseSteps`) read `state`/`active`/`eventCount`/`steps` off the top level of the polled `capture_status`/`capture_api_status` JSON.
- Since #3881, `CaptureService#status()`/`apiStatus()` (`shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java:319-326`, `:553-558`) return a union (`McpCaptureUnionStatus`/`McpCaptureApiUnionStatus`) with the real status nested under `webStatus`/`playwrightStatus`/`mobileStatus` — `GuidedWorkflowLiveE2ETest`'s `webStatus()`/`mobileStatus()` helpers (`GuidedWorkflowLiveE2ETest.java:369-382`) already prove this wire shape against a live server.
- The Guided workflow panel's poller never unwrapped it, so an active recording never rendered as active in the status strip for any backend (WebDriver/Playwright/mobile/API) — confirmed by writing a regression test that fed `applyStatusPoll` a real union-shaped fixture and watching it fail (status stayed "Recorder idle." instead of rendering "Recording · 2 steps...").
- Fix: added `GuidedWorkflowPanel#unwrapCaptureStatus`, which resolves the union down to whichever of `webStatus`/`playwrightStatus`/`mobileStatus` is populated (the union guarantees exactly one is), applied once in `applyStatusPoll` right after parsing the poll response so every downstream reader sees the correct nested object.

## Adjacent finding (not fixed here, per issue #3949's scope boundary)
`ShaftAssistantPanel#showCaptureStartDiagnostic` (`ShaftAssistantPanel.java:3934-3955`) has the identical bug: it reads `string(statusJson, "state", "")` and `string(statusJson, "outputPath", expectedOutputPath)` directly off the raw `capture_status` union without unwrapping `webStatus`. Confirmed by reading the code — not fixed here because `ShaftAssistantPanel.java` is being actively modified by a concurrent sequential PR chain (#3918-#3922) in the same session; touching it would cause merge conflicts. This should become its own follow-up issue.

## Test plan
- [x] New regression test `GuidedWorkflowPanelTest#applyStatusPollUnwrapsTheActiveEngineSectionFromTheUnionResponse` — watched RED (status stuck at "Recorder idle." against a union fixture), then GREEN after the fix.
- [x] `./gradlew test --tests "com.shaft.intellij.ui.GuidedWorkflowPanelTest"` — 22/22 tests pass.
- [x] Full `shaft-intellij` module `./gradlew test` — BUILD SUCCESSFUL, no regressions from widening `pollingActive`/`applyStatusPoll` visibility to package-private test seams.

Closes #3949

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz