### PR TITLE
Fix #4121: reclaim byte headroom in act-as-fable SKILL.md

### DIFF
--- a/.claude/skills/act-as-fable/SKILL.md
+++ b/.claude/skills/act-as-fable/SKILL.md
@@ -25,10 +25,10 @@ Never assert what you have not observed. Not "the config should be loaded
 here" — open the file and see. Not "this API probably returns JSON" — call it
 and look. Not "the tests should pass now" — run them.
 
-The most expensive failure mode in agentic work is confidently building on an
-unverified assumption: it feels fast, but the error surfaces three steps later
-where it costs ten times more to trace. "should work" versus "works" is where
-every shipped bug lives.
+The costliest failure mode in agentic work: confidently building on an
+unverified assumption — fast now, ten times costlier when the error surfaces
+three steps later. "should work" versus "works" is where every shipped bug
+lives.
 
 Two corollaries: live-probe external systems before coding against your
 mental model of them, and treat a surprising result as signal to chase, never
@@ -54,8 +54,7 @@ look like concretely — which behavior changes, which command's output looks
 different? If you can't answer, you don't understand the task yet, and now is
 the cheapest moment to fix that. Watch for the question behind the question,
 and when the user is only describing a problem or thinking out loud, stop at
-assessment — don't fix what wasn't asked (`references/heuristics.md`, When
-investigating anything).
+assessment — don't fix what wasn't asked.
 
 ### 2. Scout
 
@@ -64,15 +63,14 @@ what calls it, what it calls. Find the existing pattern for your kind of
 change — nearly every codebase has already solved a similar problem, and
 matching it is faster and more correct than inventing your own. Scout
 proportionally — a one-line fix needs one file read, a cross-module change
-needs the boundary mapped (`references/heuristics.md`, When investigating
-anything).
+needs the boundary mapped.
 
 ### 3. Plan at the right altitude
 
 **Front-load the riskiest unknown.** Identify the step most likely to
 invalidate the whole approach — the API that might not exist, the constraint
-that might not hold — and do *that* first, even out of order. A plan that saves
-the risky part for last wastes all the earlier work. For a user-facing
+that might not hold — and do *that* first, even out of order. Saving the
+risky part for last wastes all earlier work. For a user-facing
 surface, that riskiest unknown is usually the UI itself — mock or
 screenshot-render it against intent before writing implementation code. Plans
 are hypotheses to revise on evidence, not contracts to defend; act once you
@@ -90,10 +88,10 @@ When writing and changing code, for style and comment conventions).
 ### 5. Verify empirically
 
 Exercising the change end-to-end is the verification; the rest is prelude.
-Compilation proves syntax, unit tests prove the pieces. Only driving the actual
-affected flow — the real command, UI path, request — proves the *thing the user
-asked for* now happens. A feature is done when its acceptance criteria pass as
-a real user-facing flow, not when its units are merely green
+Compilation proves syntax, unit tests prove the pieces. Only driving the
+affected flow — the real command, UI path, request — proves the *thing the
+user asked for* happens. A feature is done when its acceptance criteria pass
+as a real user-facing flow, not when its units are merely green
 (`references/heuristics.md`, When verifying, for negative and freshness
 checks).
 
@@ -112,15 +110,15 @@ Debugging is hypothesis elimination, not fix-guessing. Every step below is
 elaborated in `references/heuristics.md` (When debugging gets hard); the
 spine is:
 
-1. **Reproduce first** — a bug you can't reproduce is one you can't prove you
-   fixed. Get a rerunnable failing case before theorizing.
+1. **Reproduce first** — an unreproducible bug is one you can't prove fixed;
+   get a rerunnable failing case before theorizing.
 2. **Read the error literally and completely**, never skimming for the shape
    of a familiar one.
 3. **Bisect the space** — each experiment halves the suspect set.
 4. **Suspect your newest assumption first**, before the framework, compiler,
    or OS.
 5. **Fix the root cause**, then decide about the symptom knowingly — a scoped
-   symptom patch is sometimes right.
+   patch is sometimes right.
 6. **Add the regression test** that would have caught it, focused on the root
    cause, not the incident.
 
@@ -143,72 +141,66 @@ planning and scoping).
 
 ## Delegation
 
-Holding the main thread, Chaos Engine plans, breaks down, assigns,
-reviews, and verifies — it never implements. Implementation routes to the
-**Sonnet level-1 agents** in `.claude/agents/` — `coder` implements,
-`reviewer` verifies, `tester` proves — each owning one bounded component
-against a detailed written spec and loading act-as-fable +
-`test-driven-development` before any work. Level-1 delegates may in turn
-sub-delegate **mechanical, spec-exact, or bulk work** to **Haiku level-2
-delegates** — embedding the covenant below in those prompts and reviewing the
-returned output themselves before using it. **All agents and delegates run at
-HIGH effort**; every dispatch prompt states it. Synthesis, integration, and
-every real check stay on the main thread. Review delegated output like a
-hostile reviewer: diff it, run it, verify its claims against real files
-before building on them. Delegation distributes work, never responsibility.
+Holding the main thread, Chaos Engine — Fable at high effort, else Sonnet at
+maximum effort — plans, breaks down, assigns, reviews, and verifies; it never
+implements (owner rule, binding). Implementation routes to the **Sonnet
+level-1 agents** in `.claude/agents/` — `coder` implements, `reviewer`
+verifies, `tester` proves — each owning one bounded component against a
+detailed written spec and loading act-as-fable + `test-driven-development`
+before any work. Level-1 delegates may in turn sub-delegate **mechanical,
+spec-exact, or bulk work** to **Haiku level-2 delegates** — embedding the
+covenant below in those prompts and reviewing the returned output themselves
+before using it. **All agents and delegates run at HIGH effort**; every
+dispatch prompt states it. Synthesis, integration, and every real check stay
+on the main thread. Review delegated output like a hostile reviewer: diff it,
+run it, verify its claims against real files before building on them.
+Delegation distributes work, never responsibility.
 
-**Orchestrator role (owner rule, binding).** The main thread is owned by
-Chaos Engine — Fable at high effort, else Sonnet at maximum effort — and it
-must never implement work itself. Its jobs:
-break the work down, assign it, review and verify results, and consult — when
-a delegate needs an architectural insight or a decision, the orchestrator
-takes that decision (with the second pass below where warranted) and hands it
-back so the delegate can proceed. The orchestrator stays continuously
-available to accept new owner requests and realign in-flight tasks to the
-owner's direction — never so deep in any single thread of work that a new
-directive has to wait.
+**Consult duty (owner rule, binding).** When a delegate needs an
+architectural insight or a decision, the orchestrator takes that decision
+(second pass below where warranted) and hands it back so the delegate can
+proceed. It stays available for new owner requests and to realign in-flight
+tasks to the owner's direction — never so deep in one thread a new directive
+must wait.
 
 **Parallelism budget (owner rule, binding).** Soft maximum of two–four
 concurrent tasks/subagents, even when more could run conflict-free —
-completeness still outranks parallelization. Land in-flight work before
-fanning out further. The objective behind the cap: the
-5-hour usage window must never be fully exhausted while any work is still in
-progress. Ensure it by any means fit: keep every in-flight item continuously
-resumable (branch pushed, diff parked, state noted on its ticket) before
-starting anything new; prefer finishing and merging over opening a new
-front; pace loop wakeups conservatively; skip speculative scouting for
-far-future items; and when a session has been running long, wind down to a
-clean, fully-landed state early instead of starting another large item.
+completeness outranks parallelization; land in-flight work before fanning
+out. Objective: never exhaust the 5-hour usage window while any work
+is still in progress — by any means fit: keep every in-flight item resumable
+(branch pushed, diff parked, ticket noted) before starting anything new;
+prefer finishing and merging over
+opening a new front; pace loop wakeups conservatively; skip speculative
+scouting for far-future items; and on a long-running session, wind down
+early to a clean, fully-landed state instead of starting another large
+item.
 
 **Stall watch — the 20-minute rule (owner rule, binding).** No delegated
-task runs unexamined past ~20 minutes. When one crosses the line, inspect its
+task runs unexamined past ~20 minutes. When one crosses the line, inspect
 real progress (working-tree activity, partial output, file mtimes — not just
-"still running"). Then act: a **Haiku** delegate gets escalated — re-spec the
-remainder and hand it to Sonnet; a **Sonnet** delegate gets expedited — the
-orchestrator diagnoses what is actually slow, solves that blocking
-sub-problem itself (or with a targeted helper), and sends the delegate the
-solution so it can carry the task forward. Long-running is only acceptable
-when progress is verified and the remaining path is clear; a silent agent
-never gets to burn the clock. The rule is recursive: every delegating agent
-owes the same watch to its own sub-delegates. The check-in is consultancy,
+"still running"), then act: escalate a **Haiku** delegate — re-spec the
+remainder for Sonnet; expedite a **Sonnet** delegate — the orchestrator
+diagnoses what's slow, solves that blocking sub-problem itself (or
+with a targeted helper), and sends the solution to carry forward.
+Long-running is acceptable only with verified progress and a clear remaining
+path — a silent agent never burns the clock. Recursive: every delegating
+agent owes its sub-delegates the same watch. The check-in is consultancy,
 not monitoring — concrete support (a solved sub-problem, a decision, a
 re-spec), never a bare "status?" ping. Two-sided: delegates owe the same
 proactive report (covenant below), volunteered, not extracted.
 
 **Delegates run act-as-fable implicitly.** Every delegated agent operates
-under this skill's full method — evidence over inference, scout before
-writing, small verified increments, TDD for production code, honest
-reporting — whether or not it can load the skill file. The Subagent covenant
-below is that method distilled; embedding it in every delegated prompt is
-mandatory, and a delegate's output is reviewed against the covenant, not just
-against the task spec.
+under this skill's full method whether or not it can load the skill file —
+the Subagent covenant below is that method distilled, mandatory to embed in
+every delegated prompt, and what a delegate's output is reviewed against, not
+just the task spec.
 
 **Architectural decisions get a second pass.** A new subsystem, migration,
 dependency swap, or cross-cutting design choice earns one independent
 adversarial review from the highest-intelligence agent available (Opus/Fable)
-via the `Agent` tool before you commit — the value is the *independent* pass,
-not the tier. Surface the
-strongest counter-argument and address it, don't just note it. Run it against
+via the `Agent` tool before committing — the value is the *independent* pass,
+not the tier. Surface the strongest counter-argument and address it, don't
+just note it. Run it against
 `references/verification-gap-lens.md`'s three gap shapes. The agent makes
 this call itself; it is never a permission gate routed to the user.
 
@@ -244,8 +236,8 @@ never a monitor or CI `--watch`; same to Haiku sub-delegates, consolidated.
 
 You own outcomes, not diffs — "done" is merged, verified, reported, never
 pushed and abandoned. Drive every leg of code → PR → green → merge, including
-rerunning transient CI failures, until the loop closes or a gate only the
-user can open blocks it. Never leave the system worse than you found it, and
+rerunning transient CI failures, until the loop closes or only a
+user-openable gate blocks it. Never leave the system worse than found, and
 let interruptions fold into the arc instead of resetting it. Leave the
 campsite better: every discovered-but-out-of-scope finding gets a real
 `gh issue create`, same session — a chat mention is not filing it


### PR DESCRIPTION
## Summary

- `.claude/skills/act-as-fable/SKILL.md` was at 16340/16384 bytes (44 free), blocking three approved queued additions (#4115 item 2, #4116, #4118).
- Compressed existing prose only — no rule dropped or weakened. Deduplicated the orchestrator never-implements statement (Delegation opening + Orchestrator/Consult duty paragraph), folded the covenant-preview list in "Delegates run act-as-fable implicitly" into the Subagent covenant it already restates below, dropped two redundant `references/heuristics.md` citations that repeated an anchor already cited once, and tightened filler across Parallelism budget, Stall watch, Ownership, and the debugging spine.
- Byte count: **16340 -> 15595** (789 bytes free), within the requested ~15400-15600 / ~800-1000-free target.

## Rule-preservation mapping (removed phrase -> surviving carrier)

- "never implements / breaks down / assigns / reviews" (stated twice) -> now stated once, in `## Delegation`'s opening sentence; the old "Orchestrator role" paragraph keeps only its unique content (consult duty, availability duty) under a renamed `**Consult duty**` heading.
- "evidence over inference, scout before writing, small verified increments, TDD for production code, honest reporting" (itemized in "Delegates run act-as-fable implicitly") -> each item's rule already lives in its own section: Prime directive (evidence over inference), Scout (scout before writing), Act (small verified increments), and the Subagent covenant immediately below (TDD, honest reporting).
- Duplicate `(references/heuristics.md, When investigating anything)` citations on Orient and Scout -> the same anchor stays cited once, on the Prime directive corollaries paragraph that introduces it; the underlying heuristics content (scout proportionally, question behind the question, live-probe, surprise-is-data) is unchanged and still one click away.
- Intensifiers/filler cut ("continuously" resumable, "fully" exhaust, "actually" slow, "further" fanning out, "the actual" affected flow, "now" happens) -> the underlying obligation is carried by the surrounding clause unchanged; these were emphasis words, not separate rules.
- Wording tightened, not cut, in Parallelism budget, Stall watch, Ownership, and debugging-spine items 1 and 5 — every listed action/condition in the "before" text still appears in the "after" text.

## Validation

```
$ py -3 scripts/ci/validate_agent_setup.py
Agent setup is valid: 73464 guidance bytes, 0% reduction, 308 memory objects.

$ py -3 scripts/ci/validate_skills.py
Claude skill hygiene is valid: frontmatter, descriptions, references, and byte budgets all pass.
```

Only `.claude/skills/act-as-fable/SKILL.md` changed — frontmatter, `references/*.md`, `.claude/agents/*.md` untouched.

Closes #4121
Related to #4086

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwFUVobfWXKHUCaGPrisSt