### PR TITLE
Fix reentrant WebDriver call inside CDP Fetch interception callback (#4046)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/network/CaptureNetworkRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/network/CaptureNetworkRecorder.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Per-session network transaction recorder. Registers a single Selenium DevTools {@link Filter}
@@ -70,6 +71,7 @@ public final class CaptureNetworkRecorder implements AutoCloseable {
     private final AtomicLong recordedCount = new AtomicLong();
     private final Deque<String> lastEndpoints = new ArrayDeque<>();
     private final Object lastEndpointsLock = new Object();
+    private final Supplier<String> currentPageUrlSupplier;
     private volatile boolean maxTransactionsWarned;
     private NetworkInterceptor interceptor;
     private volatile boolean started;
@@ -81,6 +83,10 @@ public final class CaptureNetworkRecorder implements AutoCloseable {
      * @param bodiesDirectory directory used to persist request/response bodies
      * @param options network capture filtering and body-capture options
      * @param sessionId owning capture session identifier, used for deterministic secret-ref derivation
+     * @param currentPageUrlSupplier supplies the last-known top-level page URL for first-party
+     *                               classification and {@code initiatorPageUrl} tagging; must be a
+     *                               non-blocking read (see {@link #createFilter()} for why it must
+     *                               never call back into the WebDriver session)
      * @param sink destination for each recorded, redacted network transaction
      * @param warn destination for safe one-time warnings
      */
@@ -89,17 +95,21 @@ public final class CaptureNetworkRecorder implements AutoCloseable {
             Path bodiesDirectory,
             NetworkCaptureOptions options,
             String sessionId,
+            Supplier<String> currentPageUrlSupplier,
             Consumer<RecordedTransaction> sink,
             Consumer<String> warn) {
-        if (driver == null || bodiesDirectory == null || sink == null || warn == null) {
+        if (driver == null || bodiesDirectory == null || currentPageUrlSupplier == null
+                || sink == null || warn == null) {
             throw new IllegalArgumentException(
-                    "Network recorder requires a driver, bodies directory, sink, and warn consumer.");
+                    "Network recorder requires a driver, bodies directory, current-page-URL supplier, "
+                            + "sink, and warn consumer.");
         }
         this.driver = driver;
         this.bodyStore = new NetworkBodyStore();
         this.sessionDirectory = bodiesDirectory.toAbsolutePath().normalize();
         this.options = options == null ? NetworkCaptureOptions.defaults() : options;
         this.sessionId = sessionId == null || sessionId.isBlank() ? "capture-session" : sessionId;
+        this.currentPageUrlSupplier = currentPageUrlSupplier;
         this.sink = sink;
         this.warn = warn;
     }
@@ -444,9 +454,18 @@ public final class CaptureNetworkRecorder implements AutoCloseable {
         }
     }
 
+    /**
+     * Never calls back into the WebDriver session (issue #4046): this runs on the CDP
+     * {@code Fetch.requestPaused} callback thread, before the request it is handling has been
+     * continued. A classic WebDriver command issued from here (e.g. {@code driver.getCurrentUrl()})
+     * is queued by chromedriver behind the very page load that cannot complete until this callback
+     * continues the paused request -- a circular wait that deadlocks both this call and any other
+     * in-flight WebDriver command on the same session (observed: {@code executeScript} hanging
+     * forever). {@link #currentPageUrlSupplier} must therefore be a non-blocking read.
+     */
     private String currentPageOrigin() {
         try {
-            return originOf(driver.getCurrentUrl());
+            return originOf(currentPageUrlSupplier.get());
         } catch (RuntimeException exception) {
             return "";
         }

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
@@ -95,7 +95,9 @@ class ManagedCaptureRecorder {
      * injectable so the stop-time flush can be tested without launching a real browser.
      */
     private Supplier<List<String>> pendingBrowserDeletesReader = this::readPendingBrowserDeletesFromOverlay;
-    private String currentUrl;
+    // Volatile: read from the CDP network-interception callback thread (via the currentPageUrlSupplier
+    // passed to CaptureNetworkRecorder, issue #4046) as well as the owning thread and status() callers.
+    private volatile String currentUrl;
     private volatile boolean paused;
     private volatile boolean uiStopRequested;
 
@@ -977,7 +979,7 @@ class ManagedCaptureRecorder {
         try {
             networkRecorder = new CaptureNetworkRecorder(
                     activeDriver, networkBodiesDirectory, resolvedNetworkCaptureOptions(), sessionId,
-                    this::acceptNetworkEvent, this::warn);
+                    () -> currentUrl, this::acceptNetworkEvent, this::warn);
             if (!networkRecorder.start()) {
                 networkRecorder = null;
             }

--- a/shaft-capture/src/test/java/com/shaft/capture/network/CaptureNetworkRecorderTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/network/CaptureNetworkRecorderTest.java
@@ -60,7 +60,8 @@ class CaptureNetworkRecorderTest {
         AtomicReference<HttpRequest> observedByNext = new AtomicReference<>();
         try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
             CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
-                    driver, temp.resolve("bodies"), options, "session-1", events::add, warnings::add);
+                    driver, temp.resolve("bodies"), options, "session-1", driver::getCurrentUrl,
+                    events::add, warnings::add);
             assertTrue(recorder.start());
 
             String requestPayload = "abcdefghij"; // 10 bytes, exceeds maxBodyBytes=5
@@ -112,7 +113,8 @@ class CaptureNetworkRecorderTest {
         AtomicReference<Filter> filterRef = new AtomicReference<>();
         try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
             CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
-                    driver, temp.resolve("bodies"), options, "session-1", events::add, warnings::add);
+                    driver, temp.resolve("bodies"), options, "session-1", driver::getCurrentUrl,
+                    events::add, warnings::add);
             assertTrue(recorder.start());
 
             HttpRequest request = new HttpRequest(HttpMethod.POST, "https://example.test/api/orders");
@@ -145,7 +147,8 @@ class CaptureNetworkRecorderTest {
         AtomicReference<Filter> filterRef = new AtomicReference<>();
         try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
             CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
-                    driver, temp.resolve("bodies"), options, "session-1", events::add, warnings::add);
+                    driver, temp.resolve("bodies"), options, "session-1", driver::getCurrentUrl,
+                    events::add, warnings::add);
             assertTrue(recorder.start());
 
             HttpRequest request = new HttpRequest(HttpMethod.POST, "https://example.test/api/orders");
@@ -175,7 +178,8 @@ class CaptureNetworkRecorderTest {
         AtomicReference<Filter> filterRef = new AtomicReference<>();
         try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
             CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
-                    driver, temp.resolve("bodies"), options, "session-1", events::add, warnings::add);
+                    driver, temp.resolve("bodies"), options, "session-1", driver::getCurrentUrl,
+                    events::add, warnings::add);
             assertTrue(recorder.start());
 
             HttpRequest assetRequest = new HttpRequest(HttpMethod.GET, "https://example.test/static/app.css");
@@ -201,7 +205,8 @@ class CaptureNetworkRecorderTest {
         AtomicReference<Filter> filterRef = new AtomicReference<>();
         try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
             CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
-                    driver, temp.resolve("bodies"), options, "session-1", events::add, warnings::add);
+                    driver, temp.resolve("bodies"), options, "session-1", driver::getCurrentUrl,
+                    events::add, warnings::add);
             assertTrue(recorder.start());
 
             filterRef.get().apply(req -> new HttpResponse().setStatus(200).addHeader("Content-Type", "text/css"))
@@ -226,7 +231,8 @@ class CaptureNetworkRecorderTest {
         AtomicReference<Filter> filterRef = new AtomicReference<>();
         try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
             CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
-                    driver, temp.resolve("bodies"), options, "session-1", events::add, warnings::add);
+                    driver, temp.resolve("bodies"), options, "session-1", driver::getCurrentUrl,
+                    events::add, warnings::add);
             assertTrue(recorder.start());
 
             HttpRequest crossOrigin = new HttpRequest(HttpMethod.GET, "https://third-party.test/pixel.gif");
@@ -253,7 +259,8 @@ class CaptureNetworkRecorderTest {
         AtomicReference<Filter> filterRef = new AtomicReference<>();
         try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
             CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
-                    driver, temp.resolve("bodies"), options, "session-1", events::add, warnings::add);
+                    driver, temp.resolve("bodies"), options, "session-1", driver::getCurrentUrl,
+                    events::add, warnings::add);
             assertTrue(recorder.start());
             HttpHandler next = req -> new HttpResponse().setStatus(200);
 
@@ -282,7 +289,8 @@ class CaptureNetworkRecorderTest {
         AtomicReference<Filter> filterRef = new AtomicReference<>();
         try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
             CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
-                    driver, temp.resolve("bodies"), options, "session-1", events::add, warnings::add);
+                    driver, temp.resolve("bodies"), options, "session-1", driver::getCurrentUrl,
+                    events::add, warnings::add);
             assertTrue(recorder.start());
             HttpHandler next = req -> new HttpResponse().setStatus(200);
 
@@ -298,13 +306,46 @@ class CaptureNetworkRecorderTest {
     }
 
     @Test
+    void neverCallsDriverGetCurrentUrlFromTheInterceptionFilter() throws Exception {
+        // Regression for issue #4046: the interception filter used to call driver.getCurrentUrl()
+        // (a classic WebDriver command) from inside the CDP Fetch.requestPaused callback, before
+        // continuing the very request that callback was handling. chromedriver serializes classic
+        // command processing per session; since the pending page load cannot complete until this
+        // callback continues the paused request, the reentrant getCurrentUrl() call contended with
+        // (and, against a real browser, deadlocked) any other in-flight WebDriver command on the
+        // same session (observed: RemoteWebDriver.executeScript hanging forever). The page origin
+        // must instead come from the supplied, non-reentrant currentPageUrlSupplier.
+        List<CaptureNetworkRecorder.RecordedTransaction> events = new ArrayList<>();
+        WebDriver driver = Mockito.mock(WebDriver.class, Mockito.withSettings().extraInterfaces(HasDevTools.class));
+        Mockito.when(driver.getCurrentUrl()).thenThrow(new AssertionError(
+                "CaptureNetworkRecorder must never call driver.getCurrentUrl() from its interception "
+                        + "filter -- see issue #4046."));
+        NetworkCaptureOptions options = new NetworkCaptureOptions(true, List.of(), List.of(), true, 500, 0);
+
+        AtomicReference<Filter> filterRef = new AtomicReference<>();
+        try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
+            CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
+                    driver, temp.resolve("bodies"), options, "session-1", () -> "https://example.test/app",
+                    events::add, warnings::add);
+            assertTrue(recorder.start());
+
+            HttpHandler next = req -> new HttpResponse().setStatus(200);
+            filterRef.get().apply(next).execute(new HttpRequest(HttpMethod.GET, "https://example.test/api/data"));
+
+            assertEquals(1, events.size());
+            assertEquals("https://example.test", events.getFirst().initiatorPageUrl());
+            recorder.close();
+        }
+    }
+
+    @Test
     void warnsAndSkipsWhenDriverDoesNotSupportDevTools() {
         List<CaptureNetworkRecorder.RecordedTransaction> events = new ArrayList<>();
         WebDriver driver = Mockito.mock(WebDriver.class);
 
         CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
                 driver, temp.resolve("bodies"), NetworkCaptureOptions.defaults(), "session-1",
-                events::add, warnings::add);
+                driver::getCurrentUrl, events::add, warnings::add);
 
         assertFalse(recorder.start());
         assertTrue(warnings.stream().anyMatch(warning -> warning.contains("DevTools") || warning.contains("driver")));
@@ -338,7 +379,7 @@ class CaptureNetworkRecorderTest {
 
                 CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
                         driver, temp.resolve("bodies"), NetworkCaptureOptions.defaults(), "session-1",
-                        events::add, warnings::add);
+                        driver::getCurrentUrl, events::add, warnings::add);
 
                 assertTrue(recorder.start(),
                         "CaptureNetworkRecorder must become the sole interceptor owner instead of "
@@ -382,7 +423,7 @@ class CaptureNetworkRecorderTest {
 
                 CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
                         driver, temp.resolve("bodies"), NetworkCaptureOptions.defaults(), "session-1",
-                        ignoredTransaction -> { }, warnings::add);
+                        driver::getCurrentUrl, ignoredTransaction -> { }, warnings::add);
 
                 assertFalse(recorder.start(),
                         "The recorder must not double-register a competing DevTools network filter "
@@ -412,6 +453,7 @@ class CaptureNetworkRecorderTest {
         try (MockedConstruction<NetworkInterceptor> ignored = mockInterceptor(filterRef)) {
             CaptureNetworkRecorder recorder = new CaptureNetworkRecorder(
                     driver, temp.resolve("bodies"), options, "network-session",
+                    driver::getCurrentUrl,
                     transaction -> store.append(toNetworkEvent(store, transaction)),
                     warnings::add);
             assertTrue(recorder.start());

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -1499,28 +1499,45 @@ class ManagedCaptureRecorderBrowserTest {
      * <p><b>Isolation result (2026-07-26):</b> disabling {@code startCollector} (the BiDi UI-event
      * collector) and re-running left the hang unchanged -- CDP {@code NetworkInterceptor} alone
      * conflicts with a subsequent {@code executeScript} call; this is not a BiDi+CDP concurrency
-     * conflict. Root-cause fix is tracked on #4046 and intentionally not attempted here (tester
-     * scope: reproduce and hand off, not implement).
+     * conflict.
      *
-     * <p><b>Disabled, not merely tagged:</b> this class already carries {@code @Tag("external-e2e")},
-     * but that is not sufficient gating here -- {@code .github/actions/capture-browser-e2e} runs
-     * this exact class (by name, all methods) with {@code -DincludeCaptureBrowserE2E} from
-     * {@code pr-gate.yml} (PR-blocking), {@code mavenCentral_cd.yml}, and
-     * {@code shaft-pilot-release.yml}. Left enabled, this test would hang every PR's gate. Remove
-     * {@code @Disabled} only once the underlying hang is fixed.
+     * <p><b>Root cause (confirmed with a debug-instrumented run, thread names and timestamps):</b>
+     * {@code CaptureNetworkRecorder}'s interception filter called {@code driver.getCurrentUrl()} --
+     * a classic WebDriver command -- from inside the CDP {@code Fetch.requestPaused} callback,
+     * <em>before</em> continuing the very request that callback was handling
+     * ({@code CaptureNetworkRecorder.currentPageOrigin()}, invoked from
+     * {@code createFilter()} ahead of {@code next.execute(request)}). chromedriver serializes
+     * classic command processing per session; the pending page load cannot complete until the
+     * paused request is continued, and continuing it was blocked on this very reentrant call --
+     * a circular wait that deadlocked both the reentrant call and the main thread's concurrent
+     * {@code executeScript}. Fixed by sourcing the page origin from a non-reentrant
+     * {@code currentPageUrlSupplier} (backed by {@code ManagedCaptureRecorder}'s passively-tracked
+     * {@code currentUrl}) instead of querying the driver from the callback thread.
      *
-     * <p>Note for whoever picks this up: {@code @Timeout(60)} below does NOT reliably abort this
-     * particular hang locally -- the blocked thread is parked inside a native
+     * <p>Note for whoever revisits this: {@code @Timeout(60)} below does NOT reliably abort this
+     * class of hang locally -- the blocked thread parks inside a native
      * {@code CompletableFuture.get()} round-trip to chromedriver that did not honor interrupt in
-     * two separate local runs (test kept running 2+ minutes past the bound until the process tree
-     * was killed externally). Don't trust the annotation alone to keep a future CI run bounded.
+     * separate local runs (the test kept running well past the bound until the process tree was
+     * killed externally). Don't trust the annotation alone to keep a future CI run bounded if this
+     * regresses.
+     *
+     * <p><b>Still disabled -- second, separate failure found (2026-07-26):</b> with the deadlock
+     * fixed, this test no longer hangs (it now completes in ~32s against a 55s external bound,
+     * confirmed via a hard-killed, PID-tracked run), but it fails with a distinct, bounded
+     * {@code org.openqa.selenium.ScriptTimeoutException: script timeout} at
+     * {@code ManagedCaptureRecorder.java:153} (the same {@code executeScript} call site), against
+     * Selenium's default {@code timeouts:{script: 30000}}. This is un-root-caused -- left disabled
+     * and handed off rather than guessed at. Re-enable only once that failure is independently
+     * diagnosed and fixed.
      */
     @Test
     @org.junit.jupiter.api.Timeout(60)
-    @org.junit.jupiter.api.Disabled("Issue #4046: reproduces a real hang (CDP NetworkInterceptor "
-            + "poisons a subsequent executeScript call) -- @Timeout does not reliably abort it, and "
-            + "this class runs unconditionally from pr-gate.yml's capture-browser-e2e step. Re-enable "
-            + "once the root cause is fixed.")
+    @org.junit.jupiter.api.Disabled("Issue #4046: the CDP-NetworkInterceptor-vs-executeScript "
+            + "deadlock is fixed (see PR history), but a second, separate ScriptTimeoutException "
+            + "surfaced once the deadlock stopped masking it -- un-root-caused, tracked as a "
+            + "follow-up. @Timeout does not reliably abort a regression of the original hang, and "
+            + "this class runs unconditionally from pr-gate.yml's capture-browser-e2e step. "
+            + "Re-enable once the ScriptTimeoutException is fixed.")
     void startCompletesWhenApiCaptureIsEnabledAgainstARealBrowser(@TempDir Path temp) throws Exception {
         HttpServer server = localFixture();
         ManagedCaptureRecorder recorder = null;


### PR DESCRIPTION
## Summary

Fixes the deadlock behind #4046 (Guided Workflows Live E2E nightly, red 5/5 nights). Does **not** close #4046: the nightly's E2E path still fails on a second, separate, un-root-caused issue (see Handoff below), so the regression test stays `@Disabled`.

Related: #4068 (tester's reproduction, root-cause investigation handed off from there), #4064 (merged, already in `main`), #4066 (`CaptureManager.invoke()` unbounded wait — separate issue, untouched here, owned by another agent).

## Mechanism (full detail — this must not live only in a chat message)

**The bug:** `CaptureNetworkRecorder`'s network interception filter called `driver.getCurrentUrl()` — a classic WebDriver command — from inside the CDP `Fetch.requestPaused` callback, **before** continuing the very request that callback was handling.

`CaptureNetworkRecorder.java` (pre-fix), inside `createFilter()`:
```java
private Filter createFilter() {
    return next -> request -> {
        long transactionId = nextTransactionId.incrementAndGet();
        String pageOrigin = currentPageOrigin();   // <-- driver.getCurrentUrl(), BEFORE continuing
        ...
        HttpResponse response = next.execute(request);   // <-- this is what actually continues the paused request
        ...
    };
}

private String currentPageOrigin() {
    try {
        return originOf(driver.getCurrentUrl());   // reentrant classic WebDriver command
    } catch (RuntimeException exception) {
        return "";
    }
}
```

**Why that deadlocks — read straight from Selenium's own source** (`selenium-remote-driver-4.46.0-sources.jar`, pinned version, `org/openqa/selenium/devtools/idealized/Network.java:200-265`): the `Fetch.requestPaused` listener runs on a CDP executor thread and, for the request-stage pause, synchronously blocks on a `CompletableFuture` (`res.get()`) waiting for the **paired response-stage** `Fetch.requestPaused` event for the same transaction before it returns control to our filter's `next.execute()`/`continueRequest`. `enableFetchForAllPatterns()` (`v150Network.java:75-84`) explicitly registers interception at **both** `RequestStage.REQUEST` and `RequestStage.RESPONSE` — so this two-stage, blocking-until-paired design is deliberate on Selenium's side, not a bug there.

chromedriver serializes classic W3C command processing per session — one command in flight at a time. `driver.navigate().to(url)` triggers the top-level document request, which gets Fetch-paused. Our filter's callback (on the CDP executor thread) reaches `currentPageOrigin()` and issues a **second** classic command (`getCurrentUrl()`) on the *same session* — but the page load that `navigate()`/the pending request depends on cannot settle until **our own filter continues the paused request** (`next.execute()` → `continueRequest`), which cannot happen until `currentPageOrigin()` returns, which cannot happen until chromedriver services `getCurrentUrl()` — which it won't, because the session is still occupied by the load that's waiting on us. **Circular wait.** This also explains why the unrelated `executeScript()` call on the main thread hung too: it queued on the same serialized session behind the stuck state.

**Confirmed live, not inferred.** I ran the disabled regression test once with temporary debug instrumentation (thread name + `System.nanoTime()` at each step) against the *unfixed* code, hard-killed the process tree at a 50s external bound (PID-tracked `taskkill /F /T`, verified no leaks). Captured log:

```
[main] MAIN THREAD BEFORE navigate() at 11914732213900
[main] MAIN THREAD AFTER navigate() at 11914822311600
[main] MAIN THREAD BEFORE executeScript() at 11914822810700
[CDP Connection] tx=1 url=http://127.0.0.1:52630/ BEFORE currentPageOrigin() at 11914885055200
   <-- no "AFTER currentPageOrigin()" line ever printed; both threads dead-stopped here
```

This is also consistent with the isolation experiment in #4068 (disabling the BiDi UI-event collector left the hang unchanged) — the mechanism has nothing to do with BiDi at all; it is a pure CDP-Fetch + classic-command reentrancy bug in *our own* filter.

### The reusable rule

**Never call a classic WebDriver command from inside a CDP interception callback before continuing the paused request.** Selenium's `Fetch.requestPaused` handling blocks the callback thread on a paired CDP event; chromedriver serializes classic commands per session; any classic command issued from inside that callback — before the request it is handling has been continued — risks a circular wait against whatever the pending network activity is blocking (a navigation, a page load, any other in-flight command on the same session). This generalizes beyond this one bug to any future CDP `NetworkInterceptor`/`Filter` implementation in this codebase.

## Fix

- `CaptureNetworkRecorder`: added a `Supplier<String> currentPageUrlSupplier` constructor parameter; `currentPageOrigin()` now reads it instead of calling `driver.getCurrentUrl()`. Zero WebDriver calls remain in the interception filter's hot path.
- `ManagedCaptureRecorder`: wires `() -> currentUrl` — the field it already tracks passively via BiDi/polling navigation signals (never from inside the CDP callback). Made `currentUrl` `volatile` since it is now read cross-thread from the CDP executor.
- `CaptureNetworkRecorderTest`: updated all 11 existing call sites to pass `driver::getCurrentUrl` (safe there — Mockito-stubbed, no real chromedriver, no reentrancy risk), preserving every existing assertion (e.g. `dropsCrossOriginRequestsWhenFirstPartyOnlyIsTrue`) unchanged. Added `neverCallsDriverGetCurrentUrlFromTheInterceptionFilter`, which stubs `getCurrentUrl()` to throw and proves the filter never calls it. TDD: watched RED (`AssertionError` at the old `currentPageOrigin()` call site) then GREEN. Full suite: 13/13 pass.

Why not the other candidate fixes from the issue: "fix the filter so every request continues" did not apply as framed — the filter already called `next.execute()` unconditionally for every request (verified by direct read; no branch skips it). Reordering JS-injection-before-interceptor-install was the fallback candidate; unnecessary once the actual reentrant call was identified, and this fix is a strictly smaller, more targeted diff.

## Handoff: second, separate failure — un-root-caused, deliberately not investigated

With the deadlock fixed, `ManagedCaptureRecorderBrowserTest#startCompletesWhenApiCaptureIsEnabledAgainstARealBrowser` **no longer hangs** — it completes in ~32s against a 55s external bound (previously: still running past 2+ minutes, requiring a process-tree kill). That is confirmed, not inferred.

It now fails with a different, bounded error:
```
org.openqa.selenium.ScriptTimeoutException: script timeout
  at RemoteWebDriver.executeScript(RemoteWebDriver.java:555)
  at ManagedCaptureRecorder.start(ManagedCaptureRecorder.java:153)
```
against Selenium's default `timeouts:{script: 30000}` (visible in the driver's reported capabilities in the failure log). This is a clean, catchable timeout — not a hang — but its cause has **not** been investigated. Stating this plainly rather than guessing at a mechanism with no supporting evidence. The test stays `@Disabled` (updated reason references this specific failure) pending a fresh, separate diagnosis.

## Verification

- `CaptureNetworkRecorderTest` (unit, 13/13 pass): `mvn -pl shaft-capture -Dtest=CaptureNetworkRecorderTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false`
- `mvn -pl shaft-capture test-compile` clean.
- Browser regression test run twice (bounded, PID-tracked, hard-killed/completed cleanly both times, zero leaked processes verified via `Get-CimInstance` after each): pre-fix reproduces the hang exactly as #4068 described; post-fix no longer hangs, fails on the separate `ScriptTimeoutException` above.
- Out of scope, untouched: `CaptureManager.java` (#4066's territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
