### PR TITLE
shaft-intellij: add GitHub Copilot CLI terminal action

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/actions/OpenCopilotCliTerminalAction.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/actions/OpenCopilotCliTerminalAction.java
@@ -1,0 +1,52 @@
+package com.shaft.intellij.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.shaft.intellij.notifications.ShaftNotifier;
+import com.shaft.intellij.ui.CliTerminalSupport;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Opens a real interactive terminal tab running the GitHub Copilot CLI ({@code copilot}, its
+ * normal interactive TUI, entered with no arguments) so power users can opt into the raw CLI
+ * experience alongside the guided Assistant chat, not instead of it (issue #3963, follow-up to
+ * #3959/#3960's Claude Code and Codex terminal actions). Targets the standalone {@code copilot}
+ * binary from the {@code @github/copilot} npm package (GitHub Copilot CLI, generally available),
+ * not the {@code gh copilot} `gh` subcommand -- {@code CliExecutableDetector}/{@code
+ * CliTerminalSupport} only know how to detect and launch a single bare executable on {@code PATH},
+ * with no concept of "a subcommand of another CLI", matching the same single-binary pattern already
+ * used for {@code claude} and {@code codex}. Only ever invokes an already-installed {@code copilot}
+ * binary found on {@code PATH} -- nothing is bundled or redistributed.
+ */
+public final class OpenCopilotCliTerminalAction extends AnAction implements DumbAware {
+    private static final String EXECUTABLE = "copilot";
+    private static final String TAB_NAME = "Copilot CLI";
+    private static final String NOTIFICATION_TITLE = "Copilot CLI terminal";
+    private static final String INSTALL_HINT = "GitHub Copilot CLI (`copilot`) isn't on PATH. Install it first: "
+            + "npm install -g @github/copilot";
+    private static final String TERMINAL_UNAVAILABLE_HINT = "Couldn't open a terminal automatically -- the "
+            + "JetBrains Terminal plugin may be missing or disabled. Open a terminal yourself and run: " + EXECUTABLE;
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        Project project = event.getProject();
+        if (project == null) {
+            return;
+        }
+        if (!CliTerminalSupport.isExecutableOnPath(EXECUTABLE)) {
+            ShaftNotifier.warn(project, NOTIFICATION_TITLE, INSTALL_HINT);
+            return;
+        }
+        String workingDirectory = project.getBasePath() == null ? "." : project.getBasePath();
+        // No invokeLater: onOutcome's real caller is a javax.swing.Timer listener, which the Swing
+        // contract already guarantees runs on the EDT (see ShaftMcpSetupPanel#copyCommandIntoTerminal
+        // for the same reasoning against the same ShaftTerminalCommands seam).
+        CliTerminalSupport.openInteractiveCliTerminal(project, workingDirectory, TAB_NAME, EXECUTABLE, typed -> {
+            if (!typed) {
+                ShaftNotifier.warn(project, NOTIFICATION_TITLE, TERMINAL_UNAVAILABLE_HINT);
+            }
+        });
+    }
+}

--- a/shaft-intellij/src/main/resources/META-INF/plugin.xml
+++ b/shaft-intellij/src/main/resources/META-INF/plugin.xml
@@ -79,6 +79,12 @@
                     description="Open a real interactive terminal running the Codex CLI (advanced, alongside the guided Assistant chat)"
                     icon="/icons/actions/view.svg"
                     iconDark="/icons/actions/view_dark.svg"/>
+            <action id="Shaft.OpenCopilotCliTerminal"
+                    class="com.shaft.intellij.actions.OpenCopilotCliTerminalAction"
+                    text="Open Copilot CLI Terminal"
+                    description="Open a real interactive terminal running the GitHub Copilot CLI (advanced, alongside the guided Assistant chat)"
+                    icon="/icons/actions/view.svg"
+                    iconDark="/icons/actions/view_dark.svg"/>
         </group>
     </actions>
 </idea-plugin>

--- a/shaft-intellij/src/test/java/com/shaft/intellij/actions/CliTerminalActionsRegistrationTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/actions/CliTerminalActionsRegistrationTest.java
@@ -10,9 +10,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Pins that the two new raw-CLI terminal actions (issue #3959) are registered in the
- * {@code Shaft.ToolsMenu} group next to {@code Shaft.OpenToolWindow}, mirroring {@code
- * ShaftIconAssetsTest#pluginDescriptorRegistersSvgIconsAndRestartRequirement}'s plain-text
+ * Pins that the raw-CLI terminal actions (issue #3959, plus the Copilot CLI follow-up #3963) are
+ * registered in the {@code Shaft.ToolsMenu} group next to {@code Shaft.OpenToolWindow}, mirroring
+ * {@code ShaftIconAssetsTest#pluginDescriptorRegistersSvgIconsAndRestartRequirement}'s plain-text
  * descriptor assertions -- no live IDE bootstrap needed. Also pins that no new {@code
  * bundledPlugin(...)} Terminal dependency was introduced in {@code build.gradle.kts}: this
  * feature must stay on the same optional/reflection discipline {@code ShaftTerminalCommands}
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class CliTerminalActionsRegistrationTest {
     @Test
-    void pluginDescriptorRegistersBothCliTerminalActionsInTheToolsMenuGroup() throws IOException {
+    void pluginDescriptorRegistersAllCliTerminalActionsInTheToolsMenuGroup() throws IOException {
         String descriptor = Files.readString(Path.of("src/main/resources/META-INF/plugin.xml"));
 
         assertTrue(descriptor.contains("id=\"Shaft.ToolsMenu\""));
@@ -28,6 +28,8 @@ class CliTerminalActionsRegistrationTest {
                 "class=\"com.shaft.intellij.actions.OpenClaudeCodeTerminalAction\""));
         assertTrue(descriptor.contains(
                 "class=\"com.shaft.intellij.actions.OpenCodexTerminalAction\""));
+        assertTrue(descriptor.contains(
+                "class=\"com.shaft.intellij.actions.OpenCopilotCliTerminalAction\""));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `OpenCopilotCliTerminalAction`, mirroring `OpenClaudeCodeTerminalAction`/`OpenCodexTerminalAction` (#3960) exactly, reusing `CliExecutableDetector`/`CliTerminalSupport` as-is (no Copilot-specific logic).
- Targets the standalone `copilot` binary (`npm install -g @github/copilot`), not the `gh copilot` `gh` subcommand — GitHub Copilot CLI is generally available (GA'd 2026-02-25) as a standalone npm package/binary, and `CliExecutableDetector` only detects a single bare executable on PATH (no concept of "a subcommand of another CLI"), matching the existing `claude`/`codex` single-binary pattern. This also matches how the other two actions describe their own install command (`npm install -g @anthropic-ai/claude-code` / `npm install -g @openai/codex` style).
- Registers `Shaft.OpenCopilotCliTerminal` in the `Shaft.ToolsMenu` group, right after the existing two entries.
- Extends `CliTerminalActionsRegistrationTest` to also assert the new action's registration.

File-isolated per #3960's discipline: only the new action file, `plugin.xml`, and the registration test changed. `CliExecutableDetector.java`, `CliTerminalSupport.java`, and the Assistant panel files are untouched.

## Test plan
- [x] TDD: extended `CliTerminalActionsRegistrationTest`, watched it fail (missing `OpenCopilotCliTerminalAction` registration), then implemented and watched it pass.
- [x] `./gradlew test --tests CliTerminalActionsRegistrationTest` (JDK 21) — BUILD SUCCESSFUL
- [x] `./gradlew test --tests CliExecutableDetectorTest --tests CliTerminalSupportTest` (JDK 21) — BUILD SUCCESSFUL, unaffected
- [x] `./gradlew compileJava compileTestJava` (JDK 21) — BUILD SUCCESSFUL

Closes #3963

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz