### PR TITLE
Trim copilot host-context guidance to restore token-budget margin

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,9 +5,7 @@ Follow `AGENTS.md` as the canonical repository policy.
 - Apply `.github/instructions/framework-source.instructions.md` only to
   production Java and `.github/instructions/java-tests.instructions.md` only
   to test Java.
-- Load one matching playbook from `.github/skills/` for CI, flaky tests,
-  release/deps, UI, ads, docs, MCP, modules, reports, guidance, or PDCA work.
+- Route via `AGENTS.md`'s Routing bridge, loaded from `.github/skills/`.
 - Prefer targeted reads and deterministic local checks; reuse valid evidence.
 - Preserve unrelated work and never expose secrets or claim unverified remote
   results.
-- Guidance/memory changes: run `python3 scripts/ci/validate_agent_setup.py`.

--- a/.github/instructions/framework-source.instructions.md
+++ b/.github/instructions/framework-source.instructions.md
@@ -4,26 +4,24 @@ applyTo: "**/src/main/java/**/*.java"
 
 # Framework Source Rules
 
-- Preserve public compatibility. Deprecate before removing or renaming public
-  APIs; prefer overloads to changed signatures.
-- Add concise JavaDoc to public classes and methods, including applicable
-  `@param`, `@return`, and `@throws` tags.
+- Deprecate before removing or renaming public APIs; prefer overloads to
+  changed signatures.
+- Add concise JavaDoc (`@param`/`@return`/`@throws` where applicable) to
+  public classes and methods.
 - Keep user-facing APIs consistent with the `SHAFT` facade and its namespaced
   nested classes. Utility classes use a private constructor that throws
   `IllegalStateException("Utility class")`.
-- Throw specific exceptions, retain useful causes, and use SHAFT
-  reporting/logging utilities. Do not print to standard output or silently
-  swallow failures.
-- Declare configurable versions, URLs, timeouts, thresholds, and switches in
-  the appropriate `com.shaft.properties.internal` interface with a default.
-  Access them through `SHAFT.Properties`; do not call `System.getProperty()`
-  directly in framework code.
-- Use `ThreadLocalPropertiesManager` for per-thread overrides and clear cached
-  values with `Properties.clearForCurrentThread()` at lifecycle boundaries.
-  Document shared or thread-local state where ownership is not obvious.
-- New external tools must remain batteries-included: resolve from PATH, then a
-  package manager where applicable, then a controlled Maven-cache download.
-  Keep the version in the properties layer.
+- Throw specific exceptions, retain causes, and use SHAFT reporting/logging
+  utilities. Never print to standard output or swallow failures silently.
+- Declare configurable versions/URLs/timeouts/thresholds/switches in the
+  matching `com.shaft.properties.internal` interface with a default; access
+  via `SHAFT.Properties`, never `System.getProperty()` directly.
+- Use `ThreadLocalPropertiesManager` for per-thread overrides; clear with
+  `Properties.clearForCurrentThread()` at lifecycle boundaries. Document
+  non-obvious shared/thread-local state ownership.
+- New external tools stay batteries-included: resolve from PATH, then a
+  package manager where applicable, then a controlled Maven-cache download;
+  keep the version in the properties layer.
 - Merge existing vendor capability maps and keep all WebDriver extensions
   namespaced. Never restore top-level legacy capabilities such as
   `enableVideo`.
@@ -32,7 +30,7 @@ applyTo: "**/src/main/java/**/*.java"
   report root.
 - Preserve UTF-8 flags in Maven and CI configuration when touching process or
   reporting setup.
-- For a bug, reproduce the defect and add a focused regression test when
-  practical. Make the smallest behavior-preserving fix.
+- For a bug, reproduce the defect (add a focused regression test when
+  practical); make the smallest behavior-preserving fix.
 - Route release metadata work through
   [the release guard](../skills/release-dependency-guard/SKILL.md).

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -8,20 +8,18 @@ applyTo: "**/src/test/java/**/*.java"
   Use descriptive scenario-based test names.
 - Browser tests create a fresh driver per test and clean it in an always-run
   teardown. For `ThreadLocal` drivers, call both `quit()` and `remove()`.
-- Browser tests must run headlessly. Do not start a headed browser during
-  ordinary agent validation; inherently headed-only behavior requires explicit
-  user approval before execution.
-- Under TestNG method parallelism, ordinary instance fields are shared by
-  concurrent methods. Keep per-method paths, files, mocks, drivers, and mutable
-  setup in locals or `ThreadLocal`; cleanup must read and clear the same
-  thread-owned state.
-- `@Test(singleThreaded = true)` serializes one class only. Static services or
+- Browser tests run headlessly; headed-only behavior needs explicit user
+  approval before execution (see AGENTS.md).
+- Under TestNG method parallelism, instance fields are shared across
+  concurrent methods; keep per-method paths/files/mocks/drivers/mutable setup
+  in locals or `ThreadLocal`, and clear the same thread-owned state in
+  cleanup.
+- `@Test(singleThreaded = true)` serializes one class only; static services or
   SHAFT global properties shared across classes need an explicit cross-class
-  lock or prerequisites set inside each test, followed by always-run
-  restoration.
-- Use `Properties.clearForCurrentThread()` when tests set per-thread SHAFT
-  properties — except JVM-global `SHAFT.Properties.flags`: capture and
-  restore the original in `finally`/`@AfterMethod`.
+  lock or per-test prerequisites, plus always-run restoration.
+- Use `Properties.clearForCurrentThread()` for per-thread SHAFT properties,
+  except JVM-global `SHAFT.Properties.flags` — capture/restore the original
+  in `finally`/`@AfterMethod`.
 - Preserve the live `allure-results` directory and delete only its contents.
   Replacing the root can race with Allure writers on Windows.
 - Confirm result JSON files are populated before interpreting Allure status.
@@ -35,8 +33,8 @@ applyTo: "**/src/test/java/**/*.java"
   logic can be tested directly.
 - Mock external services when the contract is not under test. Disable status
   validation only when response status is intentionally outside the assertion.
-- For a bug fix, first prove the regression when practical, then run the focused
-  test after the fix. Repeat or parallelize runs only when needed to evaluate a
+- For a bug fix, prove the regression first when practical, then run the
+  focused test after the fix; repeat/parallelize runs only to evaluate a
   flaky or concurrency failure.
 - Reuse passing test evidence unless later edits affect the tested behavior or
   its dependencies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,11 @@ At session start fetch/prune, branch/worktree fresh `ChaosEngine/*` from `origin
 - Never expose secrets or run deploy/publish/rewrites/cleanup/cloud suites unless asked.
 - No generated reports, binaries, or `target/`; browser tests headless unless headed approved.
 - Blockers in path: fix inline. Any other out-of-scope finding -- never drop or just chat it: interactive -> ask now-vs-issue; noninteractive -> `gh issue create` same session (search first, consolidate). Don't hunt for extras.
-- PR review: scan for deferred/out-of-scope/adjacent-finding language (yours or a delegate's) -- each needs a tracked issue before closing (search first, cross-link tracker).
+- PR review: scan for deferred/out-of-scope/adjacent-finding language (yours or a delegate's) -- track before closing per the rule above, cross-link the tracker.
 
 ## Windows/Codex Safety
 
-No GUI/shell-open: avoid `start`, `explorer`, `Invoke-Item`, `Start-Process`, `rundll32`, `os.startfile`, browsers/editors/installers. Run via `py -3`, `node`, `powershell -ExecutionPolicy Bypass -File`, `Get-Content`, `mvn`, `npm`, `dotnet`, `git`. Ask before Allure report/serve, servers/watchers, browser capture, mobile inspector/emulator, waits. Maven: always `-Dallure.automaticallyOpen=false` (SHAFT prop, defaults `true` -- auto-opens browser; not Allure-3-CLI `allure.open`) + GUI-off Lighthouse `-D...=false`.
+No GUI/shell-open: avoid `start`, `explorer`, `Invoke-Item`, `Start-Process`, `rundll32`, `os.startfile`, browsers/editors/installers. Run via `py -3`, `node`, `powershell -ExecutionPolicy Bypass -File`, `Get-Content`, `mvn`, `npm`, `dotnet`, `git`. Ask before Allure report/serve, servers/watchers, browser capture, mobile inspector/emulator, waits. Maven: always `-Dallure.automaticallyOpen=false` (SHAFT prop, not Allure-3-CLI `allure.open`) + GUI-off Lighthouse `-D...=false`.
 
 ## Memory & Learning Loop
 


### PR DESCRIPTION
## Summary

Closes #3709.

`py -3 scripts/ci/validate_agent_setup.py` on a fresh `origin/main` (post-#3966) was failing `host-token-budget: copilot`. Re-verified the second check #3709 named, `total-reduction: agent-guidance`, and found it is **no longer an active check** -- PR #3748 already removed `reduction_baseline_bytes`/`minimum_reduction_percent` from `scripts/ci/agent_guidance_budget.json`, replacing the shared corpus-wide reduction floor with per-surface caps (see the config's own `notes` field). So only the copilot host-token-budget check needed a real fix here.

## Before / after (real validator output, this branch)

**Before** (`py -3 scripts/ci/validate_agent_setup.py --skip-external --format json`, fresh branch off `origin/main`):
```
host-token-budget: copilot: estimated 2943 tokens exceeds configured maximum 2900
estimated_host_tokens: {"codex": 2070, "claude": 2802, "copilot": 2943}
AGENTS.md: 6522 / 6528 bytes (own per-file cap -- 6 bytes margin)
```

**After:**
```
valid: true, errors: []
estimated_host_tokens: {"codex": 2057, "claude": 2789, "copilot": 2821}
AGENTS.md: 6470 / 6528 bytes (58 bytes margin)
```

`copilot` margin: **79 tokens / ~316 chars** below the 2900 cap (was -43 tokens over). `claude` and `codex` also gained margin as a side effect of the shared `AGENTS.md` trim (98->111 tokens and 830->843 tokens of margin respectively -- neither was failing, but both had some of the same recurring-erosion risk).

`total-reduction: agent-guidance` is not currently an active check (see above) -- nothing to fix, nothing regressed.

## What was trimmed (by category, not line-by-line -- see diff for that)

All cuts came from the four files loaded together into the copilot host context (`AGENTS.md`, `.github/copilot-instructions.md`, `.github/instructions/framework-source.instructions.md`, `.github/instructions/java-tests.instructions.md`), prioritized per the issue since that check had the least margin:

- **Cross-file duplication removed**: a `copilot-instructions.md` bullet re-stating the `validate_agent_setup.py` command already in `AGENTS.md`'s Validation section; a `copilot-instructions.md` routing bullet re-listing the same skill topics already enumerated in `AGENTS.md`'s Routing bridge (replaced with a one-line pointer); a `java-tests.instructions.md` headed-browser bullet re-stating `AGENTS.md`'s own "browser tests headless unless headed approved" rule (replaced with a pointer, approval requirement kept intact).
- **Verbose phrasing tightened** (rule content unchanged): several `framework-source.instructions.md`/`java-tests.instructions.md` bullets (e.g. "and switches in the appropriate X" -> "/X/switches in the matching X"), an `AGENTS.md` Allure-flag parenthetical (dropped the restated "defaults to true, auto-opens browser" explanation, kept the actionable "don't confuse with Allure-3-CLI `allure.open`" distinction), and an `AGENTS.md` PR-review bullet that repeated "search first" from the Working Rules bullet directly above it.

No rule, constraint, or routing instruction was removed -- every trimmed bullet's actual guidance either stays verbatim (just shorter wording) or is preserved via a same-context cross-reference to where it's already stated.

## Judgment calls flagged, not decided

- The `AGENTS.md` Allure parenthetical trim removes *why* the flag matters (defaults to `true`, auto-opens a browser) while keeping the *what* (which flag, and not to confuse it with the CLI's `allure.open`). I judged this safe since the imperative itself ("always `-Dallure.automaticallyOpen=false`") doesn't depend on the explanation, but it's a borderline call worth a second look.
- No other rule looked obsolete or worth flagging as a removal candidate.

## Regression margin

79 tokens / ~316 chars of headroom on the previously-failing `copilot` check, plus AGENTS.md's own per-file byte cap went from 6 bytes of margin to 58. This should absorb several rounds of the kind of small, routine guidance additions (e.g. #3966's one-bullet PR-review rule) that caused this exact recurrence twice already, without needing another emergency trim immediately.

## Other findings

- Filed #3971: an unrelated, pre-existing `memory-check` `MemorySecretDetected` false positive (introduced by #3950, predates this branch) that made the *full* validator run (without `--skip-external`) still exit non-zero. Out of scope for this PR -- not one of the two checks #3709 tracks, and the script itself confirms it's a local/manual check, not wired into CI.
- `py -3 scripts/agents/sync_user_harness.py --check` was re-run per AGENTS.md's Memory & Learning Loop note: none of this PR's edited files (`AGENTS.md`, `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`) are in that script's synced surface (only `.claude/user-harness/` + `.claude/agents/` are), so no resync is needed from this change. The `DRIFTED agents/chaos-engine.md` line it reports is pre-existing local-machine drift unrelated to this PR.

## Test plan

- [x] `py -3 scripts/ci/validate_agent_setup.py --skip-external` -- exits 0 (was failing on `host-token-budget: copilot` before these edits)
- [x] Verified `total-reduction: agent-guidance` is not an active check on this branch (config no longer defines its thresholds, since #3748)
- [x] `py -3 scripts/agents/sync_user_harness.py --check` -- confirms no resync needed from this PR's files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz