### PR TITLE
Revert global -Xmx1024m Surefire cap that OOMs E2E and Local E2E nightlies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,15 +50,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <!-- -Xmx: macos-latest GitHub-hosted runners have only 7GB RAM (vs 16GB on windows-latest/
-             ubuntu-latest), so the JVM's ergonomic default heap (unset otherwise) is smaller there,
-             and the single reused surefire fork (reuseForks=true) that runs the whole module's tests
-             sequentially under the JaCoCo agent accumulates garbage until it exceeds that smaller
-             ceiling, crashing with OutOfMemoryError: Java heap space (#3930). 1024m gives generous,
-             empirically verified headroom: locally reproduced a clean heap-space OOM at -Xmx80m, and
-             confirmed -Xmx128m comfortably clears 300+ sequential tests in the same fork, while
-             leaving about 6GB of the 7GB macOS runner for the browser and OS. -->
-        <surefireArgLine>--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8 -Xmx1024m</surefireArgLine>
+        <surefireArgLine>--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Xshare:off -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8</surefireArgLine>
         <mockito.version>5.23.0</mockito.version>
         <mockitoAgentArgLine>-javaagent:"${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"</mockitoAgentArgLine>
         <surefire.excludedGroups>allure3-visual-demo</surefire.excludedGroups>


### PR DESCRIPTION
## Summary

Reverts the `-Xmx1024m` addition to root `pom.xml`'s `surefireArgLine` property (and its explanatory comment) from 3022ebb4ae (#3942), back to exactly its pre-3022ebb4ae value. This is a pure revert -- no per-OS profiles, no workflow-level overrides, no replacement number.

## Why

Before 3022ebb4ae, no `-Xmx` was set anywhere (root pom.xml, shaft-engine/pom.xml, or the workflow files), so every GitHub-hosted runner used HotSpot's ergonomic default heap: `MaxRAMPercentage=25%` of physical RAM (verified locally with `java -XX:+PrintFlagsFinal -version`, which reports `MaxRAMPercentage = 25.000000 {product} {default}` on this machine). Applied to the actual runners:

- `macos-latest` (7GB RAM) -> ~1792m ergonomic default
- `windows-latest` / `ubuntu-latest` (16GB RAM) -> ~4096m ergonomic default

`-Xmx1024m` therefore *lowered* macOS below the heap that was already exhausting it -- which cannot fix a heap-space OOM by the original PR's own stated mechanism, and `MacOSX_Safari_Local` is still failing with `OutOfMemoryError` today. Meanwhile it cut the 16GB runners to a quarter of their prior working heap:

- `Windows_Chrome_Local` and `Windows_Edge_Local` were both green on 07-20/07-21 and red on the first nightly run after the merge.
- `Ubuntu_Chrome_Grid` shows 41 `OutOfMemoryError` occurrences since the merge, `Ubuntu_MicrosoftEdge_Grid` shows 7.

The original PR's empirical basis -- a 334-test slice on a local Windows box showing 80m crashes / 128m clears -- establishes a floor for that slice, not that 1024m suffices for the real ~2105-test (Windows Local) or ~787-test x 4-thread (Ubuntu Grid) nightly workloads.

Related, but explicitly NOT closed by this PR (no closing keywords used, on purpose):
- #3985 -- has a second live cause (Playwright-scope leak in Grid jobs), tracked separately as #4006. Not fixed here.
- #3987 -- has an entangled Safari finding tracked as #1548. Not fixed here.

Both should be closed manually only after a green nightly run confirms this revert plus their other tracked causes are resolved.

## What this PR does NOT do

- Does not touch `.github/workflows/e2eTests.yml` or `e2eLocalTests.yml`.
- Does not add per-OS Surefire heap profiles or a `-DsurefireArgLine` override anywhere.
- Does not touch `shaft-intellij` or `shaft-mcp`.
- Does not fix #3930's original macOS OOM -- that issue is being reopened separately with an explanation.

## Test plan

A forked full Surefire run would prove nothing meaningful locally and is exactly the kind of run this repo's guidance says to avoid before a change like this. Validation performed:

- `mvn -q -DskipTests compile` -- exit code 0, confirms the POM still parses and the multi-module reactor resolves cleanly after removing the property override.

**CI is the real verification for this change.** The claim being tested -- that removing the cap lets `MacOSX_Chrome_Local`, `Windows_Chrome_Local`, `Windows_Edge_Local`, `Ubuntu_Chrome_Grid`, and `Ubuntu_MicrosoftEdge_Grid` pass again on their ergonomic default heaps -- can only be confirmed by the next nightly E2E / Local E2E workflow runs. This PR does not claim the nightly is fixed; it claims the regression this PR reverts should not have been merged, and removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zitr1nnKo9tQtCSvX3u8W