### PR TITLE
Extend the autoclose guard to commit messages and re-run it on edited PR bodies

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -10,6 +10,29 @@ name: PR Gate
 # .github/workflows/README.md). If a merge queue is ever enabled, add
 # `merge_group:` to the triggers below.
 #
+# Issue #4145: the `pull_request` trigger's default activity types (opened,
+# synchronize, reopened) never re-run the gate when a PR's body is edited with
+# no new commit. That leaves two failure modes for the pr-body-autoclose-guard
+# leg below: a red check stays red forever after a rewording (stale-red, until
+# an unrelated commit or a close+reopen forces a re-run), and a body edited
+# *after* the last push to add a hazard sails through on the old green result
+# (stale-pass -- confirmed live: PR #4150's failing check did not re-run after
+# its body was reworded, with no new commit). `edited` is added below so the
+# guard job re-runs on a bare body/title edit. Every *heavy* leg (build/test/
+# install/dependency-review jobs, gated further down with `&& github.event.
+# action != 'edited'`) explicitly skips on that action instead: re-running the
+# IntelliJ build, unit-test matrix, etc. on every typo fix is real,
+# non-trivial cost paid by every PR, and none of those legs read PR body/title
+# text -- only pr-body-autoclose-guard needs to see it. The alternative
+# (a separate workflow triggered only on `edited`) was rejected: it would be a
+# status check outside `PR Gate Summary`, needing its own branch-protection
+# entry to actually block a merge, for no cost saving over gating in place.
+# The concurrency group below is split for `edited` events for the same
+# reason: without that split, a bare body edit mid-run would cancel an
+# in-flight *heavy* run (same PR, same default group) via cancel-in-progress
+# and replace it with a summary where those legs report "skipped" -- passing
+# vacuously without ever actually re-validating the current commit.
+#
 # Deliberately pull_request + push(main) only, no workflow_dispatch:
 # dorny/paths-filter cannot resolve a diff base outside push/pull_request
 # events, so a workflow_dispatch run would either always fail the changes job
@@ -26,6 +49,7 @@ name: PR Gate
 
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, edited ]
   push:
     branches: [ main ]
 
@@ -33,7 +57,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: pr-gate-${{ github.event.pull_request.number || github.ref }}
+  # `edited` gets its own subgroup per PR so a bare body/title edit cancels
+  # only another in-flight edit, never an in-flight opened/synchronize/
+  # reopened run's heavy legs (see the `edited`-handling note above).
+  group: pr-gate-${{ github.event.pull_request.number || github.ref }}${{ github.event.action == 'edited' && '-edited' || '' }}
   cancel-in-progress: true
 
 jobs:
@@ -123,7 +150,7 @@ jobs:
   docs-boundary:
     name: Documentation Boundary Gate
     needs: changes
-    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.infra == 'true'
+    if: (needs.changes.outputs.docs == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
@@ -138,7 +165,7 @@ jobs:
   installer-verify:
     name: Installer verification (${{ matrix.os }})
     needs: changes
-    if: needs.changes.outputs.intellij == 'true' || needs.changes.outputs.infra == 'true'
+    if: (needs.changes.outputs.intellij == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -173,7 +200,7 @@ jobs:
   intellij-build:
     name: Build IntelliJ plugin
     needs: changes
-    if: needs.changes.outputs.intellij == 'true' || needs.changes.outputs.infra == 'true'
+    if: (needs.changes.outputs.intellij == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -191,7 +218,7 @@ jobs:
   cli:
     name: shaft-cli (${{ matrix.os }})
     needs: changes
-    if: needs.changes.outputs.cli == 'true' || needs.changes.outputs.infra == 'true'
+    if: (needs.changes.outputs.cli == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -232,7 +259,7 @@ jobs:
   capture-e2e:
     name: SHAFT Capture Browser E2E
     needs: changes
-    if: needs.changes.outputs.capture == 'true' || needs.changes.outputs.infra == 'true'
+    if: (needs.changes.outputs.capture == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -292,7 +319,7 @@ jobs:
   unit-tests:
     name: Unit Tests (${{ matrix.module }})
     needs: changes
-    if: needs.changes.outputs.javacore == 'true' || needs.changes.outputs.infra == 'true'
+    if: (needs.changes.outputs.javacore == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
@@ -347,7 +374,7 @@ jobs:
   template-coupling:
     name: Template Coupling Gate
     needs: changes
-    if: needs.changes.outputs.templates == 'true' || needs.changes.outputs.infra == 'true'
+    if: (needs.changes.outputs.templates == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -379,7 +406,7 @@ jobs:
   workflow-timeouts:
     name: Workflow Timeout Guard
     needs: changes
-    if: needs.changes.outputs.workflows == 'true' || needs.changes.outputs.infra == 'true'
+    if: (needs.changes.outputs.workflows == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -411,7 +438,7 @@ jobs:
   orphaned-suite-files:
     name: Orphaned Suite XML Guard
     needs: changes
-    if: needs.changes.outputs.javacore == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.infra == 'true'
+    if: (needs.changes.outputs.javacore == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -430,15 +457,30 @@ jobs:
   # it auto-closed #3930 from PR #4009's "Does not fix #3930's original macOS
   # OOM", overriding a human's manual reopen 7 minutes earlier. Runs
   # unconditionally on every pull_request (like dependency-review below, it
-  # concerns PR body text, not changed files, so no `changes` path leg gates
-  # it) and reads the live PR body via `github.event.pull_request.body`,
-  # which only exists on the pull_request event.
+  # concerns PR body/commit text, not changed files, so no `changes` path leg
+  # gates it) and does NOT skip on `edited` (issue #4145): it is the one leg
+  # that must re-run when only the body changes, and it is cheap enough that
+  # re-running it on every edit is the whole point, not a cost to avoid.
+  #
+  # Issue #4146: GitHub scans commit messages pushed to the default branch,
+  # not just the PR body -- confirmed live via issue #3930's timeline, which
+  # recorded its second auto-close via a squash-merge commit SHA, with the
+  # PR's own body and closingIssuesReferences clean. A force-push can add a
+  # hazardous commit to an already-auto-merge-armed PR and merge within a
+  # minute, so the PR's individual commit messages are fetched via the REST
+  # API (not `git log` -- this job's checkout is unauthenticated for that
+  # range and shallow by default; the API reflects the current commit list
+  # even after a force-push, i.e. on the next `synchronize`) and scanned with
+  # the same detection function, unchanged, reused from the PR-body path.
   pr-body-autoclose-guard:
-    name: PR Body Autoclose Guard
+    name: PR Body & Commit Autoclose Guard
     needs: changes
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -446,11 +488,23 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: "3.13"
+      - name: Fetch PR commit messages
+        id: pr-commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo 'commits_json<<PR_COMMITS_JSON_EOF'
+            gh api -X GET "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
+              -f per_page=100 --jq '[.[] | {sha: .sha, message: .commit.message}]'
+            echo 'PR_COMMITS_JSON_EOF'
+          } >> "$GITHUB_OUTPUT"
       - name: Run PR body autoclose guard unit tests
         run: python3 -m unittest tests.scripts.test_validate_pr_closing_keywords -v
-      - name: Validate PR body has no negated closing-keyword references
+      - name: Validate PR body and commit messages have no negated closing-keyword references
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_COMMITS_JSON: ${{ steps.pr-commits.outputs.commits_json }}
         run: python3 scripts/ci/validate_pr_closing_keywords.py
 
   # Moved from security.yml's dependency-review job. Runs unconditionally on
@@ -461,7 +515,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     needs: changes
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'edited'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -10,29 +10,6 @@ name: PR Gate
 # .github/workflows/README.md). If a merge queue is ever enabled, add
 # `merge_group:` to the triggers below.
 #
-# Issue #4145: the `pull_request` trigger's default activity types (opened,
-# synchronize, reopened) never re-run the gate when a PR's body is edited with
-# no new commit. That leaves two failure modes for the pr-body-autoclose-guard
-# leg below: a red check stays red forever after a rewording (stale-red, until
-# an unrelated commit or a close+reopen forces a re-run), and a body edited
-# *after* the last push to add a hazard sails through on the old green result
-# (stale-pass -- confirmed live: PR #4150's failing check did not re-run after
-# its body was reworded, with no new commit). `edited` is added below so the
-# guard job re-runs on a bare body/title edit. Every *heavy* leg (build/test/
-# install/dependency-review jobs, gated further down with `&& github.event.
-# action != 'edited'`) explicitly skips on that action instead: re-running the
-# IntelliJ build, unit-test matrix, etc. on every typo fix is real,
-# non-trivial cost paid by every PR, and none of those legs read PR body/title
-# text -- only pr-body-autoclose-guard needs to see it. The alternative
-# (a separate workflow triggered only on `edited`) was rejected: it would be a
-# status check outside `PR Gate Summary`, needing its own branch-protection
-# entry to actually block a merge, for no cost saving over gating in place.
-# The concurrency group below is split for `edited` events for the same
-# reason: without that split, a bare body edit mid-run would cancel an
-# in-flight *heavy* run (same PR, same default group) via cancel-in-progress
-# and replace it with a summary where those legs report "skipped" -- passing
-# vacuously without ever actually re-validating the current commit.
-#
 # Deliberately pull_request + push(main) only, no workflow_dispatch:
 # dorny/paths-filter cannot resolve a diff base outside push/pull_request
 # events, so a workflow_dispatch run would either always fail the changes job
@@ -49,7 +26,6 @@ name: PR Gate
 
 on:
   pull_request:
-    types: [ opened, synchronize, reopened, edited ]
   push:
     branches: [ main ]
 
@@ -57,10 +33,7 @@ permissions:
   contents: read
 
 concurrency:
-  # `edited` gets its own subgroup per PR so a bare body/title edit cancels
-  # only another in-flight edit, never an in-flight opened/synchronize/
-  # reopened run's heavy legs (see the `edited`-handling note above).
-  group: pr-gate-${{ github.event.pull_request.number || github.ref }}${{ github.event.action == 'edited' && '-edited' || '' }}
+  group: pr-gate-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -150,7 +123,7 @@ jobs:
   docs-boundary:
     name: Documentation Boundary Gate
     needs: changes
-    if: (needs.changes.outputs.docs == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
+    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
@@ -165,7 +138,7 @@ jobs:
   installer-verify:
     name: Installer verification (${{ matrix.os }})
     needs: changes
-    if: (needs.changes.outputs.intellij == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
+    if: needs.changes.outputs.intellij == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -200,7 +173,7 @@ jobs:
   intellij-build:
     name: Build IntelliJ plugin
     needs: changes
-    if: (needs.changes.outputs.intellij == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
+    if: needs.changes.outputs.intellij == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -218,7 +191,7 @@ jobs:
   cli:
     name: shaft-cli (${{ matrix.os }})
     needs: changes
-    if: (needs.changes.outputs.cli == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
+    if: needs.changes.outputs.cli == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -259,7 +232,7 @@ jobs:
   capture-e2e:
     name: SHAFT Capture Browser E2E
     needs: changes
-    if: (needs.changes.outputs.capture == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
+    if: needs.changes.outputs.capture == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -319,7 +292,7 @@ jobs:
   unit-tests:
     name: Unit Tests (${{ matrix.module }})
     needs: changes
-    if: (needs.changes.outputs.javacore == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
+    if: needs.changes.outputs.javacore == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
@@ -374,7 +347,7 @@ jobs:
   template-coupling:
     name: Template Coupling Gate
     needs: changes
-    if: (needs.changes.outputs.templates == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
+    if: needs.changes.outputs.templates == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -406,7 +379,7 @@ jobs:
   workflow-timeouts:
     name: Workflow Timeout Guard
     needs: changes
-    if: (needs.changes.outputs.workflows == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
+    if: needs.changes.outputs.workflows == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -438,7 +411,7 @@ jobs:
   orphaned-suite-files:
     name: Orphaned Suite XML Guard
     needs: changes
-    if: (needs.changes.outputs.javacore == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.infra == 'true') && github.event.action != 'edited'
+    if: needs.changes.outputs.javacore == 'true' || needs.changes.outputs.workflows == 'true' || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -457,30 +430,15 @@ jobs:
   # it auto-closed #3930 from PR #4009's "Does not fix #3930's original macOS
   # OOM", overriding a human's manual reopen 7 minutes earlier. Runs
   # unconditionally on every pull_request (like dependency-review below, it
-  # concerns PR body/commit text, not changed files, so no `changes` path leg
-  # gates it) and does NOT skip on `edited` (issue #4145): it is the one leg
-  # that must re-run when only the body changes, and it is cheap enough that
-  # re-running it on every edit is the whole point, not a cost to avoid.
-  #
-  # Issue #4146: GitHub scans commit messages pushed to the default branch,
-  # not just the PR body -- confirmed live via issue #3930's timeline, which
-  # recorded its second auto-close via a squash-merge commit SHA, with the
-  # PR's own body and closingIssuesReferences clean. A force-push can add a
-  # hazardous commit to an already-auto-merge-armed PR and merge within a
-  # minute, so the PR's individual commit messages are fetched via the REST
-  # API (not `git log` -- this job's checkout is unauthenticated for that
-  # range and shallow by default; the API reflects the current commit list
-  # even after a force-push, i.e. on the next `synchronize`) and scanned with
-  # the same detection function, unchanged, reused from the PR-body path.
+  # concerns PR body text, not changed files, so no `changes` path leg gates
+  # it) and reads the live PR body via `github.event.pull_request.body`,
+  # which only exists on the pull_request event.
   pr-body-autoclose-guard:
-    name: PR Body & Commit Autoclose Guard
+    name: PR Body Autoclose Guard
     needs: changes
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    permissions:
-      contents: read
-      pull-requests: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -488,23 +446,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: "3.13"
-      - name: Fetch PR commit messages
-        id: pr-commits
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          {
-            echo 'commits_json<<PR_COMMITS_JSON_EOF'
-            gh api -X GET "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
-              -f per_page=100 --jq '[.[] | {sha: .sha, message: .commit.message}]'
-            echo 'PR_COMMITS_JSON_EOF'
-          } >> "$GITHUB_OUTPUT"
       - name: Run PR body autoclose guard unit tests
         run: python3 -m unittest tests.scripts.test_validate_pr_closing_keywords -v
-      - name: Validate PR body and commit messages have no negated closing-keyword references
+      - name: Validate PR body has no negated closing-keyword references
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-          PR_COMMITS_JSON: ${{ steps.pr-commits.outputs.commits_json }}
         run: python3 scripts/ci/validate_pr_closing_keywords.py
 
   # Moved from security.yml's dependency-review job. Runs unconditionally on
@@ -515,7 +461,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     needs: changes
-    if: github.event_name == 'pull_request' && github.event.action != 'edited'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:

--- a/scripts/ci/validate_pr_closing_keywords.py
+++ b/scripts/ci/validate_pr_closing_keywords.py
@@ -64,11 +64,28 @@ def _is_negated(body: str, keyword_start: int) -> bool:
     return bool(NEGATION_RE.search(window))
 
 
+def _dewrap_hard_wrapped_text(text: str) -> str:
+    """Collapse a hard-wrapped single newline into a space, preserving paragraph breaks.
+
+    Both commit messages (git's ~72-column convention) and PR bodies composed in an
+    editor/CLI that hard-wraps at ~72-80 columns can split a negation cue like "Does
+    not" onto its own line from the "fix #N" that follows (issue #4146: the real commit
+    that squash-merged into PR #4141 did exactly this -- 0 matches unwrapped, 1
+    flattened, confirmed against the shipped guard). The clause-boundary logic below
+    treats any bare newline as a hard stop by design, so an unrelated bullet's negation
+    can't leak into the next bullet in a PR body -- but that same rule silently defeats
+    detection on hard-wrapped prose. A blank line (double newline) still marks a real
+    paragraph/bullet break and is left alone.
+    """
+    return re.sub(r"(?<!\n)\n(?!\n)", " ", text)
+
+
 def find_negated_autocloses(body: str) -> list[dict[str, str]]:
     """Flag every closing-keyword+issue-reference pair written inside a negation."""
     errors: list[dict[str, str]] = []
     if not body:
         return errors
+    body = _dewrap_hard_wrapped_text(body)
     for match in CLOSING_REFERENCE_RE.finditer(body):
         if not _is_negated(body, match.start(1)):
             continue
@@ -86,12 +103,45 @@ def find_negated_autocloses(body: str) -> list[dict[str, str]]:
     return errors
 
 
+def find_negated_autocloses_in_commits(commits: list[tuple[str, str]]) -> list[dict[str, str]]:
+    """Flag every negated closing-keyword+issue-reference pair in any commit message.
+
+    Reuses find_negated_autocloses unchanged (issue #4146: the detection logic itself
+    is surface-agnostic, dewrapping included) and tags the offending commit.
+    """
+    errors: list[dict[str, str]] = []
+    for sha, message in commits:
+        for error in find_negated_autocloses(message):
+            errors.append(
+                issue(
+                    error["code"],
+                    f"commit:{sha}",
+                    f"{sha[:12]}: {error['message']}",
+                )
+            )
+    return errors
+
+
+def parse_commits_json(raw: str) -> list[tuple[str, str]]:
+    """Parse a JSON array of {"sha": ..., "message": ...} objects (e.g. from `gh api .../commits`)."""
+    if not raw:
+        return []
+    return [(entry["sha"], entry["message"]) for entry in json.loads(raw)]
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the command-line parser."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--body",
         help="PR body text to validate; defaults to the $PR_BODY environment variable",
+    )
+    parser.add_argument(
+        "--commits-json",
+        help=(
+            "JSON array of {sha, message} commit objects to validate; defaults to the "
+            "$PR_COMMITS_JSON environment variable"
+        ),
     )
     parser.add_argument("--format", choices=("text", "json"), default="text")
     return parser
@@ -101,7 +151,11 @@ def main() -> int:
     """Run the CLI."""
     args = build_parser().parse_args()
     body = args.body if args.body is not None else os.environ.get("PR_BODY", "")
+    commits_json = (
+        args.commits_json if args.commits_json is not None else os.environ.get("PR_COMMITS_JSON", "")
+    )
     errors = find_negated_autocloses(body)
+    errors.extend(find_negated_autocloses_in_commits(parse_commits_json(commits_json)))
     if args.format == "json":
         print(json.dumps({"valid": not errors, "errors": errors}, indent=2))
     elif errors:

--- a/scripts/ci/validate_pr_closing_keywords.py
+++ b/scripts/ci/validate_pr_closing_keywords.py
@@ -65,18 +65,16 @@ def _is_negated(body: str, keyword_start: int) -> bool:
 
 
 def _dewrap_hard_wrapped_text(text: str) -> str:
-    """Collapse a hard-wrapped single newline into a space, preserving paragraph breaks.
-
-    Both commit messages (git's ~72-column convention) and PR bodies composed in an
-    editor/CLI that hard-wraps at ~72-80 columns can split a negation cue like "Does
-    not" onto its own line from the "fix #N" that follows (issue #4146: the real commit
-    that squash-merged into PR #4141 did exactly this -- 0 matches unwrapped, 1
-    flattened, confirmed against the shipped guard). The clause-boundary logic below
-    treats any bare newline as a hard stop by design, so an unrelated bullet's negation
-    can't leak into the next bullet in a PR body -- but that same rule silently defeats
-    detection on hard-wrapped prose. A blank line (double newline) still marks a real
-    paragraph/bullet break and is left alone.
-    """
+    """Collapse a hard-wrapped single newline into a space, preserving paragraph breaks."""
+    # Both commit messages (git's ~72-column convention) and PR bodies composed in an
+    # editor/CLI that hard-wraps at ~72-80 columns can split a negation cue like "Does
+    # not" onto its own line from the "fix #N" that follows (issue #4146: the real commit
+    # that squash-merged into PR #4141 did exactly this -- 0 matches unwrapped, 1
+    # flattened, confirmed against the shipped guard). The clause-boundary logic below
+    # treats any bare newline as a hard stop by design, so an unrelated bullet's negation
+    # can't leak into the next bullet in a PR body -- but that same rule silently defeats
+    # detection on hard-wrapped prose. A blank line (double newline) still marks a real
+    # paragraph/bullet break and is left alone.
     return re.sub(r"(?<!\n)\n(?!\n)", " ", text)
 
 
@@ -104,11 +102,9 @@ def find_negated_autocloses(body: str) -> list[dict[str, str]]:
 
 
 def find_negated_autocloses_in_commits(commits: list[tuple[str, str]]) -> list[dict[str, str]]:
-    """Flag every negated closing-keyword+issue-reference pair in any commit message.
-
-    Reuses find_negated_autocloses unchanged (issue #4146: the detection logic itself
-    is surface-agnostic, dewrapping included) and tags the offending commit.
-    """
+    """Flag every negated closing-keyword+issue-reference pair in any commit message."""
+    # Reuses find_negated_autocloses unchanged (issue #4146: the detection logic itself
+    # is surface-agnostic, dewrapping included) and tags the offending commit.
     errors: list[dict[str, str]] = []
     for sha, message in commits:
         for error in find_negated_autocloses(message):

--- a/tests/scripts/test_validate_pr_closing_keywords.py
+++ b/tests/scripts/test_validate_pr_closing_keywords.py
@@ -1,6 +1,17 @@
+import json
+import os
+import subprocess
+import sys
 import unittest
 
-from scripts.ci.validate_pr_closing_keywords import find_negated_autocloses
+from scripts.ci.validate_pr_closing_keywords import (
+    find_negated_autocloses,
+    find_negated_autocloses_in_commits,
+    parse_commits_json,
+)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CLI_SCRIPT = os.path.join(REPO_ROOT, "scripts", "ci", "validate_pr_closing_keywords.py")
 
 # Real body of PR #4009 (verified via `gh pr view 4009 --json body`). GitHub's
 # closing-keyword scanner matched "fix #3930" inside "Does not fix #3930's..."
@@ -99,12 +110,148 @@ class FindNegatedAutoclosesTest(unittest.TestCase):
             [],
         )
 
+    def test_hard_wrapped_body_negation_is_flagged(self):
+        """Coordinator-reproduced gap: an editor/CLI that hard-wraps a PR body at ~72-80
+        columns can split "Does not" onto its own line from "fix #N", and a bare '\\n'
+        clause boundary would silently swallow the negation. Confirmed independently
+        against the shipped guard: the real PR #4141 commit text (see
+        FindNegatedAutoclosesInCommitsTest) scores 0 matches unwrapped, 1 flattened."""
+        errors = find_negated_autocloses("This PR does not\nfix #3930 here.")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("#3930", errors[0]["message"])
+
     def test_full_issue_url_negation_is_flagged(self):
         errors = find_negated_autocloses(
             "This does not fix https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3930 fully."
         )
         self.assertEqual(len(errors), 1)
         self.assertIn("#3930", errors[0]["message"])
+
+
+class FindNegatedAutoclosesInCommitsTest(unittest.TestCase):
+    # Exact raw commit text (byte-for-byte, via `gh api
+    # repos/ShaftHQ/SHAFT_ENGINE/commits/82b7d875331ecb28a16256907949477f86f8add2`) of the
+    # real branch commit behind the #3930 incident (issue #4146): a force-push at
+    # 15:47:32Z added this as a second commit to PR #4141's already-auto-merge-armed
+    # branch, and the merge one minute later (15:48:09Z) squash-merged it byte-for-byte
+    # into commit c0f82a611bbf5a93d81c4f7cdc3c56ac55069d8f -- arming auto-merge does not
+    # freeze a PR against later pushes. Git hard-wraps prose at ~72 columns, so this real
+    # text splits "Does not" from "fix #3930" across a single newline; the shipped `main`
+    # implementation (before this PR) scores 0 matches against it, confirmed empirically.
+    PR_4141_COMMIT_BODY = (
+        "Record two post-PR gotchas: negation-blind auto-close, PR prose isn't merge-state\n"
+        "\n"
+        "GitHub's issue-closing keyword scan matched \"fix #3930\" inside \"Does not\n"
+        "fix #3930\" in PR 4009's body, auto-closing the issue on merge despite the\n"
+        "PR explicitly disclaiming it and despite a human having manually reopened\n"
+        "it 7 minutes earlier with \"Leaving open.\" Verified via the issue's own\n"
+        "timeline and PR 4009's closingIssuesReferences. Cross-references 4142,\n"
+        "which tracks the fix.\n"
+        "\n"
+        "Also records that PR/issue prose describing work as landed is not a\n"
+        "merge-state source of truth -- gh pr view state/mergedAt is.\n"
+    )
+
+    def test_real_pr_4141_commit_body_is_flagged(self):
+        """RED fixture: real hard-wrapped commit text that squash-merged and closed #3930 (issue #4146)."""
+        errors = find_negated_autocloses_in_commits(
+            [("82b7d875331ecb28a16256907949477f86f8add2", self.PR_4141_COMMIT_BODY)]
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("#3930", errors[0]["message"])
+        self.assertIn("82b7d875331e", errors[0]["message"])
+
+    # Exact raw commit text (via `gh api
+    # repos/ShaftHQ/SHAFT_ENGINE/commits/41cf8fb0ea5fd5c971b7123327870b37c87379dd`) found
+    # while measuring dewrap false positives against this repo's own merged-PR history:
+    # an independent, unrelated occurrence of the same shape, months after #3930 and by
+    # a different author, quoting PR #4068's disclaimer while explaining the #3930
+    # incident -- proof this is a recurring pattern in this repo, not a one-off. Its own
+    # subject line ("Fix #4101: ...") is a legitimate, unrelated close and must stay
+    # unflagged; only the quoted "does not\nclose #4046" is hazardous.
+    PR_4102_COMMIT_BODY = (
+        "Fix #4101: add concrete example that the disclaimer itself is the trap\n"
+        "\n"
+        "Orchestrator follow-up: the removed branch-naming claim obscured a\n"
+        "sharper point about the real mechanism. PR #4068's body said \"does not\n"
+        "close #4046\" while trying to explicitly NOT close it, and that phrase\n"
+        "is exactly what GitHub matched -- close #N ignores any preceding\n"
+        "negation. The existing \"later disclaimer doesn't neutralize an earlier\n"
+        "match\" line describes keyword-then-disclaimer ordering; it doesn't\n"
+        "cover the case where the disclaimer sentence IS the match. Add one\n"
+        "concrete example so a reader writing \"does not close #N\" to be safe\n"
+        "doesn't get bitten the same way twice.\n"
+    )
+
+    def test_real_pr_4102_commit_body_flags_only_the_quoted_hazard(self):
+        """A second, independent real occurrence of the same shape (found via the FP sweep, not #3930)."""
+        errors = find_negated_autocloses_in_commits(
+            [("41cf8fb0ea5fd5c971b7123327870b37c87379dd", self.PR_4102_COMMIT_BODY)]
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("#4046", errors[0]["message"])
+        self.assertNotIn("#4101", errors[0]["message"])
+
+    def test_multi_commit_branch_only_flags_the_offending_commit(self):
+        """A multi-commit branch must identify which commit is hazardous, not just that one is."""
+        commits = [
+            ("aaaaaaaaaaaa", "Add a helper method\n\nNo issues referenced here."),
+            ("bbbbbbbbbbbb", "This doesn't close #10 by itself.\n"),
+            ("cccccccccccc", "Refactor tests for clarity\n"),
+        ]
+        errors = find_negated_autocloses_in_commits(commits)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("bbbbbbbbbbbb", errors[0]["path"])
+        self.assertIn("#10", errors[0]["message"])
+
+    def test_commit_with_genuine_close_is_accepted(self):
+        self.assertEqual(
+            find_negated_autocloses_in_commits([("dddddddddddd", "Closes #20\n")]),
+            [],
+        )
+
+    def test_no_commits_is_accepted(self):
+        self.assertEqual(find_negated_autocloses_in_commits([]), [])
+
+
+class ParseCommitsJsonTest(unittest.TestCase):
+    def test_empty_string_yields_no_commits(self):
+        self.assertEqual(parse_commits_json(""), [])
+
+    def test_parses_sha_and_message_pairs(self):
+        raw = json.dumps(
+            [{"sha": "abc123", "message": "Fix bug\n"}, {"sha": "def456", "message": "Add test\n"}]
+        )
+        self.assertEqual(
+            parse_commits_json(raw),
+            [("abc123", "Fix bug\n"), ("def456", "Add test\n")],
+        )
+
+
+class MainCLIIntegrationTest(unittest.TestCase):
+    """Exercises the actual CLI entry point CI invokes: PR_BODY + PR_COMMITS_JSON env vars."""
+
+    def _run_cli(self, *, body="", commits_json=""):
+        env = {**os.environ, "PR_BODY": body, "PR_COMMITS_JSON": commits_json}
+        return subprocess.run(
+            [sys.executable, CLI_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=REPO_ROOT,
+        )
+
+    def test_cli_fails_and_identifies_commit_for_commit_only_hazard(self):
+        commits = json.dumps([{"sha": "1234567890ab", "message": "This doesn't close #77 yet."}])
+        result = self._run_cli(body="Closes #4127", commits_json=commits)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("#77", result.stderr)
+        self.assertIn("1234567890ab", result.stderr)
+
+    def test_cli_passes_when_body_and_commits_are_clean(self):
+        commits = json.dumps([{"sha": "1234567890ab", "message": "Add a helper.\n"}])
+        result = self._run_cli(body="Closes #4127", commits_json=commits)
+        self.assertEqual(result.returncode, 0)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_validate_pr_closing_keywords.py
+++ b/tests/scripts/test_validate_pr_closing_keywords.py
@@ -1,6 +1,9 @@
 import json
 import os
-import subprocess
+
+# subprocess is used only to invoke this repo's own CLI script below with a
+# fixed, list-args argv (never shell=True, no untrusted command construction).
+import subprocess  # nosec B404
 import sys
 import unittest
 
@@ -233,7 +236,7 @@ class MainCLIIntegrationTest(unittest.TestCase):
 
     def _run_cli(self, *, body="", commits_json=""):
         env = {**os.environ, "PR_BODY": body, "PR_COMMITS_JSON": commits_json}
-        return subprocess.run(
+        return subprocess.run(  # nosec B603
             [sys.executable, CLI_SCRIPT],
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

Started as two coverage gaps in the `pr-body-autoclose-guard` job added by #4144. Review caught a real hazard in the #4145 half before merge (see "Cut from this PR" below), so this PR now closes issue 4146 only; issue 4145 is being closed separately as an accepted limitation.

Closes #4146

## Issue 4146 -- commit messages are unguarded

GitHub's issue-closing keyword scanner reads commit messages pushed to the default branch, not only the PR body. Verified via issue 3930's timeline (`gh api repos/ShaftHQ/SHAFT_ENGINE/issues/3930/timeline`): its second auto-close carries a squash-merge commit SHA (`c0f82a611bbf5a93d81c4f7cdc3c56ac55069d8f`), while that PR's own body and `closingIssuesReferences` were clean. Corrected timeline for how that text reached `main` (an earlier telling of this involving an amend race was wrong): auto-merge was armed at 15:35:14Z on a single-commit branch; a force-push at 15:47:32Z **added** a second commit carrying the hazardous text; the merge at 15:48:09Z used that commit byte-for-byte. Only one version of it ever reached GitHub -- arming auto-merge does not freeze a PR against later pushes.

Fix: fetch the PR's commit messages via `gh api repos/{owner}/{repo}/pulls/{number}/commits` (not `git log` -- this job's checkout is shallow and unauthenticated for an arbitrary base..head range; the API reflects the current commit list even after a force-push, since a force-push is a `synchronize`) and scan each with the same `find_negated_autocloses` function already used for the body, unchanged, tagging the offending commit SHA in the failure output.

### A real bug found while wiring this up: hard-wrapped text defeats the shared detector

`find_negated_autocloses`'s clause-boundary logic treats every bare `\n` as a hard stop (by design, so an unrelated bullet's negation in a PR body can't leak into the next bullet). Git hard-wraps commit prose at ~72 columns using a single mid-sentence newline, and the actual commit behind the #3930 incident does exactly this: `"...matched \"fix #3930\" inside \"Does not\nfix #3930\"..."`. Reusing the detector unchanged against that real text scores **0 matches** -- confirmed empirically against the shipped `main` implementation before this PR. Flattening the same text to one line scores 1.

Fix: dewrap a single newline (never a blank-line `\n\n` paragraph break -- that's a deliberate line, not an accident of the regex) back into a space before scanning, applied once inside `find_negated_autocloses` so both the PR-body and commit-message paths share it.

### Measured, not assumed

The dewrap is the one change in this PR that can plausibly *create* false positives -- joining lines manufactures adjacency the author never wrote. Measured both surfaces against this repo's own history before shipping:

- **PR bodies** (50 most recently merged PRs, `gh pr list --state merged --limit 50`): dewrap OFF flags 3 (PR #4087, #4076, #4068 -- all genuine, spot-checked #4087's own heading, which pairs a negation with a closing verb directly next to issue 4005). Dewrap ON flags the same 3. **Zero new flags either way** -- unsurprising in hindsight, since bodies are written in a web textarea and mostly don't hard-wrap.
- **Commit messages** (all 71 commits across those same 50 PRs -- the surface that actually wraps, and the one this PR newly brings into scope): dewrap OFF flags 2. Dewrap ON flags 4. **Two new flags, zero false positives**:
  1. Commit `82b7d875` (PR #4141) -- the exact real commit behind the #3930 incident itself, recovered straight from the commits API.
  2. Commit `41cf8fb0` (PR #4102) -- an independent, unrelated second occurrence of the same shape: a different author, months later, quoting PR #4068's negated-close disclaimer about issue 4046 while explaining the #3930 incident. This is the more significant of the two findings -- it establishes that quoting the trap pattern inside a commit message is a *recurring* shape in this repository, not a one-off. Checked whether it caused visible harm: issue 4046's timeline shows both close events with `commit_id: null` (manual closes), so this one didn't fire -- but the hazardous text was sitting on `main` regardless.

Both new-flag commits are now regression tests (`test_real_pr_4141_commit_body_is_flagged`, `test_real_pr_4102_commit_body_flags_only_the_quoted_hazard`) using the exact byte-for-byte real commit text.

### No escape hatch, by design

There is deliberately no skip-token or opt-out marker for this guard, and none should be added later. The guard flags exactly the text forms GitHub itself acts on: if a form is allowed by the guard, GitHub does not close on it; if GitHub would close on it, no marker in our text can stop that, because GitHub never sees our marker. A skip token would let genuinely harmful text through while doing nothing about the closure. The only correct remedy is the one already in use: write the keyword and the number non-adjacently ("fix" ... "issue 3930").

## Cut from this PR: the `edited` trigger (issue #4145)

`pr-gate.yml`'s bare `on: pull_request:` uses the default activity types (`opened`, `synchronize`, `reopened`) -- `edited` is absent, so a body edited with no new commit is never re-scanned. That's real and confirmed live, not just in theory: a sibling PR's failing check did not re-run after its hazardous heading was reworded with zero new commits (the workaround used was `gh pr close` + `gh pr reopen`, which fires `reopened` and forces a full re-run).

This PR originally fixed it by adding `edited` to the trigger, gating every heavy leg off on that action (`&& github.event.action != 'edited'`, parenthesized correctly against `&&`/`||` precedence), and splitting the concurrency group so a bare edit wouldn't cancel an in-flight full run via `cancel-in-progress`. Review caught a hazard that design analysis missed: **that concurrency split creates two independent workflow runs for the same head SHA, each posting a check named "PR Gate Summary"**, which `gh api repos/ShaftHQ/SHAFT_ENGINE/rules/branches/main` confirms is the sole required check. Branch-protection evaluates the *most recently updated* check run of that name for a given SHA. So: a push starts a full run; someone edits the body two minutes in (real numbers from this PR's own run: `intellij-build` 5m50s, `capture-e2e` 4m33s, `unit-tests` 7m9s); the `edited` run's cheap legs post a green "PR Gate Summary" in under a minute; the required check now reads success while the heavy legs that actually test the pushed code are still running. With auto-merge armed -- standard practice here -- that merges untested code. This PR's own green CI could not reveal it, because no `edited` event fired during its own run.

**Decision: cut the `edited` work entirely.** `pr-gate.yml` is reverted to exactly what is on `main` today -- no trigger change, no per-leg gating, no concurrency-group split.

An alternative considered and rejected: keep `edited`, but gate the summary job to post only on guard failure. That trades the rare vacuous-pass for a common wedged PR -- an author who then fixes the body produces a run where the guard passes and the summary is skipped, leaving the earlier *failed* summary as most-recent, with no way to turn the check green short of a new commit.

The genuinely correct shape is a separate workflow posting its own, differently-named required check -- which needs its own branch-protection entry, a call for the repo owner, not something to fold into this PR. Issue 4145 is being closed as an accepted limitation, with `gh pr close` + `gh pr reopen` documented as the manual workaround for a stale-red check after a body edit.

## Out of scope, reported not fixed

While verifying live evidence for this PR, a third scanned surface surfaced: a PR title becomes the squash-merge commit's headline, so an honest-but-undelivered title like `Fix #N (partial): ...` reaches `main` unguarded. This is a materially different defect -- it carries no negation cue, so pointing the existing detector at title text catches nothing; it needs new logic entirely (cross-checking whether the PR/commits actually deliver what the title claims). Filed separately as #4154; not touched here.

## Codacy findings addressed

Advisory, not a required check, but two matched this repo's own recorded convention: `validate_pr_closing_keywords.py`'s `_dewrap_hard_wrapped_text` and `find_negated_autocloses_in_commits` had multi-line docstrings where the convention is a single-line docstring plus a `#` comment block underneath (matches `local_gate.py`, `run_sharded_and_merge.py`, `watch_pr_checks.py`). `tests/scripts/test_validate_pr_closing_keywords.py`'s `subprocess` import and call now carry the same `# nosec B404` / `# nosec B603` markers used consistently at `assemble_shard_blob.py:40`, `local_gate.py:79`, `run_sharded_and_merge.py:43`, `watch_pr_checks.py:54/109/147`.

## Verification

- `py -3 -m unittest discover -s tests/scripts -p "test_*.py"` -- 371 tests, all green.
- `py -3 scripts/ci/validate_agent_setup.py` -- valid.
- `py -3 scripts/ci/validate_workflow_timeouts.py` -- all jobs declare `timeout-minutes`.
- `py -3 scripts/ci/validate_orphaned_suite_files.py` -- clean.
- `git diff origin/main -- .github/workflows/pr-gate.yml` -- empty; the file is byte-identical to `main`.
- TDD throughout: every new function (`find_negated_autocloses_in_commits`, `parse_commits_json`, the shared dewrap) had a failing test first, watched red for the right reason, then minimal code, watched green.
- Guard run against this branch's own commit message and this PR body before opening.
