### PR TITLE
shaft-intellij: additive raw-CLI terminal tab for Claude Code and Codex (#3959)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/actions/OpenClaudeCodeTerminalAction.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/actions/OpenClaudeCodeTerminalAction.java
@@ -1,0 +1,48 @@
+package com.shaft.intellij.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.shaft.intellij.notifications.ShaftNotifier;
+import com.shaft.intellij.ui.CliTerminalSupport;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Opens a real interactive terminal tab running the Claude Code CLI ({@code claude}, no
+ * {@code --print}/stream-json flags -- its normal interactive TUI) so power users can opt into the
+ * raw CLI experience alongside the guided Assistant chat, not instead of it (issue #3959, follow-up
+ * to the #3917 embed-terminal spike's no-go on replacing the chat). Only ever invokes an
+ * already-installed {@code claude} binary found on {@code PATH} -- nothing is bundled or
+ * redistributed.
+ */
+public final class OpenClaudeCodeTerminalAction extends AnAction implements DumbAware {
+    private static final String EXECUTABLE = "claude";
+    private static final String TAB_NAME = "Claude Code";
+    private static final String NOTIFICATION_TITLE = "Claude Code terminal";
+    private static final String INSTALL_HINT = "Claude Code CLI (`claude`) isn't on PATH. Install it first: "
+            + "npm install -g @anthropic-ai/claude-code";
+    private static final String TERMINAL_UNAVAILABLE_HINT = "Couldn't open a terminal automatically -- the "
+            + "JetBrains Terminal plugin may be missing or disabled. Open a terminal yourself and run: " + EXECUTABLE;
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        Project project = event.getProject();
+        if (project == null) {
+            return;
+        }
+        if (!CliTerminalSupport.isExecutableOnPath(EXECUTABLE)) {
+            ShaftNotifier.warn(project, NOTIFICATION_TITLE, INSTALL_HINT);
+            return;
+        }
+        String workingDirectory = project.getBasePath() == null ? "." : project.getBasePath();
+        // No invokeLater: onOutcome's real caller is a javax.swing.Timer listener, which the Swing
+        // contract already guarantees runs on the EDT (see ShaftMcpSetupPanel#copyCommandIntoTerminal
+        // for the same reasoning against the same ShaftTerminalCommands seam).
+        CliTerminalSupport.openInteractiveCliTerminal(project, workingDirectory, TAB_NAME, EXECUTABLE, typed -> {
+            if (!typed) {
+                ShaftNotifier.warn(project, NOTIFICATION_TITLE, TERMINAL_UNAVAILABLE_HINT);
+            }
+        });
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/actions/OpenCodexTerminalAction.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/actions/OpenCodexTerminalAction.java
@@ -1,0 +1,47 @@
+package com.shaft.intellij.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.shaft.intellij.notifications.ShaftNotifier;
+import com.shaft.intellij.ui.CliTerminalSupport;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Opens a real interactive terminal tab running the Codex CLI ({@code codex}, no {@code exec}
+ * one-shot flag -- its normal interactive TUI) so power users can opt into the raw CLI experience
+ * alongside the guided Assistant chat, not instead of it (issue #3959, follow-up to the #3917
+ * embed-terminal spike's no-go on replacing the chat). Only ever invokes an already-installed
+ * {@code codex} binary found on {@code PATH} -- nothing is bundled or redistributed.
+ */
+public final class OpenCodexTerminalAction extends AnAction implements DumbAware {
+    private static final String EXECUTABLE = "codex";
+    private static final String TAB_NAME = "Codex";
+    private static final String NOTIFICATION_TITLE = "Codex terminal";
+    private static final String INSTALL_HINT = "Codex CLI (`codex`) isn't on PATH. Install it first: "
+            + "npm install -g @openai/codex";
+    private static final String TERMINAL_UNAVAILABLE_HINT = "Couldn't open a terminal automatically -- the "
+            + "JetBrains Terminal plugin may be missing or disabled. Open a terminal yourself and run: " + EXECUTABLE;
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        Project project = event.getProject();
+        if (project == null) {
+            return;
+        }
+        if (!CliTerminalSupport.isExecutableOnPath(EXECUTABLE)) {
+            ShaftNotifier.warn(project, NOTIFICATION_TITLE, INSTALL_HINT);
+            return;
+        }
+        String workingDirectory = project.getBasePath() == null ? "." : project.getBasePath();
+        // No invokeLater: onOutcome's real caller is a javax.swing.Timer listener, which the Swing
+        // contract already guarantees runs on the EDT (see ShaftMcpSetupPanel#copyCommandIntoTerminal
+        // for the same reasoning against the same ShaftTerminalCommands seam).
+        CliTerminalSupport.openInteractiveCliTerminal(project, workingDirectory, TAB_NAME, EXECUTABLE, typed -> {
+            if (!typed) {
+                ShaftNotifier.warn(project, NOTIFICATION_TITLE, TERMINAL_UNAVAILABLE_HINT);
+            }
+        });
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/CliExecutableDetector.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/CliExecutableDetector.java
@@ -36,9 +36,35 @@ final class CliExecutableDetector {
                 continue;
             }
             for (String extension : extensions) {
-                if (new File(directory, executable + extension).isFile()) {
+                String candidate = executable + extension;
+                boolean found = windows
+                        ? directoryContainsCaseInsensitive(directory, candidate)
+                        : new File(directory, candidate).isFile();
+                if (found) {
                     return true;
                 }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Windows PATHEXT matching is case-insensitive by definition (cmd.exe resolves {@code .exe},
+     * {@code .Exe} and {@code .EXE} identically), regardless of whether the underlying filesystem
+     * happens to fold case itself. {@link File#isFile()} only matches case-insensitively on
+     * filesystems (like NTFS) that fold case at the OS level -- on a case-sensitive filesystem
+     * (e.g. the ext4 runners CI builds on) it would silently miss a real match. Listing the
+     * directory and comparing names with {@link String#equalsIgnoreCase} implements the
+     * case-insensitive match explicitly, so behavior no longer depends on the host filesystem.
+     */
+    private static boolean directoryContainsCaseInsensitive(String directory, String candidateName) {
+        File[] entries = new File(directory).listFiles();
+        if (entries == null) {
+            return false;
+        }
+        for (File entry : entries) {
+            if (entry.isFile() && entry.getName().equalsIgnoreCase(candidateName)) {
+                return true;
             }
         }
         return false;

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/CliExecutableDetector.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/CliExecutableDetector.java
@@ -1,0 +1,57 @@
+package com.shaft.intellij.ui;
+
+import java.io.File;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Detects whether an agent CLI ({@code claude}, {@code codex}) is present on {@code PATH}, so the
+ * CLI terminal actions (issue #3959) can point a user at the install command instead of opening a
+ * terminal tab that just prints "command not found". Pure PATH/PATHEXT lookup -- no process is
+ * spawned -- with the same injected-state DI shape {@link SetupPrerequisites} already uses so
+ * this stays trivially testable without touching the real environment.
+ */
+final class CliExecutableDetector {
+    private static final List<String> DEFAULT_WINDOWS_EXTENSIONS = List.of(".exe", ".cmd", ".bat", ".ps1");
+    private static final List<String> NO_EXTENSION = List.of("");
+
+    private CliExecutableDetector() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static boolean isOnPath(String executable) {
+        return isOnPath(executable, System.getenv("PATH"), System.getenv("PATHEXT"), isWindows());
+    }
+
+    /**
+     * Package-private overload used by tests to stub {@code PATH}/{@code PATHEXT} and the OS.
+     */
+    static boolean isOnPath(String executable, String pathEnv, String pathExtEnv, boolean windows) {
+        if (executable == null || executable.isBlank() || pathEnv == null || pathEnv.isBlank()) {
+            return false;
+        }
+        List<String> extensions = windows ? windowsExtensions(pathExtEnv) : NO_EXTENSION;
+        for (String directory : pathEnv.split(java.util.regex.Pattern.quote(File.pathSeparator))) {
+            if (directory.isBlank()) {
+                continue;
+            }
+            for (String extension : extensions) {
+                if (new File(directory, executable + extension).isFile()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static List<String> windowsExtensions(String pathExtEnv) {
+        if (pathExtEnv == null || pathExtEnv.isBlank()) {
+            return DEFAULT_WINDOWS_EXTENSIONS;
+        }
+        return List.of(pathExtEnv.split(";"));
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/CliTerminalSupport.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/CliTerminalSupport.java
@@ -1,0 +1,58 @@
+package com.shaft.intellij.ui;
+
+import com.intellij.openapi.project.Project;
+
+import java.util.function.Consumer;
+
+/**
+ * Opens a real interactive terminal tab running an agent CLI ({@code claude}/{@code codex}) in its
+ * normal PTY-backed interactive mode (issue #3959) -- a standalone, additive entry point alongside
+ * the existing Assistant chat, never a replacement of it. Deliberately reuses {@link
+ * ShaftTerminalCommands}'s reflection-based Terminal-plugin detection and clipboard-paste-free
+ * fallback rather than a second implementation of that discipline (the #3917 spike's load-bearing
+ * constraint): the only behavior this adds on top is submitting the typed command immediately,
+ * since launching the CLI *is* the point of the action, unlike the pre-type-and-let-the-user-review
+ * flow {@code ShaftMcpSetupPanel} uses for setup scripts.
+ */
+public final class CliTerminalSupport {
+    private CliTerminalSupport() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Opens (or reuses) a terminal tab named {@code tabName} rooted at {@code workingDirectory} and
+     * immediately runs {@code command} in it. {@code onOutcome} mirrors {@link
+     * ShaftTerminalCommands#openWithPreparedCommand(Project, String, String, String, Consumer)}:
+     * invoked at most once, on the EDT (its real caller is a {@code javax.swing.Timer} listener --
+     * see {@code ShaftMcpSetupPanel#copyCommandIntoTerminal} for why that needs no extra {@code
+     * invokeLater}), once the async submit has genuinely finished. The boolean return value only
+     * means "opening was scheduled" -- false means the Terminal plugin is missing/disabled/drifted
+     * (or {@code project}/{@code command} was invalid), and the caller should fall back to telling
+     * the user to run {@code command} themselves.
+     */
+    public static boolean openInteractiveCliTerminal(Project project, String workingDirectory, String tabName,
+                                                       String command, Consumer<Boolean> onOutcome) {
+        return ShaftTerminalCommands.openWithPreparedCommand(
+                project, workingDirectory, tabName, submitCommand(command), onOutcome);
+    }
+
+    /**
+     * Package-private for {@code CliTerminalSupportTest}: appends the carriage return that submits
+     * the typed command to the shell, the one difference from {@code ShaftTerminalCommands}'s
+     * default pre-type-without-Enter behavior.
+     */
+    static String submitCommand(String command) {
+        return command + "\r";
+    }
+
+    /**
+     * Whether {@code executable} is present on {@code PATH}, so callers outside this package (the
+     * CLI terminal actions) can point the user at the install command instead of opening a terminal
+     * tab that just prints "command not found". Public facade over the package-private {@link
+     * CliExecutableDetector} -- kept the same minimal-exposure shape {@link ShaftToolWindowPanel}
+     * already uses for {@code com.shaft.intellij.actions}.
+     */
+    public static boolean isExecutableOnPath(String executable) {
+        return CliExecutableDetector.isOnPath(executable);
+    }
+}

--- a/shaft-intellij/src/main/resources/META-INF/plugin.xml
+++ b/shaft-intellij/src/main/resources/META-INF/plugin.xml
@@ -62,6 +62,23 @@
                     description="Open the SHAFT tool window"
                     icon="/icons/shaftToolWindow.svg"
                     iconDark="/icons/shaftToolWindow_dark.svg"/>
+            <!-- Additive, opt-in raw-CLI terminal entry points (issue #3959): a real interactive
+                 PTY session running the official agent CLI, alongside the guided Assistant chat,
+                 never a replacement of it. Reuse ShaftTerminalCommands's reflection-based Terminal
+                 plugin detection, so these degrade gracefully (a notification instead of a crash)
+                 when that optional plugin is missing or disabled. -->
+            <action id="Shaft.OpenClaudeCodeTerminal"
+                    class="com.shaft.intellij.actions.OpenClaudeCodeTerminalAction"
+                    text="Open Claude Code Terminal"
+                    description="Open a real interactive terminal running the Claude Code CLI (advanced, alongside the guided Assistant chat)"
+                    icon="/icons/actions/view.svg"
+                    iconDark="/icons/actions/view_dark.svg"/>
+            <action id="Shaft.OpenCodexTerminal"
+                    class="com.shaft.intellij.actions.OpenCodexTerminalAction"
+                    text="Open Codex Terminal"
+                    description="Open a real interactive terminal running the Codex CLI (advanced, alongside the guided Assistant chat)"
+                    icon="/icons/actions/view.svg"
+                    iconDark="/icons/actions/view_dark.svg"/>
         </group>
     </actions>
 </idea-plugin>

--- a/shaft-intellij/src/test/java/com/shaft/intellij/actions/CliTerminalActionsRegistrationTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/actions/CliTerminalActionsRegistrationTest.java
@@ -1,0 +1,40 @@
+package com.shaft.intellij.actions;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins that the two new raw-CLI terminal actions (issue #3959) are registered in the
+ * {@code Shaft.ToolsMenu} group next to {@code Shaft.OpenToolWindow}, mirroring {@code
+ * ShaftIconAssetsTest#pluginDescriptorRegistersSvgIconsAndRestartRequirement}'s plain-text
+ * descriptor assertions -- no live IDE bootstrap needed. Also pins that no new {@code
+ * bundledPlugin(...)} Terminal dependency was introduced in {@code build.gradle.kts}: this
+ * feature must stay on the same optional/reflection discipline {@code ShaftTerminalCommands}
+ * already established (the #3917 spike's load-bearing constraint).
+ */
+class CliTerminalActionsRegistrationTest {
+    @Test
+    void pluginDescriptorRegistersBothCliTerminalActionsInTheToolsMenuGroup() throws IOException {
+        String descriptor = Files.readString(Path.of("src/main/resources/META-INF/plugin.xml"));
+
+        assertTrue(descriptor.contains("id=\"Shaft.ToolsMenu\""));
+        assertTrue(descriptor.contains(
+                "class=\"com.shaft.intellij.actions.OpenClaudeCodeTerminalAction\""));
+        assertTrue(descriptor.contains(
+                "class=\"com.shaft.intellij.actions.OpenCodexTerminalAction\""));
+    }
+
+    @Test
+    void buildScriptDeclaresNoNewHardTerminalPluginDependency() throws IOException {
+        String buildScript = Files.readString(Path.of("build.gradle.kts"));
+
+        assertFalse(buildScript.contains("bundledPlugin(\"org.jetbrains.plugins.terminal\")"),
+                "the Terminal plugin must stay optional/reflection-only, per the #3917 spike");
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/CliExecutableDetectorTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/CliExecutableDetectorTest.java
@@ -1,0 +1,58 @@
+package com.shaft.intellij.ui;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure PATH/PATHEXT lookup used to decide whether {@code claude}/{@code codex} are actually
+ * installed before the new CLI terminal actions (issue #3959) try to launch one -- injected
+ * PATH/PATHEXT/OS state, same DI shape as {@link SetupPrerequisitesTest}, so this runs headless
+ * with no real process spawned.
+ */
+class CliExecutableDetectorTest {
+    @TempDir
+    Path binDir;
+
+    @Test
+    void bareExecutableOnPosixPathIsFound() throws IOException {
+        Files.createFile(binDir.resolve("claude"));
+
+        assertTrue(CliExecutableDetector.isOnPath("claude", binDir.toString(), null, false));
+    }
+
+    @Test
+    void windowsExecutableNeedsAPathextExtensionMatch() throws IOException {
+        Files.createFile(binDir.resolve("claude.cmd"));
+
+        assertTrue(CliExecutableDetector.isOnPath("claude", binDir.toString(), ".COM;.EXE;.CMD", true));
+    }
+
+    @Test
+    void windowsLookupFallsBackToDefaultExtensionsWhenPathextIsBlank() throws IOException {
+        Files.createFile(binDir.resolve("codex.exe"));
+
+        assertTrue(CliExecutableDetector.isOnPath("codex", binDir.toString(), "", true));
+    }
+
+    @Test
+    void missingExecutableIsNotFound() {
+        assertFalse(CliExecutableDetector.isOnPath("claude", binDir.toString(), null, false));
+    }
+
+    @Test
+    void blankPathEnvIsNotFound() {
+        assertFalse(CliExecutableDetector.isOnPath("claude", "", null, false));
+    }
+
+    @Test
+    void blankExecutableIsNotFound() {
+        assertFalse(CliExecutableDetector.isOnPath("", binDir.toString(), null, false));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/CliTerminalSupportTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/CliTerminalSupportTest.java
@@ -1,0 +1,33 @@
+package com.shaft.intellij.ui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * The additive raw-CLI terminal tab (issue #3959) reuses {@link ShaftTerminalCommands}'s existing
+ * reflection + fallback discipline rather than inventing a new one: this class only adds the one
+ * behavior that differs from the pre-type-and-wait flow {@code ShaftMcpSetupPanel} already uses --
+ * actually submitting the command, since the whole point of the action is to launch an interactive
+ * CLI session immediately, not to stage a command for the user to review first.
+ */
+class CliTerminalSupportTest {
+    @Test
+    void submitCommandAppendsCarriageReturnSoTheShellRunsItImmediately() {
+        assertEquals("claude\r", CliTerminalSupport.submitCommand("claude"));
+    }
+
+    @Test
+    void openInteractiveCliTerminalReturnsFalseWhenProjectIsNull() {
+        boolean opened = CliTerminalSupport.openInteractiveCliTerminal(
+                null, ".", "Claude Code", "claude", typed -> { });
+
+        assertFalse(opened);
+    }
+
+    @Test
+    void isExecutableOnPathReturnsFalseForAnObviouslyMissingCommand() {
+        assertFalse(CliTerminalSupport.isExecutableOnPath("definitely-not-a-real-cli-xyz123"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds two opt-in Tools-menu actions, **Open Claude Code Terminal** and **Open Codex Terminal**, that launch a real interactive PTY terminal running the user's already-installed `claude`/`codex` binary in its normal interactive TUI mode -- alongside the existing Assistant chat panel, never replacing it. This is the follow-up ticket the #3917 embed-terminal spike explicitly recommended after its no-go on replacing the chat.
- Reuses `ShaftTerminalCommands`'s existing reflection-based Terminal-plugin detection and clipboard-paste-free fallback discipline (the load-bearing constraint from #3917) rather than a second implementation of it. `CliTerminalSupport` is a thin public facade over it, adding only the one behavior that genuinely differs: submitting the typed command immediately (append `\r`) instead of waiting for the user to press Enter, since launching the CLI *is* the point of the action -- unlike `ShaftMcpSetupPanel`'s pre-type-and-review flow for setup scripts.
- `CliExecutableDetector` is a small, pure PATH/PATHEXT lookup (own implementation, no dependency on the excluded `AssistantLocalAgentRunner`) so each action can point the user at the npm install command instead of opening a terminal tab that just prints "command not found".
- No new hard dependency on the optional Terminal plugin: `build.gradle.kts` is untouched (no `bundledPlugin("org.jetbrains.plugins.terminal")`), and `plugin.xml`'s existing `optional="true"` Terminal dependency is unchanged -- pinned by a new registration test.
- No CLI binary is bundled or redistributed; only an already-installed binary on `PATH` is invoked.

Closes #3959

## Explicitly deferred / out of scope

- **GitHub Copilot CLI** is not included in this PR. Landing Claude Code + Codex proves the pattern; Copilot CLI can follow in a separate, small PR per the task's own allowance for that split.
- No changes anywhere in `ShaftAssistantPanel.java`, `AssistantTranscriptView.java`, `AssistantLocalAgentRunner.java`, `ShaftAssistantChatState.java`, or `ShaftStatusPresentation.java` -- this PR is file-isolated from the in-flight #3918-#3923 chat-transparency round, per the task's hard isolation requirement.

## Test plan

All run scoped via Gradle (`shaft-intellij` is a Gradle module, not part of the Maven reactor), JDK 21 (`-Dorg.gradle.java.home=<ms-21.0.11>`; JDK 25 is a known Gradle-daemon crasher on this repo, see #3784), `-DheadlessExecution=true`:

- [x] `CliExecutableDetectorTest` (6 tests) -- pure PATH/PATHEXT lookup, POSIX and Windows extension matching, blank/missing inputs. Written first, watched RED (compile failure), then GREEN.
- [x] `CliTerminalSupportTest` (3 tests) -- `submitCommand` appends the carriage return; `openInteractiveCliTerminal` returns `false` for a null project; `isExecutableOnPath` returns `false` for an obviously-missing command. Written first, watched RED, then GREEN.
- [x] `CliTerminalActionsRegistrationTest` (2 tests) -- `plugin.xml` registers both new actions in `Shaft.ToolsMenu`; `build.gradle.kts` declares no new hard Terminal-plugin dependency. Written first, watched RED, then GREEN.
- [x] `compileJava` + `compileTestJava` for the full `shaft-intellij` module -- clean, no regressions.
- [x] `ShaftIconAssetsTest` (existing, adjacent) rerun after the `plugin.xml` edit -- still green.
- Not tested (by design, per the task's own carve-out): a live interactive PTY session launching `claude`/`codex` in a real IDE. That needs a running IntelliJ instance with the Terminal plugin and the CLI actually installed -- not something a headless Swing/Gradle unit test can drive. The reflection/detection logic and action registration above are the testable seams, and both are covered.

## Notes for the reviewer

While scouting `ShaftTerminalCommands.openWithPreparedCommand`'s `onOutcome` contract, I found its javadoc claims the callback fires "off the EDT" -- but the implementation uses a `javax.swing.Timer` listener, which the Swing contract guarantees runs *on* the EDT (confirmed by `ShaftMcpSetupPanel#copyCommandIntoTerminal`'s own comment: "No invokeLater here... the Swing contract already guarantees runs on the EDT"). I did not touch `ShaftTerminalCommands.java` (kept the diff isolated to new files + `plugin.xml`), and wrote my own two actions to match the real (EDT) behavior rather than the docstring. Flagging this pre-existing doc/comment inaccuracy for a separate small fix -- not blocking, not part of this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz