### PR TITLE
Fix #4074: bound JunitExtension retry re-execution timeout

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/JunitExtension.java
@@ -30,12 +30,16 @@ import org.junit.platform.launcher.listeners.TestExecutionSummary;
 import org.opentest4j.TestAbortedException;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -49,6 +53,18 @@ public class JunitExtension implements BeforeAllCallback, AfterAllCallback, Befo
             ExtensionContext.Namespace.create(JunitExtension.class, "retry");
     private static final String PENDING_RETRY_KEY = "pendingRetry";
     private static final ConcurrentMap<String, ActiveRetryAttempt> activeRetryAttempts = new ConcurrentHashMap<>();
+    // Bounds every retry re-execution (#4074): same shape as #4066/PR #4073's
+    // CaptureManager.invoke() -- an unbounded executor.submit(...).get() turned a wedged retried
+    // test into an unbounded, undiagnosable hang, and the executor.shutdownNow() cleanup sitting in
+    // this method's own finally block never got a chance to run because the blocking get() never
+    // returned. This repo already paid for exactly that shape of bug at the CI level (#4009):
+    // Ubuntu_Chrome_Grid/Ubuntu_Firefox_Grid jobs ran to their 360-minute wall-clock limit instead
+    // of failing fast. Unlike CaptureManager's internal, bounded-duration browser-lifecycle calls, a
+    // retry re-executes arbitrary user test code (its own @BeforeEach/@AfterEach, browser session,
+    // assertions) whose legitimate duration varies far more, so the bound is generous (30 minutes)
+    // rather than CaptureManager's 90 seconds -- while still failing well inside the 360-minute job
+    // ceiling even across a handful of retry attempts.
+    private static final Duration DEFAULT_RETRY_ATTEMPT_TIMEOUT = Duration.ofMinutes(30);
 
     @Override
     public void beforeAll(ExtensionContext context) {
@@ -192,13 +208,16 @@ public class JunitExtension implements BeforeAllCallback, AfterAllCallback, Befo
     private static TestExecutionSummary executeRetryAttempt(ExtensionContext context, Method method, int attempt,
                                                            int maxRetryCount) throws Exception {
         String uniqueId = context.getUniqueId();
+        String operationName = (method == null ? context.getDisplayName() : method.getName())
+                + " retry attempt " + attempt + "/" + maxRetryCount;
         activeRetryAttempts.put(uniqueId, new ActiveRetryAttempt(attempt, maxRetryCount));
         try {
             TestExecutionSummary summary = executeRetryRequest(
-                    retryRequest(DiscoverySelectors.selectUniqueId(uniqueId)));
+                    retryRequest(DiscoverySelectors.selectUniqueId(uniqueId)), operationName);
             if (summary.getTestsFoundCount() == 0 && method != null) {
                 summary = executeRetryRequest(
-                        retryRequest(DiscoverySelectors.selectMethod(context.getRequiredTestClass(), method)));
+                        retryRequest(DiscoverySelectors.selectMethod(context.getRequiredTestClass(), method)),
+                        operationName);
             }
             return summary;
         } finally {
@@ -214,27 +233,51 @@ public class JunitExtension implements BeforeAllCallback, AfterAllCallback, Befo
                 .build();
     }
 
-    private static TestExecutionSummary executeRetryRequest(LauncherDiscoveryRequest request) throws Exception {
+    private static TestExecutionSummary executeRetryRequest(LauncherDiscoveryRequest request, String operationName)
+            throws Exception {
+        return executeRetryRequest(request, operationName, DEFAULT_RETRY_ATTEMPT_TIMEOUT);
+    }
+
+    // Test-only seam: production always resolves to DEFAULT_RETRY_ATTEMPT_TIMEOUT; tests inject a
+    // short bound so a deliberately-wedged retried test proves the timeout in milliseconds instead
+    // of waiting out the real one.
+    static TestExecutionSummary executeRetryRequest(LauncherDiscoveryRequest request, String operationName,
+                                                      Duration timeout) throws Exception {
         ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
             Thread thread = new Thread(runnable, "shaft-junit-retry");
             thread.setDaemon(false);
             return thread;
         });
+        Future<TestExecutionSummary> future = executor.submit(() -> {
+            SummaryGeneratingListener summaryListener = new SummaryGeneratingListener();
+            LauncherFactory.create(LauncherConfig.builder()
+                    .enableLauncherSessionListenerAutoRegistration(false)
+                    .enableTestExecutionListenerAutoRegistration(false)
+                    .build()).execute(request, summaryListener);
+            return summaryListener.getSummary();
+        });
         try {
-            return executor.submit(() -> {
-                SummaryGeneratingListener summaryListener = new SummaryGeneratingListener();
-                LauncherFactory.create(LauncherConfig.builder()
-                        .enableLauncherSessionListenerAutoRegistration(false)
-                        .enableTestExecutionListenerAutoRegistration(false)
-                        .build()).execute(request, summaryListener);
-                return summaryListener.getSummary();
-            }).get();
+            return future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            future.cancel(true);
             throw e;
         } catch (ExecutionException e) {
             throwAsException(e.getCause() == null ? e : e.getCause());
             throw e;
+        } catch (TimeoutException e) {
+            // Best-effort cancellation: interrupts the "shaft-junit-retry" worker thread. If the
+            // retried test is blocked on native/browser I/O (the #4066/#4046 case, and #4074's own
+            // finding that a JUnit @Timeout in same-thread interrupt mode failed to unblock a native
+            // hang) the interrupt may not land -- but the caller must get a bounded, named answer
+            // either way instead of hanging forever.
+            future.cancel(true);
+            throw new IllegalStateException(
+                    "SHAFT JUnit retry " + operationName + " timed out after " + timeout.toSeconds()
+                            + "s. The retried test was cancelled, but if it was blocked on native/browser I/O it "
+                            + "may still be running and holding its browser/driver process -- check for and "
+                            + "clean up an orphaned browser or driver process.",
+                    e);
         } finally {
             executor.shutdownNow();
         }

--- a/shaft-engine/src/test/java/com/shaft/listeners/JunitExtensionRetryTimeoutTest.java
+++ b/shaft-engine/src/test/java/com/shaft/listeners/JunitExtensionRetryTimeoutTest.java
@@ -1,0 +1,84 @@
+package com.shaft.listeners;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code JunitExtension.executeRetryRequest} used to call {@code executor.submit(...).get()} with
+ * no timeout (#4074, the same shape as #4066/PR #4073's {@code CaptureManager.invoke()}): a retried
+ * test that wedges blocked the retry executor forever, and the {@code executor.shutdownNow()}
+ * cleanup sitting in the {@code finally} block below it never ran because the blocking {@code get()}
+ * never returned. Each test carries its own hard wall-clock bound (assertTimeoutPreemptively) so a
+ * regression in the fix -- the exact failure mode under repair -- cannot hang this suite.
+ */
+class JunitExtensionRetryTimeoutTest {
+    @Test
+    void retriedTestThatWedgesTimesOutWithANamedDiagnosableErrorInsteadOfHangingForever() {
+        CountDownLatch releaseBlockedTest = new CountDownLatch(1);
+        BlockingRetryFixture.releaseLatch = releaseBlockedTest;
+
+        try {
+            IllegalStateException failure = assertTimeoutPreemptively(Duration.ofSeconds(5), () ->
+                    assertThrows(IllegalStateException.class, () -> JunitExtension.executeRetryRequest(
+                            requestFor(BlockingRetryFixture.class), "wedgedFixture retry attempt 1/1",
+                            Duration.ofMillis(200))));
+
+            assertTrue(failure.getMessage().contains("wedgedFixture retry attempt 1/1"), failure.getMessage());
+            assertTrue(failure.getMessage().toLowerCase(java.util.Locale.ROOT).contains("timed out"),
+                    failure.getMessage());
+        } finally {
+            // Let the blocked worker thread unwind so it doesn't leak a permanently blocked
+            // thread past this test.
+            releaseBlockedTest.countDown();
+        }
+    }
+
+    @Test
+    void aLegitimatelySlowRetriedTestStillSucceedsUnderTheBound() {
+        var summary = assertTimeoutPreemptively(Duration.ofSeconds(5), () -> JunitExtension.executeRetryRequest(
+                requestFor(SlowButSuccessfulRetryFixture.class), "slowFixture retry attempt 1/1",
+                Duration.ofSeconds(2)));
+
+        assertEquals(0, summary.getFailures().size(), () -> summary.getFailures().toString());
+        assertEquals(1, summary.getTestsSucceededCount());
+    }
+
+    private static LauncherDiscoveryRequest requestFor(Class<?> fixtureClass) {
+        return LauncherDiscoveryRequestBuilder.request()
+                .selectors(DiscoverySelectors.selectClass(fixtureClass))
+                .configurationParameter("junit.jupiter.extensions.autodetection.enabled", "true")
+                .configurationParameter("junit.jupiter.execution.parallel.enabled", "false")
+                .build();
+    }
+}
+
+@ExtendWith(JunitExtension.class)
+class BlockingRetryFixture {
+    static volatile CountDownLatch releaseLatch = new CountDownLatch(0);
+
+    @Test
+    void wedges() throws InterruptedException {
+        releaseLatch.await();
+    }
+}
+
+@ExtendWith(JunitExtension.class)
+class SlowButSuccessfulRetryFixture {
+    @Test
+    void succeedsSlowly() throws InterruptedException {
+        // Well under the 2s bound configured above, but not instantaneous: proves a legitimately
+        // slow (bounded) retried test is not spuriously killed by the timeout.
+        Thread.sleep(300);
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/listeners/JunitExtensionRetryTimeoutTest.java
+++ b/shaft-engine/src/test/java/com/shaft/listeners/JunitExtensionRetryTimeoutTest.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -70,6 +71,9 @@ class BlockingRetryFixture {
     @Test
     void wedges() throws InterruptedException {
         releaseLatch.await();
+        // Reached only on a clean (non-interrupted) release: proves this fixture really did wait
+        // for the test-controlled latch rather than returning on some other, spurious path.
+        assertEquals(0, releaseLatch.getCount());
     }
 }
 
@@ -80,5 +84,8 @@ class SlowButSuccessfulRetryFixture {
         // Well under the 2s bound configured above, but not instantaneous: proves a legitimately
         // slow (bounded) retried test is not spuriously killed by the timeout.
         Thread.sleep(300);
+        // Proves the in-bound sleep ran to completion rather than being cut short by a cancel(true)
+        // interrupt -- the exact distinction this fixture exists to demonstrate.
+        assertFalse(Thread.currentThread().isInterrupted());
     }
 }


### PR DESCRIPTION
## Summary

- `JunitExtension.executeRetryRequest()` called `executor.submit(...).get()` with no timeout on the JUnit retry re-execution path -- the same shape as #4066's `CaptureManager.invoke()` (PR #4073). A retried test that wedges blocked the retry executor indefinitely, and this method's own `executor.shutdownNow()` cleanup -- sitting in the `finally` block directly below the blocking `get()` -- never got a chance to run because the blocking call never returned.
- Mirrors PR #4073's mechanism exactly: a named `Duration` constant, `future.get(timeout, unit)`, `cancel(true)` on timeout (also added to the pre-existing `InterruptedException` path, matching #4073), and an `IllegalStateException` naming the operation and the bound instead of a bare, undiagnosable hang. Test seam is the same idiom too: a package-private `Duration`-injecting overload lets tests prove the timeout in milliseconds.
- Diverges from #4073 only on the timeout's **magnitude**, for a reason grounded in the two code paths' real difference: `CaptureManager` bounds its own internal, fixed-duration browser-lifecycle calls (90s, ~5x an observed 18s browser start). `JunitExtension` re-executes arbitrary user test code (its own `@BeforeEach`/`@AfterEach`, browser session, assertions) whose legitimate duration varies far more, so a 90s bound would spuriously kill real slow-but-passing retries. Picked 30 minutes: generous for realistic SHAFT E2E retries, while still failing well inside the 360-minute CI job ceiling this repo already burned once before PR #4009 -- even across a handful of retry attempts.
- Interrupt-the-abandoned-work: `future.cancel(true)` on both the timeout and (now) the `InterruptedException` path, same best-effort caveat as #4073 (native/browser I/O may not actually unblock, but the caller gets a bounded, diagnosable answer either way).

## Test plan

- [x] `JunitExtensionRetryTimeoutTest`: a deliberately-wedged retried test (blocks on a `CountDownLatch`) fails with a bounded, named error instead of hanging forever -- watched RED (compile failure for the missing method signature), then GREEN.
- [x] Mutation-checked: temporarily made the bound effectively unbounded (`future.get(Long.MAX_VALUE, ...)`); the test failed for the right reason (JUnit's own `assertTimeoutPreemptively` caught the runaway block: `execution timed out after 5000 ms`), then reverted and re-confirmed GREEN (diff-verified identical to the fixed version before restoring).
- [x] A legitimately slow (but in-bound) retried test still succeeds, proving the bound isn't too tight for real slow retries.
- [x] `mvn -Pjunit -pl shaft-engine test -DskipTestNG=true -Dtest=JunitExtensionRetryTimeoutTest,JunitExtensionLifecycleTest -DheadlessExecution=true` -- 10/10 passed (this repo's `mvn test` defaults to the TestNG surefire provider, which silently runs 0 JUnit5 tests; reproduced the same `-Pjunit -DskipTestNG=true` + service-file setup this repo's own CI "Enable JUnit Test Runtime" step uses -- those service files are gitignored/generated, backed up and restored after each run so the worktree state is unchanged).
- [x] `mvn -pl shaft-engine compile test-compile -DheadlessExecution=true` -- green.

## Grepped for other unbounded futures (not fixed, in scope was JunitExtension.java only)

No other unbounded `executor.submit(...).get()` sites found in `shaft-engine/src/main/java/`. All other `Future.get()` call sites already pass an explicit timeout: `TerminalActions.java:1102` (`output.get(1, TimeUnit.SECONDS)`), `TerminalActions.java:1235` (`future.get(timeoutMillis, ...)`), `AllureManager.java` stream capture (bounded via `process.waitFor(timeout, ...)` + a 1s-bounded output drain). `ProgressBarLogger.submit()` and `SshShellSession.submit()` are fire-and-forget (no `.get()` at all).

Closes #4074