### PR TITLE
Fix(mcp): capture_api_start networkOptions schema wrongly requires all 6 fields

### DIFF
--- a/shaft-capture/pom.xml
+++ b/shaft-capture/pom.xml
@@ -36,6 +36,14 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <!-- Jackson 2 (legacy) annotations, distinct from the tools.jackson (Jackson 3) family
+                 above, needed solely so NetworkCaptureOptions can compile against
+                 com.fasterxml.jackson.annotation.JsonProperty; see that class's javadoc. Version
+                 managed by the root pom (jackson.annotations.version). -->
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/NetworkCaptureOptions.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/NetworkCaptureOptions.java
@@ -1,5 +1,7 @@
 package com.shaft.capture.runtime;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 
 /**
@@ -10,37 +12,56 @@ import java.util.Objects;
  * binds {@code @Tool} method parameters of this type directly from tool-call JSON; {@link #equals}
  * and {@link #hashCode} are still overridden for structural equality since instances round-trip
  * through {@link CaptureStartOptions}, a record whose generated {@code equals} depends on it.
+ *
+ * <p><b>Do not switch the field annotations below to {@code @ToolParam(required = false)}.</b> That
+ * is the usual Spring AI idiom (see {@code CaptureService#apiStart} parameters and {@code
+ * McpMobileInitOptions}), but this class lives in {@code shaft-capture} -- a low-level runtime
+ * module that {@code shaft-mcp} depends on, not the reverse -- and {@code @ToolParam} lives in
+ * {@code spring-ai-model}, which {@code shaft-capture} deliberately does not depend on. Pulling that
+ * in here would invert the module boundary just to annotate a DTO. Instead this relies on Spring
+ * AI's JSON schema generator (victools' {@code JacksonModule} with {@code
+ * RESPECT_JSONPROPERTY_REQUIRED}) honouring the framework-neutral {@code
+ * com.fasterxml.jackson.annotation.JsonProperty(required = ...)} as an equivalent signal --
+ * confirmed by decompiling {@code spring-ai-model}'s {@code JsonSchemaGenerator}. {@code
+ * ShaftMcpApplicationTests#captureApiStartNetworkOptionsSchemaHasNoRequiredFieldsSoPartialNetworkOptionsSucceed}
+ * guards this behavior against regression (issue #3986).
  */
 public class NetworkCaptureOptions {
     /**
      * Whether to capture network requests.
      */
+    @JsonProperty(required = false)
     public boolean enabled = true;
 
     /**
      * Whether to exclude asset resource types (images, fonts, stylesheets).
      */
+    @JsonProperty(required = false)
     public boolean excludeAssets = false;
 
     /**
      * Glob pattern for URL paths to exclude from capture.
      */
+    @JsonProperty(required = false)
     public String excludePattern = "";
 
     /**
      * Glob pattern for URL paths to include in capture.
      * Empty string means include all (subject to other filters).
      */
+    @JsonProperty(required = false)
     public String includePattern = "";
 
     /**
      * Whether to record HTTP response bodies.
      */
+    @JsonProperty(required = false)
     public boolean captureResponseBodies = false;
 
     /**
      * Whether to record HTTP request bodies.
      */
+    @JsonProperty(required = false)
     public boolean captureRequestBodies = false;
 
     /**

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftMcpApplicationTests.java
@@ -376,6 +376,34 @@ class ShaftMcpApplicationTests {
                 "capture_generate_replay (the @McpTool-annotated overload) still requires sessionPath: " + required);
     }
 
+    /**
+     * Issue #3986: Spring AI 2.0.0 emits {@code requiredByDefault=true} for @Tool parameter POJOs,
+     * so {@link com.shaft.capture.runtime.NetworkCaptureOptions}'s six unannotated public fields
+     * were all schema-required -- rejecting any caller (including the curated
+     * {@code capture_api_start} example in tool-index.json) that sends a partial
+     * {@code networkOptions} object. Asserts the live-served nested schema, not just the source
+     * annotations, so a unit-level Java caller bypassing JSON-schema validation can never hide this
+     * again.
+     */
+    @Test
+    void captureApiStartNetworkOptionsSchemaHasNoRequiredFieldsSoPartialNetworkOptionsSucceed() throws Exception {
+        JsonNode networkOptionsSchema = toolInputSchema("capture_api_start").path("properties").path("networkOptions");
+
+        List<String> requiredNames = new java.util.ArrayList<>();
+        for (JsonNode node : networkOptionsSchema.path("required")) {
+            requiredNames.add(node.asText());
+        }
+
+        assertTrue(requiredNames.isEmpty(),
+                "capture_api_start's networkOptions schema still requires: " + requiredNames
+                        + " -- a partial networkOptions object must succeed schema validation");
+        for (String field : List.of("enabled", "excludeAssets", "excludePattern", "includePattern",
+                "captureResponseBodies", "captureRequestBodies")) {
+            assertTrue(networkOptionsSchema.path("properties").has(field),
+                    "networkOptions schema is missing property: " + field);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private JsonNode toolInputSchema(String toolName) throws Exception {
         Object bean = context.getBean("shaftTools");


### PR DESCRIPTION
## Summary

Closes #3986.

Spring AI 2.0.0 defaults to `requiredByDefault=true` when generating `@Tool` parameter JSON schemas. `NetworkCaptureOptions` (`shaft-capture/src/main/java/com/shaft/capture/runtime/NetworkCaptureOptions.java`) declared six public fields with no `@ToolParam`/annotation guidance, so all six were emitted as schema-**required**. Any caller sending a partial `networkOptions` object to `capture_api_start` was rejected at schema validation before the class's own null-safe defaults ever ran — including `GuidedWorkflowLiveE2ETest.apiStart()`, which is why the nightly failed.

The shipped documentation was already wrong against our own schema: `shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index.json:806-810`'s curated `capture_api_start` example (recorded live 2026-07-21) sends only 3 of the 6 `networkOptions` fields. That example now validates against the fixed schema.

## Why `@JsonProperty(required = false)` instead of `@ToolParam(required = false)`

`@ToolParam(required = false)` is the usual Spring AI idiom in this codebase (see `CaptureService#apiStart`'s own top-level parameters, and `McpMobileInitOptions`). It was the obvious first fix and was rejected: `NetworkCaptureOptions` lives in `shaft-capture` — a low-level runtime capture module that `shaft-mcp` depends on, not the reverse — while `@ToolParam` lives in `spring-ai-model`, which `shaft-capture` deliberately does not depend on. Making `shaft-capture` compile against `spring-ai-model` purely to annotate a DTO would invert that module boundary — a worse defect than the one being fixed here, and exactly what this repo's `modular-boundary-auditor` exists to catch.

Instead, this relies on Spring AI's JSON schema generator (victools' `JacksonModule` with `RESPECT_JSONPROPERTY_REQUIRED`) honouring the framework-neutral `com.fasterxml.jackson.annotation.JsonProperty(required = false)` as an equivalent signal — confirmed by decompiling `spring-ai-model`'s `JsonSchemaGenerator` class and verified empirically: the regression test below fails (RED) without the annotation and passes (GREEN) with it.

`shaft-capture/pom.xml` gains an explicit `jackson-annotations` dependency (version inherited from the root pom's existing `dependencyManagement`, no conflict with the module's own Jackson 3 `tools.jackson` databind usage) — it was previously only resolved transitively, which is fragile (an upstream dependency change could silently re-tighten the schema).

## Out of scope (known, tracked separately)

`CaptureCodegenStartRequest` (`shaft-mcp/CaptureService.java:264-293`) has the identical latent defect across 28 unannotated fields. It lives in `shaft-mcp`, which already depends on Spring AI, so it will correctly use `@ToolParam` there in its own separate PR. Not touched here.

`GuidedWorkflowLiveE2ETest.java` was not modified — with the schema fixed, it needs no change.

## Test plan

- [x] Added `ShaftMcpApplicationTests#captureApiStartNetworkOptionsSchemaHasNoRequiredFieldsSoPartialNetworkOptionsSucceed`, asserting the live-served `capture_api_start` schema's nested `networkOptions.required` array is empty. Watched RED against unmodified `NetworkCaptureOptions` (listed all 6 fields as still-required), then GREEN after the fix.
- [x] `mvn test -pl shaft-mcp -Dtest=ShaftMcpApplicationTests -DheadlessExecution=true -Dallure.automaticallyOpen=false` (no `-am`) — 13/13 passed.
- [x] `mvn clean compile -pl shaft-capture -DheadlessExecution=true` — standalone build still succeeds with the new explicit dependency.
- [x] `mvn test -pl shaft-capture -Dtest=CaptureManagerNetworkTransactionsTest,CaptureManagerLifecycleTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` — 14/14 passed, confirming the annotation doesn't change existing `NetworkCaptureOptions` construction/equality behavior. Note: no existing test round-trips `NetworkCaptureOptions` through JSON serialization (`tools.jackson` or `com.fasterxml.jackson`) — confirmed via repo-wide grep for `writeValue`/`readValue`/`convertValue` against the class, zero hits — so this is the closest available coverage, not a JSON round-trip proof.

Do not merge — orchestrator will review and arm auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zitr1nnKo9tQtCSvX3u8W