### PR TITLE
Fix #4084: reconcile orchestrator concurrency cap to 2-4, strengthen plan/architecture duty

### DIFF
--- a/.claude/agents/chaos-engine.md
+++ b/.claude/agents/chaos-engine.md
@@ -13,8 +13,10 @@ the delegation tiers. Speak caveman-full (auto-clarity exceptions apply).
 ## Charter
 
 - You never implement: break work down, write detailed specs, assign it to
-  `coder`/`reviewer`/`tester`, review and verify results, and consult on
-  architecture. Every other owner-binding orchestrator rule — dispatch
+  `coder`/`reviewer`/`tester`. For complex tasks the spec supplies the plan
+  and the architecture up front, not just a consult on request, and you stay
+  continuously available for consultation while delegates run — then review
+  and verify results. Every other owner-binding orchestrator rule — dispatch
   effort, delegation tiers, the concurrency budget, the stall watch, usage
   pacing, delegate-output verification, staying interruptible — is canonical
   in act-as-fable's `## Delegation` section

--- a/.claude/skills/act-as-fable/SKILL.md
+++ b/.claude/skills/act-as-fable/SKILL.md
@@ -168,7 +168,7 @@ available to accept new owner requests and realign in-flight tasks to the
 owner's direction — never so deep in any single thread of work that a new
 directive has to wait.
 
-**Parallelism budget (owner rule, binding).** Soft maximum of four–five
+**Parallelism budget (owner rule, binding).** Soft maximum of two–four
 concurrent tasks/subagents, even when more could run conflict-free —
 completeness still outranks parallelization. Land in-flight work before
 fanning out further. The objective behind the cap: the


### PR DESCRIPTION
## Summary
- act-as-fable `## Delegation` -> Parallelism budget: cap changed from "four–five" to "two–four" concurrent tasks/subagents, matching the owner's standing 2-4 rule. Rationale text (completeness over parallelization, usage-window discipline, resumability, wind-down) is unchanged.
- chaos-engine.md Charter bullet 1: strengthened "consult on architecture" into supplying the plan and architecture up front in the dispatch spec for complex tasks, plus staying continuously available for consultation while delegates run. The pointer that every other orchestrator rule (including the concurrency number) is canonical in act-as-fable is kept intact and unchanged.
- AGENTS.md not touched (per #4067 byte cap).

Closes #4084

## Test plan
1. `py -3 scripts/ci/validate_agent_setup.py` — fails with a pre-existing, unrelated `memory-check` secret-detector error in `.memory/memory/gotchas/worktree-isolated-agents-...json` (committed 2026-07-21, PR #3950). Confirmed identical failure on a clean `origin/main` checkout via `git stash` before re-applying this diff — not caused by or related to this change. Filing separately as an adjacent finding.
2. `py -3 scripts/agents/sync_user_harness.py --check` — reports `DRIFTED agents/chaos-engine.md` (expected: canonical repo copy is now ahead of deployed `~/.claude`). Note: the sync manifest only tracks `CLAUDE.md`, `settings.json`, `statusline-command.sh`, and `agents/*.md` — `.claude/skills/` is not part of this deployment, so `act-as-fable/SKILL.md` correctly shows no drift line (it isn't synced by this script at all).
3. `py -3 scripts/agents/sync_user_harness.py --apply` — deployed `agents/chaos-engine.md` to `~/.claude`, backed up the prior copy to `chaos-engine.md.bak`.
4. `py -3 scripts/agents/sync_user_harness.py --check` (again) — all `IN-SYNC`, confirms clean.
5. `rg -n "four.five|four-five|4-5|five concurrent" .claude/ AGENTS.md CLAUDE.md` — one unrelated hit (`graphify/references/full-pipeline.md:609`, "Steps 4-5" in an unrelated pipeline doc, not a concurrency-cap statement). Zero stale statements of the old concurrency cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
