### PR TITLE
Fix #4067: reclaim AGENTS.md byte headroom by moving the routing bridge list out of the budget glob

### DIFF
--- a/.agents/routing-bridges.txt
+++ b/.agents/routing-bridges.txt
@@ -1,0 +1,3 @@
+# Routing bridges
+
+`framework-source-rules` main Java; `java-test-rules` tests; `ci-failure-investigator` CI; `flaky-test-stabilizer` flaky; `release-dependency-guard` release/deps; `graphify` graph; `shaft-ui-design` UI; `shaft-marketing-ad-producer` ads; `public-behavior-docs-synchronizer` docs; `mcp-transport-contract-auditor` MCP; `modular-boundary-auditor` modules; `allure-extent-report-operator` reports; `agent-guidance-boundary-guard` guidance; `agentic-pdca-loop` PDCA phases.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ ChaosEngine, by Mohab Mohie. SHAFT_ENGINE is a Maven Java automation framework; 
 
 ## Routing
 
-Bridge (`.agents/skills/<name>/SKILL.md`, not Skill-invocable): `framework-source-rules` main Java; `java-test-rules` tests; `ci-failure-investigator` CI; `flaky-test-stabilizer` flaky; `release-dependency-guard` release/deps; `graphify` graph; `shaft-ui-design` UI; `shaft-marketing-ad-producer` ads; `public-behavior-docs-synchronizer` docs; `mcp-transport-contract-auditor` MCP; `modular-boundary-auditor` modules; `allure-extent-report-operator` reports; `agent-guidance-boundary-guard` guidance; `agentic-pdca-loop` PDCA phases.
+Bridges (`.agents/skills/<name>/SKILL.md`, not Skill-invocable) enumerated in [routing bridges](.agents/routing-bridges.txt); consult before touching an unfamiliar area.
 
 ## New Task Flow
 

--- a/scripts/ci/validate_agent_guidance.py
+++ b/scripts/ci/validate_agent_guidance.py
@@ -376,36 +376,33 @@ def validate_local_references(root: Path, files: list[Path]) -> list[dict[str, s
     return errors
 
 
-ROUTING_HEADING = "## Routing"
+ROUTING_BRIDGES_PATH = ".agents/routing-bridges.txt"
 ROUTING_BRIDGE_NAME = re.compile(r"`([a-z0-9][a-z0-9-]*)`")
 
 
 def validate_routing_bridges(root: Path) -> list[dict[str, str]]:
-    """Ensure every bridge AGENTS.md's Routing section names by backtick
-    resolves to a .agents/skills/<name>/SKILL.md file.
+    """Ensure every bridge ROUTING_BRIDGES_PATH names by backtick resolves to
+    a .agents/skills/<name>/SKILL.md file.
 
-    Bridges are read as files, never `Skill`-tool invocable (issue #4053); a
-    name that only exists under .claude/skills (the Skill-tool-invocable
-    tree) does not satisfy this -- the two trees are independent.
+    The enumeration lives outside every guidance budget glob (#4067);
+    AGENTS.md's Routing section keeps only the always-on rule that bridges
+    exist and where to find them. Bridges are read as files, never
+    `Skill`-tool invocable (issue #4053); a name that only exists under
+    .claude/skills (the Skill-tool-invocable tree) does not satisfy this --
+    the two trees are independent.
     """
-    agents_path = root / "AGENTS.md"
-    if not agents_path.is_file():
+    bridges_path = root / ROUTING_BRIDGES_PATH
+    if not bridges_path.is_file():
         return []
-    content = agents_path.read_text(encoding="utf-8")
-    start = content.find(ROUTING_HEADING)
-    if start < 0:
-        return []
-    start += len(ROUTING_HEADING)
-    end = content.find("\n## ", start)
-    section = content[start : end if end >= 0 else len(content)]
+    content = bridges_path.read_text(encoding="utf-8")
     errors: list[dict[str, str]] = []
-    for name in ROUTING_BRIDGE_NAME.findall(section):
+    for name in ROUTING_BRIDGE_NAME.findall(content):
         if not (root / ".agents/skills" / name / "SKILL.md").is_file():
             errors.append(
                 issue(
                     "routing-bridge-missing",
-                    "AGENTS.md",
-                    f"Routing references bridge '{name}' with no .agents/skills/{name}/SKILL.md",
+                    ROUTING_BRIDGES_PATH,
+                    f"references bridge '{name}' with no .agents/skills/{name}/SKILL.md",
                 )
             )
     return errors

--- a/tests/scripts/test_validate_agent_guidance.py
+++ b/tests/scripts/test_validate_agent_guidance.py
@@ -3,7 +3,11 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.ci.validate_agent_guidance import parse_frontmatter, validate_repository
+from scripts.ci.validate_agent_guidance import (
+    parse_frontmatter,
+    validate_repository,
+    validate_routing_bridges,
+)
 
 
 class ValidateAgentGuidanceTest(unittest.TestCase):
@@ -255,11 +259,22 @@ policy:
         )
         self.assertIn("unmatched-scope", self.codes())
 
+    def test_validate_routing_bridges_reads_dedicated_file_directly(self):
+        # Direct call (not via validate_repository) of the current contract
+        # (#4067): the enumeration lives in ROUTING_BRIDGES_PATH
+        # (.agents/routing-bridges.txt), outside every guidance budget glob --
+        # AGENTS.md's own "## Routing" section is no longer parsed for it.
+        self.write(
+            ".agents/routing-bridges.txt",
+            "`example-bridge` example; `missing-bridge` gone.\n",
+        )
+        codes = {error["code"] for error in validate_routing_bridges(self.root)}
+        self.assertIn("routing-bridge-missing", codes)
+
     def test_rejects_routing_bridge_with_no_skill_file(self):
         self.write(
-            "AGENTS.md",
-            "# Agents\n\n[Local](docs/local.md)\n\n"
-            "## Routing\n\nBridge: `example-bridge` example; `missing-bridge` gone.\n",
+            ".agents/routing-bridges.txt",
+            "`example-bridge` example; `missing-bridge` gone.\n",
         )
         self.assertIn("routing-bridge-missing", self.codes())
 
@@ -272,11 +287,7 @@ policy:
             ".claude/skills/native-only/SKILL.md",
             "---\nname: native-only\ndescription: Native skill only.\n---\n\n# Native\n",
         )
-        self.write(
-            "AGENTS.md",
-            "# Agents\n\n[Local](docs/local.md)\n\n"
-            "## Routing\n\nBridge: `native-only` example.\n",
-        )
+        self.write(".agents/routing-bridges.txt", "`native-only` example.\n")
         self.assertIn("routing-bridge-missing", self.codes())
 
     def test_rejects_costly_mandate(self):


### PR DESCRIPTION
## Summary

`AGENTS.md` sat at 6526/6528 bytes against its per-file cap (issue #4067), leaving effectively zero headroom for the next legitimate edit. Per the issue's own recommendation (option 2), this moves the Routing section's bridge *enumeration* out of the always-on file while keeping the routing *rule* inline, following the outside-the-glob pattern from #4048/#4058.

- `AGENTS.md`: Routing section keeps the rule inline ("bridges exist, not Skill-invocable, consult before touching an unfamiliar area") and points to the new reference file via a real Markdown link (so `validate_local_references` checks it exists for free).
- `.agents/routing-bridges.txt` (new): holds the moved 14-bridge enumeration, byte-identical in content shape to the old inline text. Plain `.txt`, not `.md` -- deliberately, for two reasons: (1) it sits outside every glob in `agent_guidance_budget.json` (checked below), and (2) it's therefore outside `validate_documentation_boundaries.py`'s Markdown allowlist too, which only scans `.md`/`.mdx` files -- same technique PR #4058 used for `.github/skills/shaft-ui-design/references/standards.txt`.
- `scripts/ci/validate_agent_guidance.py`: `validate_routing_bridges()` now reads the new file (`ROUTING_BRIDGES_PATH`) instead of parsing AGENTS.md's `## Routing` section directly. Same regex, same per-bridge `.agents/skills/<name>/SKILL.md` existence check, same `routing-bridge-missing` error code -- only the parse target moved. Checking was not weakened.
- `tests/scripts/test_validate_agent_guidance.py`: rewrote the two existing indirect tests to place their bridge lists in the dedicated file, and added a direct-call test for the new contract.

## Why the glob claim is true, not asserted

`agent_guidance_budget.json`'s globs that could plausibly match: `active_guidance_globs`/`total_guidance_globs` list `AGENTS.md`, `CLAUDE.md`, `.agents/skills/*/SKILL.md`, `.agents/skills/*/agents/openai.yaml`, `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, `.github/skills/*/SKILL.md` (+`README.md`). None match `.agents/routing-bridges.txt`: it isn't `AGENTS.md`/`CLAUDE.md`, it isn't inside a `.agents/skills/<name>/` subdirectory (it sits at `.agents/` root), and it isn't `.md` at all. Confirmed unchanged: `scripts/ci/agent_guidance_budget.json` has zero diff in this PR -- no cap raised, no cap-adjacent value touched.

## TDD evidence (watched, not asserted)

1. Added a direct-call test pinning the **pre-change** contract (`validate_routing_bridges` parsing AGENTS.md's `## Routing` section) -- ran it, watched it **pass** against the unmodified code, confirming the current behavior was understood correctly before touching it.
2. Rewrote the two existing indirect tests (`test_rejects_routing_bridge_with_no_skill_file`, `test_routing_bridge_only_in_native_skills_tree_still_fails`) to the new dedicated-file contract, plus a new direct-call test for it -- ran the suite, watched all three **fail red** for the right reason (`'routing-bridge-missing' not found in set()` -- the old implementation still only looked at AGENTS.md, found nothing to check, and silently passed).
3. Implemented the parser change (read `ROUTING_BRIDGES_PATH` instead of the AGENTS.md section) -- ran the suite again, watched all three go **green**, and watched the now-obsolete pinning test from step 1 correctly **fail** (proving the old path was genuinely retired), then removed it.
4. Full suite: `py -3 -m unittest tests.scripts.test_validate_agent_guidance tests.scripts.test_validate_agent_setup -v` -- **28/28 pass**, including `test_current_repository_configuration_is_valid` (runs `validate_repository` against the real repo root -- proves the real `AGENTS.md` + real new file + real validator all cohere, not just the synthetic fixtures).

## Byte accounting

| | before | after | delta |
|---|---|---|---|
| `AGENTS.md` bytes (LF-normalized) | 6526 | 6162 | -364 |
| `AGENTS.md` headroom vs 6528 cap | 2 | 366 | +364 |
| repo-wide `guidance_bytes` | 74228 | 73864 | -364 |
| `estimated_host_tokens.claude` | 2691 | 2572 | -119 |

(`guidance_bytes`/token deltas match the AGENTS.md-only delta exactly, since `.agents/routing-bridges.txt` and the two Python files touched by this PR are not matched by any guidance-budget glob.)

All 14 bridges named in `.agents/routing-bridges.txt` verified to resolve to a real `.agents/skills/<name>/SKILL.md` on disk (checked programmatically, all 14 present).

## Test plan

- [x] `py -3 -m unittest tests.scripts.test_validate_agent_guidance -v` -- 23/23 pass
- [x] `py -3 -m unittest tests.scripts.test_validate_agent_setup -v` -- 5/5 pass
- [x] `py -3 scripts/ci/validate_agent_setup.py --skip-external` -- valid, 73864 guidance bytes
- [x] `git diff origin/main --stat` -- only `AGENTS.md`, `.agents/routing-bridges.txt`, `scripts/ci/validate_agent_guidance.py`, `tests/scripts/test_validate_agent_guidance.py`
- [x] `scripts/ci/agent_guidance_budget.json` untouched (verified via `git diff --stat` on that path alone)

Related to #4053, #4048, #4065.

Closes #4067

Co-Authored-By: Claude Sonnet 5 (Coder) <noreply@anthropic.com>