### PR TITLE
shaft-intellij: fix incorrect off-EDT javadoc on terminal pre-type callback

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -101,9 +101,10 @@ final class ShaftMcpSetupPanel extends JPanel {
      * Opens a terminal tab (name, command) with the command pre-typed; injectable for tests.
      * Returns whether the terminal actually opened (the pre-type was scheduled) — that alone does
      * not mean the command was actually typed, since the pre-type is async and can still fail after
-     * the widget opens (issue #3551). {@code onOutcome} fires exactly once, off the EDT boundary of
-     * the caller's choosing, with the real outcome once it is known; callers that don't need it may
-     * pass a no-op consumer.
+     * the widget opens (issue #3551). {@code onOutcome} fires exactly once, on the EDT (the real
+     * implementation's caller is a {@code javax.swing.Timer} listener, which the Swing contract
+     * guarantees runs on the EDT), with the real outcome once it is known; callers that don't need
+     * it may pass a no-op consumer.
      */
     @FunctionalInterface
     interface TerminalOpener {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftTerminalCommands.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftTerminalCommands.java
@@ -37,10 +37,11 @@ final class ShaftTerminalCommands {
 
     /**
      * Same as {@link #openWithPreparedCommand(Project, String, String, String)}, but {@code
-     * onOutcome} is invoked exactly once, off the EDT, once the async pre-type has genuinely
-     * finished: {@code true} only on a real {@code TtyConnector.write()} success, {@code false} when
-     * retries were exhausted or the write threw (issue #3551 — the boolean return here only means
-     * "typing was scheduled", not "the command was typed").
+     * onOutcome} is invoked exactly once, on the EDT (its real caller is a {@code javax.swing.Timer}
+     * listener, which the Swing contract guarantees runs on the EDT), once the async pre-type has
+     * genuinely finished: {@code true} only on a real {@code TtyConnector.write()} success, {@code
+     * false} when retries were exhausted or the write threw (issue #3551 — the boolean return here
+     * only means "typing was scheduled", not "the command was typed").
      */
     static boolean openWithPreparedCommand(Project project, String workingDirectory, String tabName, String command,
                                             Consumer<Boolean> onOutcome) {


### PR DESCRIPTION
## Summary
- `ShaftTerminalCommands#openWithPreparedCommand`'s `onOutcome` javadoc claimed the callback fires "off the EDT". The real implementation invokes it from inside a `javax.swing.Timer` `ActionListener` (`scheduleCommandTyping`), and the Swing `Timer` contract guarantees listeners fire **on** the EDT -- matching the already-correct comment in `ShaftMcpSetupPanel#copyCommandIntoTerminal`.
- Fixed the same echoed claim on `ShaftMcpSetupPanel.TerminalOpener#open`, whose production implementation (`openTerminalWithPreparedCommand`) delegates straight to `ShaftTerminalCommands.openWithPreparedCommand`.
- Doc-only change, no behavioral difference.

Closes #3964

## Test plan
- [x] `gradlew compileJava compileTestJava` for `shaft-intellij` (JDK 21) -- BUILD SUCCESSFUL
- [x] Verified no other file in `shaft-intellij` restates the incorrect "off the EDT" claim for this callback (grepped module-wide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz