### PR TITLE
Fix #4048: harvest guidance from spec-kit / humanizer / taste-skill (SHAFT_ENGINE half)

### DIFF
--- a/.claude/skills/work-github/references/playbook.md
+++ b/.claude/skills/work-github/references/playbook.md
@@ -149,6 +149,13 @@ session may open several grouped PRs, one per group of related subtasks.
   checked, close the tracking issue itself in the same session, with a final
   summary comment — don't leave it open awaiting a human close.
 
+When a tracking issue's checkbox list will be worked by more than one agent,
+suffix each line that is safe to run concurrently with `[P]` — meaning its
+file scope is disjoint from every other `[P]` line. Lines without the marker
+are sequential. This records the pre-dispatch disjoint-scope check on the line
+it applies to instead of re-deriving it per dispatch (convention adapted from
+github/spec-kit, MIT, Copyright GitHub, Inc.).
+
 ### Example `gh` invocations
 
 Open the tracking issue with a checkbox list (subtask issues don't exist yet,

--- a/.github/skills/shaft-ui-design/references/standards.txt
+++ b/.github/skills/shaft-ui-design/references/standards.txt
@@ -32,6 +32,8 @@
 - Components: icon buttons use existing icon libraries when available; familiar controls beat custom widgets.
 - Motion: purposeful and sparse; never gate visibility on animations; avoid layout-property animation; always respect `prefers-reduced-motion`.
 - Assets: prefer real product/report/docs imagery or deterministic screenshots. Do not use generated images for exact UI text, code, logos, or claims.
+- Color: never pure `#000000` or `#ffffff` for surfaces or body text; keep one accent role and let neutrals carry the rest. Accent saturation above ~80% reads as a default theme, not a choice.
+- States: every interactive surface ships focus, loading, empty, and error states. A loading state mirrors the real layout's dimensions rather than a centered spinner, so the page does not jump when content arrives.
 
 ## Unslop Rules
 
@@ -61,3 +63,7 @@ Reject and rewrite these unless the brief explicitly requires them and the choic
 - Do not hand-draw replacement glyphs in screenshot renderers or paint fake icons over components. If screenshots show blank or broken icons, fix the shared icon source (`ShaftIcons` or assets) so runtime UI and screenshots use the same real icon.
 - Preserve icon-only button shape, size, tooltip, and accessible-name behavior through `ShaftIconButtons`; do not add one-off button styling in individual panels.
 - Validate IntelliJ icon/UI changes with the smallest relevant set: `ShaftIconAssetsTest`, focused panel tests that assert icons paint visible pixels, screenshot renderer output, and visual inspection of light, dark, and narrow states.
+- Swing surfaces obey the same states and color rules as the web surfaces above: focus, loading, empty, and error states are required; one accent role; never pure black or white. The plugin-screenshot renderer is where you verify them, not a browser.
+- Keep icon stroke weight and metaphor consistent across a panel. Avoid cliche metaphors (rocket for run, shield for security) when a platform `AllIcons` entry already names the concept.
+
+Portions of the color/state rules above are re-expressed from leonxlnx/taste-skill (MIT, Copyright (c) 2026 Leonxlnx).


### PR DESCRIPTION
## Summary
- `.github/skills/shaft-ui-design/references/standards.txt`: adds a color-restraint rule and a focus/loading/empty/error states rule to the Quality Floor, plus the Swing-applicable subset of the same to the IntelliJ Plugin UI section. Re-expressed from `leonxlnx/taste-skill` (MIT, Copyright (c) 2026 Leonxlnx).
- `.claude/skills/work-github/references/playbook.md`: records the `[P]` parallel-safety task-annotation convention for tracking-issue checkboxes. Adapted from `github/spec-kit` (MIT, Copyright GitHub, Inc.).
- Both files sit outside every `agent_guidance_budget.json` glob: `guidance_bytes`/`estimated_host_tokens` are byte-identical before and after this diff. No new skill, no `AGENTS.md` change, zero always-on cost — per the approved architecture spec on #4048.

Companion PR in the docs repo carries the humanizer/taste-skill merge into `DESIGN_LANGUAGE.md` and the new CI enforcement.

## Test plan
- [x] `py -3 scripts/ci/validate_agent_setup.py --skip-external --format json` before and after: identical `guidance_bytes` (73131) and `estimated_host_tokens.claude` (2666); only the two pre-existing `memory-filename-length` errors (#3991), no new failures.
- [x] `py -3 .claude/hooks/guard.py --self-test`: 54/54 + graphify + TDD self-test suites pass.

Closes #4048

🤖 Generated with [Claude Code](https://claude.com/claude-code)