### PR TITLE
shaft-intellij: keep Verbose raw stream buffer reachable on normal completion

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -2070,7 +2070,7 @@ final class ShaftAssistantPanel extends JPanel {
             setStatus(terminalStep);
             return;
         }
-        showAgentToolResult(streamToken, currentStream, success, result, error, captureIntegrationRun);
+        showAgentToolResult(streamToken, currentStream, success, result, error, captureIntegrationRun, partialOutput);
     }
 
     private boolean handleKilledOrStaleAgentStream(int streamToken) {
@@ -2107,12 +2107,12 @@ final class ShaftAssistantPanel extends JPanel {
 
     private void showAgentToolResult(
             int streamToken, boolean currentStream, boolean success, ShaftMcpToolResult result, Throwable error) {
-        showAgentToolResult(streamToken, currentStream, success, result, error, false);
+        showAgentToolResult(streamToken, currentStream, success, result, error, false, "");
     }
 
     private void showAgentToolResult(
             int streamToken, boolean currentStream, boolean success, ShaftMcpToolResult result, Throwable error,
-            boolean captureIntegrationRun) {
+            boolean captureIntegrationRun, String verboseStreamedBuffer) {
         String output = resolveOutput(result, error, "No response returned.");
         boolean rejectedGeneratedJava = AssistantMarkdown.containsRejectedGeneratedJava(output);
         if (!output.isBlank() && !rejectedGeneratedJava) {
@@ -2153,6 +2153,19 @@ final class ShaftAssistantPanel extends JPanel {
         // code narrative already carries its own headline, so it is left alone.
         if (!success && !rejectedGeneratedJava) {
             response = AssistantMarkdown.localAgentFailureMarkdown(response);
+        }
+        // Issue #3976: finishLocalAgentResponse used to always replace the streaming bubble with this
+        // polished answer, discarding the accumulated raw buffer regardless of Verbose state -- so a
+        // compacted/pointer-text milestone line (e.g. RAW_STRUCTURED_OUTPUT_NOTICE) streamed last
+        // became a dead end once the run completed normally, with no more streaming bubble left to
+        // re-render once Verbose was toggled on. verboseStreamedBuffer is already gated on Verbose's
+        // CURRENT state by the caller (mirrors showAgentCancelled/stopLocalAgentStreaming's own
+        // "respect live Verbose state at finalization time" reasoning), so it is appended here --
+        // unless it's already represented in the polished answer -- instead of unconditionally
+        // discarding it.
+        if (!verboseStreamedBuffer.isBlank() && !response.contains(verboseStreamedBuffer)) {
+            response = response + "\n\n**Verbose — raw streamed output**\n\n"
+                    + formatLocalAgentStreamingResponse(verboseStreamedBuffer);
         }
         // A genuine CLI failure gets KIND_ERROR; a rejected-generated-code narrative already carries
         // its own headline and is a guardrail outcome, not an error, so it stays the default kind.

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -4020,6 +4020,53 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantVerboseFinalizationKeepsRawStreamedBufferReachableAfterNormalCompletion() throws Exception {
+        // Issue #3976: finishLocalAgentResponse always replaced the streaming bubble with the
+        // polished final answer on normal completion, discarding the accumulated localAgentOutput
+        // raw buffer regardless of Verbose state. Concretely: a compacted/pointer-text milestone
+        // line (e.g. the RAW_STRUCTURED_OUTPUT_NOTICE issue #3920 added) streamed last before the
+        // run completed normally became a dead end -- no more streaming bubble left to re-render
+        // once Verbose was toggled on, because finalization already replaced it. Mirrors
+        // stopLocalAgentStreaming's Verbose-gated raw-buffer rendering (issue #3918/#3961) applied
+        // to the normal-completion path.
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JCheckBox verbose = findByAccessibleName(panel, "Show verbose agent output", JCheckBox.class);
+        verbose.setSelected(true);
+
+        appendStreamingLocalAgentBubble(panel, 801);
+        appendLocalAgentOutput(panel, 801, "{\"type\":\"raw_structured_line\",\"value\":42}");
+
+        showAgentResult(panel, 801, ShaftMcpToolResult.success("final answer"));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("final answer"), markdown),
+                () -> assertTrue(markdown.contains("raw_structured_line"),
+                        "With Verbose on, the raw streamed buffer must still be reachable after a "
+                                + "normal completion, not silently discarded: " + markdown));
+    }
+
+    @Test
+    void assistantNonVerboseFinalizationShowsOnlyThePolishedAnswerNoRawBufferLeakage() throws Exception {
+        // Companion pin for the fix above (issue #3976): with Verbose OFF throughout, a normal
+        // completion must keep showing only the polished final answer -- the raw streamed buffer
+        // must not leak into the transcript.
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+
+        appendStreamingLocalAgentBubble(panel, 802);
+        appendLocalAgentOutput(panel, 802, "{\"type\":\"raw_structured_line\",\"value\":42}");
+
+        showAgentResult(panel, 802, ShaftMcpToolResult.success("final answer"));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("final answer"), markdown),
+                () -> assertFalse(markdown.contains("raw_structured_line"),
+                        "Verbose is off, so the raw streamed buffer must not leak into the transcript: "
+                                + markdown));
+    }
+
+    @Test
     void assistantNonVerboseRunShowsNoPlaceholderBubbleWhileRunning() throws Exception {
         // Issue #3919: the "_Running local assistant..._" placeholder bubble is gone -- progress
         // while a run is in flight is the toolbar spinner/status label's job alone, not a transcript


### PR DESCRIPTION
## Summary
- `finishLocalAgentResponse` always replaced the streaming bubble with the polished final answer on normal completion, discarding the accumulated `localAgentOutput` raw buffer regardless of Verbose state -- so a compacted/pointer-text milestone line (e.g. `RAW_STRUCTURED_OUTPUT_NOTICE`, added by PR #3961) streamed last before a normal completion became a dead end once Verbose was live at finalization time.
- `showAgentResult` already snapshots the raw buffer gated on Verbose's CURRENT state at the moment a run finishes (mirroring `stopLocalAgentStreaming`'s Kill-path change from #3918/#3961 and `showAgentCancelled`'s Cancel-path change from #3920), but only threaded that snapshot into the Cancel branch -- the normal-completion branch silently dropped it.
- Threads the same snapshot through `showAgentToolResult` and appends it under the polished answer (`**Verbose — raw streamed output**`) when non-blank and not already represented in it, applying the same "respect live Verbose state at finalization time" principle to the normal-completion path. Verbose-off behavior (discard, polished answer only) is unchanged.

## Test plan
- [x] `assistantVerboseFinalizationKeepsRawStreamedBufferReachableAfterNormalCompletion` (new) -- watched RED (buffer discarded), then GREEN after the fix.
- [x] `assistantNonVerboseFinalizationShowsOnlyThePolishedAnswerNoRawBufferLeakage` (new) -- pins Verbose-off behavior unchanged, passed both before and after.
- [x] Full `ShaftPanelSetupTest` (262 tests) + `ShaftAssistantPanelQuestionTest` (7 tests): 269/269 green, 0 failures/errors.
- [x] `compileJava` / `compileTestJava` for `shaft-intellij`: BUILD SUCCESSFUL.

Closes #3976

https://claude.ai/code/session_01NDQpYzvnTbDPYwqDwHQoRz