### PR TITLE
Fix #3996: FlutterIntegration TouchActions.swipeElementIntoView issues flutter: scrollTillVisible

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
@@ -17,6 +17,7 @@ import com.shaft.validation.internal.WebDriverElementValidationsBuilder;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.flutter.commands.ScrollParameter;
 import io.appium.java_client.ios.IOSDriver;
 import org.openqa.selenium.*;
 import org.openqa.selenium.interactions.*;
@@ -717,7 +718,9 @@ public class TouchActions extends FluentWebDriverAction {
             try {
                 if (driverFactoryHelper.getDriver() instanceof AppiumDriver appiumDriver) {
                     // appium native application
-                    boolean isElementFound = attemptW3cCompliantActionsScroll(swipeDirection, scrollableElementLocator, targetElementLocator);
+                    boolean isElementFound = targetElementLocator instanceof AppiumBy.FlutterBy flutterTarget
+                            ? attemptFlutterScrollTillVisible(appiumDriver, flutterTarget, scrollableElementLocator, swipeDirection)
+                            : attemptW3cCompliantActionsScroll(swipeDirection, scrollableElementLocator, targetElementLocator);
                     if (!isElementFound) {
                         elementActionsHelper.failAction(appiumDriver, testData, targetElementLocator);
                     }
@@ -1129,6 +1132,38 @@ public class TouchActions extends FluentWebDriverAction {
         }
         ReportManager.logDiscrete("Element found on screen.");
         return true;
+    }
+
+    /**
+     * Scrolls a Flutter widget into view via the Flutter integration driver's "flutter: scrollTillVisible"
+     * command. Unlike the native "mobile: scrollGesture", this drives Flutter's own widget tree instead of
+     * the (nonexistent) native scrollable, so it works against a bare FlutterView.
+     * <p>
+     * Always returns {@code true}: the underlying command throws when the target widget is never found, and
+     * that exception propagates to the caller's existing catch block, which reports it via failAction.
+     */
+    private boolean attemptFlutterScrollTillVisible(AppiumDriver appiumDriver, AppiumBy.FlutterBy targetElementLocator,
+                                                      By scrollableElementLocator, SwipeDirection swipeDirection) {
+        var scrollParameter = new ScrollParameter(targetElementLocator, mapToFlutterScrollDirection(swipeDirection));
+        if (scrollableElementLocator instanceof AppiumBy.FlutterBy flutterScrollView) {
+            scrollParameter.setScrollView(flutterScrollView);
+        } else if (scrollableElementLocator != null) {
+            ReportManager.logDiscrete("Ignoring non-Flutter scrollable element locator \"" + scrollableElementLocator
+                    + "\" for the Flutter integration driver; a native container cannot scroll inside a FlutterView.");
+        }
+        ReportManager.logDiscrete("Swiping to find Element using the Flutter integration driver. SwipeDirection \""
+                + swipeDirection + "\", TargetElementLocator \"" + targetElementLocator + "\".");
+        appiumDriver.executeScript("flutter: scrollTillVisible", scrollParameter.toJson());
+        return true;
+    }
+
+    private ScrollParameter.ScrollDirection mapToFlutterScrollDirection(SwipeDirection swipeDirection) {
+        return switch (swipeDirection) {
+            case UP -> ScrollParameter.ScrollDirection.UP;
+            case DOWN -> ScrollParameter.ScrollDirection.DOWN;
+            case LEFT -> ScrollParameter.ScrollDirection.LEFT;
+            case RIGHT -> ScrollParameter.ScrollDirection.RIGHT;
+        };
     }
 
     private void attemptPinchToZoomIn() {

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -6,7 +6,9 @@ import com.shaft.driver.internal.FluentWebDriverAction;
 import com.shaft.gui.element.TouchActions;
 import com.shaft.gui.element.internal.ElementActionsHelper;
 import com.shaft.properties.internal.Properties;
+import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.flutter.commands.ScrollParameter;
 import io.appium.java_client.ios.IOSDriver;
 import org.mockito.ArgumentCaptor;
 import org.openqa.selenium.By;
@@ -18,6 +20,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.opentest4j.AssertionFailedError;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -515,6 +518,110 @@ public class AndroidTouchActionsCoverageUnitTest {
 
         verify(driver, times(3)).executeScript(eq("mobile: scrollGesture"), anyMap());
         verify(driver, never()).findElements(isNull());
+    }
+
+    // Issue #3996: FlutterIntegration driver targets must scroll via "flutter: scrollTillVisible",
+    // not the native "mobile: scrollGesture" (a no-op against a single FlutterView with no native scrollable).
+
+    @Test
+    public void swipeElementIntoViewWithFlutterLocatorShouldIssueFlutterScrollCommand() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        doReturn(false).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        when(elementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
+        // Pre-fix reproduction: the native path throws "Element not found after scrolling to the end of the page."
+        // (TouchActions.java:1105), and failAction converts it into the reporter's real AssertionFailedError.
+        doThrow(new AssertionFailedError("Element not found after scrolling to the end of the page."))
+                .when(elementActionsHelper).failAction(any(WebDriver.class), anyString(), any(), any(Throwable.class));
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+
+        var targetLocator = AppiumBy.flutterKey("category_item_2");
+        touchActions.swipeElementIntoView(targetLocator, TouchActions.SwipeDirection.DOWN);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(driver).executeScript(eq("flutter: scrollTillVisible"), payloadCaptor.capture());
+        verify(driver, never()).executeScript(eq("mobile: scrollGesture"), anyMap());
+
+        Map<String, Object> payload = payloadCaptor.getValue();
+        SHAFT.Validations.assertThat().object(payload.get("finder"))
+                .isEqualTo(Map.of("using", "-flutter key", "value", "category_item_2")).perform();
+        SHAFT.Validations.assertThat().object(payload.get("scrollDirection")).isEqualTo("down").perform();
+    }
+
+    @Test
+    public void swipeElementIntoViewWithNativeLocatorShouldStillUseMobileScrollGesture() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        WebElement targetElement = mock(WebElement.class);
+        when(driver.findElements(any(By.class))).thenReturn(List.of(), List.of(targetElement));
+        doReturn(true).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        when(elementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+
+        touchActions.swipeElementIntoView(By.id("target"), TouchActions.SwipeDirection.DOWN);
+
+        verify(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+        verify(driver, never()).executeScript(eq("flutter: scrollTillVisible"), any());
+    }
+
+    @Test
+    public void swipeElementIntoViewWithFlutterScrollableAndFlutterTargetShouldIncludeScrollView() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        when(elementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+
+        var scrollableLocator = AppiumBy.flutterType("ListView");
+        var targetLocator = AppiumBy.flutterKey("category_item_2");
+        touchActions.swipeElementIntoView(scrollableLocator, targetLocator, TouchActions.SwipeDirection.UP);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(driver).executeScript(eq("flutter: scrollTillVisible"), payloadCaptor.capture());
+        SHAFT.Validations.assertThat().object(payloadCaptor.getValue().containsKey("scrollView")).isTrue().perform();
+    }
+
+    @Test
+    public void swipeElementIntoViewWithFlutterTargetAndNativeScrollableShouldOmitScrollView() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        when(elementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+
+        var targetLocator = AppiumBy.flutterKey("category_item_2");
+        touchActions.swipeElementIntoView(By.id("nativeContainer"), targetLocator, TouchActions.SwipeDirection.LEFT);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(driver).executeScript(eq("flutter: scrollTillVisible"), payloadCaptor.capture());
+        verify(driver, never()).executeScript(eq("mobile: scrollGesture"), anyMap());
+        SHAFT.Validations.assertThat().object(payloadCaptor.getValue().containsKey("scrollView")).isFalse().perform();
+    }
+
+    @Test
+    public void mapToFlutterScrollDirectionShouldPreserveWireFormatForAllDirections() throws Exception {
+        Method mapToFlutterScrollDirection = TouchActions.class.getDeclaredMethod("mapToFlutterScrollDirection", TouchActions.SwipeDirection.class);
+        mapToFlutterScrollDirection.setAccessible(true);
+        TouchActions touchActions = new TouchActions(createMockAndroidDriver());
+
+        Map<TouchActions.SwipeDirection, String> expectedWireDirections = Map.of(
+                TouchActions.SwipeDirection.UP, "up",
+                TouchActions.SwipeDirection.DOWN, "down",
+                TouchActions.SwipeDirection.LEFT, "left",
+                TouchActions.SwipeDirection.RIGHT, "right");
+
+        for (var entry : expectedWireDirections.entrySet()) {
+            ScrollParameter.ScrollDirection direction =
+                    (ScrollParameter.ScrollDirection) mapToFlutterScrollDirection.invoke(touchActions, entry.getKey());
+            SHAFT.Validations.assertThat().object(direction.getDirection()).isEqualTo(entry.getValue()).perform();
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #3996

## Root cause

With `automationName=FlutterIntegration`, `DriverFactoryHelper.java:672` still builds a plain `new AndroidDriver(...)` (setting only `driverType=APPIUM_FLUTTER`, `DriverFactoryHelper.java:1406-1408`). `swipeElementIntoView` therefore issued UiAutomator2's `mobile: scrollGesture` (`TouchActions.java:1068`), which drives the **native** view tree. A Flutter app is a single `FlutterView` with no native scrollable, so the gesture is a no-op, `canScrollMore` is `false` on the first iteration, and `TouchActions.java:1105` throws `"Element not found after scrolling to the end of the page."` even when the target widget is genuinely on screen.

`SupportsScrollingOfFlutterElements.scrollTillVisible(ScrollParameter)` (java-client) is a default method whose body is `executeScript("flutter: scrollTillVisible", param.toJson())` -- reachable from the `AndroidDriver` SHAFT already builds, since `AndroidDriver` is a `JavascriptExecutor`. No driver-class change, no new dependency.

## Fix

`shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java`:
- `swipeElementIntoView(By, By, SwipeDirection)` now detects a Flutter locator **by type** (`targetElementLocator instanceof AppiumBy.FlutterBy`), not by driver config -- a FlutterIntegration session can still legitimately target a native overlay with a plain `By`, and that must keep using the native path unchanged.
- New `attemptFlutterScrollTillVisible(...)` builds a `ScrollParameter` from the Flutter target + mapped `SwipeDirection`, optionally sets `scrollView` when the scrollable locator is also a `FlutterBy` (logging and ignoring it otherwise, since a native container can't scroll inside a `FlutterView`), and calls `appiumDriver.executeScript("flutter: scrollTillVisible", ...)` directly.
- New `mapToFlutterScrollDirection(...)` is an exhaustive `switch` (not `valueOf`) mapping SHAFT's `SwipeDirection` to java-client's `ScrollParameter.ScrollDirection` -- fails to compile if either enum changes, rather than failing at runtime.
- The helper always returns `true`: `flutter: scrollTillVisible` throws when the widget is never found, and that exception propagates to the existing `catch (Exception e)` -> `failAction`, so failure UX is unchanged (real driver message instead of the old synthetic one).
- No other `swipeElementIntoView` overload, `swipeToEndOfView`, `HealingManager`, or `DriverFactoryHelper` touched. Public API unchanged.

Verified against java-client 10.1.1 (`javap`/class-string extraction on the jar in `~/.m2`) before relying on any of it: `ScrollParameter(AppiumBy.FlutterBy, ScrollParameter.ScrollDirection)` 2-arg constructor, `setScrollView(AppiumBy.FlutterBy)`, and `ScrollDirection` constants `UP/RIGHT/DOWN/LEFT` serializing to lowercase `"up"/"right"/"down"/"left"`; `AppiumBy.flutterKey("category_item_2")` serializes to `{"using":"-flutter key","value":"category_item_2"}` in the `finder` payload key.

## Tests (`AndroidTouchActionsCoverageUnitTest.java`)

Five new tests, all watched RED before the fix and GREEN after:

1. `swipeElementIntoViewWithFlutterLocatorShouldIssueFlutterScrollCommand` -- primary repro. Pre-fix, failed with the reporter's own message via a real `org.opentest4j.AssertionFailedError`:
   ```
   org.opentest4j.AssertionFailedError: Element not found after scrolling to the end of the page.
   	at com.shaft.gui.element.internal.ElementActionsHelper.failAction(ElementActionsHelper.java:911)
   	at com.shaft.gui.element.TouchActions.swipeElementIntoView(TouchActions.java:741)
   ```
   Post-fix: asserts `executeScript("flutter: scrollTillVisible", ...)` is called with `finder == {"using":"-flutter key","value":"category_item_2"}` and `scrollDirection == "down"`, and `never()` calls `mobile: scrollGesture`.
2. `swipeElementIntoViewWithNativeLocatorShouldStillUseMobileScrollGesture` -- regression guard: a native `By` locator still routes to `mobile: scrollGesture`. Green-by-construction pre-fix (behavior unchanged), so given teeth via an explicit **mutation check**: the branch was temporarily forced to always take the Flutter path, this test went red (`Wanted but not invoked: mobile: scrollGesture` -- confirmed observed, not assumed), then the mutation was reverted and the full class re-confirmed green (22/22).
3. `swipeElementIntoViewWithFlutterScrollableAndFlutterTargetShouldIncludeScrollView` -- FlutterBy scrollable + FlutterBy target -> `scrollView` present in payload.
4. `swipeElementIntoViewWithFlutterTargetAndNativeScrollableShouldOmitScrollView` -- FlutterBy target + native `By` scrollable -> `scrollView` absent, command still dispatches (and logs the ignored locator).
5. `mapToFlutterScrollDirectionShouldPreserveWireFormatForAllDirections` -- all four `SwipeDirection` values map to the correct lowercase wire strings; pre-fix failed with `NoSuchMethodException` since the method didn't exist yet.

Full class: `Tests run: 22, Failures: 0, Errors: 0, Skipped: 0` (all pre-existing tests unaffected).

## Validation actually run this session

- `mvn -pl shaft-engine test-compile -Dallure.automaticallyOpen=false` -- clean.
- `mvn -pl shaft-engine test -Dtest=AndroidTouchActionsCoverageUnitTest ...` -- RED (5 new tests, correct failure reasons) before the fix, GREEN (22/22) after, GREEN again (22/22) after the mutation-check revert.
- `mvn -pl shaft-engine compile -Dallure.automaticallyOpen=false` -- clean.
- The Surefire "delete gotcha" from memory (`memory load` is currently broken repo-wide by a secret-scanner false positive, tracked as #4005) was checked by reading `.memory/gotchas/` directly rather than skipped: it concerns `isolation:'worktree'` Agent-tool spawns whose long forked-Maven read-only phase touches no tracked files, tripping the harness's auto-cleanup heuristic. This session ran directly in the primary checkout (`git worktree list` confirmed), not an isolated worktree, and the very first action was a tracked-file edit -- so the trigger condition never applied, and scoped `mvn test` runs were used normally.

## What CI cannot prove

- That `flutter: scrollTillVisible` actually moves a real Flutter scrollable on a device -- these are mocked-driver unit tests; no real Appium/Flutter session is exercised.
- That `SwipeDirection` -> `ScrollParameter.ScrollDirection` semantics (visual scroll direction) match on-device behavior -- only wire-string mapping is verified.
- That a real Appium server accepts this exact payload shape end-to-end.

All three need a real device via `shaft.enableFlutterE2E=true` (`shaft-engine/src/test/java/testPackage/appium/FlutterTest.java:24,32-36` is the right home for a gated on-device follow-up). That test was not un-gated and no device coverage was faked.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>