### PR TITLE
Fix: chain recorded accessible name onto ROLE-strategy capture locators

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -1395,7 +1395,7 @@ public final class CaptureGenerator {
                 String roleLocator = "SHAFT.GUI.Locator.hasRole(Role." + ariaRole.name() + ")";
                 return semanticName.isBlank()
                         ? roleLocator + ".build()"
-                        : roleLocator + ".hasText(\"" + javaString(semanticName) + "\").build()";
+                        : roleLocator + ".hasNormalizedText(\"" + javaString(semanticName) + "\").build()";
             }
         }
         if (semanticName.isBlank()) {

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -1392,7 +1392,10 @@ public final class CaptureGenerator {
         if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE) {
             Role ariaRole = ariaRole(target.role());
             if (ariaRole != null) {
-                return "SHAFT.GUI.Locator.hasRole(Role." + ariaRole.name() + ").build()";
+                String roleLocator = "SHAFT.GUI.Locator.hasRole(Role." + ariaRole.name() + ")";
+                return semanticName.isBlank()
+                        ? roleLocator + ".build()"
+                        : roleLocator + ".hasText(\"" + javaString(semanticName) + "\").build()";
             }
         }
         if (semanticName.isBlank()) {

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -734,6 +734,50 @@ class CaptureGeneratorTest {
                 result.report().compilation().diagnostics().toString());
     }
 
+    /**
+     * Issue #TBD: the ROLE branch of {@code semanticLocator} computed the recorded accessible name
+     * into a local {@code semanticName} and then discarded it, emitting the bare
+     * {@code SHAFT.GUI.Locator.hasRole(Role.BUTTON).build()} -- which {@link com.shaft.gui.internal.locator.LocatorBuilder#byRole}
+     * expands into a union of every button-shaped element on the page. Since ROLE is the
+     * highest-scoring strategy and therefore almost always selected, every recorded step generated a
+     * locator that matched many elements instead of the one that was clicked, so replay hit the wrong
+     * element or failed. The fix chains the recorded name as a {@code hasText(...)} predicate onto the
+     * role locator so the union narrows back down to the one recorded element.
+     */
+    @Test
+    void roleStrategyLocatorChainsRecordedAccessibleNameAsHasTextPredicate() throws Exception {
+        Path session = session(roleLocatorSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result = new CaptureGenerator()
+                .generate(request(session, temp.resolve("role-name")));
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText(\"Log in\").build()"),
+                "generated ROLE locator must chain the recorded accessible name so replay does not match "
+                        + "every button on the page: " + source);
+        assertFalse(source.contains("SHAFT.GUI.Locator.hasRole(Role.BUTTON).build()"), source);
+    }
+
+    /**
+     * When no accessible name was recorded for the target (e.g. an icon-only control), there is
+     * nothing to narrow the ROLE union with, so generation must fall back to the bare
+     * {@code hasRole(...).build()} form rather than emitting an empty/blank predicate.
+     */
+    @Test
+    void roleStrategyLocatorWithoutAccessibleNameEmitsBareHasRole() throws Exception {
+        Path session = session(roleLocatorSessionWithoutAccessibleName());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result = new CaptureGenerator()
+                .generate(request(session, temp.resolve("role-blank-name")));
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("SHAFT.GUI.Locator.hasRole(Role.BUTTON).build()"), source);
+    }
+
     private static CaptureSession roleLocatorSession() {
         ElementSnapshot loginButton = new ElementSnapshot(
                 "login-button",
@@ -759,6 +803,38 @@ class CaptureGeneratorTest {
                         new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
                                 CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
                         new CaptureEvent.ClickEvent(CaptureFixtures.context(2), loginButton,
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+    }
+
+    private static CaptureSession roleLocatorSessionWithoutAccessibleName() {
+        ElementSnapshot iconButton = new ElementSnapshot(
+                "icon-button",
+                "button",
+                "button",
+                "",
+                "",
+                Map.of(),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
+                        "button:", 1, true, true,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE))),
+                true,
+                true,
+                false);
+        return new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "role-locator-session-blank-name",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(3),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), iconButton,
                                 CaptureEvent.MouseButton.PRIMARY, 1)),
                 List.of(),
                 List.of(),

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -741,11 +741,20 @@ class CaptureGeneratorTest {
      * expands into a union of every button-shaped element on the page. Since ROLE is the
      * highest-scoring strategy and therefore almost always selected, every recorded step generated a
      * locator that matched many elements instead of the one that was clicked, so replay hit the wrong
-     * element or failed. The fix chains the recorded name as a {@code hasText(...)} predicate onto the
-     * role locator so the union narrows back down to the one recorded element.
+     * element or failed.
+     *
+     * <p>The fix chains the recorded name as a predicate onto the role locator so the union narrows
+     * back down to the one recorded element. It must use
+     * {@link com.shaft.gui.internal.locator.LocatorBuilder#hasNormalizedText}, not {@code hasText}:
+     * the browser capture recorder whitespace-collapses and trims every recorded name before
+     * persisting it ({@code shaft-capture-recorder.js}'s {@code text()} helper), so an exact raw
+     * string-value comparison ({@code hasText}'s {@code [.="..."]}) fails against ordinary markup
+     * whose text carries surrounding/internal whitespace -- see
+     * {@code LocatorBuilderExtendedUnitTest#recordedNamePredicateShouldResolveRealisticWhitespacePaddedMarkup}
+     * in shaft-engine for the real-markup-resolution proof of that mismatch.
      */
     @Test
-    void roleStrategyLocatorChainsRecordedAccessibleNameAsHasTextPredicate() throws Exception {
+    void roleStrategyLocatorChainsRecordedAccessibleNameAsHasNormalizedTextPredicate() throws Exception {
         Path session = session(roleLocatorSession());
         writeCaptureData("alice");
 
@@ -754,10 +763,12 @@ class CaptureGeneratorTest {
 
         assertTrue(result.successful(), result.report().unsupportedEvents().toString());
         String source = Files.readString(result.sourcePath());
-        assertTrue(source.contains("SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText(\"Log in\").build()"),
-                "generated ROLE locator must chain the recorded accessible name so replay does not match "
-                        + "every button on the page: " + source);
+        assertTrue(source.contains("SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText(\"Log in\").build()"),
+                "generated ROLE locator must chain the recorded accessible name via hasNormalizedText so "
+                        + "replay does not match every button on the page and still resolves against "
+                        + "whitespace-padded real markup: " + source);
         assertFalse(source.contains("SHAFT.GUI.Locator.hasRole(Role.BUTTON).build()"), source);
+        assertFalse(source.contains(".hasText(\"Log in\")"), source);
     }
 
     /**

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java
@@ -86,6 +86,22 @@ public class LocatorBuilder {
         return this;
     }
 
+    /**
+     * Matches an element whose whitespace-normalized text equals {@code text}: internal runs of
+     * whitespace collapsed to a single space, then leading/trailing whitespace trimmed (XPath
+     * {@code normalize-space(.)}), rather than {@link #hasText}'s exact raw string-value comparison.
+     * Use this when the expected text was itself captured through an equivalent normalization step
+     * (e.g. a recorded accessible name), since real markup is rarely free of surrounding or internal
+     * whitespace.
+     *
+     * @param text the whitespace-normalized text to match
+     * @return self reference to continue building the locator
+     */
+    public LocatorBuilder hasNormalizedText(String text) {
+        parameters.add("[normalize-space(.)=\"" + text + "\"]");
+        return this;
+    }
+
     public LocatorBuilder containsText(String text) {
         parameters.add("[contains(.,\"" + text + "\")]");
         return this;
@@ -258,8 +274,9 @@ public class LocatorBuilder {
             return "[" + containsAttr.group(1) + "*=\"" + containsAttr.group(2) + "\"]";
         }
 
-        // contains(.,"text") or [.="text"]  →  no CSS equivalent, skip
-        if (parameter.contains("contains(.,") || parameter.startsWith("[.=")) {
+        // contains(.,"text"), [.="text"], or [normalize-space(.)="text"]  →  no CSS equivalent, skip
+        if (parameter.contains("contains(.,") || parameter.startsWith("[.=")
+                || parameter.startsWith("[normalize-space(.)=")) {
             return "";
         }
 

--- a/shaft-engine/src/test/java/testPackage/unitTests/LocatorBuilderExtendedUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/LocatorBuilderExtendedUnitTest.java
@@ -267,6 +267,53 @@ public class LocatorBuilderExtendedUnitTest {
         }
     }
 
+    // ─── recorded-name predicate normalization (capture-replay regression) ────
+
+    /**
+     * Regression reproduction for the SHAFT capture-replay defect: the recorded accessible name
+     * predicate chained onto a ROLE locator must still resolve to the element on realistic markup,
+     * i.e. markup whose text carries leading/trailing/internal whitespace -- the overwhelmingly common
+     * case in real HTML (e.g. {@code <button>\n  Log in\n</button>}). The SHAFT capture recorder
+     * whitespace-collapses and trims every recorded accessible name before persisting it
+     * ({@code shaft-capture-recorder.js}'s {@code text()} helper: {@code String(value).replace(/\s+/g, " ").trim()}),
+     * so the recorded name {@code "Log in"} must be matched via the same normalization, not via an
+     * exact raw string-value comparison. This test resolves the real-world XPath the capture generator
+     * emits against realistic whitespace-padded markup via jsoup's XPath evaluator (no browser needed)
+     * to prove resolution empirically rather than by inference.
+     *
+     * <p>As committed, the capture generator chains {@link LocatorBuilder#hasText}, whose
+     * {@code [.="..."]} predicate compares the raw, un-normalized string-value -- so this assertion
+     * fails against realistic markup. Switching to {@code hasNormalizedText}'s
+     * {@code [normalize-space(.)="..."]} predicate (added by this change) matches the recorder's own
+     * normalization semantics and resolves correctly.
+     */
+    @Test(description = "Capture-replay regression: the recorded-name predicate chained onto a ROLE "
+            + "locator must resolve against realistic whitespace-padded markup")
+    public void recordedNamePredicateShouldResolveRealisticWhitespacePaddedMarkup() {
+        org.jsoup.nodes.Document markup = org.jsoup.Jsoup.parse("<button>\n    Log in\n  </button>");
+        String xpath = Locator.hasRole(Role.BUTTON).hasNormalizedText("Log in").build().toString()
+                .substring("By.xpath: ".length());
+        Assert.assertEquals(markup.selectXpath(xpath).size(), 1,
+                "recorded-name predicate must resolve to the one recorded element against realistic "
+                        + "whitespace-padded markup, exactly as the capture recorder normalizes names "
+                        + "before persisting them");
+    }
+
+    @Test(description = "hasNormalizedText: locator should embed a normalize-space(.) XPath predicate")
+    public void hasNormalizedTextShouldEmbedNormalizeSpacePredicate() {
+        By locator = Locator.hasTagName("button").hasNormalizedText("Log in").build();
+        Assert.assertEquals(locator.toString(), "By.xpath: //button[normalize-space(.)=\"Log in\"]");
+    }
+
+    @Test(description = "hasRole(BUTTON).hasNormalizedText(...): built xpath string must chain the "
+            + "normalize-space(.) predicate onto the parenthesized role union")
+    public void hasRoleThenHasNormalizedTextShouldProduceExpectedXpathString() {
+        By locator = Locator.hasRole(Role.BUTTON).hasNormalizedText("Log in").build();
+        String expected = "By.xpath: (//button | //input[@type='button'] | //input[@type='submit'] "
+                + "| //input[@type='reset'] | //a[contains(@class,'button')])[normalize-space(.)=\"Log in\"]";
+        Assert.assertEquals(locator.toString(), expected);
+    }
+
     // ─── combined attribute chaining with axis ─────────────────────────────────
 
     @Test(description = "Axis followed by attribute predicate should produce compound expression")


### PR DESCRIPTION
## Summary

Two stacked defects, both in the ROLE-strategy locator path of SHAFT's capture-and-replay codegen, together causing "recorded scenarios don't replay":

1. **Union-not-narrowed** (first commit): the recorded element's accessible name was computed and then discarded, so every ROLE locator matched *every* button-shaped element on the page.
2. **Predicate-normalization mismatch** (second commit, found in review): narrowing the union with an exact-match predicate still failed against ordinary real-world markup, because the recorder normalizes whitespace in recorded names but the exact-match XPath predicate does not — trading "matches every button" for "matches no button."

## Defect 1 — discarded accessible name

`shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java:1387-1400` (`semanticLocator`): the recorded element's accessible name is computed into a local `semanticName` and then **discarded** on the ROLE branch, emitting the bare `SHAFT.GUI.Locator.hasRole(Role.BUTTON).build()`.

`LocatorBuilder.byRole` (`shaft-engine/src/main/java/com/shaft/gui/internal/locator/LocatorBuilder.java:128-176`) expands that to a union, e.g. for BUTTON: `(//button | //input[@type='button'] | //input[@type='submit'] | //input[@type='reset'] | //a[contains(@class,'button')])` — every button-shaped element on the page. ROLE is the highest-scoring `LocatorCandidate.LocatorStrategy` (`LocatorCandidate.java:27`) and is therefore almost always selected, so nearly every recorded step generated a locator matching many elements instead of the one clicked.

### Fix 1

`CaptureGenerator.semanticLocator` now chains the recorded name onto the role locator, falling back to the bare `hasRole(...).build()` form when no name was recorded (e.g. icon-only controls), avoiding an empty predicate.

**Precedence verification**: `LocatorBuilder.byRole` already wraps its union in parentheses (`LocatorBuilder.java:175`, `builder.partialXpath = "(" + builder.partialXpath + ")";`), and `buildXpathExpression()` appends predicate parameters *after* that parenthesized `partialXpath` (`LocatorBuilder.java:199-215`). So a chained predicate binds to the whole union, not just its last member. Verified both by reading the method and by asserting on the built XPath string in tests — not taken on trust.

### `aria-label` vs. other name sources — scope note

The original spec asked for `.hasAttribute("aria-label", name)` when the recorded name came from an `aria-label`, and a text-based predicate otherwise, determined from the real recorded model rather than guessed. I verified the model does **not** distinguish the two:
- `ElementSnapshot` (`shaft-capture/src/main/java/com/shaft/capture/model/ElementSnapshot.java:20-26`) carries a single `accessibleName` field with no source tag.
- `LocatorCandidate` (`shaft-capture/src/main/java/com/shaft/capture/model/LocatorCandidate.java:16-22`) likewise carries no source tag; for ROLE its `expression` is just `"<role>:<name>"` (`shaft-capture-recorder.js:411`).
- The browser recorder's `accessibleName()` function (`shaft-capture-recorder.js:285-290`) computes the name as a merged fallback chain — `aria-label` OR label OR `alt` OR `title` OR `innerText` — and discards which source won before it ever reaches the Java side.

Per the spec's instruction for this case, I implemented only the text-predicate form and reported this rather than inventing a source distinction.

## Defect 2 — exact-match predicate vs. normalized recorded text (found in review, addressed here)

Reviewed independently: `LocatorBuilder.hasText` (`LocatorBuilder.java:84-86`) emits `parameters.add("[.=\"" + text + "\"]")`. XPath `.` is the element's **raw, un-normalized string-value** — it does not collapse or trim whitespace.

But `shaft-capture-recorder.js:15`'s `text()` helper — `String(value || "").replace(/\s+/g, " ").trim().slice(0, 500)` — whitespace-collapses and trims every recorded value, and `accessibleName()` (`:285-290`) routes all five of its sources through it. So for ordinary markup like `<button>\n    Log in\n  </button>`:
- DOM raw string-value: `"\n    Log in\n  "`
- recorded `semanticName`: `"Log in"`
- Fix-1's predicate `[.="Log in"]` → **no match**

The recorded value is normalized; `hasText`'s predicate compares against un-normalized text. They only agree when the element's markup happens to have zero surrounding/internal whitespace — the minority case in real HTML.

### Fix 2

Added `LocatorBuilder.hasNormalizedText(String)` — **additive**, does not modify `hasText`/`containsText` (shipped public API other tests depend on) — emitting an XPath `normalize-space(.)` predicate: `parameters.add("[normalize-space(.)=\"" + text + "\"]")`. `normalize-space(.)` performs exactly the recorder's own `\s+ → " "` + trim transform (XPath 1.0 semantics), so the predicate now agrees with what was actually recorded.

Also updated `LocatorBuilder`'s CSS-conversion skip guard (`convertXpathParameterToCss`, `LocatorBuilder.java:261-268`, used by `insideShadowDom()`/CSS mode) to recognize `[normalize-space(.)="..."]` as having no CSS equivalent, alongside the existing `[.="..."]`/`contains(.,...)` guards — read the method first to confirm this was needed (it was: without the guard, the fallthrough `parameter.replace("@", "")` branch would emit the raw XPath predicate text as bogus "CSS").

`CaptureGenerator.semanticLocator`'s ROLE branch now emits `.hasNormalizedText(...)` instead of `.hasText(...)`.

**This touches `shaft-engine` public API** (`LocatorBuilder`, a shipped SHAFT locator-building class) — additively only: one new public method, no changes to existing method signatures or semantics.

### Do NOT use `containsText`

`contains(., "Log in")` would also match a button reading "Log in with Google", reintroducing ambiguity from the other direction. Not used.

## Produced XPath, before → after → after-whitespace-fix

For a recorded `"Log in"` button:
- Defect (pre-fix): `(//button | //input[@type='button'] | //input[@type='submit'] | //input[@type='reset'] | //a[contains(@class,'button')])`
- Fix 1 only (still buggy): `(//button | //input[@type='button'] | //input[@type='submit'] | //input[@type='reset'] | //a[contains(@class,'button')])[.="Log in"]` — correctly narrowed, but fails to match realistic whitespace-padded markup
- Fix 2 (final): `(//button | //input[@type='button'] | //input[@type='submit'] | //input[@type='reset'] | //a[contains(@class,'button')])[normalize-space(.)="Log in"]` — narrowed *and* resolves against realistic markup

## Tests changed to accommodate a fix?

Yes, twice, both called out explicitly:
- `CaptureGeneratorTest.java:709-735`'s precedent test (`roleStrategyLocatorGeneratesAnImportForTheRoleEnumSoCompilationSucceeds`) and its Issue #3905 javadoc were checked closely and grepped repo-wide for `hasRole(Role.` assertions — no existing assertion pinned the bare `hasRole(...).build()` form, so nothing needed to change for Fix 1.
- For Fix 2, the test I added for Fix 1 (`roleStrategyLocatorChainsRecordedAccessibleNameAsHasTextPredicate`) was renamed to `roleStrategyLocatorChainsRecordedAccessibleNameAsHasNormalizedTextPredicate` and its expected generated-source string changed from `.hasText("Log in")` to `.hasNormalizedText("Log in")` — watched RED against the just-committed Fix-1 code (still emitting `hasText`), then GREEN after Fix 2.
- The golden-file test (`representativeSessionGeneratesDeterministicCompilableSourceAndExternalData`, backed by `shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java`) has no ROLE-strategy candidates, so it is unaffected by either fix.

## Tests (TDD, all watched red then green)

**shaft-capture** (`CaptureGeneratorTest.java`):
- `roleStrategyLocatorChainsRecordedAccessibleNameAsHasNormalizedTextPredicate` — asserts generated source contains `hasRole(Role.BUTTON).hasNormalizedText("Log in").build()`, and contains neither the bare `hasRole(...).build()` nor a `.hasText("Log in")` form.
- `roleStrategyLocatorWithoutAccessibleNameEmitsBareHasRole` — new fixture with a blank recorded name; asserts the bare `hasRole(Role.BUTTON).build()` form is still emitted (already passed pre-fix; guards the blank-name path going forward).

**shaft-engine** (`LocatorBuilderExtendedUnitTest.java`):
- `hasNormalizedTextShouldEmbedNormalizeSpacePredicate` — exact string assertion: `Locator.hasTagName("button").hasNormalizedText("Log in").build().toString()` equals `By.xpath: //button[normalize-space(.)="Log in"]`.
- `hasRoleThenHasNormalizedTextShouldProduceExpectedXpathString` — exact string assertion for the built XPath: `By.xpath: (//button | //input[@type='button'] | //input[@type='submit'] | //input[@type='reset'] | //a[contains(@class,'button')])[normalize-space(.)="Log in"]`.
- `recordedNamePredicateShouldResolveRealisticWhitespacePaddedMarkup` — **the regression test that would have caught the whitespace defect.** Uses `org.jsoup:jsoup` (already a compile-scope dependency of `shaft-engine`, transitively reachable from `shaft-capture`; `Document.selectXpath(String)` has been available since jsoup 1.15.1, well below the repo's pinned 1.22.2) to resolve the real built XPath string against `Jsoup.parse("<button>\n    Log in\n  </button>")` — no browser needed. Asserts exactly one match.
  - **Watched RED against the just-committed Fix-1 code** (predicate built via `hasText`): `java.lang.AssertionError: ... expected [1] but found [0]` — a genuine runtime assertion failure from jsoup's real XPath evaluator, not a compile error, confirming the reproduction is correct for the right reason.
  - **Watched GREEN** after switching the test to `hasNormalizedText` and implementing it: 1 match found.

I did not add a full HtmlUnit/live-browser end-to-end check: no such harness exists yet anywhere in the repo for XPath-against-HTML resolution (checked — `LocatorBuilderTest.java`/`ShadowDomTest.java` validate via a real Selenium session against `TestPageServer`, not an XPath-string-vs-markup unit check). The jsoup-based real-XPath-resolution test above is the closest available proxy to "the element is found" without spinning up a browser, and is a materially stronger check than a pure string-equality assertion — it runs a genuine XPath 1.0 evaluator against genuine (if synthetic) HTML.

## Validation

```
mvn install -pl shaft-engine -DskipTests -Dgpg.skip=true -Dallure.automaticallyOpen=false
mvn test -pl shaft-engine -Dtest=LocatorBuilderExtendedUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false
mvn test -pl shaft-capture -Dtest=CaptureGeneratorTest -DheadlessExecution=true -Dallure.automaticallyOpen=false
```
Results: `shaft-engine` `LocatorBuilderExtendedUnitTest`: **29/29 passed**. `shaft-capture` `CaptureGeneratorTest`: **34/34 passed**, `BUILD SUCCESS` for both. (The `mvn install -pl shaft-engine` step was required so `shaft-capture`'s own internal `javac` compile-validation step — part of `CaptureGenerator.generate()` — could resolve the newly-added `LocatorBuilder.hasNormalizedText` method from the local repo; this is not `-am`, it's a single scoped install of the one upstream module that changed.)

## Note on file paths in the original spec

The spec referenced `shaft-mcp/.../CaptureGenerator.java` and `shaft-mcp/src/test/java/.../CaptureGeneratorTest.java`. The real files are in the `shaft-capture` module: `shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java` and `shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java`. Content and line numbers otherwise match the spec's description exactly.

## Out of scope (untouched, per spec)

`shaft-capture-recorder.js` uniquenessCount fabrication, ACCESSIBLE_NAME/XPATH recorder rungs, `captureReplayLocator` fallback ladder/budget, `TestAutomationService` POM rule/SMART_LOCATOR severity, anything under `shaft-skills/`, `NetworkCaptureOptions`/`CaptureCodegenStartRequest` schema.

https://claude.ai/code/session_012zitr1nnKo9tQtCSvX3u8W
