### PR TITLE
Fix: retry local Safari session creation after clearing a stale pairing (#1548)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -1007,14 +1007,14 @@ public class DriverFactoryHelper {
                     }
                 } else if (message != null && message.contains("The Safari instance is already paired with another WebDriver session.")) {
                     //this issue happens when running locally via safari/mac platform
-                    // attempting blind fix by trying to quit existing safari instances if any
+                    // attempting blind fix by trying to quit existing safari instances if any, then
+                    // retrying (issue #1548): safaridriver only allows one active session system-wide,
+                    // so killing the stale pairing is useless unless we retry with the now-freed instance
                     try {
                         SHAFT.CLI.terminal().performTerminalCommands(Arrays.asList(
                                 "osascript -e 'quit app \"Safari\"'", "osascript -e 'quit app \"SafariDriver\"'",
                                 "pkill -x Safari", "pkill -x SafariDriver",
                                 "killall Safari", "killall SafariDriver"));
-                        //minimizing retry attempts to save execution time
-                        shouldRetry = false;
                     } catch (Throwable throwable) {
                         ReportManagerHelper.logDiscrete(throwable, Level.DEBUG);
                     }

--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperCoverageUnitTest.java
@@ -1,5 +1,6 @@
 package com.shaft.driver.internal.DriverFactory;
 
+import com.shaft.cli.TerminalActions;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.DriverFactory.OptionsManager;
@@ -34,6 +35,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.safari.SafariOptions;
 import org.openqa.selenium.safari.SafariDriver;
+import org.openqa.selenium.SessionNotCreatedException;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.mockito.MockedConstruction;
 import org.testng.annotations.AfterMethod;
@@ -1203,6 +1205,39 @@ public class DriverFactoryHelperCoverageUnitTest {
             helper.initializeDriver(com.shaft.driver.DriverFactory.DriverType.CHROME, null);
             org.mockito.Mockito.verify(window).setSize(new org.openqa.selenium.Dimension(1234, 678));
             SHAFT.Validations.assertThat().object(helper.getDriver()).isEqualTo(mockedRemoteDriver).perform();
+        }
+    }
+
+    @Test
+    public void createNewLocalDriverInstanceShouldRetryLocalSafariSessionAfterRecoveringFromPairingConflict() throws Exception {
+        // issue #1548: safaridriver permits exactly one active WebDriver session system-wide. When
+        // that "already paired" conflict is hit, the recovery branch kills any lingering
+        // Safari/SafariDriver processes -- but it must then retry driver construction, or the
+        // recovery is pointless: the session gets freed but the caller still fails with the very
+        // error the recovery just fixed.
+        DriverFactoryHelper helper = new DriverFactoryHelper();
+        OptionsManager mockedOptionsManager = org.mockito.Mockito.mock(OptionsManager.class);
+        org.mockito.Mockito.when(mockedOptionsManager.getSfOptions())
+                .thenThrow(new SessionNotCreatedException(
+                        "Could not create a session: The Safari instance is already paired with another WebDriver session."))
+                .thenReturn(new SafariOptions());
+
+        Field optionsManagerField = DriverFactoryHelper.class.getDeclaredField("optionsManager");
+        optionsManagerField.setAccessible(true);
+        optionsManagerField.set(helper, mockedOptionsManager);
+
+        Method createNewLocalDriverInstance = DriverFactoryHelper.class.getDeclaredMethod(
+                "createNewLocalDriverInstance", com.shaft.driver.DriverFactory.DriverType.class, int.class);
+        createNewLocalDriverInstance.setAccessible(true);
+
+        try (MockedConstruction<TerminalActions> ignoredTerminal = org.mockito.Mockito.mockConstruction(TerminalActions.class);
+             MockedConstruction<SafariDriver> ignoredSafari = org.mockito.Mockito.mockConstruction(SafariDriver.class)) {
+            createNewLocalDriverInstance.invoke(helper, com.shaft.driver.DriverFactory.DriverType.SAFARI, 1);
+
+            SHAFT.Validations.assertThat().object(helper.getDriver()).isNotNull().perform();
+            org.mockito.Mockito.verify(mockedOptionsManager, org.mockito.Mockito.times(2)).getSfOptions();
+            org.mockito.Mockito.verify(ignoredTerminal.constructed().get(0))
+                    .performTerminalCommands(org.mockito.ArgumentMatchers.anyList());
         }
     }
 


### PR DESCRIPTION
## Summary

- `DriverFactoryHelper.createNewLocalDriverInstance`'s "already paired" recovery branch for local Safari killed any lingering `Safari`/`SafariDriver` processes, then **unconditionally set `shouldRetry = false`** right after — so the recovery it just performed was thrown away and the caller failed with the very error the recovery had just cleared.
- Removed the `shouldRetry = false` override, restoring the pre-#2914 behavior: retry (bounded by the existing per-attempt retry budget/backoff) after the stale pairing is cleared.

Closes #1548

## Root cause (verified from code + git history, file:line evidence)

`safaridriver` permits exactly one active WebDriver session system-wide. When a stale session is still paired, `createNewLocalDriverInstance` already had a recognized recovery path for this exact message:

`shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java:1008-1020` (before this PR):
```java
} else if (message != null && message.contains("The Safari instance is already paired with another WebDriver session.")) {
    //this issue happens when running locally via safari/mac platform
    // attempting blind fix by trying to quit existing safari instances if any
    try {
        SHAFT.CLI.terminal().performTerminalCommands(Arrays.asList(
                "osascript -e 'quit app \"Safari\"'", "osascript -e 'quit app \"SafariDriver\"'",
                "pkill -x Safari", "pkill -x SafariDriver",
                "killall Safari", "killall SafariDriver"));
        //minimizing retry attempts to save execution time
        shouldRetry = false;
    } catch (Throwable throwable) {
        ReportManagerHelper.logDiscrete(throwable, Level.DEBUG);
    }
```
`shouldRetry` starting false skips straight to `failAction("Failed to create new Browser Session", ...)` at `DriverFactoryHelper.java:1052` — reproducing exactly the issue's stack trace (`createNewLocalDriverInstance` -> `failAction` -> `AssertionError`).

Confirmed via `git log -L` that before PR #2914 (`d951e2a5c1`, "Improve browser session initialization diagnostics and CI performance") this branch did **not** disable retry — it fell through into the shared recursive retry logic (`retryAttempts > 0`), so a fresh `SafariDriver` construction was always attempted after the kill commands. PR #2914 rewrote the method into an explicit per-branch `shouldRetry` boolean and, only for this Safari branch, hard-coded it `false` with the comment "minimizing retry attempts to save execution time" — a regression: without a retry, killing the stale process accomplishes nothing observable to the caller.

### Adjacent lead ruled out with evidence

The issue named `RemoteGridPreflightUnitTest.beforeSessionShouldThrottleConcurrentLocalSessionCreationToMatchingGridCapacity`'s throttle as a lead. Verified this does **not** apply here:
- `RemoteGridPreflight.beforeSession(...)` has exactly one call site: `DriverFactoryHelper.java:1201`, inside `createNewRemoteDriverInstance` (the *remote* Selenium Grid path).
- Local driver creation (`createNewLocalDriverInstance`, `DriverFactoryHelper.java:922`, where the Safari "already paired" error actually originates) never calls `RemoteGridPreflight` at all.
- So the throttle is fully exempt for local Safari — it isn't "sized wrongly," it's simply never in the loop.
- Actual concurrent-construction protection for local drivers comes from the `static synchronized(LOCAL_DRIVER_INITIALIZATION_LOCK)` block in `runWithLocalDriverInitializationLock` (`DriverFactoryHelper.java:916-920`), which serializes `new SafariDriver(...)` calls JVM-wide across parallel TestNG threads. That part already works as intended and needed no change.

## Adjacent finding filed separately (not folded into this PR)

While investigating, confirmed `RemoteGridPreflightUnitTest.beforeSessionShouldThrottleConcurrentLocalSessionCreationToMatchingGridCapacity` genuinely failed on unrelated PR #4019 (a `shaft-mcp/pom.xml`-only diff) — attempt 1 of run 30175905867, job [89724536704](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30175905867/job/89724536704), `AssertionError ... expected false, but found true` at `RemoteGridPreflightUnitTest.java:92`. As shown above, the throttle this test exercises is unrelated to local Safari / #1548, so this is a **distinct** flaky-test defect (test's own timing assumption racing its embedded fake grid `HttpServer`, not a #1548 mechanism). Filed as #4040 with the evidence and a working hypothesis; not fixed here.

## What is verified here (this session, Windows, no macOS/Safari available)

- **RED**: added `DriverFactoryHelperCoverageUnitTest.createNewLocalDriverInstanceShouldRetryLocalSafariSessionAfterRecoveringFromPairingConflict`, which mocks `OptionsManager.getSfOptions()` to throw the exact `SessionNotCreatedException` message from the issue on the first call and succeed on the second, with `TerminalActions` construction mocked out (no real OS commands run). Watched it fail red against the pre-fix code with the exact `failAction` trace from the issue (`Driver Factory Action "createNewLocalDriverInstance" failed ... already paired ...`, `DriverFactoryHelper.java:1052`).
- **GREEN**: after removing `shouldRetry = false`, watched the same test pass (`attempt 2/2` in the log), confirming the retry now happens and reaches a working local Safari session per the code path's own logic.
- Full regression pass: `DriverFactoryHelperCoverageUnitTest`, `DriverFactoryHelperAugmentationUnitTest`, `DriverFactoryHelperStorageStateUnitTest`, `RemoteGridPreflightUnitTest`, `DriverFactoryHelperUnitTest`, `DriverFactoryHelperAdditionalUnitTest` — 92/92 passed, 0 failures (confirmed via fresh `testng-results.xml`, all 6 target classes present).
- `mvn -pl shaft-engine test-compile` — `BUILD SUCCESS`, no new warnings introduced by this change.

Commands run (all headless, scoped, no full-module `mvn test`):
```
mvn -pl shaft-engine test -Dtest=DriverFactoryHelperCoverageUnitTest#createNewLocalDriverInstanceShouldRetryLocalSafariSessionAfterRecoveringFromPairingConflict -DheadlessExecution=true -Dallure.automaticallyOpen=false
mvn -pl shaft-engine test -Dtest=DriverFactoryHelperCoverageUnitTest,DriverFactoryHelperAugmentationUnitTest,DriverFactoryHelperStorageStateUnitTest,RemoteGridPreflightUnitTest,DriverFactoryHelperUnitTest,DriverFactoryHelperAdditionalUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false
mvn -pl shaft-engine test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false
```

## What is NOT verified here — explicitly unverified until the next macOS nightly (`MacOSX_Safari_Local`)

**This is a Windows machine; Safari/`safaridriver` cannot run here. Nothing below was observed directly — treat as hypothesis, not fact, until the nightly confirms it:**

1. That `osascript`/`pkill`/`killall` against real `Safari`/`SafariDriver` processes on macOS actually clears the OS-level pairing in practice (the unit test mocks this call away entirely).
2. That a real retried `new SafariDriver(...)` construction succeeds once the pairing is cleared (the unit test only proves the *code path* retries and that the second construction attempt is reached — it uses a mocked `SafariDriver`, not a real browser session).
3. Whether this was the **only** contributing mechanism. The issue's own diagnostic comment also raised a second, unruled-out hypothesis: an earlier test in the same run leaking its own Safari session by never reaching `driver.quit()` (framework-level teardown is a test-authoring responsibility SHAFT can't force; no shutdown-hook safety net exists for this today, confirmed by `rg` — out of scope for this fix per the tight scope given). If that mechanism is *also* active in a given nightly run, this fix alone will not fully eliminate `MacOSX_Safari_Local` failures.
4. The nightly's own diagnostic comment notes a large, separate `OutOfMemoryError` cascade (#3930/#3942) that was dominating recent logs and may mask or interact with this failure mode. Not addressed here.

**Bottom line:** the retry-abandonment bug is real, reproduced, and fixed with a green unit test proving the *logic* now retries as intended. Whether that's sufficient to close out `MacOSX_Safari_Local` failures in #3987 can only be confirmed by watching the next nightly run.

## Scope

Touched only `DriverFactoryHelper.java`'s Safari recovery branch and its regression test. No workflow files touched (per instruction, another agent owns `.github/workflows/`). No tests skipped/quarantined/disabled.
