### PR TITLE
Fix #4077: stop acceptNetworkEvent() reentrant getWindowHandle() inside the CDP Fetch callback

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/ManagedCaptureRecorder.java
@@ -98,6 +98,19 @@ class ManagedCaptureRecorder {
     // Volatile: read from the CDP network-interception callback thread (via the currentPageUrlSupplier
     // passed to CaptureNetworkRecorder, issue #4046) as well as the owning thread and status() callers.
     private volatile String currentUrl;
+    // Captured once, on the owning thread, right after the driver is created (issue #4077): the sole
+    // window this session starts with. acceptNetworkEvent() -- CaptureNetworkRecorder's sink -- runs
+    // synchronously on the CDP Fetch.requestPaused callback thread, before the paused request it is
+    // handling is continued; calling driver.getWindowHandle() from there is the exact same reentrant
+    // WebDriver-call-from-inside-the-Fetch-callback deadlock #4076 fixed for getCurrentUrl(), just at
+    // a different call site (confirmed via jstack: the callback thread parked in
+    // JdkHttpClient.execute() -> CompletableFuture.get() waiting on chromedriver's response to
+    // getWindowHandle(), which cannot be served until the very request this callback is blocking
+    // resolves -- the main thread's concurrent executeScript() then times out at Selenium's 30s
+    // script-timeout bound). Not updated across tab switches; multi-window attribution for network
+    // events is already a documented best-effort limitation elsewhere in this pipeline (see
+    // CaptureEventPipeline.resolveBrowsingContextId(), issue #3816).
+    private volatile String currentWindowHandle = "";
     private volatile boolean paused;
     private volatile boolean uiStopRequested;
 
@@ -136,6 +149,10 @@ class ManagedCaptureRecorder {
             configureShaft();
             shaftDriver = new SHAFT.GUI.WebDriver(request.browser().driverType(), browserOptions());
             driver = shaftDriver.getDriver();
+            // Cache the starting window handle before any CDP network interception is installed
+            // (issue #4077); see the currentWindowHandle field javadoc for why acceptNetworkEvent()
+            // must never call driver.getWindowHandle() itself.
+            currentWindowHandle = safeWindowHandle();
             applyRuntimeOptions();
             store = new CaptureSessionStore(request.outputPath());
             store.start(startSession(browserMetadata(driver)));
@@ -1079,7 +1096,7 @@ class ManagedCaptureRecorder {
         try {
             long sequence = store.nextSequence();
             com.shaft.capture.model.PageContext page = new com.shaft.capture.model.PageContext(
-                    transaction.initiatorPageUrl(), "", safeWindowHandle(), List.of(), 0, 0);
+                    transaction.initiatorPageUrl(), "", currentWindowHandle, List.of(), 0, 0);
             com.shaft.capture.model.EventContext context = new com.shaft.capture.model.EventContext(
                     sequence, Instant.now(), page,
                     com.shaft.capture.model.EventContext.ReplayStatus.NOT_REPLAYED, List.of(), Map.of());

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -1532,12 +1532,6 @@ class ManagedCaptureRecorderBrowserTest {
      */
     @Test
     @org.junit.jupiter.api.Timeout(60)
-    @org.junit.jupiter.api.Disabled("Issue #4046: the CDP-NetworkInterceptor-vs-executeScript "
-            + "deadlock is fixed (see PR history), but a second, separate ScriptTimeoutException "
-            + "surfaced once the deadlock stopped masking it -- un-root-caused, tracked as a "
-            + "follow-up. @Timeout does not reliably abort a regression of the original hang, and "
-            + "this class runs unconditionally from pr-gate.yml's capture-browser-e2e step. "
-            + "Re-enable once the ScriptTimeoutException is fixed.")
     void startCompletesWhenApiCaptureIsEnabledAgainstARealBrowser(@TempDir Path temp) throws Exception {
         HttpServer server = localFixture();
         ManagedCaptureRecorder recorder = null;


### PR DESCRIPTION
Closes #4077

## Summary

- `ManagedCaptureRecorder.acceptNetworkEvent()` (the sink `CaptureNetworkRecorder` invokes) ran synchronously on the CDP `Fetch.requestPaused` callback thread, before the paused request it was handling had been continued, and called `driver.getWindowHandle()` to build each `NetworkEvent`'s `PageContext`. This is the exact reentrant-WebDriver-call-from-inside-the-Fetch-callback deadlock class PR #4076 fixed for `CaptureNetworkRecorder.currentPageOrigin()` -- just at a second call site #4076 didn't touch.
- Confirmed with a real `jstack` thread dump on a hung run (not inferred): a thread renamed `"Forwarding getCurrentWindowHandle on session ... to remote"` was parked in `JdkHttpClient.execute()` -> `CompletableFuture.get()`, waiting for chromedriver's response to `getWindowHandle()` -- a call issued from `ManagedCaptureRecorder.acceptNetworkEvent(ManagedCaptureRecorder.java:1082)` -> `safeWindowHandle()`, itself called from inside `CaptureNetworkRecorder.recordIfAccepted()` -> the CDP `Fetch.requestPaused` listener (`org.openqa.selenium.devtools.idealized.Network.java:265`, still on the CDP dispatch thread, before `Fetch.fulfillRequest` is ever sent). chromedriver serializes classic command processing per session, so it could not serve `getWindowHandle()` until the very network request this callback was blocking got continued -- a circular wait. The main thread's concurrent `executeScript()` call (`ManagedCaptureRecorder.java:153`) then hit Selenium's 30s script-timeout bound and surfaced as `ScriptTimeoutException`, matching #4077 exactly.
- This refutes my initial "CDP Fetch pausing browser-initiated resource requests" hypothesis -- the actual mechanism is our own code calling a classic WebDriver command from inside the Fetch callback, same class of bug as #4076, different call site.

## Fix

Cache the session's starting window handle once, on the owning thread, right after the driver is created and before the CDP network interceptor is installed (`currentWindowHandle`), and read that cached value from `acceptNetworkEvent()` instead of calling the driver live from the callback thread.

**Known trade-off (documented in the field javadoc, tracked as follow-up issue #4090):** the cached handle is not updated across tab switches, so a network event recorded after a mid-session tab/window switch attributes to the session's original window. Checked #3816 first (closed, and about a different mechanism -- UI-event window resolution during the loopback/BiDi race, not network-event attribution) before filing a fresh issue rather than duplicating it.

## On #4046

This fix plausibly clears the capture-start path #4046's nightly exercises, but #4046's live failure is `java.io.IOException` at `GuidedWorkflowLiveE2ETest.java:185` -- a different exception class from the `ScriptTimeoutException` reproduced and fixed here. Not asserting #4046 is fixed; no closing keyword for it in this PR.

## Test plan

`ManagedCaptureRecorderBrowserTest#startCompletesWhenApiCaptureIsEnabledAgainstARealBrowser` was `@Disabled` specifically for this failure; re-enabled it as the regression test.

**RED (pre-fix, `git stash` equivalent -- ran before any production code changed):**
```
$ mvn -pl shaft-capture -DincludeCaptureBrowserE2E -Dtest=ManagedCaptureRecorderBrowserTest#startCompletesWhenApiCaptureIsEnabledAgainstARealBrowser test -DheadlessExecution=true -Dallure.automaticallyOpen=false
...
 ✗ Finished test method '...startCompletesWhenApiCaptureIsEnabledAgainstARealBrowser'.
   Root cause: "org.openqa.selenium.ScriptTimeoutException: script timeout"
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 35.63 s <<< FAILURE!
```

**GREEN (post-fix):**
```
$ mvn -pl shaft-capture -DincludeCaptureBrowserE2E -Dtest=ManagedCaptureRecorderBrowserTest#startCompletesWhenApiCaptureIsEnabledAgainstARealBrowser test -DheadlessExecution=true -Dallure.automaticallyOpen=false
...
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.970 s
[INFO] BUILD SUCCESS
```

**Full module regression sweep (post-fix, external-e2e excluded by default, unchanged from CI's normal gate):**
```
$ mvn -pl shaft-capture -DheadlessExecution=true test -Dallure.automaticallyOpen=false
...
[INFO] Tests run: 308, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

- `mvn -pl shaft-capture -DheadlessExecution=true test-compile` -- clean.

Refs #4046, #4076, #4090

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwFUVobfWXKHUCaGPrisSt