### PR TITLE
Fix #4044: enforce Smart Locator/POM guardrail ERRORs at the MCP boundary

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java
@@ -171,6 +171,7 @@ public class AutobotService {
             AiResponse response = aiExecutor.apply(request);
             JsonNode payload = response.structuredPayload();
             List<AutobotCodeBlock> codeBlocks = parseCodeBlocks(payload.path("codeBlocks"));
+            McpCodeGuardrailResult guardrails = guardrailResult(codeBlocks);
             return new AutobotProviderChatResponse(
                     response.status().name(),
                     response.provider().isBlank() ? normalizedProvider : response.provider(),
@@ -178,11 +179,11 @@ public class AutobotService {
                     normalizedMode,
                     payload.path("answer").asText(""),
                     payload.path("summary").asText(""),
-                    codeBlocks,
+                    enforcedCodeBlocks(codeBlocks, guardrails),
                     stringList(payload.path("citedGuideUrls")),
                     stringList(payload.path("locatorAssumptions")),
-                    guardrailStatus(codeBlocks),
-                    response.warnings(),
+                    guardrailStatusLabel(guardrails),
+                    withGuardrailWarning(response.warnings(), guardrails),
                     response.duration(),
                     response.fallbackReason());
         } finally {
@@ -304,15 +305,21 @@ public class AutobotService {
         return List.copyOf(values);
     }
 
-    private static String guardrailStatus(List<AutobotCodeBlock> blocks) {
+    private static McpCodeGuardrailResult guardrailResult(List<AutobotCodeBlock> blocks) {
         List<String> codes = blocks.stream()
                 .map(AutobotCodeBlock::code)
                 .filter(value -> !value.isBlank())
                 .toList();
         if (codes.isEmpty()) {
+            return null;
+        }
+        return new TestAutomationService().checkGeneratedCode("java", String.join("\n", codes));
+    }
+
+    private static String guardrailStatusLabel(McpCodeGuardrailResult result) {
+        if (result == null) {
             return "NOT_CHECKED";
         }
-        McpCodeGuardrailResult result = new TestAutomationService().checkGeneratedCode("java", String.join("\n", codes));
         if (result.passed()) {
             return "PASSED";
         }
@@ -320,6 +327,25 @@ public class AutobotService {
                 .filter(violation -> "ERROR".equals(violation.severity()))
                 .count();
         return "VIOLATIONS: " + errors + " error(s)";
+    }
+
+    /**
+     * Withholds generated code that fails guardrails instead of merely labelling it, so an
+     * {@code ERROR}-severity violation (such as a Smart Locator) never reaches the MCP caller.
+     */
+    private static List<AutobotCodeBlock> enforcedCodeBlocks(
+            List<AutobotCodeBlock> blocks, McpCodeGuardrailResult result) {
+        return result == null || result.passed() ? blocks : List.of();
+    }
+
+    private static List<String> withGuardrailWarning(List<String> warnings, McpCodeGuardrailResult result) {
+        if (result == null || result.passed()) {
+            return warnings;
+        }
+        List<String> combined = new ArrayList<>(warnings);
+        combined.add("Guardrail-violating generated code was withheld: " + guardrailStatusLabel(result)
+                + ". Fix the reported violations (see test_code_guardrails_check) and retry.");
+        return List.copyOf(combined);
     }
 
     private static String keyEnvironmentVariable(String provider) {

--- a/shaft-mcp/src/test/java/com/shaft/mcp/AutobotServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/AutobotServiceTest.java
@@ -216,6 +216,52 @@ class AutobotServiceTest {
         assertTrue(response.guardrailStatus().startsWith("VIOLATIONS"));
     }
 
+    @Test
+    void providerChatWithholdsCodeContainingSmartLocatorGuardrailErrors() {
+        AutobotService service = new AutobotService(McpWorkspacePolicy.of(workspace),
+                new LocalAgentService(client -> true, new CapturingRunner()), request -> {
+                    var payload = tools.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+                    payload.put("answer", "done");
+                    payload.putArray("codeBlocks").addObject()
+                            .put("code", "driver.element().click(SHAFT.GUI.Locator.clickableField(\"Sign in\"));");
+                    return AiResponse.success("gemini", "gemini-3.5-flash", payload,
+                            Duration.ofMillis(10), com.shaft.pilot.ai.AiUsage.empty(),
+                            request.deterministicFallback());
+                });
+
+        AutobotProviderChatResponse response = service.runProviderChat(
+                "gemini", "gemini-3.5-flash", "PLAN", "Write a sign-in test", "", 10, false);
+
+        assertTrue(response.codeBlocks().isEmpty(),
+                "Generated code with a SMART_LOCATOR guardrail ERROR must never reach the MCP caller");
+        assertTrue(response.guardrailStatus().startsWith("VIOLATIONS"));
+        assertTrue(response.warnings().stream().anyMatch(warning -> warning.contains("guardrail")),
+                "A withheld code block must explain why via warnings");
+    }
+
+    @Test
+    void providerChatStillReturnsAriaRoleAndPlainXpathCodeThatPassesGuardrails() {
+        AutobotService service = new AutobotService(McpWorkspacePolicy.of(workspace),
+                new LocalAgentService(client -> true, new CapturingRunner()), request -> {
+                    var payload = tools.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+                    payload.put("answer", "done");
+                    payload.putArray("codeBlocks").addObject().put("code", """
+                            By signIn = SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasText("Sign in").build();
+                            By legacyFallback = By.xpath("//button[@id='legacy-submit']");
+                            driver.element().click(signIn);
+                            """);
+                    return AiResponse.success("gemini", "gemini-3.5-flash", payload,
+                            Duration.ofMillis(10), com.shaft.pilot.ai.AiUsage.empty(),
+                            request.deterministicFallback());
+                });
+
+        AutobotProviderChatResponse response = service.runProviderChat(
+                "gemini", "gemini-3.5-flash", "PLAN", "Write a sign-in test", "", 10, false);
+
+        assertEquals(1, response.codeBlocks().size());
+        assertEquals("PASSED", response.guardrailStatus());
+    }
+
     private static final class CapturingRunner implements LocalAgentProcessRunner {
         private final AtomicReference<List<String>> command = new AtomicReference<>();
         private final AtomicReference<Path> workingDirectory = new AtomicReference<>();


### PR DESCRIPTION
## Summary

- Follow-up to merged PR #4042 (subtask of tracker #4024). #4042 flipped `SMART_LOCATOR` from `WARNING` to `ERROR` and added `POM_VIOLATION` as `ERROR`, but #4044 established that `ERROR` severity was purely informational — nothing actually blocked a Smart Locator from being returned.
- Confirmed the swallow point with fresh evidence: `AutobotService.runProviderChat` (`shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java`) is the one real generated-code path that consumes `TestAutomationService.checkGeneratedCode`. Before this change it computed a `guardrailStatus` label but always returned `codeBlocks` unchanged regardless of `ERROR` violations — the label was cosmetic (`AutobotServiceTest.providerChatFlagsGuardrailViolationsInReturnedCode` only asserted the status string, never that the code was withheld). The only other reference, `CodingPartnerService`, merely suggests running `test_code_guardrails_check` as advisory guidance text and never invokes it programmatically.
- Now: when the aggregate guardrail check on a provider's generated `codeBlocks` reports any `ERROR`-severity violation (`SMART_LOCATOR`, `SHAFT_LOCATOR_XPATH`, `POM_VIOLATION`, ...), `runProviderChat` withholds the code blocks entirely (returns `List.of()`) and adds a warning explaining why, instead of handing policy-violating generated code back to the MCP caller. Code containing only permitted locators (ARIA-role `hasRole(...)`, or plain `By.xpath(...)` as fallback) is returned unchanged.

## Scope note

Enforcement shape chosen: refuse to return the generated source (withhold `codeBlocks`), reusing the existing `REJECTED`-style refusal pattern already used in this method for AGENT-mode source mutation. This is a targeted enforcement fix, not #4029 ("Loud, diagnosable codegen failures gated on confirmed scenario replay") — that is a separate, later ticket about gating on confirmed scenario replay and is not touched here.

## Test plan

- [x] New test `providerChatWithholdsCodeContainingSmartLocatorGuardrailErrors` — watched RED against the pre-fix code (`codeBlocks.isEmpty()` failed, proving the unenforced behavior), then GREEN after the fix.
- [x] Mutation-checked: reverted `enforcedCodeBlocks` to unconditionally return `blocks`, re-ran the test, confirmed it fails; restored the fix, confirmed green again.
- [x] New test `providerChatStillReturnsAriaRoleAndPlainXpathCodeThatPassesGuardrails` — proves the permitted path (ARIA-role locator + plain `By.xpath` fallback) still returns code unchanged.
- [x] `mvn -pl shaft-mcp test -Dtest=AutobotServiceTest -DheadlessExecution=true -Dallure.automaticallyOpen=false -Dgpg.skip=true` — 12/12 green.
- [x] `mvn -pl shaft-mcp test -Dtest=TestAutomationServiceTest -DheadlessExecution=true -Dallure.automaticallyOpen=false -Dgpg.skip=true` — 12/12 green (no regression to the underlying guardrail rules from #4042).
- [x] `mvn -pl shaft-mcp compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false -Dgpg.skip=true` — BUILD SUCCESS.

Closes #4044. Relates to tracker #4024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)