### PR TITLE
Fix #4021: decouple the panel gate fixture from HealerService's repositoryRoot check

### DIFF
--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLiveDiagnosticsToolE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLiveDiagnosticsToolE2ETest.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,15 +103,20 @@ class ShaftAssistantPanelLiveDiagnosticsToolE2ETest {
         try (LiveChatToolE2ESupport support = LiveChatToolE2ESupport.install(context.workspace(), context.mcpCommand())) {
             ShaftAssistantPanel panel = support.newPanel();
 
-            // "mvn.cmd" (not bare "mvn") on Windows: HealerService/verify_run_focused spawn the
-            // command via a raw ProcessBuilder (HealerService.java:450), which calls CreateProcess
-            // directly -- unlike a shell, Windows CreateProcess never appends PATHEXT extensions, so
-            // the extensionless "mvn" POSIX shim on PATH cannot be launched that way even though
-            // `where mvn` resolves it (reproduced empirically: intermittent "MCP healer command could
-            // not be launched" IOException). "mvn.cmd"/"mvnw.cmd" are explicitly allowlisted
-            // executables (HealerService.java:349) precisely for this platform difference.
+            // HealerService/verify_run_focused spawn the command via a raw ProcessBuilder
+            // (HealerService.java:450), which calls CreateProcess directly on Windows -- unlike a
+            // shell, Windows CreateProcess never appends PATHEXT extensions, so the extensionless
+            // "mvn" POSIX shim on PATH cannot be launched that way even though `where mvn` resolves it
+            // (reproduced empirically: intermittent "MCP healer command could not be launched"
+            // IOException). "mvn.cmd" is required there. But this test only ever runs in CI on the
+            // ubuntu-22.04 "intellij-tools-diagnostics" job (live-tools-nightly.yml), which has no
+            // "mvn.cmd" file at all -- only the "mvn" POSIX shell script -- so hardcoding "mvn.cmd"
+            // fails process launch outright on Linux (issue #4021). HealerService allowlists both
+            // names (HealerService.java:349); pick the one that actually exists for the current OS.
+            String mavenExecutable = mavenExecutableForOs();
             String healResponse = support.send(panel,
-                    "/mcp healer_run_failed_test {\"repositoryRoot\":\"non-shaft-target\",\"testCommand\":[\"mvn.cmd\",\"test\"],"
+                    "/mcp healer_run_failed_test {\"repositoryRoot\":\"non-shaft-target\",\"testCommand\":[\""
+                            + mavenExecutable + "\",\"test\"],"
                             + "\"outputDirectory\":\"\",\"maxAttempts\":1,\"includeScreenshots\":false,"
                             + "\"includePageSnapshots\":false,\"allowedSourcePaths\":[],"
                             + "\"networkValidationApproved\":false,\"useConfiguredAi\":false,\"allowLocalAi\":false,"
@@ -121,7 +127,8 @@ class ShaftAssistantPanelLiveDiagnosticsToolE2ETest {
                     "healer_run_failed_test: Maven command failed to launch: " + healResponse);
 
             String verifyResponse = support.send(panel,
-                    "/mcp verify_run_focused {\"repositoryRoot\":\"non-shaft-target\",\"command\":[\"mvn.cmd\",\"-q\",\"compile\"],"
+                    "/mcp verify_run_focused {\"repositoryRoot\":\"non-shaft-target\",\"command\":[\""
+                            + mavenExecutable + "\",\"-q\",\"compile\"],"
                             + "\"networkValidationApproved\":false}",
                     Duration.ofSeconds(60));
             assertNotError(verifyResponse, "verify_run_focused");
@@ -204,6 +211,19 @@ class ShaftAssistantPanelLiveDiagnosticsToolE2ETest {
             assertNotError(response, "autobot_provider_status");
             assertTrue(payload.contains("\"provider\":\"anthropic\""), "Expected the requested provider echoed back: " + payload);
         }
+    }
+
+    /**
+     * The Maven executable name valid for {@link ProcessBuilder} on the current OS: {@code "mvn.cmd"}
+     * on Windows (bare {@code "mvn"} cannot be launched there -- CreateProcess never appends PATHEXT
+     * extensions), {@code "mvn"} everywhere else, including this test's actual CI runner
+     * ({@code ubuntu-22.04}, which has no {@code mvn.cmd} file at all). Both names are allowlisted by
+     * {@code HealerService} (HealerService.java:349).
+     */
+    private static String mavenExecutableForOs() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win")
+                ? "mvn.cmd"
+                : "mvn";
     }
 
     /**

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLiveDiagnosticsToolE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLiveDiagnosticsToolE2ETest.java
@@ -39,6 +39,7 @@ class ShaftAssistantPanelLiveDiagnosticsToolE2ETest {
     @Timeout(120)
     void doctorServiceAnalyzesAFailedAllureResultThroughTheRealChatPanel() throws Exception {
         LiveContext context = LiveContext.assumeConfigured();
+        markWorkspaceAsShaftProject(context.workspace());
         Path allureResult = context.workspace().resolve("allure-results/failed-login-result.json");
         Files.createDirectories(allureResult.getParent());
         Files.writeString(allureResult, failedAllureResult(), StandardCharsets.UTF_8);
@@ -72,15 +73,31 @@ class ShaftAssistantPanelLiveDiagnosticsToolE2ETest {
     }
 
     /**
-     * {@code healer_run_failed_test} in a directory with no SHAFT project returns a real, graceful
-     * {@code GUARDRAIL_STOPPED} result (not an MCP error) -- proving live dispatch without the cost
-     * of a real Maven test run. {@code verify_run_focused} similarly runs a real (offline) Maven
-     * process against an empty directory and reports its real (non-zero-exit) outcome.
+     * {@code healer_run_failed_test} against a non-SHAFT {@code repositoryRoot} returns a real,
+     * graceful {@code GUARDRAIL_STOPPED} result (not an MCP error) -- proving live dispatch without
+     * the cost of a real Maven test run. {@code verify_run_focused} similarly runs a real (offline)
+     * Maven process against an empty directory and reports its real (non-zero-exit) outcome.
+     *
+     * <p>Both tools are gated behind {@link AssistantCommand#SHAFT_PROJECT_TOOLS}
+     * ({@code AssistantCommandRoutingTest#requiresShaftProjectGatesOnlyMutatingOrShaftReportingSpecificTools}
+     * asserts this by design, issue #4021), so the panel only dispatches them at all when
+     * {@code ShaftProjectDetector.isShaftProject(project)} -- a coarse check of the fake IntelliJ
+     * project's own root -- says yes. {@link #markWorkspaceAsShaftProject} gives the workspace root
+     * that marker so the panel routes the call through instead of nudging onboarding. The tool calls
+     * themselves still target a genuinely separate, marker-free {@code non-shaft-target} child
+     * directory as their {@code repositoryRoot}, so {@code HealerService}'s own
+     * {@code ShaftProjectMarker.isShaftRepository(repository)} check (HealerService.java:135) still
+     * sees no SHAFT project and takes the real non-SHAFT-directory branch this test means to exercise
+     * -- "through the real chat panel" and "against a non-SHAFT directory" are about two different
+     * roots (the panel's project vs. the tool's repositoryRoot), not a contradiction.
      */
     @Test
     @Timeout(120)
     void healerServiceRunsAgainstANonShaftDirectoryThroughTheRealChatPanel() throws Exception {
         LiveContext context = LiveContext.assumeConfigured();
+        markWorkspaceAsShaftProject(context.workspace());
+        Path nonShaftDirectory = context.workspace().resolve("non-shaft-target");
+        Files.createDirectories(nonShaftDirectory);
 
         try (LiveChatToolE2ESupport support = LiveChatToolE2ESupport.install(context.workspace(), context.mcpCommand())) {
             ShaftAssistantPanel panel = support.newPanel();
@@ -93,7 +110,7 @@ class ShaftAssistantPanelLiveDiagnosticsToolE2ETest {
             // not be launched" IOException). "mvn.cmd"/"mvnw.cmd" are explicitly allowlisted
             // executables (HealerService.java:349) precisely for this platform difference.
             String healResponse = support.send(panel,
-                    "/mcp healer_run_failed_test {\"repositoryRoot\":\".\",\"testCommand\":[\"mvn.cmd\",\"test\"],"
+                    "/mcp healer_run_failed_test {\"repositoryRoot\":\"non-shaft-target\",\"testCommand\":[\"mvn.cmd\",\"test\"],"
                             + "\"outputDirectory\":\"\",\"maxAttempts\":1,\"includeScreenshots\":false,"
                             + "\"includePageSnapshots\":false,\"allowedSourcePaths\":[],"
                             + "\"networkValidationApproved\":false,\"useConfiguredAi\":false,\"allowLocalAi\":false,"
@@ -104,7 +121,7 @@ class ShaftAssistantPanelLiveDiagnosticsToolE2ETest {
                     "healer_run_failed_test: Maven command failed to launch: " + healResponse);
 
             String verifyResponse = support.send(panel,
-                    "/mcp verify_run_focused {\"repositoryRoot\":\"\",\"command\":[\"mvn.cmd\",\"-q\",\"compile\"],"
+                    "/mcp verify_run_focused {\"repositoryRoot\":\"non-shaft-target\",\"command\":[\"mvn.cmd\",\"-q\",\"compile\"],"
                             + "\"networkValidationApproved\":false}",
                     Duration.ofSeconds(60));
             assertNotError(verifyResponse, "verify_run_focused");
@@ -187,6 +204,39 @@ class ShaftAssistantPanelLiveDiagnosticsToolE2ETest {
             assertNotError(response, "autobot_provider_status");
             assertTrue(payload.contains("\"provider\":\"anthropic\""), "Expected the requested provider echoed back: " + payload);
         }
+    }
+
+    /**
+     * Writes a minimal {@code pom.xml} at {@code workspace} root that
+     * {@code ShaftProjectDetector}/{@code ShaftProjectMarker} (both scan a root's own build file, or
+     * one belonging to a direct child) recognize as a SHAFT dependency, so
+     * {@code AssistantCommand#requiresShaftProject}-gated tools dispatch through the panel instead of
+     * getting the "doesn't look like a SHAFT project yet" onboarding nudge (issue #4021). Idempotent:
+     * safe to call once per test even though every test method in this class shares one workspace
+     * directory across the whole live-tool-E2E JVM run.
+     */
+    private static void markWorkspaceAsShaftProject(Path workspace) throws Exception {
+        Path pom = workspace.resolve("pom.xml");
+        if (Files.exists(pom)) {
+            return;
+        }
+        Files.writeString(pom, """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.shaft.live.diagnostics</groupId>
+                    <artifactId>diagnostics-shaft-marker</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.github.shafthq</groupId>
+                            <artifactId>shaft-bom</artifactId>
+                            <version>1.0.0</version>
+                            <type>pom</type>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """, StandardCharsets.UTF_8);
     }
 
     private static void assertNotError(String rawResponse, String toolName) {


### PR DESCRIPTION
## Summary

`ShaftAssistantPanelLiveDiagnosticsToolE2ETest` has two methods that dispatch SHAFT-project-gated tools (`doctor_analyze_failed_allure`, `healer_run_failed_test`, `verify_run_focused`) through the real chat panel. They've been failing in every scheduled run of the Diagnostics job because two *independent* checks happened to collide:

- The client-side panel gate, `ShaftProjectDetector.isShaftProject(project)` (`shaft-intellij/src/main/java/com/shaft/intellij/project/ShaftProjectDetector.java:44-72`) — keyed off the fake IntelliJ project's base path.
- The tool-side non-SHAFT check, `HealerService.runFailedTest` → `ShaftProjectMarker.isShaftRepository(repository)` (`shaft-mcp/src/main/java/com/shaft/mcp/HealerService.java:135`) — keyed off the `repositoryRoot` argument in the tool-call JSON.

They only collided because the test passed `"repositoryRoot":"."`, i.e. the same directory as the panel's project root. Neither check itself is wrong — `AssistantCommand.SHAFT_PROJECT_TOOLS` (`AssistantCommand.java:1598-1604`) and `AssistantCommandRoutingTest#requiresShaftProjectGatesOnlyMutatingOrShaftReportingSpecificTools` (`AssistantCommandRoutingTest.java:809-834`) assert, by design, that these tools must be gated. This PR does not touch either.

## What changed

Only `ShaftAssistantPanelLiveDiagnosticsToolE2ETest.java`:
- New helper `markWorkspaceAsShaftProject(Path)` plants a minimal marker `pom.xml` at the workspace root so the panel actually dispatches the gated calls instead of showing the onboarding nudge.
- `healerServiceRunsAgainstANonShaftDirectoryThroughTheRealChatPanel` additionally points `repositoryRoot` at a fresh, marker-free `non-shaft-target/` subdirectory for both `healer_run_failed_test` and `verify_run_focused`, so `HealerService`'s own non-SHAFT-directory `GUARDRAIL_STOPPED` branch is still genuinely exercised. "Through the real chat panel" and "against a non-SHAFT directory" are about two different roots, not a contradiction — this fixture makes that explicit instead of conflating them.

## Verdict on the design question in #4021

Neither of the issue's two framed options fit cleanly:
- Not "wrong CI job, exclude it" (the #4006/#4038 pattern): `intellij-tools-diagnostics` in `live-tools-nightly.yml` is the sole, purpose-built job for this class — there's no other job to move it to.
- Not "the gate is over-broad, narrow it": the gate is intentional and already asserted by its own unit test, which stays untouched and green (46/46, see below).

This is a test-fixture fix: the fixture now gives the (unchanged) gate what it needs while keeping each tool's own graceful-non-SHAFT-directory behavior genuinely under test.

## Evidence

**Red nightly**, not a silent skip or a wasted job — 5/5 consecutive scheduled runs of `Live Tools Nightly E2E` → `IntelliJ live tools (Diagnostics)` have failed:
```
ShaftAssistantPanelLiveDiagnosticsToolE2ETest > healerServiceRunsAgainstANonShaftDirectoryThroughTheRealChatPanel() FAILED
    org.opentest4j.AssertionFailedError at ShaftAssistantPanelLiveDiagnosticsToolE2ETest.java:95
ShaftAssistantPanelLiveDiagnosticsToolE2ETest > doctorServiceAnalyzesAFailedAllureResultThroughTheRealChatPanel() FAILED
    org.opentest4j.AssertionFailedError at ShaftAssistantPanelLiveDiagnosticsToolE2ETest.java:49
5 tests completed, 2 failed
```
(run 30190833709, job 89763701272). Tracked by the auto-filed nightly tracker #4047.

**Gate unchanged and still enforced**: `AssistantCommandRoutingTest` — 46 tests, 0 failures, 0 errors (`gradle test --tests com.shaft.intellij.ui.AssistantCommandRoutingTest`), run locally against this branch.

## Verification status — please read before merging

This test only runs in the `Live Tools Nightly E2E` scheduled workflow (`intellij-tools-diagnostics` job) — none of the PR's ordinary required checks exercise it. **Auto-merge is intentionally NOT armed on this PR.** A local watched RED→GREEN cycle against a live MCP server was attempted but not completed (IntelliJ platform test fixtures bootstrap slowly enough that CI itself budgets 45 minutes for this job). Instead, this PR should be verified by dispatching `live-tools-nightly.yml` against this branch via `workflow_dispatch` before merge — that is the authoritative proof for a fix that only this workflow can exercise.

Closes #4021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWzHNJ2qYHfFDQy1ve1G1w