### PR TITLE
Fix #4115: add targeted workflow_dispatch inputs to the E2E workflows

### DIFF
--- a/.claude/skills/shaft-mastery/references/ci-forensics.md
+++ b/.claude/skills/shaft-mastery/references/ci-forensics.md
@@ -39,3 +39,45 @@ relevant scoped tests yourself.
 - Sharded runs: merge via explicit post-step (SHAFT: `report_merge_shards`,
   `assemble_shard_blob.py`) — shard-local reports alone hide cross-shard
   patterns.
+
+## Targeted dispatch — never run the full E2E DAG to verify one test (#4115)
+Verifying a fix means running the failing test(s) plus a few plausibly
+impacted neighbours — never a full `E2E Tests` / `Local E2E Tests` dispatch.
+Both `.github/workflows/e2eTests.yml` and `e2eLocalTests.yml` take
+`workflow_dispatch` inputs for exactly this:
+- `jobs` — comma-separated job names, **no spaces** (e.g. `Ubuntu_APIs` or
+  `Ubuntu_APIs,Ubuntu_Database`). Defaults to `all` (every job — today's
+  behaviour, unchanged). Enforced per-job via a job-level `if:` guard keyed
+  off `github.event.inputs.jobs`, not a matrix — so it composes with each
+  job's pre-existing OS/browser-specific steps unchanged.
+- `tests` — a Maven `-Dtest=` selector, threaded into *every selected job's*
+  Run-tests step. Empty (the default) leaves each job's own hard-coded
+  selector untouched; a non-empty value overrides it identically across
+  whichever job(s) you selected. There's only one `tests` field for the
+  whole workflow (not per-job), so pick one job when you also pass `tests`
+  unless you deliberately want the same selector tried against several jobs.
+
+Dispatch exactly one job with one test, no full-suite run:
+```
+gh workflow run e2eTests.yml --ref <branch-or-main> \
+  -f jobs=Ubuntu_APIs \
+  -f tests=SomeApiTest#someMethod
+```
+Pick a fast job for any exploratory dispatch — `Ubuntu_APIs` and
+`Ubuntu_Database` finish in a couple of minutes. Never pick a Grid or
+BrowserStack job just to check one test ran.
+
+**Why the scheduled nightly is unaffected:** on a `schedule` trigger,
+`github.event_name != 'workflow_dispatch'` is unconditionally true (a
+scheduled run's event name is always exactly `'schedule'`), which is the
+first clause of every job's `if:` guard — so the guard short-circuits to
+`true` and every job runs, with zero dependence on how `github.event.inputs.*`
+happens to evaluate on a non-dispatch trigger. That said,
+`github.event.inputs.<name> == ''` is also true on non-dispatch events (the
+property is present-but-empty, not unset, per GitHub's loose-equality
+coercion of the missing/null value to `''`) — a second, independent reason
+the same guard degrades safely even without the `event_name` clause.
+A partial (non-`all`) `workflow_dispatch` also flips the failing-nightly
+tracking-issue `outcome` input to `'skip'` in both workflows' notify job —
+otherwise a single targeted job passing would read as the whole suite
+having recovered.

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -8,6 +8,21 @@ on:
   schedule:
     - cron: '00 1 * * *'
   workflow_dispatch:
+    inputs:
+      jobs:
+        description: >-
+          Comma-separated job names to run, no spaces (e.g. "Windows_Chrome_Local" or
+          "Windows_Chrome_Local,MacOSX_Safari_Local"). Defaults to every job -- today's
+          behaviour -- and is always every job on the scheduled nightly run.
+        required: false
+        default: 'all'
+      tests:
+        description: >-
+          Maven -Dtest= selector, threaded into every selected job's Run
+          tests step. Leave empty to keep each selected job's own default
+          selector unchanged.
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -41,6 +56,7 @@ jobs:
           needs-json: ${{ toJSON(needs) }}
 
   Windows_Edge_Local:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Windows_Edge_Local,')
     runs-on: windows-latest
     timeout-minutes: 90
     outputs:
@@ -69,7 +85,7 @@ jobs:
         run: (Get-Item (Get-Command msedge).Source).VersionInfo.ProductVersion
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -79,6 +95,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Safari_Local:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_Local,')
     runs-on: macos-latest
     timeout-minutes: 90
     outputs:
@@ -100,7 +117,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}, !%regex[.*MobileEmulation.*]"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || format('{0}, !%regex[.*MobileEmulation.*]', env.GLOBAL_TESTING_SCOPE) }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -110,6 +127,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Windows_Chrome_Local:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Windows_Chrome_Local,')
     runs-on: windows-latest
     timeout-minutes: 75
     outputs:
@@ -135,7 +153,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -145,6 +163,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Windows_SikuliX_Local:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Windows_SikuliX_Local,')
     runs-on: windows-latest
     timeout-minutes: 10
     outputs:
@@ -168,7 +187,7 @@ jobs:
           node-version: '20'
       - name: Run SikuliX Windows desktop flow
         continue-on-error: true
-        run: mvn -pl shaft-sikulix -am -e test "-DrunWindowsDesktopE2E=true" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DautomaticallyOpen=false" "-DopenLighthouseReportWhileExecution=false" "-DgenerateAllureReportArchive=true" "-Dtest=SikuliWindowsDesktopE2ETest"
+        run: mvn -pl shaft-sikulix -am -e test "-DrunWindowsDesktopE2E=true" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DautomaticallyOpen=false" "-DopenLighthouseReportWhileExecution=false" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'SikuliWindowsDesktopE2ETest' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -179,6 +198,7 @@ jobs:
           module-directory: shaft-sikulix
 
   Windows_Appium_Desktop_Local:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Windows_Appium_Desktop_Local,')
     runs-on: windows-latest
     timeout-minutes: 15
     outputs:
@@ -260,7 +280,7 @@ jobs:
             }
             throw "Appium server did not become ready."
           }
-          mvn -pl shaft-engine -am -e test "-DrunWindowsDesktopE2E=true" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=http://127.0.0.1:4723" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=WindowsApp" "-DheadlessExecution=false" "-DplatformName=Windows" "-Dmobile_automationName=Windows" "-Dmobile_app=C:\Windows\System32\notepad.exe" "-DautomaticallyOpen=false" "-DopenLighthouseReportWhileExecution=false" "-DgenerateAllureReportArchive=true" "-Dtest=WindowsDesktopAppiumE2ETest"
+          mvn -pl shaft-engine -am -e test "-DrunWindowsDesktopE2E=true" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=http://127.0.0.1:4723" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=WindowsApp" "-DheadlessExecution=false" "-DplatformName=Windows" "-Dmobile_automationName=Windows" "-Dmobile_app=C:\Windows\System32\notepad.exe" "-DautomaticallyOpen=false" "-DopenLighthouseReportWhileExecution=false" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'WindowsDesktopAppiumE2ETest' }}"
       - name: Dump Appium server log
         if: always()
         shell: powershell
@@ -290,6 +310,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Chrome_Local:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Chrome_Local,')
     runs-on: macos-latest
     timeout-minutes: 90
     outputs:
@@ -311,7 +332,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -321,6 +342,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Windows_Edge_Cucumber_Local:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Windows_Edge_Cucumber_Local,')
     runs-on: windows-latest
     timeout-minutes: 10
     outputs:
@@ -347,7 +369,7 @@ jobs:
         run: (Get-Item (Get-Command msedge).Source).VersionInfo.ProductVersion
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DmaximumPerformanceMode=2" "-DtargetBrowserName=MicrosoftEdge" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*CucumberTests.*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DmaximumPerformanceMode=2" "-DtargetBrowserName=MicrosoftEdge" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*CucumberTests.*]' }}"
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -396,6 +418,11 @@ jobs:
       - name: File or recover the nightly tracking issue
         uses: ./.github/actions/notify-nightly-failure
         with:
-          outcome: ${{ contains(needs.*.result, 'failure') && 'failure' || (contains(needs.*.result, 'cancelled') && 'skip' || 'success') }}
+          # A targeted dispatch (github.event.inputs.jobs set to something other than
+          # '' / 'all') only runs a subset of jobs on purpose (#4115) -- most needs.*.result
+          # entries are 'skipped', not real passes, so this must never be read as a
+          # full-suite recovery/failure signal. Only a schedule run or a full ('all'/empty)
+          # dispatch feeds the real outcome into the tracking-issue logic below.
+          outcome: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.jobs != '' && github.event.inputs.jobs != 'all') && 'skip' || (contains(needs.*.result, 'failure') && 'failure') || (contains(needs.*.result, 'cancelled') && 'skip') || 'success' }}
           workflow-name: ${{ github.workflow }}
           label: 'nightly-failure:local-e2e-tests'

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -265,7 +265,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -303,7 +303,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -341,7 +341,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -8,6 +8,21 @@ on:
   schedule:
     - cron: '00 1 * * *'
   workflow_dispatch:
+    inputs:
+      jobs:
+        description: >-
+          Comma-separated job names to run, no spaces (e.g. "Ubuntu_APIs" or
+          "Ubuntu_APIs,Ubuntu_Database"). Defaults to every job -- today's
+          behaviour -- and is always every job on the scheduled nightly run.
+        required: false
+        default: 'all'
+      tests:
+        description: >-
+          Maven -Dtest= selector, threaded into every selected job's Run
+          tests step. Leave empty to keep each selected job's own default
+          selector unchanged.
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -80,6 +95,7 @@ jobs:
           needs-json: ${{ toJSON(needs) }}
 
   Ubuntu_Database:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Database,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -119,7 +135,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DretryMaximumNumberOfAttempts=2" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*DatabaseActions.*], %regex[.*DB.*], %regex[.*Db.*], %regex[.*db.*]"
+        run: mvn -pl shaft-engine -am -e test "-DretryMaximumNumberOfAttempts=2" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*DatabaseActions.*], %regex[.*DB.*], %regex[.*Db.*], %regex[.*db.*]' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -129,6 +145,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_APIs:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_APIs,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -148,7 +165,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*API.*], %regex[.*Api.*], %regex[.*PathParamTest.*], %regex[.*SwaggerContractTest.*], %regex[.*uestBuilder.*], %regex[.*Rest.*], %regex[.*Json.*], %regex[.*JSON.*], %regex[.*json.*], %regex[.*YAML.*], %regex[.*Yaml.*], %regex[.*yaml.*], %regex[.*CLIWizard.*], %regex[.*TerminalActions.*], %regex[.*properties.Mobile.*], %regex[.*CSVFileManagerUnitTest.*], %regex[.*PdfFileManager.*], %regex[.*ExcelFileManager.*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*API.*], %regex[.*Api.*], %regex[.*PathParamTest.*], %regex[.*SwaggerContractTest.*], %regex[.*uestBuilder.*], %regex[.*Rest.*], %regex[.*Json.*], %regex[.*JSON.*], %regex[.*json.*], %regex[.*YAML.*], %regex[.*Yaml.*], %regex[.*yaml.*], %regex[.*CLIWizard.*], %regex[.*TerminalActions.*], %regex[.*properties.Mobile.*], %regex[.*CSVFileManagerUnitTest.*], %regex[.*PdfFileManager.*], %regex[.*ExcelFileManager.*]' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -158,6 +175,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Visual_Module:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Visual_Module,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -177,7 +195,7 @@ jobs:
           node-version: '20'
       - name: Run visual module tests
         continue-on-error: true
-        run: mvn -pl shaft-visual -am -e test "-DretryMaximumNumberOfAttempts=1" "-DgenerateAllureReportArchive=true" "-Dtest=ImageProcessingActionsUnitTest"
+        run: mvn -pl shaft-visual -am -e test "-DretryMaximumNumberOfAttempts=1" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'ImageProcessingActionsUnitTest' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -188,6 +206,7 @@ jobs:
           module-directory: shaft-visual
 
   Ubuntu_Desktop_Video_Module:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Desktop_Video_Module,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -207,7 +226,7 @@ jobs:
           node-version: '20'
       - name: Run desktop video module tests
         continue-on-error: true
-        run: mvn -pl shaft-video -am -e test "-DretryMaximumNumberOfAttempts=1" "-DgenerateAllureReportArchive=true" "-Dtest=DesktopVideoRecordingProviderRegistrationTest"
+        run: mvn -pl shaft-video -am -e test "-DretryMaximumNumberOfAttempts=1" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'DesktopVideoRecordingProviderRegistrationTest' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -218,6 +237,7 @@ jobs:
           module-directory: shaft-video
 
   Ubuntu_Firefox_Grid:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Firefox_Grid,')
     runs-on: ubuntu-latest
     timeout-minutes: 50
     permissions:
@@ -245,7 +265,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -255,6 +275,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Chrome_Grid:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Chrome_Grid,')
     runs-on: ubuntu-latest
     timeout-minutes: 50
     permissions:
@@ -282,7 +303,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -292,6 +313,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_MicrosoftEdge_Grid:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_MicrosoftEdge_Grid,')
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
@@ -319,7 +341,7 @@ jobs:
         run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${GLOBAL_TESTING_SCOPE}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -329,6 +351,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Playwright_Chrome:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Playwright_Chrome,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -352,7 +375,7 @@ jobs:
         run: mvn -f shaft-engine/pom.xml -e exec:java "-Dexec.mainClass=com.microsoft.playwright.CLI" "-Dexec.args=install --with-deps chrome"
       - name: Run Playwright Chrome E2E
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=ChromePlaywrightActionsE2ETest"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'ChromePlaywrightActionsE2ETest' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -362,6 +385,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Playwright_Edge:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Playwright_Edge,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -385,7 +409,7 @@ jobs:
         run: mvn -f shaft-engine/pom.xml -e exec:java "-Dexec.mainClass=com.microsoft.playwright.CLI" "-Dexec.args=install --with-deps msedge"
       - name: Run Playwright Edge E2E
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=EdgePlaywrightActionsE2ETest"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'EdgePlaywrightActionsE2ETest' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -395,6 +419,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Playwright_WebKit:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Playwright_WebKit,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -418,7 +443,7 @@ jobs:
         run: mvn -f shaft-engine/pom.xml -e exec:java "-Dexec.mainClass=com.microsoft.playwright.CLI" "-Dexec.args=install --with-deps webkit"
       - name: Run Playwright WebKit E2E
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=WebKitPlaywrightActionsE2ETest"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'WebKitPlaywrightActionsE2ETest' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -428,6 +453,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Playwright_Firefox:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Playwright_Firefox,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -451,7 +477,7 @@ jobs:
         run: mvn -f shaft-engine/pom.xml -e exec:java "-Dexec.mainClass=com.microsoft.playwright.CLI" "-Dexec.args=install --with-deps firefox"
       - name: Run Playwright Firefox E2E
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=FirefoxPlaywrightActionsE2ETest"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'FirefoxPlaywrightActionsE2ETest' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -461,6 +487,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Playwright_GalaxyS26Ultra:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Playwright_GalaxyS26Ultra,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -484,7 +511,7 @@ jobs:
         run: mvn -f shaft-engine/pom.xml -e exec:java "-Dexec.mainClass=com.microsoft.playwright.CLI" "-Dexec.args=install --with-deps chromium"
       - name: Run Playwright Galaxy S26 Ultra E2E
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=GalaxyS26UltraPlaywrightActionsE2ETest"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'GalaxyS26UltraPlaywrightActionsE2ETest' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -494,6 +521,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Playwright_IPhone17ProMax:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Playwright_IPhone17ProMax,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -517,7 +545,7 @@ jobs:
         run: mvn -f shaft-engine/pom.xml -e exec:java "-Dexec.mainClass=com.microsoft.playwright.CLI" "-Dexec.args=install --with-deps webkit"
       - name: Run Playwright iPhone 17 Pro Max E2E
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=IPhone17ProMaxPlaywrightActionsE2ETest"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'IPhone17ProMaxPlaywrightActionsE2ETest' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -527,6 +555,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Android_Native_BrowserStack:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Native_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 50
     outputs:
@@ -549,7 +578,7 @@ jobs:
       - name: Run tests
         continue-on-error: true
         timeout-minutes: 40
-        run: mvn -pl shaft-browserstack -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=60" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.platformVersion=13.0" "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*ndroid.*], %regex[.*FlutterTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=60" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.platformVersion=13.0" "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*ndroid.*], %regex[.*FlutterTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -559,6 +588,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   iOS_Web_SAFARI_BrowserStack:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',iOS_Web_SAFARI_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -578,7 +608,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=iOS" "-Dmobile_automationName=XCuiTest" "-DbrowserStack.osVersion=16" "-DbrowserStack.deviceName=iPhone 14" "-DbrowserName=safari" "-DbrowserStack.appName=" "-DbrowserStack.appRelativeFilePath=" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*MobileWebTest.*], %regex[.*IOSBasicInteractionsTest.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=iOS" "-Dmobile_automationName=XCuiTest" "-DbrowserStack.osVersion=16" "-DbrowserStack.deviceName=iPhone 14" "-DbrowserName=safari" "-DbrowserStack.appName=" "-DbrowserStack.appRelativeFilePath=" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*MobileWebTest.*], %regex[.*IOSBasicInteractionsTest.*]' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -588,6 +618,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Android_Web_Chrome_BrowserStack:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Web_Chrome_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -607,7 +638,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.osVersion=13.0" "-DbrowserStack.deviceName=Samsung Galaxy S23" "-DbrowserName=chrome" "-DbrowserStack.appName=" "-DbrowserStack.appRelativeFilePath=" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*MobileWebTest.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.osVersion=13.0" "-DbrowserStack.deviceName=Samsung Galaxy S23" "-DbrowserName=chrome" "-DbrowserStack.appName=" "-DbrowserStack.appRelativeFilePath=" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*MobileWebTest.*]' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -617,6 +648,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Safari_BrowserStack:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -636,7 +668,7 @@ jobs:
           node-version: '20'
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*BrowserActionsTests.*], %regex[.*BigPageActionsTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*BrowserActionsTests.*], %regex[.*BigPageActionsTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -646,6 +678,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_Chrome_Cucumber_Grid:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Chrome_Cucumber_Grid,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -669,7 +702,7 @@ jobs:
         run: docker ps
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DmaximumPerformanceMode=2" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dcucumber.features=src/test/resources/CucumberFeatures,src/test/resources/CustomCucumberFeatures" "-Dcucumber.glue=customCucumberSteps,com.shaft.cucumber" "-Dcucumber.plugin=pretty,json:allure-results/cucumber.json,html:allure-results/cucumberReport.html,com.shaft.listeners.CucumberTestRunnerListener" "-Dtest=%regex[.*(CucumberTests|CucumberFeatureListenerUnitTest|CucumberTestRunnerListenerUnitTest).*]"
+        run: mvn -pl shaft-engine -am -e test "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DmaximumPerformanceMode=2" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dcucumber.features=src/test/resources/CucumberFeatures,src/test/resources/CustomCucumberFeatures" "-Dcucumber.glue=customCucumberSteps,com.shaft.cucumber" "-Dcucumber.plugin=pretty,json:allure-results/cucumber.json,html:allure-results/cucumberReport.html,com.shaft.listeners.CucumberTestRunnerListener" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*(CucumberTests|CucumberFeatureListenerUnitTest|CucumberTestRunnerListenerUnitTest).*]' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -679,6 +712,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Safari_Cucumber_BrowserStack:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_Cucumber_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -698,7 +732,7 @@ jobs:
           node-version: 'lts/*'
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DmaximumPerformanceMode=1" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=%regex[.*CucumberTests.*]"
+        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DmaximumPerformanceMode=1" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*CucumberTests.*]' }}"
       # module-directory defaults to shaft-engine, but this job's -pl target is shaft-browserstack
       # (which has no Cucumber TestNG runner class at all -- find shaft-browserstack -iname
       # CucumberTests.java returns nothing, issue #4079). The default silently checked
@@ -721,6 +755,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Ubuntu_JUnit_E2E:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_JUnit_E2E,')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -856,7 +891,7 @@ jobs:
             "-DgenerateAllureReportArchive=true" \
             "-Dallure.automaticallyOpen=false" \
             "-Dallure.open=false" \
-            "-Dtest=Junit*,MoonTests"
+            "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'Junit*,MoonTests' }}"
 
       - name: Verify JUnit Test Results Exist
         if: always()
@@ -911,6 +946,11 @@ jobs:
       - name: File or recover the nightly tracking issue
         uses: ./.github/actions/notify-nightly-failure
         with:
-          outcome: ${{ contains(needs.*.result, 'failure') && 'failure' || (contains(needs.*.result, 'cancelled') && 'skip' || 'success') }}
+          # A targeted dispatch (github.event.inputs.jobs set to something other than
+          # '' / 'all') only runs a subset of jobs on purpose (#4115) -- most needs.*.result
+          # entries are 'skipped', not real passes, so this must never be read as a
+          # full-suite recovery/failure signal. Only a schedule run or a full ('all'/empty)
+          # dispatch feeds the real outcome into the tracking-issue logic below.
+          outcome: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.jobs != '' && github.event.inputs.jobs != 'all') && 'skip' || (contains(needs.*.result, 'failure') && 'failure') || (contains(needs.*.result, 'cancelled') && 'skip') || 'success' }}
           workflow-name: ${{ github.workflow }}
           label: 'nightly-failure:e2e-tests'


### PR DESCRIPTION
## Summary
Issue #4115 needs an enabling capability for the owner's "never run the full E2E suite to verify one test" directive: today `e2eTests.yml`/`e2eLocalTests.yml` have no per-job `workflow_dispatch` input, so `gh workflow run` always executes the whole ~20-job DAG.

Adds two `workflow_dispatch` inputs to both `.github/workflows/e2eTests.yml` and `.github/workflows/e2eLocalTests.yml`:
- `jobs` (comma-separated, no spaces) — which job(s) run, enforced with a job-level `if:` guard. Default `'all'`, so today's behaviour is unchanged when omitted.
- `tests` — a Maven `-Dtest=` override threaded into every selected job's Run-tests step. Default `''` keeps each job's existing hard-coded/`GLOBAL_TESTING_SCOPE` selector untouched.

Also forces each workflow's `notify_*_failure` job's `outcome` input to `'skip'` whenever the dispatch is partial (`jobs` not `''`/`'all'`), so a lone targeted job passing never reads as the whole nightly having recovered (most `needs.*.result` entries would be `skipped`, not real passes).

Documents the mechanism in `.claude/skills/shaft-mastery/references/ci-forensics.md`: the concrete `gh workflow run -f jobs=... -f tests=...` invocation, which job names are cheapest for exploratory dispatches, and the cron-safety argument.

## Recovered vs. changed
This branch is a clean recovery of two commits from an interrupted prior session (machine crash zeroed `.git/config`; repo repaired) that were stranded on a locked local branch/worktree, never pushed or reviewed:
- `de0af325db` — the targeted-dispatch inputs + job-level `if:` guards + notify-outcome guard + ci-forensics doc.
- `2048c19ede` — a follow-up fixing the `GLOBAL_TESTING_SCOPE` default for the three native Grid jobs in `e2eTests.yml`: the first pass had switched `-Dtest=${GLOBAL_TESTING_SCOPE}` (bash runtime expansion of the ~1.5kB exclusion list) to a GH-expression ternary, which would have textually inlined the literal value at compile time instead — a real mechanism change. Fixed so the ternary's default branch is the string literal `'${GLOBAL_TESTING_SCOPE}'` (braces included), byte-identical to the pre-existing bash-expansion behaviour when no `tests` override is given.

I cherry-picked both commits verbatim (`git cherry-pick de0af325db 2048c19ede`, clean, no conflicts) onto a fresh branch off current `origin/main`, then reviewed the full resulting diff line-by-line as if I hadn't written it. I did not change anything — every job in both files that should have gotten the `if:` guard has it (verified by grepping every job header against every guard line), both YAML files parse cleanly, and the `GLOBAL_TESTING_SCOPE`/`env.GLOBAL_TESTING_SCOPE` preservation matches the repo's memory gotcha on this exact trap.

## Cron-unchanged argument
Every job's guard is:
```
if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',<JobName>,')
```
On a `schedule` trigger, `github.event_name` is exactly `'schedule'`, so the first clause `github.event_name != 'workflow_dispatch'` evaluates `true` unconditionally — the `||` short-circuits and every job's guard is `true` regardless of `github.event.inputs.*`. Belt-and-suspenders: GitHub Actions' `==` coerces a missing/null value to `''` when compared against a string, so `github.event.inputs.jobs == ''` is independently also `true` on a schedule run (there is no `inputs` key at all in a schedule event payload) — the guard degrades safely even without the `event_name` clause. Same reasoning applies to the `tests` input inside each `-Dtest=` ternary (`github.event.inputs.tests != '' && ... || <original selector>`), and to the `notify_*_failure` job's `outcome` guard.

## Real validation performed
- `python3 -c "import yaml,sys; yaml.safe_load(open(r'.github/workflows/e2eTests.yml'))"` → OK
- `python3 -c "import yaml,sys; yaml.safe_load(open(r'.github/workflows/e2eLocalTests.yml'))"` → OK
- `python3 scripts/ci/validate_agent_setup.py` → `Agent setup is valid: 73464 guidance bytes, 0% reduction, 314 memory objects.`
- Real targeted dispatch on this branch: `gh workflow run "E2E Tests" --repo ShaftHQ/SHAFT_ENGINE --ref ChaosEngine/fix-4115-targeted-dispatch-v2 -f jobs=Ubuntu_Database -f tests=DatabaseActionsMockedTests`
  Run: https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30206707565
  Polled job list mid-run: `Ubuntu_Database: in_progress`, all other 19 jobs `completed/skipped` — exactly the "one named job, one named test" behaviour the issue asks for. Watch stopped there per the delegate CI-watch ban (#4103); the run was not driven to completion in this session.

## Test plan
- [x] Both workflow YAML files parse (`yaml.safe_load`)
- [x] `validate_agent_setup.py` passes after the `ci-forensics.md` edit
- [x] Real `workflow_dispatch` run on this branch selects exactly one job, skips all others (run 30206707565)
- [x] Cron-path safety argued from the actual guard expression, not asserted

Closes #4115
