### PR TITLE
Test: reproduce #4046 Guided Workflows Live E2E hang (disabled, no fix)

### DIFF
--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -1480,6 +1480,74 @@ class ManagedCaptureRecorderBrowserTest {
         return condition.getAsBoolean();
     }
 
+    /**
+     * Regression repro for issue #4046: the nightly {@code guided-workflows-live.yml} run has
+     * failed 100% of the time (5/5 scheduled runs since PR #3938 merged) on
+     * {@code GuidedWorkflowLiveE2ETest#apiRecorderCapturesNetworkTrafficAndGeneratesShaftApiCode},
+     * which times out waiting for {@code capture_api_start} to respond. That is the only
+     * {@code CaptureManager} caller in the whole repo that starts a real browser with
+     * {@code apiCapture=true} (network recording via {@link org.openqa.selenium.devtools.HasDevTools})
+     * -- every other caller, including this file's other browser tests, only exercises the plain
+     * BiDi-based UI event collector ({@code ManagedCaptureRecorder#startCollector}). This test
+     * isolates that exact combination against a real Chrome session and reproduces the hang
+     * locally: {@code jstack} pins the blocked thread at
+     * {@code ManagedCaptureRecorder.start(ManagedCaptureRecorder.java:151)}, inside
+     * {@code RemoteWebDriver.executeScript} -&gt; {@code JdkHttpClient.execute} -&gt;
+     * {@code CompletableFuture.get()}, which never returns once the CDP {@code NetworkInterceptor}
+     * (installed one line earlier by {@code startNetworkRecorder}) is active.
+     *
+     * <p><b>Isolation result (2026-07-26):</b> disabling {@code startCollector} (the BiDi UI-event
+     * collector) and re-running left the hang unchanged -- CDP {@code NetworkInterceptor} alone
+     * conflicts with a subsequent {@code executeScript} call; this is not a BiDi+CDP concurrency
+     * conflict. Root-cause fix is tracked on #4046 and intentionally not attempted here (tester
+     * scope: reproduce and hand off, not implement).
+     *
+     * <p><b>Disabled, not merely tagged:</b> this class already carries {@code @Tag("external-e2e")},
+     * but that is not sufficient gating here -- {@code .github/actions/capture-browser-e2e} runs
+     * this exact class (by name, all methods) with {@code -DincludeCaptureBrowserE2E} from
+     * {@code pr-gate.yml} (PR-blocking), {@code mavenCentral_cd.yml}, and
+     * {@code shaft-pilot-release.yml}. Left enabled, this test would hang every PR's gate. Remove
+     * {@code @Disabled} only once the underlying hang is fixed.
+     *
+     * <p>Note for whoever picks this up: {@code @Timeout(60)} below does NOT reliably abort this
+     * particular hang locally -- the blocked thread is parked inside a native
+     * {@code CompletableFuture.get()} round-trip to chromedriver that did not honor interrupt in
+     * two separate local runs (test kept running 2+ minutes past the bound until the process tree
+     * was killed externally). Don't trust the annotation alone to keep a future CI run bounded.
+     */
+    @Test
+    @org.junit.jupiter.api.Timeout(60)
+    @org.junit.jupiter.api.Disabled("Issue #4046: reproduces a real hang (CDP NetworkInterceptor "
+            + "poisons a subsequent executeScript call) -- @Timeout does not reliably abort it, and "
+            + "this class runs unconditionally from pr-gate.yml's capture-browser-e2e step. Re-enable "
+            + "once the root cause is fixed.")
+    void startCompletesWhenApiCaptureIsEnabledAgainstARealBrowser(@TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        ManagedCaptureRecorder recorder = null;
+        try {
+            Path output = temp.resolve("recordings").resolve("api-capture.json");
+            Path runtime = temp.resolve("runtime");
+            CaptureStartOptions options = new CaptureStartOptions(
+                    "", "", "", "", "", "", "", false, false,
+                    "", "", "", "", "", "", "", "", Duration.ZERO, "", null, "",
+                    true, new NetworkCaptureOptions());
+            recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                    "http://127.0.0.1:" + server.getAddress().getPort() + "/",
+                    CaptureBrowser.CHROME,
+                    output,
+                    runtime,
+                    true,
+                    options));
+            recorder.start();
+            assertEquals(CaptureStatus.State.ACTIVE, recorder.status().state());
+        } finally {
+            if (recorder != null && recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
     private static HttpServer localFixture() throws IOException {
         HttpServer server = HttpServer.create(
                 new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0), 0);


### PR DESCRIPTION
## Summary

Adds a **disabled** regression test that reproduces, on demand, the hang behind #4046 (nightly `Guided Workflows Live E2E`, 5/5 red since PR #3938 merged). This PR does **not** fix the root cause and does **not** close #4046 — see "Refs #4046" in the commit, not "Closes".

## What was found (full diagnosis on #4046)

- `GuidedWorkflowLiveE2ETest#apiRecorderCapturesNetworkTrafficAndGeneratesShaftApiCode` times out waiting for `capture_api_start` to respond (`java.io.IOException: Timed out waiting for SHAFT MCP response`).
- Reproduced locally (not just from CI logs): `ManagedCaptureRecorderBrowserTest#startCompletesWhenApiCaptureIsEnabledAgainstARealBrowser` drives the same combination — real headless Chrome + `apiCapture=true` — through `ManagedCaptureRecorder` directly, and hangs identically.
- `jstack` on the hung JVM pins the blocked thread inside `RemoteWebDriver.executeScript` → `JdkHttpClient.execute` → `CompletableFuture.get()`, called from `ManagedCaptureRecorder.start(ManagedCaptureRecorder.java:151)` — the JS event-listener injection call made right after `driver.navigate()`, one line after the CDP `NetworkInterceptor` is installed (`startNetworkRecorder`, `ManagedCaptureRecorder.java:148`).
- **Isolation experiment**: disabled the WebDriver BiDi collector (`startCollector`) and re-ran — hang persisted unchanged. So this is **not** a BiDi+CDP concurrency conflict; CDP `NetworkInterceptor` alone poisons a subsequent `executeScript` call. No existing test in the repo previously combined a real browser with `apiCapture=true` before PR #3938's E2E test, which is why this was never caught pre-merge.
- Also found (informational, not fixed here): the test's own `@Timeout(60)` did not reliably abort the hang locally — it kept running 2+ minutes past the bound in two separate runs until I killed the process tree manually.

## Why `@Disabled` and not just relying on the existing `@Tag("external-e2e")`

`ManagedCaptureRecorderBrowserTest` already carries a class-level `@Tag("external-e2e")`, but that alone is **not sufficient** gating: `.github/actions/capture-browser-e2e` runs this exact class (all methods, by name) with `-DincludeCaptureBrowserE2E` from **`pr-gate.yml` (PR-blocking)**, `mavenCentral_cd.yml`, and `shaft-pilot-release.yml`. Left enabled, this test would hang every PR's gate. Verified locally that `@Disabled` actually skips it under the exact CI command shape (`Tests run: 1, Skipped: 1`, `BUILD SUCCESS`, 31s, no browser launched).

## Not in scope here

- The production fix (root-causing/fixing the CDP `NetworkInterceptor` + `executeScript` conflict) — tracked on #4046, left for a follow-up.
- `CaptureManager.invoke()`'s unbounded `executor.submit(operation).get()` wait (`CaptureManager.java:386-399`) — a related but separate robustness defect (an MCP tool call should never be able to hang forever regardless of what the recorder does), being filed as its own ticket by the orchestrator.

## Verification

- `mvn -pl shaft-capture -DheadlessExecution=true test-compile` — clean.
- `mvn -pl shaft-capture -DincludeCaptureBrowserE2E -Dtest=ManagedCaptureRecorderBrowserTest#startCompletesWhenApiCaptureIsEnabledAgainstARealBrowser test -DheadlessExecution=true -Dallure.automaticallyOpen=false` — `Tests run: 1, Skipped: 1`, `BUILD SUCCESS` (confirms the disabled test does not hang PR gate).
- No production code changed (`git diff` on `shaft-capture/src/main/java` is empty).
- No stray processes left running (verified via `jps`/`tasklist` after each experiment; killed two leaked chromedriver/chrome trees during investigation).

## Auto-merge

**Not armed.** Per orchestrator direction, this needs human review of the gating (a browser test that hangs must not be reachable from a default CI path) before it lands.

Refs #4046

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWzHNJ2qYHfFDQy1ve1G1w