### PR TITLE
IntelliJ plugin: setup panel greeting no longer contradicts Done badge on reopen

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -76,6 +76,13 @@ final class ShaftMcpSetupPanel extends JPanel {
             "Next: pick your agent, then press Install SHAFT MCP -- this opens a terminal with the MCP+skills+CLI "
                     + "install command ready to go; run it there, then press Check.";
     private static final String CHECK_NEXT_STEP = "Press Check now.";
+    // Issue #4160 area A: a returning user reopening the panel in a new IDE session after setup
+    // already succeeded sees "4 Check setup: Done" (settings.mcpSetupComplete persists) alongside
+    // steps 1-3, which always reset to neutral on a fresh landing (issue #3426 A4/A5, #3560) --
+    // CHECK_NEXT_STEP's "Press Check now." reads as if nothing had ever been verified, contradicting
+    // the Done badge right above it. This greeting acknowledges the prior success instead.
+    private static final String ALREADY_VERIFIED_STEP =
+            "SHAFT MCP was verified in a previous session. Press Check to re-verify now.";
     private static final String GEMINI_FAMILY = "GEMINI";
     private static final String GEMINI_KEY_NAME = "GEMINI_API_KEY";
     /** Client-property key {@link #stepRow} stashes its action component under, so the row-collapse
@@ -763,7 +770,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         refreshPrerequisites();
         refreshRealChecks();
         if (!currentCommand().isBlank()) {
-            setStatusText(CHECK_NEXT_STEP);
+            setStatusText(settings.mcpSetupComplete ? ALREADY_VERIFIED_STEP : CHECK_NEXT_STEP);
         }
         updateActionState(false);
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1296,6 +1296,20 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void setupPanelReopeningAfterPriorCompletionDoesNotContradictTheDoneBadge() {
+        // Issue #4160 area A: reopening the panel in a new IDE session after setup previously
+        // succeeded (settings.mcpSetupComplete persists) shows "4 Check setup: Done" immediately --
+        // but until now the greeting text always said "Press Check now.", as if nothing had ever
+        // been verified. A returning user reading "Done" and "Press Check now." side by side has no
+        // way to tell whether setup actually works; the guidance must acknowledge the prior success.
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), connectedMcpSettings(), () -> {
+        });
+        JLabel nextStep = findByAccessibleName(panel, "SHAFT MCP setup next step", JLabel.class);
+        assertNotEquals("Press Check now.", nextStep.getText(),
+                "greeting text must not contradict the already-Done Check-setup badge");
+    }
+
+    @Test
     void setupPanelUpgradeStepReflectsRealProjectVersionCheck() throws Exception {
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
         });


### PR DESCRIPTION
## Summary

Area A audit of tracker #4160 (IntelliJ plugin initial setup/onboarding polish, no new features).

Audited the real first-run/setup surface (`ShaftMcpSetupPanel`, `SetupPrerequisites`, `ShaftProjectDetector`) by exercising it through the plugin screenshot renderer across every documented state: fresh landing, Gemini family, narrow/dark, success, error, MCP-version-offline, and post-setup reopen. Most of this area has already been through many rounds of dedicated UX hardening (issues #3396, #3425-3427, #3538, #3540, #3546-3552, #3560, #3601-3605, #3696, #3768, all closed) and held up well.

One genuine, reachable defect found and fixed:

- **Reopening the setup panel after a previously-completed setup showed a contradictory greeting.** `ShaftMcpSetupPanel`'s constructor always set the status line to `"Press Check now."` whenever a command was configured, regardless of `settings.mcpSetupComplete`. A returning user opening the tool window in a new IDE session (the everyday "I set this up yesterday, opened the IDE today" flow) saw "4 Check setup: **Done**" (green) directly above guidance implying nothing had ever been verified — no way to tell which signal to trust. `shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java:75-82,773` now shows an acknowledging message ("SHAFT MCP was verified in a previous session. Press Check to re-verify now.") when reopening with a persisted-complete setup, while leaving the deliberate "steps 1-3 always reset to neutral on a fresh landing" design (issues #3426 A4/A5, #3560) untouched.

## Evidence

- Regression test (TDD, watched red then green): `shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java:1298` (`setupPanelReopeningAfterPriorCompletionDoesNotContradictTheDoneBadge`).
- Full `ShaftPanelSetupTest` suite green after the fix (no regressions across the ~6000-line setup panel test class).
- Rendered before/after evidence via `ShaftPluginScreenshotRendererTest -Dshaft.intellij.screenshotDir=...` (`intellij-plugin-mcp-setup-post-setup.png`): before showed "Done" + "Press Check now." side by side; after shows "Done" + "SHAFT MCP was verified in a previous session. Press Check to re-verify now."

## Audit findings not acted on

- A cosmetic-only gap: clicking "Recheck" (prerequisites row) doesn't re-run `collapseStepsBehindProgress`, so a just-fixed prerequisite stays visually expanded (still accurate, just not auto-collapsed) until the next unrelated action. Self-corrects on the next interaction; not filed as a ticket (too minor to be worth its own tracking issue, noted here for the record per tracker #4160's method).
- No other open GitHub issues reference `shaft-intellij` setup/onboarding defects at time of audit; searched before starting to avoid duplication.

## Test plan

- [x] `gradlew test --tests com.shaft.intellij.ui.ShaftPanelSetupTest.setupPanelReopeningAfterPriorCompletionDoesNotContradictTheDoneBadge` (watched RED then GREEN)
- [x] `gradlew test --tests com.shaft.intellij.ui.ShaftPanelSetupTest` (full class, green)
- [x] `gradlew test --tests com.shaft.intellij.ui.ShaftToolWindowPanelTest --tests com.shaft.intellij.settings.ShaftSettingsConfigurableTest` (neighboring tests, green)
- [x] `gradlew test --tests com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest -Dshaft.intellij.screenshotDir=...` (rendered evidence regenerated, all assertions green)

Relates to tracker #4160 (area A). No new features; no other in-scope defects found worth fixing beyond this one after a thorough audit.