### PR TITLE
Fix: measure real locator uniqueness for ROLE/LABEL capture-recorder candidates

### DIFF
--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -371,6 +371,36 @@
   };
   const isControlElement = element =>
     Boolean(element && element.closest && element.closest("[data-shaft-capture-control]"));
+  // ROLE/LABEL candidates have no CSS selector to run through count() -- their uniqueness can
+  // only be measured by walking the page and re-deriving each element's role/accessible-name/
+  // label the same way it was derived to build the candidate (issue #4025: this used to be
+  // hardcoded to 1, fabricating uniqueness for locators that in fact matched many elements).
+  // locatorScore()/readinessFor() (below) only ever distinguish "0 matches" / "exactly 1" /
+  // "more than 1", so the walk stops the moment a second match is found: a page with many
+  // duplicate roles/labels never stalls recording on every keystroke, and the count can never be
+  // inflated back down to a false "unique" once it has found real evidence otherwise.
+  const MULTI_MATCH_CAP = 2;
+  const semanticMatchCount = predicate => {
+    try {
+      let found = 0;
+      const candidates = document.querySelectorAll("body *");
+      for (let index = 0; index < candidates.length && found < MULTI_MATCH_CAP; index++) {
+        const candidate = candidates[index];
+        if (!isControlElement(candidate) && predicate(candidate)) found++;
+      }
+      return found;
+    } catch (ignored) {
+      return 0;
+    }
+  };
+  const roleMatchCount = expression => {
+    const separator = expression.indexOf(":");
+    const role = separator < 0 ? expression : expression.slice(0, separator);
+    const name = separator < 0 ? "" : expression.slice(separator + 1);
+    return semanticMatchCount(candidate =>
+      inferredRole(candidate) === role && (!name || accessibleName(candidate) === name));
+  };
+  const labelMatchCount = expression => semanticMatchCount(candidate => label(candidate) === expression);
   const cssPath = element => {
     const parts = [];
     let current = element;
@@ -397,10 +427,21 @@
     const visible = Boolean(element.getClientRects && element.getClientRects().length);
     const add = (strategy, expression, selector, stable, signals) => {
       if (!expression) return;
+      const normalized = text(expression);
+      let uniquenessCount;
+      if (selector) {
+        uniquenessCount = count(selector);
+      } else if (strategy === "ROLE") {
+        uniquenessCount = roleMatchCount(normalized);
+      } else if (strategy === "LABEL") {
+        uniquenessCount = labelMatchCount(normalized);
+      } else {
+        uniquenessCount = 1;
+      }
       result.push({
         strategy,
-        expression: text(expression),
-        uniquenessCount: selector ? count(selector) : 1,
+        expression: normalized,
+        uniquenessCount,
         visible,
         stable,
         signals

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -5,6 +5,7 @@ import com.shaft.capture.model.CaptureEvent;
 import com.shaft.capture.model.CaptureSession;
 import com.shaft.capture.model.CaptureStep;
 import com.shaft.capture.model.Checkpoint;
+import com.shaft.capture.model.LocatorCandidate;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Tag;
@@ -1289,6 +1290,64 @@ class ManagedCaptureRecorderBrowserTest {
         }
     }
 
+    /**
+     * Regression for issue #4025: the recorder's in-page {@code locators()} function used to
+     * hardcode {@code uniquenessCount: 1} for the ROLE and LABEL strategies instead of measuring
+     * whether the locator actually matches exactly one element. Two buttons sharing the same
+     * inferred role ("button") and accessible name ("Submit") make the ROLE candidate
+     * ("button:Submit") built from clicking either one truthfully match both elements; the
+     * recorded {@code uniquenessCount} must reflect that real count instead of the fabricated
+     * {@code 1}, which previously caused the locator to be scored/treated as uniquely identifying
+     * its target.
+     */
+    @Test
+    void recordedRoleLocatorReflectsTrueUniquenessCountWhenMultipleElementsMatch(@TempDir Path temp)
+            throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve("multi-match.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/multi-match",
+                CaptureBrowser.parse("chrome"),
+                output,
+                temp.resolve("multi-match-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("submit-a")));
+
+            driver.findElement(By.id("submit-a")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.contains("Submit")));
+
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+
+        CaptureSession session = new CaptureJsonCodec().read(output);
+        CaptureEvent.ClickEvent click = session.events().stream()
+                .filter(CaptureEvent.ClickEvent.class::isInstance)
+                .map(CaptureEvent.ClickEvent.class::cast)
+                .filter(event -> "submit-a".equals(event.target().logicalElementId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("The click on #submit-a must be recorded."));
+        LocatorCandidate role = click.target().locatorCandidates().stream()
+                .filter(candidate -> candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "A ROLE locator candidate must be recorded for the clicked button: "
+                                + click.target().locatorCandidates()));
+        assertEquals(2, role.uniquenessCount(),
+                "Both buttons share role \"button\" and accessible name \"Submit\", so the ROLE "
+                        + "candidate " + role.expression() + " truthfully matches both elements; a "
+                        + "hardcoded uniquenessCount of 1 would wrongly claim it identifies its "
+                        + "target uniquely.");
+    }
+
     private static By assertionChoice(String label) {
         return By.xpath("//*[@id='shaft-capture-assertion-panel']//button[normalize-space()='" + label + "']");
     }
@@ -1508,6 +1567,19 @@ class ManagedCaptureRecorderBrowserTest {
                     setTimeout(() => typeInto("username", "demo.user"), 2500);
                     setTimeout(() => typeInto("password", "demo.pass"), 2900);
                   </script>
+                </body>
+                </html>
+                """));
+        // Two elements sharing the same inferred role ("button") and accessible name ("Submit"),
+        // so a ROLE-strategy locator built from either one matches both -- proves uniquenessCount
+        // is measured, not hardcoded to 1 (issue #4025).
+        server.createContext("/multi-match", exchange -> respond(exchange, """
+                <!doctype html>
+                <html>
+                <head><title>Multi Match Fixture</title></head>
+                <body>
+                  <button id="submit-a">Submit</button>
+                  <button id="submit-b">Submit</button>
                 </body>
                 </html>
                 """));


### PR DESCRIPTION
## Summary

- `shaft-capture-recorder.js`'s `locators()` hardcoded `uniquenessCount: 1` for the ROLE and LABEL strategies (`shaft-capture-recorder.js:395-432` pre-fix) instead of measuring whether the candidate actually matches one element. Downstream `locatorScore()`/`readinessFor()` treated that fabricated `1` as proof of uniqueness, so a ROLE/LABEL locator matching several elements got scored and surfaced as trustworthy — risking generated code that silently resolves the wrong element at replay time.
- Added `roleMatchCount`/`labelMatchCount` (backed by a shared `semanticMatchCount` walker) that re-derive each element's role/accessible-name/label the same way the candidate itself was built, and record the true count. CSS/ID/NAME/TEST_ID candidates already counted matches via a live `querySelectorAll()`/`count()` and are unchanged.
- **Before**: two identical `<button>Submit</button>` elements each recorded `ROLE button:Submit` with `uniquenessCount: 1` — a fabricated claim of uniqueness.
- **After**: the same DOM records `uniquenessCount: 2` for that candidate, which correctly demotes its score and flags the step as `RISKY` ("locator has multiple matches") instead of `READY`.

## Design notes (stating my interpretation plainly, since the tracking issue's phrasing doesn't map 1:1)

- Issue #4025 says "evaluate each candidate with the same engine replay will use (XPath via `document.evaluate`, CSS via `querySelectorAll`)" — but ROLE/LABEL are neither CSS nor XPath at the JS layer (they're semantic role+accessible-name / label-text matches; `CaptureGenerator` only turns them into `SHAFT.GUI.Locator.hasRole(...)`/`.hasAttribute("aria-label", ...)`/`.containsText(...)` much later, server-side, during codegen — not something the injected page script can simulate). I matched the closest thing this file already treats as "how a ROLE/LABEL candidate really matches" — `locatorProbe()` (`shaft-capture-recorder.js:563-590`), the same predicate logic already used to live re-probe candidates in the locator picker panel — rather than inventing a new synthesized-XPath translator.
- **Cost bound (my call, not asked)**: `emit()` calls `locators()` synchronously on every `input` event (every keystroke), so an uncapped full-page role/accessible-name walk could visibly stall typing on a large page. `locatorScore()`/`readinessFor()` only ever distinguish 0 / exactly-1 / more-than-1 matches, so the walk stops as soon as a **second** match is found. The reported count can undercount on pages with many duplicates (e.g. reports `2` for a locator that actually matches 40) but never wrongly reports `1` — it can only ever be truthful or a truthful lower bound, never fabricated.
- **Evaluation failures**: wrapped in try/catch, falling back to `0` (same failure mode as the existing `count()` helper) rather than throwing — a malformed candidate can't break recording, and `0` never risks a false "unique" claim.
- Left `locatorProbe()` itself untouched (still exact/uncapped) since it's only invoked on-demand when the user opens the locator panel, not on the hot per-keystroke path, and changing its behavior was outside this slice.

## Out of scope (left untouched, per the subtask boundary)

- Which strategies are emitted, and their ranking/scoring weights — unchanged. Only the `uniquenessCount` measurement changed.

## Test plan

- [x] Watched RED: `mvn -pl shaft-capture test -Dtest=ManagedCaptureRecorderBrowserTest#recordedRoleLocatorReflectsTrueUniquenessCountWhenMultipleElementsMatch -DincludeCaptureBrowserE2E -DheadlessExecution=true -Dallure.automaticallyOpen=false` failed against the hardcoded `1`: `expected: <2> but was: <1>`.
- [x] Watched GREEN: same command, `Total: 1 · Passed: 1` after the fix.
- [x] Full-class regression: `mvn -pl shaft-capture test -Dtest=ManagedCaptureRecorderBrowserTest -DincludeCaptureBrowserE2E -DheadlessExecution=true -Dallure.automaticallyOpen=false` → `Tests run: 26, Failures: 0, Errors: 0, Skipped: 0` (chrome+edge, all pre-existing recorder behaviors unaffected).
- [x] `node -e "new vm.Script(...)"` syntax-check on the edited recorder JS (per this repo's established "no JS unit-test harness" workflow for this file).
- [x] Confirmed the Java-side `CaptureGeneratorTest`/`LocatorRankerTest`/`CaptureFixtures` construct `LocatorCandidate`/`ElementSnapshot` directly and never execute the browser JS, so this change carries no risk to codegen/ranking unit tests.

## What CI cannot prove

- CI's default run excludes the `external-e2e` tag (`shaft-capture/pom.xml:100`), so the new regression test and the rest of `ManagedCaptureRecorderBrowserTest` only run when `-DincludeCaptureBrowserE2E` is explicitly passed (as this session did). A default CI run will not exercise this fix or its regression test on its own.
- The 2-match cap's real-world "does not visibly stall typing" claim is reasoned from code (per-keystroke O(page-elements) work bounded to at most 2 matches for the common case, or a full scan when a candidate is genuinely 0/1-unique) rather than measured against a very-large synthetic DOM; no perf benchmark was run.

Closes #4025. Subtask of tracker #4024 — strategy emission and locator ranking changes are out of scope here (see #4028/#4030).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zitr1nnKo9tQtCSvX3u8W