### PR TITLE
Fix #4101: remove false branch-naming auto-close claim from playbook

### DIFF
--- a/.claude/skills/work-github/references/playbook.md
+++ b/.claude/skills/work-github/references/playbook.md
@@ -272,11 +272,14 @@ manufacturing a memory entry to fill the step.
   issue when a closing keyword appears anywhere in the PR body — `close`/
   `closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`
   immediately before `#N` — and a later disclaimer sentence does not
-  neutralize an earlier match. A partial-fix PR (`Related to #N`, never
-  `Closes #N`) must avoid every keyword above anywhere in its body,
-  including ordinary prose. Immediately after opening, run `gh pr view <n>
-  --json closingIssuesReferences`; if it lists an issue this PR does not
-  fully resolve, unlink it from the PR's Development sidebar.
+  neutralize an earlier match. The matcher also ignores negation:
+  `"does not close #4046"` auto-closes #4046 too, because `close #4046` is
+  the match — the disclaimer itself is the trigger, not something ordering
+  can save. A partial-fix PR (`Related to #N`, never `Closes #N`) must
+  avoid every keyword above anywhere in its body, including ordinary prose.
+  Immediately after opening, run `gh pr view <n> --json
+  closingIssuesReferences`; if it lists an issue this PR does not fully
+  resolve, unlink it from the PR's Development sidebar.
 - Wait for CI. If it fails, fix forward on the same branch — don't force-
   push over history the user might want to inspect, just add a fixing
   commit, unless the failure is trivially a fixup of the last commit itself.

--- a/.claude/skills/work-github/references/playbook.md
+++ b/.claude/skills/work-github/references/playbook.md
@@ -269,19 +269,14 @@ manufacturing a memory entry to fill the step.
 - Push the branch, open one PR per the shape decided in step 1, with a
   description that lists each sub-item and its commit.
 - **Verify no accidental auto-close, every time.** GitHub auto-closes an
-  issue two ways: a closing keyword anywhere in the PR body — `close`/
+  issue when a closing keyword appears anywhere in the PR body — `close`/
   `closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`
-  immediately before `#N` — where a later disclaimer sentence does not
-  neutralize an earlier match; or a branch named after an issue, which
-  creates a Development-sidebar link on merge independently of body text
-  (this repo's `ChaosEngine/fix-<issue>-<slug>` convention triggers this on
-  every branch). A partial-fix PR (`Related to #N`, never `Closes #N`) must
-  avoid every keyword above anywhere in its body, including ordinary prose.
-  Immediately after opening, run `gh pr view <n> --json
-  closingIssuesReferences`; if it lists an issue this PR does not fully
-  resolve, unlink it from the PR's Development sidebar — this is the only
-  check that reports the effective link regardless of which mechanism
-  created it.
+  immediately before `#N` — and a later disclaimer sentence does not
+  neutralize an earlier match. A partial-fix PR (`Related to #N`, never
+  `Closes #N`) must avoid every keyword above anywhere in its body,
+  including ordinary prose. Immediately after opening, run `gh pr view <n>
+  --json closingIssuesReferences`; if it lists an issue this PR does not
+  fully resolve, unlink it from the PR's Development sidebar.
 - Wait for CI. If it fails, fix forward on the same branch — don't force-
   push over history the user might want to inspect, just add a fixing
   commit, unless the failure is trivially a fixup of the last commit itself.


### PR DESCRIPTION
Closes #4101

## Summary
- Removes the false "branch named after an issue" auto-close mechanism (and its `ChaosEngine/fix-<issue>-<slug>` parenthetical) from step 7 of `.claude/skills/work-github/references/playbook.md`, added by #4096.
- Keeps, unchanged in substance: the closing-keyword set, the no-negation warning (a later disclaimer doesn't neutralize an earlier match), the `Related to #N` partial-fix convention, and the mandatory post-open `gh pr view <n> --json closingIssuesReferences` check.

## Why
Re-verified the evidence #4096's claim rested on. `gh pr view 4068 --json body,headRefName,closingIssuesReferences` shows PR #4068's body contains the literal string "does not **close** #4046" — a closing keyword immediately before `#N`, matched by GitHub regardless of the preceding "not". So the auto-link came from the keyword mechanism, not branch naming. There was never a second, branch-based mechanism to document. Full disproof (including the #4100 branch-without-keyword counter-example) is in #4101.

## Test plan
- [x] `py -3 scripts/ci/validate_agent_setup.py` — passes
- [x] `py -3 scripts/ci/validate_skills.py` — passes
- [x] Independently re-ran the #4068 evidence check before editing; confirmed the body does contain a closing keyword

🤖 Generated with [Claude Code](https://claude.com/claude-code)