### PR TITLE
Fix #4138: replace dead output-budget preflight check with a real warning

### DIFF
--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiExecutionService.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiExecutionService.java
@@ -132,7 +132,38 @@ public final class AiExecutionService {
         } else if (isCircuitFailure(result.status())) {
             circuit.failure(configuration.circuitBreakerFailureThreshold());
         }
+        String outputBudgetWarning = reducedOutputBudgetWarning(request, configuration);
+        if (outputBudgetWarning != null) {
+            result = withWarning(result, outputBudgetWarning);
+        }
         return finish(request, providerId, model, redaction.safeSummary(), started, result);
+    }
+
+    /**
+     * Reports when a caller's requested output token budget was silently reduced to the configured
+     * maximum, so a mismatch between a per-call budget and the global ceiling (as in #4113) surfaces
+     * immediately instead of only showing up as truncated output.
+     *
+     * @param request request carrying the caller's requested budget
+     * @param configuration configured output token ceiling
+     * @return a safe warning message, or {@code null} when the request was already within budget
+     */
+    private static String reducedOutputBudgetWarning(AiRequest request, PilotConfiguration configuration) {
+        long requested = request.budget().maxOutputTokens();
+        long configured = configuration.maxOutputTokens();
+        if (requested <= 0 || requested <= configured) {
+            return null;
+        }
+        return "Requested output token budget (" + requested + ") exceeds the configured maximum ("
+                + configured + ") and was silently reduced.";
+    }
+
+    private static AiResponse withWarning(AiResponse response, String warning) {
+        java.util.ArrayList<String> warnings = new java.util.ArrayList<>(response.warnings());
+        warnings.add(warning);
+        return new AiResponse(response.schemaVersion(), response.status(), response.provider(), response.model(),
+                response.structuredPayload(), warnings, response.duration(), response.usage(),
+                response.fallbackReason(), response.deterministicFallback());
     }
 
     private AiResponse preflight(AiRequest request, PilotConfiguration configuration, AiProvider provider,
@@ -162,8 +193,7 @@ public final class AiExecutionService {
         }
         long estimatedInputTokens = Math.max(1, (requestBytes + 3) / 4);
         long inputLimit = inheritedLimit(request.budget().maxInputTokens(), configuration.maxInputTokens());
-        long outputLimit = inheritedLimit(request.budget().maxOutputTokens(), configuration.maxOutputTokens());
-        if (estimatedInputTokens > inputLimit || outputLimit > configuration.maxOutputTokens()) {
+        if (estimatedInputTokens > inputLimit) {
             return failure(request, AiResponseStatus.BUDGET_EXCEEDED, providerId, model,
                     "The request exceeds the configured token budget.", started);
         }

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiExecutionServiceTest.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiExecutionServiceTest.java
@@ -199,6 +199,40 @@ class AiExecutionServiceTest {
     }
 
     @Test
+    void reducedOutputBudgetSurfacesWarningOnSuccess() {
+        StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider);
+        try {
+            AiResponse response = service(registry,
+                    PilotTestConfiguration.enabled("stub", ProcessingLocation.REMOTE))
+                    .execute(request(approved(ProcessingLocation.REMOTE), 8_000));
+
+            assertEquals(AiResponseStatus.SUCCESS, response.status());
+            assertTrue(response.warnings().stream().anyMatch(warning -> warning.contains("output token budget")));
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    @Test
+    void inBudgetOutputRequestStaysSilent() {
+        StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
+        AiProviderRegistry registry = new AiProviderRegistry();
+        registry.registerForCurrentThread(provider);
+        try {
+            AiResponse response = service(registry,
+                    PilotTestConfiguration.enabled("stub", ProcessingLocation.REMOTE))
+                    .execute(request(approved(ProcessingLocation.REMOTE), 100));
+
+            assertEquals(AiResponseStatus.SUCCESS, response.status());
+            assertTrue(response.warnings().stream().noneMatch(warning -> warning.contains("output token budget")));
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    @Test
     void auditSinkFailureDoesNotReplaceProviderOrFallbackResult() {
         StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
         AiProviderRegistry registry = new AiProviderRegistry();
@@ -225,6 +259,10 @@ class AiExecutionServiceTest {
     }
 
     private static AiRequest request(ApprovalPolicy approvalPolicy) {
+        return request(approvalPolicy, 100);
+    }
+
+    private static AiRequest request(ApprovalPolicy approvalPolicy, long maxOutputTokens) {
         JsonNode schema = JSON.createObjectNode()
                 .put("type", "object")
                 .set("properties", JSON.createObjectNode()
@@ -233,7 +271,7 @@ class AiExecutionServiceTest {
                 .putArray("required").add("answer");
         return AiRequest.builder("unit-test", schema)
                 .text("password=top-secret")
-                .budget(new AiBudget(1_000, 100, BigDecimal.ONE))
+                .budget(new AiBudget(1_000, maxOutputTokens, BigDecimal.ONE))
                 .approvalPolicy(approvalPolicy)
                 .deterministicFallback(JSON.createObjectNode().put("answer", "deterministic"))
                 .timeout(Duration.ofSeconds(1))


### PR DESCRIPTION
## Summary

- `AiExecutionService.java:166` guarded on `outputLimit > configuration.maxOutputTokens()`. `outputLimit` is `inheritedLimit(requested, configured)`, which is either `configured` or `min(requested, configured)` -- never greater than `configured`. Confirmed the branch was unreachable and verified `outputLimit` was never propagated anywhere else (the real clamp lives independently in `AbstractHttpAiProvider#outputTokenLimit`), so removing it has zero behavioral effect on execution.
- Replaced the dead check with a warning computed on the pre-clamp `requested` value: when a caller asks for more output tokens than the configured ceiling, the request still proceeds, but the response now carries a warning that its budget was silently reduced. This is the exact condition that let #4113 (PR #3371 raising a per-call budget to 8000 while the global default stayed 2000) truncate output for months with no signal.
- The warning fires only when `requested > 0 && requested > configured` (never on ordinary in-budget calls) and is computed once per `execute()` call, so it cannot spam.

Fixes #4138

## Test plan

- [x] `mvn -pl shaft-pilot-core test -Dtest='AiExecutionServiceTest#reducedOutputBudgetSurfacesWarningOnSuccess+inBudgetOutputRequestStaysSilent' -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- watched RED (new test failed for the right reason: no warning existed), then GREEN after the fix.
- [x] `mvn -pl shaft-pilot-core test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 43/43 passed.
- [x] `mvn test-compile -pl shaft-ai,shaft-capture,shaft-doctor,shaft-heal,shaft-mcp -am -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- BUILD SUCCESS across all modules depending on `shaft-pilot-core`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH