### PR TITLE
Fix #4079: fail zero-scenario Cucumber CI jobs instead of reporting green

### DIFF
--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -352,15 +352,26 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
-      # The %regex[.*CucumberTests.*] selector also matches unrelated unit tests
-      # (e.g. CucumberTestsHelperCoverageUnitTest, testPackage.properties.CucumberTests)
-      # whose passing runs kept the aggregate Allure total above zero even when the actual
-      # Cucumber runner found zero scenarios (issue #4079). Check its own Surefire report
-      # directly so a real zero-scenario regression can never hide behind that padding.
+      # The %regex[.*CucumberTests.*] selector also matches unrelated unit tests (e.g.
+      # CucumberTestsHelperCoverageUnitTest, testPackage.properties.CucumberTests). Their
+      # passing runs previously kept the aggregate Allure total above zero even during
+      # #4079's original defect, when the real Cucumber runner found zero scenarios and
+      # every job on this selector reported false-green. #4078 fixed the underlying
+      # auto-wiring (verified: cucumberTestRunner.CucumberTests now finds and runs all 4
+      # scenarios both locally and in CI), but this check remains as the regression guard --
+      # a future break in that auto-wiring must fail loudly and can never hide behind the
+      # unrelated classes' passing counts. Checked via the runner's own Surefire report so
+      # this can't be fooled by that padding the way the aggregate Allure total can.
+      #
+      # Path note: when more than one class matches -Dtest (as here), Surefire's TestNG
+      # provider writes each class's JUnit-style report under surefire-reports/junitreports/,
+      # not a top-level surefire-reports/TEST-<Class>.xml (that top-level path is only
+      # produced when a single class is selected directly, e.g. -Dtest=<FQCN> with no other
+      # matches -- confirmed empirically both ways).
       - name: Verify Cucumber scenarios actually executed
         run: >-
           python3 scripts/ci/assert_tests_executed.py
-          shaft-engine/target/surefire-reports/TEST-cucumberTestRunner.CucumberTests.xml
+          shaft-engine/target/surefire-reports/junitreports/TEST-cucumberTestRunner.CucumberTests.xml
           --min-executed 1
       - name: Post-Test Report and Check
         id: post_test_report

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -348,6 +348,20 @@ jobs:
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DmaximumPerformanceMode=2" "-DtargetBrowserName=MicrosoftEdge" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*CucumberTests.*]"
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+      # The %regex[.*CucumberTests.*] selector also matches unrelated unit tests
+      # (e.g. CucumberTestsHelperCoverageUnitTest, testPackage.properties.CucumberTests)
+      # whose passing runs kept the aggregate Allure total above zero even when the actual
+      # Cucumber runner found zero scenarios (issue #4079). Check its own Surefire report
+      # directly so a real zero-scenario regression can never hide behind that padding.
+      - name: Verify Cucumber scenarios actually executed
+        run: >-
+          python3 scripts/ci/assert_tests_executed.py
+          shaft-engine/target/surefire-reports/TEST-cucumberTestRunner.CucumberTests.xml
+          --min-executed 1
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -699,12 +699,25 @@ jobs:
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DmaximumPerformanceMode=1" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*CucumberTests.*]"
+      # module-directory defaults to shaft-engine, but this job's -pl target is shaft-browserstack
+      # (which has no Cucumber TestNG runner class at all -- find shaft-browserstack -iname
+      # CucumberTests.java returns nothing, issue #4079). The default silently checked
+      # shaft-engine's allure-results instead, which the reactor -am build also populates via
+      # unrelated matched classes, masking that shaft-browserstack itself produces zero output.
+      # Pointing this at the actual target module makes the existing zero-result guard below
+      # (RESULT_COUNT -eq 0 / TOTAL -eq 0 checks in post-test-report/action.yml) fire correctly.
+      # require-coverage: false because that same zero-match selector means shaft-browserstack
+      # never produces target/jacoco.exec here either -- without this, the coverage-upload
+      # substep would fail first on a missing jacoco.xml and mask the real "zero scenarios"
+      # signal behind an unrelated, misleading coverage error.
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
         uses: ./.github/actions/post-test-report
         with:
           job-name: MacOSX_Safari_Cucumber_BrowserStack
+          module-directory: shaft-browserstack
+          require-coverage: 'false'
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_JUnit_E2E:

--- a/scripts/ci/assert_tests_executed.py
+++ b/scripts/ci/assert_tests_executed.py
@@ -35,6 +35,19 @@ def main(argv: list[str] | None = None) -> int:
 
     total_tests = total_failures = total_errors = total_skipped = 0
     for report in args.reports:
+        if not report.is_file():
+            # No report file at all means Surefire/Gradle never even ran (or never discovered)
+            # the class this report was expected for -- a stronger "zero" than an all-skipped
+            # report. Fail with a clear, actionable message instead of an unhandled
+            # FileNotFoundError traceback, which reads as a script bug rather than the actual
+            # zero-test-execution signal this gate exists to surface (issue #4079).
+            print(f"::error::expected report not found: {report} -- the test class this report "
+                  "belongs to never ran (or never produced output); check the test selector, and "
+                  "whether it matched multiple classes causing this report to land somewhere else "
+                  "(e.g. Surefire's TestNG provider writes per-class reports under "
+                  "surefire-reports/junitreports/ instead of the top-level directory when more "
+                  "than one class matches -Dtest)")
+            return 1
         tests, failures, errors, skipped = summarize(report)
         executed = tests - skipped
         print(f"{report}: tests={tests} failures={failures} errors={errors} skipped={skipped} executed={executed}")

--- a/tests/scripts/test_assert_tests_executed.py
+++ b/tests/scripts/test_assert_tests_executed.py
@@ -71,6 +71,19 @@ class AssertTestsExecutedTest(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
 
+    def test_missing_report_fails_with_a_clear_message_not_a_traceback(self):
+        # Regression for #4079: a runner class that Surefire never even discovers (e.g. because
+        # multiple classes matched the same -Dtest selector, so its report landed under
+        # surefire-reports/junitreports/ instead of the path a caller expected) writes no report
+        # file at all. That must fail the gate with a clear, actionable message -- not an
+        # unhandled FileNotFoundError traceback, which is barely more legible than the silent
+        # false-green this script exists to prevent.
+        missing_report = Path(self.temp_dir.name) / "TEST-does.not.Exist.xml"
+
+        exit_code = main([str(missing_report), "--min-executed", "1"])
+
+        self.assertEqual(exit_code, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #4079

## Timeline, so this reads correctly six months from now

#4079 reported two nightly Cucumber jobs running zero scenarios and reporting
green. **#4078 (merged today, before this PR started) already fixed the root
cause** — `TestNGListener.alter()` now correctly detects a Cucumber-over-TestNG
suite and wires `cucumber.features`/`cucumber.glue`/`cucumber.plugin`. By the
time this PR's evidence was gathered, `Windows_Edge_Cucumber_Local` was already
running real scenarios again. **This PR does not fix an active zero-scenario
condition** — it adds the regression guard #4079 also asked for, so a future
break in that auto-wiring (or a future zero-match test selector) fails loudly
instead of silently padding past a coarse "some test ran somewhere in this
module" check the way the original defect did.

## What's in this PR

- **`Windows_Edge_Cucumber_Local`** (`e2eLocalTests.yml`): added a step that
  checks `cucumberTestRunner.CucumberTests`' own Surefire report via the
  existing `scripts/ci/assert_tests_executed.py`, targeting that class
  specifically rather than the module-level Allure aggregate. The job's
  `%regex[.*CucumberTests.*]` selector also matches unrelated unit tests
  (`CucumberTestsHelperCoverageUnitTest`, `testPackage.properties.CucumberTests`,
  `AssertionStepsCucumberTestsCoverageUnitTest`) whose passing runs keep the
  aggregate Allure total above zero regardless of what the real runner does —
  that padding is exactly what let #4079's original two broken jobs report
  green undetected. Checking the runner's own report bypasses that padding
  entirely, so it can't recur silently.
- **`MacOSX_Safari_Cucumber_BrowserStack`** (`e2eTests.yml`): `shaft-browserstack`
  has no Cucumber TestNG runner class at all (`find shaft-browserstack -iname
  CucumberTests.java` returns nothing) and never will run real scenarios as
  currently structured. Its `post-test-report` step was checking the wrong
  module (`shaft-engine`, the action's default) instead of the actual `-pl`
  target (`shaft-browserstack`) — confirmed empirically that
  `shaft-browserstack/allure-results` and `shaft-browserstack/target/surefire-reports`
  are never created for this job's selector. Pointed `module-directory` at the
  real target so the module's actual (zero) output is what gets checked,
  and set `require-coverage: false` since the same zero-match selector means
  `jacoco.exec` never gets produced there either.
- **`scripts/ci/assert_tests_executed.py`**: a missing report file (stronger
  than "all skipped" — the class produced no output at all) now fails with a
  clear `::error::` message instead of an unhandled `FileNotFoundError`
  traceback. New regression test, watched RED then GREEN.
- `continue-on-error: true` on both jobs' "Run tests" step is **left as-is**:
  it's a deliberate, working pattern shared by the already-correct
  `Ubuntu_Chrome_Cucumber_Grid` job in the same file (line 671) — it lets the
  report/check step run and own the pass/fail verdict instead of trusting
  Maven's raw exit code, matching this repo's own operating rule that a local
  `mvn test` exit code is not a trustworthy verdict on its own.

## Live CI evidence (workflow_dispatch against this branch — the actual acceptance criterion)

**`Windows_Edge_Cucumber_Local`** — genuinely green, real scenarios (job
[89796128671](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30203005810/job/89796128671)):
```
Scenario: Browser steps                              # src/test/resources/CucumberFeatures/SHAFT_BDD_Sample_EN.feature:4
Scenario: Browser attribute assertions                # src/test/resources/CucumberFeatures/SHAFT_BDD_Sample_EN.feature:17
Scenario: Element visual assertions                    # src/test/resources/CucumberFeatures/SHAFT_BDD_Sample_EN.feature:28
Scenario: This is the first test scenario in the sample feature file  # src/test/resources/CustomCucumberFeatures/localTest.feature:3
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
(An earlier push of this branch had the guard step pointed at the wrong Surefire
report path — `surefire-reports/TEST-<Class>.xml` instead of
`surefire-reports/junitreports/TEST-<Class>.xml`, which is where Surefire's
TestNG provider actually writes a per-class report when more than one class
matches `-Dtest`. That produced a `FileNotFoundError` on this same run, which
was corrected before this evidence was captured — see commit history.)

**`Ubuntu_Chrome_Cucumber_Grid`** — untouched by this PR, confirmed still
genuinely green and not padding-only (job
[89796131687](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30203007029/job/89796131687)):
```
Scenario: Browser steps                              # src/test/resources/CucumberFeatures/SHAFT_BDD_Sample_EN.feature:4
Scenario: Browser attribute assertions                # src/test/resources/CucumberFeatures/SHAFT_BDD_Sample_EN.feature:17
Scenario: Element visual assertions                    # src/test/resources/CucumberFeatures/SHAFT_BDD_Sample_EN.feature:28
Scenario: This is the first test scenario in the sample feature file  # src/test/resources/CustomCucumberFeatures/localTest.feature:3
Tests run: 26, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

**`MacOSX_Safari_Cucumber_BrowserStack`** — **fails** on this branch (job
[89796131765](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30203007029/job/89796131765)),
which is the expected and correct outcome given `shaft-browserstack` has no
runner class to run. This is flagged for the orchestrator, not decided here:
the job goes red not via the clean `post-test-report` message this PR was
meant to activate, but via an uncaught crash — `post-test-report/action.yml`'s
"Write Summary and Check Test Results" script runs
`find "$ALLURE_RESULTS_DIR" ... | wc -l` under `set -euo pipefail`; GNU `find`
returns a nonzero exit when its start path doesn't exist at all (as opposed to
existing-but-empty), and `pipefail` propagates that through the pipe, so `-e`
kills the script before it ever reaches the intended
`"::error::No Allure summary or raw result files were generated..."` message.
Verified by running that exact script snippet against the real (confirmed
absent) `shaft-browserstack/allure-results` path locally — it dies at the
`find` line, no output at all. This is a latent bug in the **shared**
`post-test-report/action.yml`, used by every job in the CI suite, only now
exposed because this is the first time `module-directory` has ever pointed at
a module whose `allure-results` directory is entirely absent rather than
merely empty. Fixing it is out of this PR's scope (`.github/workflows/e2eLocalTests.yml`,
`.github/workflows/e2eTests.yml`) and has a blast radius across every job that
uses the composite action — flagged for a decision, not fixed here.
`MacOSX_Safari_Cucumber_BrowserStack`'s underlying "does it need a runner class
or should it not exist" question is tracked in #4097.

**Static checks:**
```
$ py -3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2eLocalTests.yml')); yaml.safe_load(open('.github/workflows/e2eTests.yml'))"
OK (both files)
$ py -3 scripts/ci/validate_workflow_timeouts.py
All workflow jobs declare timeout-minutes.
$ python3 -m unittest tests.scripts.test_assert_tests_executed -v
Ran 7 tests in 0.033s — OK
```

## Adjacent findings (filed separately, not fixed here)

- #4097: `shaft-browserstack` has no Cucumber TestNG runner class at all —
  `MacOSX_Safari_Cucumber_BrowserStack` fails on this branch and will keep
  failing every night until it gets a runner class or is removed. Escalated
  rather than decided unilaterally, per the explicit instruction that removing
  CI coverage is not a delegate's call.
- `post-test-report/action.yml`'s "Write Summary and Check Test Results" step
  crashes via an uncaught `set -e`/`pipefail` interaction with `find` on a
  wholly-missing `allure-results` directory, instead of reaching its own
  intended clean zero-result message. Reported above with exact repro; not
  fixed here (shared file, out of this PR's named scope, wide blast radius).
