### PR TITLE
Fix #4053: clarify bridges are read as files, not Skill-invocable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ ChaosEngine, by Mohab Mohie. SHAFT_ENGINE is a Maven Java automation framework; 
 
 ## Routing
 
-Bridge: `framework-source-rules` main Java; `java-test-rules` tests; `ci-failure-investigator` CI; `flaky-test-stabilizer` flaky; `release-dependency-guard` release/deps; `graphify` graph; `shaft-ui-design` UI; `shaft-marketing-ad-producer` ads; `public-behavior-docs-synchronizer` docs; `mcp-transport-contract-auditor` MCP; `modular-boundary-auditor` modules; `allure-extent-report-operator` reports; `agent-guidance-boundary-guard` guidance; `agentic-pdca-loop` PDCA phases.
+Bridge (`.agents/skills/<name>/SKILL.md`, not Skill-invocable): `framework-source-rules` main Java; `java-test-rules` tests; `ci-failure-investigator` CI; `flaky-test-stabilizer` flaky; `release-dependency-guard` release/deps; `graphify` graph; `shaft-ui-design` UI; `shaft-marketing-ad-producer` ads; `public-behavior-docs-synchronizer` docs; `mcp-transport-contract-auditor` MCP; `modular-boundary-auditor` modules; `allure-extent-report-operator` reports; `agent-guidance-boundary-guard` guidance; `agentic-pdca-loop` PDCA phases.
 
 ## New Task Flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 - Imported `AGENTS.md` is canonical (including binding `act-as-fable`);
   do not restate it or append logs.
-- Load one matching `.agents/skills/` bridge only when its trigger applies;
-  native Graphify via `.claude/skills/graphify`.
+- Read one matching `.agents/skills/<name>/SKILL.md` bridge (not `Skill`-tool
+  invocable) only when its trigger applies; native Graphify via `.claude/skills/graphify`.
 - Keep plans and final responses proportional to the task; stop when the
   requested behavior is verified.

--- a/scripts/ci/validate_agent_guidance.py
+++ b/scripts/ci/validate_agent_guidance.py
@@ -376,6 +376,41 @@ def validate_local_references(root: Path, files: list[Path]) -> list[dict[str, s
     return errors
 
 
+ROUTING_HEADING = "## Routing"
+ROUTING_BRIDGE_NAME = re.compile(r"`([a-z0-9][a-z0-9-]*)`")
+
+
+def validate_routing_bridges(root: Path) -> list[dict[str, str]]:
+    """Ensure every bridge AGENTS.md's Routing section names by backtick
+    resolves to a .agents/skills/<name>/SKILL.md file.
+
+    Bridges are read as files, never `Skill`-tool invocable (issue #4053); a
+    name that only exists under .claude/skills (the Skill-tool-invocable
+    tree) does not satisfy this -- the two trees are independent.
+    """
+    agents_path = root / "AGENTS.md"
+    if not agents_path.is_file():
+        return []
+    content = agents_path.read_text(encoding="utf-8")
+    start = content.find(ROUTING_HEADING)
+    if start < 0:
+        return []
+    start += len(ROUTING_HEADING)
+    end = content.find("\n## ", start)
+    section = content[start : end if end >= 0 else len(content)]
+    errors: list[dict[str, str]] = []
+    for name in ROUTING_BRIDGE_NAME.findall(section):
+        if not (root / ".agents/skills" / name / "SKILL.md").is_file():
+            errors.append(
+                issue(
+                    "routing-bridge-missing",
+                    "AGENTS.md",
+                    f"Routing references bridge '{name}' with no .agents/skills/{name}/SKILL.md",
+                )
+            )
+    return errors
+
+
 def validate_scopes(root: Path, budget: dict) -> list[dict[str, str]]:
     """Ensure every path-scoped instruction matches repository files."""
     errors: list[dict[str, str]] = []
@@ -471,6 +506,7 @@ def validate_repository(root: Path = ROOT, budget_path: Path | None = None) -> l
         *validate_file_budgets(root, budget),
         *validate_host_contexts(root, budget),
         *validate_total_reduction(root, budget),
+        *validate_routing_bridges(root),
         *validate_skills(root, budget),
         *validate_local_references(root, reference_files),
         *validate_scopes(root, budget),

--- a/tests/scripts/test_validate_agent_guidance.py
+++ b/tests/scripts/test_validate_agent_guidance.py
@@ -10,7 +10,11 @@ class ValidateAgentGuidanceTest(unittest.TestCase):
     def setUp(self):
         self.temporary_directory = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary_directory.name)
-        self.write("AGENTS.md", "# Agents\n\n[Local](docs/local.md)\n")
+        self.write(
+            "AGENTS.md",
+            "# Agents\n\n[Local](docs/local.md)\n\n"
+            "## Routing\n\nBridge: `example-bridge` example.\n",
+        )
         self.write("CLAUDE.md", "# Claude\n\n@AGENTS.md\n")
         self.write(".github/copilot-instructions.md", "# Copilot\n")
         self.write(
@@ -250,6 +254,30 @@ policy:
             '---\napplyTo: "**/src/missing/**/*.java"\n---\n\n# Source\n',
         )
         self.assertIn("unmatched-scope", self.codes())
+
+    def test_rejects_routing_bridge_with_no_skill_file(self):
+        self.write(
+            "AGENTS.md",
+            "# Agents\n\n[Local](docs/local.md)\n\n"
+            "## Routing\n\nBridge: `example-bridge` example; `missing-bridge` gone.\n",
+        )
+        self.assertIn("routing-bridge-missing", self.codes())
+
+    def test_routing_bridge_only_in_native_skills_tree_still_fails(self):
+        # A name that resolves under .claude/skills (Skill-tool invocable)
+        # must not be mistaken for a .agents/skills bridge (read-as-file):
+        # the two trees are independent, and issue #4053 exists precisely
+        # because agents confuse them.
+        self.write(
+            ".claude/skills/native-only/SKILL.md",
+            "---\nname: native-only\ndescription: Native skill only.\n---\n\n# Native\n",
+        )
+        self.write(
+            "AGENTS.md",
+            "# Agents\n\n[Local](docs/local.md)\n\n"
+            "## Routing\n\nBridge: `native-only` example.\n",
+        )
+        self.assertIn("routing-bridge-missing", self.codes())
 
     def test_rejects_costly_mandate(self):
         self.write("AGENTS.md", "# Agents\n\nRun the build before every commit.\n")


### PR DESCRIPTION
## Summary
- `AGENTS.md` § Routing and `CLAUDE.md` listed `.agents/skills/` bridges in a shape ambiguous with native `.claude/skills/` `Skill`-tool entries. Agents ran `Skill(<bridge-name>)`, got `Unknown skill`, and escalated a false defect instead of reading the bridge file (correct behavior, per #4053).
- `AGENTS.md` Routing line now states bridges resolve at `.agents/skills/<name>/SKILL.md` and are not `Skill`-invocable; `CLAUDE.md` reworded "Load" to "Read", with the path shape.
- New `validate_routing_bridges()` in `scripts/ci/validate_agent_guidance.py` asserts every backticked name in `AGENTS.md`'s Routing section resolves to a real `.agents/skills/<name>/SKILL.md`, so a genuinely missing bridge is caught by CI (`routing-bridge-missing`) instead of by a confused agent at runtime. Explicitly tested against the `.agents/skills` vs `.claude/skills` `graphify` double-tree case (a name resolving only in the native tree must still fail).

## Guidance budget
Baseline before edit: `guidance_bytes 73131`, `claude host tokens 2666` (both within `agent_guidance_budget.json` caps). After the AGENTS.md/CLAUDE.md wording: `guidance_bytes 73231` (+100), `claude host tokens 2691` (+25) — `py -3 scripts/ci/validate_agent_setup.py --skip-external --format json` reports `"valid": true` with no budget errors.

## Test plan
- [x] TDD: `test_rejects_routing_bridge_with_no_skill_file` and `test_routing_bridge_only_in_native_skills_tree_still_fails` written first, watched red (function missing), then green after `validate_routing_bridges()` landed.
- [x] `py -3 -m unittest tests.scripts.test_validate_agent_guidance tests.scripts.test_validate_agent_setup -v` — 26/26 pass.
- [x] `py -3 scripts/ci/validate_agent_setup.py --skip-external` — clean (`Agent setup is valid: 73231 guidance bytes, 0% reduction, 300 memory objects.`).
- [x] Manually injected a fake bridge name into `AGENTS.md`, confirmed `routing-bridge-missing` fired, then reverted (working tree clean, byte count back to 73231).
- [x] `py -3 .claude/hooks/guard.py --self-test` — 54/54 plus graphify (0 failed) and TDD (0 failed) suites green.

Closes #4053

https://claude.ai/code/session_01FWzHNJ2qYHfFDQy1ve1G1w