### PR TITLE
Fix #4014: pin the excludeAssets<->includeAssetTypes polarity inversion

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
@@ -1030,7 +1030,12 @@ class ManagedCaptureRecorder {
                 && options.captureRequestBodies == defaults.captureRequestBodies;
     }
 
-    private static com.shaft.capture.network.NetworkCaptureOptions translateNetworkCaptureOptions(
+    // Package-private (not private) so ManagedCaptureRecorderControlTest can pin the
+    // excludeAssets <-> includeAssetTypes polarity inversion directly; see issue #4014 --
+    // com.shaft.capture.runtime.NetworkCaptureOptions.excludeAssets (true = drop assets) and
+    // com.shaft.capture.network.NetworkCaptureOptions.includeAssetTypes (true = keep assets) are
+    // the same concept with inverted meaning, translated here by hand with no compiler guard.
+    static com.shaft.capture.network.NetworkCaptureOptions translateNetworkCaptureOptions(
             NetworkCaptureOptions options) {
         return new com.shaft.capture.network.NetworkCaptureOptions(
                 !options.excludeAssets,

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java
@@ -252,6 +252,36 @@ class ManagedCaptureRecorderControlTest {
     }
 
     @Test
+    void translateNetworkCaptureOptionsInvertsExcludeAssetsIntoIncludeAssetTypes() {
+        // Regression for issue #4014: com.shaft.capture.runtime.NetworkCaptureOptions.excludeAssets
+        // (true = drop asset requests) and com.shaft.capture.network.NetworkCaptureOptions.includeAssetTypes
+        // (true = keep asset requests) are the same concept with inverted polarity, translated by
+        // hand at ManagedCaptureRecorder.translateNetworkCaptureOptions with no compiler guard. This
+        // pins the inversion so a "simplified" (unguarded) mapping fails loudly instead of silently
+        // recording the opposite of what the caller asked for.
+        NetworkCaptureOptions excludeAssetsRequested = new NetworkCaptureOptions();
+        excludeAssetsRequested.excludeAssets = true;
+
+        com.shaft.capture.network.NetworkCaptureOptions translated =
+                ManagedCaptureRecorder.translateNetworkCaptureOptions(excludeAssetsRequested);
+
+        assertFalse(translated.includeAssetTypes(),
+                "excludeAssets=true (drop assets) must translate to includeAssetTypes=false (keep no assets)");
+    }
+
+    @Test
+    void translateNetworkCaptureOptionsKeepsAssetTypesWhenNotExcluded() {
+        NetworkCaptureOptions includeAssetsRequested = new NetworkCaptureOptions();
+        includeAssetsRequested.excludeAssets = false;
+
+        com.shaft.capture.network.NetworkCaptureOptions translated =
+                ManagedCaptureRecorder.translateNetworkCaptureOptions(includeAssetsRequested);
+
+        assertTrue(translated.includeAssetTypes(),
+                "excludeAssets=false (keep assets) must translate to includeAssetTypes=true (keep assets)");
+    }
+
+    @Test
     void filterHarByGlobKeepsOnlyEntriesWhoseUrlMatchesTheGlobAndCountsDropped() {
         String harJson = """
                 {


### PR DESCRIPTION
## Summary
- `com.shaft.capture.runtime.NetworkCaptureOptions` (mutable, MCP JSON-bound DTO) and `com.shaft.capture.network.NetworkCaptureOptions` (record, `CaptureNetworkRecorder` internals) share a simple name but are genuinely different shapes for different consumers -- confirmed both must stay separate (Spring AI binds `@Tool` params to the runtime type directly; the network type is a validated/normalized record for the recorder). No merge.
- The hazard is the one hand-written cross-type conversion, `ManagedCaptureRecorder.translateNetworkCaptureOptions` (`shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java:1033`), which inverts `excludeAssets` (true = drop assets) into `includeAssetTypes` (true = keep assets) via a bare `!` with no compiler guard and no prior test.
- Verified today's translation is correct (a **latent trap, not a live bug**) -- both cross-boundary call sites (this one, and `CaptureService#apiTransactions`'s same-type `includeAssets` -> `excludeAssets` mapping) already invert correctly. Nothing enforced that staying true.
- Added a regression test at the translation boundary and mutation-checked it: flipped the `!` to reproduce the bug, watched the new assertions fail for the flipped-polarity reason specifically, then restored and watched them pass again.
- Relaxed `translateNetworkCaptureOptions` from `private` to package-private so the same-package test can call it directly. `ManagedCaptureRecorder` itself is package-private, so this is not a public API change.

## Test plan
- [x] `mvn -pl shaft-capture test -Dtest=ManagedCaptureRecorderControlTest#translateNetworkCaptureOptionsInvertsExcludeAssetsIntoIncludeAssetTypes+translateNetworkCaptureOptionsKeepsAssetTypesWhenNotExcluded -DheadlessExecution=true -Dallure.automaticallyOpen=false -o` -- green with the correct `!`
- [x] Mutation check: removed the `!`, reran the same two tests -- both fail with "expected: <false> but was: <true>" / "expected: <true> but was: <false>", restored, reran -- green again
- [x] `mvn -pl shaft-capture test -Dtest=ManagedCaptureRecorderControlTest -DheadlessExecution=true -Dallure.automaticallyOpen=false -o` -- 14/14 green
- [x] `mvn -pl shaft-capture compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false -o` -- BUILD SUCCESS

Closes #4014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWzHNJ2qYHfFDQy1ve1G1w