### PR TITLE
Remove orphaned unitTestSuite.xml

### DIFF
--- a/shaft-engine/src/test/resources/TestSuites/unitTestSuite.xml
+++ b/shaft-engine/src/test/resources/TestSuites/unitTestSuite.xml
@@ -1,9 +1,0 @@
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-
-<suite name="Unit Test Suite" verbose="10">
-    <test name="Unit Test">
-        <packages>
-            <package name="unitTests"/>
-        </packages>
-    </test>
-</suite>


### PR DESCRIPTION
## Summary
- `shaft-engine/src/test/resources/TestSuites/unitTestSuite.xml` is a redundant leftover, not a source of dark tests -- deleted it.
- Repo-wide grep for `suiteXmlFile` across every pom, workflow, and script in the tree: **zero hits**. Nothing in the reactor was ever pointed at any suite XML (this file, `testSuite02.xml`, or `cucumber_testSuite.xml` are all equally unwired).
- The file was already non-functional as written even had it been wired in: its `<package name="unitTests"/>` selector only matches a package literally named `unitTests`; every real test class lives under `testPackage.unitTests` or `com.shaft.test.unitTests`, neither of which that selector matches.
- The tests it intended to cover already run through the real (unrelated) route: `.github/workflows/pr-gate.yml`'s `unit-tests` job explicitly runs `-Dtest=testPackage/unitTests/*, <named classes>` on every PR, and `e2eLocalTests.yml`'s `GLOBAL_TESTING_SCOPE` (negative-exclusion only) sweeps in the `com.shaft.test.unitTests` classes on nightly local runs. Verdict: **redundant leftover, not a coverage gap.**

## Test plan
- [x] `mvn -pl shaft-engine test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- BUILD SUCCESS after deletion.
- [x] `mvn -pl shaft-engine test -Dtest=testPackage.unitTests.StringHelperUnitTest,testPackage.unitTests.JavaHelperUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- Tests run: 74, Failures: 0, Errors: 0, Skipped: 0 (proves the package's tests run via the real, unrelated route).
- [x] `grep -rn "unitTestSuite" .` (excluding target/.git) before deletion -- zero matches, confirming nothing referenced it.

Closes #4018

Co-Authored-By: Claude Sonnet 5 (Tester) <noreply@anthropic.com>