### PR TITLE
Add on-demand Maven Central release reconciliation

### DIFF
--- a/.github/workflows/maven-central-reconcile.yml
+++ b/.github/workflows/maven-central-reconcile.yml
@@ -1,0 +1,99 @@
+name: Maven Central Release Reconciliation
+# workflow_dispatch-only, on-demand reconciliation for a version whose reactor deploy died
+# partway through the reactor (parent POM + some modules published, a later module failed on a
+# transient error). mavenCentral_cd.yml's check_release_needed guard only HEAD-checks the parent
+# POM, so a later push/manual run for the SAME version would see already_released=true and skip
+# entirely - the missing module(s) never get re-uploaded, and announce_release (GitHub Release +
+# Slack) never runs since it is downstream of build_release_and_deliver.
+#
+# This workflow never triggers automatically, so it can never race or double-fire against
+# mavenCentral_cd.yml's push-triggered flow. It calls scripts/ci/reconcile_maven_central_release.py,
+# which finds exactly which packages are still missing from Central for the given version, deploys
+# only those, and then creates the GitHub Release/Slack announcement if they never ran either.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to reconcile. Default: read from the reactor via mvn help:evaluate."
+        required: false
+        type: string
+      dry_run:
+        description: "Print the planned actions without deploying/releasing/notifying."
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: maven-central-reconcile
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Reconcile Maven Central release
+    # Maven Central + GPG/OSSRH secrets are not available on forked repos; signing would fail with empty key id.
+    if: github.event.repository.fork == false
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      # A GITHUB_TOKEN-authored release does not emit a `release` event (GitHub's anti-recursion
+      # rule), so publish-intellij-plugin.yml / publish-shaft-mcp.yml would never fire. BOT_TOKEN
+      # is a PAT, so its release does trigger those workflows (mirrors announce_release).
+      GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Reclaim disk space
+        uses: ./.github/actions/reclaim-disk-space
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          check-latest: true
+          cache: 'maven'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5.1
+        with:
+          maven-version: 3.9.12
+      - name: Setup Prerequisites
+        run: |
+          git config --global user.signingKey "${{ secrets.GPG_KEYNAME }}"
+          git config --global commit.gpgsign true
+          gpg --version
+          gpgconf --kill gpg-agent
+          gpg -K --keyid-format SHORT
+          export GPG_TTY=$(tty)
+      - name: Reconcile Maven Central release
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RECONCILE_VERSION: ${{ inputs.version }}
+          RECONCILE_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          args=()
+          if [ -n "${RECONCILE_VERSION}" ]; then
+            args+=(--version "${RECONCILE_VERSION}")
+          fi
+          if [ "${RECONCILE_DRY_RUN}" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          python3 scripts/ci/reconcile_maven_central_release.py \
+            --gpg-keyname "${{ secrets.GPG_KEYNAME }}" \
+            --gpg-passphrase "${{ secrets.GPG_PASSPHRASE }}" \
+            "${args[@]}"

--- a/scripts/ci/reconcile_maven_central_release.py
+++ b/scripts/ci/reconcile_maven_central_release.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""On-demand Maven Central release reconciliation.
+
+Additive companion to ``verify_maven_central_release.py`` / ``check_maven_release_version.py``.
+A partially-failed reactor deploy (parent POM published, a later module fails on a transient
+error) leaves ``check_maven_release_version.py``'s parent-only guard reporting
+``already_released=true`` forever, so the missing module is never re-uploaded and
+``announce_release`` never runs. This script is meant to be run by hand (or via
+``workflow_dispatch``) against a version already reported "released": it finds exactly which
+packages are still missing from Central, deploys only those, and then creates the GitHub
+Release/Slack announcement if they, too, never ran for this version. Every external action
+(deploy, ``gh release``, Slack POST) goes through a plain module-level call site so tests can
+monkeypatch it - the real network/subprocess call is never made from a test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.ci import verify_maven_central_release as verify  # noqa: E402
+from scripts.ci.validate_maven_publication import PUBLIC_ARTIFACTS  # noqa: E402
+
+RELEASE_BODY_TEMPLATE = ROOT / ".github" / "RELEASE_BODY_TEMPLATE.md"
+
+# Reuse validate_maven_publication's packaging-aware, pom-derived artifact map instead of
+# assuming "directory name == artifact name" (false for shaft-parent/root and the SHAFT_ENGINE
+# relocation pom, which lives in legacy-shaft-engine/).
+MODULE_DIR_BY_ARTIFACT = {
+    name: str(pom_path.parent) for name, (pom_path, _packaging) in PUBLIC_ARTIFACTS.items()
+}
+
+
+def missing_module_dirs(missing_paths: list[str]) -> list[str]:
+    """Reduce missing Central publication paths to their unique reactor module directories."""
+    seen: list[str] = []
+    for path in missing_paths:
+        artifact = path.split("/")[3]
+        if artifact not in seen:
+            seen.append(artifact)
+    return [MODULE_DIR_BY_ARTIFACT[artifact] for artifact in seen]
+
+
+def build_deploy_command(module_dirs: list[str], gpg_keyname: str, gpg_passphrase: str) -> list[str]:
+    """Build a targeted ``mvn deploy -pl`` command, mirroring mavenCentral_cd.yml's deploy flags."""
+    return [
+        verify.maven_executable(),
+        "--batch-mode",
+        "deploy",
+        "-pl", ",".join(module_dirs),
+        "-DskipTests",
+        f"-Dgpg.keyname={gpg_keyname}",
+        f"-Dgpg.passphrase={gpg_passphrase}",
+    ]
+
+
+def release_exists(version: str) -> bool:
+    """Check whether a GitHub Release already exists for this version."""
+    result = subprocess.run(["gh", "release", "view", version], cwd=ROOT, check=False)
+    return result.returncode == 0
+
+
+def render_release_body(version: str, template_path: Path = RELEASE_BODY_TEMPLATE) -> str:
+    """Render the release body the same way announce_release's "Prepare Release Body" step does."""
+    return template_path.read_text(encoding="utf-8").replace("$RELEASE_VERSION", version)
+
+
+def build_release_create_command(version: str, body_file: Path) -> list[str]:
+    """Build the `gh release create` invocation for a version, given a rendered body file."""
+    return [
+        "gh", "release", "create", version,
+        "--title", version,
+        "--notes-file", str(body_file),
+        "--generate-notes",
+    ]
+
+
+def create_release(version: str) -> str:
+    """Create the GitHub Release for a version and return its URL."""
+    with tempfile.TemporaryDirectory(prefix="shaft-release-body-") as temp_dir:
+        body_file = Path(temp_dir) / "release_body.md"
+        body_file.write_text(render_release_body(version), encoding="utf-8")
+        command = build_release_create_command(version, body_file)
+        result = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"gh release create failed (exit {result.returncode}): "
+                f"{result.stderr.strip() or result.stdout.strip()}"
+            )
+        return result.stdout.strip()
+
+
+def build_slack_payload(version: str, release_url: str) -> dict:
+    """Build the Slack payload, mirroring mavenCentral_cd.yml's inline Python block exactly."""
+    summary = (
+        f"SHAFT_ENGINE {version} is now available. The release notes are intentionally "
+        "minimal and highlight only major new features, breaking changes, and new contributors."
+    )
+    return {
+        "text": f"SHAFT_ENGINE {version} released: {release_url}",
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f":tada: *SHAFT_ENGINE {version}* is now available!",
+                },
+            },
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": summary},
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "View release notes"},
+                        "url": release_url,
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def post_slack_notification(webhook_url: str, payload: dict) -> None:
+    """POST the release announcement payload to a Slack incoming webhook."""
+    request = urllib.request.Request(
+        webhook_url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30):
+        pass
+
+
+def read_reactor_version() -> str:
+    """Read the reactor version the same way mavenCentral_cd.yml's release_version step does."""
+    result = subprocess.run(
+        [
+            verify.maven_executable(), "-f", str(ROOT / "pom.xml"), "help:evaluate",
+            "-Dexpression=project.version", "-q", "-DforceStdout",
+        ],
+        cwd=ROOT, capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Could not read the reactor version: {result.stderr.strip() or result.stdout.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def reconcile_release(
+    version: str, repository_url: str, gpg_keyname: str, gpg_passphrase: str, dry_run: bool
+) -> int:
+    """Reconcile one version: deploy missing artifacts, then announce if genuinely new."""
+    missing = verify.missing_publication_paths(repository_url, version)
+    module_dirs = missing_module_dirs(missing)
+
+    if module_dirs:
+        command = build_deploy_command(module_dirs, gpg_keyname, gpg_passphrase)
+        if dry_run:
+            print(f"[dry-run] missing Maven Central artifacts for modules: {', '.join(module_dirs)}")
+            print("[dry-run] would run: " + " ".join(command))
+            return 0
+        print(f"Missing Maven Central artifacts for modules: {', '.join(module_dirs)}")
+        result = subprocess.run(command, cwd=ROOT, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Targeted deploy failed (exit {result.returncode}) for modules: "
+                f"{', '.join(module_dirs)}"
+            )
+        print(f"Deployed missing modules to Maven Central: {', '.join(module_dirs)}")
+    else:
+        print(f"All Maven Central artifacts already present for {version}.")
+
+    if release_exists(version):
+        print(f"GitHub Release {version} already exists.")
+        return 0
+
+    if dry_run:
+        print(f"[dry-run] would create GitHub Release {version}")
+        return 0
+
+    release_url = create_release(version)
+    print(f"Created GitHub Release {version}: {release_url}")
+
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
+    if not webhook_url:
+        print("SLACK_WEBHOOK_URL is not configured; skipping Slack release announcement.")
+        return 0
+
+    post_slack_notification(webhook_url, build_slack_payload(version, release_url))
+    print("Posted Slack release announcement.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--version", default=None,
+        help="Release version to reconcile. Default: read from the reactor via mvn help:evaluate.",
+    )
+    parser.add_argument("--repository-url", default=verify.DEFAULT_REPOSITORY)
+    parser.add_argument("--gpg-keyname", default=os.environ.get("GPG_KEYNAME", ""))
+    parser.add_argument("--gpg-passphrase", default=os.environ.get("GPG_PASSPHRASE", ""))
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the planned actions without executing them.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    version = args.version or read_reactor_version()
+    return reconcile_release(
+        version=version,
+        repository_url=args.repository_url,
+        gpg_keyname=args.gpg_keyname,
+        gpg_passphrase=args.gpg_passphrase,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/verify_maven_central_release.py
+++ b/scripts/ci/verify_maven_central_release.py
@@ -19,7 +19,7 @@ DEFAULT_REPOSITORY = "https://repo.maven.apache.org/maven2"
 JAR_ARTIFACTS = (
     "shaft-engine", "shaft-pilot-core", "shaft-capture", "shaft-capture-proxy", "shaft-doctor",
     "shaft-ai", "shaft-heal", "shaft-browserstack", "shaft-video", "shaft-visual", "shaft-sikulix",
-    "shaft-mcp",
+    "shaft-mcp", "shaft-cli",
 )
 POM_ARTIFACTS = ("shaft-parent", "shaft-bom", "SHAFT_ENGINE")
 FIXTURE_GOALS = {

--- a/tests/scripts/test_reconcile_maven_central_release.py
+++ b/tests/scripts/test_reconcile_maven_central_release.py
@@ -1,0 +1,296 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import scripts.ci.reconcile_maven_central_release as reconcile
+
+
+class MissingModuleDirsTest(unittest.TestCase):
+    def test_maps_missing_artifact_paths_to_unique_module_directories_in_order(self):
+        missing_paths = [
+            "io/github/shafthq/shaft-mcp/1.2.3/shaft-mcp-1.2.3.jar",
+            "io/github/shafthq/shaft-mcp/1.2.3/shaft-mcp-1.2.3.jar.asc",
+            "io/github/shafthq/shaft-cli/1.2.3/shaft-cli-1.2.3.jar",
+        ]
+
+        self.assertEqual(reconcile.missing_module_dirs(missing_paths), ["shaft-mcp", "shaft-cli"])
+
+    def test_maps_root_and_legacy_pom_artifacts_to_their_real_directories(self):
+        missing_paths = [
+            "io/github/shafthq/shaft-parent/1.2.3/shaft-parent-1.2.3.pom",
+            "io/github/shafthq/SHAFT_ENGINE/1.2.3/SHAFT_ENGINE-1.2.3.pom",
+        ]
+
+        self.assertEqual(reconcile.missing_module_dirs(missing_paths), [".", "legacy-shaft-engine"])
+
+
+class BuildDeployCommandTest(unittest.TestCase):
+    def test_builds_targeted_deploy_command_mirroring_the_workflow_flags(self):
+        with mock.patch.object(reconcile.verify, "maven_executable", return_value="mvn"):
+            command = reconcile.build_deploy_command(["shaft-mcp", "shaft-cli"], "KEY123", "s3cr3t")
+
+        self.assertEqual(command, [
+            "mvn", "--batch-mode", "deploy", "-pl", "shaft-mcp,shaft-cli",
+            "-DskipTests", "-Dgpg.keyname=KEY123", "-Dgpg.passphrase=s3cr3t",
+        ])
+
+
+class ReleaseExistsTest(unittest.TestCase):
+    def test_existing_release_reports_true(self):
+        with mock.patch.object(
+            reconcile.subprocess, "run", return_value=subprocess.CompletedProcess([], 0)
+        ) as run:
+            self.assertTrue(reconcile.release_exists("1.2.3"))
+        run.assert_called_once()
+        self.assertEqual(run.call_args.args[0][:3], ["gh", "release", "view"])
+
+    def test_missing_release_reports_false(self):
+        with mock.patch.object(
+            reconcile.subprocess, "run", return_value=subprocess.CompletedProcess([], 1)
+        ):
+            self.assertFalse(reconcile.release_exists("1.2.3"))
+
+
+class SlackPayloadTest(unittest.TestCase):
+    def test_payload_matches_the_workflows_inline_python_block(self):
+        payload = reconcile.build_slack_payload("1.2.3", "https://example.test/release")
+
+        self.assertEqual(payload["text"], "SHAFT_ENGINE 1.2.3 released: https://example.test/release")
+        self.assertIn(
+            ":tada: *SHAFT_ENGINE 1.2.3* is now available!",
+            payload["blocks"][0]["text"]["text"],
+        )
+        self.assertEqual(payload["blocks"][2]["elements"][0]["url"], "https://example.test/release")
+
+
+class RenderReleaseBodyTest(unittest.TestCase):
+    def test_substitutes_the_release_version_placeholder(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            template = Path(temp_dir) / "RELEASE_BODY_TEMPLATE.md"
+            template.write_text(
+                "# SHAFT $RELEASE_VERSION\n\nSee $RELEASE_VERSION docs.\n", encoding="utf-8"
+            )
+
+            body = reconcile.render_release_body("1.2.3", template)
+
+        self.assertEqual(body, "# SHAFT 1.2.3\n\nSee 1.2.3 docs.\n")
+
+
+class ReconcileReleaseTest(unittest.TestCase):
+    def setUp(self):
+        patcher = mock.patch.dict(os.environ, {}, clear=False)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        os.environ.pop("SLACK_WEBHOOK_URL", None)
+
+    def test_all_artifacts_missing_deploys_every_configured_module(self):
+        all_missing = reconcile.verify.publication_paths("1.2.3")
+        with mock.patch.object(
+            reconcile.verify, "missing_publication_paths", return_value=all_missing
+        ), mock.patch.object(reconcile, "release_exists", return_value=True), mock.patch.object(
+            reconcile.subprocess, "run", return_value=subprocess.CompletedProcess([], 0)
+        ) as run, mock.patch.object(
+            reconcile.verify, "maven_executable", return_value="mvn"
+        ):
+            exit_code = reconcile.reconcile_release(
+                version="1.2.3",
+                repository_url=reconcile.verify.DEFAULT_REPOSITORY,
+                gpg_keyname="KEY",
+                gpg_passphrase="PASS",
+                dry_run=False,
+            )
+
+        self.assertEqual(exit_code, 0)
+        run.assert_called_once()
+        command = run.call_args.args[0]
+        self.assertEqual(command[:4], ["mvn", "--batch-mode", "deploy", "-pl"])
+        modules = command[4].split(",")
+        self.assertEqual(set(modules), set(reconcile.MODULE_DIR_BY_ARTIFACT.values()))
+
+    def test_some_artifacts_missing_deploys_only_those_modules(self):
+        missing = [p for p in reconcile.verify.publication_paths("1.2.3") if "/shaft-cli/" in p]
+        with mock.patch.object(
+            reconcile.verify, "missing_publication_paths", return_value=missing
+        ), mock.patch.object(reconcile, "release_exists", return_value=True), mock.patch.object(
+            reconcile.subprocess, "run", return_value=subprocess.CompletedProcess([], 0)
+        ) as run:
+            reconcile.reconcile_release(
+                version="1.2.3",
+                repository_url=reconcile.verify.DEFAULT_REPOSITORY,
+                gpg_keyname="KEY",
+                gpg_passphrase="PASS",
+                dry_run=False,
+            )
+
+        command = run.call_args.args[0]
+        self.assertEqual(command[command.index("-pl") + 1], "shaft-cli")
+
+    def test_no_missing_artifacts_and_missing_release_creates_release_and_posts_slack(self):
+        os.environ["SLACK_WEBHOOK_URL"] = "https://hooks.slack.test/services/x"
+        release_result = subprocess.CompletedProcess(
+            [], 0, stdout="https://github.test/releases/1.2.3\n"
+        )
+        with mock.patch.object(
+            reconcile.verify, "missing_publication_paths", return_value=[]
+        ), mock.patch.object(reconcile, "release_exists", return_value=False), mock.patch.object(
+            reconcile.subprocess, "run", return_value=release_result
+        ) as run, mock.patch.object(
+            reconcile.urllib.request, "urlopen"
+        ) as urlopen:
+            urlopen.return_value.__enter__.return_value = object()
+            exit_code = reconcile.reconcile_release(
+                version="1.2.3",
+                repository_url=reconcile.verify.DEFAULT_REPOSITORY,
+                gpg_keyname="KEY",
+                gpg_passphrase="PASS",
+                dry_run=False,
+            )
+
+        self.assertEqual(exit_code, 0)
+        run.assert_called_once()
+        self.assertEqual(run.call_args.args[0][:3], ["gh", "release", "create"])
+        urlopen.assert_called_once()
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, "https://hooks.slack.test/services/x")
+        payload = json.loads(request.data)
+        self.assertIn("https://github.test/releases/1.2.3", payload["text"])
+
+    def test_no_missing_artifacts_and_existing_release_is_a_clean_no_op(self):
+        with mock.patch.object(
+            reconcile.verify, "missing_publication_paths", return_value=[]
+        ), mock.patch.object(reconcile, "release_exists", return_value=True), mock.patch.object(
+            reconcile.subprocess, "run"
+        ) as run, mock.patch.object(
+            reconcile.urllib.request, "urlopen"
+        ) as urlopen:
+            exit_code = reconcile.reconcile_release(
+                version="1.2.3",
+                repository_url=reconcile.verify.DEFAULT_REPOSITORY,
+                gpg_keyname="KEY",
+                gpg_passphrase="PASS",
+                dry_run=False,
+            )
+
+        self.assertEqual(exit_code, 0)
+        run.assert_not_called()
+        urlopen.assert_not_called()
+
+    def test_repeated_no_op_run_stays_idempotent(self):
+        with mock.patch.object(
+            reconcile.verify, "missing_publication_paths", return_value=[]
+        ), mock.patch.object(reconcile, "release_exists", return_value=True), mock.patch.object(
+            reconcile.subprocess, "run"
+        ) as run, mock.patch.object(
+            reconcile.urllib.request, "urlopen"
+        ) as urlopen:
+            kwargs = dict(
+                version="1.2.3",
+                repository_url=reconcile.verify.DEFAULT_REPOSITORY,
+                gpg_keyname="KEY",
+                gpg_passphrase="PASS",
+                dry_run=False,
+            )
+            first = reconcile.reconcile_release(**kwargs)
+            second = reconcile.reconcile_release(**kwargs)
+
+        self.assertEqual((first, second), (0, 0))
+        run.assert_not_called()
+        urlopen.assert_not_called()
+
+    def test_missing_slack_webhook_url_skips_cleanly_after_release_creation(self):
+        os.environ.pop("SLACK_WEBHOOK_URL", None)
+        release_result = subprocess.CompletedProcess(
+            [], 0, stdout="https://github.test/releases/1.2.3\n"
+        )
+        with mock.patch.object(
+            reconcile.verify, "missing_publication_paths", return_value=[]
+        ), mock.patch.object(reconcile, "release_exists", return_value=False), mock.patch.object(
+            reconcile.subprocess, "run", return_value=release_result
+        ), mock.patch.object(
+            reconcile.urllib.request, "urlopen"
+        ) as urlopen:
+            exit_code = reconcile.reconcile_release(
+                version="1.2.3",
+                repository_url=reconcile.verify.DEFAULT_REPOSITORY,
+                gpg_keyname="KEY",
+                gpg_passphrase="PASS",
+                dry_run=False,
+            )
+
+        self.assertEqual(exit_code, 0)
+        urlopen.assert_not_called()
+
+    def test_dry_run_prints_plan_without_deploying_or_creating_anything(self):
+        missing = [p for p in reconcile.verify.publication_paths("1.2.3") if "/shaft-cli/" in p]
+        with mock.patch.object(
+            reconcile.verify, "missing_publication_paths", return_value=missing
+        ), mock.patch.object(reconcile.subprocess, "run") as run, mock.patch.object(
+            reconcile.urllib.request, "urlopen"
+        ) as urlopen:
+            exit_code = reconcile.reconcile_release(
+                version="1.2.3",
+                repository_url=reconcile.verify.DEFAULT_REPOSITORY,
+                gpg_keyname="KEY",
+                gpg_passphrase="PASS",
+                dry_run=True,
+            )
+
+        self.assertEqual(exit_code, 0)
+        run.assert_not_called()
+        urlopen.assert_not_called()
+
+    def test_dry_run_with_nothing_missing_reports_the_planned_release_without_creating_it(self):
+        with mock.patch.object(
+            reconcile.verify, "missing_publication_paths", return_value=[]
+        ), mock.patch.object(reconcile, "release_exists", return_value=False), mock.patch.object(
+            reconcile.subprocess, "run"
+        ) as run, mock.patch.object(
+            reconcile.urllib.request, "urlopen"
+        ) as urlopen:
+            exit_code = reconcile.reconcile_release(
+                version="1.2.3",
+                repository_url=reconcile.verify.DEFAULT_REPOSITORY,
+                gpg_keyname="KEY",
+                gpg_passphrase="PASS",
+                dry_run=True,
+            )
+
+        self.assertEqual(exit_code, 0)
+        run.assert_not_called()
+        urlopen.assert_not_called()
+
+
+class MainTest(unittest.TestCase):
+    def test_main_reads_version_from_the_reactor_when_not_given(self):
+        version_result = subprocess.CompletedProcess([], 0, stdout="9.9.20260101\n")
+        with mock.patch.object(
+            reconcile, "reconcile_release", return_value=0
+        ) as reconcile_fn, mock.patch.object(
+            reconcile.subprocess, "run", return_value=version_result
+        ), mock.patch.object(
+            reconcile.verify, "maven_executable", return_value="mvn"
+        ):
+            exit_code = reconcile.main([])
+
+        self.assertEqual(exit_code, 0)
+        reconcile_fn.assert_called_once()
+        self.assertEqual(reconcile_fn.call_args.kwargs["version"], "9.9.20260101")
+
+    def test_main_uses_the_explicit_version_flag_without_reading_the_reactor(self):
+        with mock.patch.object(
+            reconcile, "reconcile_release", return_value=0
+        ) as reconcile_fn, mock.patch.object(reconcile.subprocess, "run") as run:
+            exit_code = reconcile.main(["--version", "1.2.3", "--dry-run"])
+
+        self.assertEqual(exit_code, 0)
+        run.assert_not_called()
+        self.assertEqual(reconcile_fn.call_args.kwargs["version"], "1.2.3")
+        self.assertTrue(reconcile_fn.call_args.kwargs["dry_run"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_verify_maven_central_release.py
+++ b/tests/scripts/test_verify_maven_central_release.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import scripts.ci.validate_maven_publication as validate_publication
 import scripts.ci.verify_maven_central_release as verify
 
 FIXTURE_GOALS = verify.FIXTURE_GOALS
@@ -54,6 +55,23 @@ class VerifyMavenCentralReleaseTest(unittest.TestCase):
                 for command in commands
             }
             self.assertEqual(len(repositories), len(FIXTURE_GOALS))
+
+    def test_artifact_lists_match_the_deployed_reactor_publication_map(self):
+        # validate_maven_publication.PUBLIC_ARTIFACTS is the cross-checked, packaging-aware
+        # source of truth for what the reactor actually deploys (it reads each pom's
+        # <packaging>); JAR_ARTIFACTS/POM_ARTIFACTS here must not drift from it, or a
+        # published module (e.g. shaft-cli) silently stops being verified/reconciled.
+        expected_jars = {
+            name for name, (_, packaging) in validate_publication.PUBLIC_ARTIFACTS.items()
+            if packaging == "jar"
+        }
+        expected_poms = {
+            name for name, (_, packaging) in validate_publication.PUBLIC_ARTIFACTS.items()
+            if packaging == "pom"
+        }
+
+        self.assertEqual(set(verify.JAR_ARTIFACTS), expected_jars)
+        self.assertEqual(set(verify.POM_ARTIFACTS), expected_poms)
 
     def test_settings_force_the_requested_repository(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

Progresses #3981.

`check_maven_release_version.py`'s `check_release_needed` gate only HEAD-checks the **parent POM** before a real deploy runs. If a reactor `mvn deploy` dies partway through (parent + some modules published, a later module fails transiently), every later run for that SAME version sees `already_released=true` and skips the whole job entirely — the missing module never gets re-uploaded, and `announce_release` (GitHub Release + Slack) never runs for that version since it's downstream.

This adds an **additive, on-demand** reconciliation path — `mavenCentral_cd.yml`'s existing push-triggered flow is untouched.

## What changed

- `scripts/ci/reconcile_maven_central_release.py` (new): reuses `verify_maven_central_release.py`'s per-artifact `missing_publication_paths()` to find exactly which packages are missing from Central for a version, builds (and only executes when not `--dry-run`) a targeted `mvn deploy -pl <missing-modules>` for just those modules, then checks/creates the GitHub Release and posts the Slack announcement only if it just created that release. Idempotent — a clean no-op when nothing is missing and the release already exists.
- `.github/workflows/maven-central-reconcile.yml` (new): `workflow_dispatch`-only (never auto-triggers, so it can't race `mavenCentral_cd.yml`), `version`/`dry_run` inputs, reuses `build_release_and_deliver`'s JDK/Maven/GPG setup steps verbatim.
- `scripts/ci/verify_maven_central_release.py`: fixed artifact-list drift found during audit — `shaft-cli` publishes to Central (`validate_maven_publication.py` already tracked it) but was missing from `JAR_ARTIFACTS`, so a partial `shaft-cli` publish failure would have gone undetected by both the existing release gate and this new tool.
- `tests/scripts/test_verify_maven_central_release.py`: added a permanent drift-guard test cross-checking `JAR_ARTIFACTS`/`POM_ARTIFACTS` against `validate_maven_publication.PUBLIC_ARTIFACTS`, so future drift fails loudly instead of silently.
- `tests/scripts/test_reconcile_maven_central_release.py` (new): 17 tests, every external call (`subprocess.run`, `urllib.request.urlopen`) mocked — no live `mvn deploy`, `gh release create`, or Slack POST is ever made by the test suite.

## Safety note

No live Maven Central deploy, GitHub Release, or Slack post was executed anywhere during development — every external call in the tests is mocked, matching the repo's existing convention for `verify_maven_central_release.py`/`check_maven_release_version.py`. The new workflow only runs on an explicit manual `workflow_dispatch` with real CI secrets, never automatically.

## Test plan

- [x] TDD: `test_artifact_lists_match_the_deployed_reactor_publication_map` watched RED (`shaft-cli` missing) → GREEN after the one-line fix.
- [x] New reconciliation module watched RED (`ModuleNotFoundError`) with the full 17-test file written first → GREEN after implementation.
- [x] `python -m unittest tests.scripts.test_reconcile_maven_central_release tests.scripts.test_verify_maven_central_release tests.scripts.test_check_maven_release_version tests.scripts.test_validate_maven_publication -v` — 41/41 green.
- [x] Full `tests/scripts` suite (`python -m unittest discover -s tests/scripts -p "test_*.py"`) — 328 tests, 1 pre-existing unrelated failure (`test_validate_agent_setup.py` memory-filename-length check on a file from already-merged PR #3980, confirmed via `git show origin/main --stat` predating this branch — not touched by this PR).
- [x] `python scripts/ci/validate_agent_setup.py --skip-external` — same 2 pre-existing errors only, nothing introduced by this change.
- [x] YAML sanity-parsed the new workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz