### PR TITLE
Fix #4001 (item 1) + #4004: FlutterAndroidDriver/FlutterIOSDriver construction and loud scroll-to-end guard

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -23,6 +23,8 @@ import com.shaft.tools.io.internal.ReportManagerHelper;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.Setting;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.flutter.android.FlutterAndroidDriver;
+import io.appium.java_client.flutter.ios.FlutterIOSDriver;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.remote.AutomationName;
 import io.appium.java_client.windows.WindowsDriver;
@@ -669,8 +671,14 @@ public class DriverFactoryHelper {
 //            else if (isIosExecution) return IOSDriver.builder().address(targetExecutionUrl).oneOf(capabilities).build();
 //            else return RemoteWebDriver.builder().address(targetExecutionUrl).oneOf(capabilities).build();
             // legacy constructor-based code block
-            if (isAndroidExecution) return new AndroidDriver(targetExecutionUrlObject, capabilities);
-            else if (isIosExecution) return new IOSDriver(targetExecutionUrlObject, capabilities);
+            if (isAndroidExecution)
+                return isFlutterAppiumExecution(capabilities)
+                        ? new FlutterAndroidDriver(targetExecutionUrlObject, capabilities)
+                        : new AndroidDriver(targetExecutionUrlObject, capabilities);
+            else if (isIosExecution)
+                return isFlutterAppiumExecution(capabilities)
+                        ? new FlutterIOSDriver(targetExecutionUrlObject, capabilities)
+                        : new IOSDriver(targetExecutionUrlObject, capabilities);
             else if (isWindowsAppiumExecution(capabilities)) return new WindowsDriver(targetExecutionUrlObject, capabilities);
             else {
                 var driver = new RemoteWebDriver(targetExecutionUrlObject, capabilities, createRemoteWebDriverClientConfig(targetExecutionUrlObject));
@@ -737,6 +745,15 @@ public class DriverFactoryHelper {
         return "windows".equalsIgnoreCase(automationName)
                 || (DriverType.APPIUM_WINDOWS.getValue().equalsIgnoreCase(SHAFT.Properties.web.targetBrowserName())
                 && !app.isBlank());
+    }
+
+    private static boolean isFlutterAppiumExecution(Capabilities capabilities) {
+        String automationName = firstCapabilityValue(
+                capabilities,
+                "appium:automationName",
+                "automationName",
+                SHAFT.Properties.mobile.automationName());
+        return AutomationName.FLUTTER_INTEGRATION.equalsIgnoreCase(automationName);
     }
 
     private static String firstCapabilityValue(Capabilities capabilities, String firstName, String secondName, String fallback) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
@@ -17,8 +17,10 @@ import com.shaft.validation.internal.WebDriverElementValidationsBuilder;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.flutter.FlutterIntegrationTestDriver;
 import io.appium.java_client.flutter.commands.ScrollParameter;
 import io.appium.java_client.ios.IOSDriver;
+import org.apache.logging.log4j.Level;
 import org.openqa.selenium.*;
 import org.openqa.selenium.interactions.*;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -943,6 +945,7 @@ public class TouchActions extends FluentWebDriverAction {
         AtomicReference<List<Object>> visualIdentificationObjects = new AtomicReference<>(
                 elementActionsHelper.findElementPresence(driverFactoryHelper.getDriver(), targetElementImage));
         AtomicBoolean canScrollMore = new AtomicBoolean(true);
+        AtomicBoolean isFirstAttempt = new AtomicBoolean(true);
         try {
             new SynchronizationManager(driverFactoryHelper.getDriver()).fluentWait().until(f -> {
                 List<Object> currentAttempt = elementActionsHelper.findElementPresence(driverFactoryHelper.getDriver(), targetElementImage);
@@ -952,7 +955,7 @@ public class TouchActions extends FluentWebDriverAction {
                     ReportManager.logDiscrete("Element found on screen.");
                     return true;
                 }
-                canScrollMore.set(performImageScrollStep(scrollableElementLocator, swipeDirection));
+                canScrollMore.set(performImageScrollStep(scrollableElementLocator, swipeDirection, isFirstAttempt.getAndSet(false)));
                 return !canScrollMore.get();
             });
         } catch (TimeoutException timeoutException) {
@@ -974,9 +977,9 @@ public class TouchActions extends FluentWebDriverAction {
         ((RemoteWebDriver) driverFactoryHelper.getDriver()).perform(ImmutableList.of(tap));
     }
 
-    private boolean performImageScrollStep(By scrollableElementLocator, SwipeDirection swipeDirection) {
+    private boolean performImageScrollStep(By scrollableElementLocator, SwipeDirection swipeDirection, boolean isFirstAttempt) {
         if (driverFactoryHelper.getDriver() instanceof AppiumDriver) {
-            return performW3cCompliantScroll(prepareParameters(swipeDirection, scrollableElementLocator, null));
+            return performW3cCompliantScroll(prepareParameters(swipeDirection, scrollableElementLocator, null), isFirstAttempt);
         }
         int deltaX = 0;
         int deltaY = 0;
@@ -1065,15 +1068,29 @@ public class TouchActions extends FluentWebDriverAction {
         return scrollParameters;
     }
 
-    private boolean performW3cCompliantScroll(HashMap<Object, Object> scrollParameters) {
+    private boolean performW3cCompliantScroll(HashMap<Object, Object> scrollParameters, boolean isFirstAttempt) {
         boolean canScrollMore = true;
-        if (driverFactoryHelper.getDriver() instanceof AndroidDriver androidDriver) {
+        var driver = driverFactoryHelper.getDriver();
+        if (driver instanceof AndroidDriver androidDriver) {
             var ret = androidDriver.executeScript("mobile: scrollGesture", scrollParameters);
             canScrollMore = ret == null || Boolean.parseBoolean(String.valueOf(ret));
-        } else if (driverFactoryHelper.getDriver() instanceof IOSDriver iosDriver) {
+        } else if (driver instanceof IOSDriver iosDriver) {
             //http://appium.github.io/appium-xcuitest-driver/4.16/execute-methods/#mobile-scroll
             var ret = iosDriver.executeScript("mobile: scroll", scrollParameters);
             canScrollMore = ret == null || (Boolean) ret;
+        }
+        // Issue #4004: "mobile: scrollGesture"/"mobile: scroll" only ever reaches a native overlay, never the
+        // FlutterView itself (java-client has no native-scroll primitive against Flutter widgets). Reporting
+        // zero effective scrolls on the very first attempt is ambiguous: it is either a native overlay that is
+        // already at its scroll end (legitimately succeeding today) or a silent no-op against the bare
+        // FlutterView (the bug). We cannot tell them apart, so warn loudly instead of either throwing a false
+        // failure or staying silent.
+        if (isFirstAttempt && !canScrollMore && driver instanceof FlutterIntegrationTestDriver) {
+            ReportManager.log("WARNING: scrolling reported no movement on the first attempt against a Flutter " +
+                    "integration session. \"mobile: scrollGesture\"/\"mobile: scroll\" only reach native overlays, " +
+                    "never the FlutterView itself; if you intended to scroll a Flutter widget, use " +
+                    "swipeElementIntoView(scrollableElementLocator, flutterTargetElementLocator, swipeDirection) " +
+                    "with an AppiumBy.FlutterBy target instead.", Level.WARN);
         }
         return canScrollMore;
     }
@@ -1082,11 +1099,19 @@ public class TouchActions extends FluentWebDriverAction {
         if (!(driverFactoryHelper.getDriver() instanceof AppiumDriver)) {
             throw new UnsupportedCommandException("swipeToEndOfView is supported only for Appium drivers.");
         }
+        if (scrollableElementLocator instanceof AppiumBy.FlutterBy) {
+            // Issue #4004: java-client's Flutter ScrollParameter mandates a scrollTo target
+            // (ScrollParameter.java:50), so there is no scroll-to-end primitive to synthesize here.
+            throw new UnsupportedCommandException("swipeToEndOfView has no scroll-to-end primitive for Flutter " +
+                    "locators; use swipeElementIntoView(scrollableElementLocator, flutterTargetElementLocator, " +
+                    "swipeDirection) with an AppiumBy.FlutterBy target instead.");
+        }
         var scrollParameters = prepareParameters(swipeDirection, scrollableElementLocator, null);
         AtomicBoolean canScrollMore = new AtomicBoolean(true);
+        AtomicBoolean isFirstAttempt = new AtomicBoolean(true);
         new SynchronizationManager(driverFactoryHelper.getDriver()).fluentWait().until(f -> {
             elementActionsHelper.takeScreenshot(driverFactoryHelper.getDriver(), null, "swipeToEndOfView", null, true);
-            canScrollMore.set(performW3cCompliantScroll(scrollParameters));
+            canScrollMore.set(performW3cCompliantScroll(scrollParameters, isFirstAttempt.getAndSet(false)));
             return !canScrollMore.get();
         });
     }
@@ -1094,6 +1119,7 @@ public class TouchActions extends FluentWebDriverAction {
     private boolean attemptW3cCompliantActionsScroll(SwipeDirection swipeDirection, By scrollableElementLocator, By targetElementLocator) {
         var scrollParameters = prepareParameters(swipeDirection, scrollableElementLocator, targetElementLocator);
         AtomicBoolean canScrollMore = new AtomicBoolean(true);
+        AtomicBoolean isFirstAttempt = new AtomicBoolean(true);
         try {
             new SynchronizationManager(driverFactoryHelper.getDriver()).fluentWait().until(f -> {
                 // for the animated GIF:
@@ -1102,7 +1128,7 @@ public class TouchActions extends FluentWebDriverAction {
                 var elementExistsOnViewPort = !ElementActionsHelper.safeFindElements(driverFactoryHelper.getDriver(), targetElementLocator).isEmpty();
                 if (elementExistsOnViewPort)
                     return true;
-                canScrollMore.set(performW3cCompliantScroll(scrollParameters));
+                canScrollMore.set(performW3cCompliantScroll(scrollParameters, isFirstAttempt.getAndSet(false)));
                 elementExistsOnViewPort = !ElementActionsHelper.safeFindElements(driverFactoryHelper.getDriver(), targetElementLocator).isEmpty();
                 if (!canScrollMore.get() && !elementExistsOnViewPort)
                     throw new RuntimeException("Element not found after scrolling to the end of the page.");

--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java
@@ -5,6 +5,8 @@ import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.DriverFactory.OptionsManager;
 import io.appium.java_client.Setting;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.flutter.android.FlutterAndroidDriver;
+import io.appium.java_client.remote.AutomationName;
 import com.shaft.properties.internal.Properties;
 import com.shaft.properties.internal.ThreadLocalPropertiesManager;
 import org.openqa.selenium.MutableCapabilities;
@@ -302,6 +304,27 @@ public class DriverFactoryHelperCoverageUnitTest {
         } catch (InvocationTargetException invocationTargetException) {
             SHAFT.Validations.assertThat().object(invocationTargetException.getCause() != null).isEqualTo(true).perform();
         }
+    }
+
+    @Test
+    public void isFlutterAppiumExecutionShouldReflectCapabilityFirstThenPropertyFallback() throws Exception {
+        Method isFlutterAppiumExecution = DriverFactoryHelper.class.getDeclaredMethod("isFlutterAppiumExecution", org.openqa.selenium.Capabilities.class);
+        isFlutterAppiumExecution.setAccessible(true);
+
+        MutableCapabilities flutterCapability = new MutableCapabilities();
+        flutterCapability.setCapability("appium:automationName", "FlutterIntegration");
+        SHAFT.Validations.assertThat().object(isFlutterAppiumExecution.invoke(null, flutterCapability)).isEqualTo(true).perform();
+
+        MutableCapabilities uiAutomator2Capability = new MutableCapabilities();
+        uiAutomator2Capability.setCapability("appium:automationName", "UiAutomator2");
+        SHAFT.Validations.assertThat().object(isFlutterAppiumExecution.invoke(null, uiAutomator2Capability)).isEqualTo(false).perform();
+
+        // empty capabilities: falls back to SHAFT.Properties.mobile.automationName()
+        SHAFT.Properties.mobile.set().automationName(AutomationName.FLUTTER_INTEGRATION);
+        SHAFT.Validations.assertThat().object(isFlutterAppiumExecution.invoke(null, new MutableCapabilities())).isEqualTo(true).perform();
+
+        SHAFT.Properties.mobile.set().automationName(AutomationName.ANDROID_UIAUTOMATOR2);
+        SHAFT.Validations.assertThat().object(isFlutterAppiumExecution.invoke(null, new MutableCapabilities())).isEqualTo(false).perform();
     }
 
     @Test
@@ -1145,6 +1168,16 @@ public class DriverFactoryHelperCoverageUnitTest {
             configureRemoteDriverInstance.invoke(helper, com.shaft.driver.DriverFactory.DriverType.APPIUM_MOBILE_NATIVE, new DesiredCapabilities());
             configureRemoteDriverInstance.invoke(helper, com.shaft.driver.DriverFactory.DriverType.APPIUM_SAMSUNG_BROWSER, new DesiredCapabilities());
             configureRemoteDriverInstance.invoke(helper, com.shaft.driver.DriverFactory.DriverType.APPIUM_BROWSER, new DesiredCapabilities());
+            SHAFT.Validations.assertThat().object(helper.getDriver()).isNotNull().perform();
+        }
+
+        // Issue #4001: APPIUM_FLUTTER must construct FlutterAndroidDriver, not AndroidDriver, once the
+        // session's automationName identifies it as a Flutter session. This MUST NOT share the AndroidDriver
+        // mockConstruction block above -- FlutterAndroidDriver is a distinct concrete type that mockConstruction
+        // does not intercept via its supertype, so an unmocked construction here would attempt a real network
+        // connection to the "http://localhost:4723" hub URL above and hang CI.
+        SHAFT.Properties.mobile.set().automationName(AutomationName.FLUTTER_INTEGRATION);
+        try (MockedConstruction<FlutterAndroidDriver> ignoredFlutter = org.mockito.Mockito.mockConstruction(FlutterAndroidDriver.class)) {
             configureRemoteDriverInstance.invoke(helper, com.shaft.driver.DriverFactory.DriverType.APPIUM_FLUTTER, new DesiredCapabilities());
             SHAFT.Validations.assertThat().object(helper.getDriver()).isNotNull().perform();
         }

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -6,15 +6,18 @@ import com.shaft.driver.internal.FluentWebDriverAction;
 import com.shaft.gui.element.TouchActions;
 import com.shaft.gui.element.internal.ElementActionsHelper;
 import com.shaft.properties.internal.Properties;
+import com.shaft.tools.io.ReportManager;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.flutter.commands.ScrollParameter;
 import io.appium.java_client.ios.IOSDriver;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.ScreenOrientation;
+import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
@@ -39,11 +42,13 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -208,10 +213,10 @@ public class AndroidTouchActionsCoverageUnitTest {
         SHAFT.Validations.assertThat().object(elementUpParameters.get("height")).isEqualTo(270).perform();
         SHAFT.Validations.assertThat().object(elementLeftParameters.get("left")).isEqualTo(260).perform();
 
-        Method performW3cCompliantScroll = TouchActions.class.getDeclaredMethod("performW3cCompliantScroll", java.util.HashMap.class);
+        Method performW3cCompliantScroll = TouchActions.class.getDeclaredMethod("performW3cCompliantScroll", java.util.HashMap.class, boolean.class);
         performW3cCompliantScroll.setAccessible(true);
-        SHAFT.Validations.assertThat().object(performW3cCompliantScroll.invoke(touchActions, downParameters)).isEqualTo(true).perform();
-        SHAFT.Validations.assertThat().object(performW3cCompliantScroll.invoke(touchActions, downParameters)).isEqualTo(false).perform();
+        SHAFT.Validations.assertThat().object(performW3cCompliantScroll.invoke(touchActions, downParameters, true)).isEqualTo(true).perform();
+        SHAFT.Validations.assertThat().object(performW3cCompliantScroll.invoke(touchActions, downParameters, false)).isEqualTo(false).perform();
         verify(iosDriver, times(2)).executeScript(eq("mobile: scroll"), anyMap());
     }
 
@@ -307,10 +312,10 @@ public class AndroidTouchActionsCoverageUnitTest {
         SHAFT.Validations.assertThat().object(leftParameters.containsKey("left")).isTrue().perform();
         SHAFT.Validations.assertThat().object(touchActions.and()).isEqualTo(touchActions).perform();
 
-        Method performW3cCompliantScroll = TouchActions.class.getDeclaredMethod("performW3cCompliantScroll", java.util.HashMap.class);
+        Method performW3cCompliantScroll = TouchActions.class.getDeclaredMethod("performW3cCompliantScroll", java.util.HashMap.class, boolean.class);
         performW3cCompliantScroll.setAccessible(true);
-        SHAFT.Validations.assertThat().object(performW3cCompliantScroll.invoke(touchActions, upParameters)).isEqualTo(true).perform();
-        SHAFT.Validations.assertThat().object(performW3cCompliantScroll.invoke(touchActions, upParameters)).isEqualTo(false).perform();
+        SHAFT.Validations.assertThat().object(performW3cCompliantScroll.invoke(touchActions, upParameters, true)).isEqualTo(true).perform();
+        SHAFT.Validations.assertThat().object(performW3cCompliantScroll.invoke(touchActions, upParameters, false)).isEqualTo(false).perform();
 
     }
 
@@ -520,6 +525,80 @@ public class AndroidTouchActionsCoverageUnitTest {
         verify(driver, never()).findElements(isNull());
     }
 
+    // Issue #4004: swipeToEndOfView has no scroll-to-end primitive against a Flutter locator (ScrollParameter
+    // mandates a scrollTo target), so it must fail loudly instead of silently doing nothing.
+    @Test
+    public void swipeToEndOfViewWithFlutterScrollableLocatorShouldThrowUnsupportedCommandException() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        when(elementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
+        // Mutation-kill: failAction only throws when invoked with the exact remedy-naming UnsupportedCommandException.
+        // If the guard regresses (e.g. silently removed), the native scroll loop runs instead and either never
+        // calls failAction with this specific throwable, or calls it with a different one -- the stub never fires,
+        // and the test fails to observe the expected exception, catching the regression instead of silently passing.
+        doThrow(new AssertionFailedError("swipeToEndOfView has no scroll-to-end primitive for Flutter locators"))
+                .when(elementActionsHelper).failAction(any(WebDriver.class), anyString(), any(),
+                        org.mockito.ArgumentMatchers.<Throwable>argThat(throwable -> throwable instanceof UnsupportedCommandException
+                                && throwable.getMessage() != null
+                                && throwable.getMessage().contains("swipeElementIntoView")));
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+
+        var scrollableLocator = AppiumBy.flutterType("ListView");
+        try {
+            touchActions.swipeToEndOfView(scrollableLocator, TouchActions.SwipeDirection.DOWN);
+            org.testng.Assert.fail("Expected the Flutter scroll-to-end guard to route into failAction with the remedy-naming UnsupportedCommandException, but no such exception propagated.");
+        } catch (AssertionFailedError expected) {
+            // expected: proves failAction was invoked with the remedy-naming UnsupportedCommandException
+        }
+        verify(driver, never()).executeScript(eq("mobile: scrollGesture"), anyMap());
+    }
+
+    // Issue #4004: a native "mobile: scrollGesture"/"mobile: scroll" call against a bare FlutterView reports
+    // zero effective scrolls on the very first attempt -- ambiguous between "already at scroll end" (legitimate,
+    // e.g. a native overlay atop the FlutterView) and "silent no-op" (the bug). Warn instead of throwing, since
+    // throwing would falsely fail the legitimate case.
+    @Test
+    public void swipeToEndOfViewWithFlutterDriverAndZeroScrollsShouldEmitLoudWarning() throws Exception {
+        io.appium.java_client.flutter.android.FlutterAndroidDriver driver = createMockFlutterAndroidDriver();
+        doReturn(false).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        when(elementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+
+        try (MockedStatic<ReportManager> reportManager = mockStatic(ReportManager.class)) {
+            touchActions.swipeToEndOfView(TouchActions.SwipeDirection.DOWN);
+
+            reportManager.verify(() -> ReportManager.log(argThat(message -> message != null
+                    && message.toLowerCase(java.util.Locale.ROOT).contains("flutter")), eq(org.apache.logging.log4j.Level.WARN)));
+        }
+        verify(elementActionsHelper, never()).failAction(any(WebDriver.class), anyString(), any(), any(Throwable.class));
+        verify(driver, times(1)).executeScript(eq("mobile: scrollGesture"), anyMap());
+    }
+
+    // Issue #4004: a Flutter session that genuinely scrolls a native overlay several times before reaching the
+    // end is a legitimate native scroll -- no warning should fire, matching today's behavior byte-for-byte.
+    @Test
+    public void swipeToEndOfViewWithFlutterDriverAndSuccessfulScrollsShouldNotWarnOrThrow() throws Exception {
+        io.appium.java_client.flutter.android.FlutterAndroidDriver driver = createMockFlutterAndroidDriver();
+        doReturn(true).doReturn(false).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        when(elementActionsHelper.takeScreenshot(any(), any(), anyString(), any(), eq(true))).thenReturn(List.of());
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+
+        try (MockedStatic<ReportManager> reportManager = mockStatic(ReportManager.class)) {
+            touchActions.swipeToEndOfView(TouchActions.SwipeDirection.DOWN);
+
+            reportManager.verify(() -> ReportManager.log(anyString(), eq(org.apache.logging.log4j.Level.WARN)), never());
+        }
+        verify(elementActionsHelper, never()).failAction(any(WebDriver.class), anyString(), any(), any(Throwable.class));
+        verify(driver, times(2)).executeScript(eq("mobile: scrollGesture"), anyMap());
+    }
+
     // Issue #3996: FlutterIntegration driver targets must scroll via "flutter: scrollTillVisible",
     // not the native "mobile: scrollGesture" (a no-op against a single FlutterView with no native scrollable).
 
@@ -678,6 +757,17 @@ public class AndroidTouchActionsCoverageUnitTest {
 
     private RemoteWebDriver createMockRemoteWebDriver() {
         RemoteWebDriver driver = mock(RemoteWebDriver.class);
+        WebDriver.Options options = mock(WebDriver.Options.class);
+        WebDriver.Window window = mock(WebDriver.Window.class);
+        when(driver.manage()).thenReturn(options);
+        when(options.window()).thenReturn(window);
+        when(window.getSize()).thenReturn(new Dimension(1080, 1920));
+        when(driver.findElements(any(By.class))).thenReturn(List.of());
+        return driver;
+    }
+
+    private io.appium.java_client.flutter.android.FlutterAndroidDriver createMockFlutterAndroidDriver() {
+        io.appium.java_client.flutter.android.FlutterAndroidDriver driver = mock(io.appium.java_client.flutter.android.FlutterAndroidDriver.class);
         WebDriver.Options options = mock(WebDriver.Options.class);
         WebDriver.Window window = mock(WebDriver.Window.class);
         when(driver.manage()).thenReturn(options);


### PR DESCRIPTION
## Summary

**Slice 1 — issue #4001 item 1.** `DriverFactoryHelper.connectToRemoteServer` (`shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java:674-681`) now constructs `FlutterAndroidDriver`/`FlutterIOSDriver` instead of `AndroidDriver`/`IOSDriver` when the session's `automationName` (capability `appium:automationName`/`automationName`, falling back to `SHAFT.Properties.mobile.automationName()`, via the new private `isFlutterAppiumExecution(Capabilities)` at `:750-757`, modeled exactly on the existing `isWindowsAppiumExecution(Capabilities)`) is `FlutterIntegration`. `javap -p` on java-client 10.1.1 confirms both Flutter driver types declare only bare `super(...)` constructors over their Android/iOS counterparts, so this is byte-identical wire traffic with the correct concrete driver type attached.

**Slice 2 — issue #4004.** `TouchActions.performW3cCompliantScroll` (`shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java:1071-1096`) is the shared choke point for all three scroll-loop callers (`swipeToEndOfViewInternal`, `attemptW3cCompliantActionsScroll`, `performImageScrollStep`). Two guards:
- **Throw** (`TouchActions.java:1102-1108`): `swipeToEndOfView` with a `scrollableElementLocator` typed `AppiumBy.FlutterBy` now throws `UnsupportedCommandException` naming the remedy (`swipeElementIntoView(scrollable, flutterTarget, direction)`) — java-client's `ScrollParameter` mandates a `scrollTo` target (`Require.precondition` at `ScrollParameter.java:50`), so there is no scroll-to-end primitive to synthesize.
- **Warn** (`TouchActions.java:1080-1090`): when the driver is a `FlutterIntegrationTestDriver` and the very first scroll attempt reports zero effective movement, a loud `ReportManager.log(..., Level.WARN)` fires instead of throwing — a native overlay already at its scroll end inside a Flutter session is a legitimate success today, and throwing there would be a false failure.

Native/iOS/web paths are unmodified. `swipeToEndOfViewShouldScrollUntilAppiumReportsEnd` (`AndroidTouchActionsCoverageUnitTest.java:505-524`) stays green **without modification**, matching the hard acceptance constraint from #4004.

## What CI does NOT prove

- No real Flutter integration server was exercised — everything above is verified against mocked `FlutterAndroidDriver`/`AndroidDriver` instances, not a live Appium/Flutter session.
- `flutter: scrollTillVisible` (pre-existing, from #4010) was never proven to move a real Flutter widget tree.
- No cloud-provider (LambdaTest/BrowserStack) capability behavior was tested.
- `FlutterTest.java` throws `SkipException` by default and only runs against a real Flutter driver when `-Dshaft.enableFlutterE2E=true` is set (`FlutterTest.java:24,34-37`) — it validates none of this in CI.

## Public runtime-behavior change (release notes)

`TouchActions.swipeToEndOfView(...)` now throws `UnsupportedCommandException` for Flutter-typed scrollable locators (previously it silently ran a no-op native scroll loop until timeout), and emits a `WARN`-level report when a Flutter session's first scroll attempt reports zero movement. This is a real behavior change for any test currently relying on the old silent-timeout behavior.

## Out of scope (filed/carved out separately, per architect spec)

- `OptionsManager.java` / `FlutterDriverOptions` (#4001 item 2) — cut, doesn't type-fit `DesiredCapabilities` and narrows capability expressiveness vs. existing `mobile_*` passthrough.
- Swapping the raw `executeScript("flutter: scrollTillVisible", ...)` for the typed `scrollTillVisible(ScrollParameter)` in `attemptFlutterScrollTillVisible` — adds a `checkcast WebElement` failure mode and breaks existing wire-format assertions for zero coverage gain.
- `appium_flutterfinder_java` dependency removal — public compile-scope surface, requires deprecate-before-removal (filed separately).
- #4001 item 3 (fluent wait/gesture/camera API) — filed separately.

## Test plan

- [x] `mvn test -Dtest=DriverFactoryHelperCoverageUnitTest,AndroidTouchActionsCoverageUnitTest -pl shaft-engine -DheadlessExecution=true -Dallure.automaticallyOpen=false` — 67/67 passed, 0 failures, 0 errors.
- [x] `mvn -pl shaft-engine compile test-compile` — clean.
- [x] `mvn -pl shaft-engine package -DskipTests` — clean.

Closes #4001
Closes #4004

Co-authored: Claude Sonnet 5 (Coder)