### PR TITLE
Add CI guard for negated closing-keyword references in PR bodies

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -426,6 +426,33 @@ jobs:
       - name: Validate no TestNG suite XML file is orphaned
         run: python3 scripts/ci/validate_orphaned_suite_files.py
 
+  # Issue #4142: GitHub's closing-keyword scanner has no negation awareness --
+  # it auto-closed #3930 from PR #4009's "Does not fix #3930's original macOS
+  # OOM", overriding a human's manual reopen 7 minutes earlier. Runs
+  # unconditionally on every pull_request (like dependency-review below, it
+  # concerns PR body text, not changed files, so no `changes` path leg gates
+  # it) and reads the live PR body via `github.event.pull_request.body`,
+  # which only exists on the pull_request event.
+  pr-body-autoclose-guard:
+    name: PR Body Autoclose Guard
+    needs: changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - name: Run PR body autoclose guard unit tests
+        run: python3 -m unittest tests.scripts.test_validate_pr_closing_keywords -v
+      - name: Validate PR body has no negated closing-keyword references
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python3 scripts/ci/validate_pr_closing_keywords.py
+
   # Moved from security.yml's dependency-review job. Runs unconditionally on
   # every pull_request (no path leg matches it in the `changes` job, mirroring
   # its unconditional-per-PR behavior in security.yml today) and temporarily
@@ -461,6 +488,7 @@ jobs:
       - template-coupling
       - workflow-timeouts
       - orphaned-suite-files
+      - pr-body-autoclose-guard
       - dependency-review
     if: always()
     runs-on: ubuntu-22.04
@@ -478,6 +506,7 @@ jobs:
           TEMPLATES_RESULT: ${{ needs.template-coupling.result }}
           WORKFLOW_TIMEOUTS_RESULT: ${{ needs.workflow-timeouts.result }}
           ORPHANED_SUITE_FILES_RESULT: ${{ needs.orphaned-suite-files.result }}
+          PR_BODY_AUTOCLOSE_GUARD_RESULT: ${{ needs.pr-body-autoclose-guard.result }}
           DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
         run: |
           set -uo pipefail
@@ -495,6 +524,7 @@ jobs:
             echo "| template-coupling | ${TEMPLATES_RESULT} |"
             echo "| workflow-timeouts | ${WORKFLOW_TIMEOUTS_RESULT} |"
             echo "| orphaned-suite-files | ${ORPHANED_SUITE_FILES_RESULT} |"
+            echo "| pr-body-autoclose-guard | ${PR_BODY_AUTOCLOSE_GUARD_RESULT} |"
             echo "| dependency-review | ${DEPENDENCY_REVIEW_RESULT} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -504,7 +534,7 @@ jobs:
           fi
 
           status=0
-          for result in "${DOCS_RESULT}" "${INTELLIJ_VERIFY_RESULT}" "${INTELLIJ_BUILD_RESULT}" "${CLI_RESULT}" "${CAPTURE_RESULT}" "${UNIT_TESTS_RESULT}" "${TEMPLATES_RESULT}" "${WORKFLOW_TIMEOUTS_RESULT}" "${ORPHANED_SUITE_FILES_RESULT}" "${DEPENDENCY_REVIEW_RESULT}"; do
+          for result in "${DOCS_RESULT}" "${INTELLIJ_VERIFY_RESULT}" "${INTELLIJ_BUILD_RESULT}" "${CLI_RESULT}" "${CAPTURE_RESULT}" "${UNIT_TESTS_RESULT}" "${TEMPLATES_RESULT}" "${WORKFLOW_TIMEOUTS_RESULT}" "${ORPHANED_SUITE_FILES_RESULT}" "${PR_BODY_AUTOCLOSE_GUARD_RESULT}" "${DEPENDENCY_REVIEW_RESULT}"; do
             case "$result" in
               success|skipped) ;;
               *)

--- a/scripts/ci/validate_pr_closing_keywords.py
+++ b/scripts/ci/validate_pr_closing_keywords.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Flag PR bodies that would auto-close an issue the author did not intend to close.
+
+Issue #4142: GitHub's closing-keyword scanner (`close`/`closes`/`closed`,
+`fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved` immediately followed by
+`#N` or a full issue URL) has no negation awareness -- it matches the keyword
+adjacent to the reference regardless of what precedes it. PR #4009's body
+said "Does not fix #3930's original macOS OOM -- that issue is being reopened
+separately", written deliberately to explain why #3930 must stay open, and
+GitHub still recorded #3930 in `closingIssuesReferences` and auto-closed it 2
+seconds after the PR merged -- overriding a human's manual reopen 7 minutes
+earlier ("Leaving open."). GitHub's behavior cannot be changed, so this guard
+catches the pattern before merge and fails the PR so the author rewords it.
+
+Scope is deliberately the confirmed-adjacent form GitHub's own docs describe
+(https://docs.github.com/.../using-keywords-in-issues-and-pull-requests:
+keyword, optional colon, then the reference with no other words between) --
+not a loose "keyword anywhere near a negation" scan. That keeps false
+positives near zero: a body needs both a closing keyword sitting directly
+next to `#N` *and* a negation cue in the few words immediately before the
+keyword ("does not", "doesn't", "cannot", "won't", "never") to be flagged.
+Ordinary intentional closes ("Closes #10"), bare references ("#10"), and
+prose that merely discusses an issue number are untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+CLOSING_KEYWORD_PATTERN = r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)"
+ISSUE_REFERENCE_PATTERN = r"(?:#\d+|https://github\.com/[\w.-]+/[\w.-]+/issues/\d+)"
+CLOSING_REFERENCE_RE = re.compile(
+    rf"\b({CLOSING_KEYWORD_PATTERN})\b\s*:?\s*({ISSUE_REFERENCE_PATTERN})",
+    re.IGNORECASE,
+)
+NEGATION_RE = re.compile(r"\b(?:not|never|cannot)\b|\w+n['’]t\b", re.IGNORECASE)
+MARKDOWN_EMPHASIS_RE = re.compile(r"[*_`]")
+SENTENCE_BOUNDARY_RE = re.compile(r"[.!?\n]")
+NEGATION_WINDOW_TOKENS = 4
+
+
+def issue(code: str, path: str, message: str) -> dict[str, str]:
+    """Create a stable validation issue."""
+    return {"code": code, "path": path, "message": message}
+
+
+def _reference_label(reference: str) -> str:
+    """Render a bare '#N' label from either a '#N' reference or an issue URL."""
+    match = re.search(r"(\d+)$", reference)
+    return f"#{match.group(1)}" if match else reference
+
+
+def _is_negated(body: str, keyword_start: int) -> bool:
+    """True when a negation cue sits in the few words right before the keyword."""
+    preceding = body[:keyword_start]
+    boundaries = [match.end() for match in SENTENCE_BOUNDARY_RE.finditer(preceding)]
+    clause_start = boundaries[-1] if boundaries else 0
+    clause = MARKDOWN_EMPHASIS_RE.sub("", preceding[clause_start:])
+    window = " ".join(clause.split()[-NEGATION_WINDOW_TOKENS:])
+    return bool(NEGATION_RE.search(window))
+
+
+def find_negated_autocloses(body: str) -> list[dict[str, str]]:
+    """Flag every closing-keyword+issue-reference pair written inside a negation."""
+    errors: list[dict[str, str]] = []
+    if not body:
+        return errors
+    for match in CLOSING_REFERENCE_RE.finditer(body):
+        if not _is_negated(body, match.start(1)):
+            continue
+        reference_label = _reference_label(match.group(2))
+        errors.append(
+            issue(
+                "autoclose-negated-reference",
+                "pull_request.body",
+                f"'{match.group(0)}' would auto-close {reference_label} on merge -- GitHub matches "
+                f"the closing keyword '{match.group(1)}' next to the issue reference regardless of "
+                f"the preceding negation. Reword to a bare '{reference_label}' (drop the closing "
+                "verb) if this PR should not close it.",
+            )
+        )
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--body",
+        help="PR body text to validate; defaults to the $PR_BODY environment variable",
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser
+
+
+def main() -> int:
+    """Run the CLI."""
+    args = build_parser().parse_args()
+    body = args.body if args.body is not None else os.environ.get("PR_BODY", "")
+    errors = find_negated_autocloses(body)
+    if args.format == "json":
+        print(json.dumps({"valid": not errors, "errors": errors}, indent=2))
+    elif errors:
+        for error in errors:
+            print(f"{error['code']}: {error['message']}", file=sys.stderr)
+    else:
+        print("No negated closing-keyword references found in the PR body.")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_validate_pr_closing_keywords.py
+++ b/tests/scripts/test_validate_pr_closing_keywords.py
@@ -1,0 +1,111 @@
+import unittest
+
+from scripts.ci.validate_pr_closing_keywords import find_negated_autocloses
+
+# Real body of PR #4009 (verified via `gh pr view 4009 --json body`). GitHub's
+# closing-keyword scanner matched "fix #3930" inside "Does not fix #3930's..."
+# and auto-closed issue #3930 the instant this PR merged, 2 seconds after a
+# human had manually reopened it with "Leaving open." (issue #4142).
+PR_4009_BODY = """## Summary
+
+Reverts the `-Xmx1024m` addition to root `pom.xml`'s `surefireArgLine` property (and its explanatory comment) from 3022ebb4ae (#3942), back to exactly its pre-3022ebb4ae value. This is a pure revert -- no per-OS profiles, no workflow-level overrides, no replacement number.
+
+## Why
+
+Before 3022ebb4ae, no `-Xmx` was set anywhere (root pom.xml, shaft-engine/pom.xml, or the workflow files), so every GitHub-hosted runner used HotSpot's ergonomic default heap: `MaxRAMPercentage=25%` of physical RAM (verified locally with `java -XX:+PrintFlagsFinal -version`, which reports `MaxRAMPercentage = 25.000000 {product} {default}` on this machine).
+
+Related, but explicitly NOT closed by this PR (no closing keywords used, on purpose):
+- #3985 -- has a second live cause (Playwright-scope leak in Grid jobs), tracked separately as #4006. Not fixed here.
+- #3987 -- has an entangled Safari finding tracked as #1548. Not fixed here.
+
+Both should be closed manually only after a green nightly run confirms this revert plus their other tracked causes are resolved.
+
+## What this PR does NOT do
+
+- Does not touch `.github/workflows/e2eTests.yml` or `e2eLocalTests.yml`.
+- Does not add per-OS Surefire heap profiles or a `-DsurefireArgLine` override anywhere.
+- Does not touch `shaft-intellij` or `shaft-mcp`.
+- Does not fix #3930's original macOS OOM -- that issue is being reopened separately with an explanation.
+
+## Test plan
+
+CI is the real verification for this change.
+"""
+
+
+class FindNegatedAutoclosesTest(unittest.TestCase):
+    def test_pr_4009_real_body_is_flagged(self):
+        """RED fixture: this real body wrongly auto-closed #3930 (issue #4142)."""
+        errors = find_negated_autocloses(PR_4009_BODY)
+        codes = {error["code"] for error in errors}
+        self.assertIn("autoclose-negated-reference", codes)
+        messages = " ".join(error["message"] for error in errors)
+        self.assertIn("#3930", messages)
+
+    def test_genuine_closes_reference_is_accepted(self):
+        """The common case: intentional 'Closes #N' must never be flagged."""
+        self.assertEqual(find_negated_autocloses("Closes #4127\n\n## Summary"), [])
+
+    def test_bare_issue_reference_is_accepted(self):
+        """A bare '#N' with no closing keyword next to it is always safe."""
+        self.assertEqual(
+            find_negated_autocloses("Related to #4053, #4048, #4065. See #3930 for context."),
+            [],
+        )
+
+    def test_ordinary_prose_mentioning_issue_is_accepted(self):
+        self.assertEqual(
+            find_negated_autocloses(
+                "This regression was first reported in #3930 and reproduced again this week."
+            ),
+            [],
+        )
+
+    def test_doesnt_close_is_flagged(self):
+        errors = find_negated_autocloses("This doesn't close #10 by itself.")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("#10", errors[0]["message"])
+
+    def test_cannot_resolve_is_flagged(self):
+        errors = find_negated_autocloses("We cannot resolve #20 until the upstream release ships.")
+        self.assertEqual(len(errors), 1)
+
+    def test_wont_fix_is_flagged(self):
+        errors = find_negated_autocloses("This won't fix #30, it only mitigates the symptom.")
+        self.assertEqual(len(errors), 1)
+
+    def test_does_not_resolve_yet_is_flagged(self):
+        errors = find_negated_autocloses("This does not resolve #40 yet -- follow-up tracked separately.")
+        self.assertEqual(len(errors), 1)
+
+    def test_markdown_bold_negation_is_flagged(self):
+        """Real phrasing from merged PR #4076: 'Does **not** close #4046'."""
+        errors = find_negated_autocloses(
+            "Fixes the deadlock behind #4046. Does **not** close #4046: the nightly's "
+            "E2E path still fails on a second, separate issue."
+        )
+        codes_and_refs = [(error["code"], "#4046" in error["message"]) for error in errors]
+        self.assertIn(("autoclose-negated-reference", True), codes_and_refs)
+        # "Fixes the deadlock behind #4046" has words between the keyword and the
+        # reference, so it is not itself a GitHub-recognized closing pair.
+        self.assertEqual(len(errors), 1)
+
+    def test_unrelated_earlier_negation_does_not_block_a_real_close(self):
+        """A 'not' several words back in the same sentence must not gate a real close."""
+        self.assertEqual(
+            find_negated_autocloses(
+                "This does not directly affect the OOM, but Closes #10 anyway as a followup."
+            ),
+            [],
+        )
+
+    def test_full_issue_url_negation_is_flagged(self):
+        errors = find_negated_autocloses(
+            "This does not fix https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3930 fully."
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("#3930", errors[0]["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

GitHub's closing-keyword scanner (`close`/`closes`/`closed`, `fix`/`fixes`/`fixed`,
`resolve`/`resolves`/`resolved` immediately before `#N` or an issue URL) has no
negation awareness -- it matches inside a sentence that was written specifically
to say the opposite. #4009's body explicitly stated that its change did not
close out issue #3930's original macOS OOM and that #3930 was being reopened
separately, using the same keyword+number adjacency GitHub's scanner looks
for right after the word "not". GitHub still recorded #3930 in
`closingIssuesReferences` and auto-closed it 2 seconds after #4009 merged,
overriding a human's manual reopen 7 minutes earlier ("Leaving open."). #3930
sat wrongly closed while the defect it tracked kept failing nightly under
#3987. Timeline verified via `gh api .../issues/3930/timeline` and
`gh pr view 4009 --json closingIssuesReferences,body`.

GitHub's behavior can't be changed, so this adds a CI check that catches the
pattern before merge and fails the PR so the author rewords it.

Closes #4142

## What this adds

- `scripts/ci/validate_pr_closing_keywords.py`: flags a closing keyword
  sitting directly next to an issue reference (the exact adjacency GitHub's
  own docs describe) only when a negation cue (`not`, `n't`, `never`,
  `cannot`) appears in the few words immediately before the keyword. A
  sentence-boundary + 4-token window keeps an unrelated earlier "not" in the
  same sentence from blocking a real, intentional close.
- `tests/scripts/test_validate_pr_closing_keywords.py`: RED fixture is
  #4009's real body text; negative cases cover a genuine close reference, a
  bare issue number, ordinary prose, and the tight-window guard against
  false gating.
- `.github/workflows/pr-gate.yml`: new `pr-body-autoclose-guard` job, wired
  the same way `dependency-review` is -- unconditional on every
  `pull_request` event (this check is about body text, not changed files, so
  it isn't gated by the `changes` path filter), added to the summary job's
  `needs`/table/status loop.

## Verification

- `py -3 -m unittest tests.scripts.test_validate_pr_closing_keywords -v` --
  11 tests, all pass (watched RED with the module missing, then GREEN after
  the implementation).
- `py -3 -m unittest discover -s tests/scripts -p "test_*.py"` -- 361 tests,
  all pass.
- `py -3 scripts/ci/validate_agent_setup.py` -- valid.
- `py -3 scripts/ci/validate_workflow_timeouts.py` and
  `validate_orphaned_suite_files.py` -- both pass against the edited
  workflow file.
- Ran the checker against 100 real merged PR bodies
  (`gh pr list --state merged --limit 100`): 81 legitimate keyword-plus-
  issue-number adjacency occurrences sampled, 5 PRs flagged, 0 false
  positives. All 5 are genuine negations: #4009 (the incident itself), two
  previously-undetected instances in #4076 and #4022 (each states its
  negation immediately before the same keyword+number pattern used
  elsewhere in that PR to link the underlying bug), and one in #4087's own
  heading, which used a "not" immediately before that same keyword+number
  pattern, inside backticks, to explain why it deliberately avoided closing
  a different issue -- backticks do not stop GitHub's scanner either.

## Scope

Touches only `scripts/ci/validate_pr_closing_keywords.py`,
`tests/scripts/test_validate_pr_closing_keywords.py`, and
`.github/workflows/pr-gate.yml`. Does not touch `e2eTests.yml` or
`e2eLocalTests.yml`, `.claude/hooks/guard.py`, `.claude/settings.json`,
`AiExecutionService.java`, or `.memory/**`.
