### PR TITLE
Fix #4046: fix GuidedWorkflowLiveE2ETest's premature-stop race in the API capture wait gate

### DIFF
--- a/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiCaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiCaptureGeneratorTest.java
@@ -335,6 +335,80 @@ class ApiCaptureGeneratorTest {
         assertFalse(result.report().unsupportedEvents().isEmpty());
     }
 
+    /**
+     * Regression test for issue #4046: a session whose only network events are page-navigation
+     * traffic (the {@code ResourceKind.DOCUMENT} document request plus the browser's automatic
+     * favicon request -- exactly what {@code GuidedWorkflowLiveE2ETest}'s nightly run recorded when
+     * its wait condition raced the fixture page's own delayed {@code fetch()} calls) must still fail
+     * with the specific "no renderable API transactions" reason, not a bare {@code successful:false}.
+     * {@code DOCUMENT} is deliberately not asset-like ({@code ResourceKind#isAsset()}), so it is
+     * still visible to callers as "network activity happened" while remaining correctly excluded
+     * from codegen's renderable-transaction extraction ({@code isRenderableResourceKind} accepts
+     * only {@code XHR}/{@code FETCH}). This locks in that distinction so a future change to either
+     * filter cannot silently reintroduce an undiagnosable failure.
+     */
+    @Test
+    void sessionWithOnlyDocumentNavigationTransactionsFailsWithTheRenderableTransactionsReason() throws Exception {
+        Path outputRoot = Files.createDirectories(tempDir.resolve("project-document-only"));
+        Path sessionPath = writeSessionWithOnlyDocumentNavigationEvents(outputRoot, "session-document-only");
+
+        ApiCaptureGenerationResult result = new ApiCaptureGenerator().generate(new ApiCaptureGenerationRequest(
+                sessionPath, outputRoot, "tests.generated", "DocumentOnlyTest",
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS, false, false, true));
+
+        assertEquals(CaptureGenerationReport.Status.FAILED, result.report().status());
+        assertTrue(result.report().unsupportedEvents().stream().anyMatch(message -> message.contains(
+                        "No renderable API transactions (XHR/FETCH with a recorded response) "
+                                + "were found in this session.")),
+                "Expected the specific renderable-transactions reason, got: " + result.report().unsupportedEvents());
+    }
+
+    private Path writeSessionWithOnlyDocumentNavigationEvents(Path outputRoot, String sessionId) throws Exception {
+        Path sessionPath = outputRoot.resolve("recordings/" + sessionId + ".json");
+        Files.createDirectories(sessionPath.getParent());
+        Path bodiesDirectory = sessionPath.getParent().resolve(sessionId + "-network-bodies");
+        Files.createDirectories(bodiesDirectory);
+        NetworkBodyStore bodyStore = new NetworkBodyStore();
+        BodyRef pageRef = bodyStore.store(
+                "<!doctype html><html></html>".getBytes(StandardCharsets.UTF_8), "text/html", bodiesDirectory);
+
+        CaptureEvent.NetworkEvent document = new CaptureEvent.NetworkEvent(
+                CaptureFixtures.context(1),
+                "tx-1",
+                ResourceKind.DOCUMENT,
+                new HttpRequestRecord("GET", "https://app.example.test/", headers(), null),
+                new HttpResponseRecord(200, headers(), pageRef),
+                new NetworkTiming(null, null, null, null, null, null),
+                "",
+                "https://app.example.test/",
+                null);
+        CaptureEvent.NetworkEvent favicon = new CaptureEvent.NetworkEvent(
+                CaptureFixtures.context(2),
+                "tx-2",
+                ResourceKind.DOCUMENT,
+                new HttpRequestRecord("GET", "https://app.example.test/favicon.ico", headers(), null),
+                new HttpResponseRecord(200, headers(), pageRef),
+                new NetworkTiming(null, null, null, null, null, null),
+                "",
+                "https://app.example.test/",
+                null);
+
+        CaptureSession session = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                sessionId,
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(2),
+                CaptureFixtures.browser(),
+                List.of(document, favicon),
+                List.of(),
+                List.of(),
+                null,
+                Map.of());
+        new CaptureJsonCodec().write(sessionPath, session);
+        return sessionPath;
+    }
+
     @Test
     void missingSessionFileFailsCleanlyWithoutThrowing() {
         Path outputRoot = tempDir.resolve("project-missing");

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
@@ -189,6 +189,7 @@ class GuidedWorkflowLiveE2ETest {
 
                 JsonObject status = awaitApiEndpoints(mcp, List.of("/api/session", "/api/profile"),
                         Duration.ofSeconds(90));
+                assertTrue(status.get("networkTransactionCount").getAsInt() >= 2, status.toString());
 
                 JsonObject stoppedStatus = webStatus(mcp.invoke(apiStop(false), TOOL_TIMEOUT));
                 assertEquals("COMPLETED", stoppedStatus.get("state").getAsString(), stoppedStatus.toString());

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
@@ -187,8 +187,8 @@ class GuidedWorkflowLiveE2ETest {
                 String outputPath = startStatus.get("outputPath").getAsString();
                 assertFalse(outputPath.isBlank(), "capture_api_start should report the persisted session path");
 
-                JsonObject status = awaitNetworkTransactions(mcp, 2, Duration.ofSeconds(90));
-                assertTrue(status.get("networkTransactionCount").getAsInt() >= 2, status.toString());
+                JsonObject status = awaitApiEndpoints(mcp, List.of("/api/session", "/api/profile"),
+                        Duration.ofSeconds(90));
 
                 JsonObject stoppedStatus = webStatus(mcp.invoke(apiStop(false), TOOL_TIMEOUT));
                 assertEquals("COMPLETED", stoppedStatus.get("state").getAsString(), stoppedStatus.toString());
@@ -264,19 +264,54 @@ class GuidedWorkflowLiveE2ETest {
         return new Invocation("capture_api_generate", arguments);
     }
 
-    private static JsonObject awaitNetworkTransactions(LiveMcp mcp, int minimumTransactions, Duration limit)
+    /**
+     * Waits until {@code capture_api_status}'s {@code lastEndpoints} reports every one of
+     * {@code expectedEndpointFragments}, instead of gating on a raw {@code networkTransactionCount}
+     * threshold the way this used to (issue #4046). {@code networkTransactionCount} counts every
+     * non-asset network transaction ({@code ResourceKind#isAsset()} excludes only stylesheet/script/
+     * image/font/media), so it includes the fixture page's own {@code DOCUMENT}-kind document
+     * request and the browser's automatic favicon request. On the nightly run that root-caused this,
+     * those two alone satisfied a {@code >= 2} gate before the fixture's delayed {@code fetch()}
+     * calls -- scheduled via {@code setTimeout} -- ever fired, so {@code capture_api_stop} ran
+     * against a session with zero renderable (XHR/FETCH) transactions and {@code capture_api_generate}
+     * correctly, diagnosably reported that. No raw-count threshold fixes this: navigation noise is
+     * unbounded. Waiting for the specific endpoints the scenario actually needs removes the race at
+     * its cause.
+     */
+    private static JsonObject awaitApiEndpoints(LiveMcp mcp, List<String> expectedEndpointFragments, Duration limit)
             throws Exception {
         long deadline = System.nanoTime() + limit.toNanos();
         JsonObject status = new JsonObject();
+        List<String> lastObservedEndpoints = List.of();
         while (System.nanoTime() < deadline) {
             status = webStatus(mcp.invoke(new Invocation("capture_api_status", new JsonObject()), TOOL_TIMEOUT));
-            if (status.has("networkTransactionCount") && status.get("networkTransactionCount").getAsInt()
-                    >= minimumTransactions) {
+            lastObservedEndpoints = observedEndpoints(status);
+            if (containsEveryFragment(lastObservedEndpoints, expectedEndpointFragments)) {
                 return status;
             }
             Thread.sleep(2000);
         }
-        return status;
+        fail("Timed out after " + limit + " waiting for capture_api_status.lastEndpoints to include every one of "
+                + expectedEndpointFragments + "; last observed endpoints were " + lastObservedEndpoints
+                + ". Final status: " + status);
+        return status; // unreachable -- fail() always throws
+    }
+
+    private static List<String> observedEndpoints(JsonObject status) {
+        JsonArray endpoints = status.getAsJsonArray("lastEndpoints");
+        if (endpoints == null) {
+            return List.of();
+        }
+        List<String> result = new ArrayList<>();
+        for (JsonElement endpoint : endpoints) {
+            result.add(endpoint.getAsString());
+        }
+        return result;
+    }
+
+    private static boolean containsEveryFragment(List<String> observedEndpoints, List<String> expectedFragments) {
+        return expectedFragments.stream().allMatch(fragment ->
+                observedEndpoints.stream().anyMatch(endpoint -> endpoint.contains(fragment)));
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #4046.

The nightly `Guided Workflows Live E2E` failure moved past the #4077 capture-start
hang fix to `AssertionFailedError` at `GuidedWorkflowLiveE2ETest.java:199`:
`capture_api_generate` returns `successful:false`.

Investigation (run 30202336592, artifact `guided-workflows-live-evidence`) found the
actual payload already names its cause:

```
"unsupportedEvents":["No renderable API transactions (XHR/FETCH with a recorded
response) were found in this session."]
```

This is **not** a codegen bug and **not** a duplicate of #4029 (loud, diagnosable
codegen failures) — codegen already reported a specific, actionable reason. The
recorded session (`sessionId 84487af3-f669-476f-9fdd-879fa78139ff`) genuinely
contained only two `ResourceKind.DOCUMENT` events (`GET /`, `GET /favicon.ico`);
the fixture's own `setTimeout`-delayed `fetch()` calls to `/api/session` and
`/api/profile` never made it into the session.

Root cause: `GuidedWorkflowLiveE2ETest.awaitNetworkTransactions` gated
`capture_api_stop` on `capture_api_status.networkTransactionCount >= 2` — a raw
counter that includes non-asset navigation noise (`ResourceKind.isAsset()` only
excludes stylesheet/script/image/font/media; `DOCUMENT` counts). The document
request plus the browser's automatic favicon request satisfied that gate before the
fixture's fetches fired, so `capture_api_stop` ran too early against a session with
zero renderable transactions.

- Every codegen path traversed here (`ApiCaptureGenerator.analyze`/`extractTransactions`)
  is unchanged and was already correct.
- `awaitNetworkTransactions` is replaced with `awaitApiEndpoints`, which polls
  `capture_api_status.lastEndpoints` until the specific endpoints the scenario needs
  (`/api/session`, `/api/profile`) appear, removing the race at its cause instead of
  raising a threshold that would still be racy at any count (navigation noise is
  unbounded). On timeout it fails with a diagnostic message naming expected vs.
  observed endpoints.
- Added a `shaft-capture` regression test locking in today's correct diagnosable
  behavior for a `DOCUMENT`-only session, matching exactly what the nightly
  recorded, so a future change to `isRenderableResourceKind` can't silently
  reintroduce an undiagnosable failure.

#4029 stays open on its own merits — separate, still-valid problem.

## Test plan

- [x] `mvn -pl shaft-capture -Dtest=ApiCaptureGeneratorTest -DheadlessExecution=true -Dallure.automaticallyOpen=false test` — 15/15 passed, including the new regression test (watched green; this characterizes existing correct behavior, no production bug to fix).
- [x] `gradle -p shaft-intellij compileTestJava` — compiles clean against JDK 21.
- [ ] `GuidedWorkflowLiveE2ETest` itself requires `-Dshaft.intellij.liveWorkflows=true` plus a live MCP process against a real browser; not runnable in this environment. Could not watch red/green for this file locally — relying on the shaft-capture regression test plus a dispatched nightly re-run for real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwFUVobfWXKHUCaGPrisSt
