### PR TITLE
Fix #4119, #4097: correct the zero-scenario guard's module path and settle the BrowserStack Cucumber job

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -79,7 +79,6 @@ jobs:
       - Android_Web_Chrome_BrowserStack
       - MacOSX_Safari_BrowserStack
       - Ubuntu_Chrome_Cucumber_Grid
-      - MacOSX_Safari_Cucumber_BrowserStack
       - Ubuntu_JUnit_E2E
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -711,49 +710,6 @@ jobs:
           job-name: Ubuntu_Chrome_Cucumber_Grid
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-  MacOSX_Safari_Cucumber_BrowserStack:
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_Cucumber_BrowserStack,')
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      job: ${{ steps.post_test_report.outputs.job }}
-      total: ${{ steps.post_test_report.outputs.total }}
-      passed: ${{ steps.post_test_report.outputs.passed }}
-      failed: ${{ steps.post_test_report.outputs.failed }}
-      broken: ${{ steps.post_test_report.outputs.broken }}
-      skipped: ${{ steps.post_test_report.outputs.skipped }}
-      duration: ${{ steps.post_test_report.outputs.duration }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v7
-      - name: Setup Test Environment
-        uses: ./.github/actions/setup-test-env
-        with:
-          node-version: 'lts/*'
-      - name: Run tests
-        continue-on-error: true
-        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DmaximumPerformanceMode=1" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*CucumberTests.*]' }}"
-      # module-directory defaults to shaft-engine, but this job's -pl target is shaft-browserstack
-      # (which has no Cucumber TestNG runner class at all -- find shaft-browserstack -iname
-      # CucumberTests.java returns nothing, issue #4079). The default silently checked
-      # shaft-engine's allure-results instead, which the reactor -am build also populates via
-      # unrelated matched classes, masking that shaft-browserstack itself produces zero output.
-      # Pointing this at the actual target module makes the existing zero-result guard below
-      # (RESULT_COUNT -eq 0 / TOTAL -eq 0 checks in post-test-report/action.yml) fire correctly.
-      # require-coverage: false because that same zero-match selector means shaft-browserstack
-      # never produces target/jacoco.exec here either -- without this, the coverage-upload
-      # substep would fail first on a missing jacoco.xml and mask the real "zero scenarios"
-      # signal behind an unrelated, misleading coverage error.
-      - name: Post-Test Report and Check
-        id: post_test_report
-        if: always()
-        uses: ./.github/actions/post-test-report
-        with:
-          job-name: MacOSX_Safari_Cucumber_BrowserStack
-          module-directory: shaft-browserstack
-          require-coverage: 'false'
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}
-
   Ubuntu_JUnit_E2E:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_JUnit_E2E,')
     runs-on: ubuntu-latest
@@ -933,7 +889,7 @@ jobs:
 
   notify_e2e_tests_failure:
     name: Notify on nightly failure
-    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack, Ubuntu_JUnit_E2E ]
+    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, Ubuntu_JUnit_E2E ]
     if: always()
     runs-on: ubuntu-22.04
     timeout-minutes: 5

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -79,6 +79,7 @@ jobs:
       - Android_Web_Chrome_BrowserStack
       - MacOSX_Safari_BrowserStack
       - Ubuntu_Chrome_Cucumber_Grid
+      - MacOSX_Safari_Cucumber_BrowserStack
       - Ubuntu_JUnit_E2E
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -710,6 +711,54 @@ jobs:
           job-name: Ubuntu_Chrome_Cucumber_Grid
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+  MacOSX_Safari_Cucumber_BrowserStack:
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_Cucumber_BrowserStack,')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      job: ${{ steps.post_test_report.outputs.job }}
+      total: ${{ steps.post_test_report.outputs.total }}
+      passed: ${{ steps.post_test_report.outputs.passed }}
+      failed: ${{ steps.post_test_report.outputs.failed }}
+      broken: ${{ steps.post_test_report.outputs.broken }}
+      skipped: ${{ steps.post_test_report.outputs.skipped }}
+      duration: ${{ steps.post_test_report.outputs.duration }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: 'lts/*'
+      - name: Run tests
+        continue-on-error: true
+        run: mvn -pl shaft-browserstack -am -e test "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=Safari" "-DmaximumPerformanceMode=1" "-DbrowserStack.os=OS X" "-DbrowserStack.osVersion=Sonoma" "-DbrowserStack.browserVersion=17.0" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*CucumberTests.*]' }}"
+      # This job runs -pl shaft-browserstack -am like every other BrowserStack job in this
+      # file (Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack,
+      # Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack) -- and like them, its
+      # -Dtest selector only matches classes that live in shaft-engine, not
+      # shaft-browserstack (here: cucumberTestRunner.CucumberTests; find shaft-browserstack
+      # -iname CucumberTests.java returns nothing). -am pulls shaft-engine into the reactor
+      # as shaft-browserstack's own dependency and runs its test phase there, writing
+      # allure-results/surefire output under shaft-engine/. None of the four sibling
+      # BrowserStack jobs override module-directory -- they rely on the shaft-engine
+      # default, and that default is correct here too. #4079 introduced a
+      # `module-directory: shaft-browserstack` override unique to this job (matching the
+      # -pl target instead of where output actually lands), which made the zero-result
+      # guard below fire "No Allure summary was generated for shaft-browserstack" on a
+      # fully passing run (issue #4119). require-coverage is left at its default (required)
+      # for the same reason: the root pom's jacoco default-report execution is bound to the
+      # `test` phase for every reactor module unconditionally (pom.xml's default-prepare-agent
+      # / default-report executions), so shaft-engine/target/jacoco/jacoco.xml is produced
+      # here exactly as it is for the sibling jobs, none of which set require-coverage either.
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: MacOSX_Safari_Cucumber_BrowserStack
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
   Ubuntu_JUnit_E2E:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_JUnit_E2E,')
     runs-on: ubuntu-latest
@@ -889,7 +938,7 @@ jobs:
 
   notify_e2e_tests_failure:
     name: Notify on nightly failure
-    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, Ubuntu_JUnit_E2E ]
+    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack, Ubuntu_JUnit_E2E ]
     if: always()
     runs-on: ubuntu-22.04
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

`MacOSX_Safari_Cucumber_BrowserStack` (`.github/workflows/e2eTests.yml`) gets a 2-line fix: delete the `module-directory: shaft-browserstack` and `require-coverage: 'false'` overrides on its post-test-report step, so it defaults to `shaft-engine` and required coverage exactly like its four sibling BrowserStack jobs.

## #4119 root cause

`.github/workflows/e2eTests.yml:735` runs `mvn -pl shaft-browserstack -am -Dtest=%regex[.*CucumberTests.*]`. `shaft-browserstack` has no Cucumber runner class (`find shaft-browserstack -iname CucumberTests.java` returns nothing), so the only class the regex matches is `shaft-engine`'s `cucumberTestRunner.CucumberTests`, pulled into the reactor only because `-am` also builds+tests `shaft-browserstack`'s own `shaft-engine` dependency. The 13 scenarios execute there and write `allure-results`/surefire output under `shaft-engine/`, never `shaft-browserstack/`. #4079's fix set `module-directory: shaft-browserstack` (matching the `-pl` target, but not where output lands), so the zero-result guard reported "No Allure summary was generated for shaft-browserstack" on a run where every test actually passed.

Verified by replaying the guard's exact check-results shell logic (`.github/actions/post-test-report/action.yml:123-252`) against a synthetic fixture built from the real run's own evidence (13 passed, 0 failed):
- `module-directory=shaft-browserstack` reproduces the reported false failure verbatim: `No Allure summary was generated for shaft-browserstack, and shaft-browserstack/allure-results does not exist.` (exit 1)
- `module-directory=shaft-engine` reads `Total=13, Passed=13, Failed=0, Broken=0` and passes (exit 0)

## #4097 -- both proposed options rejected, on sibling-job evidence

I first proposed deleting the job, reasoning `shaft-browserstack/src/test` has no Cucumber infrastructure of its own. That reasoning was wrong: **it treated this job as needing its own runner class when none of its siblings have one either.**

Every other BrowserStack job in this file runs the identical shape -- `-pl shaft-browserstack -am` with a `-Dtest` selector matching classes that live in `shaft-engine`, not `shaft-browserstack`:
- `Android_Native_BrowserStack` (`e2eTests.yml:581`) -- selector includes `%regex[.*ndroid.*]`, `%regex[.*FlutterTest.*]`
- `iOS_Web_SAFARI_BrowserStack` (`e2eTests.yml:611`) -- `%regex[.*MobileWebTest.*]`, `%regex[.*IOSBasicInteractionsTest.*]`
- `Android_Web_Chrome_BrowserStack` (`e2eTests.yml:641`) -- `%regex[.*MobileWebTest.*]`
- `MacOSX_Safari_BrowserStack` (`e2eTests.yml:671`) -- `%regex[.*BrowserActionsTests.*]`, `%regex[.*BigPageActionsTest.*]`

Confirmed by file location that all of these classes live in `shaft-engine/src/test/java/...` (`BrowserActionsTests`, `BigPageActionsTest`, `MobileWebTest`, `IOSBasicInteractionsTest`), never in `shaft-browserstack`. None of these four jobs set `module-directory` -- they rely on the default (`shaft-engine`), and that default is correct for them because that's genuinely where their tests execute and where BrowserStack Safari/Android/iOS coverage actually happens (`-DexecutionAddress=browserstack` routes the SDK regardless of which module's test-classes the JVM loaded). `Windows_Edge_Cucumber_Local` (`e2eLocalTests.yml:372`) matches this same pattern too (`-pl shaft-engine` directly, no override needed).

So this is not a job with no coverage: the 13 Cucumber scenarios really do execute against BrowserStack Safari via the reactor, and pass -- that already is real Cucumber-on-BrowserStack coverage. `MacOSX_Safari_BrowserStack` covers BrowserStack-without-Cucumber and `Ubuntu_Chrome_Cucumber_Grid` covers Cucumber-without-BrowserStack; neither covers this job's actual intersection. Deleting it would have thrown away working coverage. Adding a new runner class would have been redundant infrastructure for coverage that already runs. **Both options from #4097 are rejected**: the module never needed its own runner, for the same reason its four siblings don't have one -- #4079 introduced a `module-directory` override unique to this job that broke from the established sibling pattern, and that override was the entire bug.

### require-coverage decision (evidence, not a guess)

Removed `require-coverage: 'false'` to match the four siblings, none of which set it (default: required). This is backed by direct pom.xml evidence, not just pattern-matching: the root `pom.xml:768-787` binds `jacoco:prepare-agent` and `jacoco:report@default-report` to the `test` phase unconditionally for every reactor module (inherited by `shaft-engine`), independent of which `-Dtest` classes are selected. Since real tests execute in `shaft-engine` during this job's reactor build (13 Cucumber scenarios), `shaft-engine/target/jacoco/jacoco.xml` is produced by the same phase-bound execution that produces it for the sibling jobs' `BrowserActionsTests`/`MobileWebTest` runs. No live dispatch needed to establish this -- it's a static Maven lifecycle-binding fact, not an inferred guess.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2eTests.yml'))"` -- parses clean; job present (22 jobs total); post-test-report step's `with:` is now `{job-name: MacOSX_Safari_Cucumber_BrowserStack, codecov-token: ...}` -- no `module-directory`/`require-coverage`, matching siblings exactly
- [x] `python3 scripts/ci/validate_orphaned_suite_files.py` (#4071 guard) -- "All TestNG suite XML files are referenced by something."
- [x] `python3 scripts/ci/validate_workflow_timeouts.py` -- "All workflow jobs declare timeout-minutes."
- [x] Guard fix proven against synthetic fixture replaying `post-test-report/action.yml`'s check-results logic: old config (`shaft-browserstack`) reproduces the exact reported false failure; corrected config (`shaft-engine`) passes with the real run's own numbers (Total=13, Passed=13)
- Net diff vs `origin/main`: `.github/workflows/e2eTests.yml | 31 ++++++++++++++++++-------------`, 18 insertions(+), 13 deletions(-) -- the job, both `needs:` entries, and the guard config are all back to (corrected) baseline
- No BrowserStack job dispatched (owner constraint: never spend BrowserStack quota speculatively) and no full/E2E workflow dispatched -- the sibling-pattern and pom.xml lifecycle evidence above establish the fix without a live run

Related to #4079, #4071

Closes #4119
Closes #4097