### PR TITLE
Fix #4002: HealingManager opts out of AppiumBy.FlutterBy locators

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/healing/HealingManager.java
@@ -3,6 +3,7 @@ package com.shaft.gui.internal.healing;
 import com.shaft.gui.internal.locator.LocatorHealthReporter;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.ReportManagerHelper;
+import io.appium.java_client.AppiumBy;
 import org.apache.logging.log4j.Level;
 import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -49,6 +50,16 @@ public final class HealingManager {
             By shadowHostLocator,
             By shadowContentLocator) {
         if (!HealingStrategy.current().usesShaftHeal() || !isApplicable(action)) {
+            return Optional.empty();
+        }
+        if (locator instanceof AppiumBy.FlutterBy) {
+            // Issue #4002: FlutterBy locators address Flutter's own widget tree via the
+            // "-flutter *" strategies, which has no representation in the native page
+            // source. Alternatives derived from native page source are wrong by
+            // construction, so healing must not attempt them.
+            ReportManager.logDiscrete(
+                    "SHAFT Heal does not attempt recovery for AppiumBy.FlutterBy locators: "
+                            + "native page source has no representation of the Flutter widget tree.");
             return Optional.empty();
         }
         try {

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/healing/HealingActionsIntegrationTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/healing/HealingActionsIntegrationTest.java
@@ -6,6 +6,7 @@ import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.gui.element.internal.Actions;
 import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.ReportManager;
+import io.appium.java_client.AppiumBy;
 import io.appium.java_client.AppiumDriver;
 import org.apache.logging.log4j.Level;
 import org.openqa.selenium.By;
@@ -142,6 +143,37 @@ public class HealingActionsIntegrationTest {
 
         Optional<HealingResolution> resolution = HealingManager.resolve(
                 driver, ORIGINAL, "CLICK", true, null, null, null);
+
+        Assert.assertTrue(resolution.isPresent());
+        verify(provider, atLeastOnce()).resolve(any());
+    }
+
+    @Test
+    public void flutterByLocatorShouldNeverInvokeHealingProvider() {
+        AppiumDriver driver = mock(AppiumDriver.class);
+        HealingProvider provider = mock(HealingProvider.class);
+        HealingProviderRegistry.setProviderForTesting(provider);
+        By flutterLocator = AppiumBy.flutterKey("submit-button");
+
+        Optional<HealingResolution> resolution = HealingManager.resolve(
+                driver, flutterLocator, "CLICK", true, null, null, null);
+
+        Assert.assertTrue(resolution.isEmpty());
+        verify(provider, never()).resolve(any());
+    }
+
+    @Test
+    public void nonFlutterAppiumLocatorHealingShouldRemainUnchanged() {
+        AppiumDriver driver = mock(AppiumDriver.class);
+        WebElement recovered = mock(WebElement.class);
+        HealingProvider provider = mock(HealingProvider.class);
+        when(provider.resolve(any())).thenReturn(Optional.of(
+                new HealingResolution("attempt-accessibility-id", List.of(recovered), By.id("new-id"))));
+        HealingProviderRegistry.setProviderForTesting(provider);
+        By accessibilityIdLocator = AppiumBy.accessibilityId("submit-button");
+
+        Optional<HealingResolution> resolution = HealingManager.resolve(
+                driver, accessibilityIdLocator, "CLICK", true, null, null, null);
 
         Assert.assertTrue(resolution.isPresent());
         verify(provider, atLeastOnce()).resolve(any());


### PR DESCRIPTION
## Summary
- `HealingManager.resolve(...)` now short-circuits with `Optional.empty()` when the incoming locator is `instanceof AppiumBy.FlutterBy`, logged discreetly, before any provider lookup.
- `FlutterBy` locators address Flutter's own widget tree via the `-flutter *` strategies with no representation in native page source; healing alternatives derived from native page source are wrong by construction (fail to match, or worse, match unrelated native chrome and silently drive the wrong element).

## Call-site audit (issue item 1)
`rg` for `HealingManager.resolve(` / `HealingManager.recordOutcome(` in production code (`shaft-engine/src/main`) found exactly:
- `resolve()`: `TouchActions.java:1140`, `ElementActionsHelper.java:409`, `Actions.java:1221` — three call sites.
- `recordOutcome()`: `TouchActions.java:1151`, `ElementActionsHelper.java:518`, `Actions.java:879/886/896/903` — all guarded by `if (resolution == null) return;` inside `HealingManager.recordOutcome` itself, and every one of those call sites only reaches `recordOutcome` with a `resolution` object that was itself produced by a prior `resolve()` call at that same call site.

Confirmed empirically: a single guard inside `resolve()` covers the entire surface — `recordOutcome()` needs no separate guard because it never receives a non-null resolution for a `FlutterBy` locator once `resolve()` returns empty for it. `observe()` (a fourth entry point, recording *successful original* resolutions, not proposing alternatives) is out of scope per the issue and untouched — it isn't the correctness hazard described (it never derives an alternative from native page source).

## Bytecode verification (issue's own caveat)
`javap` against the actual `java-client-10.1.1.jar` (not assumed):
```
public abstract class io.appium.java_client.AppiumBy$FlutterBy extends io.appium.java_client.AppiumBy
public class io.appium.java_client.AppiumBy$ByFlutterKey extends io.appium.java_client.AppiumBy$FlutterBy
public abstract class io.appium.java_client.AppiumBy$FlutterByHierarchy extends io.appium.java_client.AppiumBy$FlutterBy
```
`public abstract`, so `instanceof AppiumBy.FlutterBy` works without reflection, and it catches all 7 variants named in the issue (`ByFlutterKey`/`ByFlutterText`/`ByFlutterType`/`ByFlutterSemanticsLabel`/`ByFlutterTextContaining` extend `FlutterBy` directly; `flutterAncestor`/`flutterDescendant` extend `FlutterByHierarchy`, which extends `FlutterBy`).

## Tests (issue item 2), TDD watched
Both added to `HealingActionsIntegrationTest.java`:
- `flutterByLocatorShouldNeverInvokeHealingProvider` — a `FlutterBy` locator (`AppiumBy.flutterKey(...)`) produces zero healing candidates and the provider's `resolve()` is never invoked. Watched RED first: `provider.resolve()` was invoked with the Flutter locator (Mockito `NeverWantedButInvoked`).
- `nonFlutterAppiumLocatorHealingShouldRemainUnchanged` — a non-Flutter `AppiumBy` locator (`AppiumBy.accessibilityId(...)`) keeps today's behavior: resolution present, provider invoked. Passed from the start (proves the guard is Flutter-specific, not Appium-broad).

Mutation-check performed: inverted the guard to `!(locator instanceof AppiumBy.FlutterBy)`, re-ran the suite — 5 of 15 tests went red, including both new tests (`flutterByLocatorShouldNeverInvokeHealingProvider` and `nonFlutterAppiumLocatorHealingShouldRemainUnchanged`) plus 3 pre-existing non-Flutter tests. Restored the guard and re-ran — all 15 green again.

## Test plan
- [x] `mvn -pl shaft-engine test -Dtest=HealingActionsIntegrationTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` — 15/15 green
- [x] `mvn -pl shaft-engine compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false` — BUILD SUCCESS

Closes #4002

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWzHNJ2qYHfFDQy1ve1G1w