### PR TITLE
Fix two of three Live Tools Nightly E2E leads (#3988)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -1357,9 +1357,17 @@ final class ShaftAssistantPanel extends JPanel {
                 conversationContext,
                 attachmentsContext);
         invocation = routeNaturalStopToActiveRecorder(text, invocation);
+        // AssistantCommand.requiresShaftProject(invocation) checked FIRST (and short-circuits): it is
+        // a cheap, pure tool-name-set check, whereas ShaftProjectDetector.isShaftProject(project) hits
+        // the filesystem and caches its answer per root for 30s. Checking isShaftProject first meant
+        // it ran (and cached) on EVERY send() -- including ones that never dispatch a gated tool, like
+        // shaft_project_create itself -- so a gated call moments later could see a stale "false"
+        // cached from before the project existed (issue #3988, nightly run 30146701546: a real
+        // shaft_project_create followed by shaft_project_upgrade was wrongly nudged as "doesn't look
+        // like a SHAFT project yet").
         if (!approvingCaptureReview
-                && !ShaftProjectDetector.isShaftProject(project)
-                && AssistantCommand.requiresShaftProject(invocation)) {
+                && AssistantCommand.requiresShaftProject(invocation)
+                && !ShaftProjectDetector.isShaftProject(project)) {
             invocation = AssistantCommand.shaftProjectRequiredNudge(invocation.toolName());
         }
         // Display-only: the transcript/chat-state bubble shows exactly what the user typed -- text

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantGeminiLiveE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantGeminiLiveE2ETest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
@@ -42,6 +43,14 @@ class AssistantGeminiLiveE2ETest {
         Path workspace = Path.of(System.getProperty("shaft.intellij.workspaceRoot", ".."))
                 .toAbsolutePath()
                 .normalize();
+        // ShaftMcpStdioClient spawns the MCP server with `workspace` as its ProcessBuilder working
+        // directory (ShaftMcpStdioClient.java:79-80); CreateProcess/exec fails with a raw IOException
+        // when that directory does not already exist -- reproduced empirically (nightly run
+        // 30146701546: "java.io.IOException at AssistantGeminiLiveE2ETest.java:139"). CI passes a
+        // fresh, never-created "${GITHUB_WORKSPACE}/build/live-tools/gemini" here, so it must be
+        // created before use, the same way every other live-tool-E2E test's workspace already is
+        // (e.g. ShaftAssistantPanelLiveDiagnosticsToolE2ETest.LiveContext.assumeConfigured()).
+        Files.createDirectories(workspace);
         ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
         settings.assistantProviderType = "CLOUD";
         settings.cloudProvider = "gemini";

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/LiveChatToolE2ESupport.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/LiveChatToolE2ESupport.java
@@ -6,17 +6,9 @@ import com.google.gson.JsonParser;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.editor.Caret;
-import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.fileEditor.EditorDataProvider;
-import com.intellij.openapi.fileEditor.FileEditor;
-import com.intellij.openapi.fileEditor.FileEditorComposite;
 import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.fileEditor.FileEditorNavigatable;
-import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.shaft.intellij.approval.ToolApprovalDecision;
 import com.shaft.intellij.approval.ToolApprovalService;
 import com.shaft.intellij.mcp.ShaftMcpInvocationService;
@@ -34,7 +26,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -432,148 +423,9 @@ final class LiveChatToolE2ESupport implements AutoCloseable {
                 });
     }
 
-    /**
-     * {@code getSelectedTextEditor() -> null} short-circuits {@code openFileContext} to "no open
-     * file" -- the only method of the 27 this abstract class declares that {@code
-     * ShaftAssistantPanel#openFileContext} (the only caller on the {@code send()} path) actually
-     * invokes; {@link FileEditorManager} is an abstract CLASS (not an interface), so a {@link Proxy}
-     * cannot stand in for it the way {@link #fakeApplication}/{@link #fakeProject} do.
-     */
-    private static final class NoOpFileEditorManager extends FileEditorManager {
-        @Override
-        public FileEditorComposite getComposite(VirtualFile file) {
-            return null;
-        }
-
-        @Override
-        public FileEditor[] openFile(VirtualFile file, boolean focusEditor) {
-            return new FileEditor[0];
-        }
-
-        @Override
-        public List<FileEditor> openFile(VirtualFile file) {
-            return List.of();
-        }
-
-        @Override
-        public void closeFile(VirtualFile file) {
-            // no-op: no real editors are ever open in this headless fixture
-        }
-
-        @Override
-        public Editor openTextEditor(OpenFileDescriptor descriptor, boolean focusEditor) {
-            return null;
-        }
-
-        @Override
-        public Editor getSelectedTextEditor() {
-            return null;
-        }
-
-        @Override
-        public boolean isFileOpen(VirtualFile file) {
-            return false;
-        }
-
-        @Override
-        public VirtualFile[] getOpenFiles() {
-            return new VirtualFile[0];
-        }
-
-        @Override
-        public List<VirtualFile> getOpenFilesWithRemotes() {
-            return List.of();
-        }
-
-        @Override
-        public VirtualFile[] getSelectedFiles() {
-            return new VirtualFile[0];
-        }
-
-        @Override
-        public FileEditor[] getSelectedEditors() {
-            return new FileEditor[0];
-        }
-
-        @Override
-        public FileEditor getSelectedEditor(VirtualFile file) {
-            return null;
-        }
-
-        @Override
-        public FileEditor[] getEditors(VirtualFile file) {
-            return new FileEditor[0];
-        }
-
-        @Override
-        public FileEditor[] getAllEditors(VirtualFile file) {
-            return new FileEditor[0];
-        }
-
-        @Override
-        public List<FileEditor> getAllEditorList(VirtualFile file) {
-            return List.of();
-        }
-
-        @Override
-        public FileEditor[] getAllEditors() {
-            return new FileEditor[0];
-        }
-
-        @Override
-        public void addTopComponent(FileEditor editor, JComponent component) {
-            // no-op
-        }
-
-        @Override
-        public void removeTopComponent(FileEditor editor, JComponent component) {
-            // no-op
-        }
-
-        @Override
-        public void addBottomComponent(FileEditor editor, JComponent component) {
-            // no-op
-        }
-
-        @Override
-        public void removeBottomComponent(FileEditor editor, JComponent component) {
-            // no-op
-        }
-
-        @Override
-        public List<FileEditor> openFileEditor(FileEditorNavigatable descriptor, boolean focusEditor) {
-            return List.of();
-        }
-
-        @Override
-        public Project getProject() {
-            return null;
-        }
-
-        @Override
-        @SuppressWarnings("removal")
-        public void registerExtraEditorDataProvider(EditorDataProvider provider, Disposable parentDisposable) {
-            // no-op
-        }
-
-        @Override
-        @SuppressWarnings("removal")
-        public Object getData(String dataId, Editor editor, Caret caret) {
-            return null;
-        }
-
-        @Override
-        public void setSelectedEditor(VirtualFile file, String fileEditorProviderId) {
-            // no-op
-        }
-
-        @Override
-        public void runWhenLoaded(Editor editor, Runnable runnable) {
-            // no-op: matches "never loaded" -- runnable is simply never invoked
-        }
-    }
-
-    private static final FileEditorManager NO_OPEN_FILES_EDITOR_MANAGER = new NoOpFileEditorManager();
+    // getSelectedTextEditor() -> null short-circuits ShaftAssistantPanel#openFileContext (the only
+    // caller on the send() path) to "no open file" -- see NoOpFileEditorManager's class doc.
+    private static final FileEditorManager NO_OPEN_FILES_EDITOR_MANAGER = NoOpFileEditorManager.INSTANCE;
 
     private static Application fakeApplication(ShaftSettingsState settingsState, ShaftPluginExecutor pluginExecutor,
             AtomicLong invokeLaterGeneration) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/NoOpFileEditorManager.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/NoOpFileEditorManager.java
@@ -1,0 +1,167 @@
+package com.shaft.intellij.ui;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.editor.Caret;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.EditorDataProvider;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorComposite;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.FileEditorNavigatable;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+
+import javax.swing.JComponent;
+import java.util.List;
+
+/**
+ * {@code getSelectedTextEditor() -> null} short-circuits {@code
+ * ShaftAssistantPanel#openFileContext} to "no open file" -- the only method of the 27 this
+ * abstract class declares that {@code openFileContext} (the only caller on the {@code send()}
+ * path) actually invokes; {@link FileEditorManager} is an abstract CLASS (not an interface), so a
+ * {@link java.lang.reflect.Proxy} cannot stand in for it the way a fake {@code Project} does.
+ *
+ * <p>Extracted from {@link LiveChatToolE2ESupport} (originally private there) so any test that
+ * builds a fake {@link Project} for {@code send()} -- not just the live-tool-E2E fixture -- can
+ * satisfy {@code project.getService(FileEditorManager.class)} without re-declaring all 27
+ * overrides (issue #3988).
+ */
+final class NoOpFileEditorManager extends FileEditorManager {
+    static final FileEditorManager INSTANCE = new NoOpFileEditorManager();
+
+    private NoOpFileEditorManager() {
+    }
+
+    @Override
+    public FileEditorComposite getComposite(VirtualFile file) {
+        return null;
+    }
+
+    @Override
+    public FileEditor[] openFile(VirtualFile file, boolean focusEditor) {
+        return new FileEditor[0];
+    }
+
+    @Override
+    public List<FileEditor> openFile(VirtualFile file) {
+        return List.of();
+    }
+
+    @Override
+    public void closeFile(VirtualFile file) {
+        // no-op: no real editors are ever open in this headless fixture
+    }
+
+    @Override
+    public Editor openTextEditor(OpenFileDescriptor descriptor, boolean focusEditor) {
+        return null;
+    }
+
+    @Override
+    public Editor getSelectedTextEditor() {
+        return null;
+    }
+
+    @Override
+    public boolean isFileOpen(VirtualFile file) {
+        return false;
+    }
+
+    @Override
+    public VirtualFile[] getOpenFiles() {
+        return new VirtualFile[0];
+    }
+
+    @Override
+    public List<VirtualFile> getOpenFilesWithRemotes() {
+        return List.of();
+    }
+
+    @Override
+    public VirtualFile[] getSelectedFiles() {
+        return new VirtualFile[0];
+    }
+
+    @Override
+    public FileEditor[] getSelectedEditors() {
+        return new FileEditor[0];
+    }
+
+    @Override
+    public FileEditor getSelectedEditor(VirtualFile file) {
+        return null;
+    }
+
+    @Override
+    public FileEditor[] getEditors(VirtualFile file) {
+        return new FileEditor[0];
+    }
+
+    @Override
+    public FileEditor[] getAllEditors(VirtualFile file) {
+        return new FileEditor[0];
+    }
+
+    @Override
+    public List<FileEditor> getAllEditorList(VirtualFile file) {
+        return List.of();
+    }
+
+    @Override
+    public FileEditor[] getAllEditors() {
+        return new FileEditor[0];
+    }
+
+    @Override
+    public void addTopComponent(FileEditor editor, JComponent component) {
+        // no-op
+    }
+
+    @Override
+    public void removeTopComponent(FileEditor editor, JComponent component) {
+        // no-op
+    }
+
+    @Override
+    public void addBottomComponent(FileEditor editor, JComponent component) {
+        // no-op
+    }
+
+    @Override
+    public void removeBottomComponent(FileEditor editor, JComponent component) {
+        // no-op
+    }
+
+    @Override
+    public List<FileEditor> openFileEditor(FileEditorNavigatable descriptor, boolean focusEditor) {
+        return List.of();
+    }
+
+    @Override
+    public Project getProject() {
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("removal")
+    public void registerExtraEditorDataProvider(EditorDataProvider provider, Disposable parentDisposable) {
+        // no-op
+    }
+
+    @Override
+    @SuppressWarnings("removal")
+    public Object getData(String dataId, Editor editor, Caret caret) {
+        return null;
+    }
+
+    @Override
+    public void setSelectedEditor(VirtualFile file, String fileEditorProviderId) {
+        // no-op
+    }
+
+    @Override
+    public void runWhenLoaded(Editor editor, Runnable runnable) {
+        // no-op: matches "never loaded" -- runnable is simply never invoked
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelShaftProjectGateFreshnessTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelShaftProjectGateFreshnessTest.java
@@ -1,0 +1,126 @@
+package com.shaft.intellij.ui;
+
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.shaft.intellij.settings.ShaftSettingsState;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces the nightly Live Tools E2E failure (issue #3988, run 30146701546:
+ * {@code ShaftAssistantPanelLiveAuthoringToolE2ETest#shaftProjectServiceCreatesAndInitializesAgentsThroughTheRealChatPanel}).
+ *
+ * <p>{@link ShaftAssistantPanel#send} evaluates {@code
+ * !ShaftProjectDetector.isShaftProject(project) && AssistantCommand.requiresShaftProject(invocation)}
+ * left-to-right, so {@code isShaftProject} runs on EVERY dispatch -- including ones (like {@code
+ * shaft_project_create} or a plain {@code /help}) that never needed a SHAFT-project answer at all.
+ * {@link com.shaft.intellij.project.ShaftProjectDetector} caches its answer per root for 30 seconds
+ * (deliberately -- see its class doc). Dispatching any ungated command against a not-yet-a-SHAFT-project
+ * directory therefore caches a {@code false} that outlives the directory becoming a real SHAFT project a
+ * moment later (e.g. right after {@code shaft_project_create} runs), wrongly blocking the very next
+ * SHAFT-project-only tool call with the "doesn't look like a SHAFT project yet" nudge instead of
+ * dispatching it -- exactly the transcript captured in the nightly run.</p>
+ *
+ * <p>No fake {@code Application} is installed here (unlike {@code LiveChatToolE2ESupport}):
+ * {@code showLocalResponse} runs synchronously with no EDT hop (confirmed against {@code
+ * ShaftPanelSetupTest}'s {@code assistantLocalPromptCompletionOmitsSyntheticMilestoneBubbles} and
+ * sibling tests, which assert on the transcript immediately after a local {@code /help} send with a
+ * {@code null} project and no installed {@code Application}), so a synchronous check right after
+ * {@code send()} is exactly how production code behaves.</p>
+ */
+class ShaftAssistantPanelShaftProjectGateFreshnessTest {
+
+    @Test
+    void gatedToolCallSeesAProjectCreatedAfterAnEarlierUngatedSend(@TempDir Path projectRoot) throws Exception {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        Project project = fakeProject(projectRoot);
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(project, settings);
+
+        // An ungated command (never needs the SHAFT-project answer) dispatched while projectRoot is
+        // still empty -- this alone must not poison ShaftProjectDetector's cache for projectRoot.
+        send(panel, project, "/help");
+
+        // The directory becomes a genuine SHAFT project (mirrors shaft_project_create's real output).
+        Files.writeString(projectRoot.resolve("pom.xml"), """
+                <project>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.github.shafthq</groupId>
+                            <artifactId>shaft-engine</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+
+        // A SHAFT-project-only tool call, moments later (well inside the 30s cache TTL), must see the
+        // now-real project instead of a stale cached "false" from the earlier ungated /help dispatch.
+        send(panel, project, "/mcp shaft_project_upgrade");
+
+        String transcript = panel.transcriptMarkdown();
+        assertFalse(transcript.contains("doesn't look like a SHAFT project yet"),
+                "shaft_project_upgrade was wrongly blocked by a stale SHAFT-project-detection cache: "
+                        + transcript);
+        assertTrue(transcript.contains("Configure SHAFT MCP"),
+                "Expected the gate to pass and fall through to the (unconfigured) MCP setup check: "
+                        + transcript);
+    }
+
+    private static void send(ShaftAssistantPanel panel, Project project, String prompt) throws Exception {
+        panel.prefillPrompt(prompt);
+        Method send = ShaftAssistantPanel.class.getDeclaredMethod("send", Project.class);
+        send.setAccessible(true);
+        try {
+            send.invoke(panel, project);
+        } catch (InvocationTargetException exception) {
+            if (exception.getCause() instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw exception;
+        }
+    }
+
+    private static Project fakeProject(Path basePath) {
+        return (Project) Proxy.newProxyInstance(Project.class.getClassLoader(), new Class<?>[]{Project.class},
+                (proxy, method, arguments) -> {
+                    switch (method.getName()) {
+                        case "equals":
+                            return proxy == (arguments == null || arguments.length == 0 ? null : arguments[0]);
+                        case "hashCode":
+                            return System.identityHashCode(proxy);
+                        case "getBasePath":
+                            return basePath.toString();
+                        case "getName":
+                            return "shaft-assistant-panel-shaft-project-gate-freshness-test-project";
+                        case "isDisposed":
+                            return false;
+                        case "getService":
+                            Class<?> serviceClass = (Class<?>) arguments[0];
+                            // send()'s openFileContext(project) unconditionally dereferences this once
+                            // project != null (ShaftAssistantPanel.java:4023-4028); a no-open-files fake is
+                            // the honest state for a headless test with no real editor.
+                            return serviceClass == FileEditorManager.class ? NoOpFileEditorManager.INSTANCE : null;
+                        default:
+                            return defaultValue(method.getReturnType());
+                    }
+                });
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        return returnType == void.class ? null : 0;
+    }
+}


### PR DESCRIPTION
## Summary
Fixes 2 of the 4 failing live-tool-E2E tests behind issue #3988 (Live Tools Nightly E2E, never green). Does NOT close #3988 -- two Diagnostics-job failures remain, and they are a product-design conflict rather than a bug (filed as #4021).

- **`AssistantGeminiLiveE2ETest`** (`gemini-live` job): never created its workspace directory before handing it to `ShaftMcpStdioClient` as the spawned MCP server's `ProcessBuilder` working directory. CI passes a never-created `${GITHUB_WORKSPACE}/build/live-tools/gemini`, so `builder.start()` threw a raw `IOException` (`java.io.IOException at AssistantGeminiLiveE2ETest.java:139` in run 30146701552). Fixed with the same `Files.createDirectories(workspace)` every other live-tool-E2E test already does.
- **`ShaftAssistantPanel#send`** (`intellij-tools-authoring` job): evaluated `ShaftProjectDetector.isShaftProject(project)` *before* checking whether the invocation even calls a gated tool, due to `&&` operand order. That meant it ran (and cached its answer for 30s) on *every* dispatch -- including `shaft_project_create` itself, before the project it creates exists. `shaft_project_upgrade`, dispatched moments later against the now-real project, could still see that stale cached `false` and get wrongly nudged with "doesn't look like a SHAFT project yet" instead of actually running. Fixed by reordering the `&&` so the cheap `requiresShaftProject` tool-name check short-circuits first. Fixes `ShaftAssistantPanelLiveAuthoringToolE2ETest#shaftProjectServiceCreatesAndInitializesAgentsThroughTheRealChatPanel`.

## What I tried and reverted
A third fix (routing `showLocalResponse` through `invokeLater`/EDT so the live-tool-E2E harness's `invokeLaterGeneration` completion fence would observe it) initially looked necessary for the Diagnostics-job timeouts. It was reverted after a full-suite run showed it broke three pre-existing `ShaftPanelSetupTest` cases (`assistantLocalPromptCompletionOmitsSyntheticMilestoneBubbles`, `assistantPromptKeyboardShortcutsSendAndCancelRunningPrompt`, `assistantPromptCtrlClickSendsPrompt`) that correctly assert local responses complete *synchronously* with no installed `Application` -- that is the real, intended production behavior (`send()` already runs on the real EDT; there's no async work to hop for), not a bug.

## What remains (not fixed here, tracked in #4021)
`ShaftAssistantPanelLiveDiagnosticsToolE2ETest`'s two SHAFT-project-gated methods (`doctor_analyze_failed_allure`, `healer_run_failed_test`/`verify_run_focused`) still fail: their workspace never becomes a SHAFT project, and `ShaftProjectDetector.isShaftProject` correctly and freshly returns `false` every time -- this is not the caching bug above. `AssistantCommandRoutingTest` already asserts, by design, that these exact tools "must be gated" against non-SHAFT directories (`AssistantCommandRoutingTest.java:822-825`). The two Diagnostics tests' own premise -- that these tools should reach the MCP layer and self-report `GUARDRAIL_STOPPED` -- conflicts with that already-tested, intentional client-side gate. See #4021 for the three options and the evidence.

## Test plan
- [x] Reproduced the Gemini `IOException` directly against a missing `ProcessBuilder` working directory (RED), fixed, reproduced the fix resolving it (GREEN).
- [x] New regression test `ShaftAssistantPanelShaftProjectGateFreshnessTest` reproduces the stale-cache gate bug (watched RED against the unreordered `&&`, watched GREEN after reordering).
- [x] Full `shaft-intellij` module suite (`gradlew test`, JDK 21): 1178 tests, 0 failed, 21 skipped (live/gated tests self-skip without `-Dshaft.intellij.liveToolE2E=true` etc.) -- confirms no regression from either change or the `LiveChatToolE2ESupport` refactor.
- [ ] Cannot run the actual nightly workflow (`gemini-live`, `intellij-tools-authoring` jobs) here -- no `GEMINI_API_KEY` / live MCP server infra in this sandbox. Confidence is from direct reproduction + full-suite regression coverage, not a live workflow run.

Closes nothing by itself -- do not merge with a closing keyword; #3988 stays open pending #4021.

https://claude.ai/code/session_012zitr1nnKo9tQtCSvX3u8W