### PR TITLE
Fix #4081: bound every CI workflow job with timeout-minutes

### DIFF
--- a/.github/workflows/deploy-shaft-mcp.yml
+++ b/.github/workflows/deploy-shaft-mcp.yml
@@ -19,6 +19,7 @@ jobs:
   deploy-render:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Trigger Render deployment
         env:
@@ -33,6 +34,7 @@ jobs:
   deploy-fly:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - name: Checkout released source
         uses: actions/checkout@v7
@@ -53,6 +55,7 @@ jobs:
   smithery:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Record optional Smithery deployment handoff
         run: |

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -28,6 +28,7 @@ jobs:
       - MacOSX_Chrome_Local
       - Windows_Edge_Cucumber_Local
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       actions: read
@@ -41,6 +42,7 @@ jobs:
 
   Windows_Edge_Local:
     runs-on: windows-latest
+    timeout-minutes: 90
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -78,6 +80,7 @@ jobs:
 
   MacOSX_Safari_Local:
     runs-on: macos-latest
+    timeout-minutes: 90
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -108,6 +111,7 @@ jobs:
 
   Windows_Chrome_Local:
     runs-on: windows-latest
+    timeout-minutes: 75
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -142,6 +146,7 @@ jobs:
 
   Windows_SikuliX_Local:
     runs-on: windows-latest
+    timeout-minutes: 10
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -175,6 +180,7 @@ jobs:
 
   Windows_Appium_Desktop_Local:
     runs-on: windows-latest
+    timeout-minutes: 15
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -285,6 +291,7 @@ jobs:
 
   MacOSX_Chrome_Local:
     runs-on: macos-latest
+    timeout-minutes: 90
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -315,6 +322,7 @@ jobs:
 
   Windows_Edge_Cucumber_Local:
     runs-on: windows-latest
+    timeout-minutes: 10
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -353,6 +361,7 @@ jobs:
     needs: [ Windows_Edge_Local, MacOSX_Safari_Local, Windows_Chrome_Local, Windows_SikuliX_Local, Windows_Appium_Desktop_Local, MacOSX_Chrome_Local, Windows_Edge_Cucumber_Local ]
     if: always()
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -67,6 +67,7 @@ jobs:
       - MacOSX_Safari_Cucumber_BrowserStack
       - Ubuntu_JUnit_E2E
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       actions: read
@@ -80,6 +81,7 @@ jobs:
 
   Ubuntu_Database:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -128,6 +130,7 @@ jobs:
 
   Ubuntu_APIs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -156,6 +159,7 @@ jobs:
 
   Ubuntu_Visual_Module:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -185,6 +189,7 @@ jobs:
 
   Ubuntu_Desktop_Video_Module:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -214,6 +219,7 @@ jobs:
 
   Ubuntu_Firefox_Grid:
     runs-on: ubuntu-latest
+    timeout-minutes: 50
     permissions:
       contents: read
     outputs:
@@ -250,6 +256,7 @@ jobs:
 
   Ubuntu_Chrome_Grid:
     runs-on: ubuntu-latest
+    timeout-minutes: 50
     permissions:
       contents: read
     outputs:
@@ -286,6 +293,7 @@ jobs:
 
   Ubuntu_MicrosoftEdge_Grid:
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     permissions:
       contents: read
     outputs:
@@ -322,6 +330,7 @@ jobs:
 
   Ubuntu_Playwright_Chrome:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -354,6 +363,7 @@ jobs:
 
   Ubuntu_Playwright_Edge:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -386,6 +396,7 @@ jobs:
 
   Ubuntu_Playwright_WebKit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -418,6 +429,7 @@ jobs:
 
   Ubuntu_Playwright_Firefox:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -450,6 +462,7 @@ jobs:
 
   Ubuntu_Playwright_GalaxyS26Ultra:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -482,6 +495,7 @@ jobs:
 
   Ubuntu_Playwright_IPhone17ProMax:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -514,6 +528,7 @@ jobs:
 
   Android_Native_BrowserStack:
     runs-on: ubuntu-latest
+    timeout-minutes: 50
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -545,6 +560,7 @@ jobs:
 
   iOS_Web_SAFARI_BrowserStack:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -573,6 +589,7 @@ jobs:
 
   Android_Web_Chrome_BrowserStack:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -601,6 +618,7 @@ jobs:
 
   MacOSX_Safari_BrowserStack:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -629,6 +647,7 @@ jobs:
 
   Ubuntu_Chrome_Cucumber_Grid:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -661,6 +680,7 @@ jobs:
 
   MacOSX_Safari_Cucumber_BrowserStack:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -689,6 +709,7 @@ jobs:
 
   Ubuntu_JUnit_E2E:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     env:
@@ -867,6 +888,7 @@ jobs:
     needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack, Ubuntu_JUnit_E2E ]
     if: always()
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/guided-workflows-live.yml
+++ b/.github/workflows/guided-workflows-live.yml
@@ -82,6 +82,7 @@ jobs:
     needs: [live-guided-workflows]
     if: always()
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/lambdatestTests.yml
+++ b/.github/workflows/lambdatestTests.yml
@@ -27,6 +27,7 @@ jobs:
       - LambdaTest_WebApp
       - LambdaTest_DesktopWeb
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       actions: read
@@ -40,6 +41,7 @@ jobs:
 
   LambdaTest_NativeAndroid:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       LAMBDATEST_USERNAME: ${{ secrets.LAMBDATEST_USERNAME }}
       LAMBDATEST_ACCESS_KEY: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
@@ -113,6 +115,7 @@ jobs:
 
   LambdaTest_NativeIOS:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       LAMBDATEST_USERNAME: ${{ secrets.LAMBDATEST_USERNAME }}
       LAMBDATEST_ACCESS_KEY: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
@@ -191,6 +194,7 @@ jobs:
 
   LambdaTest_WebApp:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       LAMBDATEST_USERNAME: ${{ secrets.LAMBDATEST_USERNAME }}
       LAMBDATEST_ACCESS_KEY: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
@@ -242,6 +246,7 @@ jobs:
 
   LambdaTest_DesktopWeb:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       LAMBDATEST_USERNAME: ${{ secrets.LAMBDATEST_USERNAME }}
       LAMBDATEST_ACCESS_KEY: ${{ secrets.LAMBDATEST_ACCESS_KEY }}

--- a/.github/workflows/live-tools-nightly.yml
+++ b/.github/workflows/live-tools-nightly.yml
@@ -280,6 +280,7 @@ jobs:
       - gemini-live
     if: always()
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/maven-central-reconcile.yml
+++ b/.github/workflows/maven-central-reconcile.yml
@@ -37,6 +37,7 @@ jobs:
     # Maven Central + GPG/OSSRH secrets are not available on forked repos; signing would fail with empty key id.
     if: github.event.repository.fork == false
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
     permissions:
       contents: write
     env:

--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -59,6 +59,7 @@ jobs:
     # Maven Central + GPG/OSSRH secrets are not available on forked repos; signing would fail with empty key id.
     if: github.event.repository.fork == false
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       already_released: ${{ steps.guard.outputs.already_released }}
     steps:
@@ -83,6 +84,7 @@ jobs:
       MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     permissions:
       contents: read  # only builds/tests/deploys to Maven Central; the GitHub Release is created by announce_release.
     outputs:
@@ -211,6 +213,7 @@ jobs:
     # Skip when build_release_and_deliver was skipped (nothing new delivered), not just on failure.
     if: needs.build_release_and_deliver.result == 'success'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -242,6 +245,7 @@ jobs:
     # Skip when build_release_and_deliver was skipped (nothing new delivered), not just on failure.
     if: needs.build_release_and_deliver.result == 'success'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -336,6 +340,7 @@ jobs:
     # are then cleanly 'skipped', not failed - the outcome expression below must not alert on that.
     if: always()
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -40,6 +40,7 @@ jobs:
   changes:
     name: Detect changed paths
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
       intellij: ${{ steps.filter.outputs.intellij }}
@@ -48,6 +49,7 @@ jobs:
       templates: ${{ steps.filter.outputs.templates }}
       javacore: ${{ steps.filter.outputs.javacore }}
       infra: ${{ steps.filter.outputs.infra }}
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -107,12 +109,18 @@ jobs:
               - 'pom.xml'
             infra:
               - '.github/workflows/pr-gate.yml'
+            # Issue #4081's regression guard (scripts/ci/validate_workflow_timeouts.py):
+            # any workflow file change must re-check that every job still declares
+            # timeout-minutes, not only edits to this file (already covered by infra).
+            workflows:
+              - '.github/workflows/**'
 
   docs-boundary:
     name: Documentation Boundary Gate
     needs: changes
     if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -127,6 +135,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.intellij == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -161,6 +170,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.intellij == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -178,6 +188,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.cli == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -218,6 +229,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.capture == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -273,6 +285,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.javacore == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -327,6 +340,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.templates == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -348,6 +362,31 @@ jobs:
           -DheadlessExecution=true
           -Dgpg.skip
 
+  # Issue #4081: MacOSX_Safari_Local hung after a heap OOM and burned the full
+  # 6-hour default job ceiling on a macos-latest runner (10x billing
+  # multiplier) because nothing bounded it. This job is the CI-side
+  # regression guard for scripts/ci/validate_workflow_timeouts.py, which
+  # fails whenever any .github/workflows/*.yml job has no timeout-minutes.
+  workflow-timeouts:
+    name: Workflow Timeout Guard
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true' || needs.changes.outputs.infra == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - name: Install PyYAML
+        run: python3 -m pip install pyyaml --quiet
+      - name: Run workflow timeout guard unit tests
+        run: python3 -m unittest tests.scripts.test_validate_workflow_timeouts -v
+      - name: Validate every workflow job declares timeout-minutes
+        run: python3 scripts/ci/validate_workflow_timeouts.py
+
   # Moved from security.yml's dependency-review job. Runs unconditionally on
   # every pull_request (no path leg matches it in the `changes` job, mirroring
   # its unconditional-per-PR behavior in security.yml today) and temporarily
@@ -358,6 +397,7 @@ jobs:
     needs: changes
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -380,9 +420,11 @@ jobs:
       - capture-e2e
       - unit-tests
       - template-coupling
+      - workflow-timeouts
       - dependency-review
     if: always()
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Evaluate leg results
         env:
@@ -394,6 +436,7 @@ jobs:
           CAPTURE_RESULT: ${{ needs.capture-e2e.result }}
           UNIT_TESTS_RESULT: ${{ needs.unit-tests.result }}
           TEMPLATES_RESULT: ${{ needs.template-coupling.result }}
+          WORKFLOW_TIMEOUTS_RESULT: ${{ needs.workflow-timeouts.result }}
           DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
         run: |
           set -uo pipefail
@@ -409,6 +452,7 @@ jobs:
             echo "| capture-e2e | ${CAPTURE_RESULT} |"
             echo "| unit-tests | ${UNIT_TESTS_RESULT} |"
             echo "| template-coupling | ${TEMPLATES_RESULT} |"
+            echo "| workflow-timeouts | ${WORKFLOW_TIMEOUTS_RESULT} |"
             echo "| dependency-review | ${DEPENDENCY_REVIEW_RESULT} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -418,7 +462,7 @@ jobs:
           fi
 
           status=0
-          for result in "${DOCS_RESULT}" "${INTELLIJ_VERIFY_RESULT}" "${INTELLIJ_BUILD_RESULT}" "${CLI_RESULT}" "${CAPTURE_RESULT}" "${UNIT_TESTS_RESULT}" "${TEMPLATES_RESULT}" "${DEPENDENCY_REVIEW_RESULT}"; do
+          for result in "${DOCS_RESULT}" "${INTELLIJ_VERIFY_RESULT}" "${INTELLIJ_BUILD_RESULT}" "${CLI_RESULT}" "${CAPTURE_RESULT}" "${UNIT_TESTS_RESULT}" "${TEMPLATES_RESULT}" "${WORKFLOW_TIMEOUTS_RESULT}" "${DEPENDENCY_REVIEW_RESULT}"; do
             case "$result" in
               success|skipped) ;;
               *)

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   prepare-release-pr:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout Default Branch
         uses: actions/checkout@v7

--- a/.github/workflows/publish-intellij-plugin.yml
+++ b/.github/workflows/publish-intellij-plugin.yml
@@ -20,6 +20,7 @@ jobs:
     # no-op delivery for an already-published version, which must not re-publish here.
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7

--- a/.github/workflows/publish-shaft-mcp.yml
+++ b/.github/workflows/publish-shaft-mcp.yml
@@ -22,6 +22,7 @@ jobs:
     # no-op delivery for an already-published version, which must not re-publish here.
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - name: Checkout released source
         uses: actions/checkout@v7

--- a/.github/workflows/publishJavaDocs.yml
+++ b/.github/workflows/publishJavaDocs.yml
@@ -26,6 +26,7 @@ jobs:
       MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       contents: write  # if you have a protection rule on your repository, you'll need to give write permission to the workflow.
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,7 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/shaft-mcp.yml
+++ b/.github/workflows/shaft-mcp.yml
@@ -16,6 +16,7 @@ jobs:
   installer-script-tests:
     name: Installer script tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +45,7 @@ jobs:
   package-and-smoke:
     needs: installer-script-tests
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -101,6 +103,7 @@ jobs:
     needs: [installer-script-tests, package-and-smoke]
     if: always()
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/shaft-pilot-release.yml
+++ b/.github/workflows/shaft-pilot-release.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   detect-shaft-version-change:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       changed: ${{ steps.version-diff.outputs.changed }}
     steps:
@@ -71,6 +72,7 @@ jobs:
     needs: detect-shaft-version-change
     if: needs.detect-shaft-version-change.outputs.changed == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7

--- a/.github/workflows/update-selenium-grid-versions.yml
+++ b/.github/workflows/update-selenium-grid-versions.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   update-versions:
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -185,6 +186,7 @@ jobs:
     needs: [update-versions]
     if: always()
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     permissions:
       contents: read
       issues: write

--- a/scripts/ci/validate_workflow_timeouts.py
+++ b/scripts/ci/validate_workflow_timeouts.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Validate that every GitHub Actions workflow job bounds its own runtime.
+
+Issue #4081: MacOSX_Safari_Local hung after a heap OOM and burned the full
+6-hour default job ceiling on a macos-latest runner (10x billing multiplier)
+because nothing bounded it. This is the regression guard: it fails whenever
+any job in .github/workflows/*.yml has no explicit timeout-minutes. Jobs that
+call a reusable workflow via `uses:` are exempt -- GitHub Actions rejects
+timeout-minutes on that job shape, the called workflow bounds itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_GLOB = ".github/workflows/*.yml"
+
+
+def issue(code: str, path: str, message: str) -> dict[str, str]:
+    """Create a stable validation issue."""
+    return {"code": code, "path": path, "message": message}
+
+
+def validate_repository(root: Path = ROOT) -> list[dict[str, str]]:
+    """Flag every workflow job that has no explicit timeout-minutes."""
+    errors: list[dict[str, str]] = []
+    workflows_dir = root / ".github/workflows"
+    if not workflows_dir.is_dir():
+        return errors
+    for workflow_path in sorted(root.glob(WORKFLOWS_GLOB)):
+        relative = workflow_path.relative_to(root).as_posix()
+        try:
+            document = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as error:
+            errors.append(issue("workflow-timeout-parse", relative, str(error)))
+            continue
+        jobs = (document or {}).get("jobs", {})
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict) or "uses" in job:
+                continue
+            if "timeout-minutes" not in job:
+                errors.append(
+                    issue(
+                        "workflow-timeout-missing",
+                        relative,
+                        f"job '{job_name}' has no timeout-minutes",
+                    )
+                )
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser
+
+
+def main() -> int:
+    """Run the CLI."""
+    args = build_parser().parse_args()
+    errors = validate_repository(args.root.resolve())
+    if args.format == "json":
+        print(json.dumps({"valid": not errors, "errors": errors}, indent=2))
+    elif errors:
+        for error in errors:
+            print(f"{error['code']}: {error['path']}: {error['message']}", file=sys.stderr)
+    else:
+        print("All workflow jobs declare timeout-minutes.")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_validate_workflow_timeouts.py
+++ b/tests/scripts/test_validate_workflow_timeouts.py
@@ -1,0 +1,103 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.ci.validate_workflow_timeouts import validate_repository
+
+
+class ValidateWorkflowTimeoutsTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write(self, relative_path, content):
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def codes(self):
+        return {error["code"] for error in validate_repository(self.root)}
+
+    def test_job_missing_timeout_minutes_is_flagged(self):
+        self.write(
+            ".github/workflows/example.yml",
+            """
+name: Example
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+""",
+        )
+        errors = validate_repository(self.root)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], "workflow-timeout-missing")
+        self.assertEqual(errors[0]["path"], ".github/workflows/example.yml")
+        self.assertIn("build", errors[0]["message"])
+
+    def test_job_with_timeout_minutes_passes(self):
+        self.write(
+            ".github/workflows/example.yml",
+            """
+name: Example
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - run: echo hi
+""",
+        )
+        self.assertEqual(validate_repository(self.root), [])
+
+    def test_reusable_workflow_call_job_is_exempt(self):
+        self.write(
+            ".github/workflows/example.yml",
+            """
+name: Example
+jobs:
+  call-shared:
+    uses: ./.github/workflows/shared.yml
+""",
+        )
+        self.assertEqual(validate_repository(self.root), [])
+
+    def test_multiple_jobs_each_flagged_by_name(self):
+        self.write(
+            ".github/workflows/example.yml",
+            """
+name: Example
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - run: echo notify
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo deploy
+""",
+        )
+        errors = validate_repository(self.root)
+        flagged_jobs = {error["message"].split("'")[1] for error in errors}
+        self.assertEqual(flagged_jobs, {"build", "deploy"})
+
+    def test_no_workflows_directory_returns_no_errors(self):
+        self.assertEqual(validate_repository(self.root), [])
+
+    def test_current_repository_workflows_all_declare_timeout_minutes(self):
+        repository_root = Path(__file__).resolve().parents[2]
+        self.assertEqual(validate_repository(repository_root), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`MacOSX_Safari_Local` hung after a heap OOM and burned the full 6-hour default job ceiling on a `macos-latest` runner (10x billing multiplier) in run 30187807005 -- nothing bounded it. The OOM root cause is tracked separately in #3987 and is untouched here.

**Scope grew from the issue's file-level list.** A per-job audit against the live tree (`scripts/ci/validate_workflow_timeouts.py`) found **69 jobs across all 17 workflow files** missing `timeout-minutes`, not just the 14 files the issue named:
- The two files the issue counted as "already covered" (`guided-workflows-live.yml`, `live-tools-nightly.yml`) each had an uncovered `notify` job.
- `e2eTests.yml` had only **1 of 22** jobs bounded (a step-level `timeout-minutes: 40` on one step of `Android_Native_BrowserStack`, not a job-level bound).
- `e2eLocalTests.yml` had **0 of 9** jobs bounded, including `MacOSX_Safari_Local` itself.

## Workflows changed (17 files, 69 jobs + the new guard's own job)

Every job in `.github/workflows/*.yml` now has an explicit `timeout-minutes`, placed immediately after `runs-on:` (matching the existing style in `e2eTests.yml`/`guided-workflows-live.yml`/`live-tools-nightly.yml`).

## Sizing methodology

For each job, pulled the last 8 runs via `gh run list` + per-job start/end timestamps via `gh api .../actions/runs/<id>/jobs`, filtered to that job's own successful (`conclusion == "success"`) occurrences (not the whole run's conclusion -- a workflow can fail on one job while others complete normally), then chose roughly **1.5x the observed max**, rounded to a clean number.

For jobs with **no successful sample** in the recent window (rare release-only jobs that only run on a version bump, e.g. `mavenCentral_cd.yml`'s `build_release_and_deliver` and `shaft-pilot-release.yml`'s `release-candidate`; and `MacOSX_Safari_Local` itself, which is the job actually hanging under #3987), used a documented, generous judgment-based bound instead -- proxied from the closest sibling job where one exists (e.g. `MacOSX_Safari_Local` -> 90 min, proxied 1.5x off `MacOSX_Chrome_Local`'s observed 63.42 min max on the same runner/scope).

`Android_Native_BrowserStack`'s new 50-min job-level bound intentionally exceeds its pre-existing 40-min step-level bound plus checkout/setup/report overhead.

## Regression guard

`scripts/ci/validate_workflow_timeouts.py` (TDD, `tests/scripts/test_validate_workflow_timeouts.py`) fails whenever any `.github/workflows/*.yml` job lacks `timeout-minutes` (jobs that call a reusable workflow via `uses:` are exempt -- GitHub Actions rejects `timeout-minutes` there). Follows the existing `issue()`/`validate_repository()` house pattern from `scripts/ci/validate_agent_setup.py`.

Wired into `pr-gate.yml` as a new `workflow-timeouts` job, gated on a new `workflows` path-filter output (`.github/workflows/**`, kept separate from the existing narrower `infra` filter so it doesn't widen that filter's existing blast radius) OR the existing `infra` filter.

Verified with a real mutation check: removed `e2eTests.yml`'s `Ubuntu_Database` job's `timeout-minutes: 10` line, confirmed the guard failed and named the job (`workflow-timeout-missing: .github/workflows/e2eTests.yml: job 'Ubuntu_Database' has no timeout-minutes`, exit 1), restored the line, confirmed it passed again (`All workflow jobs declare timeout-minutes.`, exit 0). Also confirmed via `python -m unittest`.

## Test plan
- [x] `py -3 -m unittest tests.scripts.test_validate_workflow_timeouts -v` -- 6/6 tests pass, including one asserting the real repository tree is now clean
- [x] `py -3 scripts/ci/validate_workflow_timeouts.py` -- passes clean against the live tree
- [x] Mutation check (remove/restore a real `timeout-minutes` line) -- guard correctly fails-then-passes
- [x] `py -3 -c "import yaml,...; [yaml.safe_load(...) for f in .github/workflows/*.yml]"` -- all 17 edited workflow files parse
- [ ] CI (pr-gate.yml, including the new `workflow-timeouts` leg) -- pending, will report status separately

Closes #4081