### PR TITLE
shaft-intellij: message-kind model + central style registry (#3921)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
@@ -102,6 +102,10 @@ final class AssistantTranscriptView extends JPanel {
     static final String TRANSCRIPT_ROLE_PROPERTY = "shaft.transcript.role";
     static final String TRANSCRIPT_BUBBLE_PROPERTY = "shaft.transcript.bubble";
     static final String TRANSCRIPT_RENDERED_HTML_PROPERTY = "shaft.transcript.renderedHtml";
+    // Issue #3921: mirrors TRANSCRIPT_ROLE_PROPERTY, but carries the message's resolved
+    // ShaftAssistantChatState kind (KIND_USER/KIND_ASSISTANT_TEXT/...) rather than its role, so
+    // callers/tests can observe which MessageStyleRegistry entry a rendered row actually used.
+    static final String TRANSCRIPT_KIND_PROPERTY = "shaft.transcript.kind";
 
     private final Project project;
     private final JPanel fallbackPanel;
@@ -354,7 +358,7 @@ final class AssistantTranscriptView extends JPanel {
     private void appendBubbleIncrementally(int index) {
         ShaftAssistantChatState.Message message = messages.get(index);
         String rawEvidence = index < messageRawEvidence.size() ? messageRawEvidence.get(index) : "";
-        RenderedBubble handle = fallbackMessage(message.role, message.markdown, rawEvidence);
+        RenderedBubble handle = fallbackMessage(message.role, message.kind, message.markdown, rawEvidence);
         fallbackPanel.add(handle.row);
         renderedBubbles.add(handle);
         fallbackPanel.revalidate();
@@ -605,6 +609,7 @@ final class AssistantTranscriptView extends JPanel {
         }
         ShaftAssistantChatState.Message message = new ShaftAssistantChatState.Message();
         message.role = normalizedRole(role);
+        message.kind = ShaftAssistantChatState.resolveKind(message.kind, message.role);
         message.markdown = value;
         messages.add(message);
         messageRawEvidence.add(rawEvidence == null ? "" : rawEvidence);
@@ -656,7 +661,7 @@ final class AssistantTranscriptView extends JPanel {
             }
             ShaftAssistantChatState.Message message = messages.get(i);
             String rawEvidence = i < messageRawEvidence.size() ? messageRawEvidence.get(i) : "";
-            RenderedBubble handle = fallbackMessage(message.role, message.markdown, rawEvidence);
+            RenderedBubble handle = fallbackMessage(message.role, message.kind, message.markdown, rawEvidence);
             fallbackPanel.add(handle.row);
             renderedBubbles.add(handle);
         }
@@ -850,22 +855,21 @@ final class AssistantTranscriptView extends JPanel {
         return row;
     }
 
-    private RenderedBubble fallbackMessage(String role, String markdown, String rawEvidence) {
+    private RenderedBubble fallbackMessage(String role, String kind, String markdown, String rawEvidence) {
         bubbleCreationCount++;
         String normalizedRole = normalizedRole(role);
         boolean user = USER_ROLE.equals(normalizedRole);
-        Color background = user
-                ? resolvedColor("Panel.selectionBackground", new Color(0x2563EB))
-                : resolvedColor("Panel.background", new Color(0xF6F8FA));
-        Color foreground = user
-                ? resolvedColor("Panel.selectionForeground", Color.WHITE)
-                : resolvedColor("TextArea.foreground", new Color(0x202020));
+        String normalizedKind = ShaftAssistantChatState.resolveKind(kind, normalizedRole);
+        MessageStyleRegistry.MessageStyle style = MessageStyleRegistry.styleFor(normalizedKind);
+        Color background = style.background();
+        Color foreground = style.foreground();
         JPanel row = new PreferredHeightRow(new BorderLayout());
         row.setOpaque(false);
         row.setBorder(JBUI.Borders.emptyBottom(10));
         row.putClientProperty(TRANSCRIPT_ROLE_PROPERTY, normalizedRole);
+        row.putClientProperty(TRANSCRIPT_KIND_PROPERTY, normalizedKind);
         row.getAccessibleContext().setAccessibleName((user ? "User" : "Assistant") + " assistant message row");
-        Color stroke = user ? null : resolvedColor("Component.borderColor", new Color(0xD0D7DE));
+        Color stroke = style.stroke();
         RoundedBubblePanel bubble = new RoundedBubblePanel(background, stroke, 18);
         bubble.setLayout(new BorderLayout());
         bubble.setBorder(JBUI.Borders.empty(9, 11));

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/MessageStyleRegistry.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/MessageStyleRegistry.java
@@ -1,0 +1,66 @@
+package com.shaft.intellij.ui;
+
+import com.intellij.ui.JBColor;
+
+import java.awt.Color;
+
+/**
+ * Central kind-&gt;style registry for {@link AssistantTranscriptView}'s {@code fallbackMessage}
+ * bubble seam (issue #3921). Before this class, a bubble's color was decided by one inline
+ * user/non-user branch inside {@code fallbackMessage} -- every {@link ShaftAssistantChatState.Message#kind}
+ * value now resolves to its own {@link MessageStyle} entry here, so a later ticket can give a kind
+ * (e.g. {@code error}, {@code tool-event}) a distinct look by editing one case in this class instead
+ * of hunting for markdown text-prefix/glyph branches scattered through the rendering code. Scope for
+ * #3921 is the model + this addressable seam, not a visual redesign: every non-user kind currently
+ * resolves to the exact same colors the single "assistant" bubble style already used, so switching
+ * to this registry is a zero-pixel-diff refactor.
+ *
+ * <p>Every color is resolved through {@link JBColor#namedColor}, the same theme-aware pattern
+ * {@code AssistantTranscriptView#resolvedColor} already uses, so light/dark IDE themes are honored
+ * automatically.
+ */
+final class MessageStyleRegistry {
+    private MessageStyleRegistry() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Resolves the bubble style for {@code kind}. Unrecognized/blank kinds fall back to the same
+     * style as {@link ShaftAssistantChatState#KIND_ASSISTANT_TEXT} -- callers normally pass an
+     * already-{@link ShaftAssistantChatState#resolveKind}d value, but this stays defensive so a
+     * stale/corrupt persisted kind can never throw mid-render.
+     */
+    static MessageStyle styleFor(String kind) {
+        return switch (kind == null ? "" : kind) {
+            case ShaftAssistantChatState.KIND_USER -> new MessageStyle(
+                    color("Panel.selectionBackground", new Color(0x2563EB)),
+                    color("Panel.selectionForeground", Color.WHITE),
+                    null);
+            case ShaftAssistantChatState.KIND_TOOL_EVENT,
+                    ShaftAssistantChatState.KIND_ERROR,
+                    ShaftAssistantChatState.KIND_RAW_VERBOSE,
+                    ShaftAssistantChatState.KIND_MILESTONE,
+                    ShaftAssistantChatState.KIND_ASSISTANT_TEXT -> defaultAssistantStyle();
+            default -> defaultAssistantStyle();
+        };
+    }
+
+    private static MessageStyle defaultAssistantStyle() {
+        return new MessageStyle(
+                color("Panel.background", new Color(0xF6F8FA)),
+                color("TextArea.foreground", new Color(0x202020)),
+                color("Component.borderColor", new Color(0xD0D7DE)));
+    }
+
+    private static Color color(String uiKey, Color fallback) {
+        Color resolved = JBColor.namedColor(uiKey, fallback);
+        return resolved == null ? fallback : resolved;
+    }
+
+    /**
+     * One kind's resolved bubble colors. {@code stroke} is {@code null} for kinds that render
+     * without a border (matches today's borderless user-bubble treatment).
+     */
+    record MessageStyle(Color background, Color foreground, Color stroke) {
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -31,6 +32,19 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
     // on the persisted session below (ensureMessages), so a real "no loss ever" guarantee would need
     // both layers redesigned together regardless of a collapse bubble here.
     static final int MAX_MESSAGES_PER_SESSION = 500;
+    // Message-kind model (issue #3921): before this, a message's visual/semantic "kind" (a plain
+    // assistant reply vs. a tool-call result vs. an error vs. verbose raw output vs. a compact
+    // progress milestone) existed only implicitly, encoded in markdown text and glyph prefixes
+    // (ShaftStatusPresentation icons) that AssistantTranscriptView's fallbackMessage() never
+    // actually branched on -- it only ever distinguished USER_ROLE from everything else. These
+    // constants are the full, explicit kind vocabulary; MessageStyleRegistry is the single place
+    // that maps each one to a rendered style.
+    public static final String KIND_ASSISTANT_TEXT = "assistant-text";
+    public static final String KIND_TOOL_EVENT = "tool-event";
+    public static final String KIND_ERROR = "error";
+    public static final String KIND_RAW_VERBOSE = "raw-verbose";
+    public static final String KIND_MILESTONE = "milestone";
+    public static final String KIND_USER = "user";
     private static final String SECOND_PERSON_LABEL = String.valueOf(new char[]{'Y', 'o', 'u'});
     private static final Pattern KEY_VALUE_SECRET = Pattern.compile(
             "(?iu)([\"']?\\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|authorization|cookie|set-cookie)\\b[\"']?\\s*[:=]\\s*)([\"']?)[^\\s`'\",}]+([\"']?)");
@@ -124,6 +138,7 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
         Session session = activeSession();
         Message message = new Message();
         message.role = role == null ? "" : role;
+        message.kind = resolveKind(message.kind, message.role);
         String renderedMarkdown = "user".equals(message.role) ? stripSpeakerLabel(markdown) : markdown;
         message.markdown = redactSecrets(renderedMarkdown);
         if (message.markdown.isBlank()) {
@@ -274,9 +289,28 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
         }
         Message copy = new Message();
         copy.role = source.role == null ? "" : source.role;
+        copy.kind = resolveKind(source.kind, copy.role);
         copy.markdown = redactSecrets(source.markdown);
         copy.createdAt = source.createdAt == null ? "" : source.createdAt;
         return copy;
+    }
+
+    /**
+     * Resolves the effective kind for a message: an explicit, non-blank {@code kind} is normalized
+     * (trimmed, lower-cased) and returned as-is; otherwise the kind is inferred from {@code role} --
+     * {@code "user"} resolves to {@link #KIND_USER}, everything else (including a blank/null role)
+     * resolves to {@link #KIND_ASSISTANT_TEXT}. Used both at message-construction time ({@link
+     * #append}) and at persistence-load time ({@link #normalizeMessage}) so a session saved before
+     * the {@code kind} field existed -- where every message deserializes {@code kind} as the field's
+     * declared default {@code ""} -- still resolves a sensible, role-inferred kind instead of staying
+     * blank.
+     */
+    public static String resolveKind(String kind, String role) {
+        if (kind != null && !kind.isBlank()) {
+            return kind.trim().toLowerCase(Locale.ROOT);
+        }
+        String normalizedRole = role == null ? "" : role.trim().toLowerCase(Locale.ROOT);
+        return KIND_USER.equals(normalizedRole) ? KIND_USER : KIND_ASSISTANT_TEXT;
     }
 
     private static String redactSecrets(String value) {
@@ -356,5 +390,11 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
         public String role = "";
         public String markdown = "";
         public String createdAt = "";
+        // Left blank by default rather than eagerly resolved here: a session serialized before this
+        // field existed deserializes it as exactly this default ("", the XmlSerializer's behavior for
+        // an XML element with no matching child), which is how #resolveKind/normalizeMessage detect
+        // "no persisted kind" and fall back to a role-inferred default instead of trusting a blank
+        // value as if it were meaningful.
+        public String kind = "";
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantTranscriptViewTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantTranscriptViewTest.java
@@ -123,6 +123,37 @@ class AssistantTranscriptViewTest {
     }
 
     /**
+     * Issue #3921: {@code append()} has no explicit-kind parameter, so every bubble's {@link
+     * ShaftAssistantChatState.Message#kind} is role-inferred via {@link
+     * ShaftAssistantChatState#resolveKind} and exposed on the rendered row via {@link
+     * AssistantTranscriptView#TRANSCRIPT_KIND_PROPERTY} -- proving {@code fallbackMessage} actually
+     * reads the message model's kind (not just role) at the styling seam.
+     */
+    @Test
+    void appendedUserMessageRowCarriesTheUserKindProperty() {
+        AssistantTranscriptView view = new AssistantTranscriptView();
+        view.append("user", "hello there");
+
+        Component row = findByClientProperty(view, AssistantTranscriptView.TRANSCRIPT_KIND_PROPERTY,
+                ShaftAssistantChatState.KIND_USER);
+
+        assertNotNull(row, "A user-role bubble's row must carry the KIND_USER transcript-kind property");
+    }
+
+    @Test
+    void appendedAssistantMessageRowCarriesTheAssistantTextKindProperty() {
+        AssistantTranscriptView view = new AssistantTranscriptView();
+        view.append("assistant", "hi, how can I help?");
+
+        Component row = findByClientProperty(view, AssistantTranscriptView.TRANSCRIPT_KIND_PROPERTY,
+                ShaftAssistantChatState.KIND_ASSISTANT_TEXT);
+
+        assertNotNull(row,
+                "A non-user-role bubble's row must carry the KIND_ASSISTANT_TEXT transcript-kind property "
+                        + "by default");
+    }
+
+    /**
      * Issue #3628: streamed local-agent output calls {@code replaceLast} once per line against an
      * already-appended placeholder bubble. Before this ticket every call -- append or replaceLast --
      * rebuilt the entire transcript from scratch, which is O(n) per streamed line. Asserts the actual
@@ -575,6 +606,22 @@ class AssistantTranscriptViewTest {
         if (component instanceof Container container) {
             for (Component child : container.getComponents()) {
                 Component found = findByAccessibleName(child, accessibleName);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Component findByClientProperty(Component component, String propertyKey, Object expectedValue) {
+        if (component instanceof javax.swing.JComponent jComponent
+                && expectedValue.equals(jComponent.getClientProperty(propertyKey))) {
+            return component;
+        }
+        if (component instanceof Container container) {
+            for (Component child : container.getComponents()) {
+                Component found = findByClientProperty(child, propertyKey, expectedValue);
                 if (found != null) {
                     return found;
                 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/MessageStyleRegistryTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/MessageStyleRegistryTest.java
@@ -1,0 +1,84 @@
+package com.shaft.intellij.ui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Issue #3921: {@link MessageStyleRegistry} is the single kind-&gt;style seam {@link
+ * AssistantTranscriptView#fallbackMessage} resolves bubble colors from, replacing the old inline
+ * user/non-user branch. Every {@link ShaftAssistantChatState} kind constant must resolve to its
+ * own addressable {@link MessageStyleRegistry.MessageStyle} entry, theme-aware via {@link
+ * com.intellij.ui.JBColor#namedColor} exactly like the rest of this file's color lookups.
+ */
+class MessageStyleRegistryTest {
+    @Test
+    void everyMessageKindResolvesToANonNullStyle() {
+        assertAll(
+                () -> assertNotNull(MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_USER)),
+                () -> assertNotNull(MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_ASSISTANT_TEXT)),
+                () -> assertNotNull(MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_TOOL_EVENT)),
+                () -> assertNotNull(MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_ERROR)),
+                () -> assertNotNull(MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_RAW_VERBOSE)),
+                () -> assertNotNull(MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_MILESTONE)));
+    }
+
+    @Test
+    void everyStyleCarriesNonNullBackgroundAndForeground() {
+        for (String kind : new String[] {
+                ShaftAssistantChatState.KIND_USER, ShaftAssistantChatState.KIND_ASSISTANT_TEXT,
+                ShaftAssistantChatState.KIND_TOOL_EVENT, ShaftAssistantChatState.KIND_ERROR,
+                ShaftAssistantChatState.KIND_RAW_VERBOSE, ShaftAssistantChatState.KIND_MILESTONE
+        }) {
+            MessageStyleRegistry.MessageStyle style = MessageStyleRegistry.styleFor(kind);
+            assertNotNull(style.background(), "background must be resolved for kind " + kind);
+            assertNotNull(style.foreground(), "foreground must be resolved for kind " + kind);
+        }
+    }
+
+    @Test
+    void userKindHasNoBubbleStrokeMatchingTodaysBorderlessUserBubble() {
+        MessageStyleRegistry.MessageStyle style = MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_USER);
+
+        assertNull(style.stroke(), "User bubbles render without a border, same as before this registry existed");
+    }
+
+    @Test
+    void nonUserKindsRenderWithABubbleStroke() {
+        assertAll(
+                () -> assertNotNull(
+                        MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_ASSISTANT_TEXT).stroke()),
+                () -> assertNotNull(MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_TOOL_EVENT).stroke()),
+                () -> assertNotNull(MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_ERROR).stroke()),
+                () -> assertNotNull(
+                        MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_RAW_VERBOSE).stroke()),
+                () -> assertNotNull(
+                        MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_MILESTONE).stroke()));
+    }
+
+    @Test
+    void userStyleDiffersFromAssistantTextStyleMatchingTodaysTwoBubbleLook() {
+        MessageStyleRegistry.MessageStyle user = MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_USER);
+        MessageStyleRegistry.MessageStyle assistantText =
+                MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_ASSISTANT_TEXT);
+
+        assertAll(
+                () -> assertNotEquals(user.background(), assistantText.background()),
+                () -> assertNotEquals(user.foreground(), assistantText.foreground()));
+    }
+
+    @Test
+    void unrecognizedOrBlankKindFallsBackToAssistantTextStyleDefensively() {
+        MessageStyleRegistry.MessageStyle assistantText =
+                MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_ASSISTANT_TEXT);
+
+        assertAll(
+                () -> assertEquals(assistantText, MessageStyleRegistry.styleFor("")),
+                () -> assertEquals(assistantText, MessageStyleRegistry.styleFor(null)),
+                () -> assertEquals(assistantText, MessageStyleRegistry.styleFor("bogus-kind")));
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantChatStateTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantChatStateTest.java
@@ -2,11 +2,21 @@ package com.shaft.intellij.ui;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Issue #3921: {@link ShaftAssistantChatState.Message} gained an explicit {@code kind} field
+ * (assistant-text/tool-event/error/raw-verbose/milestone/user) instead of the kind being encoded
+ * only in markdown text and glyph prefixes. {@link ShaftAssistantChatState#resolveKind} is the
+ * single place that normalizes an explicit kind or falls back to a role-inferred default, so
+ * pre-existing serialized sessions (saved before this field existed, so {@code kind} deserializes
+ * as the field's default {@code ""}) still load and render with a sensible kind.
+ */
 class ShaftAssistantChatStateTest {
     @Test
     void newSessionReturnsExistingEmptySessionWithoutCreating() {
@@ -70,5 +80,96 @@ class ShaftAssistantChatStateTest {
                         "Previous session 2 should still exist"),
                 () -> assertEquals(result.id, state.activeSession().id,
                         "Newly created session should be active"));
+    }
+
+    @Test
+    void appendedUserMessageDefaultsKindToUser() {
+        ShaftAssistantChatState state = new ShaftAssistantChatState();
+
+        state.append("user", "hello there", "");
+
+        ShaftAssistantChatState.Message message = state.activeMessages().get(0);
+        assertEquals(ShaftAssistantChatState.KIND_USER, message.kind);
+    }
+
+    @Test
+    void appendedNonUserMessageDefaultsKindToAssistantText() {
+        ShaftAssistantChatState state = new ShaftAssistantChatState();
+
+        state.append("assistant", "hi, how can I help?", "");
+
+        ShaftAssistantChatState.Message message = state.activeMessages().get(0);
+        assertEquals(ShaftAssistantChatState.KIND_ASSISTANT_TEXT, message.kind);
+    }
+
+    /**
+     * A session saved before this field existed deserializes {@code kind} as the field's declared
+     * default {@code ""} (IntelliJ's XmlSerializer leaves fields with no matching XML element at
+     * their class-declared default). Loading such a session must still resolve a sensible kind
+     * per-message instead of leaving it blank -- role-inferred, matching {@link
+     * ShaftAssistantChatState#resolveKind}.
+     */
+    @Test
+    void loadingPreExistingSessionsWithoutAKindFieldDefaultsEachMessagesKindByRole() {
+        ShaftAssistantChatState.StateData legacyState = new ShaftAssistantChatState.StateData();
+        ShaftAssistantChatState.Session legacySession = new ShaftAssistantChatState.Session();
+        legacySession.id = "legacy-session";
+
+        ShaftAssistantChatState.Message legacyUserMessage = new ShaftAssistantChatState.Message();
+        legacyUserMessage.role = "user";
+        legacyUserMessage.markdown = "a message saved before the kind field existed";
+        // legacyUserMessage.kind intentionally left at its declared default ("") to simulate an
+        // older serialized <message> element with no <kind> child.
+
+        ShaftAssistantChatState.Message legacyAssistantMessage = new ShaftAssistantChatState.Message();
+        legacyAssistantMessage.role = "assistant";
+        legacyAssistantMessage.markdown = "an older assistant reply";
+
+        legacySession.messages = List.of(legacyUserMessage, legacyAssistantMessage);
+        legacyState.sessions = List.of(legacySession);
+        legacyState.activeSessionId = "legacy-session";
+
+        ShaftAssistantChatState state = new ShaftAssistantChatState();
+        state.loadState(legacyState);
+
+        List<ShaftAssistantChatState.Message> loaded = state.activeMessages();
+        assertAll(
+                () -> assertEquals(2, loaded.size()),
+                () -> assertEquals(ShaftAssistantChatState.KIND_USER, loaded.get(0).kind,
+                        "A legacy user-role message with no persisted kind must default to KIND_USER"),
+                () -> assertEquals(ShaftAssistantChatState.KIND_ASSISTANT_TEXT, loaded.get(1).kind,
+                        "A legacy non-user-role message with no persisted kind must default to "
+                                + "KIND_ASSISTANT_TEXT"));
+    }
+
+    /**
+     * An explicit, already-persisted kind (e.g. {@code error}) must round-trip through {@link
+     * ShaftAssistantChatState#getState()}/{@link ShaftAssistantChatState#loadState} unchanged
+     * (normalized to lowercase/trimmed), not be silently overwritten by the role-inferred default.
+     */
+    @Test
+    void explicitKindRoundTripsThroughGetStateAndLoadStateUnchanged() {
+        ShaftAssistantChatState.StateData originalState = new ShaftAssistantChatState.StateData();
+        ShaftAssistantChatState.Session session = new ShaftAssistantChatState.Session();
+        session.id = "session-with-explicit-kind";
+
+        ShaftAssistantChatState.Message errorMessage = new ShaftAssistantChatState.Message();
+        errorMessage.role = "assistant";
+        errorMessage.markdown = "Tool call failed: timeout";
+        errorMessage.kind = "  " + ShaftAssistantChatState.KIND_ERROR.toUpperCase() + "  ";
+
+        session.messages = List.of(errorMessage);
+        originalState.sessions = List.of(session);
+        originalState.activeSessionId = "session-with-explicit-kind";
+
+        ShaftAssistantChatState state = new ShaftAssistantChatState();
+        state.loadState(originalState);
+
+        ShaftAssistantChatState.StateData roundTripped = state.getState();
+        ShaftAssistantChatState.Message roundTrippedMessage = roundTripped.sessions.get(0).messages.get(0);
+
+        assertEquals(ShaftAssistantChatState.KIND_ERROR, roundTrippedMessage.kind,
+                "An explicit persisted kind must survive a getState()/loadState() round trip, "
+                        + "normalized to lowercase/trimmed rather than replaced by the role default");
     }
 }


### PR DESCRIPTION
## Summary
- Adds an explicit `ShaftAssistantChatState.Message#kind` field (`assistant-text`, `tool-event`, `error`, `raw-verbose`, `milestone`, `user`) instead of encoding kind only in markdown text/glyph prefixes.
- `ShaftAssistantChatState#resolveKind(kind, role)` normalizes an explicit kind or falls back to a role-inferred default; wired into both message construction (`append`) and persistence load (`normalizeMessage`) so sessions serialized before this field existed still deserialize and render with a sensible kind.
- Introduces `MessageStyleRegistry` as the single kind->style seam `AssistantTranscriptView#fallbackMessage` now resolves bubble colors from (theme-aware via `JBColor.namedColor`, matching the file's existing `resolvedColor` pattern), replacing the old inline user/non-user branch.
- Every kind is individually addressable in the registry; non-user kinds currently resolve to the same colors the single prior "assistant" bubble style used, so this is a zero-pixel-diff refactor at the styling seam. Differentiated per-kind visuals (e.g. a distinct `error` treatment) are intentionally deferred, matching scope (data-model + styling-seam, not a UI redesign).

Closes #3921. Step 4 of 5 in the #3923 chat-transparency tracking chain (steps 1-3 already merged); step 5 (#3922) depends on this landing.

## Test plan
- [x] `ShaftAssistantChatStateTest` (7/7 passing, 4 new): kind defaults from role, legacy-session-without-kind-field deserialization defaults, explicit-kind persistence round trip.
- [x] `MessageStyleRegistryTest` (new, 6/6 passing): every kind resolves a non-null style, user bubble has no stroke, non-user kinds have a stroke, user vs assistant-text styles differ, unrecognized/blank kind falls back defensively.
- [x] `AssistantTranscriptViewTest` (22/22 passing, 2 new): appended user/assistant messages carry the expected `TRANSCRIPT_KIND_PROPERTY` value on the rendered row.
- [x] `AssistantTranscriptViewPerformanceTest` still green (bubble-creation-cost invariants unaffected).
- [x] Full `shaft-intellij` `compileJava`/`compileTestJava` succeeded.
- [x] `ShaftAssistantPanel.java` left untouched (out of scope per #3955).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz