### PR TITLE
IntelliJ plugin: assistant raw output uses the IDE's editor font

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.editor.colors.EditorColorsScheme;
+import com.intellij.openapi.editor.colors.EditorFontType;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.fileTypes.FileType;
@@ -1065,6 +1066,28 @@ final class AssistantTranscriptView extends JPanel {
     }
 
     /**
+     * Resolves the IDE's own configured editor font family (issue #4163) -- the same {@link
+     * EditorColorsScheme} source {@link #highlightedByLexer} already reads for syntax colors -- so
+     * monospaced UI in this view (currently just {@link #rawEvidenceDisclosure}) respects the user's
+     * actual editor font/theme settings instead of the generic JDK logical name {@link
+     * Font#MONOSPACED}, which ignores them and renders inconsistently across platforms. Falls back to
+     * {@code Font.MONOSPACED} when no live {@code Application} exists -- this module's tests construct
+     * none (no {@code BasePlatformTestCase} fixture) -- guarding on {@link
+     * ApplicationManager#getApplication()} itself rather than on {@code EditorColorsManager
+     * .getInstance()}'s return value: that call unconditionally dereferences {@code
+     * ApplicationManager.getApplication().getService(...)} with no null guard of its own, so it
+     * throws (never returns {@code null}) once there is no live {@code Application} to ask.
+     */
+    static String monospacedFontFamily() {
+        if (ApplicationManager.getApplication() == null) {
+            return Font.MONOSPACED;
+        }
+        EditorColorsScheme scheme = EditorColorsManager.getInstance().getGlobalScheme();
+        Font editorFont = scheme == null ? null : scheme.getFont(EditorFontType.PLAIN);
+        return editorFont == null ? Font.MONOSPACED : editorFont.getFamily();
+    }
+
+    /**
      * Builds the collapsed-by-default "Show raw output" disclosure for a message's raw evidence
      * (issue #3601 A5) -- for example a tool's raw JSON result, available here because {@link
      * ShaftAssistantPanel#runToolAndRenderCard} passes it straight through {@link #append(String,
@@ -1087,7 +1110,7 @@ final class AssistantTranscriptView extends JPanel {
         rawArea.setLineWrap(true);
         rawArea.setWrapStyleWord(true);
         Font monospaced = rawArea.getFont();
-        rawArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, monospaced == null ? 12 : monospaced.getSize()));
+        rawArea.setFont(new Font(monospacedFontFamily(), Font.PLAIN, monospaced == null ? 12 : monospaced.getSize()));
         rawArea.setCaretPosition(0);
         rawArea.getAccessibleContext().setAccessibleName("Raw tool output");
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantTranscriptViewTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantTranscriptViewTest.java
@@ -80,6 +80,43 @@ class AssistantTranscriptViewTest {
                 () -> assertFalse(isVisibleInHierarchy(rawArea), "Raw output must hide again after a second click"));
     }
 
+    /**
+     * Issue #4163's bundled font finding: the raw-output disclosure hardcoded its family to the
+     * generic JDK logical name {@code Font.MONOSPACED}, which ignores the IDE's own configured
+     * editor font (and the user's font/theme settings) -- unlike every other theme-derived value this
+     * class already reads through {@link com.intellij.openapi.editor.colors.EditorColorsManager}
+     * (see {@code highlightedByLexer}'s syntax-color lookup a few hundred lines below). The raw text
+     * area must instead use the same {@code EditorColorsScheme}-sourced font every real IntelliJ
+     * editor surface uses.
+     */
+    @Test
+    void rawOutputTextAreaUsesTheIdesConfiguredEditorFontFamilyNotTheHardcodedLogicalMonospacedName() {
+        AssistantTranscriptView view = new AssistantTranscriptView();
+        view.append("assistant", "Tool ran.", "{\"raw\":true}");
+
+        JBTextArea rawArea = findByType(view, JBTextArea.class);
+        assertNotNull(rawArea, "Expected a raw output text area for a message with evidence");
+
+        assertEquals(AssistantTranscriptView.monospacedFontFamily(), rawArea.getFont().getFamily(),
+                "Raw output must resolve its font family through the same IDE-editor-font lookup "
+                        + "this class already uses for syntax colors (EditorColorsManager), not a "
+                        + "hardcoded logical java.awt.Font.MONOSPACED name");
+    }
+
+    /**
+     * This module builds no live {@code Application} in its tests (no {@code BasePlatformTestCase}
+     * fixture -- see {@code PickLocatorAtCaretActionTest}'s javadoc), and {@code
+     * EditorColorsManager.getInstance()} unconditionally dereferences {@code
+     * ApplicationManager.getApplication()} with no null guard of its own, so calling it here would
+     * throw. Pins the documented {@code ApplicationManager.getApplication() == null} guard's fallback
+     * so a future refactor cannot silently reintroduce that {@code NullPointerException} in every
+     * test in this class that appends a message with raw evidence.
+     */
+    @Test
+    void monospacedFontFamilyFallsBackToLogicalMonospacedWithoutALiveEditorColorsScheme() {
+        assertEquals(java.awt.Font.MONOSPACED, AssistantTranscriptView.monospacedFontFamily());
+    }
+
     @Test
     void rawEvidenceNeverLeaksIntoTranscriptMarkdown() {
         AssistantTranscriptView view = new AssistantTranscriptView();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -3,6 +3,7 @@ package com.shaft.intellij.ui;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBScrollPane;
 import com.shaft.intellij.mcp.ShaftMcpToolResult;
 import com.shaft.intellij.settings.ShaftSettingsConfigurable;
 import com.shaft.intellij.settings.ShaftSettingsState;
@@ -22,6 +23,8 @@ import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
+import javax.swing.JScrollBar;
+import javax.swing.JViewport;
 import javax.swing.LookAndFeel;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
@@ -35,6 +38,7 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -56,6 +60,7 @@ import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShaftPluginScreenshotRendererTest {
@@ -486,6 +491,73 @@ class ShaftPluginScreenshotRendererTest {
             image.set(render(component, width, height));
         });
         return image.get();
+    }
+
+    /**
+     * Issue #4163 (tracker #4160 area B): a static render of {@code intellij-plugin-assistant-empty-
+     * narrow.png} was read as showing the first-run welcome bubble's "Got it" dismiss button cut off
+     * below the visible frame, with no scrollbar visually distinguishable in the PNG. That finding was
+     * filed at medium confidence with an explicit caveat: {@link AssistantTranscriptView#showWidget}
+     * adds the welcome bubble into a panel that sits inside a real scroll pane (this view's own
+     * "Assistant transcript" {@link JBScrollPane}), so a static render alone cannot prove the button is
+     * unreachable -- only a live check of the real {@link JViewport}/{@link JScrollBar} model can.
+     *
+     * <p>This test drives the exact same narrow/dark construction {@link #renderAssistantEmpty} uses
+     * for its screenshot evidence and checks reachability directly. Against current {@code main}, the
+     * button is already fully inside the initial (unscrolled) viewport -- no clip, no scroll needed --
+     * and stays inside the viewport if the transcript is scrolled to the bottom, so the dismiss control
+     * is never orphaned either way. The finding does not reproduce; no layout change is made for it
+     * (see {@code AssistantTranscriptView} class-level history for the font-family fix this issue also
+     * bundled, which is a genuine, separate defect).
+     */
+    @Test
+    void firstRunWelcomeDismissButtonIsVisibleWithoutScrollingAtNarrowDarkWidth() throws InterruptedException, InvocationTargetException {
+        AtomicReference<Boolean> reachableBeforeScrolling = new AtomicReference<>();
+        AtomicReference<Boolean> reachableAfterScrollingToBottom = new AtomicReference<>();
+        AtomicReference<JButton> dismissButton = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(DARK_THEME, true);
+            ShaftSettingsState.Settings settings = defaultSettings();
+            JComponent component = new ShaftToolWindowPanel(
+                    screenshotProject(), settings, AssistantLocalAgentRunner::readiness, new ShaftAssistantChatState());
+            component.setSize(new Dimension(NARROW_WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(NARROW_WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, false);
+
+            JButton gotIt = findByAccessibleName(component, "Dismiss first run coach", JButton.class);
+            dismissButton.set(gotIt);
+            if (gotIt == null) {
+                return;
+            }
+
+            JBScrollPane transcriptScroll = findByAccessibleName(component, "Assistant transcript", JBScrollPane.class);
+            if (transcriptScroll == null) {
+                return;
+            }
+            JViewport viewport = transcriptScroll.getViewport();
+            Component view = viewport.getView();
+            Rectangle buttonInViewCoordinates =
+                    SwingUtilities.convertRectangle(gotIt.getParent(), gotIt.getBounds(), view);
+
+            reachableBeforeScrolling.set(viewport.getViewRect().contains(buttonInViewCoordinates));
+
+            JScrollBar verticalScrollBar = transcriptScroll.getVerticalScrollBar();
+            verticalScrollBar.setValue(verticalScrollBar.getMaximum());
+            reachableAfterScrollingToBottom.set(viewport.getViewRect().contains(buttonInViewCoordinates));
+        });
+
+        assertNotNull(dismissButton.get(),
+                "The welcome bubble's Got it button must render at a narrow dark tool window width");
+        assertAll(
+                () -> assertTrue(reachableBeforeScrolling.get(),
+                        "The Got it button must already be fully inside the initial (unscrolled) "
+                                + "viewport at NARROW_WIDTH x HEIGHT under DarculaLaf -- a regression here "
+                                + "would reproduce issue #4163's reported clip."),
+                () -> assertTrue(reachableAfterScrollingToBottom.get(),
+                        "The Got it button must stay fully inside the viewport when the transcript is "
+                                + "scrolled to the bottom -- it must never become orphaned by scrolling."));
     }
 
     /**
@@ -1498,7 +1570,8 @@ class ShaftPluginScreenshotRendererTest {
      * <p>{@code rendersFeatureCatalogScreenshotsWhenOutputDirectoryIsProvided} only runs its body
      * (including every {@code configureLookAndFeel} call) when {@code -Dshaft.intellij.screenshotDir}
      * is set -- which none of this module's CI or local {@code gradlew test} invocations do -- so in
-     * practice this test is the only code in the whole module that installs a real platform L&F
+     * practice this test, and {@link #firstRunWelcomeDismissButtonIsVisibleWithoutScrollingAtNarrowDarkWidth}
+     * (issue #4163), are the only code in the whole module that installs a real platform L&F
      * (IntelliJLaf/DarculaLaf) during an ordinary test run. Other test classes (e.g.
      * {@code ShaftTestsPanelTest}, {@code ToolApprovalPromptPanelTest}) build real
      * {@code com.intellij.ui.treeStructure.Tree}/button components with no L&F of their own and


### PR DESCRIPTION
## Summary

Issue #4163 bundled two findings: a possibly-clipped welcome-bubble dismiss button (filed at medium confidence, with an explicit caveat that it needed a live-scroll check) and a non-theme-aware monospaced font in the same file.

**The button-clipping claim does not reproduce.** A live Swing reachability test (`ShaftPluginScreenshotRendererTest#firstRunWelcomeDismissButtonIsVisibleWithoutScrollingAtNarrowDarkWidth`), plus a re-rendered `intellij-plugin-assistant-empty-narrow.png` at the exact width/height/theme (360x780, DarculaLaf) the original evidence used, both show the "Got it" button is already fully inside the initial viewport with no scrolling required. Since this is the same tool-window program the audit in tracker 4160 is tracking, I'm noting the outcome here rather than treating it as settled elsewhere: the finding does not reproduce on current `main`, so no layout change is made for it.

**The font finding is real and fixed.** `AssistantTranscriptView.rawEvidenceDisclosure` hardcoded its monospaced text area's font family to the generic JDK logical name `Font.MONOSPACED`, ignoring the IDE's configured editor font and the user's theme/font settings. `AssistantTranscriptView.monospacedFontFamily()` now resolves the family through `EditorColorsScheme` (`EditorColorsManager.getInstance().getGlobalScheme().getFont(EditorFontType.PLAIN)`) -- the same theme-aware mechanism this file already uses for syntax-highlight colors (`highlightedByLexer`) -- with a `Font.MONOSPACED` fallback when no live IntelliJ `Application` exists (this module's tests build none).

While wiring the fallback I discovered `EditorColorsManager.getInstance()` itself throws `NullPointerException` rather than returning `null` when no `Application` exists (it unconditionally dereferences `ApplicationManager.getApplication().getService(...)`). The naive `EditorColorsManager.getInstance() == null ? null : ...` pattern -- copied at first from this same file's existing `highlightedByLexer` code -- broke 8 previously-green tests once actually exercised. The fix guards on `ApplicationManager.getApplication() == null` directly, before ever calling `EditorColorsManager.getInstance()`.

## Adjacent findings (filed, not fixed here)

- #4174: the welcome bubble's trailing paragraph is genuinely truncated (missing text, no ellipsis) at narrow tool-window widths -- a real, distinct defect from the button-clipping claim, discovered while re-rendering the narrow screenshot.
- #4175: `highlightedByLexer`'s pre-existing `EditorColorsManager.getInstance() == null` check is dead code (same throw-not-null-return root cause as above), dormant only because no current test exercises a fenced code block without a live `Application`.

## Evidence

- `ShaftPanelSetupTest`, `AssistantTranscriptViewTest`, `AssistantTranscriptViewPerformanceTest`, `ShaftPluginScreenshotRendererTest` all green (targeted `gradlew test --tests`, `-DheadlessExecution=true` implied by this module's sandboxed test JVM).
- Re-rendered full screenshot set via `ShaftPluginScreenshotRendererTest#rendersFeatureCatalogScreenshotsWhenOutputDirectoryIsProvided -Dshaft.intellij.screenshotDir=...`; `intellij-plugin-assistant-empty-narrow.png` confirms the button is visible without scrolling.
- Before/after `intellij-plugin-assistant-tool-result-raw-output.png` byte-compared: identical, because this Gradle test module has no live `Application` (no `BasePlatformTestCase` fixture, by explicit existing design) to source a real editor font from -- the font-family change is only observable in a genuinely running IDE, not in this headless render pipeline. Verified via source-level unit tests instead (`AssistantTranscriptViewTest`).

## Test plan

- [x] `gradlew test --tests com.shaft.intellij.ui.AssistantTranscriptViewTest` (watched RED via `NullPointerException`, then GREEN after the `ApplicationManager.getApplication()` guard)
- [x] `gradlew test --tests com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest` (watched RED on the false "must start clipped" precondition, then GREEN once corrected to match observed reality)
- [x] `gradlew test --tests com.shaft.intellij.ui.ShaftPanelSetupTest`
- [x] `gradlew test --tests com.shaft.intellij.ui.AssistantTranscriptViewPerformanceTest`

Closes #4163