### PR TITLE
Catch new memory secret-scanner openai_api_key landmines before they land

### DIFF
--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -50,6 +50,30 @@ GENERATED_MEMORY_PATHS = {
 # (133 characters) so new drift is caught before it reaches a clone.
 MAX_MEMORY_BASENAME_LENGTH = 160
 MEMORY_CANONICAL_GLOBS = ("memory/**/*.json", "memory/**/*.md", "relations/*.json")
+# The Aictx Memory CLI's `openai_api_key` block-rule pattern
+# (`sk-[A-Za-z0-9_-]{20,}`, dist/cli/main.js:3223 in @aictx/memory@0.1.55) has
+# no `\b` anchor before `sk-`, so it matches mid-word inside an ordinary
+# hyphenated slug -- e.g. "...mid-task-while-still-actively-working..." is
+# read as "ta" + "sk-while-still-actively-working", tripping
+# MemorySecretDetected and hard-failing `memory check` (exit 1). Confirmed
+# live (issue #4005) with a from-scratch `npm install @aictx/memory@0.1.55`
+# (i.e. without this machine's local patch) against a disposable copy of this
+# repo's real `.memory/` store. The upstream fix (anchor with `\b`) is
+# TDD-verified against upstream's own suite on
+# https://github.com/MohabMohie/memory/tree/fix/openai-key-pattern-word-boundary
+# but not merged/released, so this landmine is still live on any unpatched
+# machine, CI runner, or fresh clone. This check catches new occurrences
+# before they reach the store; it is not a general secret scanner and does
+# not replace one.
+SECRET_SCANNER_LANDMINE_PATTERN = re.compile(r"sk-[A-Za-z0-9_-]{20,}")
+# Grandfathered: committed before this check existed. Do not add to this set
+# for new entries -- rename the memory title/slug instead (avoid a hyphenated
+# word ending in "sk" -- task-, risk-, disk-, desk-, mask-, kiosk-, etc. --
+# immediately followed by 20+ word/hyphen characters).
+KNOWN_SECRET_SCANNER_LANDMINE_FILES = {
+    ".memory/memory/gotchas/memory-secret-scanner-local-patch-is-fragile-reinstall-update-silently-reverts-it.md",
+    ".memory/memory/gotchas/worktree-isolated-agents-can-be-reclaimed-mid-task-while-still-actively-working-with-no-committed-diff.json",
+}
 RELATION_GLOB = "relations/*.json"
 # `create_relation` (patch.schema.json #/$defs/createRelation) accepts an
 # optional, caller-supplied `id` -- confirmed live against the real Memory
@@ -152,6 +176,26 @@ def validate_memory_setup(root: Path = ROOT) -> list[dict[str, str]]:
                         f"basename exceeds {MAX_MEMORY_BASENAME_LENGTH} characters "
                         "(risks Windows MAX_PATH on checkout); shorten the object/relation id."
                         + hint,
+                    )
+                )
+            relative_posix = memory_path.relative_to(root).as_posix()
+            if relative_posix in KNOWN_SECRET_SCANNER_LANDMINE_FILES:
+                continue
+            landmine = SECRET_SCANNER_LANDMINE_PATTERN.search(
+                memory_path.read_text(encoding="utf-8")
+            )
+            if landmine:
+                errors.append(
+                    issue(
+                        "memory-secret-landmine",
+                        relative_posix,
+                        f"content matches {landmine.group(0)[:32]!r}, which the unpatched "
+                        "Aictx Memory CLI's unanchored openai_api_key rule "
+                        "(`sk-[A-Za-z0-9_-]{20,}`, no \\b before `sk-`) reads as an API "
+                        "key and hard-fails `memory check` on (issue #4005). Rename the "
+                        'title/slug to avoid a hyphenated word ending in "sk" '
+                        "(task-, risk-, disk-, desk-, mask-, kiosk-, ...) followed by "
+                        "20+ word/hyphen characters.",
                     )
                 )
 

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from scripts.ci.validate_agent_setup import (
     GENERATED_MEMORY_PATHS,
+    KNOWN_SECRET_SCANNER_LANDMINE_FILES,
     run_memory_check,
     validate_memory_setup,
     validate_repository,
@@ -132,6 +133,26 @@ approval_mode = "prompt"
         self.assertEqual(len(errors), 1)
         self.assertIn("create_relation", errors[0]["message"])
         self.assertIn("explicit", errors[0]["message"])
+
+    def test_rejects_new_memory_file_matching_secret_scanner_landmine(self):
+        # The unpatched Aictx Memory CLI's `openai_api_key` rule is
+        # `/sk-[A-Za-z0-9_-]{20,}/` with no `\b` anchor before `sk-`, so it
+        # matches mid-word inside ordinary hyphenated slugs -- confirmed live
+        # (issue #4005) via a from-scratch `npm install @aictx/memory@0.1.55`:
+        # `memory check` hard-fails (exit 1) on any canonical file whose text
+        # contains a word like "desk-" followed by 20+ word/hyphen characters.
+        self.write(
+            ".memory/memory/gotchas/new-thing-desk-abcdefghijklmnopqrstuvwxyz.md",
+            "desk-abcdefghijklmnopqrstuvwxyz\n",
+        )
+        self.assertIn("memory-secret-landmine", self.codes())
+
+    def test_known_preexisting_landmine_file_is_grandfathered(self):
+        # The two files already committed before this check existed (#4005)
+        # must not start failing every build; only NEW occurrences should.
+        allowlisted_path = sorted(KNOWN_SECRET_SCANNER_LANDMINE_FILES)[0]
+        self.write(allowlisted_path, "desk-abcdefghijklmnopqrstuvwxyz\n")
+        self.assertNotIn("memory-secret-landmine", self.codes())
 
     def test_overlong_non_relation_filename_still_caught_without_relation_hint(self):
         # Negative test: relaxing the relation-file message must not open a


### PR DESCRIPTION
## Summary

Re-verified this issue from scratch (own reproduction, not trusting the thread) and reached the same root cause the thread already converged on, then added the one mitigation not yet tried: a static in-repo check that catches **new** occurrences of the landmine before they reach the store.

## What's actually true (verified firsthand, not inferred from the thread)

- The issue's own premise — a `content_hash`/sha256 false positive — is **false**. `content_hash` is exempted upstream via `looksLikeSha256Hash` and only ever trips the non-blocking `high_entropy_string` WARN rule (never fails `memory check`).
- The real, genuinely-blocking bug: `npm install @aictx/memory@0.1.55` into a scratch dir (no local patch, confirmed unanchored via `grep -n "sk-\[A-Za-z0-9" node_modules/@aictx/memory/dist/cli/main.js` → line 3223, no `\b`), run against a **disposable copy** of this repo's real `.memory/` store: `memory check` → exit code **1**, two `MemorySecretDetected` errors:
  - `.memory/memory/gotchas/worktree-isolated-agents-can-be-reclaimed-mid-task-while-still-actively-working-with-no-committed-diff.json:2` (`body_path`, not `content_hash` — that field is line 3 and does not match)
  - `.memory/memory/gotchas/memory-secret-scanner-local-patch-is-fragile-reinstall-update-silently-reverts-it.md:3` (prose describing the bug, self-triggering)
- Both hit because `openai_api_key`'s pattern (`sk-[A-Za-z0-9_-]{20,}`, `main.js:3223`) has no `\b` before `sk-`, so it matches mid-word inside ordinary hyphenated words like "...mid-**ta** + **sk-while**-still-actively-working...".
- No in-repo config surface exists (`config.schema.json` sets `additionalProperties: false`; `scanProjectSecrets()` is called with zero options at `main.js:3704`) — already established in the thread, re-confirmed by reading the schema myself.
- The correct fix (`\bsk-[A-Za-z0-9_-]{20,}`) is already TDD-verified upstream on `https://github.com/MohabMohie/memory/tree/fix/openai-key-pattern-word-boundary`, blocked from becoming a PR by `aictx/memory`'s collaborators-only PR policy. Nothing new to add here; restating so this PR stands on its own.

## What this PR does — and does **not** — fix

`scripts/ci/validate_agent_setup.py`'s `validate_memory_setup` now statically scans every canonical `.memory/memory/**/*.{json,md}` and `.memory/relations/*.json` file's raw text for the same unanchored `sk-[A-Za-z0-9_-]{20,}` pattern and fails with an actionable rename hint (`memory-secret-landmine`), grandfathering the two files above (already committed, out of scope for me to rename this session — another agent owns `.memory/` this run).

This is **prevention, not a cure**: the two pre-existing files still hard-block a real, unpatched `memory check` today, on any machine/CI runner that hasn't applied the local `\b`-anchor patch. This PR stops a *third* landmine from landing unnoticed the same way the first two did; it does not unblock the store on a clean machine. That only happens when the upstream branch above is merged/released, or the two flagged files are renamed (out of scope here).

## Verification

- TDD: `tests/scripts/test_validate_agent_setup.py::test_rejects_new_memory_file_matching_secret_scanner_landmine` written first, watched fail red (`ImportError: cannot import name 'KNOWN_SECRET_SCANNER_LANDMINE_FILES'`), then green after the minimal implementation.
- `tests/scripts/test_validate_agent_setup.py::test_known_preexisting_landmine_file_is_grandfathered` — confirms the two known files don't newly fail the gate.
- `tests/scripts/test_validate_agent_setup.py::test_current_repository_setup_is_valid_without_external_calls` — runs against the real repo tree; still passes (grandfather list is correct and complete for this tree today).
- `py -3 -m unittest discover -s tests/scripts -p "test_*.py"` → 352 tests, all pass.
- `py -3 scripts/ci/validate_agent_setup.py` → `Agent setup is valid: 73264 guidance bytes, 0% reduction, 327 memory objects.`

## Why this stays open

The underlying upstream scanner bug is unfixed and unreleased, and the two already-committed landmine files still hard-block a real, unpatched `memory check` today. Closing would misrepresent the state. Leaving this open, same as the thread's prior convention (PR #4087 used `Refs #4005` for the same reason).

Refs #4005
