### PR TITLE
Dedup owner-binding orchestrator rules: chaos-engine.md -> act-as-fable

### DIFF
--- a/.claude/agents/chaos-engine.md
+++ b/.claude/agents/chaos-engine.md
@@ -12,25 +12,19 @@ the delegation tiers. Speak caveman-full (auto-clarity exceptions apply).
 
 ## Charter
 
-- You never implement. Break work down, write detailed specs, assign:
-  implementation -> `coder`, verification of others' work -> `reviewer`,
-  test authoring and acceptance evidence -> `tester`. They are Sonnet L1 and
-  may sub-delegate mechanical bulk to Haiku L2.
+- You never implement: break work down, write detailed specs, assign it to
+  `coder`/`reviewer`/`tester`, review and verify results, and consult on
+  architecture. Every other owner-binding orchestrator rule — dispatch
+  effort, delegation tiers, the concurrency budget, the stall watch, usage
+  pacing, delegate-output verification, staying interruptible — is canonical
+  in act-as-fable's `## Delegation` section
+  (`.claude/skills/act-as-fable/SKILL.md`); line 9 above already loads that
+  skill before any nontrivial work, so it is never restated here.
 - Consult stores before manual discovery: `memory load`, `mempalace`,
   `graphify` first; `rg` only to verify live code. Grepping for what a store
   already knows is waste.
 - Every implementation decision you approve passes the `ponytail` ladder.
 - Workflow tool and saved workflows: only when the owner explicitly asks.
-- Dispatch at HIGH effort with the covenant embedded; 4-5 concurrent tasks
-  max; 20-minute stall watch — support a stalled delegate with a solved
-  sub-problem or a re-spec, never a bare status ping.
-- Pace the 5-hour usage window: keep in-flight work resumable, finish and
-  merge before opening new fronts, never exhaust tokens mid-task.
-- Verify delegate claims against real files and runs before building on
-  them. Synthesis, architecture calls, and final verification are yours
-  alone.
-- Stay interruptible: accept owner realignment instantly, whatever is in
-  flight.
 
 ## GitHub Tracking (Binding Process)
 


### PR DESCRIPTION
## Summary

- `.claude/agents/chaos-engine.md`'s Charter restated four owner-binding orchestrator rules (orchestrator role, parallelism budget, 20-minute stall watch, delegate-output verification duty) that already exist in full in `act-as-fable`'s `## Delegation` section (`.claude/skills/act-as-fable/SKILL.md:144-236`). Collapsed the six restating bullets into one pointer bullet; act-as-fable's Delegation content is untouched (per the issue's constraint, the dedup stays on the chaos-engine.md side).
- Single canonical home per rule going forward: **`act-as-fable`'s `## Delegation` section** for all delegation/orchestration mechanics; `chaos-engine.md` keeps only its own agent-specific bits (memory/mempalace/graphify discovery order, the ponytail-ladder reminder, the Workflow-tool gate, and the GitHub-tracking process) plus a pointer.

## Decisive-question evidence (no consumer loses a rule)

1. **How does a spawned `chaos-engine` agent come to load act-as-fable?** `.claude/agents/chaos-engine.md:9-10`: *"You are Chaos Engine, the owner's orchestrator. Load `Skill(act-as-fable)` before any nontrivial work; it owns the method, the Subagent covenant, and the delegation tiers."* This line is untouched by the diff. When the `Agent` tool spawns `subagent_type: chaos-engine`, the full charter body (including this line) is loaded as its system prompt, so it self-loads act-as-fable and receives the Delegation section regardless of what the Charter bullets below it say.

2. **Does the main thread load `chaos-engine.md`'s body, or only its frontmatter?** Only frontmatter, and only as skill/agent *discovery metadata* — never the body:
   - `scripts/ci/agent_guidance_budget.json:27-30` — `host_contexts.claude` (files counted **in full** toward the main thread's always-on budget) is `["AGENTS.md", "CLAUDE.md"]`. `.claude/agents/chaos-engine.md` is not in that list.
   - `scripts/ci/agent_guidance_budget.json:42-46` — `.claude/agents/*.md` appears only under `host_skill_metadata_globs.claude`.
   - `scripts/ci/validate_agent_guidance.py:84-89` (`validate_host_contexts`) — for those metadata globs it adds only `frontmatter.get("name")` and `frontmatter.get("description")` character counts to the budget; the body is never read into the always-on estimate.
   - Corroborated by grepping the whole guidance corpus for `chaos-engine.md`: the only two hits (`AGENTS.md:68`, `.claude/user-harness/CLAUDE.md:10`) are label/pointer prose ("Charter: `~/.claude/agents/chaos-engine.md`"), not an import directive — unlike `CLAUDE.md:3`'s literal `@AGENTS.md` import, which *is* how CLAUDE.md's content actually lands in context.

   So `~/.claude/CLAUDE.md`'s claim that "the main thread runs as Chaos Engine... Charter: chaos-engine.md" is a conceptual/aspirational pointer, not a load mechanism. The main thread's real, always-loaded binding to act-as-fable comes from `AGENTS.md` itself (fully loaded per `host_contexts.claude`): `AGENTS.md:64` — *"`act-as-fable` binds always (every model/subagent; owns routing, tiers, and the always-on `caveman` voice)"* — and `AGENTS.md:68` — *"...act-as-fable owns tiers/covenant/second pass."* Both are independent of, and unaffected by, this diff.

**Conclusion:** both real consumers (a spawned chaos-engine sub-orchestrator, and the main thread) already had an independent, unedited path to act-as-fable's Delegation section before this change. The bullets removed from `chaos-engine.md` were pure restatement for both — a pointer is the correct fix, not a silent regression.

## Note on the issue's frozen-block premise

The issue records that PR #4008 justified freezing act-as-fable's Delegation block byte-for-byte as "preserving #4003's recorded line ranges" — but #4003's body was empty at merge time, so there was nothing to preserve. That's tracked in the issue text itself; this PR does not touch act-as-fable's Delegation content either way (per the issue's own constraint that the dedup belongs on the chaos-engine.md side), so it doesn't need to resolve that leftover freeze.

## Validation (worktree branched fresh from origin/main @ a9bacdc63d, i.e. post-#4008)

- `py -3 scripts/ci/validate_agent_guidance.py` — before: `Agent guidance budgets, routing, references, and refresh gates are valid.` (exit 0). After: identical (exit 0).
- `py -3 scripts/ci/validate_skills.py` — before: `Claude skill hygiene is valid: frontmatter, descriptions, references, and byte budgets all pass.` (exit 0). After: identical (exit 0).
- `py -3 scripts/ci/validate_agent_setup.py` — before and after are byte-identical (exit 1, 3 error lines): `memory-filename-length` x2 + one `memory-check` secret-scanner false positive, all pre-existing and tracked in #3991. No new errors introduced.
- `py -3 scripts/agents/sync_user_harness.py --check` (report only, not applied): flags `agents/chaos-engine.md` as `DRIFTED` from the deployed `~/.claude` copy, as expected since the repo copy just changed. `settings.json`, `agents/coder.md`, `agents/reviewer.md`, `agents/tester.md` also show `DRIFTED` but are untouched by this diff (pre-existing machine-state drift, out of scope).

## Test plan

- [x] Re-read issue #4003 in full after the orchestrator's correction (its body was populated mid-task)
- [x] Confirmed the four duplicated rule-blocks against current file content (not stale line numbers)
- [x] Confirmed act-as-fable's Delegation section content is untouched (`git diff` shows only `chaos-engine.md`)
- [x] Ran all four required validators and compared exact output against pre-edit baseline in the same worktree
- [x] Did not merge; reporting PR for owner review/auto-merge arming

Closes #4003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zitr1nnKo9tQtCSvX3u8W