### PR TITLE
Enforce POM in generated code + flip SMART_LOCATOR severity to ERROR

### DIFF
--- a/modular-era-feature-catalog.md
+++ b/modular-era-feature-catalog.md
@@ -243,8 +243,10 @@ The recorder/codegen handoff is now a three-iteration coding-partner loop before
 any source edit: plan the working set and user steps, reuse the recommended Java
 owner and insertion anchor, avoid duplicate locators/actions/classes, prove
 missing browser steps, inspect the patch preview, collect evidence, then verify
-locally. Generated code uses Smart Locators and the SHAFT locator builder before
-native `By.xpath(...)`; it must not emit `SHAFT.GUI.Locator.xpath(...)`.
+locally. Generated code uses the SHAFT locator builder's ARIA-role locators
+(`hasRole(...)`) first, native `By.xpath(...)` only as a fallback when no
+ARIA role exists; it must not emit `SHAFT.GUI.Locator.xpath(...)` or a Smart
+Locator (`inputField`/`clickableField`).
 
 The public entry point is IntelliJ, not raw MCP: Assistant `/partner` and Guided
 `Plan coding partner` gather the IDE context, then MCP returns the reuse plan,
@@ -341,7 +343,7 @@ Use the new reactor split when you want SHAFT as a framework base, not a monolit
 | Install and run | Local installers for Codex, Claude, Claude Desktop, Copilot, Copilot IntelliJ, plus installer defaults that the IntelliJ plugin can use to find the generated stdio argfile automatically. The Marketplace plugin itself does not run installer scripts. | `py -3 scripts/mcp/install_shaft_mcp.py --client intellij-plugin --json` |
 | URL intent orientation | Open a URL, bound the DOM, rank actionable elements, return SHAFT locator code, and suggest the next MCP tools. | `driver_initialize -> browser_open_intent(targetUrl, userIntent, 200000, 10)` |
 | Coding partner plan | Summarize the current IntelliJ/user intent, rank existing Java targets, return a structured `stepPlan`, recommend a target source/anchor, list missing code, suggest MCP proof calls, and return a focused verification command. | `shaft_coding_partner_plan(repositoryPath=".", intent="login", currentSourcePath="src/test/java/...")` |
-| Locator inspection | Reuse `shaft-capture` `LocatorRanker` scoring for role, accessible name, label, test id, id, name, CSS, and XPath alternatives. | `bestLocator.strategy=ROLE; shaftLocatorCode=SHAFT.GUI.Locator.clickableField("Sign in")` |
+| Locator inspection | Reuse `shaft-capture` `LocatorRanker` scoring for role, accessible name, label, test id, id, name, CSS, and XPath alternatives. | `bestLocator.strategy=ROLE; shaftLocatorCode=SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Sign in").build()` |
 | Capture review blocks | Return setup prerequisites, assertion suggestions, locator alternatives, action sequences, locator-confidence queues, validation back-links, and control-flow review notes as additive MCP code blocks after generation. | `capture_code_blocks`, `capture_record_at_target_code_blocks` |
 | Semantic actions | Combine guide search, scenario catalog, guardrail checks, and `natural_act` without leaving the MCP session. | `shaft_guide_search`, `test_automation_scenarios`, `test_code_guardrails_check`, `natural_act` |
 | Playwright MCP and CLI parity | Official Playwright MCP/CLI can be used as a delegated exploration sidecar for accessibility snapshots, browser commands, network/storage/devtools, codegen, and Test Agent planning; SHAFT converts the proven behavior into Java Page Objects, Capture sessions, Doctor/Heal evidence, and `SHAFT.GUI.Playwright` or WebDriver code. | `test_automation_scenarios(area="playwright")`, `capture_codegen_features`, `capture generate --backend playwright` |
@@ -356,7 +358,7 @@ browser_open_intent(
 )
 
 orientation.elements[0].bestLocator.strategy=ROLE
-orientation.elements[0].shaftLocatorCode=SHAFT.GUI.Locator.clickableField("Sign in")
+orientation.elements[0].shaftLocatorCode=SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Sign in").build()
 nextTools=[browser_get_page_dom, browser_take_screenshot, shaft_guide_search, element_click, natural_act, capture_start, capture_code_blocks, test_code_guardrails_check]
 ```
 
@@ -478,7 +480,7 @@ Load current shaft-capture-recorder.js into a local fixture page.
 Type email, select plan, type notes, toggle terms, submit.
 Capture overlay state: RISKY | 8 events | Step 8 needs a follow-up assertion after form submission.
 Step inspector: edit, delete, move up/down, or add a visible assertion from the captured target.
-Generated replay syntax: driver.element().click(SHAFT.GUI.Locator.inputField("Username"));
+Generated replay syntax: driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasAttribute("name", "Username").build());
 ```
 
 <table>

--- a/shaft-mcp/src/main/java/com/shaft/mcp/TestAutomationService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/TestAutomationService.java
@@ -21,6 +21,10 @@ public class TestAutomationService {
             "\\bSHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.\\s*xpath\\s*\\(");
     private static final Pattern SMART_LOCATOR = Pattern.compile(
             "\\bSHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.\\s*(?:clickableField|inputField)\\s*\\(");
+    private static final Pattern CLASS_BOUNDARY = Pattern.compile("\\bclass\\s+\\w+");
+    private static final Pattern TEST_ANNOTATION = Pattern.compile("@Test\\b");
+    private static final Pattern LOCATOR_DECLARATION = Pattern.compile(
+            "\\bBy\\s+\\w+\\s*=\\s*(?:SHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.|By\\s*\\.\\s*xpath\\s*\\()");
     private static final Pattern BY_XPATH = Pattern.compile("\\bBy\\s*\\.\\s*xpath\\s*\\(\\s*\"((?:\\\\.|[^\"\\\\])*)\"");
     private static final Pattern PAGE_FACTORY = Pattern.compile("(?:@FindBy\\b|\\bPageFactory\\b)");
     private static final Pattern IMPLICIT_WAIT = Pattern.compile(
@@ -58,6 +62,9 @@ public class TestAutomationService {
     private static final String NO_HARDCODED_SECRET = "Do not hard-code obvious header, token, or password secrets.";
     private static final String NO_SMART_LOCATOR = "Avoid generating SHAFT.GUI.Locator.clickableField/inputField"
             + " (intent-based smart locators); prefer role-based locators or the SHAFT locator builder instead.";
+    private static final String NO_POM_VIOLATION = "Do not declare locators (SHAFT.GUI.Locator.* or By.xpath) inside a"
+            + " class that also has @Test methods; move locators/actions into a Page Object class and keep"
+            + " orchestration in the test.";
     private static final List<String> GUIDANCE_RULES = List.of(
             "Call shaft_guide_search before writing SHAFT API, GUI, mobile, CLI, DB, or troubleshooting code.",
             "Keep MCP as guidance and inspection; the calling agent writes repository files and runs validation.",
@@ -146,7 +153,8 @@ public class TestAutomationService {
         List<McpCodeGuardrailViolation> violations = new ArrayList<>();
         addThreadSleepViolations(source, violations);
         addShaftLocatorXpathViolations(source, violations);
-        addSmartLocatorWarnings(source, violations);
+        addSmartLocatorViolations(source, violations);
+        addPageObjectModelViolations(source, violations);
         addAbsoluteXpathViolations(source, violations);
         addPageFactoryWarnings(source, violations);
         addImplicitWaitWarnings(source, violations);
@@ -175,8 +183,35 @@ public class TestAutomationService {
                 NO_SHAFT_LOCATOR_XPATH);
     }
 
-    private static void addSmartLocatorWarnings(String source, List<McpCodeGuardrailViolation> violations) {
-        addPatternViolations(source, violations, SMART_LOCATOR, "SMART_LOCATOR", "WARNING", NO_SMART_LOCATOR);
+    private static void addSmartLocatorViolations(String source, List<McpCodeGuardrailViolation> violations) {
+        addPatternViolations(source, violations, SMART_LOCATOR, "SMART_LOCATOR", "ERROR", NO_SMART_LOCATOR);
+    }
+
+    private static void addPageObjectModelViolations(String source, List<McpCodeGuardrailViolation> violations) {
+        List<Integer> boundaries = classBoundaries(source);
+        for (int i = 0; i < boundaries.size() - 1; i++) {
+            int start = boundaries.get(i);
+            String classBody = source.substring(start, boundaries.get(i + 1));
+            Matcher locatorMatcher = LOCATOR_DECLARATION.matcher(classBody);
+            if (!locatorMatcher.find() || !TEST_ANNOTATION.matcher(classBody).find()) {
+                continue;
+            }
+            int offset = start + locatorMatcher.start();
+            if (isCommentOnlyLine(source, offset)) {
+                continue;
+            }
+            violations.add(violation("POM_VIOLATION", "ERROR", NO_POM_VIOLATION, source, offset));
+        }
+    }
+
+    private static List<Integer> classBoundaries(String source) {
+        List<Integer> boundaries = new ArrayList<>();
+        Matcher classMatcher = CLASS_BOUNDARY.matcher(source);
+        while (classMatcher.find()) {
+            boundaries.add(classMatcher.start());
+        }
+        boundaries.add(source.length());
+        return boundaries;
     }
 
     private static void addAbsoluteXpathViolations(String source, List<McpCodeGuardrailViolation> violations) {

--- a/shaft-mcp/src/test/java/com/shaft/mcp/TestAutomationServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/TestAutomationServiceTest.java
@@ -220,7 +220,7 @@ class TestAutomationServiceTest {
     }
 
     @Test
-    void guardrailWarnsOnIntentBasedSmartLocatorUsage() {
+    void guardrailRejectsIntentBasedSmartLocatorUsage() {
         McpCodeGuardrailResult result = service.checkGeneratedCode("java", """
                 import com.shaft.driver.SHAFT;
                 import org.openqa.selenium.By;
@@ -231,10 +231,65 @@ class TestAutomationServiceTest {
                 }
                 """);
 
+        assertFalse(result.passed());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("SMART_LOCATOR")
+                && violation.severity().equals("ERROR") && violation.line() == 5));
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("SMART_LOCATOR")
+                && violation.severity().equals("ERROR") && violation.line() == 6));
+    }
+
+    @Test
+    void guardrailRejectsLocatorDeclaredInsideTestAnnotatedClass() {
+        McpCodeGuardrailResult result = service.checkGeneratedCode("java", """
+                import com.shaft.driver.SHAFT;
+                import com.shaft.gui.internal.locator.Role;
+                import org.openqa.selenium.By;
+                import org.testng.annotations.Test;
+
+                class CheckoutTest {
+                    private final By checkoutButton = SHAFT.GUI.Locator.hasRole(Role.BUTTON)
+                            .hasText("Checkout").build();
+
+                    @Test
+                    void checkout(SHAFT.GUI.WebDriver driver) {
+                        driver.element().click(checkoutButton);
+                    }
+                }
+                """);
+
+        assertFalse(result.passed());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("POM_VIOLATION")
+                && violation.severity().equals("ERROR")));
+    }
+
+    @Test
+    void guardrailAllowsLocatorsDeclaredInSeparatePageObjectFromTestClass() {
+        McpCodeGuardrailResult result = service.checkGeneratedCode("java", """
+                import com.shaft.driver.SHAFT;
+                import com.shaft.gui.internal.locator.Role;
+                import org.openqa.selenium.By;
+                import org.testng.annotations.Test;
+
+                public final class LoginPage {
+                    private final By email = SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build();
+                    private final By submit = SHAFT.GUI.Locator.hasRole(Role.BUTTON).build();
+
+                    public LoginPage login(SHAFT.GUI.WebDriver driver, String user, String password) {
+                        driver.element().type(email, user);
+                        driver.element().click(submit);
+                        return this;
+                    }
+                }
+
+                class LoginTest {
+                    @Test
+                    void login(SHAFT.GUI.WebDriver driver) {
+                        new LoginPage(driver).login(driver, "user@example.com", "secret123");
+                    }
+                }
+                """);
+
         assertTrue(result.passed());
-        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("SMART_LOCATOR")
-                && violation.severity().equals("WARNING") && violation.line() == 5));
-        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("SMART_LOCATOR")
-                && violation.severity().equals("WARNING") && violation.line() == 6));
+        assertTrue(result.violations().stream().noneMatch(violation -> violation.kind().equals("POM_VIOLATION")));
     }
 }


### PR DESCRIPTION
## Summary

- Flips the `SMART_LOCATOR` guardrail (`shaft-mcp` `test_code_guardrails_check`) from `WARNING` to `ERROR`, per owner policy that generated code must never use a Smart Locator (`SHAFT.GUI.Locator.inputField/clickableField`).
- Adds a new `POM_VIOLATION` guardrail (`ERROR`) that flags a class declaring a `By` locator (`SHAFT.GUI.Locator.*` or `By.xpath(...)`) alongside `@Test` methods in the same class body — the originally reported "codegen ignores POM" symptom, where the generator collapses locators and test orchestration into one flat class instead of separating a Page Object.
- Fixes four stale examples in `modular-era-feature-catalog.md` that still showed Smart Locator (`inputField`/`clickableField`) as the "generated"/replay locator output, contradicting the ARIA-role-first policy PR #4031 already reconciled across `shaft-skills/`.

Closes #4028 (subtask of #4024, unblocked now that #4030/PR #4031 merged).

## Two corrections to the ticket text

1. The ticket cites `.claude/skills/choosing-shaft-locators/SKILL.md`, which does not exist. The real file is `shaft-skills/choosing-shaft-locators/SKILL.md`; no new file was created.
2. The ticket's acceptance criterion "guidance no longer recommends [Smart Locator]" was already satisfied by PR #4031's two-rung ladder. I re-verified the corpus myself and found one surviving contradiction outside the files #4031 touched — `modular-era-feature-catalog.md` (a top-level feature catalog, not one of the six skill files #4031 reconciled) still showed Smart Locator calls as example "generated"/"replay" output in four places. Fixed as in-scope per the ticket's own instruction to fix any surviving corner.

## What ERROR severity actually does downstream

- `TestAutomationService.checkGeneratedCode` (`shaft-mcp/src/main/java/com/shaft/mcp/TestAutomationService.java:160`): `passed = violations.stream().noneMatch(v -> "ERROR".equals(v.severity()))`. Flipping SMART_LOCATOR to ERROR flips `passed` from `true` to `false` whenever Smart Locator is present — this is a real, observable behavior change to the `test_code_guardrails_check` MCP tool's result.
- `AutobotService.guardrailStatus` (`shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java:307-323`) calls this same check on Autobot-generated code blocks and turns the result into a `"PASSED"` / `"VIOLATIONS: N error(s)"` string on `AutobotProviderChatResponse.guardrailStatus`.
- That field is **purely informational** in the one place it is consumed: `shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java:361-363` renders it as a `**Guardrails:** <status>` line in the chat transcript. It does not block insertion, does not fail a Maven build, and does not prevent codegen output — there is no gate anywhere in the repo that refuses to write/apply code because `checkGeneratedCode` returned `passed=false`. **The ERROR severity is enforcement in the sense that the calling agent is now told "this failed" instead of "this is fine, here's a note" — but nothing currently forces the agent to act on it.** I'm reporting this plainly per the task's own instruction rather than claiming the policy is now mechanically enforced.
- The actual code generators (`CaptureGenerator.locatorCode`, `BrowserService`'s equivalent, `PickedLocatorSnippetBuilder`) already never emit `clickableField`/`inputField` — confirmed by reading their switch-based locator rendering and an explicit "never generated here" comment at `shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java:1383-1386`. So the severity flip does not newly break any real generator output; it only changes what the guardrail *tool* reports.
- One legacy exception found and deliberately left untouched: `PlaywrightService.semanticClickableLocator`/`semanticInputLocator` (`shaft-mcp/src/main/java/com/shaft/mcp/PlaywrightService.java:745-750`) still call Smart Locator APIs, but only to replay pre-existing recordings made before the `click_semantic`/`type_semantic` tools were removed; the code has an explicit comment stating they are "not reachable from any current tool." Out of scope for this ticket.

## How the POM rule is enforced and what it rejects

Since "ignores POM" needed a concrete definition: I traced the actual generator (`CaptureGenerator`, 2783 lines) and found it has **no Page Object concept at all** — it emits one flat class with `By` locator fields and `@Test` methods together. A separate, optional "Page Object draft" block already exists (`McpCaptureCodeBlockService.pageObjectDraftBlock`) but it's advisory, not enforced.

Per the tracker's sequencing note, `CaptureGenerator`'s locator-emission path is owned by sequential subtasks #4026/#4027/#4029, so I did not touch it (per this ticket's own instruction to stop and check first if the POM rule required changes there). Instead I added a new lexical guardrail in `TestAutomationService` — the same enforcement point already used for `PAGE_FACTORY`, `RAW_FIND_ELEMENT`, etc. — following that file's existing per-class-boundary-free lexical pattern:

- New `POM_VIOLATION` (ERROR) check (`TestAutomationService.java:187-211`): splits submitted source into class-boundary chunks (textual split on `\bclass\s+\w+`, matching how `AutobotService` already concatenates all generated code blocks into one string before checking), then flags any chunk that contains both a `@Test` annotation and a `By` locator declaration built through `SHAFT.GUI.Locator.*` or `By.xpath(...)`.
- This rejects the exact `CaptureGenerator`-shaped anti-pattern (locators + `@Test` in one class) while allowing the correct POM shape (locators in a separate Page Object class, `@Test` class calling into it) — verified by the two new tests below.
- This is a judgment call on my part (kind name, severity, and detection shape weren't specified in the ticket) — flagging it explicitly in case the severity/shape should be revisited.

## Hard constraint: no test weakened

- `guardrailWarnsOnIntentBasedSmartLocatorUsage` renamed to `guardrailRejectsIntentBasedSmartLocatorUsage` and its assertions changed from `assertTrue(result.passed())`/`"WARNING"` to `assertFalse(result.passed())`/`"ERROR"` — this is the test whose whole purpose is verifying SMART_LOCATOR detection; only the severity expectation changed, matching the ticket's explicit intent.
- Two new tests added (TDD, watched RED then GREEN): `guardrailRejectsLocatorDeclaredInsideTestAnnotatedClass` and `guardrailAllowsLocatorsDeclaredInSeparatePageObjectFromTestClass`.
- No existing test was deleted, disabled, or loosened.

## Verification (real command output)

```
mvn -pl shaft-mcp test -Dtest=TestAutomationServiceTest -DheadlessExecution=true "-Dallure.automaticallyOpen=false"
...
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

RED was watched first: before implementation, `guardrailRejectsIntentBasedSmartLocatorUsage` and `guardrailRejectsLocatorDeclaredInsideTestAnnotatedClass` failed with `expected: <false> but was: <true>` (SMART_LOCATOR still WARNING, POM_VIOLATION not implemented) while the other 10 tests passed.

Full module regression:

```
mvn -pl shaft-mcp test -DheadlessExecution=true "-Dallure.automaticallyOpen=false"
...
Tests run: 477, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

This includes `AutobotServiceTest` (guardrailStatus PASSED/VIOLATIONS behavior), confirming no collateral breakage anywhere else in `shaft-mcp`.

## Not touched (per explicit constraints)

- `shaft-capture/src/main/resources/browser/shaft-capture-recorder.js` (owned by PR #4035 / #4025).
- `.github/workflows/`.
- `CaptureGenerator`'s locator-emission path (owned by sequential #4026/#4027/#4029) — confirmed not required for this ticket's scope.
