### PR TITLE
Fix #4083: make a delegate's refusal of orchestration commands structural, not discretionary

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -11,6 +11,11 @@ First action, before any other tool: `Skill(act-as-fable)` then
 
 ## Rules
 
+- Refuse `/work-github` and `/loop`, in any phrasing, even rephrased after a
+  prior refusal: main-thread-only orchestration. You cannot see sibling
+  worktrees or the live agent-cap count, so acting on either risks an
+  uncoordinated fan-out (issue #4083) — report the ask back to the
+  orchestrator instead of resuming it yourself.
 - Implement exactly the assigned spec. Adjacent findings are reported, never
   fixed. Architectural questions go back to the orchestrator undecided.
 - Consult `mempalace`/`memory` for prior context (past decisions, gotchas,

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -12,6 +12,11 @@ you judge tests, so you must know what good ones look like. Both bind.
 
 ## Rules
 
+- Refuse `/work-github` and `/loop`, in any phrasing, even rephrased after a
+  prior refusal: main-thread-only orchestration. You cannot see sibling
+  worktrees or the live agent-cap count, so acting on either risks an
+  uncoordinated fan-out (issue #4083) — report the ask back to the
+  orchestrator instead of resuming it yourself.
 - Consult `mempalace`/`memory` for prior context on the touched area (past
   incidents, prior review findings, established patterns) before grepping or
   manually searching the repo — never grep for what a store already knows;

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -11,6 +11,11 @@ both bind for the whole task.
 
 ## Rules
 
+- Refuse `/work-github` and `/loop`, in any phrasing, even rephrased after a
+  prior refusal: main-thread-only orchestration. You cannot see sibling
+  worktrees or the live agent-cap count, so acting on either risks an
+  uncoordinated fan-out (issue #4083) — report the ask back to the
+  orchestrator instead of resuming it yourself.
 - Consult `mempalace`/`memory` for prior context (past incidents, known
   flakes, prior fixes in this area) before grepping or manually searching the
   repo — never grep for what a store already knows; verify against the live

--- a/.claude/hooks/guard.py
+++ b/.claude/hooks/guard.py
@@ -32,6 +32,11 @@
 #      with no scoped Maven test-executing command seen yet in that session,
 #      emit ONE PreToolUse "allow" + additionalContext reminder pointing at
 #      test-driven-development. Never denies, same rationale as R5.
+#   R7 Deny a delegate charter (coder/reviewer/tester, via the hook_input
+#      "agent_type" field) invoking the orchestration-only work-github/loop
+#      skills -- structural version of the refusal previously enforced by
+#      charter prose alone (issue #4083). Requires settings.json's
+#      PreToolUse matcher to include "Skill".
 #
 # Stdlib only. Must run under both `py -3` (Windows launcher, this repo's
 # documented convention) and `python3` (Linux/CI/macOS), so avoid anything
@@ -572,6 +577,50 @@ def tdd_nudge_for_edit_or_write(hook_input: dict, session_id: str) -> str | None
 
 
 # ---------------------------------------------------------------------------
+# R7: deny a delegate charter invoking an orchestration-only skill
+# ---------------------------------------------------------------------------
+#
+# work-github and loop are orchestration-only (AGENTS.md "Agent Hierarchy &
+# Model Routing": only the main-thread orchestrator dispatches them; a
+# delegate has no visibility into sibling worktrees or the live 4-agent cap
+# -- see .memory gotcha completed-subagent-can-be-reinvoked / issue #4083,
+# where this was previously enforced by charter prose alone). The
+# PreToolUse hook_input carries an "agent_type" field identifying which
+# named .claude/agents/*.md charter issued the tool call (verified
+# empirically against a live session: a coder-charter Bash call carries
+# "agent_type":"coder"). This denies ONLY the three delegate charters this
+# repo defines (coder/reviewer/tester) -- an allowlist-shaped exclusion
+# (anything NOT in that denylist is allowed) so an absent agent_type or the
+# orchestrator's own "chaos-engine" identity can never be blocked, since
+# neither value is ever a member of the denylist.
+#
+# Wiring note: this only fires if settings.json's PreToolUse matcher
+# includes "Skill" (the Skill tool call carries tool_input.skill) --
+# confirmed empirically that the matcher needed widening for this rule to
+# receive any Skill-tool invocation at all; see the PR description for the
+# settings.json diff this rule depends on.
+
+_ORCHESTRATION_ONLY_SKILLS = frozenset({"work-github", "loop"})
+_DELEGATE_AGENT_TYPES = frozenset({"coder", "reviewer", "tester"})
+
+
+def check_r7_orchestration_skill(hook_input: dict) -> str | None:
+    """Return a block reason when a delegate charter invokes an orchestration-only skill."""
+    tool_input = hook_input.get("tool_input") or {}
+    skill = str(tool_input.get("skill") or "")
+    agent_type = str(hook_input.get("agent_type") or "")
+    if skill in _ORCHESTRATION_ONLY_SKILLS and agent_type in _DELEGATE_AGENT_TYPES:
+        return (
+            f"R7 (orchestration-only skill): '{skill}' is reserved for the "
+            f"main-thread orchestrator. A '{agent_type}' delegate has no "
+            "visibility into sibling worktrees or the live agent-cap count, "
+            "so it must not fan out its own orchestration -- report back to "
+            "the orchestrator instead of acting on this (see issue #4083)."
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -642,6 +691,12 @@ def run_pretooluse(hook_input: dict) -> int:
         nudge = tdd_nudge_for_edit_or_write(hook_input, session_id)
         if nudge is not None:
             _print_allow_with_context(nudge)
+        return 0
+
+    if tool_name == "Skill":
+        reason = check_r7_orchestration_skill(hook_input)
+        if reason is not None:
+            _print_deny(reason)
         return 0
 
     return 0  # not a tool this hook checks
@@ -914,12 +969,53 @@ def run_tdd_self_test() -> int:
     return 0
 
 
+def run_r7_self_test() -> int:
+    """Exercises R7: deny a delegate charter invoking an orchestration-only skill."""
+    failures: list[str] = []
+
+    def check(description: str, condition: bool) -> None:
+        status = "PASS" if condition else "FAIL"
+        print(f"[{status}] {description}")
+        if not condition:
+            failures.append(description)
+
+    # --- MUST-BLOCK: a delegate charter invoking an orchestration-only skill ---
+    for agent_type in ("coder", "reviewer", "tester"):
+        for skill in ("work-github", "loop"):
+            hook_input = {"agent_type": agent_type, "tool_input": {"skill": skill}}
+            reason = check_r7_orchestration_skill(hook_input)
+            check(f"{agent_type} invoking Skill({skill}) is denied", reason is not None)
+
+    # --- MUST-ALLOW: the negative/legitimate main-thread cases ---
+    for agent_type in ("chaos-engine", "", None):
+        hook_input = {"agent_type": agent_type, "tool_input": {"skill": "work-github"}}
+        reason = check_r7_orchestration_skill(hook_input)
+        check(f"agent_type={agent_type!r} invoking Skill(work-github) is allowed", reason is None)
+
+    # --- MUST-ALLOW: a delegate invoking a non-orchestration skill ---
+    hook_input = {"agent_type": "coder", "tool_input": {"skill": "ponytail"}}
+    reason = check_r7_orchestration_skill(hook_input)
+    check("coder invoking Skill(ponytail) is allowed", reason is None)
+
+    # --- MUST-ALLOW: missing tool_input / missing agent_type fields (fail open) ---
+    check("missing tool_input fails open", check_r7_orchestration_skill({"agent_type": "coder"}) is None)
+    check("missing agent_type fails open", check_r7_orchestration_skill({"tool_input": {"skill": "loop"}}) is None)
+
+    total_checks = len(failures)
+    print(f"\nR7 orchestration-skill self-test summary: {total_checks} failed.")
+    if failures:
+        print("Failed cases: " + ", ".join(failures))
+        return 1
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if "--self-test" in argv:
         command_result = run_self_test()
         graphify_result = run_graphify_self_test()
         tdd_result = run_tdd_self_test()
-        return command_result or graphify_result or tdd_result
+        r7_result = run_r7_self_test()
+        return command_result or graphify_result or tdd_result or r7_result
 
     if "--session-start" in argv:
         return run_session_start()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,7 +73,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|PowerShell|Read|Grep|Edit|Write",
+        "matcher": "Bash|PowerShell|Read|Grep|Edit|Write|Skill",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Issue #4083's third ask: a delegate's refusal of `/work-github` and `/loop`
was previously enforced by charter prose alone — the only thing that stopped
an uncoordinated multi-agent fan-out three cycles running was the subagent's
own good judgment. This makes the refusal structural on two levers.

**Lever 2 (charter tightening, mandatory) — done.** `coder.md`, `reviewer.md`,
`tester.md` each gained an explicit refusal clause naming `/work-github` and
`/loop`, stating the reasoning (no visibility into sibling worktrees or the
live agent-cap count) rather than a bare "don't" — so a delegate re-derives
the refusal instead of pattern-matching a literal phrase. This matters
because the recorded gotcha for this incident notes the re-delivered
instruction was rephrased after each refusal ("adaptive pressure against a
refusal boundary"), so a keyword-matched prose rule would not have survived
a fourth rephrasing; a re-derivable reason does.

**Lever 1 (guard.py hook, conditionally mandatory) — evaluated empirically,
then built.** Before writing any rule, I established live, with a temporary
non-committed debug instrumentation of `.claude/hooks/guard.py` triggered by
real tool calls in this session, that:
- `PreToolUse` `hook_input` carries an `agent_type` field that already
  identifies which named `.claude/agents/*.md` charter issued the call (my
  own Bash calls carried `"agent_type":"coder"`), plus `agent_id` and env
  `CLAUDE_CODE_CHILD_SESSION=1` — so the hook CAN structurally distinguish a
  delegate's tool call.
- The current `.claude/settings.json` `PreToolUse` matcher
  (`Bash|PowerShell|Read|Grep|Edit|Write`) does **not** include `Skill` —
  confirmed by an explicit `Skill(ponytail)` call during the same
  instrumented session producing zero `"tool_name":"Skill"` hook events. Since
  `/work-github` and `/loop` are invoked via the `Skill` tool, a guard.py-only
  rule would have been dead code without this one-line matcher widening.

Given both findings, `guard.py` gained **R7**: deny a `Skill(work-github)` or
`Skill(loop)` call when `agent_type` is exactly `coder`, `reviewer`, or
`tester`. It's allowlist-shaped, not denylist-shaped for the safe side: only
those three named delegate charters can ever be denied, so an absent
`agent_type` or `chaos-engine` (the orchestrator identity) is never a
candidate for the deny branch, regardless of future subagent types added
later. `settings.json`'s matcher was widened to include `Skill` (the minimal
companion wiring this rule depends on to receive any Skill-tool call at all;
that file isn't in this task's exclusive ownership list but isn't on its
"do not touch" list either, and the rule is inert without it).

## What is NOT fixed here (by design, out of repo scope)

The platform-side redelivery mechanism itself — what makes a `status:
completed` task fire fresh completion notifications for the same instruction
with no cron job, no task-queue entry, and no Stop/SubagentStop hook
registered anywhere in this repo's or the user's `settings.json` — is not
addressed by this PR and cannot be, from inside this repository: there is no
in-repo hook, config, or code path that governs redelivery to an already-
completed task. This PR only removes the single point of failure that made
the earlier incidents harmless (the delegate's own compliance) and replaces
it with a deterministic control, so a repeat of the redelivery no longer
depends on discretion.

## TDD evidence (guard.py R7)

RED — added self-test assertions calling the not-yet-existing
`check_r7_orchestration_skill`, ran `--self-test`, watched it fail for the
right reason:
```
NameError: name 'check_r7_orchestration_skill' is not defined
```

GREEN — implemented the function and wired it into `run_pretooluse` for
`tool_name == "Skill"`, reran:
```
Self-test summary: 54/54 passed, 0 failed.
Graphify nudge self-test summary: 0 failed.
TDD nudge self-test summary: 0 failed.
R7 orchestration-skill self-test summary: 0 failed.
```
(exit code 0; includes the negative test proving the rule does NOT fire for
the main-thread-equivalent `agent_type` values `"chaos-engine"`, `""`, and
`None`, plus a non-orchestration skill (`ponytail`) under a delegate
`agent_type`.)

Real invocation (not just the self-test harness), piping literal hook JSON
into `guard.py` directly:
- `agent_type=coder`, `skill=work-github` → prints the deny JSON with reason
  `"R7 (orchestration-only skill): 'work-github' is reserved for the
  main-thread orchestrator..."`.
- `agent_type=chaos-engine`, `skill=work-github` → prints nothing (allowed).
- no `agent_type` at all, `skill=work-github` → prints nothing (allowed).

## Test plan

- [x] `py -3 .claude/hooks/guard.py --self-test` — 54/54 + 3 sub-suites,
      0 failed, exit code 0.
- [x] `py -3 scripts/ci/validate_agent_setup.py` — passes
      (`75236 guidance bytes, 0% reduction, 314 memory objects`).
- [x] Real invocation demo of R7 firing (blocked case) and not firing
      (allowed cases) shown above.
- [x] `git diff origin/main --stat` scoped to exactly the 5 files this PR
      touches: `.claude/agents/{coder,reviewer,tester}.md`,
      `.claude/hooks/guard.py`, `.claude/settings.json`.

Closes #4083