### PR TITLE
Fix #4066: bound CaptureManager.invoke() so a recorder hang cannot hang the MCP tool call forever

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureManager.java
@@ -10,9 +10,11 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 /**
@@ -24,6 +26,14 @@ public final class CaptureManager implements AutoCloseable {
     // liveness probe fail while the browser is perfectly healthy. Only consecutive failures
     // may tear the session down, or a single flaky check silently discards the recording.
     private static final int HEALTH_FAILURES_BEFORE_INTERRUPT = 3;
+    // Bounds every invoke() wait (#4066): an unbounded executor.submit(...).get() turned any
+    // recorder-side hang (a wedged CDP/BiDi round trip, a stuck WebDriver.quit()) into an
+    // unbounded, undiagnosable MCP tool hang. A real browser session start observed ~18s; this
+    // gives ~5x headroom for a slow machine while still failing well before the MCP client's own
+    // 240s SESSION_START_TIMEOUT (ShaftMcpStdioClient), so the server reports a named, diagnosable
+    // error before the client gives up. checkpoint() is in-memory only and stop()/close() share
+    // start()'s browser-teardown I/O profile, so one bound honestly covers every invoke() call site.
+    private static final Duration DEFAULT_OPERATION_TIMEOUT = Duration.ofSeconds(90);
 
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
         Thread thread = new Thread(runnable, "shaft-capture-manager");
@@ -33,6 +43,7 @@ public final class CaptureManager implements AutoCloseable {
     private static final java.util.Set<String> SUPPORTED_MODES = java.util.Set.of("record", "inspect");
 
     private final Function<CaptureStartRequest, ManagedCaptureRecorder> recorderFactory;
+    private final Duration operationTimeout;
     private volatile ManagedCaptureRecorder recorder;
     private volatile CaptureStatus lastStatus = CaptureStatus.notRunning();
     private volatile String mode = "record";
@@ -48,10 +59,18 @@ public final class CaptureManager implements AutoCloseable {
     }
 
     CaptureManager(Function<CaptureStartRequest, ManagedCaptureRecorder> recorderFactory) {
+        this(recorderFactory, DEFAULT_OPERATION_TIMEOUT);
+    }
+
+    // Test-only seam: production always resolves to DEFAULT_OPERATION_TIMEOUT; tests inject a
+    // short bound so a deliberately-blocking operation proves the timeout in milliseconds instead
+    // of waiting out the real one.
+    CaptureManager(Function<CaptureStartRequest, ManagedCaptureRecorder> recorderFactory, Duration operationTimeout) {
         if (recorderFactory == null) {
             throw new IllegalArgumentException("Capture recorder factory is required.");
         }
         this.recorderFactory = recorderFactory;
+        this.operationTimeout = operationTimeout;
     }
 
     /**
@@ -99,7 +118,7 @@ public final class CaptureManager implements AutoCloseable {
                 false,
                 ProcessHandle.current().pid(),
                 null);
-        return invoke(() -> {
+        return invoke("start", () -> {
             sessionLock = CaptureSingleSessionLock.acquire(request.runtimeDirectory());
             try {
                 cleanupExistingSessionOutput(request.outputPath());
@@ -285,7 +304,7 @@ public final class CaptureManager implements AutoCloseable {
      * @return updated status
      */
     public CaptureStatus checkpoint(String description, Checkpoint.CheckpointKind kind) {
-        return invoke(() -> {
+        return invoke("checkpoint", () -> {
             requireRecorder().checkpoint(description, kind);
             lastStatus = recorder.status();
             return lastStatus;
@@ -308,7 +327,7 @@ public final class CaptureManager implements AutoCloseable {
             return withWarning(currentStatus, NO_ACTIVE_RECORDING_WARNING);
         }
         lastStatus = copyWithState(currentStatus, CaptureStatus.State.STOPPING);
-        return invoke(() -> {
+        return invoke("stop", () -> {
             cancelHealthCheck();
             try {
                 lastStatus = current.stop(discard);
@@ -336,7 +355,7 @@ public final class CaptureManager implements AutoCloseable {
     public synchronized void close() {
         ManagedCaptureRecorder current = recorder;
         if (current != null) {
-            invoke(() -> {
+            invoke("close", () -> {
                 cancelHealthCheck();
                 lastStatus = current.interrupt();
                 if (recorder == current) {
@@ -383,11 +402,13 @@ public final class CaptureManager implements AutoCloseable {
         return recorder;
     }
 
-    private <T> T invoke(java.util.concurrent.Callable<T> operation) {
+    private <T> T invoke(String operationName, java.util.concurrent.Callable<T> operation) {
+        Future<T> future = executor.submit(operation);
         try {
-            return executor.submit(operation).get();
+            return future.get(operationTimeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
+            future.cancel(true);
             throw new IllegalStateException("SHAFT Capture control was interrupted.", exception);
         } catch (ExecutionException exception) {
             Throwable cause = exception.getCause();
@@ -395,6 +416,17 @@ public final class CaptureManager implements AutoCloseable {
                 throw runtimeException;
             }
             throw new IllegalStateException("SHAFT Capture control failed.", cause);
+        } catch (TimeoutException exception) {
+            // Best-effort cancellation: interrupts the executor's worker thread. If the operation is
+            // blocked on native/browser I/O (the #4066/#4046 case) the interrupt may not land -- but
+            // the caller must get a bounded, named answer either way instead of hanging forever.
+            future.cancel(true);
+            throw new IllegalStateException(
+                    "SHAFT Capture " + operationName + " timed out after " + operationTimeout.toSeconds()
+                            + "s. The operation was cancelled, but if it was blocked on native/browser I/O it "
+                            + "may still be running and holding its browser/driver process -- check for and "
+                            + "clean up an orphaned browser or driver process.",
+                    exception);
         }
     }
 

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerInvokeTimeoutTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureManagerInvokeTimeoutTest.java
@@ -1,0 +1,181 @@
+package com.shaft.capture.runtime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * CaptureManager.invoke() used to call executor.submit(operation).get() with no timeout (#4066):
+ * a recorder operation that blocks forever (a wedged CDP/BiDi round trip, a stuck WebDriver quit)
+ * hung the MCP tool call forever, with no upper bound and no diagnosable failure. Each test carries
+ * its own hard wall-clock bound (assertTimeoutPreemptively) so a regression in the fix -- the exact
+ * failure mode under repair -- cannot hang this suite.
+ */
+class CaptureManagerInvokeTimeoutTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void startTimesOutWithANamedDiagnosableErrorInsteadOfHangingForever() {
+        CountDownLatch releaseBlockedStart = new CountDownLatch(1);
+        CaptureManager manager = new CaptureManager(
+                request -> new BlockingRecorder(request, releaseBlockedStart),
+                Duration.ofMillis(200));
+
+        try {
+            IllegalStateException failure = assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+                    assertThrows(IllegalStateException.class, () -> manager.start(request("blocked.json"))));
+
+            assertTrue(failure.getMessage().contains("start"), failure.getMessage());
+            assertTrue(failure.getMessage().toLowerCase(java.util.Locale.ROOT).contains("timed out"),
+                    failure.getMessage());
+        } finally {
+            // Let the blocked worker thread unwind so the (non-daemon) executor thread can exit
+            // cleanly instead of leaking a permanently blocked thread past this test.
+            releaseBlockedStart.countDown();
+            manager.close();
+        }
+    }
+
+    @Test
+    void aLegitimatelySlowOperationStillSucceedsUnderTheBound() {
+        CaptureManager manager = new CaptureManager(SlowRecorder::new, Duration.ofSeconds(2));
+
+        try {
+            CaptureStatus status = assertTimeoutPreemptively(Duration.ofSeconds(5),
+                    () -> manager.start(request("slow.json")));
+
+            assertEquals(CaptureStatus.State.ACTIVE, status.state());
+        } finally {
+            manager.stop(false);
+            manager.close();
+        }
+    }
+
+    private CaptureStartRequest request(String outputName) {
+        return new CaptureStartRequest(
+                "https://example.test",
+                CaptureBrowser.CHROME,
+                temp.resolve(outputName),
+                temp.resolve("runtime"),
+                true);
+    }
+
+    private static final class BlockingRecorder extends ManagedCaptureRecorder {
+        private final CountDownLatch releaseSignal;
+        private volatile CaptureStatus.State state = CaptureStatus.State.STARTING;
+
+        BlockingRecorder(CaptureStartRequest request, CountDownLatch releaseSignal) {
+            super(request);
+            this.releaseSignal = releaseSignal;
+        }
+
+        @Override
+        void start() {
+            try {
+                releaseSignal.await();
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+            }
+            state = CaptureStatus.State.ACTIVE;
+        }
+
+        @Override
+        CaptureStatus status() {
+            return fakeStatus(state);
+        }
+
+        @Override
+        void checkpoint(String description, com.shaft.capture.model.Checkpoint.CheckpointKind kind) {
+            // Unused: this double only exercises start()'s timeout path.
+        }
+
+        @Override
+        CaptureStatus stop(boolean discard) {
+            state = discard ? CaptureStatus.State.DISCARDED : CaptureStatus.State.COMPLETED;
+            return status();
+        }
+
+        @Override
+        CaptureStatus interrupt() {
+            state = CaptureStatus.State.INCOMPLETE;
+            return status();
+        }
+
+        @Override
+        boolean isBrowserAlive() {
+            return state == CaptureStatus.State.ACTIVE;
+        }
+    }
+
+    private static final class SlowRecorder extends ManagedCaptureRecorder {
+        private volatile CaptureStatus.State state = CaptureStatus.State.STARTING;
+
+        SlowRecorder(CaptureStartRequest request) {
+            super(request);
+        }
+
+        @Override
+        void start() {
+            try {
+                // Well under the 2s bound configured above, but not instantaneous: proves a
+                // legitimately slow (bounded) operation is not spuriously killed by the timeout.
+                Thread.sleep(300);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+            }
+            state = CaptureStatus.State.ACTIVE;
+        }
+
+        @Override
+        CaptureStatus status() {
+            return fakeStatus(state);
+        }
+
+        @Override
+        void checkpoint(String description, com.shaft.capture.model.Checkpoint.CheckpointKind kind) {
+            // Unused: this double only exercises the slow-but-successful start() path.
+        }
+
+        @Override
+        CaptureStatus stop(boolean discard) {
+            state = discard ? CaptureStatus.State.DISCARDED : CaptureStatus.State.COMPLETED;
+            return status();
+        }
+
+        @Override
+        CaptureStatus interrupt() {
+            state = CaptureStatus.State.INCOMPLETE;
+            return status();
+        }
+
+        @Override
+        boolean isBrowserAlive() {
+            return state == CaptureStatus.State.ACTIVE;
+        }
+    }
+
+    private static CaptureStatus fakeStatus(CaptureStatus.State state) {
+        return new CaptureStatus(
+                state,
+                "fake-session",
+                CaptureBrowser.CHROME.name().toLowerCase(),
+                "https://example.test",
+                0,
+                List.of(),
+                "",
+                false,
+                ProcessHandle.current().pid(),
+                Instant.parse("2026-01-02T03:04:05Z"));
+    }
+}


### PR DESCRIPTION
## Summary

- `CaptureManager.invoke()` called `executor.submit(operation).get()` with no timeout, so any recorder-side hang blocked the MCP tool call forever with no diagnosable failure. Found while root-causing #4046 -- this is the amplifier, not #4046's own fix (owned separately by another agent).
- Bounded the wait to 90s (`DEFAULT_OPERATION_TIMEOUT`): ~5x a real observed ~18s browser start, well below the MCP client's 240s `SESSION_START_TIMEOUT` (`ShaftMcpStdioClient`) so the server reports before the client gives up. One bound honestly covers every call site (`start`/`checkpoint`/`stop`/`close`): `checkpoint()` is in-memory only, and `stop()`/`close()` share `start()`'s browser-teardown I/O profile.
- On timeout: cancel the `Future` (best-effort interrupt -- may not unblock native I/O per #4066's own reproduction, but is the correct standard effort) and throw an `IllegalStateException` naming the operation and the timeout duration, replacing silence with a diagnosable error.
- Added a package-private `Duration`-injecting constructor so tests can prove the timeout in milliseconds instead of waiting out the real bound.

## Test plan

- [x] `CaptureManagerInvokeTimeoutTest`: a deliberately-blocking `start()` fails with a bounded, named error instead of hanging forever -- watched RED (compile failure for the missing constructor), then GREEN.
- [x] Mutation-checked: temporarily reverted `invoke()` to the old unbounded `get()`; the test failed for the right reason (JUnit's own `assertTimeoutPreemptively` caught the runaway block), then restored the fix and re-confirmed GREEN.
- [x] A legitimately slow (but in-bound) `start()` still succeeds, proving the bound isn't too tight for real slow operations.
- [x] `mvn -pl shaft-capture test -Dtest=CaptureManagerLifecycleTest,CaptureManagerHealthCheckTest,CaptureManagerNetworkTransactionsTest,CaptureManagerModeTest,CaptureManagerInvokeTimeoutTest` -- 21/21 passed.
- [x] `mvn -pl shaft-capture compile test-compile` -- green.

## Audited, not fixed (out of scope for this ticket)

- `shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java:224-231` has the same unbounded `executor.submit(...).get()` pattern (JUnit retry re-execution). Reported here per the ticket's audit ask; left untouched since it's outside `CaptureManager.java`.

Closes #4066
Related: #4046

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWzHNJ2qYHfFDQy1ve1G1w