### PR TITLE
Fix #4078: detect Cucumber-over-TestNG runs from suite classes, not the call stack

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java
@@ -126,7 +126,11 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
      */
     @Override
     public void alter(List<XmlSuite> suites) {
-        switch (TestNGListener.identifyRunType()) {
+        // Not TestNGListener.identifyRunType(): that overload's stack probe cannot see Cucumber
+        // here (no io.cucumber.core.runner.Runner frame exists this early), which would leave the
+        // CUCUMBER branch below unreachable for a Cucumber-over-TestNG run (see #4078). This
+        // overload inspects the suites themselves instead, which is available at this call site.
+        switch (ProjectStructureManager.identifyRunType(suites)) {
             case TESTNG -> TestNGListenerHelper.configureTestNGProperties(suites);
             case CUCUMBER -> CucumberHelper.configureCucumberProperties(suites);
         }

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ProjectStructureManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ProjectStructureManager.java
@@ -6,6 +6,8 @@ import com.shaft.tools.io.ReportManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testng.TestNG;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -13,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -48,6 +51,44 @@ public class ProjectStructureManager {
         } else {
             logger.debug("Detected JUnit 5 execution.");
             return RunType.JUNIT;
+        }
+    }
+
+    /**
+     * Detects the active test runner from the TestNG suites being altered.
+     *
+     * <p>This overload exists specifically for {@link org.testng.IAlterSuiteListener#alter},
+     * which TestNG invokes directly during its own suite-processing phase, before any test
+     * method (and therefore before any Cucumber {@code io.cucumber.core.runner.Runner} stack
+     * frame) has run. At that point {@link #identifyRunType()}'s stack probe can never observe
+     * Cucumber, even for a Cucumber-over-TestNG run ({@code AbstractTestNGCucumberTests}), so a
+     * caller at that call site is already known to be TestNG-driven &mdash; the only remaining
+     * question is whether TestNG is hosting a Cucumber runner. That is answered here by
+     * inspecting the suite's own class list instead of the call stack.
+     *
+     * @param suites the suites TestNG is about to run
+     * @return {@link RunType#CUCUMBER} when any suite hosts a Cucumber TestNG runner class
+     * ({@code io.cucumber.testng.AbstractTestNGCucumberTests} subclass), {@link RunType#TESTNG}
+     * otherwise
+     */
+    public static RunType identifyRunType(List<XmlSuite> suites) {
+        boolean isUsingCucumberTestNgRunner = suites.stream()
+                .flatMap(suite -> suite.getTests().stream())
+                .flatMap(xmlTest -> xmlTest.getXmlClasses().stream())
+                .anyMatch(ProjectStructureManager::extendsAbstractTestNGCucumberTests);
+        if (isUsingCucumberTestNgRunner) {
+            logger.debug("Detected Cucumber execution (TestNG runner).");
+            return RunType.CUCUMBER;
+        }
+        logger.debug("Detected TestNG execution.");
+        return RunType.TESTNG;
+    }
+
+    private static boolean extendsAbstractTestNGCucumberTests(XmlClass xmlClass) {
+        try {
+            return io.cucumber.testng.AbstractTestNGCucumberTests.class.isAssignableFrom(xmlClass.getSupportClass());
+        } catch (Throwable throwable) {
+            return false;
         }
     }
 

--- a/shaft-engine/src/test/java/testPackage/unitTests/ProjectStructureManagerTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ProjectStructureManagerTest.java
@@ -4,12 +4,16 @@ import com.shaft.driver.SHAFT;
 import com.shaft.tools.io.internal.ProjectStructureManager;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
 
 /**
  * Unit tests for {@link ProjectStructureManager} service-file generation behavior.
@@ -50,6 +54,30 @@ public class ProjectStructureManagerTest {
                 .isEqualTo("com.shaft.listeners.TestNGListener").perform();
         SHAFT.Validations.assertThat().object(Files.readString(annotationTransformerFile).trim())
                 .isEqualTo("com.shaft.listeners.TestNGListener").perform();
+    }
+
+    @Test(description = "identifyRunType(suites) detects a Cucumber TestNG runner class in the suite even when " +
+            "called before any Cucumber Runner stack frame exists, i.e. from IAlterSuiteListener#alter")
+    public void identifyRunTypeWithSuitesDetectsCucumberTestNgRunnerClass() {
+        XmlSuite suite = new XmlSuite();
+        XmlTest xmlTest = new XmlTest(suite);
+        xmlTest.setXmlClasses(List.of(new XmlClass(cucumberTestRunner.CucumberTests.class)));
+
+        ProjectStructureManager.RunType runType = ProjectStructureManager.identifyRunType(List.of(suite));
+
+        SHAFT.Validations.assertThat().object(runType).isEqualTo(ProjectStructureManager.RunType.CUCUMBER).perform();
+    }
+
+    @Test(description = "identifyRunType(suites) still resolves TESTNG for a suite that hosts no Cucumber TestNG " +
+            "runner class, proving the fix does not misdetect a plain TestNG suite as Cucumber")
+    public void identifyRunTypeWithSuitesResolvesTestNgForPlainTestNgClass() {
+        XmlSuite suite = new XmlSuite();
+        XmlTest xmlTest = new XmlTest(suite);
+        xmlTest.setXmlClasses(List.of(new XmlClass(ProjectStructureManagerTest.class)));
+
+        ProjectStructureManager.RunType runType = ProjectStructureManager.identifyRunType(List.of(suite));
+
+        SHAFT.Validations.assertThat().object(runType).isEqualTo(ProjectStructureManager.RunType.TESTNG).perform();
     }
 
     private void deleteTempServicesDirectory() throws IOException {

--- a/shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
@@ -23,6 +23,9 @@ import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -86,6 +89,34 @@ public class TestNGListenerCoverageUnitTest {
         List<IMethodInstance> result = listener.intercept(methods, Mockito.mock(ITestContext.class));
 
         assertEquals(result.size(), 10, "Non-test (configuration) methods must never be shard-filtered.");
+    }
+
+    @Test(description = "alter() must wire cucumber.features onto the suite for a Cucumber-over-TestNG runner " +
+            "(AbstractTestNGCucumberTests subclass), reproducing #4078: this auto-wiring never fired because " +
+            "identifyRunType()'s stack probe cannot see Cucumber this early in the TestNG lifecycle")
+    public void alterConfiguresCucumberPropertiesForCucumberTestNgRunnerSuite() {
+        XmlSuite suite = new XmlSuite();
+        XmlTest xmlTest = new XmlTest(suite);
+        xmlTest.setXmlClasses(new ArrayList<>(List.of(new XmlClass(cucumberTestRunner.CucumberTests.class))));
+
+        new TestNGListener().alter(new ArrayList<>(List.of(suite)));
+
+        assertEquals(suite.getParameters().get("cucumber.features"),
+                com.shaft.driver.SHAFT.Properties.cucumber.cucumberFeatures(),
+                "alter() should have taken the CUCUMBER branch and configured cucumber.features on the suite.");
+    }
+
+    @Test(description = "alter() must NOT wire cucumber.features onto a suite that hosts no Cucumber TestNG " +
+            "runner class, proving the #4078 fix does not misdetect a plain TestNG suite as Cucumber")
+    public void alterDoesNotConfigureCucumberPropertiesForPlainTestNgSuite() {
+        XmlSuite suite = new XmlSuite();
+        XmlTest xmlTest = new XmlTest(suite);
+        xmlTest.setXmlClasses(new ArrayList<>(List.of(new XmlClass(TestNGListenerCoverageUnitTest.class))));
+
+        new TestNGListener().alter(new ArrayList<>(List.of(suite)));
+
+        assertNull(suite.getParameters().get("cucumber.features"),
+                "alter() should not have taken the CUCUMBER branch for a plain TestNG suite.");
     }
 
     private static IMethodInstance methodInstance(String className, String methodName, boolean isTest) {


### PR DESCRIPTION
Closes #4078

## Summary
- `TestNGListener.alter()` fires during TestNG's suite-processing phase, before any test method runs, so `identifyRunType()`'s stack probe for `io.cucumber.core.runner.Runner` can never observe Cucumber at that point — the `CUCUMBER` branch was dead code and `cucumber.features`/`cucumber.glue` auto-wiring never fired for `AbstractTestNGCucumberTests`-based runs.
- Reordering the two existing stack checks would not have fixed this: the Cucumber `Runner` frame is genuinely absent at `alter()` time regardless of check order, and swapping the order risks misdetecting a plain TestNG run as Cucumber.
- Added `ProjectStructureManager.identifyRunType(List<XmlSuite>)`, called only from `alter()`, which inspects the suite's own `XmlClass` list for a class assignable to `io.cucumber.testng.AbstractTestNGCucumberTests` instead of probing the call stack. Since `alter()` can only ever be invoked by TestNG itself, the only open question at that call site is whether TestNG is hosting a Cucumber runner — answered from the suite's own classes, which are fully known before any method runs. The pre-existing no-arg `identifyRunType()` (and its other callers) is untouched.

## Test plan
Verified both directions per the issue: a Cucumber-over-TestNG suite resolves `CUCUMBER` and gets `cucumber.features` wired, a plain TestNG suite still resolves `TESTNG` and is untouched.

RED (reverted the `alter()` fix, re-ran the new regression test):
```
[ERROR]   TestNGListenerCoverageUnitTest.alterConfiguresCucumberPropertiesForCucumberTestNgRunnerSuite:104
alter() should have taken the CUCUMBER branch and configured cucumber.features on the suite.
expected [src/test/resources] but found [null]
```

GREEN (fix restored):
```
mvn -pl shaft-engine -Dtest=TestNGListenerCoverageUnitTest,ProjectStructureManagerTest -DheadlessExecution=true -Dallure.automaticallyOpen=false test
...
Tests run: 25, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Also reran adjacent Cucumber/DriverFactory/TestNGListenerHelper coverage tests for regressions:
```
mvn -pl shaft-engine -Dtest=CucumberTestsHelperCoverageUnitTest,DriverFactoryCoverageUnitTest,TestNGListenerHelperCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false test
Tests run: 28, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Full module compile/test-compile:
```
mvn -pl shaft-engine -DheadlessExecution=true -Dallure.automaticallyOpen=false -DskipTests compile test-compile
BUILD SUCCESS
```

- [x] `identifyRunType(List<XmlSuite>)` resolves CUCUMBER for a suite hosting an `AbstractTestNGCucumberTests` subclass
- [x] `identifyRunType(List<XmlSuite>)` resolves TESTNG for a suite with no such class (mirror-image, no misdetection)
- [x] `TestNGListener.alter()` wires `cucumber.features` onto the suite for the Cucumber case, and leaves it unset for the plain-TestNG case