### PR TITLE
Fix #4114: make the 20-minute stall watch two-sided

### DIFF
--- a/.claude/skills/act-as-fable/SKILL.md
+++ b/.claude/skills/act-as-fable/SKILL.md
@@ -192,7 +192,8 @@ when progress is verified and the remaining path is clear; a silent agent
 never gets to burn the clock. The rule is recursive: every delegating agent
 owes the same watch to its own sub-delegates. The check-in is consultancy,
 not monitoring — concrete support (a solved sub-problem, a decision, a
-re-spec), never a bare "status?" ping.
+re-spec), never a bare "status?" ping. Two-sided: delegates owe the same
+proactive report (covenant below), volunteered, not extracted.
 
 **Delegates run act-as-fable implicitly.** Every delegated agent operates
 under this skill's full method — evidence over inference, scout before
@@ -231,7 +232,13 @@ prompts and review their output like a hostile reviewer before building on
 it; escalate architectural questions to the orchestrator instead of deciding
 them yourself. NEVER mark work complete unless every claimed check actually
 ran and passed — a test that doesn't exist, wasn't run, or wasn't watched
-green does not count as passing.
+green does not count as passing. Track elapsed time at checkpoints (a
+build, a test run, a resolved hypothesis); past ~20 minutes since your last
+report, or immediately if blocked, an assumption is refuted, scope is about
+to be exceeded, or about to wait on anything external, send one
+substantive `SendMessage` to `main`: done with evidence, in flight,
+blockers, explicit yes/no on needing help. A hand-off, not a heartbeat —
+never a monitor or CI `--watch`; same to Haiku sub-delegates, consolidated.
 
 ## Ownership: the full loop
 


### PR DESCRIPTION
Closes #4114

## Summary
- Added a checkpoint-based status-report rule to the Subagent covenant in `.claude/skills/act-as-fable/SKILL.md` (`## Delegation`), embedded verbatim into every dispatch prompt: track elapsed time at natural checkpoints (a build, a test run, a resolved hypothesis); send one substantive `SendMessage` to `main` past ~20 minutes since the last report, or immediately if blocked, an assumption is refuted, scope is about to be exceeded, or about to wait on anything external; content is done-with-evidence, in-flight, blockers, and an explicit yes/no on needing help; explicitly a hand-off, not a heartbeat, so it never becomes a monitor or CI `--watch`; extends the same watch to Haiku sub-delegates, consolidated into one report.
- Added one sentence to the stall-watch paragraph making it explicitly two-sided: delegates owe the same proactive report, volunteered rather than extracted by inspection.
- No changes to `coder.md`/`tester.md`/`reviewer.md` — see reasoning below.

## Compatibility with #4103
#4103 forbade delegates from watching CI (`gh pr checks --watch`/Monitor) after five delegates burned 180k-250k tokens each on one-line wake-ups. The new text is written to read as clearly compatible: it explicitly distinguishes a status report ("a hand-off, not a heartbeat") from a heartbeat/monitor, and explicitly restates "never a monitor or CI `--watch`" right next to the new obligation, so a reader encountering both rules together sees them as one two-sided rule, not two competing ones.

## Byte budget note
`.claude/skills/act-as-fable/SKILL.md` was already at 15771/16384 bytes (96%) before this change — only ~600 bytes of headroom for both required additions combined. The wording was tightened hard (several redraft passes, verified with a byte-accurate Python check matching the validator's own `len(text.encode('utf-8'))` method) to land at 16340/16384 bytes. Flagging as an adjacent finding: this skill file is now within ~44 bytes of its hard cap and the next guidance addition here will likely need to trim existing prose to fit, not just add.

## Test plan
- [x] `py -3 scripts/ci/validate_agent_setup.py` — passes
- [x] `py -3 scripts/ci/validate_skills.py` — passes (byte budget within cap)
- [x] Manual diff review — 9 insertions/2 deletions, one file, matches the ~15-line ponytail budget

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>