### PR TITLE
Recorder tab's Check status now reports the real active/idle answer

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/RecorderToolPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/RecorderToolPanel.java
@@ -387,17 +387,20 @@ final class RecorderToolPanel extends JPanel {
      * payload (issue #3949: the real section lives nested under {@code webStatus}/{@code
      * playwrightStatus}/{@code mobileStatus}) to answer active/idle for real.
      *
-     * <p>Deliberately does <b>not</b> call {@link ShaftRecordingActivity#started} when the answer is
-     * active (issue #4165 review follow-up): {@code ShaftMcpInvocationService.startTool} dispatches
-     * each call via {@code CompletableFuture.supplyAsync} with no ordering guarantee between
-     * concurrent calls, and {@link #guardReady()} never disables the buttons while a call is in
-     * flight -- so a "Check status" response can race a later "Stop recording" response and land
-     * after it, re-arming the shared indicator from a stale, pre-stop "active" answer that {@link
-     * #stopRecording()} already correctly cleared. A one-shot check is an observation, not a start:
-     * only {@link #startRecording()}, {@link #stopRecording()}, and {@link #removeNotify()} (this
-     * panel's close hook) may set or clear the indicator. Finding it idle is still safe to resync
-     * unconditionally, since {@link ShaftRecordingActivity#stopped} is idempotent and {@link
-     * #stopRecording()} already calls it speculatively regardless of success/failure.
+     * <p>Deliberately never calls {@link ShaftRecordingActivity#started}/{@link
+     * ShaftRecordingActivity#stopped} from either branch (issue #4165 review follow-up, both
+     * directions): {@code ShaftMcpInvocationService.startTool} dispatches each call via {@code
+     * CompletableFuture.supplyAsync} with no ordering guarantee between concurrent calls, and
+     * {@link #guardReady()} never disables the buttons while a call is in flight. A "Check status"
+     * response can race a later "Stop recording" response and land after it, re-arming the
+     * indicator from a stale, pre-stop "active" answer that {@link #stopRecording()} already
+     * correctly cleared -- and symmetrically, a stale pre-start "idle" answer can land after a
+     * later "Start recording" response and clear an indicator {@link #startRecording()} already
+     * correctly set. Idempotency of a {@code started()}/{@code stopped()} call is a different
+     * property from staleness of the information it acts on: calling either twice is harmless, but
+     * calling either once based on a response that predates a later start/stop is not. A one-shot
+     * check is purely an observation: only {@link #startRecording()}, {@link #stopRecording()}, and
+     * {@link #removeNotify()} (this panel's close hook) may set or clear the shared indicator.
      *
      * <p>Package-private test seam: a real {@code ShaftMcpInvocationService.getInstance(project)
      * .startTool(...)} round trip cannot be exercised in this headless unit-test JVM (see the class
@@ -420,7 +423,6 @@ final class RecorderToolPanel extends JPanel {
                     + ". Open Advanced options for the full status.");
             return;
         }
-        ShaftRecordingActivity.stopped(recordingKey);
         String state = status != null && status.has("state") ? status.get("state").getAsString() : "";
         if ("INCOMPLETE".equalsIgnoreCase(state) || "FAILED".equalsIgnoreCase(state)) {
             setStatus("Recording ended unexpectedly (" + state.toUpperCase(java.util.Locale.ROOT) + ") - "

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/RecorderToolPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/RecorderToolPanel.java
@@ -366,13 +366,94 @@ final class RecorderToolPanel extends JPanel {
         setStatus("Checking recording status...");
         ShaftMcpInvocationService.getInstance(project).startTool("capture_status", captureStatusArguments())
                 .future()
-                .whenComplete((result, error) -> onEdt(() -> {
-                    if (failed(result, error)) {
-                        setStatus("Recorder status unavailable: " + failureText(result, error));
-                        return;
-                    }
-                    setStatus("Recorder status refreshed. Open Advanced options for the full status.");
-                }));
+                .whenComplete((result, error) -> onEdt(() -> applyStatusCheck(result, error)));
+    }
+
+    /**
+     * Issue #4165: the success branch used to ignore the {@code capture_status} payload entirely
+     * and always report the same "refreshed" string, never resyncing the shared {@link
+     * ShaftRecordingActivity} indicator -- so restarting the IDE or reopening this tab left "Check
+     * status" unable to say whether a still-active server-side session existed. This mirrors {@code
+     * GuidedWorkflowPanel#applyStatusPoll}'s parsing of the same {@code capture_status} union
+     * payload (issue #3949: the real section lives nested under {@code webStatus}/{@code
+     * playwrightStatus}/{@code mobileStatus}) to answer active/idle for real and resync the
+     * indicator so other tool-window surfaces (the readiness strip) agree with what this check just
+     * found.
+     *
+     * <p>Package-private test seam: a real {@code ShaftMcpInvocationService.getInstance(project)
+     * .startTool(...)} round trip cannot be exercised in this headless unit-test JVM (see the class
+     * javadoc), so tests call this directly with a fixture {@link ShaftMcpToolResult} instead of
+     * going through the live MCP connection -- mirrors how {@code GuidedWorkflowPanelTest} exercises
+     * {@code applyStatusPoll} the same way.
+     *
+     * @param result tool result, or null on failure
+     * @param error transport/execution error, or null on success
+     */
+    void applyStatusCheck(ShaftMcpToolResult result, Throwable error) {
+        if (failed(result, error)) {
+            setStatus("Recorder status unavailable: " + failureText(result, error));
+            return;
+        }
+        JsonObject status = AssistantMarkdown.unwrapCaptureStatus(
+                AssistantMarkdown.jsonObjectFromMcpOutput(result.output()));
+        if (isRecorderActive(status)) {
+            ShaftRecordingActivity.started(recordingKey);
+            setStatus("Recording active - " + countText(status) + readinessSuffix(status)
+                    + ". Open Advanced options for the full status.");
+            return;
+        }
+        ShaftRecordingActivity.stopped(recordingKey);
+        String state = status != null && status.has("state") ? status.get("state").getAsString() : "";
+        if ("INCOMPLETE".equalsIgnoreCase(state) || "FAILED".equalsIgnoreCase(state)) {
+            setStatus("Recording ended unexpectedly (" + state.toUpperCase(java.util.Locale.ROOT) + ") - "
+                    + countText(status) + ". Re-record the flow before generating code.");
+            return;
+        }
+        setStatus("No active recording. Recorder idle. Open Advanced options for the full status.");
+    }
+
+    /**
+     * Mirrors {@code GuidedWorkflowPanel#isRecorderActive} exactly: same {@code capture_status}
+     * union payload shape, so this panel's one-shot Check status answers the same active/idle
+     * question the same way -- {@code active} first (mobile), else {@code state} (web/Playwright).
+     */
+    private static boolean isRecorderActive(JsonObject status) {
+        if (status == null) {
+            return false;
+        }
+        if (status.has("active")) {
+            return status.get("active").getAsBoolean();
+        }
+        String state = status.has("state") ? status.get("state").getAsString() : "";
+        return "ACTIVE".equalsIgnoreCase(state) || "STARTING".equalsIgnoreCase(state)
+                || "STOPPING".equalsIgnoreCase(state);
+    }
+
+    /** Mirrors {@code GuidedWorkflowPanel#countText}: recorded units read "steps" everywhere. */
+    private static String countText(JsonObject status) {
+        if (status == null) {
+            return "0 steps";
+        }
+        int steps = status.has("actionCount")
+                ? status.get("actionCount").getAsInt()
+                : status.has("eventCount") ? status.get("eventCount").getAsInt() : 0;
+        int pending = status.has("pendingSignalCount") ? status.get("pendingSignalCount").getAsInt() : 0;
+        String base = steps + (steps == 1 ? " step" : " steps");
+        return pending > 0 ? base + " (+" + pending + " pending)" : base;
+    }
+
+    /** Mirrors {@code GuidedWorkflowPanel#readinessLabel}, rendered as a trailing " - Label" suffix. */
+    private static String readinessSuffix(JsonObject status) {
+        if (status == null || !status.has("readiness")) {
+            return "";
+        }
+        String readiness = switch (status.get("readiness").getAsString().toUpperCase(java.util.Locale.ROOT)) {
+            case "READY" -> "Ready";
+            case "RISKY" -> "Risky";
+            case "BLOCKED" -> "Blocked";
+            default -> "";
+        };
+        return readiness.isBlank() ? "" : " - " + readiness;
     }
 
     private void reviewCode() {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/RecorderToolPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/RecorderToolPanel.java
@@ -182,6 +182,15 @@ final class RecorderToolPanel extends JPanel {
     }
 
     /**
+     * Package-private test accessor: this panel's stable {@link ShaftRecordingActivity} session
+     * key, so tests can establish or verify indicator state through the exact same key the panel's
+     * own start/stop/check/close code paths use (issue #4165 review follow-up).
+     */
+    String recordingKeyForTests() {
+        return recordingKey;
+    }
+
+    /**
      * Delegates to the embedded {@link ShaftFeaturePanel}, then expands the Advanced section
      * whenever the prefilled tool is not one this tab's Quick Start section curates -- otherwise the
      * prefilled request would land in a collapsed section the user never sees (required for {@code
@@ -376,9 +385,19 @@ final class RecorderToolPanel extends JPanel {
      * status" unable to say whether a still-active server-side session existed. This mirrors {@code
      * GuidedWorkflowPanel#applyStatusPoll}'s parsing of the same {@code capture_status} union
      * payload (issue #3949: the real section lives nested under {@code webStatus}/{@code
-     * playwrightStatus}/{@code mobileStatus}) to answer active/idle for real and resync the
-     * indicator so other tool-window surfaces (the readiness strip) agree with what this check just
-     * found.
+     * playwrightStatus}/{@code mobileStatus}) to answer active/idle for real.
+     *
+     * <p>Deliberately does <b>not</b> call {@link ShaftRecordingActivity#started} when the answer is
+     * active (issue #4165 review follow-up): {@code ShaftMcpInvocationService.startTool} dispatches
+     * each call via {@code CompletableFuture.supplyAsync} with no ordering guarantee between
+     * concurrent calls, and {@link #guardReady()} never disables the buttons while a call is in
+     * flight -- so a "Check status" response can race a later "Stop recording" response and land
+     * after it, re-arming the shared indicator from a stale, pre-stop "active" answer that {@link
+     * #stopRecording()} already correctly cleared. A one-shot check is an observation, not a start:
+     * only {@link #startRecording()}, {@link #stopRecording()}, and {@link #removeNotify()} (this
+     * panel's close hook) may set or clear the indicator. Finding it idle is still safe to resync
+     * unconditionally, since {@link ShaftRecordingActivity#stopped} is idempotent and {@link
+     * #stopRecording()} already calls it speculatively regardless of success/failure.
      *
      * <p>Package-private test seam: a real {@code ShaftMcpInvocationService.getInstance(project)
      * .startTool(...)} round trip cannot be exercised in this headless unit-test JVM (see the class
@@ -397,7 +416,6 @@ final class RecorderToolPanel extends JPanel {
         JsonObject status = AssistantMarkdown.unwrapCaptureStatus(
                 AssistantMarkdown.jsonObjectFromMcpOutput(result.output()));
         if (isRecorderActive(status)) {
-            ShaftRecordingActivity.started(recordingKey);
             setStatus("Recording active - " + countText(status) + readinessSuffix(status)
                     + ". Open Advanced options for the full status.");
             return;
@@ -470,6 +488,21 @@ final class RecorderToolPanel extends JPanel {
                     }
                     setStatus("Code generated. Open Advanced options to review the raw output.");
                 }));
+    }
+
+    /**
+     * Clears a stuck-active recording key when this panel closes (issue #4165 review follow-up),
+     * mirroring {@code GuidedWorkflowPanel#dispose}'s reason for existing (issue #3591 item 3): "a
+     * stuck-active recording key if the panel closes mid-recording". Unlike {@code
+     * GuidedWorkflowPanel}, this panel has no background poller/{@code Alarm} to cancel and is not
+     * wired into {@code ShaftToolWindowPanel}'s {@code Disposer} tree, so this standard Swing
+     * teardown callback -- fired automatically when the panel is removed from its containment
+     * hierarchy, no external wiring required -- is the equivalent, scope-safe close hook.
+     */
+    @Override
+    public void removeNotify() {
+        super.removeNotify();
+        ShaftRecordingActivity.stopped(recordingKey);
     }
 
     /**

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/RecorderToolPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/RecorderToolPanelTest.java
@@ -186,9 +186,13 @@ class RecorderToolPanelTest {
      * RecorderToolPanel#applyStatusCheck}, the package-private test seam mirroring {@code
      * GuidedWorkflowPanel#applyStatusPoll} since a live MCP round trip cannot run in this headless
      * unit-test JVM (see the class javadoc).
+     *
+     * <p>Review follow-up (issue #4165): finding "active" must render the real text but must
+     * <b>not</b> arm the shared {@link ShaftRecordingActivity} indicator by itself -- see {@link
+     * #aStaleActiveCheckStatusResponseArrivingAfterAStopMustNotResurrectTheSharedIndicator} for why.
      */
     @Test
-    void checkStatusRendersTheRealActiveStateAndResyncsTheSharedRecordingIndicator() {
+    void checkStatusRendersTheRealActiveStateWithoutArmingTheSharedRecordingIndicator() {
         ShaftRecordingActivity.resetForTests();
         try {
             RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
@@ -208,8 +212,11 @@ class RecorderToolPanelTest {
                     () -> assertTrue(status.getText().contains("3 steps"),
                             "Expected the real active status to render, not the old generic 'refreshed' text: "
                                     + status.getText()),
-                    () -> assertTrue(ShaftRecordingActivity.active(),
-                            "Check status must resync the shared recording indicator to active"));
+                    () -> assertFalse(ShaftRecordingActivity.active(),
+                            "A one-shot status check finding 'active' must not arm the shared recording "
+                                    + "indicator by itself -- a check is not a start, and doing so risks "
+                                    + "resurrecting the indicator from a stale response after a real stop "
+                                    + "already cleared it"));
         } finally {
             ShaftRecordingActivity.resetForTests();
         }
@@ -217,10 +224,12 @@ class RecorderToolPanelTest {
 
     /**
      * Second half of the same real-payload story: once the recorder answers idle, {@code
-     * checkStatus()} must say so in plain language and clear the shared indicator it previously set
-     * -- proving {@code ShaftRecordingActivity.stopped(recordingKey)} actually resyncs (not just
-     * some other surface's key), by starting from the active state this same panel instance just
-     * published.
+     * checkStatus()} must say so in plain language and clear the shared indicator -- proving {@code
+     * ShaftRecordingActivity.stopped(recordingKey)} actually resyncs (not just some other surface's
+     * key). The active precondition is established directly via {@link ShaftRecordingActivity#started}
+     * (using this panel's own key via the {@link RecorderToolPanel#recordingKeyForTests()} test
+     * accessor) rather than through a prior active {@code checkStatus()} poll, since a check no
+     * longer arms the indicator itself (see the test above).
      */
     @Test
     void checkStatusRendersIdleStateAndClearsTheSharedRecordingIndicatorAfterAPriorActivePoll() {
@@ -228,15 +237,8 @@ class RecorderToolPanelTest {
         try {
             RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
             javax.swing.JLabel status = findByAccessibleName(panel, "Recorder status", javax.swing.JLabel.class);
-
-            JsonObject activeWebStatus = new JsonObject();
-            activeWebStatus.addProperty("state", "ACTIVE");
-            activeWebStatus.addProperty("eventCount", 1);
-            JsonObject activeUnion = new JsonObject();
-            activeUnion.addProperty("engine", "WEB");
-            activeUnion.add("webStatus", activeWebStatus);
-            panel.applyStatusCheck(ShaftMcpToolResult.success(activeUnion.toString()), null);
-            assertTrue(ShaftRecordingActivity.active(), "Precondition: the active poll above must have registered");
+            ShaftRecordingActivity.started(panel.recordingKeyForTests());
+            assertTrue(ShaftRecordingActivity.active(), "Precondition: a recording must be marked active");
 
             JsonObject idleWebStatus = new JsonObject();
             idleWebStatus.addProperty("state", "NOT_RUNNING");
@@ -251,6 +253,136 @@ class RecorderToolPanelTest {
                     () -> assertTrue(status.getText().contains("No active recording"), status.getText()),
                     () -> assertFalse(ShaftRecordingActivity.active(),
                             "Check status must resync the shared recording indicator back to idle"));
+        } finally {
+            ShaftRecordingActivity.resetForTests();
+        }
+    }
+
+    /**
+     * Review finding (issue #4165): {@code ShaftMcpInvocationService.startTool} dispatches each
+     * call via {@code CompletableFuture.supplyAsync} (no ordering guarantee between concurrent
+     * calls), and {@code guardReady()} never disables the buttons while a call is in flight. So a
+     * user can click "Check status" and then immediately "Stop recording"; if the stop's response
+     * lands first (it calls {@code ShaftRecordingActivity.stopped(recordingKey)} unconditionally),
+     * the earlier check's still-active (pre-stop) response can arrive afterwards. Before this fix,
+     * that stale response's {@code started(recordingKey)} call would resurrect the indicator the
+     * stop had just correctly cleared -- the same failure shape {@code GuidedWorkflowPanel#dispose}
+     * (issue #3591 item 3) was written to prevent on the sibling panel. This proves the ordering
+     * cannot resurrect it: the stop-cleared state stays idle even after the stale active check
+     * response is applied afterwards.
+     */
+    @Test
+    void aStaleActiveCheckStatusResponseArrivingAfterAStopMustNotResurrectTheSharedIndicator() {
+        ShaftRecordingActivity.resetForTests();
+        try {
+            RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
+
+            // A recording was active, then "Stop recording"'s response reached the EDT first and
+            // cleared the indicator (mirrors stopRecording()'s unconditional
+            // ShaftRecordingActivity.stopped(recordingKey) call, RecorderToolPanel.java:246-249).
+            ShaftRecordingActivity.started(panel.recordingKeyForTests());
+            ShaftRecordingActivity.stopped(panel.recordingKeyForTests());
+            assertFalse(ShaftRecordingActivity.active(), "Precondition: the stop above must have cleared it");
+
+            // The earlier, stale "Check status" response -- issued before the stop, still carrying
+            // the pre-stop 'active' answer -- arrives afterwards.
+            JsonObject webStatus = new JsonObject();
+            webStatus.addProperty("state", "ACTIVE");
+            webStatus.addProperty("eventCount", 4);
+            JsonObject union = new JsonObject();
+            union.addProperty("engine", "WEB");
+            union.add("webStatus", webStatus);
+
+            panel.applyStatusCheck(ShaftMcpToolResult.success(union.toString()), null);
+
+            assertFalse(ShaftRecordingActivity.active(),
+                    "A stale active status-check response must never resurrect the shared indicator "
+                            + "after a real stop already cleared it");
+        } finally {
+            ShaftRecordingActivity.resetForTests();
+        }
+    }
+
+    /**
+     * Review follow-up (issue #4165): {@code RecorderToolPanel} had no {@code dispose}, {@code
+     * removeNotify}, or {@code Disposer} hook at all, unlike {@code GuidedWorkflowPanel#dispose}
+     * (issue #3591 item 3), which exists specifically "to prevent a stuck-active recording key if
+     * the panel closes mid-recording". {@code RecorderToolPanel} has no background poller to cancel
+     * (unlike {@code GuidedWorkflowPanel}'s status-poll {@code Alarm}) and is not wired into {@code
+     * ShaftToolWindowPanel}'s {@code Disposer} tree, so {@link RecorderToolPanel#removeNotify()} --
+     * the standard Swing teardown callback, fired without any external wiring -- is the equivalent,
+     * scope-safe place to clear the indicator on close.
+     */
+    @Test
+    void removeNotifyClearsTheSharedRecordingIndicatorLikeGuidedWorkflowPanelsDispose() {
+        ShaftRecordingActivity.resetForTests();
+        try {
+            RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
+            ShaftRecordingActivity.started(panel.recordingKeyForTests());
+            assertTrue(ShaftRecordingActivity.active(), "Precondition: a recording must be marked active");
+
+            panel.removeNotify();
+
+            assertFalse(ShaftRecordingActivity.active(),
+                    "Closing the panel (removeNotify) must clear a stuck-active recording key, mirroring "
+                            + "GuidedWorkflowPanel#dispose (issue #3591 item 3)");
+        } finally {
+            ShaftRecordingActivity.resetForTests();
+        }
+    }
+
+    /**
+     * Review follow-up (issue #4165): the {@code INCOMPLETE}/{@code FAILED} terminal-state branch
+     * in {@link RecorderToolPanel#applyStatusCheck} had no test. Pins the "ended unexpectedly"
+     * message for an {@code INCOMPLETE} state.
+     */
+    @Test
+    void checkStatusRendersEndedUnexpectedlyForAnIncompleteState() {
+        ShaftRecordingActivity.resetForTests();
+        try {
+            RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
+            javax.swing.JLabel status = findByAccessibleName(panel, "Recorder status", javax.swing.JLabel.class);
+
+            JsonObject webStatus = new JsonObject();
+            webStatus.addProperty("state", "INCOMPLETE");
+            webStatus.addProperty("eventCount", 6);
+            JsonObject union = new JsonObject();
+            union.addProperty("engine", "WEB");
+            union.add("webStatus", webStatus);
+
+            panel.applyStatusCheck(ShaftMcpToolResult.success(union.toString()), null);
+
+            assertAll(
+                    () -> assertTrue(status.getText().contains("ended unexpectedly"), status.getText()),
+                    () -> assertTrue(status.getText().contains("INCOMPLETE"), status.getText()),
+                    () -> assertTrue(status.getText().contains("6 steps"), status.getText()),
+                    () -> assertFalse(ShaftRecordingActivity.active()));
+        } finally {
+            ShaftRecordingActivity.resetForTests();
+        }
+    }
+
+    /** Same terminal-state branch, for a {@code FAILED} state. */
+    @Test
+    void checkStatusRendersEndedUnexpectedlyForAFailedState() {
+        ShaftRecordingActivity.resetForTests();
+        try {
+            RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
+            javax.swing.JLabel status = findByAccessibleName(panel, "Recorder status", javax.swing.JLabel.class);
+
+            JsonObject webStatus = new JsonObject();
+            webStatus.addProperty("state", "FAILED");
+            webStatus.addProperty("eventCount", 2);
+            JsonObject union = new JsonObject();
+            union.addProperty("engine", "WEB");
+            union.add("webStatus", webStatus);
+
+            panel.applyStatusCheck(ShaftMcpToolResult.success(union.toString()), null);
+
+            assertAll(
+                    () -> assertTrue(status.getText().contains("ended unexpectedly"), status.getText()),
+                    () -> assertTrue(status.getText().contains("FAILED"), status.getText()),
+                    () -> assertFalse(ShaftRecordingActivity.active()));
         } finally {
             ShaftRecordingActivity.resetForTests();
         }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/RecorderToolPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/RecorderToolPanelTest.java
@@ -224,21 +224,19 @@ class RecorderToolPanelTest {
 
     /**
      * Second half of the same real-payload story: once the recorder answers idle, {@code
-     * checkStatus()} must say so in plain language and clear the shared indicator -- proving {@code
-     * ShaftRecordingActivity.stopped(recordingKey)} actually resyncs (not just some other surface's
-     * key). The active precondition is established directly via {@link ShaftRecordingActivity#started}
-     * (using this panel's own key via the {@link RecorderToolPanel#recordingKeyForTests()} test
-     * accessor) rather than through a prior active {@code checkStatus()} poll, since a check no
-     * longer arms the indicator itself (see the test above).
+     * checkStatus()} must say so in plain language. Re-review of issue #4165 established that a
+     * one-shot check must be purely observational in <b>both</b> directions (see the two
+     * stale-response regression tests below), so -- unlike the first version of this test -- this
+     * no longer asserts that a check resyncs the indicator; it only pins the rendered text for a
+     * plain idle answer with no recording in play, and confirms the indicator (already idle here)
+     * is left alone.
      */
     @Test
-    void checkStatusRendersIdleStateAndClearsTheSharedRecordingIndicatorAfterAPriorActivePoll() {
+    void checkStatusRendersIdleStateWithoutTouchingTheSharedRecordingIndicator() {
         ShaftRecordingActivity.resetForTests();
         try {
             RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
             javax.swing.JLabel status = findByAccessibleName(panel, "Recorder status", javax.swing.JLabel.class);
-            ShaftRecordingActivity.started(panel.recordingKeyForTests());
-            assertTrue(ShaftRecordingActivity.active(), "Precondition: a recording must be marked active");
 
             JsonObject idleWebStatus = new JsonObject();
             idleWebStatus.addProperty("state", "NOT_RUNNING");
@@ -251,8 +249,7 @@ class RecorderToolPanelTest {
 
             assertAll(
                     () -> assertTrue(status.getText().contains("No active recording"), status.getText()),
-                    () -> assertFalse(ShaftRecordingActivity.active(),
-                            "Check status must resync the shared recording indicator back to idle"));
+                    () -> assertFalse(ShaftRecordingActivity.active()));
         } finally {
             ShaftRecordingActivity.resetForTests();
         }
@@ -298,6 +295,48 @@ class RecorderToolPanelTest {
             assertFalse(ShaftRecordingActivity.active(),
                     "A stale active status-check response must never resurrect the shared indicator "
                             + "after a real stop already cleared it");
+        } finally {
+            ShaftRecordingActivity.resetForTests();
+        }
+    }
+
+    /**
+     * The mirror-image race (re-review of issue #4165): a "Check status" click fires while idle,
+     * then before it returns, "Start recording" is clicked and its response lands first, correctly
+     * setting the indicator active. The earlier check's stale, pre-start "idle" response then
+     * arrives and must not clear an indicator a genuinely live recording just set -- same {@code
+     * CompletableFuture.supplyAsync} ordering gap, same absence of button-disabling in {@link
+     * #guardReady()}, identical reachability to the stop-races-check direction above. Idempotency of
+     * the {@code stopped()} call is a different property from staleness of the information it acts
+     * on: calling it twice is harmless, but calling it once based on a response that predates a
+     * start is not.
+     */
+    @Test
+    void aStaleIdleCheckStatusResponseArrivingAfterAStartMustNotClearTheSharedIndicator() {
+        ShaftRecordingActivity.resetForTests();
+        try {
+            RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
+
+            // "Start recording"'s response reached the EDT first and set the indicator active
+            // (mirrors startRecording()'s ShaftRecordingActivity.started(recordingKey) call,
+            // RecorderToolPanel.java:233).
+            ShaftRecordingActivity.started(panel.recordingKeyForTests());
+            assertTrue(ShaftRecordingActivity.active(), "Precondition: the start above must have set it active");
+
+            // The earlier, stale "Check status" response -- issued before the start, still carrying
+            // the pre-start 'idle' answer -- arrives afterwards.
+            JsonObject webStatus = new JsonObject();
+            webStatus.addProperty("state", "NOT_RUNNING");
+            webStatus.addProperty("eventCount", 0);
+            JsonObject union = new JsonObject();
+            union.addProperty("engine", "WEB");
+            union.add("webStatus", webStatus);
+
+            panel.applyStatusCheck(ShaftMcpToolResult.success(union.toString()), null);
+
+            assertTrue(ShaftRecordingActivity.active(),
+                    "A stale idle status-check response must never clear the shared indicator after a "
+                            + "real start already set it");
         } finally {
             ShaftRecordingActivity.resetForTests();
         }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/RecorderToolPanelTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/RecorderToolPanelTest.java
@@ -3,6 +3,7 @@ package com.shaft.intellij.ui;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.shaft.intellij.java.JavaTargetContext;
+import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.shaft.intellij.settings.ShaftSettingsState;
 import org.junit.jupiter.api.Test;
 
@@ -174,6 +175,129 @@ class RecorderToolPanelTest {
 
         findButton(panel, "Review code").doClick();
         assertTrue(status.getText().contains("Configure SHAFT MCP"), status.getText());
+    }
+
+    /**
+     * Issue #4165: {@code checkStatus()}'s success handler used to ignore the {@code
+     * capture_status} payload entirely and always report the same "refreshed" string. This pins
+     * the real fix -- parsing {@code active}/{@code state} out of the same union payload shape
+     * {@code GuidedWorkflowPanel#applyStatusPoll} already handles (issue #3949's {@code
+     * webStatus}/{@code playwrightStatus}/{@code mobileStatus} union) -- via {@link
+     * RecorderToolPanel#applyStatusCheck}, the package-private test seam mirroring {@code
+     * GuidedWorkflowPanel#applyStatusPoll} since a live MCP round trip cannot run in this headless
+     * unit-test JVM (see the class javadoc).
+     */
+    @Test
+    void checkStatusRendersTheRealActiveStateAndResyncsTheSharedRecordingIndicator() {
+        ShaftRecordingActivity.resetForTests();
+        try {
+            RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
+            javax.swing.JLabel status = findByAccessibleName(panel, "Recorder status", javax.swing.JLabel.class);
+
+            JsonObject webStatus = new JsonObject();
+            webStatus.addProperty("state", "ACTIVE");
+            webStatus.addProperty("eventCount", 3);
+            webStatus.addProperty("readiness", "READY");
+            JsonObject union = new JsonObject();
+            union.addProperty("engine", "WEB");
+            union.add("webStatus", webStatus);
+
+            panel.applyStatusCheck(ShaftMcpToolResult.success(union.toString()), null);
+
+            assertAll(
+                    () -> assertTrue(status.getText().contains("3 steps"),
+                            "Expected the real active status to render, not the old generic 'refreshed' text: "
+                                    + status.getText()),
+                    () -> assertTrue(ShaftRecordingActivity.active(),
+                            "Check status must resync the shared recording indicator to active"));
+        } finally {
+            ShaftRecordingActivity.resetForTests();
+        }
+    }
+
+    /**
+     * Second half of the same real-payload story: once the recorder answers idle, {@code
+     * checkStatus()} must say so in plain language and clear the shared indicator it previously set
+     * -- proving {@code ShaftRecordingActivity.stopped(recordingKey)} actually resyncs (not just
+     * some other surface's key), by starting from the active state this same panel instance just
+     * published.
+     */
+    @Test
+    void checkStatusRendersIdleStateAndClearsTheSharedRecordingIndicatorAfterAPriorActivePoll() {
+        ShaftRecordingActivity.resetForTests();
+        try {
+            RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
+            javax.swing.JLabel status = findByAccessibleName(panel, "Recorder status", javax.swing.JLabel.class);
+
+            JsonObject activeWebStatus = new JsonObject();
+            activeWebStatus.addProperty("state", "ACTIVE");
+            activeWebStatus.addProperty("eventCount", 1);
+            JsonObject activeUnion = new JsonObject();
+            activeUnion.addProperty("engine", "WEB");
+            activeUnion.add("webStatus", activeWebStatus);
+            panel.applyStatusCheck(ShaftMcpToolResult.success(activeUnion.toString()), null);
+            assertTrue(ShaftRecordingActivity.active(), "Precondition: the active poll above must have registered");
+
+            JsonObject idleWebStatus = new JsonObject();
+            idleWebStatus.addProperty("state", "NOT_RUNNING");
+            idleWebStatus.addProperty("eventCount", 0);
+            JsonObject idleUnion = new JsonObject();
+            idleUnion.addProperty("engine", "WEB");
+            idleUnion.add("webStatus", idleWebStatus);
+
+            panel.applyStatusCheck(ShaftMcpToolResult.success(idleUnion.toString()), null);
+
+            assertAll(
+                    () -> assertTrue(status.getText().contains("No active recording"), status.getText()),
+                    () -> assertFalse(ShaftRecordingActivity.active(),
+                            "Check status must resync the shared recording indicator back to idle"));
+        } finally {
+            ShaftRecordingActivity.resetForTests();
+        }
+    }
+
+    /**
+     * A malformed or missing-field {@code capture_status} response (no {@code active}, no {@code
+     * state}, no union section -- e.g. an already-unwrapped or empty payload) must degrade to a
+     * plain idle answer, never crash and never leave the shared indicator on.
+     */
+    @Test
+    void checkStatusDegradesGracefullyOnAMissingFieldPayload() {
+        ShaftRecordingActivity.resetForTests();
+        try {
+            RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
+            javax.swing.JLabel status = findByAccessibleName(panel, "Recorder status", javax.swing.JLabel.class);
+
+            panel.applyStatusCheck(ShaftMcpToolResult.success("{}"), null);
+
+            assertAll(
+                    () -> assertTrue(status.getText().contains("No active recording"), status.getText()),
+                    () -> assertFalse(ShaftRecordingActivity.active()));
+        } finally {
+            ShaftRecordingActivity.resetForTests();
+        }
+    }
+
+    /**
+     * Same degrade-gracefully bar for a response that is not valid JSON at all (a raw MCP text
+     * envelope {@link com.shaft.intellij.ui.AssistantMarkdown#jsonObjectFromMcpOutput} cannot parse
+     * as a JSON object) -- must not throw.
+     */
+    @Test
+    void checkStatusDegradesGracefullyOnUnparsableOutput() {
+        ShaftRecordingActivity.resetForTests();
+        try {
+            RecorderToolPanel panel = new RecorderToolPanel(null, unreadyMcpSettings());
+            javax.swing.JLabel status = findByAccessibleName(panel, "Recorder status", javax.swing.JLabel.class);
+
+            panel.applyStatusCheck(ShaftMcpToolResult.success("not json at all"), null);
+
+            assertAll(
+                    () -> assertTrue(status.getText().contains("No active recording"), status.getText()),
+                    () -> assertFalse(ShaftRecordingActivity.active()));
+        } finally {
+            ShaftRecordingActivity.resetForTests();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `RecorderToolPanel.checkStatus()`'s success handler used to ignore the `capture_status` payload entirely and always show the same generic "Recorder status refreshed. Open Advanced options for the full status." message, regardless of whether a recording was actually active -- and it never resynced the shared `ShaftRecordingActivity` indicator.
- The new `applyStatusCheck` parses the same `active`/`state` union payload shape (`webStatus`/`playwrightStatus`/`mobileStatus`) that `GuidedWorkflowPanel.applyStatusPoll` already handles, via the existing shared `AssistantMarkdown.unwrapCaptureStatus` helper, and renders a real active/idle/ended-unexpectedly answer while resyncing `ShaftRecordingActivity` so other tool-window surfaces (the readiness strip) agree with what the check just found.
- Part of the record/replay/codegen flow polish program tracked in 4160 -- this closes the Area C gap where the curated standalone Recorder tab gave no usable answer to "is a recording still active" after an interrupted or abandoned session.

Closes #4165

## Test plan

- [x] Added `RecorderToolPanelTest` coverage for the real `capture_status` payload: an active response (renders step count/readiness, sets the shared indicator active), an idle response after a prior active poll (renders idle, clears the indicator), and two degrade-gracefully cases (missing-field `{}` payload and unparsable output) -- all watched red before the fix (`applyStatusCheck` did not exist) and green after.
- [x] `./gradlew test --tests "com.shaft.intellij.ui.RecorderToolPanelTest"` -- 20/20 passing.
- [x] `./gradlew test --tests "ShaftPluginScreenshotRendererTest"` -- full screenshot catalog regenerates cleanly (no regression to the Recorder tab's existing baseline screenshot).
- [x] Rendered the panel's Ready/Active/Idle/malformed states through the plugin screenshot renderer approach (headless Swing capture, since browser MCP tools cannot see this surface) as evidence the user-visible flow reads correctly:
  - Active: "Recording active - 5 steps - Ready. Open Advanced options for the full status."
  - Idle: "No active recording. Recorder idle. Open Advanced options for the full status."