### PR TITLE
Fix host-OS-specific mobile_app absolute path detection in Appium capabilities

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertyFileManager.java
@@ -48,7 +48,7 @@ public final class PropertyFileManager {
         if (app != null && !app.isEmpty() && !isRemoteAppUrl(app)) {
             if (app.startsWith("src\\") || app.startsWith("src/")) {
                 appiumDesiredCapabilities.put("mobile_app", FileActions.getInstance(true).getAbsolutePath(app));
-            } else if (!new File(app).isAbsolute()) {
+            } else if (!isAbsoluteAppPath(app)) {
                 appiumDesiredCapabilities.put("mobile_app",
                         new File(System.getProperty("user.dir"), app).getAbsolutePath());
             }
@@ -106,6 +106,20 @@ public final class PropertyFileManager {
     private static boolean isRemoteAppUrl(String app) {
         return app.startsWith("bs://") || app.startsWith("lt://")
                 || app.startsWith("http://") || app.startsWith("https://");
+    }
+
+    private static final java.util.regex.Pattern WINDOWS_ABSOLUTE_PATH = java.util.regex.Pattern.compile("^[A-Za-z]:[\\\\/].*");
+
+    /**
+     * Returns {@code true} when {@code app} is already an absolute path, recognizing Windows-style
+     * (drive letter, e.g. {@code C:\...}) and Unix-style (leading {@code /}) absolute paths regardless
+     * of the host OS the JVM is running on. {@link File#isAbsolute()} alone is host-OS-specific: a
+     * Windows drive-letter path is reported as relative on a Linux JVM (and vice versa for a
+     * Unix-rooted path on a Windows JVM), which would otherwise cause an already-absolute path meant
+     * for a different-OS Appium target to be mangled by prepending {@code user.dir}.
+     */
+    private static boolean isAbsoluteAppPath(String app) {
+        return WINDOWS_ABSOLUTE_PATH.matcher(app).matches() || app.startsWith("/") || new File(app).isAbsolute();
     }
 
     private static void collectMobileProperties(java.util.Properties source, Map<String, String> target) {

--- a/shaft-engine/src/test/java/com/shaft/properties/internal/PropertyFileManagerInternalUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/properties/internal/PropertyFileManagerInternalUnitTest.java
@@ -1,6 +1,7 @@
 package com.shaft.properties.internal;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 public class PropertyFileManagerInternalUnitTest {
@@ -9,5 +10,38 @@ public class PropertyFileManagerInternalUnitTest {
         String jarResourcePath = "jar:file:/C:/test/shaft-engine.jar!/resources/properties/default/log4j2.properties";
 
         Assert.assertEquals(PropertyFileManager.normalizeLog4jConfigPath(jarResourcePath), jarResourcePath);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        ThreadLocalPropertiesManager.clear();
+    }
+
+    @Test(description = "A Windows-style absolute mobile_app path must be left unchanged regardless of the host OS running the JVM")
+    public void getAppiumDesiredCapabilitiesLeavesWindowsAbsolutePathUnchanged() {
+        ThreadLocalPropertiesManager.setProperty("mobile_app", "C:\\Windows\\System32\\notepad.exe");
+
+        var capabilities = PropertyFileManager.getAppiumDesiredCapabilities();
+
+        Assert.assertEquals(capabilities.get("mobile_app"), "C:\\Windows\\System32\\notepad.exe");
+    }
+
+    @Test(description = "A Unix-style absolute mobile_app path must be left unchanged regardless of the host OS running the JVM")
+    public void getAppiumDesiredCapabilitiesLeavesUnixAbsolutePathUnchanged() {
+        ThreadLocalPropertiesManager.setProperty("mobile_app", "/opt/apps/foo.apk");
+
+        var capabilities = PropertyFileManager.getAppiumDesiredCapabilities();
+
+        Assert.assertEquals(capabilities.get("mobile_app"), "/opt/apps/foo.apk");
+    }
+
+    @Test(description = "A genuinely relative mobile_app path is still resolved against user.dir")
+    public void getAppiumDesiredCapabilitiesResolvesRelativePathAgainstUserDir() {
+        ThreadLocalPropertiesManager.setProperty("mobile_app", "apps/foo.apk");
+
+        var capabilities = PropertyFileManager.getAppiumDesiredCapabilities();
+
+        String expected = new java.io.File(System.getProperty("user.dir"), "apps/foo.apk").getAbsolutePath();
+        Assert.assertEquals(capabilities.get("mobile_app"), expected);
     }
 }


### PR DESCRIPTION
## Summary
- `PropertyFileManager.getAppiumDesiredCapabilities()` used `new File(app).isAbsolute()` to decide whether a `mobile_app` path needed resolving against `user.dir`. `File.isAbsolute()` is host-OS-specific: on a Linux JVM a Windows drive-letter path (e.g. `C:\Windows\System32\notepad.exe`) is reported as relative, so it got mangled by prepending `user.dir` -- breaking Appium "windows" platform targets whenever SHAFT runs from a non-Windows CI/build machine.
- Adds a host-OS-independent `isAbsoluteAppPath()` check (Windows drive-letter regex `^[A-Za-z]:[\/].*` or a leading `/`, falling back to `File.isAbsolute()`) so Windows- and Unix-style absolute `mobile_app` paths are left unmodified on any host OS, while genuinely relative paths (e.g. `apps/myapp.apk`) still resolve against `user.dir` exactly as before. `src\`/`src/`-prefixed paths and remote URLs (`bs://`, `lt://`, `http(s)://`) are untouched.
- Blocking: this is the root cause of the "Unit Tests (shaft-engine)" CI failure on `ubuntu-22.04` (run https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29836658960) that is gating PR #3952.

## Test plan
- [x] Added `PropertyFileManagerInternalUnitTest` cases exercising `getAppiumDesiredCapabilities()` directly: Windows absolute path stays unchanged, Unix absolute path stays unchanged, genuinely relative path still resolves against `user.dir`.
- [x] Watched RED before the fix: on this Windows dev host, `File.isAbsolute()` already happens to return `true` for the Windows-style path (masking that specific direction locally), but the **mirror-image** manifestation of the exact same bug reproduced locally -- the Unix-style absolute path test failed, asserting `/opt/apps/foo.apk` but getting `...\shaft-engine\opt\apps\foo.apk` (i.e. `user.dir` was wrongly prepended), because `File.isAbsolute()` for a Unix-rooted path is also `false` on a Windows JVM.
- [x] Watched GREEN after the fix: all 4 tests in `PropertyFileManagerInternalUnitTest` pass.
- [x] `OptionsManagerCoverageUnitTest` (the CI-failing test's class) — all 6 tests pass.
- [x] `mvn -pl shaft-engine test-compile` — BUILD SUCCESS.
- [x] Broader regression sweep: `PropertyFileManagerInternalUnitTest`, `OptionsManagerCoverageUnitTest`, `ThreadLocalPropertiesTest`, `PropertyFileManagerUnitTest`, `PropertiesHelperInitializationUnitTest` (all classes referencing `PropertyFileManager`/`getAppiumDesiredCapabilities`) — 47/47 pass.

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz