### PR TITLE
Harness: reconcile canonical settings.json with deployed ~/.claude values

### DIFF
--- a/.claude/user-harness/settings.json
+++ b/.claude/user-harness/settings.json
@@ -5,7 +5,7 @@
   "permissions": {
     "defaultMode": "bypassPermissions"
   },
-  "model": "claude-fable-5[1m]",
+  "model": "opus[1m]",
   "statusLine": {
     "type": "command",
     "command": "bash C:/Users/Mohab/.claude/statusline-command.sh"
@@ -30,5 +30,9 @@
   "skipWorkflowUsageWarning": true,
   "theme": "dark",
   "inputNeededNotifEnabled": true,
-  "agentPushNotifEnabled": false
+  "agentPushNotifEnabled": false,
+  "skillOverrides": {
+    "find-skills": "off",
+    "rag-implementation": "off"
+  }
 }


### PR DESCRIPTION
## Summary

`scripts/agents/sync_user_harness.py --apply` overwrites `~/.claude` files wholesale (backing up to `.bak` first). Any value that has drifted locally is therefore silently reverted on the next deploy.

While deploying the `chaos-engine.md` change from #4003 / PR #4013, two `settings.json` values were found drifted — both deliberate, and both **newer** than the repo copy (live file dated 2026-07-25, repo copy 2026-07-20):

| Key | Repo (before) | Deployed / live | This PR |
|---|---|---|---|
| `model` | `claude-fable-5[1m]` | `opus[1m]` | adopts `opus[1m]` |
| `skillOverrides` | absent | `find-skills=off`, `rag-implementation=off` | adopts the overrides |

Applying the repo copy unchanged would have reverted the model and re-enabled two deliberately disabled skills.

## Verification

After this change, `sync_user_harness.py` reports `settings.json` **IN-SYNC** against the live `~/.claude/settings.json` — which confirms these two keys were the *only* deltas, and that nothing else in the live file was lost or overwritten.

Full apply run after this change:
- `settings.json` — IN-SYNC (no overwrite needed)
- `CLAUDE.md`, `statusline-command.sh` — IN-SYNC
- `agents/chaos-engine.md`, `agents/coder.md`, `agents/reviewer.md`, `agents/tester.md` — deployed, each backed up to `.bak`

## Note for the owner

If canonical is meant to stay on `claude-fable-5[1m]` and the local `opus[1m]` was a temporary override, this is a one-line revert — say so and I'll flip it back. It was preserved because the live value was the more recent deliberate choice, and silently reverting a newer decision is the riskier error.

## Test plan

- [x] `sync_user_harness.py --apply` run; `settings.json` reports IN-SYNC
- [x] Confirmed the four agent charters deployed with `.bak` backups