### PR TITLE
Fix #4110: unblock memory cross-links whose derived relation id exceeds the filename-length check

### DIFF
--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -50,6 +50,19 @@ GENERATED_MEMORY_PATHS = {
 # (133 characters) so new drift is caught before it reaches a clone.
 MAX_MEMORY_BASENAME_LENGTH = 160
 MEMORY_CANONICAL_GLOBS = ("memory/**/*.json", "memory/**/*.md", "relations/*.json")
+RELATION_GLOB = "relations/*.json"
+# `create_relation` (patch.schema.json #/$defs/createRelation) accepts an
+# optional, caller-supplied `id` -- confirmed live against the real Memory
+# CLI (v0.1.55): a `create_relation` change with no `id` derives one by
+# concatenating both full endpoint ids (no length cap), while the same
+# change with an explicit short `id` writes a short basename and stays
+# fully readable by `memory graph`/kg_query, since traversal reads the
+# `from`/`to` fields from file content, never the filename (issue #4110).
+RELATION_LENGTH_HINT = (
+    " `create_relation` accepts an explicit short `id` in the patch -- pass "
+    "one instead of leaving it to auto-derive from the concatenated "
+    "endpoint ids; `from`/`to` keep the full descriptive ids either way."
+)
 
 
 def issue(code: str, path: str, message: str) -> dict[str, str]:
@@ -131,12 +144,14 @@ def validate_memory_setup(root: Path = ROOT) -> list[dict[str, str]]:
     for pattern in MEMORY_CANONICAL_GLOBS:
         for memory_path in sorted(memory_dir.glob(pattern)):
             if len(memory_path.name) > MAX_MEMORY_BASENAME_LENGTH:
+                hint = RELATION_LENGTH_HINT if pattern == RELATION_GLOB else ""
                 errors.append(
                     issue(
                         "memory-filename-length",
                         str(memory_path.relative_to(root)),
                         f"basename exceeds {MAX_MEMORY_BASENAME_LENGTH} characters "
-                        "(risks Windows MAX_PATH on checkout); shorten the object/relation id",
+                        "(risks Windows MAX_PATH on checkout); shorten the object/relation id."
+                        + hint,
                     )
                 )
 

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -100,6 +100,54 @@ approval_mode = "prompt"
         self.assertIn("install", error["message"].lower())
         self.assertNotIn("Traceback", error["message"])
 
+    def test_overlong_relation_filename_hints_at_explicit_short_id(self):
+        # A real `create_relation` patch left to auto-derive its id from two
+        # ~90+ char endpoint ids produces a 222-char basename (issue #4110,
+        # reproduced live against the real Memory CLI). The relation's own
+        # `id`/`from`/`to` fields carry no length cap (relation.schema.json),
+        # and `create_relation` already accepts an explicit custom `id` --
+        # so the actionable fix is a short custom id, not a longer/relaxed
+        # basename cap (which would reopen the Windows MAX_PATH risk this
+        # check exists to catch).
+        overlong_name = "gotcha-" + "a" * 160 + "-related-to-fact-" + "b" * 30
+        self.write(
+            f".memory/relations/{overlong_name}.json",
+            json.dumps(
+                {
+                    "id": f"rel.{overlong_name}",
+                    "from": "gotcha." + "a" * 160,
+                    "predicate": "related_to",
+                    "to": "fact." + "b" * 30,
+                    "status": "active",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:00Z",
+                }
+            ),
+        )
+        errors = [
+            error
+            for error in validate_memory_setup(self.root)
+            if error["code"] == "memory-filename-length"
+        ]
+        self.assertEqual(len(errors), 1)
+        self.assertIn("create_relation", errors[0]["message"])
+        self.assertIn("explicit", errors[0]["message"])
+
+    def test_overlong_non_relation_filename_still_caught_without_relation_hint(self):
+        # Negative test: relaxing the relation-file message must not open a
+        # hole for genuinely over-long non-relation memory objects, which
+        # have no analogous explicit-id override and must still be shortened.
+        overlong_name = "gotcha-" + "c" * 170
+        self.write(f".memory/memory/gotchas/{overlong_name}.md", "body")
+        errors = [
+            error
+            for error in validate_memory_setup(self.root)
+            if error["code"] == "memory-filename-length"
+        ]
+        self.assertEqual(len(errors), 1)
+        self.assertNotIn("create_relation", errors[0]["message"])
+        self.assertIn("shorten the object", errors[0]["message"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Relating two descriptively-named memory objects reliably breached
  `validate_agent_setup.py`'s 160-char basename cap, forcing prose
  cross-links invisible to graph traversal (issue #4110's repro).
- The 160-char cap is a **real Windows MAX_PATH safety margin, not an
  arbitrary tidiness number** -- verified with evidence, not assumed
  (see below). Raising or exempting it for relations would reopen the
  exact class of breakage already on record (bare #3790, #3991, #4126).
- The actual fix does not touch the check's strictness at all: it
  points the error message, for relation files specifically, at an
  escape hatch the Memory CLI's `create_relation` patch **already
  supports** -- an explicit, caller-supplied short `id` -- which I
  confirmed live keeps the relation fully functional for graph
  traversal.

## Where the 160 comes from (the substance of this PR)

`scripts/ci/validate_agent_setup.py:45-51`'s own comment already says
why: a single overlong relation pair once produced a 220-char filename
that broke Windows checkouts even with a short workspace prefix. I
verified this is not stale/aspirational reasoning but a live,
reproducible constraint:

1. Bare #3790 hit a **290-char** auto-derived `supersedes` relation
   filename that failed to write atomically on Windows.
2. Bare #3991 hit the **same check**, on real merged content, for
   over-long *object* filenames (not relations) -- proving the cap
   already protects real non-relation content too, so it can't be
   relaxed wholesale.
3. Bare #4126, filed today, hit `git worktree add` itself failing
   `Filename too long` on `.memory/**` paths during checkout -- the
   identical MAX_PATH family, one layer earlier (checkout time, not
   write time).
4. I reproduced the exact #4110 scenario live against the real Memory
   CLI (`@aictx/memory@0.1.55`, installed on PATH) in a scratch
   fixture: two objects with ~90-160 char ids, related with a plain
   `create_relation` patch (no explicit `id`) produced a **222-char**
   basename -- squarely in the same danger band as 1 and 3.

Four independent data points, all in the same 200-290 char band,
across three different operations (supersede, plain relate, worktree
checkout). That is a real, physical constraint, not a style preference
-- so truncation/redirection is the right answer, per the issue's own
framing, not raising the cap.

## The fix, and why it's the right one given that origin

`patch.schema.json`'s `#/$defs/createRelation` already declares `id` as
**optional** (only `op`, `from`, `predicate`, `to` are required), and
`relation.schema.json`'s `id`/`from`/`to` fields carry **no length
cap**. Reading the CLI's bundled source (`dist/cli/main.js`) confirms
`create_relation` uses `change.id ?? generateRelationId(...)` --  a
caller-supplied `id` skips the uncapped auto-derivation entirely.

I verified end-to-end, live, in a scratch fixture (not the real
`.memory/` store):
- The naive `create_relation` (no `id`) reproduced the 222-char
  basename above.
- The same relation recreated with an explicit `id:
  "rel.4110-automerge-gate-gotcha-to-required-check-fact"` (55 chars)
  wrote a 55-char file, with `from`/`to` still carrying the full
  descriptive endpoint ids.
- `memory graph <gotcha-id> --json` (the CLI's one-hop
  relation-neighborhood/kg_query equivalent) correctly returned both
  objects and the relation through the short-id file.
- `memory check --json` on the fixture reported `"valid":true`.

Root cause of *why* filename length doesn't matter to traversal:
`readRelations` in the CLI glob-discovers every file under
`.memory/relations/**/*.json` and reads `id`/`from`/`predicate`/`to`
from the JSON **content**, never the filename. So a short custom `id`
is a zero-risk fix -- it changes nothing the graph depends on.

`scripts/ci/validate_agent_setup.py` now emits a relation-specific hint
in the `memory-filename-length` message pointing straight at this
already-working option, instead of the previous generic "shorten the
id" text that gave no indication a supported, no-compromise fix
already existed. The check's actual threshold, and its behavior on
every other file (including genuinely over-long non-relation memory
objects), is untouched.

## What remains impossible in-repo

The issue's third suggested direction -- have `memory` reject an
over-long relation at creation time -- is not implementable here.
`@aictx/memory` is an external npm package (established at bare #4005;
this repo has read-only access to its bundled `dist/cli/main.js`, not
its source). There is no in-repo lever to change `generateRelationId`
or add a creation-time guard; the only available levers were the
validator's message and how relation ids are formed, both addressed
above.

## TDD evidence

RED (`py -3 -m unittest tests.scripts.test_validate_agent_setup -v`),
failed for the right reason -- the new relation-specific hint text
wasn't in the message yet:
```
FAIL: test_overlong_relation_filename_hints_at_explicit_short_id
AssertionError: 'create_relation' not found in 'basename exceeds 160
characters (risks Windows MAX_PATH on checkout); shorten the
object/relation id'
```

GREEN after the fix, plus the negative regression test (over-long
non-relation memory object filenames still caught, with no
relation-only hint leaking into their message) and the full existing
suite, 7/7:
```
test_current_repository_setup_is_valid_without_external_calls ... ok
test_missing_memory_binary_reports_actionable_error ... ok
test_overlong_non_relation_filename_still_caught_without_relation_hint ... ok
test_overlong_relation_filename_hints_at_explicit_short_id ... ok
test_rejects_broader_mcp_tool_surface ... ok
test_rejects_large_default_memory_budget ... ok
test_valid_memory_setup_passes ... ok

Ran 7 tests in 0.424s
OK
```

## Test plan

- [x] `py -3 -m unittest tests.scripts.test_validate_agent_setup -v` --
      7/7 pass, including the new relation-specific and negative tests.
- [x] `py -3 -m unittest tests.scripts.test_validate_agent_guidance
      tests.scripts.test_validate_agent_setup -v` -- 30/30 pass.
- [x] `py -3 scripts/ci/validate_agent_setup.py` against the real repo
      -- passes clean.
- [x] Live repro against the real `@aictx/memory@0.1.55` CLI in a
      scratch fixture (not the tracked `.memory/` store): naive relate
      reproduces the 222-char failure; explicit-`id` relate produces a
      55-char file, `memory graph` traversal succeeds, `memory check`
      reports valid.
- [x] `git diff origin/main --stat` (after rebase) -- only
      `scripts/ci/validate_agent_setup.py` and
      `tests/scripts/test_validate_agent_setup.py`.

Closes #4110