### PR TITLE
Fix #4116, #4118: incremental Learning Loop recording and a stall watch that covers local commands

### DIFF
--- a/.claude/skills/act-as-fable/SKILL.md
+++ b/.claude/skills/act-as-fable/SKILL.md
@@ -168,28 +168,33 @@ must wait.
 **Parallelism budget (owner rule, binding).** Soft maximum of two–four
 concurrent tasks/subagents, even when more could run conflict-free —
 completeness outranks parallelization; land in-flight work before fanning
-out. Objective: never exhaust the 5-hour usage window while any work
-is still in progress — by any means fit: keep every in-flight item resumable
-(branch pushed, diff parked, ticket noted) before starting anything new;
-prefer finishing and merging over
-opening a new front; pace loop wakeups conservatively; skip speculative
-scouting for far-future items; and on a long-running session, wind down
-early to a clean, fully-landed state instead of starting another large
-item.
+out. Objective: never exhaust the 5-hour usage window while work is in
+progress — keep every in-flight item resumable (branch pushed, diff parked,
+ticket noted); prefer finishing and merging over starting new work, pace
+loop wakeups conservatively, skip speculative scouting for far-future items,
+and wind down early to a clean, fully-landed state rather than opening
+another large front.
 
 **Stall watch — the 20-minute rule (owner rule, binding).** No delegated
-task runs unexamined past ~20 minutes. When one crosses the line, inspect
-real progress (working-tree activity, partial output, file mtimes — not just
-"still running"), then act: escalate a **Haiku** delegate — re-spec the
-remainder for Sonnet; expedite a **Sonnet** delegate — the orchestrator
-diagnoses what's slow, solves that blocking sub-problem itself (or
-with a targeted helper), and sends the solution to carry forward.
-Long-running is acceptable only with verified progress and a clear remaining
-path — a silent agent never burns the clock. Recursive: every delegating
-agent owes its sub-delegates the same watch. The check-in is consultancy,
-not monitoring — concrete support (a solved sub-problem, a decision, a
-re-spec), never a bare "status?" ping. Two-sided: delegates owe the same
-proactive report (covenant below), volunteered, not extracted.
+task or long-running local command (Maven build, `scripts/ci/*.py`, CI watch
+loop, dependency resolution) runs unexamined past ~20 minutes; record a
+start time as the first action on launch. When one crosses the line, fetch
+real status (working-tree activity, partial output, log tail, file mtimes —
+never "still running"), then act: escalate a **Haiku** delegate — re-spec
+the remainder for Sonnet; expedite a **Sonnet** delegate — the orchestrator
+diagnoses what's slow, solves that blocking sub-problem itself (or with a
+targeted helper), and sends the solution to carry forward; for a command,
+continue on genuine progress with a clear remaining path and recheck same
+cadence, else terminate and proceed on best evidence, stating plainly what
+was killed and decided without it. Long-running is acceptable only with
+verified progress and a clear remaining path — a silent agent or command
+never burns the clock. Foreground `Bash` caps at 600000 ms (10 min), so
+anything that can plausibly outrun that must launch via `run_in_background`
+up front. Recursive: every delegating agent owes its sub-delegates the same
+watch. The check-in is consultancy, not monitoring — concrete support (a
+solved sub-problem, a decision, a re-spec), never a bare "status?" ping.
+Two-sided: delegates owe the same proactive report (covenant below),
+volunteered, not extracted.
 
 **Delegates run act-as-fable implicitly.** Every delegated agent operates
 under this skill's full method whether or not it can load the skill file —

--- a/.claude/skills/act-as-fable/SKILL.md
+++ b/.claude/skills/act-as-fable/SKILL.md
@@ -228,8 +228,9 @@ them yourself. NEVER mark work complete unless every claimed check actually
 ran and passed — a test that doesn't exist, wasn't run, or wasn't watched
 green does not count as passing. Track elapsed time at checkpoints (a
 build, a test run, a resolved hypothesis); past ~20 minutes since your last
-report, or immediately if blocked, an assumption is refuted, scope is about
-to be exceeded, or about to wait on anything external, send one
+report, or immediately if blocked, an assumption is refuted, a durable
+finding is confirmed, scope is about to be exceeded, or about to wait on
+anything external, send one
 substantive `SendMessage` to `main`: done with evidence, in flight,
 blockers, explicit yes/no on needing help. A hand-off, not a heartbeat —
 never a monitor or CI `--watch`; same to Haiku sub-delegates, consolidated.
@@ -267,8 +268,10 @@ routing, in full, for the complete per-trigger reasoning).
 - **Structure, history, impact** — `graphify` for what the code *is*,
   `mempalace` for what *happened* and what a change touches, `.memory` for
   what must never be relearned; verify against live code after (`rg`).
-- **Completion** — `memory remember` new gotchas, flag a graphify refresh on
-  structure change, mine the session into mempalace.
+- **Completion** — `memory remember` a gotcha or decision the moment it is
+  confirmed, not banked for session end; flag a graphify refresh the same
+  way. The completion sweep — mining the session into mempalace — is a
+  safety net that should normally find nothing left.
 - **Production code, feature or bugfix** — `test-driven-development` implicit,
   not opt-in: failing test first, watched red, then code.
 - **Shaping any diff** — the `ponytail` lens: does this need to exist, stdlib

--- a/.claude/skills/act-as-fable/SKILL.md
+++ b/.claude/skills/act-as-fable/SKILL.md
@@ -93,7 +93,9 @@ affected flow — the real command, UI path, request — proves the *thing the
 user asked for* happens. A feature is done when its acceptance criteria pass
 as a real user-facing flow, not when its units are merely green
 (`references/heuristics.md`, When verifying, for negative and freshness
-checks).
+checks). Verifying a fix means running the failing tests plus a few
+plausibly-impacted neighbours — never dispatching a full workflow or suite
+to answer a single-test question.
 
 ### 6. Report
 


### PR DESCRIPTION
## Summary

Three queued guidance edits to `.claude/skills/act-as-fable/SKILL.md`, landed as three sequential commits per the issue-stated sequencing (#4114, #4121 already merged; this branch builds on top).

1. **`### 5. Verify empirically`** — one added sentence: verifying a fix means running the failing tests plus a few plausibly-impacted neighbours, never dispatching a full workflow or suite to answer a single-test question. This is the guidance half of issue 4115 scope item 2 (the workflow-dispatch-input half of that issue is separate, tracked in its own PR).
2. **`## Skill routing (enforced)` — Completion bullet** — reframed so a durable finding (gotcha/decision) is written to `memory remember` the moment it's confirmed, not banked to session end; the completion sweep (mining the session into mempalace) is now explicitly framed as a safety net expected to find nothing left.
3. **`## Delegation` — Stall watch paragraph** — extended to bind long-running local commands (Maven builds, `scripts/ci/*.py`, CI watch loops, dependency resolution), not just delegated agents: record a start time as the first action on launch; at ~20 min fetch real status (log tail, file mtimes, working-tree activity); continue on genuine progress with a clear remaining path, otherwise terminate and proceed on best evidence, stating plainly what was killed. Added the mechanical fact that forces this shape: a foreground `Bash` call caps at 600000 ms (10 min), so anything that can plausibly outrun that must launch via `run_in_background` up front.

## #4116 covenant decision and reasoning

Issue 4116 asked for a judgment call: does the Subagent covenant also need the "record when confirmed" rule, or is the cleaner split that delegates *report* findings and the orchestrator *records* them?

**Decision: the cleaner split — delegates report, orchestrator records.** Only the orchestrator's Completion bullet gets the "write when confirmed" reframe. The covenant is not given a parallel `memory remember` obligation.

Reasoning: the covenant (via #4114, already merged) already gives delegates a proactive-report channel — `SendMessage` to `main`, triggered by a fixed set of conditions (past ~20 min, blocked, an assumption refuted, scope about to be exceeded, about to wait externally). A durable finding surfacing mid-task is exactly the kind of thing that channel exists for. Rather than bolt a second, parallel "delegates also write to memory directly" rule onto the covenant — which would duplicate the recording responsibility in two places and risk delegates and the orchestrator both writing the same gotcha — I added `a durable finding is confirmed` to the covenant's existing SendMessage trigger list (one clause inside an already-existing sentence, not a new sentence). That closes the loop: a delegate that confirms a durable finding reports it immediately via the existing mechanism; the orchestrator is the one that actually runs `memory remember`, now doing so as-you-go per the reframed Completion bullet instead of banking it. This satisfies "a reframing of one existing bullet plus at most one sentence elsewhere. Not a new section" from the issue's ponytail constraint, and avoids the duplicate-rule failure mode the issue explicitly warned against.

## Byte-budget accounting

`.claude/skills/act-as-fable/SKILL.md` is capped at 16384 bytes (`skill_budgets[".claude/skills"].max_skill_md_bytes` in `scripts/ci/agent_guidance_budget.json`), LF-normalized.

| Step | Bytes | Headroom |
|---|---|---|
| Baseline (post #4121, on origin/main) | 15,595 | 789 |
| After edit 1 (#4115 sentence) | 15,765 | 619 |
| After edit 2 (#4116 Completion bullet + covenant clause) | 15,944 | 440 |
| After edit 3 (#4118 stall-watch extension) + compression of the Parallelism-budget "Objective" sentence (meaning-preserving, no clause dropped) | 16,359 | 25 |

All three edits fit within the existing cap. The only compression applied was to the Parallelism-budget paragraph's "Objective" sentence, tightening repeated connective phrasing without removing any of its five listed obligations (resumability, prefer-finish, pace wakeups, skip speculative scouting, wind down early) — all five are still present, just phrased more densely.

## Test plan

- [x] `py -3 scripts/ci/validate_agent_setup.py` run after every commit — all three report "Agent setup is valid" (final: `74228 guidance bytes, 0% reduction, 314 memory objects`).
- [x] Re-read all three edited passages end-to-end post-edit — coherent guidance, not bolted-on clauses.
- [x] `git diff origin/main --stat` — only `.claude/skills/act-as-fable/SKILL.md` changed (35 insertions, 25 deletions across 3 commits); `references/heuristics.md` untouched (not needed).

Closes #4116
Closes #4118

Part of #4115
