### PR TITLE
Fix #4032: drop appium_flutterfinder_java dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <webdrivermanager.version>6.3.4</webdrivermanager.version>
         <aspectj.version>1.9.25.1</aspectj.version>
         <commons.csv.version>1.14.1</commons.csv.version>
-        <appium.flutterfinder.version>1.0.14</appium.flutterfinder.version>
         <sikulix.version>2.0.5</sikulix.version>
         <jython.slim.version>2.7.4</jython.slim.version>
         <tess4j.version>5.19.0</tess4j.version>

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -123,34 +123,6 @@
             </exclusions>
         </dependency>
 
-        <!-- APPIUM FLUTTER FINDER (DEPRECATED, see #4016)
-             Deprecated as of 10.3.20260726: its unexcluded java-client edge has already caused
-             two Maven Central delivery failures (open selenium ranges resolving against live
-             Central metadata instead of our BOM pins; see
-             .memory/memory/gotchas/appium-java-client-hard-selenium-version-ranges-beat-bom-pins.md).
-             java-client 10.1.1+ ships a native Flutter surface (AppiumBy flutter* locators,
-             FlutterIntegrationTestDriver) that replaces it; see the migrated
-             shaft-engine/src/test/java/testPackage/appium/FlutterTest.java for the equivalent
-             native locators. Still declared at compile scope to preserve the public classpath
-             during the deprecation window (AGENTS.md: "Preserve public API; deprecate before
-             removal"); tracked for demotion/removal in #4032. -->
-        <dependency>
-            <groupId>io.github.ashwithpoojary98</groupId>
-            <artifactId>appium_flutterfinder_java</artifactId>
-            <version>${appium.flutterfinder.version}</version>
-            <exclusions>
-                <!-- java-client declares open selenium ranges ([4.42.0, 5.0)); through this
-                     unexcluded path they resolve against live Central metadata, so a new
-                     Selenium release silently mixes versions on the classpath (10.3.20260722
-                     delivery failed on 4.46-compiled bytecode vs pinned 4.45 runtime).
-                     The direct java-client dependency above already prunes its selenium edges. -->
-                <exclusion>
-                    <groupId>io.appium</groupId>
-                    <artifactId>java-client</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- WEBDRIVER MANAGER -->
         <dependency>
             <groupId>io.github.bonigarcia</groupId>


### PR DESCRIPTION
## Summary
- Drops `io.github.ashwithpoojary98:appium_flutterfinder_java` entirely from `shaft-engine/pom.xml` (and its version property from the root `pom.xml`), per the owner's decision on #4016 ("Migrate and remove without deprecation").
- Removes the now-orphaned deprecation comment block that referenced this ticket.
- The migration half already landed in #4033 (`FlutterTest.java` uses native `AppiumBy.flutter*` / `FlutterIntegrationTestDriver`); this PR is the removal half (#4032, option 2 in the ticket: drop entirely).

## Verification
- `rg -n 'ashwith|FlutterFinder|flutterfinder'` across all modules (main + test sources, all poms): zero remaining consumers after removal, only this diff's own commit message / memory gotcha file mention it historically.
- `gh issue list --state all --search "FlutterFinder"` / `gh search issues --repo ShaftHQ/SHAFT_ENGINE FlutterFinder`: no downstream reliance reports, only #4032/#4016/#4001 (the tracked issues themselves).
- `mvn -pl shaft-engine compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false` -> BUILD SUCCESS (231 main + 344 test source files compiled, including `FlutterTest.java`).
- `mvn -pl shaft-engine package -DskipTests -DheadlessExecution=true -Dallure.automaticallyOpen=false` -> BUILD SUCCESS, jar built.
- `mvn -pl shaft-engine dependency:tree -Dincludes=org.seleniumhq.selenium,io.appium` on this branch vs `origin/main`: **identical** (`org.seleniumhq.selenium:selenium-java:4.46.0`, `io.appium:java-client:10.1.1`). No version shift, since the flutterfinder -> java-client edge was already excluded in the old pom.

## Why this matters
Eliminates the supply-chain risk noted in #4016/#4032: this dependency's unexcluded `java-client` edge previously caused two Maven Central delivery failures (open Selenium version ranges beating BOM pins). See `.memory/memory/gotchas/appium-java-client-hard-selenium-version-ranges-beat-bom-pins.md`.

## Test plan
- [x] `mvn -pl shaft-engine compile test-compile` green
- [x] `mvn -pl shaft-engine package -DskipTests` green
- [x] Dependency-tree diff vs `origin/main` shows no unexpected shift
- [ ] CI (pr-gate, release validators) green

Closes #4032
Ref #4016

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWzHNJ2qYHfFDQy1ve1G1w