### PR TITLE
Fix #4040: propagate throttle-test properties onto the background thread

### DIFF
--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflightUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/RemoteGridPreflightUnitTest.java
@@ -87,7 +87,19 @@ public class RemoteGridPreflightUnitTest {
         var executor = Executors.newSingleThreadExecutor();
         try (MockedStatic<ReportManagerHelper> ignored = Mockito.mockStatic(ReportManagerHelper.class);
              var firstPermit = RemoteGridPreflight.beforeSession(gridUrl(server), chromeCapabilities())) {
-            var secondPermit = executor.submit(() -> RemoteGridPreflight.beforeSession(gridUrl(server), chromeCapabilities()));
+            // SHAFT.Properties overrides are thread-local by design (Properties.java), so the
+            // background thread must set its own copy of the same overrides before calling
+            // beforeSession -- exactly as a real parallel test-execution thread would configure
+            // itself. Without this, the pooled thread reads the global defaults
+            // (remotePreflightEnabled=false), short-circuits to a no-op permit, and the Future
+            // can complete before the isDone() check below ever samples it (#4040).
+            var secondPermit = executor.submit(() -> {
+                SHAFT.Properties.platform.set()
+                        .remotePreflightEnabled(true)
+                        .remoteAdaptiveSessionThrottling(true)
+                        .remotePreflightTimeoutSeconds(1);
+                return RemoteGridPreflight.beforeSession(gridUrl(server), chromeCapabilities());
+            });
 
             SHAFT.Validations.assertThat().object(secondPermit.isDone()).isEqualTo(false).perform();
             firstPermit.close();


### PR DESCRIPTION
## Summary
- `RemoteGridPreflightUnitTest.beforeSessionShouldThrottleConcurrentLocalSessionCreationToMatchingGridCapacity` was intermittently flaky (~2% observed, matches #4040's CI evidence).
- Root cause: the test submits its second `RemoteGridPreflight.beforeSession(...)` call to a pooled background thread, but never sets `SHAFT.Properties.platform` overrides on that thread. `SHAFT.Properties` overrides are explicitly thread-local by design (see `Properties.java`'s own javadoc: "only that thread's config is updated"), so the background thread read the JVM-wide defaults (`remotePreflightEnabled=false`), took the immediate no-op-permit path, and its `Future` occasionally completed before the main thread's `isDone()==false` assertion sampled it.
- Fix: the background task now sets the same properties on its own thread before calling `beforeSession`, mirroring how a real parallel test-execution thread configures itself before creating a session (see `DriverFactoryHelper.java:1201`, where `beforeSession` always runs on the same thread that already configured its own properties).

## Reproduction
- Temporarily added `invocationCount = 50` to the test method and ran it in a single scoped, headless, forked Maven JVM: `mvn -pl shaft-engine -Dtest=RemoteGridPreflightUnitTest#beforeSessionShouldThrottleConcurrentLocalSessionCreationToMatchingGridCapacity -DheadlessExecution=true -Dallure.automaticallyOpen=false test`
- Reproduced twice: 1/50 failure each time, both on the very first invocation, with the same `expected false, but found true` assertion at line 92.
- Instrumented `RemoteGridPreflight.beforeSession` temporarily to print the calling thread's `remotePreflightEnabled()` value; confirmed the pooled background thread (`pool-N-thread-1`) saw `enabled=false` on **every** invocation -- the flake was purely a timing race between how fast that always-no-op call returned and how fast the main thread's assertion sampled the `Future`, not an intermittent exception.
- All instrumentation reverted before committing; only the real fix remains.

## Before / after (same 50-iteration loop, same forked JVM)
- Before fix: 1/50 failures (run 1), reproduced twice.
- After fix: 50/50 passed, then another 50/50 passed (100/100 total).
- Full class (`-Dtest=RemoteGridPreflightUnitTest`, 3 tests) also green.

## Test plan
- [x] `mvn -pl shaft-engine -Dtest=RemoteGridPreflightUnitTest#beforeSessionShouldThrottleConcurrentLocalSessionCreationToMatchingGridCapacity -DheadlessExecution=true -Dallure.automaticallyOpen=false test` -- green (single run)
- [x] Same command with a temporary `invocationCount=50` -- 50/50 and 50/50 green post-fix (reverted before commit)
- [x] `mvn -pl shaft-engine -Dtest=RemoteGridPreflightUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false test` -- 3/3 green

Closes #4040

https://claude.ai/code/session_01FWzHNJ2qYHfFDQy1ve1G1w