### PR TITLE
Deprecate appium_flutterfinder_java; migrate FlutterTest.java to native java-client Flutter API

### DIFF
--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -123,7 +123,17 @@
             </exclusions>
         </dependency>
 
-        <!-- APPIUM FLUTTER FINDER -->
+        <!-- APPIUM FLUTTER FINDER (DEPRECATED, see #4016)
+             Deprecated as of 10.3.20260726: its unexcluded java-client edge has already caused
+             two Maven Central delivery failures (open selenium ranges resolving against live
+             Central metadata instead of our BOM pins; see
+             .memory/memory/gotchas/appium-java-client-hard-selenium-version-ranges-beat-bom-pins.md).
+             java-client 10.1.1+ ships a native Flutter surface (AppiumBy flutter* locators,
+             FlutterIntegrationTestDriver) that replaces it; see the migrated
+             shaft-engine/src/test/java/testPackage/appium/FlutterTest.java for the equivalent
+             native locators. Still declared at compile scope to preserve the public classpath
+             during the deprecation window (AGENTS.md: "Preserve public API; deprecate before
+             removal"); tracked for demotion/removal in #4032. -->
         <dependency>
             <groupId>io.github.ashwithpoojary98</groupId>
             <artifactId>appium_flutterfinder_java</artifactId>

--- a/shaft-engine/src/test/java/testPackage/appium/FlutterTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/FlutterTest.java
@@ -3,11 +3,10 @@ package testPackage.appium;
 import com.shaft.driver.SHAFT;
 import com.shaft.properties.internal.Properties;
 import com.shaft.validation.Validations;
+import io.appium.java_client.AppiumBy;
 import io.appium.java_client.remote.AutomationName;
-import io.github.ashwith.flutter.FlutterFinder;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -16,14 +15,14 @@ import org.testng.annotations.Test;
 /**
  * Test class for Flutter app automation using Appium Flutter Driver.
  * This test uses the demo Flutter counter app to validate the Flutter driver integration.
- * 
- * The test demonstrates proper usage of FlutterFinder library to locate and interact
- * with Flutter widgets.
+ *
+ * The test demonstrates proper usage of java-client's native Flutter locators
+ * ({@link AppiumBy} {@code flutter*} factory methods) to locate and interact with Flutter
+ * widgets, superseding the deprecated {@code appium_flutterfinder_java} dependency.
  */
 public class FlutterTest {
     private static final String ENABLE_FLUTTER_E2E_PROPERTY = "shaft.enableFlutterE2E";
     public static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
-    private FlutterFinder finder;
 
     /**
      * Setup method to configure and initialize the Flutter driver.
@@ -54,17 +53,16 @@ public class FlutterTest {
         // SHAFT.Properties.mobile.set().deviceName("Android Emulator");
         // SHAFT.Properties.mobile.set().platformVersion("13.0");
         
-        // Initialize the driver
+        // Initialize the driver. With automationName set to FLUTTER_INTEGRATION, SHAFT's
+        // DriverFactoryHelper constructs a FlutterAndroidDriver/FlutterIOSDriver under the hood,
+        // so AppiumBy's native flutter* locators can be used directly via findElement() below.
         driver.set(new SHAFT.GUI.WebDriver());
-        
-        // Initialize FlutterFinder - cast to RemoteWebDriver as required by FlutterFinder
-        finder = new FlutterFinder((RemoteWebDriver) driver.get().getDriver());
     }
 
     /**
      * Test to verify basic Flutter app launch and interaction.
      * This test verifies that the Flutter counter app can be launched
-     * and that the main title is displayed using FlutterFinder.
+     * and that the main title is displayed using a native AppiumBy flutter locator.
      */
     @Test(groups = {"flutter"}, description = "Verify Flutter app launches successfully")
     public void testFlutterAppLaunch() {
@@ -72,7 +70,7 @@ public class FlutterTest {
         // The Flutter demo app typically has a title widget
         
         // Find element by text (common in Flutter counter demo)
-        WebElement titleElement = finder.byText("Flutter Demo Home Page");
+        WebElement titleElement = driver.get().getDriver().findElement(AppiumBy.flutterText("Flutter Demo Home Page"));
         Validations.assertThat().object(titleElement).isNotNull().perform();
         
         // Verify driver is initialized and working
@@ -81,7 +79,7 @@ public class FlutterTest {
 
     /**
      * Test to verify Flutter counter app functionality.
-     * This test demonstrates proper FlutterFinder usage to interact with widgets:
+     * This test demonstrates proper native Flutter locator usage to interact with widgets:
      * 1. Finding elements by ValueKey
      * 2. Clicking buttons
      * 3. Verifying text changes
@@ -90,7 +88,7 @@ public class FlutterTest {
     public void testFlutterCounterIncrement() {
         // Find the increment button by ValueKey
         // Flutter counter demo typically uses 'increment' as the key
-        WebElement incrementButton = finder.byValueKey("increment");
+        WebElement incrementButton = driver.get().getDriver().findElement(AppiumBy.flutterKey("increment"));
         Validations.assertThat().object(incrementButton).isNotNull().perform();
         
         // Click the increment button
@@ -99,7 +97,7 @@ public class FlutterTest {
         // Verify the button click was successful
         // Note: In a real test, you would verify the counter value changed
         // For example:
-        // WebElement counterText = finder.byValueKey("counterText");
+        // WebElement counterText = driver.get().getDriver().findElement(AppiumBy.flutterKey("counterText"));
         // Assert.assertTrue(counterText.getText().contains("1"), "Counter should be incremented");
         
         Validations.assertThat().object(driver.get().getDriver()).isNotNull().perform();
@@ -107,25 +105,27 @@ public class FlutterTest {
     
     /**
      * Test to demonstrate finding elements by Type.
-     * This shows how to use byType() finder method.
+     * This shows how to use the {@link AppiumBy#flutterType(String)} native locator.
      */
     @Test(groups = {"flutter"}, description = "Verify finding elements by Type")
     public void testFlutterFindByType() {
         // Find an element by its Flutter widget type
         // For example, finding a FloatingActionButton
-        WebElement fabButton = finder.byType("FloatingActionButton");
+        WebElement fabButton = driver.get().getDriver().findElement(AppiumBy.flutterType("FloatingActionButton"));
         Validations.assertThat().object(fabButton).isNotNull().perform();
     }
     
     /**
      * Test to demonstrate finding elements by ToolTip.
-     * This shows how to use byToolTip() finder method.
+     * The native API has no dedicated tooltip finder; Flutter's Tooltip widget registers its
+     * message as a semantics label, so {@link AppiumBy#flutterSemanticsLabel(String)} is the
+     * equivalent native locator.
      */
     @Test(groups = {"flutter"}, description = "Verify finding elements by ToolTip")
     public void testFlutterFindByToolTip() {
-        // Find an element by its tooltip text
+        // Find an element by its tooltip text (exposed as a semantics label)
         // The increment button in Flutter demo usually has "Increment" tooltip
-        WebElement incrementButton = finder.byToolTip("Increment");
+        WebElement incrementButton = driver.get().getDriver().findElement(AppiumBy.flutterSemanticsLabel("Increment"));
         Validations.assertThat().object(incrementButton).isNotNull().perform();
     }
 


### PR DESCRIPTION
## Summary
Closes #4016 (steps 1+2 of its suggested path only — deprecation, not removal).

`io.github.ashwithpoojary98:appium_flutterfinder_java` is declared at **compile scope**
(`shaft-engine/pom.xml:127-142`), so it's on the public classpath of every SHAFT consumer.
Demoting or dropping it now would be a silent classpath break — `AGENTS.md` ("Preserve public
API; deprecate before removal") requires a deprecation cycle first. **This PR does not change
the dependency's scope or remove it.**

- **Migrate `FlutterTest.java`** (verified via `rg` across all modules, main+test source, to be
  the dependency's *only* consumer) off `FlutterFinder` onto java-client 10.1.1's native
  `AppiumBy.flutter*` locators (`flutterKey`, `flutterText`, `flutterType`,
  `flutterSemanticsLabel`), confirmed available by `javap`-ing the real
  `java-client-10.1.1.jar`. `driver.get().getDriver()` already returns a
  `FlutterAndroidDriver`/`FlutterIOSDriver` when `automationName` is `FLUTTER_INTEGRATION`
  (merged in #4023's `DriverFactoryHelper` changes, not touched here), so the migration drops
  the old `RemoteWebDriver` cast and separate `FlutterFinder` instance entirely — `findElement`
  is called directly on the driver. `byToolTip` had no direct native equivalent, so it maps to
  `AppiumBy.flutterSemanticsLabel` (Flutter's `Tooltip` widget registers its message as a
  semantics label) with an inline comment explaining the mapping.
- **Mark the deprecation in the pom** with a comment on the dependency explaining why (its
  unexcluded java-client edge has already caused two Maven Central delivery failures — see
  `.memory/memory/gotchas/appium-java-client-hard-selenium-version-ranges-beat-bom-pins.md`) and
  what replaces it.
- **Announce the deprecation.** This repo has no separate changelog/deprecations file — GitHub
  Releases are auto-generated from merged PR titles (`.github/release.yml`), so this PR's title
  is the release-notes announcement. `docs/testing/mobile.md` (shafthq.github.io) documents
  `FlutterFinder` extensively as user-facing behavior, so a **separate** docs PR adds a
  deprecation notice and native-locator guidance there:
  ShaftHQ/shafthq.github.io#892 (base `master`).
- **Followup removal issue** (step 3, demote to `test` scope or drop entirely after the
  deprecation window): #4032.

## Verification (compile-only — see note below)
`FlutterTest.java` is gated behind `-Dshaft.enableFlutterE2E=true` and throws `SkipException` by
default (`shaft-engine/src/test/java/testPackage/appium/FlutterTest.java:33-36`), so it **never
runs in CI**. Compilation is the only automated signal for this migration; the E2E test itself
is not run or proven here (that would require a real Flutter app on a device/cloud).

```
mvn -pl shaft-engine test-compile -DheadlessExecution=true "-Dallure.automaticallyOpen=false"
# BUILD SUCCESS — FlutterTest.class produced clean, no warnings referencing FlutterTest

mvn -pl shaft-engine package -DskipTests -DheadlessExecution=true "-Dallure.automaticallyOpen=false"
# BUILD SUCCESS
```

## Test plan
- [x] `rg` confirms `FlutterTest.java` is the only consumer of `io.github.ashwith.flutter.*` /
      `appium_flutterfinder_java` in main or test source across all modules.
- [x] `mvn -pl shaft-engine test-compile` — clean, BUILD SUCCESS.
- [x] `mvn -pl shaft-engine package -DskipTests` — clean, BUILD SUCCESS.
- [ ] `FlutterTest.java` itself is not run (SkipException-gated, needs a real device/cloud) —
      migration is compile-verified only, stated plainly per the task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)