### PR TITLE
Fix #4105: guard post-test-report's find call against an absent allure-results directory

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -131,11 +131,28 @@ runs:
           grep -o "\"${field}\" *: *[0-9]*" "$file" 2>/dev/null | head -1 | grep -o '[0-9]*' || true
         }
 
+        # Describe why RESULT_COUNT is zero: absent directory vs. present-but-empty
+        # are different diagnostics and both should be actionable.
+        describe_allure_results_dir() {
+          if [ -d "$ALLURE_RESULTS_DIR" ]; then
+            echo "$ALLURE_RESULTS_DIR exists but contains no raw result files"
+          else
+            echo "$ALLURE_RESULTS_DIR does not exist"
+          fi
+        }
+
         # Count raw Allure result files before interpreting the generated summary.
         # An empty raw-results directory means the run is invalid, even if a stale summary exists.
+        # GNU find exits nonzero when its start path is entirely absent (not merely
+        # empty) -- guard with -d first so a missing directory can't kill the step
+        # via pipefail before reaching the diagnostics below (#4105).
         ALLURE_RESULTS_DIR="${{ inputs.module-directory }}/allure-results"
-        RESULT_COUNT=$(find "$ALLURE_RESULTS_DIR" -name '*-result.json' -type f 2>/dev/null | wc -l | tr -d ' ')
-        RESULT_COUNT=${RESULT_COUNT:-0}
+        if [ -d "$ALLURE_RESULTS_DIR" ]; then
+          RESULT_COUNT=$(find "$ALLURE_RESULTS_DIR" -name '*-result.json' -type f 2>/dev/null | wc -l | tr -d ' ')
+          RESULT_COUNT=${RESULT_COUNT:-0}
+        else
+          RESULT_COUNT=0
+        fi
         echo "Allure raw result files: $RESULT_COUNT"
 
         # SHAFT writes summary.json at the report root after generating the single-file HTML.
@@ -189,7 +206,7 @@ runs:
         # Primary check: use Allure report data.
         if [ -f "$ALLURE_SUMMARY" ]; then
           if [ "$RESULT_COUNT" -eq 0 ]; then
-            echo "::error::No raw Allure result files were generated in $ALLURE_RESULTS_DIR. Treating this as an invalid test run."
+            echo "::error::No raw Allure result files were generated: $(describe_allure_results_dir). Treating this as an invalid test run."
             exit 1
           fi
           if [ "$TOTAL" -eq 0 ]; then
@@ -221,7 +238,7 @@ runs:
           echo "All tests passed according to Allure report."
         else
           if [ "$RESULT_COUNT" -eq 0 ]; then
-            echo "::error::No Allure summary or raw result files were generated for ${{ inputs.module-directory }}."
+            echo "::error::No Allure summary was generated for ${{ inputs.module-directory }}, and $(describe_allure_results_dir)."
             exit 1
           fi
           echo "::warning::Allure report summary not found. Falling back to surefire reports."


### PR DESCRIPTION
Closes #4105

## Summary

`.github/actions/post-test-report/action.yml`'s "Write Summary and Check Test
Results" step runs under `set -euo pipefail`. It counted raw Allure result
files with `find "$ALLURE_RESULTS_DIR" ... | wc -l`. GNU `find` exits nonzero
when its start path is **entirely absent** (not merely empty) -- `pipefail`
propagated that through the pipe and `-e` killed the script right there,
before it ever reached the action's own intended clean
`::error::No Allure summary or raw result files were generated...` message.
First exposed by #4106 pointing `module-directory` at `shaft-browserstack`,
the first caller ever to target a module with no output directory at all.

## Fix

- `set -euo pipefail` stays on for the whole step -- untouched.
- Only the `find` call is guarded: `[ -d "$ALLURE_RESULTS_DIR" ]` is checked
  first. If the directory exists, the exact same `find | wc -l | tr -d ' '`
  pipeline runs as before. If it doesn't, `RESULT_COUNT=0` directly, no `find`
  invocation, no crash.
- The two `RESULT_COUNT -eq 0` error messages now say **why** via a small
  `describe_allure_results_dir()` helper: "does not exist" vs. "exists but
  contains no raw result files" -- different, both actionable, diagnoses.

## Other callers unaffected

31 call sites across `e2eTests.yml`, `e2eLocalTests.yml`, `lambdatestTests.yml`.
Every existing caller's `allure-results` directory exists (with or without
results) -- the `[ -d ]` guard takes the `if` branch for all of them and runs
the identical `find` pipeline that ran before. Verified directly (see test
plan): a directory with real results reaches `"All tests passed according to
Allure report."` and exits 0, byte-for-byte the same as pre-fix.

## Test plan

No test harness exists for this action's embedded shell (`tests/scripts/*.py`
only covers standalone Python scripts; nothing tests `.github/actions/*`
composite-action bash). Relied on local reproduction instead, extracting the
exact step body (post-fix) into a standalone script and running it against
three scenarios plus a manual pre-fix baseline.

**Before (pre-fix pipeline, confirmed-absent directory):**
```
$ bash repro_before.sh
exit code: 1
```
No output at all -- dies silently at the `find` line, exactly as #4105 and
#4106 described.

**After -- Scenario A, directory entirely absent:**
```
Allure raw result files: 0
=== Checking test results using Allure report data ===
Allure Report Summary: Total=0, Passed=0, Failed=0, Broken=0, Skipped=0
::error::No Allure summary was generated for .../absent-module, and .../absent-module/allure-results does not exist.
SCENARIO_A_EXIT=1
```

**After -- Scenario B, directory exists but empty:**
```
Allure raw result files: 0
=== Checking test results using Allure report data ===
Allure Report Summary: Total=0, Passed=0, Failed=0, Broken=0, Skipped=0
::error::No Allure summary was generated for .../empty-module, and .../empty-module/allure-results exists but contains no raw result files.
SCENARIO_B_EXIT=1
```

**After -- Scenario C, directory exists with real results (regression check):**
```
Allure raw result files: 1
=== Checking test results using Allure report data ===
Allure Report Summary: Total=5, Passed=5, Failed=0, Broken=0, Skipped=0
All tests passed according to Allure report.
REACHED_END
SCENARIO_C_EXIT=0
```

**Static checks:**
```
$ py -3 scripts/ci/validate_workflow_timeouts.py
All workflow jobs declare timeout-minutes.

$ py -3 -c "import yaml; yaml.safe_load(open('.github/actions/post-test-report/action.yml')); print('OK')"
OK
```
(`validate_workflow_timeouts.py` only globs `.github/workflows/*.yml` and
doesn't touch composite actions; no repo validator specifically covers
`.github/actions/*` shell logic -- confirmed by inspecting the two validators
that do mention `.github/actions/` paths, `validate_shaft_pilot_release.py`
and `validate_shaft_mcp_configuration.py`, both of which only check unrelated
actions, `intellij-verify` and `mcp-jar-build`.)

## Out of scope

#4097 (whether the BrowserStack job should have a runner or be deleted),
the workflow files themselves, and PR #4106's changes -- untouched here.
