### PR TITLE
Close the archive output stream when unpacking fails

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
@@ -696,9 +696,9 @@ public class FileActions {
             // make sure we get the actual file
             File zip = File.createTempFile("archive_", url.toString().substring(url.toString().length() - 4), targetDir);
             zip.deleteOnExit();
-            OutputStream out = new BufferedOutputStream(new FileOutputStream(zip));
-            copyInputStream(in, out);
-            out.close();
+            try (OutputStream out = new BufferedOutputStream(new FileOutputStream(zip))) {
+                copyInputStream(in, out);
+            }
             unpacked = unpackArchive(zip, targetDir);
             passAction("Target URL\"" + url + "\" | Destination Folder: \"" + destinationFolderPath + "\"");
         } catch (IOException rootCauseException) {


### PR DESCRIPTION
## Summary
- `unpackArchive(URL, String)` closed the archive output stream with an explicit `out.close()` after copying, so a failure inside `copyInputStream` leaked the handle and left the temp archive locked on Windows
- Wrap it in try with resources, matching the input stream already handled that way in the same method

## Tests
[2026-07-26_15-52-43-030_AllureReport.html](https://github.com/user-attachments/files/30387719/2026-07-26_15-52-43-030_AllureReport.html)  -->14/14 passed