### PR TITLE
Fix #4007: force UTF-8 stdout in extract_allure_failures.py

### DIFF
--- a/scripts/ci/extract_allure_failures.py
+++ b/scripts/ci/extract_allure_failures.py
@@ -14,6 +14,7 @@ import argparse
 import base64
 import json
 import re
+import sys
 import textwrap
 import xml.etree.ElementTree as ET
 import zipfile
@@ -474,6 +475,15 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    # Windows CI runners (and any non-UTF-8 console/pipe) default sys.stdout to
+    # a codec like cp1252 that cannot encode the emoji SHAFT's own assertion
+    # output contains, crashing this script's print() with UnicodeEncodeError
+    # (#4007). Force UTF-8 so the emoji print correctly instead of being
+    # stripped or crashing. Guarded because not every stdout stand-in (e.g.
+    # io.StringIO in tests) implements reconfigure().
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
     args = parse_args()
     allure_failures = extract_failures(args.paths)
     surefire_failures = extract_surefire_failures(args.surefire_reports)

--- a/tests/scripts/test_extract_allure_failures.py
+++ b/tests/scripts/test_extract_allure_failures.py
@@ -362,6 +362,38 @@ class ExtractAllureFailuresTests(unittest.TestCase):
         self.assertIn("visible exception", markdown)
         self.assertNotIn("hidden fixture should not be counted", markdown)
 
+    def test_prints_emoji_bearing_failure_reason_without_crashing_on_non_utf8_stdout(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "failed-result.json").write_text(
+                json.dumps(
+                    {
+                        "status": "failed",
+                        "fullName": "pkg.EmojiTest.fails",
+                        "statusDetails": {
+                            "message": "❌ assertion failed \U0001f50d see \U0001f4cd trace",
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            buffer = io.BytesIO()
+            # Simulate a Windows CI runner whose stdout code page is cp1252, not
+            # UTF-8 -- this is what sys.stdout looks like on windows-latest when
+            # python's stdout is piped (e.g. `python3 ... | tee`), reproducing #4007.
+            # Force the encoding explicitly rather than relying on the dev shell's
+            # ambient (already-UTF-8) console.
+            non_utf8_stdout = io.TextIOWrapper(buffer, encoding="cp1252", errors="strict")
+            with patch("sys.argv", ["extract_allure_failures.py", str(root)]), patch("sys.stdout", non_utf8_stdout):
+                exit_code = main()
+                non_utf8_stdout.flush()
+
+        self.assertEqual(exit_code, 1)
+        printed = buffer.getvalue().decode("utf-8")
+        self.assertIn("❌", printed)
+        self.assertIn("pkg.EmojiTest.fails", printed)
+
     def test_ignores_hidden_allure_failures_from_generated_report_json(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             report_data = Path(temp_dir) / "data" / "test-results"


### PR DESCRIPTION
## Summary
- `scripts/ci/extract_allure_failures.py`'s `main()` crashed with `UnicodeEncodeError` on `windows-latest` runners whenever a SHAFT assertion failure reason contained emoji (`❌`, `🔍`, `📍`), because Python's default `sys.stdout` encoding there is `cp1252`, not UTF-8.
- The crash is swallowed by `|| true` in `.github/actions/post-test-report/action.yml`, so the job still failed correctly on the real Allure-count check, but the per-test failure table (test name, error, source file) silently disappeared from Windows job logs/step summaries — exactly when triaging a real failure needs it most (seen while diagnosing #3987, #4040, #4049).
- Fix: reconfigure `sys.stdout` to UTF-8 at the top of `main()`, guarded with `hasattr(sys.stdout, "reconfigure")` since not every stdout stand-in (e.g. `io.StringIO` used in the existing CLI test) implements it. Emoji are preserved, not stripped or replaced.

## Reproduction
Real traceback matched exactly (Windows cp1252 stdout simulated via a `TextIOWrapper`):
```
UnicodeEncodeError: 'charmap' codec can't encode character '\u274c' in position ...
```
Failing layer confirmed precisely: the stdout write at `print(output)` (`extract_allure_failures.py:490`) — not file reads, which already use explicit `encoding="utf-8"` throughout the script.

## Test plan
- [x] New regression test `test_prints_emoji_bearing_failure_reason_without_crashing_on_non_utf8_stdout` forces a real `cp1252` `TextIOWrapper` as `sys.stdout` (not relying on the dev shell's ambient UTF-8 encoding) — watched RED (`UnicodeEncodeError` at line 490) before the fix, GREEN after.
- [x] Full suite: `py -3 -m unittest tests.scripts.test_extract_allure_failures -v` — 12/12 pass.
- [x] `py -3 -m py_compile scripts/ci/extract_allure_failures.py tests/scripts/test_extract_allure_failures.py` — clean.
- [x] End-to-end sanity: real CLI invocation via subprocess with `PYTHONIOENCODING=cp1252` piped through `| cat` (matching the CI `| tee` usage) — prints the Markdown table with `❌ assertion failed 🔍 📍` intact and exits 1.

## Scope note
Checked sibling `scripts/ci/*.py` for the same pattern (printing externally-sourced text that may carry emoji to a possibly non-UTF-8 stdout). None do — the others print only static/structured messages (version strings, JSON check payloads, etc.); `extract_allure_failures.py` is the only script that echoes Allure/Surefire-derived failure text. No follow-up needed.

Closes #4007

https://claude.ai/code/session_01FWzHNJ2qYHfFDQy1ve1G1w