### PR TITLE
Fix AssistantLocalAgentRunner stream reader discarding buffered output on IOException

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -378,8 +379,8 @@ final class AssistantLocalAgentRunner {
         try {
             Process process = processLauncher.launch(command, Path.of("."), Map.of());
             process.getOutputStream().close();
-            CompletableFuture<String> stdout = readAsync(process.getInputStream(), null);
-            CompletableFuture<String> stderr = readAsync(process.getErrorStream(), null);
+            StreamRead stdout = readAsync(process.getInputStream(), null);
+            StreamRead stderr = readAsync(process.getErrorStream(), null);
             if (!process.waitFor(MCP_ACCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 process.destroyForcibly();
                 return ShaftMcpToolResult.success(displayName
@@ -589,8 +590,8 @@ final class AssistantLocalAgentRunner {
                 InputStream stdoutStream = process.getInputStream();
                 InputStream stderrStream = process.getErrorStream();
                 stdinStream = process.getOutputStream();
-                CompletableFuture<String> stdout = readAsync(stdoutStream, effectiveConsumer);
-                CompletableFuture<String> stderr = readAsync(stderrStream, effectiveConsumer);
+                StreamRead stdout = readAsync(stdoutStream, effectiveConsumer);
+                StreamRead stderr = readAsync(stderrStream, effectiveConsumer);
                 stdinStream.write(stdin.getBytes(StandardCharsets.UTF_8));
                 // Every local CLI is launched with plain text input (no CLI here supports a stream-json
                 // *input* protocol yet), so each one reads its prompt from stdin until EOF before doing
@@ -1221,8 +1222,8 @@ final class AssistantLocalAgentRunner {
         try {
             Process process = processLauncher.launch(command, workingDirectory, Map.of());
             process.getOutputStream().close();
-            CompletableFuture<String> stdout = readAsync(process.getInputStream(), null);
-            CompletableFuture<String> stderr = readAsync(process.getErrorStream(), null);
+            StreamRead stdout = readAsync(process.getInputStream(), null);
+            StreamRead stderr = readAsync(process.getErrorStream(), null);
             boolean finished = process.waitFor(MODEL_LIST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
@@ -1350,8 +1351,8 @@ final class AssistantLocalAgentRunner {
         try {
             Process process = processLauncher.launch(command, workingDirectory, Map.of());
             process.getOutputStream().close();
-            CompletableFuture<String> stdout = readAsync(process.getInputStream(), null);
-            CompletableFuture<String> stderr = readAsync(process.getErrorStream(), null);
+            StreamRead stdout = readAsync(process.getInputStream(), null);
+            StreamRead stderr = readAsync(process.getErrorStream(), null);
             boolean finished = process.waitFor(COMPACT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
@@ -1721,9 +1722,23 @@ final class AssistantLocalAgentRunner {
         return String.join("\n\n", sections).trim();
     }
 
-    private static CompletableFuture<String> readAsync(InputStream stream, Consumer<String> outputConsumer) {
-        return CompletableFuture.supplyAsync(() -> {
-            StringBuilder output = new StringBuilder();
+    /**
+     * Pairs a background stream-read's eventual {@link #future} with a live {@link #capturedSoFar}
+     * view of whatever has been buffered up to any given moment. A {@code CompletableFuture} only
+     * ever yields a value once it completes, so a caller that gives up waiting on it (a timeout, or
+     * any other exception) has no way to recover partial progress from the future alone; {@code
+     * capturedSoFar} reads the same underlying (synchronized) buffer the reader thread is still
+     * writing to, so it is safe to consult at any time, whether or not the future has finished
+     * (issue #4164 follow-up: {@code stdoutNow}/{@code stderrNow} used to discard this on any
+     * exception, including a plain timeout, exactly like {@link #readAsync}'s own now-fixed
+     * IOException discard).
+     */
+    private record StreamRead(CompletableFuture<String> future, Supplier<String> capturedSoFar) {
+    }
+
+    private static StreamRead readAsync(InputStream stream, Consumer<String> outputConsumer) {
+        StringBuffer output = new StringBuffer();
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
             try {
                 try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
                     String line;
@@ -1741,18 +1756,24 @@ final class AssistantLocalAgentRunner {
             }
             return output.toString();
         }, ShaftPluginExecutor.getInstance().executor());
+        return new StreamRead(future, output::toString);
     }
 
-    private static String stdoutNow(CompletableFuture<String> future) {
+    private static String stdoutNow(StreamRead read) {
         try {
-            return future.get(2, TimeUnit.SECONDS);
+            return read.future().get(2, TimeUnit.SECONDS);
         } catch (Exception exception) {
-            return "";
+            // Issue #4164: the process has already terminated by every caller of this method, so a
+            // read that is still incomplete at this point is slow, not silent (a timeout is the case
+            // that matters most here) -- or failed for an unrelated reason (e.g. a throwing
+            // outputConsumer). Either way, fall back to whatever the buffer already holds instead of
+            // blanking it to "".
+            return read.capturedSoFar().get();
         }
     }
 
-    private static String stderrNow(CompletableFuture<String> future) {
-        return stdoutNow(future);
+    private static String stderrNow(StreamRead read) {
+        return stdoutNow(read);
     }
 
     private static void closeQuietly(InputStream stream) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -1735,7 +1735,9 @@ final class AssistantLocalAgentRunner {
                     }
                 }
             } catch (IOException exception) {
-                return "";
+                // Issue #4164: a torn-down pipe (e.g. destroyForcibly() during a Kill) must not discard
+                // whatever was already read and streamed to outputConsumer -- return the partial buffer
+                // instead of blanking it.
             }
             return output.toString();
         }, ShaftPluginExecutor.getInstance().executor());

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerStreamReadResilienceTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerStreamReadResilienceTest.java
@@ -1,0 +1,130 @@
+package com.shaft.intellij.ui;
+
+import com.shaft.intellij.mcp.ShaftMcpInvocation;
+import com.shaft.intellij.mcp.ShaftMcpToolResult;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for issue #4164: {@code AssistantLocalAgentRunner.readAsync} used to discard
+ * every line already buffered from a process's stdout/stderr when the underlying stream threw
+ * {@link IOException} partway through (e.g. a pipe torn down abruptly), resolving to an empty
+ * string instead of the content genuinely captured so far. A code-path-distinct sibling of issue
+ * #3962's discard class (that one is {@code Future}-cancellation ordering; this one is a plain
+ * stream-read exception with no cancellation involved).
+ */
+class AssistantLocalAgentRunnerStreamReadResilienceTest {
+
+    @Test
+    void alreadyBufferedStdoutSurvivesAnIOExceptionPartwayThroughTheStream() throws Exception {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Explain this failure", "CODEX", "ASK", ".", "stub-agent --print", false);
+        StubProcess process = StubProcess.stdoutThrowingAfterLines("line one", "line two");
+
+        ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
+                invocation, line -> { }, (command, workingDirectory, environment) -> process);
+        ShaftMcpToolResult result = running.future().get(5, TimeUnit.SECONDS);
+
+        assertTrue(result.success(), result.output());
+        assertTrue(result.output().contains("line one"),
+                "Already-buffered stdout must survive a mid-stream IOException: " + result.output());
+        assertTrue(result.output().contains("line two"),
+                "Already-buffered stdout must survive a mid-stream IOException: " + result.output());
+    }
+
+    /**
+     * Minimal stub {@link Process} whose stdout yields a handful of complete lines and then throws
+     * {@link IOException} instead of reaching EOF, simulating a stream torn down mid-read. Mirrors
+     * the proven {@code StubProcess} pattern in {@code AssistantLocalAgentRunnerCommandTest}.
+     */
+    private static final class StubProcess extends Process {
+        private final InputStream stdout;
+
+        private StubProcess(InputStream stdout) {
+            this.stdout = stdout;
+        }
+
+        static StubProcess stdoutThrowingAfterLines(String... lines) {
+            return new StubProcess(new ThrowingAfterLinesInputStream(lines));
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return new ByteArrayOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return stdout;
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public int waitFor() {
+            return 0;
+        }
+
+        @Override
+        public boolean waitFor(long timeout, TimeUnit unit) {
+            return true;
+        }
+
+        @Override
+        public int exitValue() {
+            return 0;
+        }
+
+        @Override
+        public void destroy() {
+            // Not exercised: this stub always reports a prompt, successful exit.
+        }
+
+        @Override
+        public Process destroyForcibly() {
+            return this;
+        }
+
+        @Override
+        public boolean isAlive() {
+            return false;
+        }
+    }
+
+    /**
+     * Yields the given lines (newline-terminated) and then throws {@link IOException} on the next
+     * read attempt instead of signalling clean EOF (-1), simulating a pipe torn down mid-stream.
+     */
+    private static final class ThrowingAfterLinesInputStream extends InputStream {
+        private final byte[] bytes;
+        private int position;
+
+        ThrowingAfterLinesInputStream(String... lines) {
+            StringBuilder builder = new StringBuilder();
+            for (String line : lines) {
+                builder.append(line).append('\n');
+            }
+            this.bytes = builder.toString().getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (position >= bytes.length) {
+                throw new IOException("Simulated pipe teardown after buffered lines");
+            }
+            return bytes[position++] & 0xFF;
+        }
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerStreamReadResilienceTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerStreamReadResilienceTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,6 +43,63 @@ class AssistantLocalAgentRunnerStreamReadResilienceTest {
     }
 
     /**
+     * Sibling defect in the same file, same investigation (issue #4164 follow-up): {@code
+     * stdoutNow}/{@code stderrNow} returned {@code ""} on <em>any</em> exception from {@code
+     * future.get(2, TimeUnit.SECONDS)} -- including a plain {@link java.util.concurrent.TimeoutException}
+     * -- discarding whatever the background reader thread had already captured. The process has
+     * already terminated by every caller of these methods (this stub reports a prompt, successful
+     * exit), so a still-incomplete read at the 2-second mark means the drain is slow, not silent;
+     * its buffered content is exactly what a user needs to see when something hangs.
+     */
+    @Test
+    void alreadyBufferedStdoutSurvivesWhenTheDrainReadIsStillRunningPastTheGraceWindow() throws Exception {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Explain this failure", "CODEX", "ASK", ".", "stub-agent --print", false);
+        StubProcess process = StubProcess.stdoutBlockingAfterOneLine(
+                "buffered before the drain stalled", 5000);
+
+        long startNanos = System.nanoTime();
+        ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
+                invocation, line -> { }, (command, workingDirectory, environment) -> process);
+        ShaftMcpToolResult result = running.future().get(8, TimeUnit.SECONDS);
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+        assertTrue(elapsedMillis < 4500,
+                "The result must arrive via stdoutNow's own 2-second grace window timing out, not by "
+                        + "waiting out the simulated 5-second stall: took " + elapsedMillis + "ms");
+        assertTrue(result.success(), result.output());
+        assertTrue(result.output().contains("buffered before the drain stalled"),
+                "Buffered stdout must survive stdoutNow's own get() timing out while the background "
+                        + "read is still running: " + result.output());
+    }
+
+    /**
+     * Same defect, a different triggering path: the read future can also complete <em>exceptionally</em>
+     * for a reason that has nothing to do with a timeout (here, the caller-supplied live
+     * {@code outputConsumer} itself throws) -- {@code stdoutNow}'s old blanket {@code catch (Exception)}
+     * discarded the buffer in this case too. The already-buffered line is appended before the consumer
+     * is invoked (see {@code readAsync}), so it must survive regardless of what the consumer does.
+     */
+    @Test
+    void alreadyBufferedStdoutSurvivesWhenTheReadFutureCompletesExceptionallyForAnUnrelatedReason()
+            throws Exception {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Explain this failure", "CODEX", "ASK", ".", "stub-agent --print", false);
+        StubProcess process = StubProcess.stdoutThrowingAfterLines("captured before the consumer failed");
+        Consumer<String> throwingConsumer = line -> {
+            throw new IllegalStateException("consumer boom");
+        };
+
+        ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
+                invocation, throwingConsumer, (command, workingDirectory, environment) -> process);
+        ShaftMcpToolResult result = running.future().get(5, TimeUnit.SECONDS);
+
+        assertTrue(result.output().contains("captured before the consumer failed"),
+                "Buffered stdout must survive the read future completing exceptionally for a non-timeout "
+                        + "reason: " + result.output());
+    }
+
+    /**
      * Minimal stub {@link Process} whose stdout yields a handful of complete lines and then throws
      * {@link IOException} instead of reaching EOF, simulating a stream torn down mid-read. Mirrors
      * the proven {@code StubProcess} pattern in {@code AssistantLocalAgentRunnerCommandTest}.
@@ -55,6 +113,10 @@ class AssistantLocalAgentRunnerStreamReadResilienceTest {
 
         static StubProcess stdoutThrowingAfterLines(String... lines) {
             return new StubProcess(new ThrowingAfterLinesInputStream(lines));
+        }
+
+        static StubProcess stdoutBlockingAfterOneLine(String line, long blockMillis) {
+            return new StubProcess(new BlockingAfterLineInputStream(line, blockMillis));
         }
 
         @Override
@@ -125,6 +187,54 @@ class AssistantLocalAgentRunnerStreamReadResilienceTest {
                 throw new IOException("Simulated pipe teardown after buffered lines");
             }
             return bytes[position++] & 0xFF;
+        }
+    }
+
+    /**
+     * Yields one newline-terminated line in its very first bulk read, then blocks for {@code
+     * blockMillis} on the next read before signalling clean EOF -- simulating a background reader
+     * thread whose drain is still genuinely in flight when a caller's short grace-period wait gives
+     * up on it. Overrides the bulk {@link #read(byte[], int, int)} directly (rather than relying on
+     * {@link InputStream}'s default single-byte-at-a-time loop) so the line's bytes are handed back
+     * in one fill -- otherwise the default loop would keep calling {@link #read()} within the very
+     * same bulk read and block before ever returning the line to {@code BufferedReader.readLine()}.
+     */
+    private static final class BlockingAfterLineInputStream extends InputStream {
+        private final byte[] bytes;
+        private final long blockMillis;
+        private boolean lineDelivered;
+        private boolean blocked;
+
+        BlockingAfterLineInputStream(String line, long blockMillis) {
+            this.bytes = (line + "\n").getBytes(StandardCharsets.UTF_8);
+            this.blockMillis = blockMillis;
+        }
+
+        @Override
+        public synchronized int read() throws IOException {
+            byte[] single = new byte[1];
+            int read = read(single, 0, 1);
+            return read == -1 ? -1 : single[0] & 0xFF;
+        }
+
+        @Override
+        public synchronized int read(byte[] b, int off, int len) throws IOException {
+            if (!lineDelivered) {
+                lineDelivered = true;
+                int length = Math.min(len, bytes.length);
+                System.arraycopy(bytes, 0, b, off, length);
+                return length;
+            }
+            if (!blocked) {
+                blocked = true;
+                try {
+                    Thread.sleep(blockMillis);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while simulating a stalled drain", interrupted);
+                }
+            }
+            return -1;
         }
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -155,6 +155,8 @@ class ShaftPluginScreenshotRendererTest {
         Path assistantProgressMilestonesScreenshot = outputPath.resolve("intellij-plugin-assistant-progress-milestones.png");
         Path assistantFailureRecoveryCardScreenshot = outputPath.resolve("intellij-plugin-assistant-failure-recovery-card.png");
         Path assistantToolResultRawOutputScreenshot = outputPath.resolve("intellij-plugin-assistant-tool-result-raw-output.png");
+        Path assistantCancelledScreenshot = outputPath.resolve("intellij-plugin-assistant-cancelled.png");
+        Path assistantKilledScreenshot = outputPath.resolve("intellij-plugin-assistant-killed.png");
         Path assistantApprovalPromptScreenshot = outputPath.resolve("intellij-plugin-assistant-approval-prompt.png");
         Path assistantModelFallbackScreenshot = outputPath.resolve("intellij-plugin-assistant-model-fallback.png");
         Path assistantSlashCommandsScreenshot = outputPath.resolve("intellij-plugin-assistant-slash-commands.png");
@@ -194,6 +196,8 @@ class ShaftPluginScreenshotRendererTest {
         write(assistantProgressMilestonesScreenshot, renderAssistantProgressMilestones(LIGHT_THEME, false));
         write(assistantFailureRecoveryCardScreenshot, renderAssistantFailureRecoveryCard(LIGHT_THEME, false));
         write(assistantToolResultRawOutputScreenshot, renderAssistantToolResultRawOutput(LIGHT_THEME, false));
+        write(assistantCancelledScreenshot, renderAssistantCancelled(LIGHT_THEME, false));
+        write(assistantKilledScreenshot, renderAssistantKilled(LIGHT_THEME, false));
         write(assistantApprovalPromptScreenshot, renderApprovalPrompt(LIGHT_THEME, false));
         write(assistantModelFallbackScreenshot, renderAssistantModelFallback(LIGHT_THEME, false));
         write(assistantSlashCommandsScreenshot, renderAssistantSlashCommands(LIGHT_THEME, false));
@@ -234,6 +238,8 @@ class ShaftPluginScreenshotRendererTest {
                         assistantProgressMilestonesScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantFailureRecoveryCardScreenshot) > 0,
                         assistantFailureRecoveryCardScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantCancelledScreenshot) > 0, assistantCancelledScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantKilledScreenshot) > 0, assistantKilledScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantApprovalPromptScreenshot) > 0, assistantApprovalPromptScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantModelFallbackScreenshot) > 0, assistantModelFallbackScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantSlashCommandsScreenshot) > 0, assistantSlashCommandsScreenshot + " should be non-empty"),
@@ -271,6 +277,8 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertDimensions(assistantLiveDarkScreenshot),
                 () -> assertDimensions(assistantProgressMilestonesScreenshot),
                 () -> assertDimensions(assistantFailureRecoveryCardScreenshot),
+                () -> assertDimensions(assistantCancelledScreenshot),
+                () -> assertDimensions(assistantKilledScreenshot),
                 () -> assertDimensions(assistantApprovalPromptScreenshot),
                 () -> assertDimensions(assistantModelFallbackScreenshot),
                 () -> assertDimensions(toolsHumanizedDoctorCardScreenshot),
@@ -706,6 +714,52 @@ class ShaftPluginScreenshotRendererTest {
             SwingUtilities.updateComponentTreeUI(component);
             component.doLayout();
             clickAccessible(component, "Show raw output");
+            layout(component, !dark);
+            image.set(render(component, WIDTH, HEIGHT));
+        });
+        return image.get();
+    }
+
+    /**
+     * Renders the terminal "Cancelled" chat bubble (tracker #4160 Area B audit / issue #4164: the
+     * screenshot-evidence suite had zero rendered coverage of either terminal Cancel/Kill state).
+     * Mirrors exactly how {@code ShaftAssistantPanel#showAgentCancelled} composes the bubble in
+     * production: the already-streamed partial output wrapped in the same fenced-code-block format
+     * {@code formatLocalAgentStreamingResponse} produces, followed by the terminal marker -- proving
+     * a user-cancelled run stays legible instead of going blank.
+     */
+    private static BufferedImage renderAssistantCancelled(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        return renderAssistantTerminalState(lookAndFeelClassName, dark, "Cancelled");
+    }
+
+    /**
+     * Same composition as {@link #renderAssistantCancelled}, for the user-initiated Kill
+     * ({@code destroyForcibly()}) path -- distinct label, identical layout.
+     */
+    private static BufferedImage renderAssistantKilled(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        return renderAssistantTerminalState(lookAndFeelClassName, dark, "Killed");
+    }
+
+    private static BufferedImage renderAssistantTerminalState(String lookAndFeelClassName, boolean dark, String label)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+            chatState.append("user", "/codegen recordings/demo-recording.json", "");
+            ShaftSettingsState.Settings settings = defaultSettings();
+            ShaftAssistantPanel component = new ShaftAssistantPanel(screenshotProject(), settings, chatState,
+                    () -> {
+                    });
+            String partialOutput = "Reading pom.xml...\nAnalyzing dependency tree for shaft-mcp...";
+            String markdown = "```text\n" + partialOutput + "\n```\n\n_" + label + "._ (partial output above)";
+            component.simulateAppendForTest("assistant", markdown, "");
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
             layout(component, !dark);
             image.set(render(component, WIDTH, HEIGHT));
         });


### PR DESCRIPTION
## Summary
- `AssistantLocalAgentRunner.readAsync` (`shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java:1737`) discarded every line already buffered from a process's stdout/stderr when the stream threw `IOException` partway through, resolving the future to `""` instead of the content genuinely captured so far. Fixed by falling through to the existing `output.toString()` return instead of short-circuiting to an empty string.
- **Sibling fix in the same file, added after initial review**: `stdoutNow`/`stderrNow` had the same defect one level up -- they returned `""` on *any* exception from `future.get(2, TimeUnit.SECONDS)`, including a plain timeout, discarding whatever the background reader thread had already buffered. `readAsync` now returns a small `StreamRead` record pairing the `CompletableFuture` with a live view over the same buffer, so `stdoutNow`/`stderrNow` can recover whatever was captured so far on any exception (a timeout, or an unrelated failure such as a throwing `outputConsumer`) instead of blanking to `""`. All 8 call sites across the file (`mcpAccessReadiness`, the main run path, `listModels`, `runCompactPreamble`) get this for free. Verified no caller depends on the old empty-string return as a failure signal distinct from `""` -- every call site already determines success/failure via `process.exitValue()`/`process.waitFor()`, using the stdout/stderr strings purely as informational payload.
- Adds `AssistantLocalAgentRunnerStreamReadResilienceTest`: three regression tests -- the original `IOException`-mid-stream case, a genuine `TimeoutException` case (stream read still running past the 2-second grace window, proven via an elapsed-time assertion so the test can't pass by coincidentally waiting out the full stall), and a future-completes-exceptionally-for-an-unrelated-reason case (a throwing `outputConsumer`). All three watched RED before their respective fix, GREEN after.
- Adds rendered-evidence coverage for the terminal Cancelled/Killed chat-bubble states to `ShaftPluginScreenshotRendererTest`, which previously had none.

This is a code-path-distinct sibling of issue #3962's discard class (that one is `Future`-cancellation ordering; this one is a plain stream-read exception). Surfaced during tracker 4160's Area B (Assistant chat experience) audit.

Closes #4164

## Test plan
- [x] `gradlew test --tests AssistantLocalAgentRunnerStreamReadResilienceTest` -- all 3 tests watched RED (for their respective defect) then GREEN
- [x] `gradlew test --tests "AssistantLocalAgentRunner*"` -- all pass, no regressions from the shared `readAsync`/`StreamRead` change
- [x] `gradlew test --tests ShaftPluginScreenshotRendererTest -Dshaft.intellij.screenshotDir=...` -- new Cancelled/Killed screenshots render and pass size/dimension assertions
- [x] `gradlew test --tests ShaftPluginScreenshotRendererTest` (no screenshotDir) -- still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH