### PR TITLE
Fix #4037: stop silent no-op when remote Grid session lacks CDP access for basic-auth

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -720,7 +720,16 @@ public class DriverFactoryHelper {
                 augmenter = augmenter.addDriverAugmentation(new AddHasAuthentication());
             }
         }
-        return augmenter.augment(driver);
+        var augmentedDriver = augmenter.augment(driver);
+        // Diagnostic evidence for issue #4037: AddHasAuthentication's own register() handler is a silent
+        // no-op unless the augmented driver also implements HasDevTools (CDP-backed), which Selenium only
+        // grants when the session capabilities returned by the remote endpoint advertise a reachable CDP
+        // endpoint (se:cdp/se:cdpEnabled or an equivalent reported URI). Log both so a remote-only failure
+        // can be diagnosed from the returned capabilities instead of guessed at.
+        ReportManagerHelper.logDiscrete("Remote session capabilities after augmentation: `" + driver.getCapabilities()
+                + "`. HasAuthentication=" + (augmentedDriver instanceof HasAuthentication)
+                + ", HasDevTools=" + (augmentedDriver instanceof HasDevTools) + ".", Level.DEBUG);
+        return augmentedDriver;
     }
 
     private static boolean isWindowsPlatform() {

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -32,6 +32,7 @@ import io.appium.java_client.ios.IOSDriver;
 import io.qameta.allure.Step;
 import org.apache.logging.log4j.Level;
 import org.openqa.selenium.*;
+import org.openqa.selenium.devtools.HasDevTools;
 import org.openqa.selenium.remote.http.HttpRequest;
 import org.openqa.selenium.remote.http.HttpResponse;
 
@@ -493,9 +494,26 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
             String domainName = browserActionsHelper.getDomainNameFromUrl(targetUrl);
             var strategy = browserActionsHelper.determineBasicAuthenticationStrategy(
                     SHAFT.Properties.platform.executionAddress(), SHAFT.Properties.platform.enableBiDi());
-            if (strategy == BrowserActionsHelper.BasicAuthenticationStrategy.NATIVE_HAS_AUTHENTICATION) {
+            var activeDriver = driverFactoryHelper.getDriver();
+            // HasAuthentication is CDP-backed (Selenium's AddHasAuthentication#getImplementation only
+            // installs the handler when the wrapped driver also implements HasDevTools); Augmenter still
+            // weaves the HasAuthentication interface onto a remote session regardless of CDP reachability
+            // (AddHasAuthentication#isApplicable only checks the browser name), so register() can be
+            // called without throwing yet silently do nothing on a Grid session with no reachable CDP
+            // endpoint. Local drivers (ChromeDriver/EdgeDriver) always implement HasDevTools natively, so
+            // this only gates the remote, Augmenter-based path (issue #4037).
+            boolean isLocalExecution = "local".equalsIgnoreCase(SHAFT.Properties.platform.executionAddress());
+            boolean nativeHandlerCanActuallyWork = activeDriver instanceof HasAuthentication
+                    && (isLocalExecution || activeDriver instanceof HasDevTools);
+            if (strategy == BrowserActionsHelper.BasicAuthenticationStrategy.NATIVE_HAS_AUTHENTICATION && nativeHandlerCanActuallyWork) {
                 Predicate<URI> uriPredicate = uri -> uri.getHost().contains(domainName);
-                ((HasAuthentication) driverFactoryHelper.getDriver()).register(uriPredicate, UsernameAndPassword.of(username, password));
+                ((HasAuthentication) activeDriver).register(uriPredicate, UsernameAndPassword.of(username, password));
+            } else if (strategy == BrowserActionsHelper.BasicAuthenticationStrategy.NATIVE_HAS_AUTHENTICATION) {
+                ReportManagerHelper.logDiscrete("Basic authentication downgraded to URL-embedded credentials: the native "
+                        + "HasAuthentication handler is CDP-backed and this remote driver session does not expose a "
+                        + "reachable Chrome DevTools Protocol endpoint (no HasDevTools augmentation), so register() "
+                        + "would silently do nothing. Falling back to URL-embedded credentials.", Level.WARN);
+                targetUrl = browserActionsHelper.formatUrlForBasicAuthentication(username, password, targetUrl);
             } else {
                 ReportManagerHelper.logDiscrete("Basic authentication downgraded to URL-embedded credentials: execution is remote and "
                         + "SHAFT.Properties.platform.enableBiDi() is disabled, so no native HasAuthentication handler can be provisioned "

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -490,6 +490,7 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
     @SuppressWarnings("UnusedReturnValue")
     @Override
     public BrowserActions navigateToURLWithBasicAuthentication(String targetUrl, String username, String password, String targetUrlAfterAuthentication) {
+        String resolvedUrl = targetUrl;
         try {
             String domainName = browserActionsHelper.getDomainNameFromUrl(targetUrl);
             var strategy = browserActionsHelper.determineBasicAuthenticationStrategy(
@@ -513,18 +514,18 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
                         + "HasAuthentication handler is CDP-backed and this remote driver session does not expose a "
                         + "reachable Chrome DevTools Protocol endpoint (no HasDevTools augmentation), so register() "
                         + "would silently do nothing. Falling back to URL-embedded credentials.", Level.WARN);
-                targetUrl = browserActionsHelper.formatUrlForBasicAuthentication(username, password, targetUrl);
+                resolvedUrl = browserActionsHelper.formatUrlForBasicAuthentication(username, password, targetUrl);
             } else {
                 ReportManagerHelper.logDiscrete("Basic authentication downgraded to URL-embedded credentials: execution is remote and "
                         + "SHAFT.Properties.platform.enableBiDi() is disabled, so no native HasAuthentication handler can be provisioned "
                         + "on the remote driver. Enable BiDi to use the native handler for remote executions.", Level.WARN);
-                targetUrl = browserActionsHelper.formatUrlForBasicAuthentication(username, password, targetUrl);
+                resolvedUrl = browserActionsHelper.formatUrlForBasicAuthentication(username, password, targetUrl);
             }
         } catch (Exception e) {
             ReportManagerHelper.logDiscrete(e);
-            targetUrl = browserActionsHelper.formatUrlForBasicAuthentication(username, password, targetUrl);
+            resolvedUrl = browserActionsHelper.formatUrlForBasicAuthentication(username, password, targetUrl);
         }
-        return navigateToURL(targetUrl, targetUrlAfterAuthentication);
+        return navigateToURL(resolvedUrl, targetUrlAfterAuthentication);
     }
 
     /**

--- a/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/BrowserActionsCoverageUnitTest.java
@@ -255,11 +255,45 @@ public class BrowserActionsCoverageUnitTest {
     }
 
     @Test
-    public void navigateWithBasicAuthenticationShouldUseNativeHandlerForRemoteExecutionWhenBiDiIsEnabled() {
-        // Regression for issue #3732: remote execution with BiDi enabled (the default) must use the
-        // real HasAuthentication.register() handler instead of silently downgrading to URL-embedded
-        // credentials, so BasicAuthenticationTests#basicAuthenticationWebdriverBidi actually exercises
-        // the BiDi-augmented path remotely.
+    public void navigateWithBasicAuthenticationShouldUseNativeHandlerForRemoteExecutionWhenBiDiIsEnabledAndCdpIsAvailable() {
+        // Regression for issue #3732: remote execution with BiDi enabled (the default) AND a reachable
+        // CDP endpoint (HasDevTools) must use the real HasAuthentication.register() handler instead of
+        // silently downgrading to URL-embedded credentials, so
+        // BasicAuthenticationTests#basicAuthenticationWebdriverBidi actually exercises the
+        // BiDi-augmented path remotely. See #4037 for the sibling "no CDP access" fallback case.
+        SHAFT.Properties.platform.set().executionAddress("remote-grid");
+        SHAFT.Properties.platform.set().enableBiDi(true);
+
+        WebDriver cdpCapableDriver = mock(WebDriver.class, Mockito.withSettings()
+                .extraInterfaces(JavascriptExecutor.class, TakesScreenshot.class, HasAuthentication.class, HasDevTools.class));
+        WebDriver.Options cdpOptions = mock(WebDriver.Options.class);
+        WebDriver.Navigation cdpNavigation = mock(WebDriver.Navigation.class);
+        when(cdpCapableDriver.manage()).thenReturn(cdpOptions);
+        when(cdpCapableDriver.navigate()).thenReturn(cdpNavigation);
+        when(cdpCapableDriver.getCurrentUrl()).thenReturn("https://example.com/start");
+        doNothing().when(cdpNavigation).to(anyString());
+
+        BrowserActions cdpBrowserActions = new BrowserActions(cdpCapableDriver, true);
+        cdpBrowserActions.navigateToURLWithBasicAuthentication(
+                "https://example.com/secure",
+                "user",
+                "pass",
+                "https://example.com/secure");
+
+        Mockito.verify((HasAuthentication) cdpCapableDriver).register(any(), any());
+        Mockito.verify(cdpNavigation).to("https://example.com/secure");
+    }
+
+    @Test
+    public void navigateWithBasicAuthenticationShouldFallBackWhenRemoteDriverHasNoCdpAccess() {
+        // Regression for issue #4037: Selenium's HasAuthentication is CDP-backed -- its
+        // AddHasAuthentication augmentation only actually installs an auth handler when the wrapped
+        // driver also implements HasDevTools (see AddHasAuthentication#getImplementation). A remote
+        // Augmented session that lacks a reachable CDP endpoint still gets the HasAuthentication
+        // interface woven on by Augmenter#addDependentAugmentations, so register() can be called
+        // without throwing -- but Selenium's handler silently does nothing without HasDevTools, and
+        // the auth prompt is never answered (nightly Ubuntu_Chrome_Grid failure). Detect that case
+        // and use the URL-embedded fallback instead of trusting a handler that cannot actually work.
         SHAFT.Properties.platform.set().executionAddress("remote-grid");
         SHAFT.Properties.platform.set().enableBiDi(true);
         when(driver.getCurrentUrl()).thenReturn("https://example.com/start");
@@ -270,8 +304,8 @@ public class BrowserActionsCoverageUnitTest {
                 "pass",
                 "https://example.com/secure");
 
-        Mockito.verify((HasAuthentication) driver).register(any(), any());
-        Mockito.verify(navigation).to("https://example.com/secure");
+        Mockito.verify((HasAuthentication) driver, Mockito.never()).register(any(), any());
+        Mockito.verify(navigation).to("https://user:pass@example.com/secure");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #4037

`navigateToURLWithBasicAuthentication` trusted a bare `driver instanceof HasAuthentication` cast as proof the native auth handler would work on a remote session. It doesn't: Selenium's `AddHasAuthentication#getImplementation` (verified in the Selenium 4.46.0 sources) is CDP-backed and only actually installs the auth handler when the wrapped driver also implements `HasDevTools`:

```java
if (((RemoteExecuteMethod) executeMethod).getWrappedDriver() instanceof HasDevTools) {
    ...devTools.getDomains().network().addAuthHandler(whenThisMatches, useTheseCredentials);
}
// else: silent no-op
```

`Augmenter` still weaves the `HasAuthentication` interface onto a remote session regardless of CDP reachability, because `AddHasAuthentication#isApplicable` only checks the browser name (`CHROME`/`EDGE`/`OPERA`), not any capability. So on a Grid session with no reachable CDP endpoint, `register()` can be called without throwing, yet silently does nothing — the auth prompt is never answered, and the test fails downstream with a confusing `Login Failure` assertion instead of a clear signal at the point of the real problem.

`HasDevTools` itself is only granted by Selenium's own `DevToolsProvider` when the returned session capabilities advertise a reachable CDP endpoint (`se:cdp` / `se:cdpEnabled` / a reported CDP URI) — separate from `HasCdp` (chrome/edge's own `AddHasCdp`, which applies unconditionally to any Chromium browser name and only grants the low-level `executeCdpCommand` method, not `getDevTools()`).

### Fix

- `BrowserActions.navigateToURLWithBasicAuthentication` now also requires `HasDevTools` before trusting the native path on **remote** executions (local drivers are real `ChromeDriver`/`EdgeDriver` instances that always implement `HasDevTools` directly, so local behavior is unchanged). When CDP isn't available, it logs a loud, specific `WARN` explaining why and falls back to the existing, already-proven URL-embedded-credentials path — instead of silently calling a handler that cannot work.
- `DriverFactoryHelper.augmentRemoteWebDriver` now logs the real post-session capabilities plus the resulting `HasAuthentication`/`HasDevTools` augmentation outcome at `DEBUG`, so a remote-only failure can be diagnosed from evidence instead of guessed at.

### Verdict on the `webSocketUrl`/BiDi hypothesis

Refuted at the code level, refined: `HasAuthentication` is CDP-backed, not BiDi-backed (also called out by PR #3744's own description). The actual gate is Selenium's `DevToolsProvider` (`se:cdp`/`se:cdpEnabled`/reported CDP URI), not `BiDiProvider`'s `webSocketUrl`. `HasCdp` (granted unconditionally to any Chromium remote session) is a different interface from `HasDevTools` (capability-gated) — conflating the two is exactly how the previous fix (#3744) shipped a cast that always structurally succeeds but doesn't guarantee the handler is functional.

### Known caveat: `basicAuthenticationWebdriverBidi` naming vs. actual path

On `Ubuntu_Chrome_Grid` today, `BasicAuthenticationTests#basicAuthenticationWebdriverBidi` will now pass via the **URL-embedded-credentials fallback**, not via the native CDP-backed handler, because that Grid's returned session capabilities don't expose a reachable CDP endpoint (`HasDevTools` unavailable — see the new `DEBUG` log in `augmentRemoteWebDriver`). That's the correct outcome for #4037 (a real, working path instead of a silent no-op), but the test's name — and its "BiDi" framing — no longer describes the path it actually exercises on this Grid. Flagging for the orchestrator to decide whether that needs its own follow-up (rename, split into an explicit fallback-covering test, or track the underlying "no CDP on this Grid" limitation separately).

## Test plan

- TDD: added `navigateWithBasicAuthenticationShouldFallBackWhenRemoteDriverHasNoCdpAccess` — watched RED against the pre-fix code (`register()` was called when it shouldn't be: `NeverWantedButInvoked`), watched GREEN after the fix, with the expected WARN log observed in output.
- Updated `navigateWithBasicAuthenticationShouldUseNativeHandlerForRemoteExecutionWhenBiDiIsEnabled` → `...WhenBiDiIsEnabledAndCdpIsAvailable`, using a driver mock that implements both `HasAuthentication` and `HasDevTools`, to keep proving the native path still fires when CDP genuinely is available.
- Full class: `mvn -pl shaft-engine test -Dtest=BrowserActionsCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` → 21/21 passed, before and after rebase onto latest `main`.
- Related coverage unaffected: `mvn -pl shaft-engine test -Dtest=DriverFactoryHelperCoverageUnitTest,DriverFactoryHelperAugmentationUnitTest,BrowserActionsHelperCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` → 55/55 passed.
- `mvn -pl shaft-engine test-compile` clean, before and after rebase.
- Codacy flagged reassigning the `targetUrl` parameter in the fallback branches; fixed by introducing a `resolvedUrl` local instead (behavior-preserving — every fallback still formats credentials against the original, unmodified `targetUrl`). Re-ran `BrowserActionsCoverageUnitTest` after the fix: 21/21 passed.
- Remote evidence (this cannot be reproduced locally without a live Grid, and starting one locally is out of bounds per repo policy): E2E Tests dispatched on this branch, run [30202238233](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30202238233) — `Ubuntu_Chrome_Grid` job result to be added here once the run completes; the 3 most recent nightly runs already establish the pre-fix red baseline for `basicAuthenticationWebdriverBidi` ([30143487701](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30143487701), [30066165998](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30066165998), [29979003187](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/29979003187)).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EwFUVobfWXKHUCaGPrisSt
