### PR TITLE
Fix #4088: validate the PATH-resolved memory CLI, not an npx-cached copy

### DIFF
--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -182,6 +182,39 @@ def validate_memory_setup(root: Path = ROOT) -> list[dict[str, str]]:
     return errors
 
 
+def run_memory_check(root: Path) -> list[dict[str, str]]:
+    """Run `memory check` against the PATH-resolved Memory CLI.
+
+    Agents invoke `memory` from PATH (AGENTS.md, "Memory & Learning Loop"),
+    so this validates the toolchain copy actually in use rather than an
+    `npx --package`-cached copy nobody runs. Fails loudly with an actionable
+    message when the binary is missing instead of falling back to a download.
+    """
+    executable = shutil.which("memory")
+    if executable is None:
+        return [
+            issue(
+                "memory-check",
+                "memory",
+                "memory CLI not found on PATH. Install it globally with "
+                f"`npm install -g {MEMORY_PACKAGE}` and ensure the npm global "
+                "bin directory is on PATH, then retry.",
+            )
+        ]
+    completed = subprocess.run(
+        [executable, "check"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if completed.returncode == 0:
+        return []
+    detail = (completed.stderr or completed.stdout).strip().replace("\n", " ")
+    return [issue("memory-check", "memory", detail[:500] or f"exit code {completed.returncode}")]
+
+
 def run_command(root: Path, command: list[str], code: str) -> list[dict[str, str]]:
     """Run one external check and return a concise issue on failure."""
     executable = shutil.which(command[0])
@@ -261,21 +294,7 @@ def validate_repository(
         *validate_skill_hygiene(root),
     ]
     if run_external:
-        errors.extend(
-            run_command(
-                root,
-                [
-                    "npx",
-                    "--yes",
-                    "--package",
-                    MEMORY_PACKAGE,
-                    "--",
-                    "memory",
-                    "check",
-                ],
-                "memory-check",
-            )
-        )
+        errors.extend(run_memory_check(root))
         errors.extend(run_command(root, ["git", "diff", "--check"], "diff-check"))
     return (
         sorted(errors, key=lambda item: (item["path"], item["code"], item["message"])),

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -2,9 +2,11 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from scripts.ci.validate_agent_setup import (
     GENERATED_MEMORY_PATHS,
+    run_memory_check,
     validate_memory_setup,
     validate_repository,
 )
@@ -86,6 +88,17 @@ approval_mode = "prompt"
         repository_root = Path(__file__).resolve().parents[2]
         errors, _ = validate_repository(repository_root, run_external=False)
         self.assertEqual(errors, [])
+
+    def test_missing_memory_binary_reports_actionable_error(self):
+        with patch("scripts.ci.validate_agent_setup.shutil.which", return_value=None):
+            errors = run_memory_check(self.root)
+        self.assertEqual(len(errors), 1)
+        error = errors[0]
+        self.assertEqual(error["code"], "memory-check")
+        self.assertEqual(error["path"], "memory")
+        self.assertIn("PATH", error["message"])
+        self.assertIn("install", error["message"].lower())
+        self.assertNotIn("Traceback", error["message"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #4088

## Summary
- `validate_repository()` in `scripts/ci/validate_agent_setup.py` ran `npx --yes --package @aictx/memory@0.1.55 -- memory check`, which resolves into npx's own cache dir -- a copy separate from the globally installed `memory` binary agents actually invoke via PATH (per `AGENTS.md`, "Memory & Learning Loop"). The two copies could silently diverge, so the gate validated a phantom install instead of the toolchain in use.
- Added `run_memory_check()`: looks up `memory` on PATH with `shutil.which`, runs `memory check` against that binary, and fails with a clear, actionable message (naming the binary and the install command) instead of a `FileNotFoundError` traceback or a silent npx fallback download. The `run_external` / `--skip-external` gating and the `memory-check` error label are unchanged.
- `MEMORY_PACKAGE` is kept: it's still referenced by the `.codex/config.toml` `shaft-memory` MCP-server-args check (`scripts/ci/validate_agent_setup.py:161`), and now also doubles as the install hint in the new error message.
- `.codex/config.toml`'s `shaft-memory` MCP server config is left unchanged. It still uses `npx --package @aictx/memory@0.1.55 -- memory-mcp`. Reasoning: Codex spawns that MCP server subprocess directly, not through an interactive shell, so there's no guarantee the npm global bin directory (where the PATH `memory` install lives) is on that subprocess's PATH. A pinned, self-installing npx spec is the right call there. That's different from this validator script, which runs from the same shell/agent context whose PATH it exists to check -- so checking PATH there is the honest thing to do.

## Test plan
New regression test `test_missing_memory_binary_reports_actionable_error` in `tests/scripts/test_validate_agent_setup.py`, mocking `shutil.which` to return `None` and asserting a clear `memory-check` error (not a traceback).

RED (before the fix -- `run_memory_check` doesn't exist yet):
```
ImportError: cannot import name 'run_memory_check' from 'scripts.ci.validate_agent_setup'
Ran 1 test in 0.000s
FAILED (errors=1)
```

GREEN (after the fix):
```
test_current_repository_setup_is_valid_without_external_calls ... ok
test_missing_memory_binary_reports_actionable_error ... ok
test_rejects_broader_mcp_tool_surface ... ok
test_rejects_large_default_memory_budget ... ok
test_valid_memory_setup_passes ... ok
Ran 5 tests in 0.601s
OK
```

Full validator, both modes:
```
$ py -3 scripts/ci/validate_agent_setup.py
Agent setup is valid: 73394 guidance bytes, 0% reduction, 304 memory objects.

$ py -3 scripts/ci/validate_agent_setup.py --skip-external
Agent setup is valid: 73394 guidance bytes, 0% reduction, 304 memory objects.
```

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
https://claude.ai/code/session_01EwFUVobfWXKHUCaGPrisSt