### PR TITLE
Document events.jsonl GitHub false-positive CONFLICTING (#4137)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Bridges (`.agents/skills/<name>/SKILL.md`, not Skill-invocable) enumerated in [r
 
 ## New Task Flow
 
-At session start fetch/prune, branch/worktree fresh `ChaosEngine/*` from `origin/main`; reuse session -- sub-tasks are commits, unless file-dependent (merge first, branch+PR/issue). Before PR sync default, resolve conflicts, rerun checks; commit, push, tracker+subtasks (work-github 3b).
+At session start fetch/prune, branch/worktree fresh `ChaosEngine/*` from `origin/main`; reuse session -- sub-tasks are commits, unless file-dependent (merge first, branch+PR/issue). Before PR sync default, resolve conflicts (`.memory/events.jsonl` CONFLICTING on GitHub alone is a false positive -- `merge=union` already resolves it locally keeping both sides; just rebase+push, #4137), rerun checks; commit, push, tracker+subtasks (work-github 3b).
 
 ## Working Rules
 


### PR DESCRIPTION
## Summary

Riskiest unknown settled empirically first, in a disposable copy of `.memory/` (never the tracked store): `.memory/events.jsonl`'s file *presence* is a hard requirement of the `@aictx/memory` CLI, not merely a nice-to-have activity log.

- `memory check` / `memory load` / `memory inspect` all fail (exit 1: `CanonicalFileMissing` / `MemoryValidationFailed: File could not be read as valid UTF-8`) when the file is genuinely absent.
- The same three commands pass identically whether the file holds full history or is truncated to 0 bytes -- content isn't what's required, only presence.
- `memory search` degrades gracefully (still returns full results, only a soft "Project registry was not updated" warning) when the file is absent -- the one command that doesn't hard-depend on it.
- Source citations: `dist/cli/main.js:3652-3659` (`validateRequiredStorage` requires the file), `:3661-3679` (`requireFile` errors `CanonicalFileMissing` on ENOENT), `:4482-4486` (`readEvents` reads via the non-tolerant path used by load/inspect), `:92-139` (`readUtf8FileInsideRoot` hard-errors on ENOENT), `:183-213` (`appendJsonl` uses `O_CREAT`, so only the write path auto-recreates it), `:13788-13792` (`memory init` always creates it, even empty).

Because `AGENTS.md`'s New Task Flow mandates every session start with a **fresh** `git worktree add`/clone followed by a mandatory `memory load "<task>"`, untracking the file would leave it genuinely missing after every future fresh checkout -- breaking that mandatory first step for every session until some other write recreated it. That's a bigger, systemic regression than the current per-PR rebase churn, which already resolves locally with zero manual conflict-marker edits via the existing `merge=union` attribute (verified: `git check-attr merge .memory/events.jsonl` -> `union`, confirmed against real repo history this session).

The actual defect is on GitHub's side: its server-side mergeability precheck doesn't evaluate custom merge drivers, so it flags a PR CONFLICTING on this file even though any local rebase resolves it cleanly. That's not something this repo can fix. So per the evidence -- required-but-content-irrelevant, "genuinely mixed," lower-risk option chosen -- this documents the false positive and the safe recovery procedure instead of gitignoring/untracking the file:

- `.gitattributes`'s `merge=union` is untouched (still correct, still resolves this locally).
- `.gitignore` and the file's tracking status are untouched (untracking was ruled out above).
- `AGENTS.md`'s New Task Flow gets one added clause: a `.memory/events.jsonl`-only CONFLICTING/DIRTY status is a known GitHub false positive; rebase+push, no manual edits needed.

## Verification

- `memory check`, `memory load`, `memory search` all re-run against the real repo store (this worktree, unmodified `.memory/**`) after the change: all pass. `memory rebuild` also run to regenerate the gitignored SQLite index the worktree doesn't carry.
- `py -3 scripts/ci/validate_agent_setup.py` -> `Agent setup is valid: 73426 guidance bytes, 0% reduction, 327 memory objects.`
- Strict file scope respected: only `AGENTS.md` changed (1 line). No `.memory/**` content, `.claude/hooks/guard.py`, `.claude/settings.json`, or `scripts/ci/**` touched.

Closes #4137

Related PRs that hit the false positive this session: #4132, #4134, #4136, #4141. Related tracker for the auto-close-keyword negation gotcha: #4142.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH