### PR TITLE
shaft-intellij: align StructuredStreamParser with real Codex/Claude stream schemas

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -968,6 +968,9 @@ final class AssistantLocalAgentRunner {
             if ("user".equals(type)) {
                 return describeClaudeToolResults(event);
             }
+            if ("system".equals(type)) {
+                return describeClaudeSystemEvent(event);
+            }
             if ("result".equals(type)) {
                 String resultText = stringField(event, "result");
                 answer = resultText == null ? "" : resultText;
@@ -982,6 +985,36 @@ final class AssistantLocalAgentRunner {
                 }
                 // Fully consumed: this event becomes the final answer, so it is mapped, not hidden.
                 return CONSUMED;
+            }
+            return null;
+        }
+
+        /**
+         * Describes a Claude {@code system} event (session lifecycle/control-plane notices, distinct
+         * from the assistant/user/result conversation events above). Official subtypes per the
+         * documented stream-json schema: {@code init}, {@code api_retry}, {@code plugin_install},
+         * {@code hook_started}/{@code hook_progress}/{@code hook_response}, and {@code
+         * compact_boundary}. Only the two most user-visible subtypes get a compact rendering here
+         * (issue #3922); the rest fall through to {@code null} -- raw-JSON passthrough in Verbose mode,
+         * same as any other unrecognized event, so nothing is silently hidden even though it isn't
+         * translated yet.
+         */
+        private static String describeClaudeSystemEvent(JsonObject event) {
+            String subtype = stringField(event, "subtype");
+            if ("init".equals(subtype)) {
+                List<String> parts = new ArrayList<>();
+                String model = stringField(event, "model");
+                String sessionId = stringField(event, "session_id");
+                if (model != null && !model.isBlank()) {
+                    parts.add("model " + model);
+                }
+                if (sessionId != null && !sessionId.isBlank()) {
+                    parts.add("session " + sessionId);
+                }
+                return parts.isEmpty() ? "Session started." : "Session started (" + String.join(", ", parts) + ").";
+            }
+            if ("compact_boundary".equals(subtype)) {
+                return "Conversation history was compacted to save context.";
             }
             return null;
         }
@@ -1055,19 +1088,24 @@ final class AssistantLocalAgentRunner {
         /**
          * Aggregates a completed Codex tool item's failure into the same per-tool bucket Claude's
          * {@code permission_denials} array populates, using the completed item's {@code status}
-         * field, a non-zero {@code exit_code} (shell commands), or a present {@code error} object
-         * (MCP tool calls) as the failure signal. Codex's {@code --json} schema has no field that
-         * distinguishes a sandbox/approval denial from an ordinary execution failure (see issue
-         * #3679), so both are merged here; {@link #activitySummary()} labels this bucket "Failed or
-         * denied tool calls" for Codex runs rather than reusing Claude's more precise "Denied tool
-         * calls" wording, so the footer never overclaims what the CLI's own output can actually prove.
+         * field (including {@code "failed"} and {@code "declined"} -- {@code CommandExecutionStatus}
+         * per {@code exec_events.rs} -- the latter being Codex's approval/sandbox-rejection outcome,
+         * which carries neither a non-zero exit code nor an error object of its own), a non-zero
+         * {@code exit_code} (shell commands), or a present {@code error} object (MCP tool calls) as
+         * the failure signal. Codex's {@code --json} schema has no field that distinguishes a
+         * sandbox/approval denial from an ordinary execution failure (see issue #3679), so both are
+         * merged here; {@link #activitySummary()} labels this bucket "Failed or denied tool calls" for
+         * Codex runs rather than reusing Claude's more precise "Denied tool calls" wording, so the
+         * footer never overclaims what the CLI's own output can actually prove.
          */
         private void recordCodexToolFailure(String toolName, JsonObject item) {
             if (toolName == null || toolName.isBlank() || item == null) {
                 return;
             }
             Integer exitCode = intField(item, "exit_code");
-            boolean failed = "failed".equals(stringField(item, "status"))
+            String status = stringField(item, "status");
+            boolean failed = "failed".equals(status)
+                    || "declined".equals(status)
                     || (exitCode != null && exitCode != 0)
                     || objectField(item, "error") != null;
             if (failed) {
@@ -1110,47 +1148,16 @@ final class AssistantLocalAgentRunner {
         private String describeCodexEvent(JsonObject event) {
             String type = stringField(event, "type");
             if ("item.completed".equals(type) || "item.updated".equals(type)) {
-                JsonObject item = objectField(event, "item");
-                String itemType = stringField(item, "type");
-                if ("reasoning".equals(itemType)) {
-                    String reasoning = firstNonBlank(stringField(item, "text"), stringField(item, "summary"));
-                    return reasoning == null ? null : "Reasoning: " + reasoning;
-                }
-                if ("tool_call".equals(itemType) || "command_execution".equals(itemType) || "mcp_tool_call".equals(itemType)) {
-                    String toolName = firstNonBlank(stringField(item, "name"), stringField(item, "tool"), stringField(item, "command"));
-                    String label = toolName == null ? "(unknown)" : toolName;
-                    String summary = toolInputSummary(item);
-                    List<String> lines = new ArrayList<>();
-                    lines.add(summary == null || summary.equals(label)
-                            ? "Calling tool " + label + "..."
-                            : "Calling tool " + label + " (" + summary + ")...");
-                    if ("item.completed".equals(type)) {
-                        recordCodexToolFailure(label, item);
-                        String output = firstNonBlank(
-                                stringField(item, "aggregated_output"), stringField(item, "output"), stringField(item, "result"));
-                        if (output != null && !output.isBlank()) {
-                            Integer exitCode = intField(item, "exit_code");
-                            String outputSummary = output.strip();
-                            lines.add(exitCode != null && exitCode != 0
-                                    ? "Tool failed (" + label + ", exit " + exitCode + "): " + outputSummary
-                                    : "Tool result (" + label + "): " + outputSummary);
-                        }
-                    }
-                    return String.join("\n", lines);
-                }
-                if ("file_change".equals(itemType)) {
-                    if ("item.completed".equals(type)) {
-                        recordCodexFileMutation(item);
-                    }
-                    return null;
-                }
-                if ("agent_message".equals(itemType)) {
-                    String text = stringField(item, "text");
-                    if (text != null && !text.isBlank()) {
-                        return text;
-                    }
-                }
-                return null;
+                return describeCodexItemEvent(type, event);
+            }
+            if ("thread.started".equals(type)) {
+                // ThreadStartedEvent per exec_events.rs carries only { thread_id }; a compact fixed
+                // notice is enough to mark the session boundary without overclaiming detail.
+                return "Codex session started.";
+            }
+            if ("turn.started".equals(type)) {
+                // TurnStartedEvent per exec_events.rs is field-free ({}).
+                return "Codex turn started.";
             }
             if ("turn.completed".equals(type) || "turn.failed".equals(type)) {
                 JsonObject usage = objectField(event, "usage");
@@ -1168,7 +1175,108 @@ final class AssistantLocalAgentRunner {
                 // Fully consumed: this event becomes the final answer/usage, so it is mapped, not hidden.
                 return CONSUMED;
             }
+            if ("error".equals(type)) {
+                // ThreadEvent::Error per exec_events.rs -- a FATAL top-level error, distinct from
+                // turn.failed's nested error above. Feeds terminalDetail so a run that dies here gets a
+                // real reason in failureOutput() instead of the generic "exited with code N" fallback.
+                String message = stringField(event, "message");
+                if (message != null && !message.isBlank()) {
+                    terminalDetail = message;
+                    return "Error: " + message;
+                }
+                return null;
+            }
             return null;
+        }
+
+        /**
+         * Describes an {@code item.completed}/{@code item.updated} event's {@code item.type}. Real
+         * Codex {@code --json} item variants per {@code codex-rs/exec/src/exec_events.rs}'s {@code
+         * ThreadItemDetails} enum: {@code agent_message}, {@code reasoning}, {@code command_execution},
+         * {@code file_change}, {@code mcp_tool_call}, {@code collab_tool_call}, {@code web_search},
+         * {@code todo_list}, {@code error}. Note there is no {@code "tool_call"} variant -- an earlier
+         * revision of this switch matched it under a stale assumption, but it never appears in live
+         * Codex output (issue #3922); only the three real tool-call-shaped variants are handled below.
+         */
+        private String describeCodexItemEvent(String type, JsonObject event) {
+            JsonObject item = objectField(event, "item");
+            String itemType = stringField(item, "type");
+            if ("reasoning".equals(itemType)) {
+                String reasoning = firstNonBlank(stringField(item, "text"), stringField(item, "summary"));
+                return reasoning == null ? null : "Reasoning: " + reasoning;
+            }
+            if ("command_execution".equals(itemType) || "mcp_tool_call".equals(itemType)
+                    || "collab_tool_call".equals(itemType)) {
+                String toolName = firstNonBlank(stringField(item, "name"), stringField(item, "tool"), stringField(item, "command"));
+                String label = toolName == null ? "(unknown)" : toolName;
+                String summary = toolInputSummary(item);
+                List<String> lines = new ArrayList<>();
+                lines.add(summary == null || summary.equals(label)
+                        ? "Calling tool " + label + "..."
+                        : "Calling tool " + label + " (" + summary + ")...");
+                if ("item.completed".equals(type)) {
+                    recordCodexToolFailure(label, item);
+                    String output = firstNonBlank(
+                            stringField(item, "aggregated_output"), stringField(item, "output"), stringField(item, "result"));
+                    if (output != null && !output.isBlank()) {
+                        Integer exitCode = intField(item, "exit_code");
+                        String outputSummary = output.strip();
+                        lines.add(exitCode != null && exitCode != 0
+                                ? "Tool failed (" + label + ", exit " + exitCode + "): " + outputSummary
+                                : "Tool result (" + label + "): " + outputSummary);
+                    }
+                }
+                return String.join("\n", lines);
+            }
+            if ("file_change".equals(itemType)) {
+                if ("item.completed".equals(type)) {
+                    recordCodexFileMutation(item);
+                }
+                return null;
+            }
+            if ("agent_message".equals(itemType)) {
+                String text = stringField(item, "text");
+                return text != null && !text.isBlank() ? text : null;
+            }
+            if ("web_search".equals(itemType)) {
+                String query = stringField(item, "query");
+                return query != null && !query.isBlank() ? "Web search: " + query : null;
+            }
+            if ("todo_list".equals(itemType)) {
+                return describeCodexTodoList(item);
+            }
+            if ("error".equals(itemType)) {
+                // ErrorItem per exec_events.rs -- item-level, non-fatal (e.g. "command output
+                // truncated"), distinct from the top-level ThreadEvent::Error handled above.
+                String message = stringField(item, "message");
+                return message != null && !message.isBlank() ? "Error: " + message : null;
+            }
+            return null;
+        }
+
+        /**
+         * Renders a completed Codex {@code todo_list} item ({@code items: [{ text, completed }] }) as
+         * a Markdown checklist, one line per entry.
+         */
+        private static String describeCodexTodoList(JsonObject item) {
+            JsonElement itemsElement = item == null ? null : item.get("items");
+            if (itemsElement == null || !itemsElement.isJsonArray()) {
+                return null;
+            }
+            List<String> lines = new ArrayList<>();
+            lines.add("Todo list:");
+            for (JsonElement element : itemsElement.getAsJsonArray()) {
+                if (!element.isJsonObject()) {
+                    continue;
+                }
+                JsonObject todo = element.getAsJsonObject();
+                String text = stringField(todo, "text");
+                if (text == null || text.isBlank()) {
+                    continue;
+                }
+                lines.add((booleanField(todo, "completed") ? "- [x] " : "- [ ] ") + text);
+            }
+            return lines.size() <= 1 ? null : String.join("\n", lines);
         }
 
         private static String firstNonBlank(String... candidates) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
@@ -112,7 +112,9 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
     void codexReasoningItemsAreShownWithALabelAlongsideToolCalls() throws Exception {
         String reasoningEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"reasoning\","
                 + "\"text\":\"deciding which file to inspect\"}}";
-        String toolEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"tool_call\",\"name\":\"shell\"}}";
+        // "command_execution" is the real Codex --json item variant (exec_events.rs); the stale
+        // "tool_call" variant this fixture used to use is covered separately below (issue #3922).
+        String toolEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"command\":\"shell\"}}";
         String turnCompleted = "{\"type\":\"turn.completed\",\"last_agent_message\":\"ok\","
                 + "\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}";
 
@@ -120,6 +122,103 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
 
         assertTrue(lines.contains("Reasoning: deciding which file to inspect"), lines.toString());
         assertTrue(lines.stream().anyMatch(line -> line.contains("Calling tool shell")), lines.toString());
+    }
+
+    @Test
+    void codexToolCallItemTypeIsNotARealVariantAndFallsBackToRawPassthrough() throws Exception {
+        // Issue #3922: the real Codex --json item variants are command_execution/mcp_tool_call (see
+        // codex-rs/exec/src/exec_events.rs); "tool_call" never appears in live Codex output and was a
+        // stale assumption that must not be treated as a known item type going forward.
+        String staleEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"tool_call\",\"name\":\"shell\"}}";
+
+        List<String> lines = run(codexInvocation(), staleEvent + "\n" + codexTurnCompletedEvent() + "\n");
+
+        assertTrue(lines.contains(staleEvent),
+                "An item.type Codex never actually emits must fall back to raw passthrough, not render as a tool call: "
+                        + lines);
+        assertTrue(lines.stream().noneMatch(line -> line.contains("Calling tool shell")), lines.toString());
+    }
+
+    @Test
+    void codexDeclinedCommandExecutionCountsAsAFailedOrDeniedToolCall() throws Exception {
+        // CommandExecutionStatus::Declined (an approval/sandbox rejection) carries no non-zero
+        // exit_code and no error object, so it must be recognized via status alone or a decline
+        // silently misses the "Failed or denied tool calls" footer built for exactly this (#3679).
+        String toolEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\","
+                + "\"name\":\"shell\",\"command\":\"rm -rf /\",\"status\":\"declined\"}}";
+
+        String output = finalOutput(codexInvocation(), toolEvent + "\n" + codexTurnCompletedEvent() + "\n");
+
+        assertTrue(output.contains("Failed or denied tool calls: shell"), output);
+    }
+
+    @Test
+    void codexCollabToolCallItemsAreRenderedLikeOtherToolCalls() throws Exception {
+        String collabEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"collab_tool_call\","
+                + "\"name\":\"pair_review\",\"status\":\"completed\"}}";
+
+        List<String> lines = run(codexInvocation(), collabEvent + "\n" + codexTurnCompletedEvent() + "\n");
+
+        assertTrue(lines.stream().anyMatch(line -> line.contains("Calling tool pair_review")), lines.toString());
+    }
+
+    @Test
+    void codexWebSearchItemsAreShownWithTheQuery() throws Exception {
+        String webSearchEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"web_search\","
+                + "\"id\":\"ws-1\",\"query\":\"latest Selenium 4 release notes\"}}";
+
+        List<String> lines = run(codexInvocation(), webSearchEvent + "\n" + codexTurnCompletedEvent() + "\n");
+
+        assertTrue(lines.contains("Web search: latest Selenium 4 release notes"), lines.toString());
+    }
+
+    @Test
+    void codexTodoListItemsAreShownAsAChecklist() throws Exception {
+        String todoListEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"todo_list\",\"items\":["
+                + "{\"text\":\"Write failing test\",\"completed\":true},"
+                + "{\"text\":\"Implement fix\",\"completed\":false}]}}";
+
+        List<String> lines = run(codexInvocation(), todoListEvent + "\n" + codexTurnCompletedEvent() + "\n");
+
+        assertTrue(lines.contains("Todo list:\n- [x] Write failing test\n- [ ] Implement fix"), lines.toString());
+    }
+
+    @Test
+    void codexItemLevelErrorsAreShownWithoutFailingTheRun() throws Exception {
+        String itemError = "{\"type\":\"item.completed\",\"item\":{\"type\":\"error\","
+                + "\"message\":\"command output truncated\"}}";
+
+        List<String> lines = run(codexInvocation(), itemError + "\n" + codexTurnCompletedEvent() + "\n");
+
+        assertTrue(lines.contains("Error: command output truncated"), lines.toString());
+    }
+
+    @Test
+    void codexThreadStartedAndTurnStartedEventsAreShownAsProgressLines() throws Exception {
+        String threadStarted = "{\"type\":\"thread.started\",\"thread_id\":\"t-1\"}";
+        String turnStarted = "{\"type\":\"turn.started\"}";
+
+        List<String> lines = run(codexInvocation(),
+                threadStarted + "\n" + turnStarted + "\n" + codexTurnCompletedEvent() + "\n");
+
+        assertTrue(lines.contains("Codex session started."), lines.toString());
+        assertTrue(lines.contains("Codex turn started."), lines.toString());
+    }
+
+    @Test
+    void codexTopLevelErrorFeedsAPlainLanguageFailureReasonInsteadOfTheGenericExitCodeFallback() throws Exception {
+        // ThreadEvent::Error is Codex's fatal top-level error (distinct from turn.failed's nested
+        // error) and previously had no handling at all, so failureOutput fell back to the generic
+        // "exited with code N" message even when Codex sent an explicit reason.
+        String fatalError = "{\"type\":\"error\",\"message\":\"context length exceeded\"}";
+
+        ShaftMcpToolResult result = failingRun(codexInvocation(), fatalError + "\n", "", 1);
+
+        assertFalse(result.success(), result.output());
+        assertTrue(result.output().contains("context length exceeded"),
+                "The top-level error's message must drive the failure reason: " + result.output());
+        assertFalse(result.output().contains("exited with code 1"),
+                "A real reason must replace the generic exit-code fallback: " + result.output());
     }
 
     @Test
@@ -258,13 +357,37 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
 
     @Test
     void unmappedJsonEventsPassThroughRawSoVerboseModeNeverHidesInformation() throws Exception {
-        String systemInitEvent = "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"abc\"}";
+        // subtype "api_retry" has no rendering yet (deferred per issue #3922's scope call) -- still a
+        // valid example of a genuinely unmapped event, unlike "init"/"compact_boundary" below which
+        // now render compactly.
+        String apiRetryEvent = "{\"type\":\"system\",\"subtype\":\"api_retry\",\"attempt\":1}";
 
         List<String> lines = run(claudeInvocation(),
-                systemInitEvent + "\n" + claudeAssistantTextEvent("hi") + "\n" + claudeResultEvent("hi") + "\n");
+                apiRetryEvent + "\n" + claudeAssistantTextEvent("hi") + "\n" + claudeResultEvent("hi") + "\n");
 
-        assertTrue(lines.contains(systemInitEvent),
+        assertTrue(lines.contains(apiRetryEvent),
                 "Events with no human-readable mapping must be shared as-is (raw JSON): " + lines);
+    }
+
+    @Test
+    void claudeSystemInitEventShowsSessionAndModelInfo() throws Exception {
+        String systemInit = "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"abc123\","
+                + "\"model\":\"claude-sonnet-5\"}";
+
+        List<String> lines = run(claudeInvocation(),
+                systemInit + "\n" + claudeAssistantTextEvent("hi") + "\n" + claudeResultEvent("hi") + "\n");
+
+        assertTrue(lines.contains("Session started (model claude-sonnet-5, session abc123)."), lines.toString());
+    }
+
+    @Test
+    void claudeSystemCompactBoundaryEventShowsACompactionNotice() throws Exception {
+        String compactBoundary = "{\"type\":\"system\",\"subtype\":\"compact_boundary\"}";
+
+        List<String> lines = run(claudeInvocation(),
+                compactBoundary + "\n" + claudeAssistantTextEvent("hi") + "\n" + claudeResultEvent("hi") + "\n");
+
+        assertTrue(lines.contains("Conversation history was compacted to save context."), lines.toString());
     }
 
     @Test
@@ -280,11 +403,14 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
 
     @Test
     void unmappedCodexEventsPassThroughRaw() throws Exception {
-        String threadStarted = "{\"type\":\"thread.started\",\"thread_id\":\"t-1\"}";
+        // "item.started" in-flight status is explicitly deferred (issue #3922 scope) -- still a valid
+        // example of a genuinely unmapped event, unlike "thread.started"/"turn.started" below which
+        // now render as progress lines.
+        String itemStarted = "{\"type\":\"item.started\",\"item\":{\"type\":\"reasoning\",\"text\":\"x\"}}";
 
-        List<String> lines = run(codexInvocation(), threadStarted + "\n" + codexTurnCompletedEvent() + "\n");
+        List<String> lines = run(codexInvocation(), itemStarted + "\n" + codexTurnCompletedEvent() + "\n");
 
-        assertTrue(lines.contains(threadStarted), lines.toString());
+        assertTrue(lines.contains(itemStarted), lines.toString());
         assertTrue(lines.stream().noneMatch(line -> line.contains("turn.completed")),
                 "The terminal usage event is consumed, not echoed: " + lines);
     }


### PR DESCRIPTION
## Summary

Implements the refactor half of #3922 against `StructuredStreamParser` (`shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java`), against the research comment's gap analysis of the official Claude Code / Codex CLI stream schemas (posted 2026-07-21 on the issue). Research itself is not redone here — see the issue comment for citations.

Closes #3922

### Fully implemented

**Must fix**
1. Codex `item.type == "tool_call"` dead branch removed — real Codex `--json` variants (`exec_events.rs`'s `ThreadItemDetails`) are `command_execution`/`mcp_tool_call`; `tool_call` never appears in live output and is no longer treated as a known type (falls back to raw passthrough like any other unrecognized item).
2. `CommandExecutionStatus::Declined` now recognized by `recordCodexToolFailure` — a decline (no non-zero `exit_code`, no `error` object of its own) now lands in the "Failed or denied tool calls" footer built for exactly this (#3679).

**Should add**
3. Codex item types: `web_search` (renders the query), `todo_list` (renders as a Markdown checklist), `collab_tool_call` (folded into the existing tool-call rendering path — no documented field shape beyond "present in current source" per the research, so it reuses the generic `name`/`tool`/`command` + `toolInputSummary` renderer), item-level `error` (non-fatal, distinct from the fatal top-level one).
4. Codex top-level: `thread.started` and `turn.started` (compact fixed notices — both carry no/minimal fields per `exec_events.rs`), and top-level `error` (`ThreadEvent::Error`, distinct from `turn.failed`'s nested error) — this **feeds `terminalDetail`**, so a fatal top-level error now drives `failureOutput()`'s reason instead of the generic "exited with code N" fallback.
5. Claude `system` type: compact rendering added for `init` (session id + model) and `compact_boundary` (the two most user-visible subtypes per the research). `api_retry`, `plugin_install`, and `hook_started`/`hook_progress`/`hook_response` are **deferred** — no concrete field shapes were pinned down in the research and they're lower-visibility; they still fall through to raw-JSON passthrough in Verbose mode (unchanged, safe fallback), never silently dropped.

### Explicitly deferred (per the research comment's own scoping call, or judgment calls under this PR's time budget)

- Claude `stream_event`/`content_block_delta` token-level streaming — the CLI isn't invoked with `--include-partial-messages` today; adopting it is a UX decision for the owner, not this refactor.
- The full `ClaudeStreamEventMapper`/`CodexStreamEventMapper`/sealed `MapResult` restructuring from the design sketch — judged too high-risk for one PR against a large working file; fixes/gaps were instead implemented in place within the existing `describeClaudeEvent`/`describeCodexEvent` structure (though the Codex item-type switch was extracted into its own `describeCodexItemEvent` method for readability, since it had grown large). The fuller restructuring is left as follow-up work for the orchestrator to consider as its own issue.
- Claude `system` subtypes `api_retry`/`plugin_install`/`hook_*` — no rendering added (see above); still safely raw-passthrough in Verbose mode.
- `parent_tool_use_id` subagent attribution, non-text `tool_result` content blocks, `item.started` in-flight status — all noted as minor/deferred in the research; skipped as instructed (none were trivial to add without more schema detail).

## Test plan

- [x] New/updated fixture-driven unit tests in `AssistantLocalAgentRunnerVerboseStreamTest` — TDD'd: watched RED (10 new/changed tests failing for the right reason) before implementing, watched GREEN after.
  - Regression fixture for the `tool_call` dead branch (must now raw-passthrough, not render as a tool call).
  - Fixture for the `declined` status footer fix.
  - One fixture per newly-handled event type: `web_search`, `todo_list`, `collab_tool_call`, item-level `error`, `thread.started`/`turn.started`, top-level `error` (asserted via `failureOutput`), Claude `system` `init` and `compact_boundary`.
  - Updated two pre-existing tests whose fixtures had baked in the stale `tool_call`/soon-to-be-mapped `thread.started`/`system init` assumptions, to keep using genuinely real/unmapped examples.
- [x] `AssistantLocalAgentRunner*` test classes (10 classes, 116 tests total) — all green, 0 failures/errors, scoped Gradle run (`--tests "com.shaft.intellij.ui.AssistantLocalAgentRunner*"`), JDK 21.
- [x] `compileJava compileTestJava` for the `shaft-intellij` module — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz