### PR TITLE
shaft-intellij: wire panel Verbose checkbox into local-agent stderr gating

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -259,6 +259,32 @@ final class AssistantLocalAgentRunner {
     }
 
     /**
+     * Starts a local agent invocation with a real interactive-approval callback and an explicit
+     * {@code verbose} flag (see {@link #startWithOptionalCompact(AssistantCommand.Invocation, boolean,
+     * Consumer)} for the compact preamble behavior, unchanged here, and {@link #start(
+     * AssistantCommand.Invocation, Consumer, ProcessLauncher, boolean,
+     * LocalAgentApprovalBridge.ApprovalRequestHandler, ApprovalBridgeLauncher, boolean)} for what
+     * {@code verbose} gates). {@link ShaftAssistantPanel} calls this overload -- not the 4-arg one
+     * above, which always defaults to {@code verbose=true} -- so its live Verbose checkbox state
+     * actually reaches the CLI's raw-stderr folding decision (issue #3965).
+     */
+    static ShaftMcpInvocation startWithOptionalCompact(
+            AssistantCommand.Invocation invocation,
+            boolean autoCompactEnabled,
+            Consumer<String> outputConsumer,
+            LocalAgentApprovalBridge.ApprovalRequestHandler approvalHandler,
+            boolean verbose) {
+        if (autoCompactEnabled) {
+            ShaftMcpToolResult compactResult = runCompactPreamble(invocation.arguments());
+            if (outputConsumer != null && compactResult.output() != null && !compactResult.output().isBlank()) {
+                outputConsumer.accept(compactResult.output());
+            }
+        }
+        return start(invocation, outputConsumer, AssistantLocalAgentRunner::launchProcess, true, approvalHandler,
+                LocalAgentApprovalBridge::start, verbose);
+    }
+
+    /**
      * Package-private overload used by tests to drive a stub process for both the compact preamble
      * and the main invocation, and to assert their relative ordering.
      */

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -1434,7 +1434,8 @@ final class ShaftAssistantPanel extends JPanel {
                     invocation,
                     autoCompact.isSelected(),
                     localAgentOutputCoalescer::enqueue,
-                    localAgentApprovalHandler(streamToken));
+                    localAgentApprovalHandler(streamToken),
+                    verboseLocalAgentOutput());
             currentInvocation.future().whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
                     () -> showAgentResult(streamToken, result, error)));
             return;

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2995,6 +2995,71 @@ class ShaftPanelSetupTest {
                 () -> assertEquals(ShaftAssistantChatState.KIND_RAW_VERBOSE, lastMessageKind(panel)));
     }
 
+    /**
+     * Issue #3965 (final wiring step): PR #3977 threaded a {@code verbose} parameter through {@code
+     * AssistantLocalAgentRunner.agentOutput}/{@code StructuredStreamParser#failureOutput} and the new
+     * canonical 7-arg {@code start(...)} overload, proven at the runner level by {@code
+     * AssistantLocalAgentRunnerVerboseStreamTest}. But {@code ShaftAssistantPanel#send}'s own call
+     * site into {@code AssistantLocalAgentRunner.startWithOptionalCompact(...)} still resolved to an
+     * overload that hardcodes {@code verbose=true}, so production stderr leaked into the compact
+     * answer regardless of this Verbose checkbox. These two tests drive the REAL {@code send()} call
+     * site end to end -- a real (non-stubbed) OS process, the bundled JVM's own {@code java}
+     * executable invoked against a bogus main class, which deterministically exits non-zero with a
+     * stable stderr message -- so this is genuine evidence the panel's live Verbose state now reaches
+     * the runner, not just a re-assertion of the already-covered runner-level mechanism.
+     */
+    @Test
+    void localAgentVerboseOffWithholdsRawStderrFromTheCompactAnswerThroughTheRealPanelSendPath() throws Exception {
+        ShaftMcpToolResult result = runRealFailingCustomCommandThroughPanel(false);
+
+        assertFalse(result.output().contains(LOCAL_AGENT_VERBOSE_TEST_BOGUS_CLASS),
+                "Verbose off must withhold the real CLI's raw stderr from the compact answer: " + result.output());
+    }
+
+    @Test
+    void localAgentVerboseOnStillSurfacesRawStderrThroughTheRealPanelSendPath() throws Exception {
+        ShaftMcpToolResult result = runRealFailingCustomCommandThroughPanel(true);
+
+        assertTrue(result.output().contains(LOCAL_AGENT_VERBOSE_TEST_BOGUS_CLASS),
+                "Verbose on must still surface the real CLI's raw stderr in the compact answer: " + result.output());
+    }
+
+    private static final String LOCAL_AGENT_VERBOSE_TEST_BOGUS_CLASS = "NoSuchClassXYZ12345ForShaftVerboseTest";
+
+    private static ShaftMcpToolResult runRealFailingCustomCommandThroughPanel(boolean verbose) throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ((JBCheckBox) getField(panel, "verboseAgentOutput")).setSelected(verbose);
+        JTextComponent customCommand = textComponent(panel, "Optional local agent command");
+        customCommand.setText(realJavaBogusClassCommandLine());
+
+        // "Explain this failure" is the same prompt AssistantLocalAgentRunnerVerboseStreamTest's
+        // customCommandInvocation() uses to route to the local-agent tool in ASK mode without
+        // tripping isCodeGenerationRequest/promptNeedsMcpToolCalls (which would otherwise redirect
+        // to the "needs MCP tool access" gate instead of ever reaching the local agent runner).
+        assistantPrompt(panel).setText("Explain this failure");
+        clickAccessible(panel, "Send assistant prompt");
+
+        ShaftMcpInvocation invocation = (ShaftMcpInvocation) getField(panel, "currentInvocation");
+        assertNotNull(invocation, "Expected send() to have started a real local-agent invocation");
+        ShaftMcpToolResult result = invocation.future().get(20, TimeUnit.SECONDS);
+        assertFalse(result.success(),
+                "The bogus main class must make the real java process exit non-zero: " + result.output());
+        // The real stderr line reaching send()'s live outputConsumer schedules the coalescer's real
+        // ~100ms one-shot javax.swing.Timer (ShaftAssistantPanel.java's LocalAgentOutputCoalescer
+        // wiring); this test never pumps the EDT to let it fire and self-stop, so without this wait
+        // the platform's SwingTimerWatcherExtension flags it as "Not disposed" in afterEach even
+        // though the assertions above already have everything they need.
+        Thread.sleep(250);
+        return result;
+    }
+
+    /** The bundled JVM's own {@code java} executable, invoked by absolute path (no PATH dependency). */
+    private static String realJavaBogusClassCommandLine() {
+        boolean windows = System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("win");
+        String javaBin = Path.of(System.getProperty("java.home"), "bin", windows ? "java.exe" : "java").toString();
+        return "\"" + javaBin + "\" " + LOCAL_AGENT_VERBOSE_TEST_BOGUS_CLASS;
+    }
+
     @Test
     void toolApprovalDenialOutcomeCarriesTheToolEventKind() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());


### PR DESCRIPTION
## Summary
- `ShaftAssistantPanel#send()`'s local-agent call site still resolved to an `AssistantLocalAgentRunner.startWithOptionalCompact` overload that hardcoded `verbose=true` (PR #3977 added the mechanism but this wiring step was explicitly deferred), so raw CLI stderr kept leaking into the compact answer bubble even with the Verbose checkbox off.
- Adds a 5-arg `startWithOptionalCompact(invocation, autoCompactEnabled, outputConsumer, approvalHandler, boolean verbose)` overload to `AssistantLocalAgentRunner`, delegating to the existing canonical 7-arg `start(...)` (matches the file's shorter-delegates-to-longer overload convention).
- Threads the panel's live `verboseLocalAgentOutput()` state into that new overload at the real call site (`ShaftAssistantPanel.java`).

## Test plan
- [x] New tests in `ShaftPanelSetupTest` drive the REAL `send()` path end to end with a real (non-stubbed) OS process — the bundled JVM's own `java` executable invoked against a bogus main class, deterministically exiting non-zero with a stable stderr message:
  - `localAgentVerboseOffWithholdsRawStderrFromTheCompactAnswerThroughTheRealPanelSendPath` — watched RED (failed) before the fix, proving the actual production gap; GREEN after.
  - `localAgentVerboseOnStillSurfacesRawStderrThroughTheRealPanelSendPath` — pins that Verbose on still surfaces stderr.
- [x] `./gradlew compileJava compileTestJava` — BUILD SUCCESSFUL
- [x] `./gradlew test --tests "com.shaft.intellij.ui.AssistantLocalAgentRunnerVerboseStreamTest"` — BUILD SUCCESSFUL (existing runner-level verbose mechanism unaffected)
- [x] `./gradlew test --tests "com.shaft.intellij.ui.ShaftPanelSetupTest"` — full suite, 260 tests, BUILD SUCCESSFUL (zero regressions)

Closes #3965

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz