### PR TITLE
Fix #4037: stop pre-registering AddHasAuthentication, let Augmenter sequence it correctly

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -684,7 +684,7 @@ public class DriverFactoryHelper {
                 var driver = new RemoteWebDriver(targetExecutionUrlObject, capabilities, createRemoteWebDriverClientConfig(targetExecutionUrlObject));
                 try {
                     driver.setFileDetector(new LocalFileDetector());
-                    return augmentRemoteWebDriver(driver, SHAFT.Properties.web.targetBrowserName().toLowerCase(), SHAFT.Properties.platform.enableBiDi());
+                    return augmentRemoteWebDriver(driver, SHAFT.Properties.platform.enableBiDi());
                 } catch (Throwable postCreationFailure) {
                     // the live RemoteWebDriver session was already created against the grid; quit it
                     // before rethrowing so a post-creation failure doesn't leak a pinned grid slot (#3811)
@@ -709,23 +709,31 @@ public class DriverFactoryHelper {
     // collect two Augmentation entries for the same HasCdp interface; ByteBuddy's DynamicType.Builder#implement
     // then throws "IllegalStateException: Already implemented interface ... HasCdp" the moment the second
     // .implement(HasCdp.class) is requested, killing every chromium remote/grid session (issue #3788).
-    static WebDriver augmentRemoteWebDriver(RemoteWebDriver driver, String browserName, boolean enableBiDi) {
+    //
+    // Do NOT add a custom AddHasAuthentication augmentation here either, for a different reason (issue
+    // #4037): Augmenter#augment captures the ExecuteMethod used by every augmentation registered in the
+    // SAME .augment() call BEFORE the final, actually-augmented class exists -- AddHasAuthentication's own
+    // register() handler checks `((RemoteExecuteMethod) executeMethod).getWrappedDriver() instanceof
+    // HasDevTools`, and getWrappedDriver() always returns the ORIGINAL, pre-augmentation RemoteWebDriver
+    // that was captured in that closure, which never implements HasDevTools. So a manually pre-registered
+    // AddHasAuthentication's handler is a silent no-op FOREVER, regardless of what the real session
+    // capabilities say (confirmed empirically: DriverFactoryHelperAugmentationUnitTest#
+    // nativeAuthHandlerShouldAttemptCdpConnectionRatherThanSilentlyNoOp). Selenium's own
+    // Augmenter#addDependentAugmentations safety net (which AddHasAuthentication exists specifically to
+    // cover, since it is not ServiceLoader-discoverable) does not have this problem: it runs a SEPARATE,
+    // LATER .augment() pass using the already-partially-augmented driver, so by the time its
+    // RemoteExecuteMethod is built, extractRemoteWebDriver returns an object that already implements
+    // HasDevTools (when the session capabilities actually grant it). Leaving AddHasAuthentication
+    // unregistered here lets that safety net do the (correctly-sequenced) job instead.
+    static WebDriver augmentRemoteWebDriver(RemoteWebDriver driver, boolean enableBiDi) {
         var augmenter = new Augmenter();
         if (enableBiDi) {
             augmenter = augmenter.addDriverAugmentation(new BiDiProvider());
-            if (Arrays.asList("chrome", "edge").contains(browserName)) {
-                // Selenium's HasAuthentication is CDP-backed (org.openqa.selenium.remote.AddHasAuthentication),
-                // not auto-discovered via ServiceLoader for RemoteWebDriver, so navigateToURLWithBasicAuthentication
-                // would otherwise always fall back to URL-embedded credentials on remote executions (issue #3732).
-                augmenter = augmenter.addDriverAugmentation(new AddHasAuthentication());
-            }
         }
         var augmentedDriver = augmenter.augment(driver);
-        // Diagnostic evidence for issue #4037: AddHasAuthentication's own register() handler is a silent
-        // no-op unless the augmented driver also implements HasDevTools (CDP-backed), which Selenium only
-        // grants when the session capabilities returned by the remote endpoint advertise a reachable CDP
-        // endpoint (se:cdp/se:cdpEnabled or an equivalent reported URI). Log both so a remote-only failure
-        // can be diagnosed from the returned capabilities instead of guessed at.
+        // Diagnostic evidence for issue #4037: log the real post-session capabilities plus the resulting
+        // HasAuthentication/HasDevTools augmentation outcome, so a remote-only failure can be diagnosed
+        // from evidence instead of guessed at.
         ReportManagerHelper.logDiscrete("Remote session capabilities after augmentation: `" + driver.getCapabilities()
                 + "`. HasAuthentication=" + (augmentedDriver instanceof HasAuthentication)
                 + ", HasDevTools=" + (augmentedDriver instanceof HasDevTools) + ".", Level.DEBUG);

--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperAugmentationUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelperAugmentationUnitTest.java
@@ -1,16 +1,23 @@
 package com.shaft.driver.internal.DriverFactory;
 
 import com.shaft.driver.SHAFT;
+import org.openqa.selenium.HasAuthentication;
 import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.UsernameAndPassword;
 import org.openqa.selenium.chromium.HasCdp;
 import org.openqa.selenium.remote.Command;
 import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.Response;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Regression coverage for issue #3788 Defect A: on any chromium (chrome/edge) remote/grid
@@ -58,7 +65,7 @@ public class DriverFactoryHelperAugmentationUnitTest {
     public void augmentingChromeRemoteSessionShouldNotThrowAndShouldYieldHasCdp() {
         RemoteWebDriver driver = newStubbedChromeRemoteWebDriver();
 
-        var augmented = DriverFactoryHelper.augmentRemoteWebDriver(driver, "chrome", false);
+        var augmented = DriverFactoryHelper.augmentRemoteWebDriver(driver, false);
 
         SHAFT.Validations.assertThat().object(augmented instanceof HasCdp).isEqualTo(true).perform();
     }
@@ -67,8 +74,61 @@ public class DriverFactoryHelperAugmentationUnitTest {
     public void augmentingChromeRemoteSessionWithBiDiEnabledShouldNotThrowAndShouldYieldHasCdp() {
         RemoteWebDriver driver = newStubbedChromeRemoteWebDriver();
 
-        var augmented = DriverFactoryHelper.augmentRemoteWebDriver(driver, "chrome", true);
+        var augmented = DriverFactoryHelper.augmentRemoteWebDriver(driver, true);
 
         SHAFT.Validations.assertThat().object(augmented instanceof HasCdp).isEqualTo(true).perform();
+    }
+
+    /**
+     * Regression coverage for issue #4037 (second pass): {@code Augmenter#augment} captures the
+     * {@code ExecuteMethod} used by {@code AddHasAuthentication}'s internal
+     * {@code instanceof HasDevTools} check BEFORE the final, actually-augmented class exists --
+     * that check runs against {@code RemoteExecuteMethod#getWrappedDriver()}, which returns the
+     * exact object {@code Augmenter#extractRemoteWebDriver} was given, captured in the closure at
+     * augmentation-build time. Pre-registering {@code AddHasAuthentication} via
+     * {@code addDriverAugmentation()} in the SAME {@code .augment()} call as everything else (as
+     * {@code DriverFactoryHelper} used to) makes {@code getWrappedDriver()} always return the
+     * ORIGINAL, pre-augmentation {@code RemoteWebDriver} -- which never implements
+     * {@code HasDevTools} -- so {@code register()}'s handler body is skipped and it returns having
+     * attempted nothing, no matter what the real session capabilities say. Selenium's own
+     * {@code Augmenter#addDependentAugmentations} safety net (which runs a separate, later
+     * {@code .augment()} pass using the already-partially-augmented driver) does not have this
+     * problem, because by then {@code extractRemoteWebDriver} returns an object that already
+     * implements {@code HasDevTools}.
+     *
+     * <p>Proven here without a live grid or Docker: point {@code se:cdp} at a local TCP port
+     * nothing is listening on. If the native handler is genuinely wired to CDP, {@code register()}
+     * attempts a connection and fails loudly (connection refused). If it silently no-ops, nothing
+     * happens and no exception is thrown.
+     */
+    @Test
+    public void nativeAuthHandlerShouldAttemptCdpConnectionRatherThanSilentlyNoOp() throws IOException {
+        int unreachablePort;
+        try (ServerSocket unusedSocket = new ServerSocket(0)) {
+            unreachablePort = unusedSocket.getLocalPort();
+        } // closed immediately -- nothing listens here, so any connection attempt refuses fast
+
+        CommandExecutor stubExecutor = (Command command) -> {
+            Response response = new Response();
+            response.setState("success");
+            if (DriverCommand.NEW_SESSION.equals(command.getName())) {
+                response.setSessionId("stub-session-id");
+                response.setValue(Map.of(
+                        "browserName", "chrome",
+                        "se:cdp", "ws://localhost:" + unreachablePort + "/session/stub-session-id/se/cdp",
+                        "se:cdpVersion", "120.0.6099.109"
+                ));
+            } else {
+                response.setValue(null);
+            }
+            return response;
+        };
+        RemoteWebDriver driver = new RemoteWebDriver(stubExecutor, new MutableCapabilities(Map.of("browserName", "chrome")));
+
+        var augmented = DriverFactoryHelper.augmentRemoteWebDriver(driver, true);
+
+        Predicate<URI> anyUri = uri -> true;
+        Assert.assertThrows(Exception.class, () ->
+                ((HasAuthentication) augmented).register(anyUri, UsernameAndPassword.of("user", "pass")));
     }
 }


### PR DESCRIPTION
## Summary

Closes #4037

Follow-up to #4095, which fixed a real but different silent-degrade bug (the code trusted `instanceof HasAuthentication` without checking `HasDevTools`) but did not fix the actual nightly failure: `Ubuntu_Chrome_Grid` run [30202238233](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30202238233) still failed deterministically (all 3 retries) with `expected Login Success, but found Login Failure`, even though the job log showed `se:cdp`/`webSocketUrl` genuinely present in the returned capabilities and Selenium's own `DevToolsProvider` genuinely granting `HasDevTools` (`"WebDriver augmented with DevTools interface..."`). So `#4095`'s fallback never triggered -- the native path ran, and still failed.

### Root cause (confirmed by reading Selenium 4.46.0 sources and empirically, no live grid needed)

`Augmenter#augment` captures the `ExecuteMethod` shared by **every** augmentation registered in the **same** `.augment()` call **before** the final, actually-augmented class exists:

```java
RemoteWebDriver remote = extractRemoteWebDriver(driver);      // driver = the ORIGINAL, pre-augmentation RemoteWebDriver
ExecuteMethod execute = new RemoteExecuteMethod(remote);      // permanently wraps that original driver
for (Augmentation<?> augmentation : matchingAugmenters) {
    Object instance = augmentation.implementation.apply(caps, execute);  // ALL augmentations share this `execute`
    ...
}
```

`AddHasAuthentication`'s own `register()` handler checks `((RemoteExecuteMethod) executeMethod).getWrappedDriver() instanceof HasDevTools`. `RemoteExecuteMethod#getWrappedDriver()` just returns the field it was constructed with -- the exact pre-augmentation `RemoteWebDriver` captured above. That object **never** implements `HasDevTools` (only the final ByteBuddy-generated subclass does), so the check is **always false**, deterministically, regardless of what the real session capabilities say.

`DriverFactoryHelper.augmentRemoteWebDriver` explicitly pre-registered `AddHasAuthentication` alongside `BiDiProvider` in one `.augment()` call (added by #3744 to work around `AddHasAuthentication` not being ServiceLoader-discoverable) -- which is exactly the scenario that breaks the check above. `register()` therefore silently returned having attempted **zero** CDP calls.

**Proven empirically without Docker/a live grid** (`DriverFactoryHelperAugmentationUnitTest#nativeAuthHandlerShouldAttemptCdpConnectionRatherThanSilentlyNoOp`): build a real `RemoteWebDriver` via a stubbed `CommandExecutor` reporting `se:cdp` pointed at a local TCP port nothing listens on, augment it, call `register()`. On the pre-fix code: no exception, nothing happens -- watched RED (`AssertionError: Expected Exception to be thrown, but nothing was thrown`). On the fixed code: `register()` genuinely attempts the CDP connection and fails loudly (connection refused) -- watched GREEN.

Selenium ships its own fix for the "not ServiceLoader-discoverable" gap: `Augmenter#addDependentAugmentations`, called unconditionally at the end of every augmentation round, adds `AddHasAuthentication` **only if not already present** -- in a **separate, later** `.augment()` pass, using the **already-partially-augmented** driver. By then `extractRemoteWebDriver` returns an object that already implements `HasDevTools` (when the real capabilities grant it), so its `ExecuteMethod` closure is correct. #3744 didn't need to (and shouldn't have) pre-registered `AddHasAuthentication` at all.

### Fix

- `DriverFactoryHelper.augmentRemoteWebDriver`: removed the explicit `augmenter.addDriverAugmentation(new AddHasAuthentication())` call. Selenium's own `addDependentAugmentations` safety net now does the job, correctly sequenced. Dropped the now-unused `browserName` parameter (its only use gated the removed call; `AddHasAuthentication#isApplicable` already does the same chromium-browser-name check internally) and updated all 4 call sites.
- Kept from #4095: the diagnostic capability/augmentation-outcome logging, the `resolvedUrl` cleanup, and the `HasDevTools`-presence check in `BrowserActions.navigateToURLWithBasicAuthentication` -- that check is still a legitimate defense for a genuinely different scenario (a session that never gets `HasDevTools` at all, e.g. no `se:cdp` advertised), distinct from this bug.

## Test plan

- TDD: `DriverFactoryHelperAugmentationUnitTest#nativeAuthHandlerShouldAttemptCdpConnectionRatherThanSilentlyNoOp` -- watched RED against pre-fix code (no exception thrown, proving zero CDP calls attempted), watched GREEN after removing the pre-registration (connection genuinely attempted and fails loudly against the unreachable stub port).
- `mvn -pl shaft-engine test -Dtest=DriverFactoryHelperAugmentationUnitTest,DriverFactoryHelperCoverageUnitTest,BrowserActionsCoverageUnitTest,BrowserActionsHelperCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` -> 77/77 passed (run twice to rule out the one observed timing-sensitive flake in `DriverFactoryHelperCoverageUnitTest`, unrelated to this change -- passed both times on retry, and in isolation).
- `mvn -pl shaft-engine test-compile` clean.
- Remote evidence (per the owner's explicit ask this round -- **not claiming this is fixed until the run itself reports success**): E2E Tests dispatched on this branch, run [30203603958](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30203603958) -- `Ubuntu_Chrome_Grid` result to follow once it completes.

**Not auto-merging this PR.** Leaving it for the owner to arm once the Grid run is confirmed green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EwFUVobfWXKHUCaGPrisSt