### PR TITLE
shaft-intellij: thread explicit message kinds through ShaftAssistantPanel (#3968)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
@@ -236,8 +236,21 @@ final class AssistantTranscriptView extends JPanel {
      * @param rawEvidence raw evidence to show behind the disclosure toggle, or blank/{@code null} for none
      */
     void append(String role, String message, String rawEvidence) {
+        append(role, message, rawEvidence, null);
+    }
+
+    /**
+     * Same as {@link #append(String, String, String)}, plus an explicit {@code kind} (issue #3968)
+     * for callers that already know they are producing a non-default kind -- a tool-event, an error,
+     * a raw-verbose dump, a milestone -- instead of always relying on the role-inferred default. A
+     * blank/{@code null} kind behaves exactly like the 3-arg overload.
+     *
+     * @param kind explicit {@link ShaftAssistantChatState} kind constant, or blank/{@code null} to
+     *             fall back to the role-inferred default
+     */
+    void append(String role, String message, String rawEvidence, String kind) {
         int sizeBeforeAdd = messages.size();
-        addMessage(role, message, rawEvidence);
+        addMessage(role, message, rawEvidence, kind);
         if (messages.size() == sizeBeforeAdd) {
             // addMessage() silently dropped a blank message -- nothing changed, nothing to render.
             return;
@@ -293,21 +306,47 @@ final class AssistantTranscriptView extends JPanel {
     }
 
     void replaceLast(String role, String message) {
+        replaceLast(role, message, null);
+    }
+
+    /**
+     * Same as {@link #replaceLast(String, String)}, plus an explicit {@code kind} (issue #3968) for
+     * a streamed bubble whose final content changes kind -- for example a local-agent run that
+     * streamed as plain assistant text but terminates in failure, and must be re-styled as
+     * {@link ShaftAssistantChatState#KIND_ERROR} in place, not just re-worded. A blank/{@code null}
+     * kind leaves the message's existing kind untouched exactly like the 2-arg overload -- callers
+     * that only re-word content (the common streamed-line case) never risk silently decaying an
+     * already-explicit kind back to the role-inferred default.
+     *
+     * <p>A kind change forces a full {@link #refresh()} rather than the fast in-place incremental
+     * update: {@link #updateLastBubbleIncrementally} only mutates the already-rendered bubble's HTML
+     * content, never its background/foreground/stroke colors, so those must be re-resolved from
+     * scratch via a normal render pass whenever the kind genuinely changes. This only affects the
+     * (at most once per streamed run) terminal call that actually changes kind, not the common
+     * same-kind streamed-line path issue #3751 part 2 optimized.
+     */
+    void replaceLast(String role, String message, String kind) {
         if (message == null || message.isBlank()) {
             return;
         }
         if (messages.isEmpty()) {
-            append(role, message);
+            append(role, message, "", kind);
             return;
         }
         ShaftAssistantChatState.Message last = messages.get(messages.size() - 1);
         last.role = normalizedRole(role);
+        boolean kindChanged = false;
+        if (kind != null && !kind.isBlank()) {
+            String resolvedKind = ShaftAssistantChatState.resolveKind(kind, last.role);
+            kindChanged = !resolvedKind.equals(last.kind);
+            last.kind = resolvedKind;
+        }
         last.markdown = message;
         // The replaced content no longer corresponds to whatever evidence (if any) was captured for
         // the message being overwritten, and replaceLast() has no evidence of its own to carry over.
         setLastRawEvidence("");
         markdownDirty = true;
-        if (updateLastBubbleIncrementally(last.role, message)) {
+        if (!kindChanged && updateLastBubbleIncrementally(last.role, message)) {
             scrollLatestIntoView();
         } else {
             refresh();
@@ -513,7 +552,11 @@ final class AssistantTranscriptView extends JPanel {
                     continue;
                 }
                 // Restored messages never carry evidence -- it was never persisted in the first place.
-                addMessage(message.role, message.markdown, "");
+                // The explicit kind (issue #3968) IS carried over, though: without it, every
+                // non-default-kind message (an error, a milestone, ...) would silently decay back to
+                // its role-inferred default the moment a session is restored (panel construction) or
+                // the user switches chat tabs and back -- both of which route through this method.
+                addMessage(message.role, message.markdown, "", message.kind);
             }
         }
         markdown = joinMessages(messages);
@@ -604,12 +647,16 @@ final class AssistantTranscriptView extends JPanel {
     }
 
     private void addMessage(String role, String value, String rawEvidence) {
+        addMessage(role, value, rawEvidence, null);
+    }
+
+    private void addMessage(String role, String value, String rawEvidence, String kind) {
         if (value == null || value.isBlank()) {
             return;
         }
         ShaftAssistantChatState.Message message = new ShaftAssistantChatState.Message();
         message.role = normalizedRole(role);
-        message.kind = ShaftAssistantChatState.resolveKind(message.kind, message.role);
+        message.kind = ShaftAssistantChatState.resolveKind(kind, message.role);
         message.markdown = value;
         messages.add(message);
         messageRawEvidence.add(rawEvidence == null ? "" : rawEvidence);

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/MessageStyleRegistry.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/MessageStyleRegistry.java
@@ -8,12 +8,25 @@ import java.awt.Color;
  * Central kind-&gt;style registry for {@link AssistantTranscriptView}'s {@code fallbackMessage}
  * bubble seam (issue #3921). Before this class, a bubble's color was decided by one inline
  * user/non-user branch inside {@code fallbackMessage} -- every {@link ShaftAssistantChatState.Message#kind}
- * value now resolves to its own {@link MessageStyle} entry here, so a later ticket can give a kind
- * (e.g. {@code error}, {@code tool-event}) a distinct look by editing one case in this class instead
- * of hunting for markdown text-prefix/glyph branches scattered through the rendering code. Scope for
- * #3921 is the model + this addressable seam, not a visual redesign: every non-user kind currently
- * resolves to the exact same colors the single "assistant" bubble style already used, so switching
- * to this registry is a zero-pixel-diff refactor.
+ * value now resolves to its own {@link MessageStyle} entry here, so a kind can get a distinct look
+ * by editing one case in this class instead of hunting for markdown text-prefix/glyph branches
+ * scattered through the rendering code. #3921 itself shipped this as a zero-pixel-diff refactor
+ * (model + addressable seam only); #3968 is the follow-up that actually differentiates kinds:
+ *
+ * <ul>
+ *   <li>{@code error} gets a genuinely distinct background/foreground/stroke -- the stated original
+ *       motivation for the whole kind model (owner directive: "ensure that we can dynamically style
+ *       and parse the agent messages") -- so a failed tool call or local-agent run reads as an error
+ *       at a glance, not just from its text.</li>
+ *   <li>{@code milestone} gets a dimmer foreground only: it is the highest-volume kind in a run
+ *       (every compact non-verbose progress line), so a restrained "ambient status" distinction was
+ *       chosen over a loud recolor that would compete with the assistant's actual answers.</li>
+ *   <li>{@code tool-event} and {@code raw-verbose} stay uniform with {@code assistant-text} on
+ *       purpose: tool-event lines are already short, self-explanatory confirmations (e.g. "Approved
+ *       `x`."), and raw-verbose content already visually sets itself apart via its own fenced-code-
+ *       block markdown rendering, so an additional bubble-level color would be redundant chrome
+ *       rather than a genuine readability aid.</li>
+ * </ul>
  *
  * <p>Every color is resolved through {@link JBColor#namedColor}, the same theme-aware pattern
  * {@code AssistantTranscriptView#resolvedColor} already uses, so light/dark IDE themes are honored
@@ -36,10 +49,10 @@ final class MessageStyleRegistry {
                     color("Panel.selectionBackground", new Color(0x2563EB)),
                     color("Panel.selectionForeground", Color.WHITE),
                     null);
+            case ShaftAssistantChatState.KIND_ERROR -> errorStyle();
+            case ShaftAssistantChatState.KIND_MILESTONE -> milestoneStyle();
             case ShaftAssistantChatState.KIND_TOOL_EVENT,
-                    ShaftAssistantChatState.KIND_ERROR,
                     ShaftAssistantChatState.KIND_RAW_VERBOSE,
-                    ShaftAssistantChatState.KIND_MILESTONE,
                     ShaftAssistantChatState.KIND_ASSISTANT_TEXT -> defaultAssistantStyle();
             default -> defaultAssistantStyle();
         };
@@ -49,6 +62,31 @@ final class MessageStyleRegistry {
         return new MessageStyle(
                 color("Panel.background", new Color(0xF6F8FA)),
                 color("TextArea.foreground", new Color(0x202020)),
+                color("Component.borderColor", new Color(0xD0D7DE)));
+    }
+
+    /**
+     * A failed tool call or local-agent run must read as an error at a glance (issue #3968's
+     * mandatory minimum): a red-tinted background/foreground plus a stronger red border, all three
+     * distinct from {@link #defaultAssistantStyle()}. {@code Notification.error*} are IntelliJ's own
+     * theme-aware error UI keys, matching this file's established {@link #color} pattern.
+     */
+    private static MessageStyle errorStyle() {
+        return new MessageStyle(
+                color("Notification.errorBackground", new Color(0xFDECEA)),
+                color("Notification.errorForeground", new Color(0x8B1D1D)),
+                color("Notification.errorBorderColor", new Color(0xE5484D)));
+    }
+
+    /**
+     * Milestone bubbles keep {@link #defaultAssistantStyle()}'s background/border and only dim the
+     * foreground text, signaling "ambient status" without competing for attention with the
+     * assistant's real answers -- see the class doc for the full reasoning.
+     */
+    private static MessageStyle milestoneStyle() {
+        return new MessageStyle(
+                color("Panel.background", new Color(0xF6F8FA)),
+                color("Label.disabledForeground", new Color(0x6B7280)),
                 color("Component.borderColor", new Color(0xD0D7DE)));
     }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
@@ -132,13 +132,23 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
     }
 
     void append(String role, String markdown, String raw) {
+        append(role, markdown, raw, null);
+    }
+
+    /**
+     * Same as {@link #append(String, String, String)}, plus an explicit {@code kind} (issue #3968)
+     * for call sites that already know they are producing a non-default kind -- a tool-event, an
+     * error, a raw-verbose dump, a milestone -- instead of always falling back to the role-inferred
+     * default. A blank/{@code null} kind behaves exactly like the 3-arg overload.
+     */
+    void append(String role, String markdown, String raw, String kind) {
         if (markdown == null || markdown.isBlank()) {
             return;
         }
         Session session = activeSession();
         Message message = new Message();
         message.role = role == null ? "" : role;
-        message.kind = resolveKind(message.kind, message.role);
+        message.kind = resolveKind(kind, message.role);
         String renderedMarkdown = "user".equals(message.role) ? stripSpeakerLabel(markdown) : markdown;
         message.markdown = redactSecrets(renderedMarkdown);
         if (message.markdown.isBlank()) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -2217,7 +2217,9 @@ final class ShaftAssistantPanel extends JPanel {
         String canceledResponse = partialOutput == null || partialOutput.isBlank()
                 ? "_" + label + "._"
                 : formatLocalAgentStreamingResponse(partialOutput) + "\n\n_" + label + "._ (partial output above)";
-        showAgentResponse(streamToken, currentStream, canceledResponse, "");
+        // A user-initiated Cancel/Kill is a tool-event outcome, not a genuine failure -- mirrors
+        // showTerminalSequenceResult's cancelled branch for the MCP-tool-sequence path.
+        showAgentResponse(streamToken, currentStream, canceledResponse, "", ShaftAssistantChatState.KIND_TOOL_EVENT);
     }
 
     private void showAgentResponse(int streamToken, boolean currentStream, String response, String output) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -779,7 +779,7 @@ final class ShaftAssistantPanel extends JPanel {
         ShaftMcpInvocationService.getInstance(project).startTool(toolName, arguments).future()
                 .whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
                         () -> append("assistant", toolCardMarkdown(toolName, result, error),
-                                result == null ? "" : result.output())));
+                                result == null ? "" : result.output(), toolCardKind(result, error))));
     }
 
     /**
@@ -805,6 +805,17 @@ final class ShaftAssistantPanel extends JPanel {
         }
         String markdown = AssistantMarkdown.fromMcpOutput(toolName, result.output());
         return result.success() ? markdown : AssistantMarkdown.toolFailureMarkdown(toolName, markdown);
+    }
+
+    /**
+     * Companion to {@link #toolCardMarkdown}: the transcript kind for the same card (issue #3968).
+     * Mirrors that method's exact success/failure branching (a thrown error, a missing result, or a
+     * tool-level {@code success() == false} result are all failures) rather than re-deriving it, so
+     * the two can never disagree about whether a given card is an error.
+     */
+    static String toolCardKind(ShaftMcpToolResult result, Throwable error) {
+        boolean failed = error != null || result == null || !result.success();
+        return failed ? ShaftAssistantChatState.KIND_ERROR : ShaftAssistantChatState.KIND_TOOL_EVENT;
     }
 
     /** Package-private test accessor: current composer text. */
@@ -946,7 +957,7 @@ final class ShaftAssistantPanel extends JPanel {
         // through the same markdown pass everything else does, or JSON/code-shaped content (e.g. a
         // tool-result summary) renders as an unformatted blob instead of a proper fenced block.
         String markdown = AssistantMarkdown.normalizeMarkdown(step);
-        append("assistant", markdown, "");
+        append("assistant", markdown, "", ShaftAssistantChatState.KIND_MILESTONE);
     }
 
     List<ContextSuggestion> contextSuggestionsForTest(char trigger) {
@@ -955,6 +966,10 @@ final class ShaftAssistantPanel extends JPanel {
 
     void simulateAppendForTest(String role, String message, String rawResponse) {
         append(role, message, rawResponse);
+    }
+
+    void simulateAppendForTest(String role, String message, String rawResponse, String kind) {
+        append(role, message, rawResponse, kind);
     }
 
     /**
@@ -1504,7 +1519,7 @@ final class ShaftAssistantPanel extends JPanel {
             // request being sent — not only local agent CLI streams (issue #3426 B5).
             append("assistant", "**Verbose — exact tool request**\n\n```json\n"
                     + "{\"tool\": \"" + invocation.toolName() + "\", \"arguments\": "
-                    + invocation.arguments() + "}\n```", "");
+                    + invocation.arguments() + "}\n```", "", ShaftAssistantChatState.KIND_RAW_VERBOSE);
         }
         // #3513 A8: name the routed tool in a plain-language "Running: <tool> …" confirmation.
         setRunning(true, "Running: " + invocation.toolName() + " …");
@@ -1553,7 +1568,8 @@ final class ShaftAssistantPanel extends JPanel {
 
     private void showDeniedToolResult(String toolName) {
         setRunning(false, "Denied " + toolName);
-        showResponse("**SHAFT Assistant (" + toolName + " denied)**\n\nThe request was denied.", "");
+        showResponse("**SHAFT Assistant (" + toolName + " denied)**\n\nThe request was denied.", "",
+                ShaftAssistantChatState.KIND_TOOL_EVENT);
     }
 
     private void startToolSequence(List<AssistantCommand.ToolCall> toolCalls) {
@@ -1592,7 +1608,8 @@ final class ShaftAssistantPanel extends JPanel {
                 .append("The request was denied.")
                 .append("\n\n");
         setRunning(false, "Denied " + toolCall.toolName());
-        showResponse("**SHAFT Assistant sequence denied**\n\n" + sequenceMarkdown, sequenceRawOutput.toString());
+        showResponse("**SHAFT Assistant sequence denied**\n\n" + sequenceMarkdown, sequenceRawOutput.toString(),
+                ShaftAssistantChatState.KIND_TOOL_EVENT);
         clearSequenceState();
     }
 
@@ -1657,7 +1674,7 @@ final class ShaftAssistantPanel extends JPanel {
                 return;
             }
             approvalService().record(decision, toolName);
-            append("assistant", approvalOutcomeMessage(toolName, decision), "");
+            append("assistant", approvalOutcomeMessage(toolName, decision), "", ShaftAssistantChatState.KIND_TOOL_EVENT);
             onDecision.accept(decision);
         }));
     }
@@ -1722,7 +1739,7 @@ final class ShaftAssistantPanel extends JPanel {
                 .append("\n\n");
         setRunning(false, "Rejected generated code");
         showResponse("**SHAFT Assistant sequence rejected**\n\n" + sequenceMarkdown,
-                sequenceRawOutput.toString());
+                sequenceRawOutput.toString(), ShaftAssistantChatState.KIND_TOOL_EVENT);
         clearSequenceState();
     }
 
@@ -1750,8 +1767,11 @@ final class ShaftAssistantPanel extends JPanel {
         boolean killed = cancelled && killRequested;
         String terminalStep = cancelled ? (killed ? "Killed" : "Cancelled") : "Failed";
         setRunning(false, terminalStep);
+        // A user-initiated Cancel/Kill is a tool-event outcome, not a genuine failure; only the
+        // "Failed" branch (a real tool error) gets KIND_ERROR.
         showResponse("**SHAFT Assistant sequence " + statusText + "**\n\n" + sequenceMarkdown,
-                sequenceRawOutput.toString());
+                sequenceRawOutput.toString(),
+                cancelled ? ShaftAssistantChatState.KIND_TOOL_EVENT : ShaftAssistantChatState.KIND_ERROR);
         clearSequenceState();
     }
 
@@ -1896,7 +1916,8 @@ final class ShaftAssistantPanel extends JPanel {
             captureReviewGenerationRunning = false;
             clearPendingCaptureReview();
         }
-        showResponse("**SHAFT Assistant (" + toolName + " " + terminalStep.toLowerCase(Locale.ROOT) + ")**", "");
+        showResponse("**SHAFT Assistant (" + toolName + " " + terminalStep.toLowerCase(Locale.ROOT) + ")**", "",
+                ShaftAssistantChatState.KIND_TOOL_EVENT);
         setStatus(terminalStep);
     }
 
@@ -1904,7 +1925,8 @@ final class ShaftAssistantPanel extends JPanel {
         if (captureReviewGenerationRunning && isRecordingCodeReviewTool(toolName)) {
             captureReviewGenerationRunning = false;
         }
-        showResponse("**SHAFT Assistant (" + toolName + " rejected)**\n\n" + markdown, "");
+        showResponse("**SHAFT Assistant (" + toolName + " rejected)**\n\n" + markdown, "",
+                ShaftAssistantChatState.KIND_TOOL_EVENT);
         setStatus("Rejected generated code");
     }
 
@@ -1983,7 +2005,9 @@ final class ShaftAssistantPanel extends JPanel {
         // success header is unchanged.
         showResponse(success
                 ? "**SHAFT Assistant (" + toolName + " OK)**\n\n" + body
-                : AssistantMarkdown.toolFailureMarkdown(toolName, body), output);
+                : AssistantMarkdown.toolFailureMarkdown(toolName, body),
+                output,
+                success ? null : ShaftAssistantChatState.KIND_ERROR);
         if (success && ("capture_start".equals(toolName) || "capture_api_start".equals(toolName))) {
             // Feeds the shared readiness strip's recording badge (issue #3500 A4). capture_api_start
             // (issue #3726) shares CaptureManager's single-session lock with capture_start, so it is
@@ -2129,7 +2153,10 @@ final class ShaftAssistantPanel extends JPanel {
         if (!success && !rejectedGeneratedJava) {
             response = AssistantMarkdown.localAgentFailureMarkdown(response);
         }
-        showAgentResponse(streamToken, currentStream, response, rejectedGeneratedJava ? "" : output);
+        // A genuine CLI failure gets KIND_ERROR; a rejected-generated-code narrative already carries
+        // its own headline and is a guardrail outcome, not an error, so it stays the default kind.
+        String kind = !success && !rejectedGeneratedJava ? ShaftAssistantChatState.KIND_ERROR : null;
+        showAgentResponse(streamToken, currentStream, response, rejectedGeneratedJava ? "" : output, kind);
         if (hasPlanProposal) {
             showPlanProposalActions();
         }
@@ -2194,14 +2221,25 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void showAgentResponse(int streamToken, boolean currentStream, String response, String output) {
+        showAgentResponse(streamToken, currentStream, response, output, null);
+    }
+
+    /**
+     * Same as {@link #showAgentResponse(int, boolean, String, String)}, plus an explicit {@code
+     * kind} (issue #3968) for a run whose final answer changes kind -- most notably a local-agent CLI
+     * failure, threaded through to whichever of the two terminal paths below actually applies. A
+     * blank/{@code null} kind behaves exactly like the 4-arg overload.
+     */
+    private void showAgentResponse(
+            int streamToken, boolean currentStream, String response, String output, String kind) {
         if (currentStream) {
-            finishLocalAgentResponse(streamToken, response, output);
+            finishLocalAgentResponse(streamToken, response, output, kind);
         } else {
             // Not showResponse(): that applies the generic withTokenUsage, which stays silent when no
             // usage metadata is found. Every local-agent terminal response -- this is the "stale/not
             // the active stream" branch, still a local-agent run -- must say so explicitly instead
             // (issue #3703), which withLocalAgentTokenUsage does.
-            persistAndAppendResponse(withLocalAgentTokenUsage(response, output), output);
+            persistAndAppendResponse(withLocalAgentTokenUsage(response, output), output, kind);
         }
     }
 
@@ -2372,12 +2410,22 @@ final class ShaftAssistantPanel extends JPanel {
      * both real bugs when this branched on the live checkbox instead.
      */
     private void finishLocalAgentResponse(int streamToken, String response, String rawResponse) {
+        finishLocalAgentResponse(streamToken, response, rawResponse, null);
+    }
+
+    /**
+     * Same as {@link #finishLocalAgentResponse(int, String, String)}, plus an explicit {@code kind}
+     * (issue #3968) for a run whose final answer changes kind -- most notably a local-agent CLI
+     * failure, which must land as {@link ShaftAssistantChatState#KIND_ERROR}. A blank/{@code null}
+     * kind behaves exactly like the 3-arg overload.
+     */
+    private void finishLocalAgentResponse(int streamToken, String response, String rawResponse, String kind) {
         if (streamToken != activeLocalAgentStreamToken && activeLocalAgentStreamToken != -1) {
             return;
         }
         String displayResponse = withLocalAgentTokenUsage(response, rawResponse);
         ResolvedQuestion resolved = resolveQuestion(displayResponse, rawResponse);
-        replaceLocalAgentStreamPlaceholder("assistant", resolved.toPersist(), true);
+        replaceLocalAgentStreamPlaceholder("assistant", resolved.toPersist(), true, kind);
         localAgentStreamPlaceholderMessageIndex = -1;
         lastResponse = resolved.toPersist();
         lastRawResponse = rawResponse == null ? "" : rawResponse;
@@ -2639,10 +2687,24 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void showResponse(String response, String rawResponse) {
-        persistAndAppendResponse(withTokenUsage(response, rawResponse), rawResponse);
+        showResponse(response, rawResponse, null);
+    }
+
+    /**
+     * Same as {@link #showResponse(String, String)}, plus an explicit {@code kind} (issue #3968) for
+     * callers that already know the response is a non-default kind -- a genuine failure ({@code
+     * error}), or a denial/rejection/cancellation outcome ({@code tool-event}) -- instead of always
+     * relying on the role-inferred {@code assistant-text} default.
+     */
+    private void showResponse(String response, String rawResponse, String kind) {
+        persistAndAppendResponse(withTokenUsage(response, rawResponse), rawResponse, kind);
     }
 
     private void persistAndAppendResponse(String displayResponse, String rawResponse) {
+        persistAndAppendResponse(displayResponse, rawResponse, null);
+    }
+
+    private void persistAndAppendResponse(String displayResponse, String rawResponse, String kind) {
         ResolvedQuestion resolved = resolveQuestion(displayResponse, rawResponse);
         lastResponse = resolved.toPersist();
         lastRawResponse = rawResponse == null ? "" : rawResponse;
@@ -2650,7 +2712,7 @@ final class ShaftAssistantPanel extends JPanel {
         copyRawResponse.setEnabled(!lastRawResponse.isBlank());
         // append() clears any showing widget first, so a detected question's answer chips are only
         // shown AFTER the persisted append -- otherwise this call would immediately wipe them again.
-        append("assistant", resolved.toPersist(), rawResponse);
+        append("assistant", resolved.toPersist(), rawResponse, kind);
         if (resolved.question() != null) {
             showAssistantQuestionOptions(resolved.question());
         }
@@ -2714,6 +2776,16 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void append(String role, String text, String rawResponse) {
+        append(role, text, rawResponse, null);
+    }
+
+    /**
+     * Same as {@link #append(String, String, String)}, plus an explicit {@code kind} (issue #3968)
+     * for call sites that already know they are producing a non-default kind -- a tool-event, an
+     * error, a raw-verbose dump, a milestone -- instead of always relying on the role-inferred
+     * default. A blank/{@code null} kind behaves exactly like the 3-arg overload.
+     */
+    private void append(String role, String text, String rawResponse, String kind) {
         // Any real message (user or assistant) ends the first-run welcome (issue #3540): the
         // welcome is only ever valid on a genuinely empty transcript, and this always follows
         // showFirstRunWelcomeIfNeeded() showing it (or a no-op if never shown/already dismissed),
@@ -2721,8 +2793,8 @@ final class ShaftAssistantPanel extends JPanel {
         // called while an approval widget occupies the same slot (see showFirstRunWelcomeIfNeeded's
         // javadoc), so this never fights that widget for the slot.
         transcript.clearWidget();
-        transcript.append(role, text, rawResponse);
-        chatState.append(role, text, rawResponse);
+        transcript.append(role, text, rawResponse, kind);
+        chatState.append(role, text, rawResponse, kind);
         updateContextTruncationBoundary();
         refreshChatSelector();
         updateActionChrome();
@@ -4157,6 +4229,17 @@ final class ShaftAssistantPanel extends JPanel {
      *     never leave the bubble showing stale throttled-away content)
      */
     private void replaceLocalAgentStreamPlaceholder(String role, String message, boolean forceRender) {
+        replaceLocalAgentStreamPlaceholder(role, message, forceRender, null);
+    }
+
+    /**
+     * Same as {@link #replaceLocalAgentStreamPlaceholder(String, String, boolean)}, plus an explicit
+     * {@code kind} (issue #3968) for a run whose terminal content changes kind -- most notably a
+     * local-agent CLI failure, which must re-style the streamed placeholder bubble as {@link
+     * ShaftAssistantChatState#KIND_ERROR} in place, not just re-word it. A blank/{@code null} kind
+     * leaves the placeholder's existing kind untouched exactly like the 3-arg overload.
+     */
+    private void replaceLocalAgentStreamPlaceholder(String role, String message, boolean forceRender, String kind) {
         if (message == null || message.isBlank()) {
             return;
         }
@@ -4164,26 +4247,29 @@ final class ShaftAssistantPanel extends JPanel {
         if (active == null || active.messages == null
                 || localAgentStreamPlaceholderMessageIndex < 0
                 || localAgentStreamPlaceholderMessageIndex >= active.messages.size()) {
-            append(role, message, "");
+            append(role, message, "", kind);
             localAgentStreamPlaceholderMessageIndex = currentSessionMessageCount() - 1;
             return;
         }
         String normalizedRole = role == null || role.isBlank() ? "assistant" : role.trim().toLowerCase(Locale.ROOT);
         ShaftAssistantChatState.Message target = active.messages.get(localAgentStreamPlaceholderMessageIndex);
         target.role = normalizedRole;
+        if (kind != null && !kind.isBlank()) {
+            target.kind = ShaftAssistantChatState.resolveKind(kind, normalizedRole);
+        }
         target.markdown = message;
         if (localAgentStreamPlaceholderMessageIndex == active.messages.size() - 1) {
             // Common case: no milestone bubble was appended after the placeholder yet -- the fast,
             // incremental single-bubble update still applies.
-            transcript.replaceLast(normalizedRole, message);
+            transcript.replaceLast(normalizedRole, message, kind);
             if (forceRender) {
                 transcript.flushStreamedRender();
             }
         } else {
             // A milestone bubble now sits after the placeholder -- resync the whole transcript from
-            // the chat-state source of truth, so the placeholder's own bubble (not the trailing
-            // milestone bubble) is the one that visibly changes. Always a full, immediate render
-            // already, so forceRender needs no special handling here.
+            // the chat-state source of truth (target.kind above already updated), so the placeholder's
+            // own bubble (not the trailing milestone bubble) is the one that visibly changes. Always a
+            // full, immediate render already, so forceRender needs no special handling here.
             transcript.setMessages(active.messages);
         }
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantTranscriptViewTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantTranscriptViewTest.java
@@ -154,6 +154,79 @@ class AssistantTranscriptViewTest {
     }
 
     /**
+     * Issue #3968: the 4-arg {@code append} lets a caller that already knows it is producing a
+     * non-default kind (a tool-event, an error, a raw-verbose dump, a milestone) say so explicitly
+     * instead of relying on {@code append(role, message, rawEvidence)}'s always role-inferred kind.
+     */
+    @Test
+    void fourArgAppendWithExplicitKindOverridesTheRoleInferredDefault() {
+        AssistantTranscriptView view = new AssistantTranscriptView();
+        view.append("assistant", "Tool call failed: timeout", "", ShaftAssistantChatState.KIND_ERROR);
+
+        Component row = findByClientProperty(view, AssistantTranscriptView.TRANSCRIPT_KIND_PROPERTY,
+                ShaftAssistantChatState.KIND_ERROR);
+
+        assertNotNull(row, "An explicit KIND_ERROR must be honored instead of the role-inferred default");
+    }
+
+    /**
+     * Issue #3968: {@code replaceLast} gained a 3-arg overload so a streamed bubble whose final
+     * content changes kind (for example a local-agent run that streamed as plain assistant text but
+     * terminates in failure) can be re-styled in place, not just re-worded.
+     */
+    @Test
+    void replaceLastWithExplicitKindChangesTheRenderedBubblesKindProperty() {
+        AssistantTranscriptView view = new AssistantTranscriptView();
+        view.append("assistant", "Running...");
+
+        view.replaceLast("assistant", "Tool call failed: timeout", ShaftAssistantChatState.KIND_ERROR);
+
+        Component row = findByClientProperty(view, AssistantTranscriptView.TRANSCRIPT_KIND_PROPERTY,
+                ShaftAssistantChatState.KIND_ERROR);
+        assertNotNull(row, "replaceLast with an explicit kind must re-style the bubble, not just re-word it");
+    }
+
+    /**
+     * The 2-arg {@code replaceLast} (used by every pre-existing caller, and by the fast streamed-
+     * update path) must keep leaving {@code kind} untouched exactly as before this ticket -- a
+     * milestone bubble streamed via repeated 2-arg {@code replaceLast} calls must not silently
+     * decay back to the role-inferred default.
+     */
+    @Test
+    void twoArgReplaceLastPreservesThePriorKindUnchanged() {
+        AssistantTranscriptView view = new AssistantTranscriptView();
+        view.append("assistant", "Tool selected: local assistant", "", ShaftAssistantChatState.KIND_MILESTONE);
+
+        view.replaceLast("assistant", "Tool selected: local assistant (updated)");
+
+        Component row = findByClientProperty(view, AssistantTranscriptView.TRANSCRIPT_KIND_PROPERTY,
+                ShaftAssistantChatState.KIND_MILESTONE);
+        assertNotNull(row, "A 2-arg replaceLast (no explicit kind) must never change an existing message's kind");
+    }
+
+    /**
+     * Issue #3968: {@code setMessages} restores a persisted session (on panel construction, and on
+     * every chat-tab switch) -- it must preserve each message's already-persisted {@code kind}
+     * instead of silently re-resolving it from role alone, or every explicitly-kinded message (an
+     * error, a milestone, ...) would visually decay back to the default the moment a session is
+     * reloaded or the user switches chat tabs and back.
+     */
+    @Test
+    void setMessagesPreservesEachMessagesExplicitKindInsteadOfReResolvingFromRoleAlone() {
+        AssistantTranscriptView view = new AssistantTranscriptView();
+        ShaftAssistantChatState.Message errorMessage = new ShaftAssistantChatState.Message();
+        errorMessage.role = "assistant";
+        errorMessage.kind = ShaftAssistantChatState.KIND_ERROR;
+        errorMessage.markdown = "Tool call failed: timeout";
+
+        view.setMessages(List.of(errorMessage));
+
+        Component row = findByClientProperty(view, AssistantTranscriptView.TRANSCRIPT_KIND_PROPERTY,
+                ShaftAssistantChatState.KIND_ERROR);
+        assertNotNull(row, "setMessages must preserve a restored message's persisted KIND_ERROR");
+    }
+
+    /**
      * Issue #3628: streamed local-agent output calls {@code replaceLast} once per line against an
      * already-appended placeholder bubble. Before this ticket every call -- append or replaceLast --
      * rebuilt the entire transcript from scratch, which is O(n) per streamed line. Asserts the actual

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/MessageStyleRegistryTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/MessageStyleRegistryTest.java
@@ -81,4 +81,64 @@ class MessageStyleRegistryTest {
                 () -> assertEquals(assistantText, MessageStyleRegistry.styleFor(null)),
                 () -> assertEquals(assistantText, MessageStyleRegistry.styleFor("bogus-kind")));
     }
+
+    /**
+     * Issue #3968: the original motivation for the whole kind model (owner directive: "ensure that
+     * we can dynamically style and parse the agent messages") -- {@code error} must be visually
+     * distinguishable from plain assistant text at a glance, on every channel {@link MessageStyle}
+     * exposes, not just one.
+     */
+    @Test
+    void errorStyleDiffersFromAssistantTextStyleOnBackgroundForegroundAndStroke() {
+        MessageStyleRegistry.MessageStyle error = MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_ERROR);
+        MessageStyleRegistry.MessageStyle assistantText =
+                MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_ASSISTANT_TEXT);
+
+        assertAll(
+                () -> assertNotEquals(error.background(), assistantText.background(),
+                        "error must not share assistant-text's background"),
+                () -> assertNotEquals(error.foreground(), assistantText.foreground(),
+                        "error must not share assistant-text's foreground"),
+                () -> assertNotEquals(error.stroke(), assistantText.stroke(),
+                        "error must not share assistant-text's border color"));
+    }
+
+    /**
+     * Issue #3968 design decision: milestone bubbles are the highest-volume message kind in a run
+     * (every compact non-verbose progress line), so they get a restrained distinction -- a dimmer
+     * foreground signaling "ambient status" -- rather than a loud recolor that would compete with the
+     * assistant's actual answers for attention. Background and border stay shared with assistant-text
+     * on purpose (see {@link #nonUserKindsRenderWithABubbleStroke} for the still-bordered contract).
+     */
+    @Test
+    void milestoneStyleUsesADimmerForegroundThanAssistantTextButSharesItsBackgroundAndBorder() {
+        MessageStyleRegistry.MessageStyle milestone =
+                MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_MILESTONE);
+        MessageStyleRegistry.MessageStyle assistantText =
+                MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_ASSISTANT_TEXT);
+
+        assertAll(
+                () -> assertNotEquals(milestone.foreground(), assistantText.foreground(),
+                        "milestone must read as visually distinct (dimmer) from a real assistant answer"),
+                () -> assertEquals(assistantText.background(), milestone.background()),
+                () -> assertEquals(assistantText.stroke(), milestone.stroke()));
+    }
+
+    /**
+     * Issue #3968 design decision: tool-event outcomes (e.g. "Approved `x`.") and raw-verbose dumps
+     * are intentionally left uniform with assistant-text -- tool-event lines are already short,
+     * self-explanatory confirmations, and raw-verbose content already visually sets itself apart via
+     * its own fenced-code-block markdown rendering, so an additional bubble-level color would be
+     * redundant chrome rather than a genuine readability aid.
+     */
+    @Test
+    void toolEventAndRawVerboseStylesAreUniformWithAssistantTextByDesign() {
+        MessageStyleRegistry.MessageStyle assistantText =
+                MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_ASSISTANT_TEXT);
+
+        assertAll(
+                () -> assertEquals(assistantText, MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_TOOL_EVENT)),
+                () -> assertEquals(assistantText,
+                        MessageStyleRegistry.styleFor(ShaftAssistantChatState.KIND_RAW_VERBOSE)));
+    }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantChatStateTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantChatStateTest.java
@@ -172,4 +172,30 @@ class ShaftAssistantChatStateTest {
                 "An explicit persisted kind must survive a getState()/loadState() round trip, "
                         + "normalized to lowercase/trimmed rather than replaced by the role default");
     }
+
+    /**
+     * Issue #3968: {@code append} gained a 4-arg overload so {@code ShaftAssistantPanel} call sites
+     * that already know they are producing a non-default kind (a tool-event, an error, a raw-verbose
+     * dump, a milestone) can say so explicitly instead of always falling back to the role-inferred
+     * default the 3-arg {@link ShaftAssistantChatState#append(String, String, String)} still uses.
+     */
+    @Test
+    void fourArgAppendWithExplicitKindOverridesTheRoleInferredDefault() {
+        ShaftAssistantChatState state = new ShaftAssistantChatState();
+
+        state.append("assistant", "Tool call failed: timeout", "", ShaftAssistantChatState.KIND_ERROR);
+
+        ShaftAssistantChatState.Message message = state.activeMessages().get(0);
+        assertEquals(ShaftAssistantChatState.KIND_ERROR, message.kind);
+    }
+
+    @Test
+    void fourArgAppendWithBlankKindFallsBackToTheRoleInferredDefaultLikeTheThreeArgOverload() {
+        ShaftAssistantChatState state = new ShaftAssistantChatState();
+
+        state.append("assistant", "hi, how can I help?", "", "");
+
+        ShaftAssistantChatState.Message message = state.activeMessages().get(0);
+        assertEquals(ShaftAssistantChatState.KIND_ASSISTANT_TEXT, message.kind);
+    }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelToolCardTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelToolCardTest.java
@@ -4,6 +4,7 @@ import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -81,5 +82,34 @@ class ShaftAssistantPanelToolCardTest {
         assertAll(
                 () -> assertTrue(markdown.contains("couldn't finish"), markdown),
                 () -> assertTrue(markdown.contains("Trace path could not be read."), markdown));
+    }
+
+    /**
+     * Issue #3968: {@link ShaftAssistantPanel#runToolAndRenderCard} now threads an explicit kind
+     * through to the transcript instead of always defaulting to {@code assistant-text} -- a genuine
+     * tool failure (thrown error, or a tool-level {@code success() == false} result) must render as
+     * {@code KIND_ERROR}; a successful diagnostic card renders as {@code KIND_TOOL_EVENT}.
+     */
+    @Test
+    void toolCardKindIsErrorWhenTheMcpCallThrows() {
+        assertEquals(ShaftAssistantChatState.KIND_ERROR,
+                ShaftAssistantPanel.toolCardKind(null, new IllegalStateException("boom")));
+    }
+
+    @Test
+    void toolCardKindIsErrorOnAToolLevelFailureResultWithoutAThrownException() {
+        assertEquals(ShaftAssistantChatState.KIND_ERROR,
+                ShaftAssistantPanel.toolCardKind(ShaftMcpToolResult.failure("Trace path could not be read."), null));
+    }
+
+    @Test
+    void toolCardKindIsErrorWhenNoResultAndNoErrorAreAvailable() {
+        assertEquals(ShaftAssistantChatState.KIND_ERROR, ShaftAssistantPanel.toolCardKind(null, null));
+    }
+
+    @Test
+    void toolCardKindIsToolEventOnASuccessfulResult() {
+        assertEquals(ShaftAssistantChatState.KIND_TOOL_EVENT,
+                ShaftAssistantPanel.toolCardKind(ShaftMcpToolResult.success("{}"), null));
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.ui.WrapLayout;
@@ -2951,6 +2952,106 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertTrue(markdown.contains("couldn't finish"), markdown),
                 () -> assertTrue(markdown.contains("_Next:"), markdown));
+    }
+
+    /**
+     * Issue #3968: {@code ShaftAssistantPanel}'s {@code append(...)} call sites previously all
+     * role-inferred their kind via {@link ShaftAssistantChatState#resolveKind}'s default (everything
+     * non-user defaults to {@code assistant-text}) even when the call site already knew it was
+     * producing a tool-event, an error, a raw-verbose dump, or a milestone. These prove the relevant
+     * call sites now thread an explicit kind through to the persisted message.
+     */
+    @Test
+    void toolSelectedMilestoneCarriesTheMilestoneKind() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        Method appendAgentMilestone =
+                ShaftAssistantPanel.class.getDeclaredMethod("appendAgentMilestone", String.class);
+        appendAgentMilestone.setAccessible(true);
+
+        appendAgentMilestone.invoke(panel, "Tool selected: local assistant");
+
+        assertEquals(ShaftAssistantChatState.KIND_MILESTONE, lastMessageKind(panel));
+    }
+
+    @Test
+    void verboseExactToolRequestDumpCarriesTheRawVerboseKind() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ((JBCheckBox) getField(panel, "verboseAgentOutput")).setSelected(true);
+        approvalServiceOf(panel).record(ToolApprovalDecision.APPROVE_ALL_TOOLS, "unused");
+        AssistantCommand.Invocation invocation =
+                AssistantCommand.Invocation.tool("shaft_guide_search", new JsonObject());
+        Method startMcpInvocation = ShaftAssistantPanel.class.getDeclaredMethod(
+                "startMcpInvocation", AssistantCommand.Invocation.class);
+        startMcpInvocation.setAccessible(true);
+
+        // A null project fails the actual MCP dispatch with an NPE past the point where the Verbose
+        // exact-tool-request dump is appended, mirroring
+        // directCodegenToolDispatchArmsSameStickyReviewGateAsRecordFlow.
+        assertThrows(InvocationTargetException.class, () -> startMcpInvocation.invoke(panel, invocation));
+
+        assertAll(
+                () -> assertTrue(transcriptMarkdown(panel).contains("Verbose — exact tool request"),
+                        transcriptMarkdown(panel)),
+                () -> assertEquals(ShaftAssistantChatState.KIND_RAW_VERBOSE, lastMessageKind(panel)));
+    }
+
+    @Test
+    void toolApprovalDenialOutcomeCarriesTheToolEventKind() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        AssistantCommand.Invocation invocation = AssistantCommand.Invocation.tool("capture_start", new JsonObject());
+        Method startMcpInvocation = ShaftAssistantPanel.class.getDeclaredMethod(
+                "startMcpInvocation", AssistantCommand.Invocation.class);
+        startMcpInvocation.setAccessible(true);
+        startMcpInvocation.invoke(panel, invocation);
+        JButton deny = approvalDecisionButton((ToolApprovalPromptPanel) transcriptWidget(panel), "Deny");
+
+        SwingUtilities.invokeAndWait(deny::doClick);
+
+        assertAll(
+                () -> assertTrue(transcriptMarkdown(panel).contains("Denied `capture_start`")),
+                () -> assertEquals(ShaftAssistantChatState.KIND_TOOL_EVENT, lastMessageKind(panel)));
+    }
+
+    @Test
+    void mcpToolFailureRendersWithTheErrorKind() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        showAssistantResult(panel, "shaft_guide_search", ShaftMcpToolResult.failure("Tool exploded."));
+
+        assertEquals(ShaftAssistantChatState.KIND_ERROR, lastMessageKind(panel));
+    }
+
+    @Test
+    void mcpToolSuccessRendersWithTheDefaultAssistantTextKind() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        showAssistantResult(panel, "shaft_guide_search",
+                ShaftMcpToolResult.success(mcpText("Use Page Object locators.")));
+
+        assertEquals(ShaftAssistantChatState.KIND_ASSISTANT_TEXT, lastMessageKind(panel));
+    }
+
+    @Test
+    void localAgentStreamedFailureRendersWithTheErrorKindOnTheSameBubbleItStreamedInto() throws Exception {
+        // Issue #3968: the terminal failure replaces the SAME streaming placeholder bubble via
+        // replaceLast (issue #3628's fast in-place path) -- proving the kind change actually reaches
+        // the persisted message even though the streamed bubble started life with the default kind.
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        appendStreamingLocalAgentBubble(panel, 11);
+        showAgentResult(panel, 11, ShaftMcpToolResult.failure("Timed out after 300 seconds."));
+
+        assertEquals(ShaftAssistantChatState.KIND_ERROR, lastMessageKind(panel));
+    }
+
+    @Test
+    void localAgentStreamedSuccessRendersWithTheDefaultAssistantTextKind() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        appendStreamingLocalAgentBubble(panel, 12);
+        showAgentResult(panel, 12, ShaftMcpToolResult.success("Final answer from Codex."));
+
+        assertEquals(ShaftAssistantChatState.KIND_ASSISTANT_TEXT, lastMessageKind(panel));
     }
 
     @Test
@@ -6509,6 +6610,19 @@ class ShaftPanelSetupTest {
         Method method = ShaftAssistantPanel.class.getDeclaredMethod("approvalService");
         method.setAccessible(true);
         return (ToolApprovalService) method.invoke(panel);
+    }
+
+    /**
+     * Issue #3968: the persisted {@link ShaftAssistantChatState.Message#kind} of the most recently
+     * appended message in the panel's active session -- reads the same source of truth {@link
+     * MessageStyleRegistry#styleFor} resolves bubble colors from, so this is a stronger assertion
+     * than scraping rendered markdown text for a kind-specific string.
+     */
+    private static String lastMessageKind(ShaftAssistantPanel panel) throws Exception {
+        ShaftAssistantChatState chatState = (ShaftAssistantChatState) getField(panel, "chatState");
+        List<ShaftAssistantChatState.Message> messages = chatState.activeMessages();
+        assertFalse(messages.isEmpty(), "Expected at least one persisted message");
+        return messages.get(messages.size() - 1).kind;
     }
 
     private static JComponent transcriptWidget(ShaftAssistantPanel panel) throws Exception {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -3054,6 +3054,34 @@ class ShaftPanelSetupTest {
         assertEquals(ShaftAssistantChatState.KIND_ASSISTANT_TEXT, lastMessageKind(panel));
     }
 
+    /**
+     * Issue #3968 follow-up (hostile review finding): a user-initiated Cancel/Kill of a running
+     * local-agent CLI is the same kind of event {@link #showTerminalSequenceResult}'s cancelled
+     * branch already treats as {@code KIND_TOOL_EVENT} for the MCP-tool-sequence path -- an aborted
+     * operation, not a genuine failure. {@code showAgentCancelled} must apply the same reasoning
+     * instead of leaving the cancellation bubble at the role-inferred default.
+     */
+    @Test
+    void localAgentCancelledRendersWithTheToolEventKind() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        appendStreamingLocalAgentBubble(panel, 13);
+        showAgentResult(panel, 13, null, new CancellationException("cancelled"));
+
+        assertEquals(ShaftAssistantChatState.KIND_TOOL_EVENT, lastMessageKind(panel));
+    }
+
+    @Test
+    void localAgentKilledRendersWithTheToolEventKind() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedMcpSettings());
+
+        appendStreamingLocalAgentBubble(panel, 14);
+        setField(panel, "killRequested", true);
+        showAgentResult(panel, 14, null, new CancellationException("killed"));
+
+        assertEquals(ShaftAssistantChatState.KIND_TOOL_EVENT, lastMessageKind(panel));
+    }
+
     @Test
     void assistantLocalAgentCompletedWithoutUsageMetadataStatesTokenUsageNotAvailable() throws Exception {
         // Issue #3703: silence must never stand in for "no data" -- the user must be able to tell


### PR DESCRIPTION
## Summary

Closes #3968.

Follow-up to #3967 (closed #3921), which added the `ShaftAssistantChatState.Message#kind` model and `MessageStyleRegistry` seam as a deliberately "zero-pixel-diff refactor" -- every `ShaftAssistantPanel` append call site still role-inferred its kind. This PR actually uses the model:

- **`appendAgentMilestone`** -> `KIND_MILESTONE`. This is the single choke point for every "Tool selected: ..." announcement and every compact non-verbose local-agent progress line, so fixing it here covers the large majority of the panel's ~40 append call sites in one place instead of touching each caller.
- **The Verbose "exact tool request" JSON dump** (`dispatchApprovedTool`) -> `KIND_RAW_VERBOSE`.
- **Tool approval outcomes** (Approved/Denied `x`) and **denied/rejected/cancelled tool & sequence results** (`showDeniedToolResult`, `showDeniedSequenceResult`, `showRejectedToolResult`, `showRejectedSequenceResult`, `showCancelledToolResult`, the Cancelled/Killed branch of `showTerminalSequenceResult`) -> `KIND_TOOL_EVENT`. These are decision/guardrail outcomes, not free-form assistant prose.
- **Genuine MCP tool failures** (`showFinalToolResult`) and **genuine local-agent CLI failures** (`showAgentToolResult`, including the streamed-placeholder path via `finishLocalAgentResponse`/`replaceLocalAgentStreamPlaceholder`) -> `KIND_ERROR`. The Failed branch of `showTerminalSequenceResult` also gets `KIND_ERROR`.
- **`runToolAndRenderCard`**'s Doctor/Healer diagnostic card -> `KIND_ERROR`/`KIND_TOOL_EVENT` via a new `toolCardKind(...)` static helper that mirrors `toolCardMarkdown(...)`'s exact success/failure branching so the two can never disagree.

### Visual differentiation decisions (`MessageStyleRegistry`)

- **`error`** gets a genuinely distinct background/foreground/stroke (IntelliJ's own theme-aware `Notification.error*` UI keys) -- the mandatory minimum per the issue, and the stated original motivation for the whole kind model.
- **`milestone`** gets a dimmer foreground only, keeping the same background/border as `assistant-text`. It's the highest-volume kind in a run (every compact progress line), so a restrained "ambient status" distinction was chosen over a loud recolor that would compete with the assistant's actual answers.
- **`tool-event`** and **`raw-verbose`** stay uniform with `assistant-text` on purpose: tool-event lines are already short, self-explanatory confirmations, and raw-verbose content already visually sets itself apart via its own fenced-code-block markdown rendering -- an additional bubble-level color would be redundant chrome.

### Necessary supporting changes (kept additive)

`ShaftAssistantPanel.append`/`showResponse`/`persistAndAppendResponse`/`showAgentResponse`/`finishLocalAgentResponse`/`replaceLocalAgentStreamPlaceholder` each already had `append`-shaped overloads (per repo convention); I added a kind-carrying overload to each, so every pre-existing 3-arg call site keeps its exact prior behavior (`kind=null` == today's role-inferred default). Same pattern for `ShaftAssistantChatState.append` and `AssistantTranscriptView.append`/`replaceLast`.

Two touches to `AssistantTranscriptView.java`/`ShaftAssistantChatState.java` beyond the new overloads, both minimal and load-bearing:
- `replaceLast` now forces a full `refresh()` only when the kind actually changes (not on every streamed line) -- `updateLastBubbleIncrementally` only mutates a bubble's HTML content, never its colors, so a kind change needs a real render pass to pick up the new style. This is a once-per-run cost at most, not the per-line cost issue #3751 part 2 optimized away.
- `setMessages` now carries a restored message's explicit kind instead of re-resolving from role alone. Without this fix, a persisted `error`/`milestone` message would silently lose its kind (and its distinct color) the moment a session reloads (panel construction) or a chat tab is switched and back -- both of which call `setMessages` -- which would have quietly defeated this entire feature the first time a user switched tabs.

Did **not** touch `AssistantLocalAgentRunner.java` (another issue, #3965, is in flight there) or the persisted `Message.kind` XML shape.

## Test plan

- [x] TDD throughout: every behavior change has a test that was watched red before the fix, then green after.
- [x] `ShaftAssistantChatStateTest`, `AssistantTranscriptViewTest`, `AssistantTranscriptViewPerformanceTest`, `MessageStyleRegistryTest`, `ShaftAssistantPanelToolCardTest` -- all green.
- [x] `ShaftPanelSetupTest` (the full ~7000-line suite, including new kind-wiring tests for milestone/raw-verbose/tool-event/error across MCP-tool and local-agent-run paths) -- all green, no regressions.
- [x] `com.shaft.intellij.ui.*` full package -- all green (includes `ShaftPluginScreenshotRendererTest`; Live E2E tests self-skip via the `shaft.intellij.liveToolE2E` system property default).
- [x] `compileJava`/`compileTestJava` for the module -- clean.

All runs: Gradle 9.3.0, JDK 21 (`ms-21.0.11`), headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz