### PR TITLE
Fix #4080: cover both auto-close mechanisms in work-github playbook

### DIFF
--- a/.claude/skills/work-github/references/playbook.md
+++ b/.claude/skills/work-github/references/playbook.md
@@ -268,6 +268,20 @@ manufacturing a memory entry to fill the step.
 
 - Push the branch, open one PR per the shape decided in step 1, with a
   description that lists each sub-item and its commit.
+- **Verify no accidental auto-close, every time.** GitHub auto-closes an
+  issue two ways: a closing keyword anywhere in the PR body — `close`/
+  `closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`
+  immediately before `#N` — where a later disclaimer sentence does not
+  neutralize an earlier match; or a branch named after an issue, which
+  creates a Development-sidebar link on merge independently of body text
+  (this repo's `ChaosEngine/fix-<issue>-<slug>` convention triggers this on
+  every branch). A partial-fix PR (`Related to #N`, never `Closes #N`) must
+  avoid every keyword above anywhere in its body, including ordinary prose.
+  Immediately after opening, run `gh pr view <n> --json
+  closingIssuesReferences`; if it lists an issue this PR does not fully
+  resolve, unlink it from the PR's Development sidebar — this is the only
+  check that reports the effective link regardless of which mechanism
+  created it.
 - Wait for CI. If it fails, fix forward on the same branch — don't force-
   push over history the user might want to inspect, just add a fixing
   commit, unless the failure is trivially a fixup of the last commit itself.


### PR DESCRIPTION
## Summary
- Issue #4080 confirmed two distinct GitHub auto-close mechanisms hit issue #4046 twice: (1) a closing keyword matched inside ordinary prose even with a later disclaimer sentence, and (2) a branch named after an issue creating a Development-sidebar link that closes it on merge independently of body text — which this repo's `ChaosEngine/fix-<issue>-<slug>` branch convention triggers on every branch.
- `.claude/skills/work-github/references/playbook.md` close-out section (step 7) only defended against mechanism 1. Added one bullet listing the full GitHub closing-keyword set (close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved), the branch-link risk with the unlink action, and made `gh pr view <n> --json closingIssuesReferences` an explicit mandatory post-open verification step rather than advice buried in prose.
- Confirmed `scripts/ci/agent_guidance_budget.json`'s `max_skill_md_bytes` budget applies only to each skill's `SKILL.md` (see `scripts/ci/validate_agent_guidance.py:273-333`, which reads `directory / "SKILL.md"` specifically) — `references/playbook.md` is not byte-capped, so no budget constraint applied to this edit.

Closes #4080

## Test plan
- [x] `py -3 scripts/ci/validate_agent_setup.py` — passes: `Agent setup is valid: 73394 guidance bytes, 0% reduction, 304 memory objects.`
- [x] `py -3 scripts/ci/validate_skills.py` — passes: `Claude skill hygiene is valid: frontmatter, descriptions, references, and byte budgets all pass.`