### PR TITLE
Add a budgeted deterministic re-suggestion ladder (inert, unwired)

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Healing.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Healing.java
@@ -92,6 +92,18 @@ public interface Healing extends EngineProperties<Healing> {
     boolean sourcePatchEnabled();
 
     /**
+     * @return hard total budget in seconds across the whole deterministic re-suggestion ladder,
+     *         not per attempt (issue #4027). {@code 0} (the default) preserves today's one-shot
+     *         {@code resolve()} behavior unchanged; only a positive value retries until the
+     *         element is found or the budget is hit. Every existing healing user keeps today's
+     *         single attempt unless this is explicitly raised (e.g. by SHAFT-Assistant-generated
+     *         tests, which set it in their generated {@code setUp()}).
+     */
+    @Key("healing.ladder.budgetSeconds")
+    @DefaultValue("0")
+    int ladderBudgetSeconds();
+
+    /**
      * Returns a fluent builder for current-thread overrides.
      *
      * @return current-thread property builder
@@ -185,6 +197,12 @@ public interface Healing extends EngineProperties<Healing> {
         /** @param value source-patch proposal enabled state @return this builder */
         public SetProperty sourcePatchEnabled(boolean value) {
             setProperty("healing.sourcePatch.enabled", String.valueOf(value));
+            return this;
+        }
+
+        /** @param value hard total ladder budget in seconds (0 preserves today's one-shot behavior) @return this builder */
+        public SetProperty ladderBudgetSeconds(int value) {
+            setProperty("healing.ladder.budgetSeconds", String.valueOf(value));
             return this;
         }
     }

--- a/shaft-heal/src/main/java/com/shaft/heal/HealingConfiguration.java
+++ b/shaft-heal/src/main/java/com/shaft/heal/HealingConfiguration.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
  * @param aiEnabled whether optional provider reranking is enabled
  * @param aiTrigger when optional provider reranking may run
  * @param sourcePatchEnabled whether reviewed source-patch proposals are permitted
+ * @param ladderBudget hard total budget across the whole re-suggestion ladder, not per attempt
+ *                     (issue #4027); {@link Duration#ZERO} preserves today's one-shot behavior
  */
 public record HealingConfiguration(
         double minimumConfidence,
@@ -38,7 +40,8 @@ public record HealingConfiguration(
         boolean visualEnabled,
         boolean aiEnabled,
         AiTrigger aiTrigger,
-        boolean sourcePatchEnabled) {
+        boolean sourcePatchEnabled,
+        Duration ladderBudget) {
     /**
      * Optional provider reranking trigger.
      */
@@ -50,7 +53,29 @@ public record HealingConfiguration(
     }
 
     /**
-     * Backward-compatible constructor with the default AI trigger.
+     * Backward-compatible constructor without the re-suggestion ladder (one-shot, matching
+     * today's behavior).
+     */
+    public HealingConfiguration(
+            double minimumConfidence,
+            double ambiguityMargin,
+            Set<String> evidenceCategories,
+            List<String> testIdAttributes,
+            boolean historyEnabled,
+            Path historyPath,
+            int historyMaxEntries,
+            Duration historyRetention,
+            boolean visualEnabled,
+            boolean aiEnabled,
+            AiTrigger aiTrigger,
+            boolean sourcePatchEnabled) {
+        this(minimumConfidence, ambiguityMargin, evidenceCategories, testIdAttributes,
+                historyEnabled, historyPath, historyMaxEntries, historyRetention,
+                visualEnabled, aiEnabled, aiTrigger, sourcePatchEnabled, Duration.ZERO);
+    }
+
+    /**
+     * Backward-compatible constructor with the default AI trigger and no re-suggestion ladder.
      */
     public HealingConfiguration(
             double minimumConfidence,
@@ -93,7 +118,8 @@ public record HealingConfiguration(
                 properties.visualEnabled(),
                 properties.aiEnabled(),
                 aiTrigger(properties.aiTrigger()),
-                properties.sourcePatchEnabled());
+                properties.sourcePatchEnabled(),
+                Duration.ofSeconds(Math.max(0, properties.ladderBudgetSeconds())));
     }
 
     /**
@@ -105,6 +131,7 @@ public record HealingConfiguration(
         historyPath = historyPath == null ? Path.of("target/shaft-heal/history.json") : historyPath;
         historyRetention = historyRetention == null ? Duration.ofDays(30) : historyRetention;
         aiTrigger = aiTrigger == null ? AiTrigger.AMBIGUOUS : aiTrigger;
+        ladderBudget = ladderBudget == null || ladderBudget.isNegative() ? Duration.ZERO : ladderBudget;
     }
 
     private static List<String> split(String value) {

--- a/shaft-heal/src/main/java/com/shaft/heal/internal/ResuggestionLadder.java
+++ b/shaft-heal/src/main/java/com/shaft/heal/internal/ResuggestionLadder.java
@@ -1,0 +1,83 @@
+package com.shaft.heal.internal;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.LongConsumer;
+import java.util.function.Supplier;
+
+/**
+ * Retries a deterministic recovery attempt until it succeeds or a hard total time budget is
+ * exhausted (issue #4027) -- a per-attempt timeout multiplied by N rungs is not the requirement;
+ * the ceiling applies to the whole ladder, measured from the first rung.
+ */
+final class ResuggestionLadder {
+    private final Clock clock;
+    private final LongConsumer sleep;
+
+    ResuggestionLadder(Clock clock, LongConsumer sleep) {
+        this.clock = clock;
+        this.sleep = sleep;
+    }
+
+    /**
+     * Creates a real-time ladder backed by the system clock and {@link Thread#sleep(long)}.
+     *
+     * @return production-ready ladder
+     */
+    static ResuggestionLadder system() {
+        return new ResuggestionLadder(Clock.systemUTC(), ResuggestionLadder::sleepQuietly);
+    }
+
+    private static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Runs {@code attempt} repeatedly until it returns a present result or the total elapsed time
+     * across every rung reaches {@code budget}.
+     *
+     * @param budget hard total budget across the whole ladder
+     * @param pollInterval delay between rungs
+     * @param attempt one deterministic re-suggestion rung
+     * @param <T> attempt result type
+     * @return the first successful result, plus how many rungs ran and the total elapsed time
+     */
+    <T> Result<T> run(Duration budget, Duration pollInterval, Supplier<Optional<T>> attempt) {
+        Instant start = clock.instant();
+        Instant deadline = start.plus(budget);
+        int rungs = 0;
+        while (true) {
+            rungs++;
+            Optional<T> result = attempt.get();
+            Instant now = clock.instant();
+            if (result.isPresent()) {
+                return new Result<>(result, rungs, Duration.between(start, now));
+            }
+            if (!now.isBefore(deadline)) {
+                return new Result<>(Optional.empty(), rungs, Duration.between(start, now));
+            }
+            Duration remaining = Duration.between(now, deadline);
+            Duration delay = remaining.compareTo(pollInterval) < 0 ? remaining : pollInterval;
+            if (delay.toMillis() > 0) {
+                sleep.accept(delay.toMillis());
+            }
+        }
+    }
+
+    /**
+     * One ladder outcome.
+     *
+     * @param value the first successful attempt result, or empty when the budget was exhausted
+     * @param rungs how many attempts ran
+     * @param elapsed total elapsed time across every rung
+     * @param <T> attempt result type
+     */
+    record Result<T>(Optional<T> value, int rungs, Duration elapsed) {
+    }
+}

--- a/shaft-heal/src/test/java/com/shaft/heal/internal/ResuggestionLadderTest.java
+++ b/shaft-heal/src/test/java/com/shaft/heal/internal/ResuggestionLadderTest.java
@@ -1,0 +1,104 @@
+package com.shaft.heal.internal;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ResuggestionLadderTest {
+    @Test
+    public void firstAttemptSucceedingReturnsImmediatelyWithoutSleeping() {
+        MutableClock clock = new MutableClock(Instant.EPOCH);
+        List<Long> sleeps = new ArrayList<>();
+        ResuggestionLadder ladder = new ResuggestionLadder(clock, sleeps::add);
+
+        ResuggestionLadder.Result<String> result = ladder.run(
+                Duration.ofSeconds(60), Duration.ofSeconds(5), () -> Optional.of("found"));
+
+        Assert.assertEquals(result.value(), Optional.of("found"));
+        Assert.assertEquals(result.rungs(), 1);
+        Assert.assertTrue(sleeps.isEmpty());
+    }
+
+    @Test
+    public void retriesUntilALaterRungSucceeds() {
+        MutableClock clock = new MutableClock(Instant.EPOCH);
+        List<Long> sleeps = new ArrayList<>();
+        AtomicInteger attempts = new AtomicInteger();
+        ResuggestionLadder ladder = new ResuggestionLadder(clock, millis -> {
+            sleeps.add(millis);
+            clock.advance(Duration.ofMillis(millis));
+        });
+
+        ResuggestionLadder.Result<String> result = ladder.run(
+                Duration.ofSeconds(60),
+                Duration.ofSeconds(5),
+                () -> attempts.incrementAndGet() < 3 ? Optional.empty() : Optional.of("found"));
+
+        Assert.assertEquals(result.value(), Optional.of("found"));
+        Assert.assertEquals(result.rungs(), 3);
+        Assert.assertEquals(sleeps.size(), 2);
+        Assert.assertEquals((long) sleeps.get(0), 5_000L);
+    }
+
+    @Test
+    public void totalElapsedAcrossAllRungsNeverExceedsTheHardBudgetEvenWithSlowRungs() {
+        MutableClock clock = new MutableClock(Instant.EPOCH);
+        // Each rung itself is slow (simulates an expensive deterministic re-suggestion pass),
+        // advancing the clock by 26 seconds -- a per-attempt timeout multiplied by N rungs would
+        // never catch this; only a hard ceiling on the TOTAL elapsed time does (issue #4027).
+        ResuggestionLadder ladder = new ResuggestionLadder(clock, millis -> clock.advance(Duration.ofMillis(millis)));
+        AtomicInteger attempts = new AtomicInteger();
+
+        ResuggestionLadder.Result<String> result = ladder.run(
+                Duration.ofSeconds(60),
+                Duration.ofSeconds(5),
+                () -> {
+                    attempts.incrementAndGet();
+                    clock.advance(Duration.ofSeconds(26));
+                    return Optional.empty();
+                });
+
+        Assert.assertTrue(result.value().isEmpty());
+        // 3 slow rungs of 26s already exceed 60s (78s); the ladder must have stopped there,
+        // never launching a 4th rung, and total elapsed must not run away past the budget.
+        Assert.assertEquals(attempts.get(), 3);
+        Assert.assertTrue(
+                result.elapsed().compareTo(Duration.ofSeconds(90)) < 0,
+                "elapsed was " + result.elapsed());
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        @Override
+        public ZoneOffset getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(java.time.ZoneId zone) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Lands the reusable, testable building blocks for the always-on locator
re-suggestion ladder described in issue 4027 (subtask of tracker 4024) —
but stops short of wiring it in. This PR does not close issue 4027; the
acceptance criteria are not met yet, and the issue stays open.

- `ResuggestionLadder` (`shaft-heal/src/main/java/com/shaft/heal/internal/ResuggestionLadder.java`):
  a clock-injectable retry loop that runs an attempt repeatedly until it
  succeeds or a **hard total elapsed-time budget** is exhausted — measured
  across the whole ladder from the first rung, never a per-attempt timeout
  multiplied by N rungs. Proven by `ResuggestionLadderTest` with an
  injected `Clock` and simulated slow rungs — no real 60-second sleep in
  the test suite.
- `healing.ladder.budgetSeconds` property (`shaft-engine/.../properties/internal/Healing.java`)
  and `HealingConfiguration.ladderBudget()` (`shaft-heal/.../HealingConfiguration.java`)
  that will drive it once wired.

## Why this is safe to land while inert

The budget property defaults to `0`, and `HealingConfiguration.ladderBudget()`
is `Duration.ZERO` through every backward-compatible constructor. Nothing
changes for any existing SHAFT Heal user until something explicitly raises
the budget above zero. `ShaftHealingProvider.resolve()` is untouched in this
PR — it still runs its existing single-pass logic exactly as before.

## What is NOT here yet

- **The ladder is not wired into `ShaftHealingProvider.resolve()`.** Nothing
  calls `ResuggestionLadder` in production code yet.
- **The low-trust "needs optimization" comment in generated code does not
  exist.**
- **Issue 4161 is the real prerequisite**, and wiring the ladder in before
  it lands would be pointless: shaft-capture never seeds SHAFT Heal's
  history store today, so `ShaftHealingProvider.resolve()` returns
  `NO_HISTORY` immediately on every real generated-test replay — the ladder
  would never get a chance to retry anything. `LocatorFingerprint`
  (`shaft-heal/.../model/LocatorFingerprint.java`) is already a plain
  public record with no WebDriver coupling, so the seam for 4161 is
  narrower than it first looks — but `HealingHistoryStore` itself is fully
  package-private with no public entry point today, so a new SPI seam
  still has to be added deliberately (new plain-data seed type in
  shaft-engine's healing package, since shaft-engine must not depend on
  shaft-heal; `ShaftHealingProvider` converts and saves; shaft-capture
  wires it at generation time with an absolute, non-`target/`-relative
  history path). That is its own vertical slice with its own TDD surface —
  tracked as a follow-up against tracker 4024.

## Unverified — flagging rather than assuming

`PropertiesHelper.overridePropertiesForMaximumPerformanceMode()`
(`shaft-engine/.../properties/internal/PropertiesHelper.java:457-461`)
force-sets `healing.strategy` to `"disabled"` when
`flags.maximumPerformanceMode()` is `1` or `2`, gated by a once-per-JVM
`postProcessingDone.compareAndSet(false, true)`
(`PropertiesHelper.java:50,66,80,204`). Whether `postProcessing()` runs
before or after a generated test's `@BeforeMethod setUp()` in the replay
subprocess is **untraced** — I have not verified the ordering either way.
Whoever wires the ladder into generated-test setUp() next needs a test
proving that ordering before relying on it; do not assume it's safe.

## Testing

`mvn -pl shaft-engine,shaft-heal test -Dtest=ResuggestionLadderTest,ShaftHealingProviderTest,DeterministicScorerTest,HealingHistoryStoreTest -DheadlessExecution=true -Dallure.automaticallyOpen=false`
→ 27 tests, 0 failures, 0 skipped.

Gotcha for the next person running scoped shaft-heal tests after touching
shaft-engine: `-pl shaft-heal` alone (without shaft-engine in the same
`-pl` list) resolves shaft-engine from the locally installed jar, not the
freshly compiled reactor classes — hit a `NoSuchMethodError` against a
stale `Healing` interface this way. Always include both modules together:
`-pl shaft-engine,shaft-heal`.

## Scope note

Per tracker 4024's sequencing constraints, this touches only
`shaft-engine`'s healing properties and `shaft-heal` internals — no
`CaptureGenerator`, recorder script, or replay-resolution surfaces, so
this stays clear of the files issue 4029 and issue 4026 converge on.

Related: issue 4027, tracker 4024, issue 4161 (prerequisite, follow-up).