### PR TITLE
Agent charters: state mempalace/memory discovery-first explicitly for coder/reviewer/tester

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -13,7 +13,11 @@ First action, before any other tool: `Skill(act-as-fable)` then
 
 - Implement exactly the assigned spec. Adjacent findings are reported, never
   fixed. Architectural questions go back to the orchestrator undecided.
-- Scout the touched files first; match the codebase's existing patterns.
+- Consult `mempalace`/`memory` for prior context (past decisions, gotchas,
+  who/what touched this before) before grepping or manually searching the
+  repo — never grep for what a store already knows. Scout the touched files
+  after, to verify against the live tree and match existing patterns; stores
+  reflect what was mined, not necessarily current code.
 - TDD always: failing test first, watched red, minimal code, watched green.
 - Ponytail shapes every diff: does it need to exist, stdlib before custom,
   one line before fifty.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -12,6 +12,10 @@ you judge tests, so you must know what good ones look like. Both bind.
 
 ## Rules
 
+- Consult `mempalace`/`memory` for prior context on the touched area (past
+  incidents, prior review findings, established patterns) before grepping or
+  manually searching the repo — never grep for what a store already knows;
+  verify against the live tree after, since stores can be stale.
 - The change is guilty until proven innocent. Read the full diff, then run
   what it claims: affected tests (scoped, headless), the touched flow, the
   validators.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -11,6 +11,10 @@ both bind for the whole task.
 
 ## Rules
 
+- Consult `mempalace`/`memory` for prior context (past incidents, known
+  flakes, prior fixes in this area) before grepping or manually searching the
+  repo — never grep for what a store already knows; verify against the live
+  tree after, since stores can be stale.
 - Reproduce before anything: a defect you cannot rerun on demand cannot be
   proven fixed. Capture the failing output verbatim.
 - Regression tests target the root cause, not the incident's surface shape.


### PR DESCRIPTION
## Summary
- `coder.md`, `reviewer.md`, `tester.md` didn't state the mempalace/memory-before-manual-search rule themselves — it only lived in `chaos-engine.md` (main-thread orchestrator) and buried in `act-as-fable`'s full skill text. Adds an explicit line to each of the three dispatched-subagent charters: consult `mempalace`/`memory` for prior context before grepping or manually searching the repo; verify against the live tree afterward since stores can go stale.
- Prompted by a mid-session owner correction: subagents dispatched earlier in this session weren't explicitly told this in their own charter (they only inherit it via loading `act-as-fable`, which is a much longer document).

Filed as a follow-up (found while validating this change, unrelated to it): #3991 — `validate_agent_setup.py` currently fails on `main` due to a pre-existing oversized memory filename from an earlier merge.

## Test plan
- [x] `python3 scripts/ci/validate_agent_setup.py --skip-external` — fails only on the pre-existing #3991 issue, unrelated to this change; no new failures introduced.

## Follow-up (not this PR)
After merge, the user's local `~/.claude/agents/` harness mirror should be re-synced via `py -3 scripts/agents/sync_user_harness.py --apply` per `AGENTS.md`'s harness-deploy step, so the running session actually picks up the updated charters.