### PR TITLE
shaft-intellij: close silent content drops in Assistant transcript pipeline (#3920)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
@@ -21,8 +21,16 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
     private static final int MAX_SESSIONS = 12;
     // Package-private (not private): AssistantTranscriptView reuses this exact constant, rather than
     // duplicating the number, to bound its own rendered messages/bubbles to the same trim policy
-    // (issue #3751 part 2, MEDIUM finding 4).
-    static final int MAX_MESSAGES_PER_SESSION = 80;
+    // (issue #3751 part 2, MEDIUM finding 4). Trimming past this cap deletes the oldest messages
+    // outright -- a real agent-response content loss, not just a rendering choice (issue #3920). Raised
+    // from 80 to make genuine mid-session data loss practically unreachable while still bounding
+    // memory/render cost against a runaway pathological run; a disclosure-collapse ("N earlier
+    // messages") alternative was considered and rejected as disproportionate to this ticket -- the trim
+    // logic in AssistantTranscriptView is tightly coupled to precise index bookkeeping across three
+    // parallel structures with existing fragile invariants, and this same cap is enforced independently
+    // on the persisted session below (ensureMessages), so a real "no loss ever" guarantee would need
+    // both layers redesigned together regardless of a collapse bubble here.
+    static final int MAX_MESSAGES_PER_SESSION = 500;
     private static final String SECOND_PERSON_LABEL = String.valueOf(new char[]{'Y', 'o', 'u'});
     private static final Pattern KEY_VALUE_SECRET = Pattern.compile(
             "(?iu)([\"']?\\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|authorization|cookie|set-cookie)\\b[\"']?\\s*[:=]\\s*)([\"']?)[^\\s`'\",}]+([\"']?)");

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -236,7 +236,6 @@ final class ShaftAssistantPanel extends JPanel {
      * shadow. -1 while no local-agent stream is active. */
     private int localAgentStreamPlaceholderMessageIndex = -1;
     private StringBuilder localAgentOutput;
-    private boolean localAgentBubbleRendersContent;
     /** Issue #3918: false for a buffered/custom-command local-agent run (Copilot's default command, or
      * any hand-typed custom command) -- such a run's entire live stream is raw CLI passthrough with no
      * SHAFT-translated milestone content, so non-verbose mode must render none of it as a compact
@@ -2023,7 +2022,11 @@ final class ShaftAssistantPanel extends JPanel {
         // Cancel (as opposed to Kill, which finalizes synchronously in stopLocalAgentStreaming) reaches
         // this method asynchronously once the future completes, and the partial output the user already
         // saw would otherwise be silently discarded by showAgentCancelled's hardcoded "_Cancelled._".
-        boolean hadPartialOutput = localAgentBubbleRendersContent && localAgentOutput != null && !localAgentOutput.isEmpty();
+        // Issue #3920 fold-in (mirrors the #3918/PR#3958 Kill-path fix in stopLocalAgentStreaming):
+        // gated on Verbose's CURRENT state, not localAgentBubbleRendersContent -- a sticky flag that
+        // stays true for the rest of the run once Verbose has rendered anything even if the user flips
+        // it back off before cancelling, which used to dump the raw buffer into a non-verbose transcript.
+        boolean hadPartialOutput = verboseLocalAgentOutput() && localAgentOutput != null && !localAgentOutput.isEmpty();
         String partialOutput = hadPartialOutput ? localAgentOutput.toString() : "";
         localAgentOutput = null;
         if (currentStream) {
@@ -2214,7 +2217,6 @@ final class ShaftAssistantPanel extends JPanel {
     private void appendStreamingLocalAgentBubble(int streamToken) {
         activeLocalAgentStreamToken = streamToken;
         localAgentOutput = new StringBuilder();
-        localAgentBubbleRendersContent = false;
         localAgentStreamPlaceholderMessageIndex = -1;
         // Permissive default: the real production call site overrides this right after, once the
         // invocation is known (issue #3918); callers that start a stream without one (tests) keep
@@ -2242,7 +2244,6 @@ final class ShaftAssistantPanel extends JPanel {
         }
         localAgentOutput.append(content == null ? "" : content);
         if (verboseLocalAgentOutput()) {
-            localAgentBubbleRendersContent = true;
             replaceLocalAgentStreamPlaceholder(
                     "assistant", formatLocalAgentStreamingResponse(localAgentOutput.toString()), false);
         } else if (activeLocalAgentStreamHasStructuredMilestones && !rawPassthrough) {
@@ -2260,6 +2261,10 @@ final class ShaftAssistantPanel extends JPanel {
     // action -- unlike Bash/Read/Edit/... or any mcp__-prefixed SHAFT tool, which do represent real
     // progress and must keep surfacing. Kept small and named on purpose (#3672); extend only for a
     // confirmed report of another internal meta-tool leaking into the visible milestone bubbles.
+    // Policy (issue #3920): this only filters the *compact non-verbose* milestone bubble below --
+    // appendLocalAgentOutput's Verbose branch renders the raw accumulated stream unfiltered, so a
+    // suppressed tool call is gated behind Verbose, never truly gone, satisfying the "formatted,
+    // behind a disclosure, or behind Verbose" contract without adding noise to the common case.
     private static final Set<String> NON_ACTIONABLE_META_TOOL_NAMES = Set.of("ToolSearch");
 
     /**
@@ -2267,17 +2272,19 @@ final class ShaftAssistantPanel extends JPanel {
      * runs (issue #3695; this fed a separately-scrollable "Run timeline" list before that removal).
      * Raw NDJSON lines (an unmapped Claude/Codex structured-stream event with no human-readable
      * translation, see {@code AssistantLocalAgentRunner}'s {@code StructuredStreamParser#accept})
-     * always start with {@code {}; skipping those keeps this method's visibility contract identical
-     * to Verbose mode's pre-#3546 raw-content boundary (#3545: raw stdout stays invisible unless the
-     * user opts into Verbose) while still giving a signal of progress for everything else — translated
-     * milestones ("Calling tool X...", "Thinking: ...") and plain-prose/banner lines. Sub-lines that
-     * name a {@link #NON_ACTIONABLE_META_TOOL_NAMES} tool call are dropped first (#3672: internal
-     * harness meta-tool calls like ToolSearch were leaking into the visible milestone bubbles). A
-     * "Tool result (X): .../Tool failed (X): ..." sub-line whose content is long enough to look like
-     * a raw dump rather than a short status is compacted by {@link #compactIfRawToolResult}, closing
-     * a gap where non-JSON raw tool output (a Bash stdout dump, a file's full contents) still leaked
-     * through as-is even with Verbose off, contradicting the "only human readable messages" contract
-     * this method exists to enforce.
+     * always start with {@code {}; those never render verbatim here (Verbose mode's pre-#3546
+     * raw-content boundary stays intact: #3545, raw stdout stays invisible unless the user opts into
+     * Verbose) but a {@link #RAW_STRUCTURED_OUTPUT_NOTICE} milestone surfaces in their place instead of
+     * silently showing nothing (issue #3920: a JSON-only line that never streams again while Verbose is
+     * on -- e.g. it was the run's last line before a normal completion -- used to vanish with zero
+     * trace, not merely "hidden until Verbose"). Sub-lines that name a {@link
+     * #NON_ACTIONABLE_META_TOOL_NAMES} tool call are dropped first (#3672: internal harness meta-tool
+     * calls like ToolSearch were leaking into the visible milestone bubbles). A "Tool result (X): .../
+     * Tool failed (X): ..." sub-line whose content is long enough to look like a raw dump rather than a
+     * short status is compacted by {@link #compactIfRawToolResult}, closing a gap where non-JSON raw
+     * tool output (a Bash stdout dump, a file's full contents) still leaked through as-is even with
+     * Verbose off, contradicting the "only human readable messages" contract this method exists to
+     * enforce.
      */
     private void addCompactLocalAgentMilestone(String line) {
         if (line == null) {
@@ -2294,11 +2301,21 @@ final class ShaftAssistantPanel extends JPanel {
             filtered.append(compactIfRawToolResult(subLine));
         }
         String trimmed = filtered.toString().strip();
-        if (trimmed.isEmpty() || trimmed.startsWith("{") || trimmed.startsWith("[")) {
+        if (trimmed.isEmpty()) {
+            return;
+        }
+        if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+            appendAgentMilestone(RAW_STRUCTURED_OUTPUT_NOTICE);
             return;
         }
         appendAgentMilestone(trimmed);
     }
+
+    // Issue #3920: shown in place of a raw, unmapped NDJSON milestone line (never rendered verbatim
+    // in non-verbose mode) so its content is still discoverable instead of vanishing with no trace --
+    // the full line remains reachable by enabling Verbose, matching compactIfRawToolResult's pointer.
+    private static final String RAW_STRUCTURED_OUTPUT_NOTICE =
+            "_Raw structured output received — enable Verbose to see it._";
 
     private static final Pattern TOOL_RESULT_PREFIX =
             Pattern.compile("^(Tool (?:result|failed) \\([^)]*\\)): (.*)$");

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantTranscriptViewTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantTranscriptViewTest.java
@@ -145,6 +145,37 @@ class AssistantTranscriptViewTest {
                 "replaceLast must mutate the existing last bubble in place and construct zero new bubbles");
     }
 
+    /**
+     * Issue #3920: {@link AssistantTranscriptView#trimOldestIfOverCapacity} deletes the oldest bubbles
+     * outright once a session exceeds {@link ShaftAssistantChatState#MAX_MESSAGES_PER_SESSION} -- a
+     * real content loss, not just a rendering choice, for any real-world session that runs long (many
+     * non-verbose milestone bubbles, one per streamed line). The cap is raised substantially (from 80)
+     * so genuine mid-session data loss becomes practically unreachable, while still bounding memory/
+     * render cost against a genuinely runaway pathological run -- a disclosure-collapse alternative was
+     * considered and rejected as disproportionate: the trim logic is tightly coupled to precise index
+     * bookkeeping across three parallel structures (messages/messageRawEvidence/renderedBubbles) with
+     * existing fragile invariants (canAppendIncrementally, truncationBoundaryIndex, the streamed-fence-
+     * delta fast path), and {@code ShaftAssistantChatState} enforces the identical cap independently on
+     * the persisted session, so a real "no loss ever" guarantee would need both layers redesigned
+     * together regardless.
+     */
+    @Test
+    void assistantTranscriptRetainsMessagesWellBeyondTheOldEightyMessageCapToAvoidSilentContentLoss() {
+        AssistantTranscriptView view = new AssistantTranscriptView();
+        int messageCount = 150;
+
+        for (int i = 0; i < messageCount; i++) {
+            view.append("assistant", "Milestone " + i);
+        }
+
+        assertAll(
+                () -> assertEquals(messageCount, view.currentMessageCountForTest(),
+                        "150 messages must all be retained -- the old 80-message cap used to silently "
+                                + "drop the oldest 70: " + view.currentMessageCountForTest()),
+                () -> assertTrue(view.markdown().contains("Milestone 0"),
+                        "The oldest message must not be silently dropped: " + view.markdown()));
+    }
+
     @Test
     void replaceLastUpdatesTheExistingBubblesRenderedHtmlInPlace() {
         AssistantTranscriptView view = new AssistantTranscriptView();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -3508,6 +3508,28 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantVerboseModeStillSurfacesToolSearchDespiteNonVerboseMilestoneSuppression() throws Exception {
+        // Issue #3920: NON_ACTIONABLE_META_TOOL_NAMES only ever filters the *compact* non-verbose
+        // milestone bubble (addCompactLocalAgentMilestone) -- appendLocalAgentOutput's Verbose branch
+        // renders the raw accumulated stream unfiltered, so ToolSearch is not silently dropped
+        // system-wide, only gated behind Verbose (the policy this issue requires: formatted, behind a
+        // disclosure, or behind Verbose -- never truly gone). Pins that policy so a future change can't
+        // accidentally filter ToolSearch out of the Verbose stream too, which would make it a genuine
+        // silent drop with no escape hatch at all.
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JCheckBox verbose = findByAccessibleName(panel, "Show verbose agent output", JCheckBox.class);
+        verbose.setSelected(true);
+
+        appendStreamingLocalAgentBubble(panel, 611);
+        appendLocalAgentOutput(panel, 611, "Calling tool ToolSearch...");
+
+        String transcript = transcriptMarkdown(panel);
+        assertTrue(transcript.contains("Calling tool ToolSearch"),
+                "ToolSearch must still reach the user via Verbose, even though the compact non-verbose "
+                        + "milestone bubble suppresses it: " + transcript);
+    }
+
+    @Test
     void assistantAgentMilestoneBubbleIsSkippedWhenSuppressedToolCallIsTheOnlyContent() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         appendStreamingLocalAgentBubble(panel, 112);
@@ -3574,6 +3596,53 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(transcript.contains("Tool result (Bash):"), transcript),
                 () -> assertTrue(transcript.toLowerCase(java.util.Locale.ROOT).contains("verbose"),
                         "The compacted preview must point the user at Verbose for the full output: " + transcript));
+    }
+
+    @Test
+    void assistantCompactedToolResultPointerIsReachableByTogglingVerboseMidRun() throws Exception {
+        // Issue #3920: confirms the "enable Verbose to see the full output" pointer from the sibling
+        // test above actually leads somewhere rather than being a dead end. localAgentOutput retains
+        // the full, uncompacted content for the whole run regardless of what the compact milestone
+        // bubble showed, so flipping Verbose on and letting the run stream at least one more line
+        // renders the complete original content via the (separate) live streaming bubble.
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JCheckBox verbose = findByAccessibleName(panel, "Show verbose agent output", JCheckBox.class);
+        String rawOutput = "line ".repeat(120).strip();
+        String longLine = "Tool result (Bash): " + rawOutput;
+
+        appendStreamingLocalAgentBubble(panel, 621);
+        appendLocalAgentOutput(panel, 621, longLine);
+        verbose.setSelected(true);
+        appendLocalAgentOutput(panel, 621, "next streamed line after enabling Verbose");
+
+        String transcript = transcriptMarkdown(panel);
+        assertTrue(transcript.contains(rawOutput),
+                "Enabling Verbose mid-run must actually surface the previously compacted full content: "
+                        + transcript);
+    }
+
+    @Test
+    void assistantNonVerboseModeSurfacesANoticeInsteadOfSilentlyDroppingRawJsonMilestoneLines() throws Exception {
+        // Issue #3920: addCompactLocalAgentMilestone used to silently return (append nothing at all)
+        // for an unmapped raw NDJSON sub-line ("{"/"[" -- see StructuredStreamParser#accept's raw
+        // passthrough for an event with no human-readable mapping). If that line never streams again
+        // while Verbose is on and the run finishes normally, the content was gone with zero trace it
+        // ever existed -- a genuine silent content drop, not "verbose-gated" in any meaningful sense.
+        // A compact milestone bubble must now surface instead, pointing the user at Verbose, matching
+        // the established compactIfRawToolResult pointer-text pattern for the same "reachable via
+        // Verbose" contract as every other suppression point in this issue.
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        String rawJson = "{\"type\":\"system\",\"subtype\":\"thinking_tokens\",\"tokens\":42}";
+
+        appendStreamingLocalAgentBubble(panel, 601);
+        appendLocalAgentOutput(panel, 601, rawJson);
+
+        String transcript = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertFalse(transcript.contains(rawJson),
+                        "Raw NDJSON must never render verbatim while Verbose is off: " + transcript),
+                () -> assertTrue(transcript.toLowerCase(java.util.Locale.ROOT).contains("verbose"),
+                        "A notice must point the user at Verbose instead of showing nothing at all: " + transcript));
     }
 
     @Test
@@ -3793,6 +3862,33 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(markdown.contains("Killed"), markdown),
                 () -> assertFalse(markdown.contains("raw content shown while verbose was on"),
                         "Verbose was off at kill time, so the raw partial buffer must not be dumped: "
+                                + markdown));
+    }
+
+    @Test
+    void assistantCancelledRunAfterVerboseToggledOffMidStreamDoesNotDumpRawBuffer() throws Exception {
+        // Issue #3920 fold-in: unlike stopLocalAgentStreaming (the Kill path, fixed for #3918 by
+        // PR#3958), showAgentResult's plain-Cancel path still keyed its "show the raw partial
+        // buffer?" decision off the sticky localAgentBubbleRendersContent flag (true forever once
+        // Verbose rendered anything this run) instead of Verbose's CURRENT state -- so a user who saw
+        // raw content while Verbose was on, then flipped it back off before cancelling (as opposed to
+        // killing), still got the entire raw buffer dumped into the "Cancelled" bubble. Mirrors
+        // assistantKilledRunAfterVerboseToggledOffMidStreamDoesNotDumpRawBuffer above.
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JCheckBox verbose = findByAccessibleName(panel, "Show verbose agent output", JCheckBox.class);
+        verbose.setSelected(true);
+
+        appendStreamingLocalAgentBubble(panel, 501);
+        appendLocalAgentOutput(panel, 501, "raw content shown while verbose was on");
+        verbose.setSelected(false);
+
+        showAgentResult(panel, 501, null, new CancellationException("cancelled"));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("Cancelled"), markdown),
+                () -> assertFalse(markdown.contains("raw content shown while verbose was on"),
+                        "Verbose was off at cancel time, so the raw partial buffer must not be dumped: "
                                 + markdown));
     }
 


### PR DESCRIPTION
## Summary

Closes #3920 (subtask of tracking issue #3923, owner directive: "ensure
full transparency and fully forwarding agent responses").

Fixes four of the five verified suppression points plus a fold-in
cancel-path bug; point 5's mechanism was investigated and found to be
unfixable at the layer the issue named -- see "Point 5" below for the
finding and why it needs an orchestrator decision instead of a unilateral
fix here.

### 1. Raw-JSON drop -- fixed
`ShaftAssistantPanel#addCompactLocalAgentMilestone`: a sub-line starting
with `{`/`[` (unmapped raw NDJSON) used to `return` with **nothing**
appended -- if that line never streamed again while Verbose was on and the
run finished normally, the content vanished with zero trace, not merely
"hidden until Verbose". Now appends a compact `RAW_STRUCTURED_OUTPUT_NOTICE`
milestone pointing at Verbose, matching `compactIfRawToolResult`'s existing
pointer-text pattern.

### 2. Meta-tool drop -- verified compliant, documented
`NON_ACTIONABLE_META_TOOL_NAMES` (`ToolSearch`) only ever filters the
*compact non-verbose* milestone bubble. `appendLocalAgentOutput`'s Verbose
branch renders the raw accumulated stream unfiltered, so a suppressed tool
call is gated behind Verbose, never truly gone -- already policy-compliant.
Added a regression test pinning this (`assistantVerboseModeStillSurfaces
ToolSearchDespiteNonVerboseMilestoneSuppression`) and a doc comment stating
the policy explicitly, so a future change can't silently start filtering
the Verbose stream too.

### 3. Tool-result compaction reachability -- verified reachable
`compactIfRawToolResult`'s "enable Verbose to see the full output" pointer
already leads somewhere for the common case: `localAgentOutput` retains
the full, uncompacted content for the whole run, so toggling Verbose on
and letting at least one more line stream renders the complete original
content via the (separate) live streaming bubble. Added a confirming
regression test. **Narrower edge case found, not fixed** (see Known
follow-ups below).

### 4. Transcript cap-trim -- fixed by raising the cap
`AssistantTranscriptView#trimOldestIfOverCapacity` genuinely deletes the
oldest bubbles past `MAX_MESSAGES_PER_SESSION`. Raised from 80 to 500
(one-line change, both `AssistantTranscriptView` and the independently-
enforced persisted-session cap in `ShaftAssistantChatState#ensureMessages`
share the same constant). A disclosure-collapse ("N earlier messages")
alternative was considered and rejected: the trim logic is tightly coupled
to precise index bookkeeping across three parallel structures
(`messages`/`messageRawEvidence`/`renderedBubbles`) with existing fragile
invariants, and the identical cap is enforced independently on the
persisted session, so a true "no loss ever" guarantee would need both
layers redesigned together regardless of a collapse bubble in one of them.
Documented the decision at the constant's declaration.

### 5. Terminal-event CONSUMED suppression on cancel/kill -- investigated, not fixed here
Traced a real race: `AssistantLocalAgentRunner#run()` unconditionally
throws `CancellationException` once it observes `cancellationRequested`
after the process exits, discarding an already-parsed terminal "result"
event's answer text even if the CLI genuinely finished right before/as
cancellation registered. I implemented and TDD-verified a fix inside
`run()` (guard the throw on `streamParser.hasTerminalEvent()`) -- **then
discovered it is entirely inert in production** and reverted it: `ShaftMcpInvocation#cancel()`/`kill()`
deliberately call `future.cancel(true)` **before** `cancelAction`/`killAction`
run (issue #3758/#3768, empirically validated across 500 runs per that
class's own doc comment). Once the wrapping `CompletableFuture` is
Future-cancelled, *any* value `run()` later returns or throws is silently
discarded by the JDK -- my fix inside `run()` never had a chance to be
observed by any real caller. Confirmed empirically: the fix made zero
difference to the reproducing test's outcome.

The actual fix, if wanted, would need to forward the terminal event's
answer text into the **live** output-consumer stream (so it lands in
`localAgentOutput` during the run, before any cancellation race can
discard the final-return-value path) rather than holding it back as
`CONSUMED` until `finalOutput()`. That changes the terminal-event handling
contract for every run, not just cancelled ones (risk of duplicating the
answer in both the live stream and the final polished bubble), and touches
the same concurrency-sensitive area the #3758 fix carefully reasoned
through with real race data. That's an architectural call, not something
to change unilaterally within this task's scope -- reporting it back
rather than guessing.

### Fold-in: Cancel-path sticky-flag bug (from #3918/PR#3958) -- fixed
PR #3958 fixed the Kill path's `stopLocalAgentStreaming` to key its
"dump the raw partial buffer?" decision off `verboseLocalAgentOutput()`'s
*live* state instead of the sticky `localAgentBubbleRendersContent` flag
(true forever once Verbose rendered anything that run). The mirror-image
Cancel path (`showAgentResult`'s `hadPartialOutput`) had the identical bug
and was explicitly out of that PR's scope. Applied the same fix here;
`localAgentBubbleRendersContent` is now unused everywhere, so the dead
field/its two write sites were removed.

## Known follow-ups (not fixed, reporting per scope discipline)

- **Point 3 narrower edge case**: if a compacted "Tool result" milestone
  is the *very last* line before a run completes normally (no more
  streamed lines after Verbose is toggled on, and no cancel/kill), the
  pointer's promise is never fulfilled -- `finishLocalAgentResponse`
  replaces the streaming bubble with the polished final answer regardless
  of Verbose, and `localAgentOutput` is discarded on completion without
  ever dumping the raw buffer in that path. Narrower than the general case
  (which does work), and would need the same terminal-completion redesign
  point 5 identifies.
- **Point 5**: see above -- needs an explicit decision on forwarding
  terminal-event content live vs. leaving the current (already fairly rare)
  cancel/kill race as-is.

## Test plan
- [x] TDD red/green for every fix: fold-in Cancel-path sticky flag, raw-JSON
      notice, Verbose-gating regression, compaction-reachability regression,
      transcript-cap raise.
- [x] Scoped Gradle runs (JDK 21, `ms-21.0.11`):
      `ShaftPanelSetupTest`, `AssistantTranscriptViewTest`,
      `AssistantTranscriptViewPerformanceTest`,
      `AssistantLocalAgentRunnerVerboseStreamTest`, `ShaftAssistantChatStateTest`
      -- all green.
- [x] `compileJava`/`compileTestJava` full module compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz