### PR TITLE
Consolidate capture-status parsing helpers onto AssistantMarkdown

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
@@ -165,8 +165,11 @@ final class AssistantMarkdown {
      * on that nested section, not at the union's top level. The union guarantees exactly one section
      * is populated, so returning the first populated section is equivalent to dispatching on the
      * union's {@code engine} field. A payload with none of these keys (already unwrapped, or a
-     * non-union shape) is returned unchanged. Shared by {@code GuidedWorkflowPanel} and {@code
-     * ShaftAssistantPanel} -- both poll the same union-shaped capture status tools (issue #3955).
+     * non-union shape) is returned unchanged. Shared by {@code GuidedWorkflowPanel}, {@code
+     * RecorderToolPanel}, and {@code ShaftAssistantPanel} -- all three poll the same union-shaped
+     * capture status tools (issue #3955; consolidated onto this single call-through home, issue
+     * #4171, after a private same-named/same-signature method in {@code GuidedWorkflowPanel} had
+     * been shadowing this one for every unqualified call in that class).
      *
      * @param status the raw parsed tool output, or null
      * @return the unwrapped engine-specific status section, or {@code status} itself when it has no
@@ -182,6 +185,69 @@ final class AssistantMarkdown {
             }
         }
         return status;
+    }
+
+    /**
+     * Answers active/idle for an (already {@link #unwrapCaptureStatus}-unwrapped) engine-specific
+     * status section: {@code active} first (mobile), else {@code state} (web/Playwright). Issue
+     * #4171: consolidated single home for logic that used to be duplicated byte-for-byte in both
+     * {@code GuidedWorkflowPanel} and {@code RecorderToolPanel}.
+     *
+     * @param status the unwrapped status section, or null
+     * @return true when the status represents an active/starting/stopping recording
+     */
+    static boolean isRecorderActive(JsonObject status) {
+        if (status == null) {
+            return false;
+        }
+        if (status.has("active")) {
+            return status.get("active").getAsBoolean();
+        }
+        String state = status.has("state") ? status.get("state").getAsString() : "";
+        return "ACTIVE".equalsIgnoreCase(state) || "STARTING".equalsIgnoreCase(state)
+                || "STOPPING".equalsIgnoreCase(state);
+    }
+
+    /**
+     * Renders an (already unwrapped) status section's recorded-unit count as "N step(s)", with a
+     * trailing "(+N pending)" when pending signals exist -- recorded units read "steps" in every
+     * user-facing surface (shared authoring glossary, #3496/#3501) even though the wire fields keep
+     * their eventCount/actionCount names. Issue #4171: consolidated single home, see {@link
+     * #isRecorderActive}.
+     *
+     * @param status the unwrapped status section, or null
+     * @return the human-readable step count text
+     */
+    static String countText(JsonObject status) {
+        if (status == null) {
+            return "0 steps";
+        }
+        int steps = status.has("actionCount")
+                ? status.get("actionCount").getAsInt()
+                : status.has("eventCount") ? status.get("eventCount").getAsInt() : 0;
+        int pending = status.has("pendingSignalCount") ? status.get("pendingSignalCount").getAsInt() : 0;
+        String base = steps + (steps == 1 ? " step" : " steps");
+        return pending > 0 ? base + " (+" + pending + " pending)" : base;
+    }
+
+    /**
+     * Maps an (already unwrapped) status section's {@code readiness} wire enum to its human-cased
+     * label ("Ready"/"Risky"/"Blocked"), or {@code ""} when absent or unrecognized. Issue #4171:
+     * consolidated single home, see {@link #isRecorderActive}.
+     *
+     * @param status the unwrapped status section, or null
+     * @return the human-cased readiness label, or {@code ""}
+     */
+    static String readinessLabel(JsonObject status) {
+        if (status == null || !status.has("readiness")) {
+            return "";
+        }
+        return switch (status.get("readiness").getAsString().toUpperCase(java.util.Locale.ROOT)) {
+            case "READY" -> "Ready";
+            case "RISKY" -> "Risky";
+            case "BLOCKED" -> "Blocked";
+            default -> "";
+        };
     }
 
     /**

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/GuidedWorkflowPanel.java
@@ -1225,13 +1225,14 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
             scheduleNextStatusPoll();
             return;
         }
-        JsonObject status = unwrapCaptureStatus(AssistantMarkdown.jsonObjectFromMcpOutput(result.output()));
+        JsonObject status = AssistantMarkdown.unwrapCaptureStatus(
+                AssistantMarkdown.jsonObjectFromMcpOutput(result.output()));
         // Issue #3639: the steps list is a pure projection of this same polled status, refreshed on
         // every poll (active or the final post-stop poll) -- there is no separate client-side state
         // store. A capture_status payload (WebDriver) has no "steps" key, so this naturally renders
         // an empty list for that backend, matching updateFieldRelevance() disabling the controls.
         renderStepsFromStatus(status);
-        boolean active = isRecorderActive(status);
+        boolean active = AssistantMarkdown.isRecorderActive(status);
         // Feeds the shared readiness strip's recording badge (issue #3500 A4).
         if (active) {
             ShaftRecordingActivity.started(recordingKey);
@@ -1250,11 +1251,11 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
             String state = status != null && status.has("state") ? status.get("state").getAsString() : "";
             if ("INCOMPLETE".equalsIgnoreCase(state) || "FAILED".equalsIgnoreCase(state)) {
                 setRecorderStatus("Recording ended unexpectedly (" + state.toUpperCase(java.util.Locale.ROOT)
-                        + ") - " + countText(status)
+                        + ") - " + AssistantMarkdown.countText(status)
                         + ". The browser or recorder died before Stop; re-record the flow before generating code.");
                 return;
             }
-            setRecorderStatus("Recording finished - " + countText(status)
+            setRecorderStatus("Recording finished - " + AssistantMarkdown.countText(status)
                     + ". Use Review code to generate the reviewed test.");
             return;
         }
@@ -1404,51 +1405,11 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
         }
     }
 
-    /**
-     * Unwraps a {@code capture_status}/{@code capture_api_status} union response ({@code
-     * McpCaptureUnionStatus}/{@code McpCaptureApiUnionStatus}, design doc amendment A3, landed by
-     * #3881) down to whichever of {@code webStatus}/{@code playwrightStatus}/{@code mobileStatus}
-     * the active engine populated -- mirrors {@code GuidedWorkflowLiveE2ETest}'s {@code
-     * webStatus()}/{@code mobileStatus()} helpers, which confirmed this wire shape against a live
-     * server (issue #3949): {@code state}/{@code active}/{@code actionCount}/{@code steps} live on
-     * that nested section, not at the union's top level. The union guarantees exactly one section is
-     * populated, so returning the first populated section is equivalent to dispatching on the
-     * union's {@code engine} field. A payload with none of these keys (already unwrapped, or a
-     * non-union shape) is returned unchanged.
-     *
-     * @param status the raw parsed tool output, or null
-     * @return the unwrapped engine-specific status section, or {@code status} itself when it has no
-     *         union section to unwrap
-     */
-    private static JsonObject unwrapCaptureStatus(JsonObject status) {
-        if (status == null) {
-            return null;
-        }
-        for (String section : new String[]{"webStatus", "playwrightStatus", "mobileStatus"}) {
-            if (status.has(section) && status.get(section).isJsonObject()) {
-                return status.getAsJsonObject(section);
-            }
-        }
-        return status;
-    }
-
-    private static boolean isRecorderActive(JsonObject status) {
-        if (status == null) {
-            return false;
-        }
-        if (status.has("active")) {
-            return status.get("active").getAsBoolean();
-        }
-        String state = status.has("state") ? status.get("state").getAsString() : "";
-        return "ACTIVE".equalsIgnoreCase(state) || "STARTING".equalsIgnoreCase(state)
-                || "STOPPING".equalsIgnoreCase(state);
-    }
-
     // Mirrors the overlay's pill glossary (#3496 B7): mode, steps count, and human-cased
     // readiness read identically in both surfaces, and either surface can stop safely.
     private static String activeStatusText(JsonObject status) {
-        StringBuilder text = new StringBuilder("Recording · ").append(countText(status));
-        String readiness = readinessLabel(status);
+        StringBuilder text = new StringBuilder("Recording · ").append(AssistantMarkdown.countText(status));
+        String readiness = AssistantMarkdown.readinessLabel(status);
         if (!readiness.isBlank()) {
             text.append(" · ").append(readiness);
         }
@@ -1457,32 +1418,6 @@ final class GuidedWorkflowPanel extends JPanel implements Disposable {
             text.append(" · ").append(displayUrl(status.get("currentUrl").getAsString()));
         }
         return text.append(". Stop here or in the browser overlay - both save the session.").toString();
-    }
-
-    private static String readinessLabel(JsonObject status) {
-        if (status == null || !status.has("readiness")) {
-            return "";
-        }
-        return switch (status.get("readiness").getAsString().toUpperCase(java.util.Locale.ROOT)) {
-            case "READY" -> "Ready";
-            case "RISKY" -> "Risky";
-            case "BLOCKED" -> "Blocked";
-            default -> "";
-        };
-    }
-
-    // Recorded units read "steps" in every user-facing surface (shared authoring glossary,
-    // #3496/#3501) even though the wire fields keep their eventCount/actionCount names.
-    private static String countText(JsonObject status) {
-        if (status == null) {
-            return "0 steps";
-        }
-        int steps = status.has("actionCount")
-                ? status.get("actionCount").getAsInt()
-                : status.has("eventCount") ? status.get("eventCount").getAsInt() : 0;
-        int pending = status.has("pendingSignalCount") ? status.get("pendingSignalCount").getAsInt() : 0;
-        String base = steps + (steps == 1 ? " step" : " steps");
-        return pending > 0 ? base + " (+" + pending + " pending)" : base;
     }
 
     private static String displayUrl(String url) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/RecorderToolPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/RecorderToolPanel.java
@@ -418,61 +418,23 @@ final class RecorderToolPanel extends JPanel {
         }
         JsonObject status = AssistantMarkdown.unwrapCaptureStatus(
                 AssistantMarkdown.jsonObjectFromMcpOutput(result.output()));
-        if (isRecorderActive(status)) {
-            setStatus("Recording active - " + countText(status) + readinessSuffix(status)
+        if (AssistantMarkdown.isRecorderActive(status)) {
+            setStatus("Recording active - " + AssistantMarkdown.countText(status) + readinessSuffix(status)
                     + ". Open Advanced options for the full status.");
             return;
         }
         String state = status != null && status.has("state") ? status.get("state").getAsString() : "";
         if ("INCOMPLETE".equalsIgnoreCase(state) || "FAILED".equalsIgnoreCase(state)) {
             setStatus("Recording ended unexpectedly (" + state.toUpperCase(java.util.Locale.ROOT) + ") - "
-                    + countText(status) + ". Re-record the flow before generating code.");
+                    + AssistantMarkdown.countText(status) + ". Re-record the flow before generating code.");
             return;
         }
         setStatus("No active recording. Recorder idle. Open Advanced options for the full status.");
     }
 
-    /**
-     * Mirrors {@code GuidedWorkflowPanel#isRecorderActive} exactly: same {@code capture_status}
-     * union payload shape, so this panel's one-shot Check status answers the same active/idle
-     * question the same way -- {@code active} first (mobile), else {@code state} (web/Playwright).
-     */
-    private static boolean isRecorderActive(JsonObject status) {
-        if (status == null) {
-            return false;
-        }
-        if (status.has("active")) {
-            return status.get("active").getAsBoolean();
-        }
-        String state = status.has("state") ? status.get("state").getAsString() : "";
-        return "ACTIVE".equalsIgnoreCase(state) || "STARTING".equalsIgnoreCase(state)
-                || "STOPPING".equalsIgnoreCase(state);
-    }
-
-    /** Mirrors {@code GuidedWorkflowPanel#countText}: recorded units read "steps" everywhere. */
-    private static String countText(JsonObject status) {
-        if (status == null) {
-            return "0 steps";
-        }
-        int steps = status.has("actionCount")
-                ? status.get("actionCount").getAsInt()
-                : status.has("eventCount") ? status.get("eventCount").getAsInt() : 0;
-        int pending = status.has("pendingSignalCount") ? status.get("pendingSignalCount").getAsInt() : 0;
-        String base = steps + (steps == 1 ? " step" : " steps");
-        return pending > 0 ? base + " (+" + pending + " pending)" : base;
-    }
-
-    /** Mirrors {@code GuidedWorkflowPanel#readinessLabel}, rendered as a trailing " - Label" suffix. */
+    /** Mirrors {@link AssistantMarkdown#readinessLabel}, rendered as a trailing " - Label" suffix. */
     private static String readinessSuffix(JsonObject status) {
-        if (status == null || !status.has("readiness")) {
-            return "";
-        }
-        String readiness = switch (status.get("readiness").getAsString().toUpperCase(java.util.Locale.ROOT)) {
-            case "READY" -> "Ready";
-            case "RISKY" -> "Risky";
-            case "BLOCKED" -> "Blocked";
-            default -> "";
-        };
+        String readiness = AssistantMarkdown.readinessLabel(status);
         return readiness.isBlank() ? "" : " - " + readiness;
     }
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
@@ -961,6 +961,73 @@ class AssistantMarkdownTest {
                 () -> assertTrue(markdown.contains("\"value\": 1")));
     }
 
+    /**
+     * Issue #4171: {@code isRecorderActive}/{@code countText}/{@code readinessLabel} used to be
+     * duplicated (byte-identical) in both {@code GuidedWorkflowPanel} and {@code RecorderToolPanel}
+     * alongside {@link AssistantMarkdown#unwrapCaptureStatus}. This pins their consolidated home here
+     * directly, matching the exact semantics {@code GuidedWorkflowPanelTest
+     * .applyStatusPollUnwrapsTheActiveEngineSectionFromTheUnionResponse} already exercises indirectly
+     * through {@code GuidedWorkflowPanel}.
+     */
+    @Test
+    void isRecorderActiveReadsTheBooleanFieldFirstThenFallsBackToEngineState() {
+        JsonObject activeByFlag = new JsonObject();
+        activeByFlag.addProperty("active", true);
+
+        JsonObject idleByFlag = new JsonObject();
+        idleByFlag.addProperty("active", false);
+
+        JsonObject activeByState = new JsonObject();
+        activeByState.addProperty("state", "STARTING");
+
+        JsonObject idleByState = new JsonObject();
+        idleByState.addProperty("state", "NOT_RUNNING");
+
+        assertAll(
+                () -> assertTrue(AssistantMarkdown.isRecorderActive(activeByFlag)),
+                () -> assertFalse(AssistantMarkdown.isRecorderActive(idleByFlag)),
+                () -> assertTrue(AssistantMarkdown.isRecorderActive(activeByState)),
+                () -> assertFalse(AssistantMarkdown.isRecorderActive(idleByState)),
+                () -> assertFalse(AssistantMarkdown.isRecorderActive(null)),
+                () -> assertFalse(AssistantMarkdown.isRecorderActive(new JsonObject())));
+    }
+
+    @Test
+    void countTextPluralizesStepsAndAppendsPendingSignalCount() {
+        JsonObject oneStep = new JsonObject();
+        oneStep.addProperty("actionCount", 1);
+
+        JsonObject manyStepsWithPending = new JsonObject();
+        manyStepsWithPending.addProperty("eventCount", 5);
+        manyStepsWithPending.addProperty("pendingSignalCount", 2);
+
+        assertAll(
+                () -> assertEquals("0 steps", AssistantMarkdown.countText(null)),
+                () -> assertEquals("0 steps", AssistantMarkdown.countText(new JsonObject())),
+                () -> assertEquals("1 step", AssistantMarkdown.countText(oneStep)),
+                () -> assertEquals("5 steps (+2 pending)", AssistantMarkdown.countText(manyStepsWithPending)));
+    }
+
+    @Test
+    void readinessLabelMapsTheWireEnumToHumanCasedText() {
+        JsonObject ready = new JsonObject();
+        ready.addProperty("readiness", "ready");
+        JsonObject risky = new JsonObject();
+        risky.addProperty("readiness", "RISKY");
+        JsonObject blocked = new JsonObject();
+        blocked.addProperty("readiness", "Blocked");
+        JsonObject unknown = new JsonObject();
+        unknown.addProperty("readiness", "SOMETHING_ELSE");
+
+        assertAll(
+                () -> assertEquals("Ready", AssistantMarkdown.readinessLabel(ready)),
+                () -> assertEquals("Risky", AssistantMarkdown.readinessLabel(risky)),
+                () -> assertEquals("Blocked", AssistantMarkdown.readinessLabel(blocked)),
+                () -> assertEquals("", AssistantMarkdown.readinessLabel(unknown)),
+                () -> assertEquals("", AssistantMarkdown.readinessLabel(new JsonObject())),
+                () -> assertEquals("", AssistantMarkdown.readinessLabel(null)));
+    }
+
     private static String mcpText(String text) {
         JsonObject item = new JsonObject();
         item.addProperty("type", "text");


### PR DESCRIPTION
## Summary

- `GuidedWorkflowPanel` had a private `unwrapCaptureStatus` shadowing `AssistantMarkdown`'s method of the same name and signature (the sharing was introduced by issue 3955), so every unqualified call inside that class silently resolved to the local copy instead of the shared one the javadoc claimed.
- `isRecorderActive`, `countText`, and `readinessLabel` were also duplicated byte-for-byte in `GuidedWorkflowPanel` and `RecorderToolPanel` — the `RecorderToolPanel` copy was deliberately fenced there by PR #4170 to avoid colliding with concurrent sibling work on tracker 4160, not sloppiness.
- All four are now lifted onto `AssistantMarkdown` as the single home both panels call through. No behavior change.

Closes #4171

## Verification

- Diffed the duplicated copies before merging them: `unwrapCaptureStatus`, `isRecorderActive`, and `countText` were byte-identical across both panels. `readinessLabel`/`readinessSuffix` were **not** identical — `GuidedWorkflowPanel` renders the bare label inline (`"· Ready"`), `RecorderToolPanel` renders a `" - Ready"` trailing suffix. The underlying classification switch (READY/RISKY/BLOCKED -> human-cased label) was identical in both; only the call-site wrapping differed. Lifted the shared classification into `AssistantMarkdown.readinessLabel` (bare label, matching `GuidedWorkflowPanel`'s original exactly) and kept `RecorderToolPanel.readinessSuffix` as a thin local wrapper around it, so neither panel's rendered text changes.
- Checked `ShaftAssistantPanel`: it already calls `AssistantMarkdown.unwrapCaptureStatus` correctly (qualified, no shadow) and never duplicated the other three helpers, so it needed no change.
- Confirmed no mutation crept into the parsing helpers: `ShaftRecordingActivity.started`/`stopped` calls remain exactly where PR #4170 left them (`GuidedWorkflowPanel#applyStatusPoll`, `RecorderToolPanel#startRecording`/`stopRecording`/`removeNotify`) — none of the consolidated helpers touch the shared indicator.
- New `AssistantMarkdownTest` coverage for `isRecorderActive`/`countText`/`readinessLabel` (none existed before, since they were private to the panels): written first, watched red (`cannot find symbol`, methods didn't exist yet), then green after adding the methods.
- `./gradlew test --tests "com.shaft.intellij.ui.GuidedWorkflowPanelTest"` -- 22/22 passing.
- `./gradlew test --tests "com.shaft.intellij.ui.RecorderToolPanelTest"` -- 25/25 passing.
- `./gradlew test --tests "com.shaft.intellij.ui.ShaftRecordingActivityTest"` -- 5/5 passing.
- `./gradlew test --tests "com.shaft.intellij.ui.AssistantMarkdownTest"` -- 43/43 passing (3 new).
- `./gradlew test --tests "com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest" -Dshaft.intellij.screenshotDir=...` -- full catalog regenerates cleanly; Recorder and Guided tab screenshots confirmed unchanged (both render their default "Ready"/"Recorder idle." state, since the consolidated helpers only affect text rendered from a live `capture_status` poll/check, not the default state).
- Full module `compileJava`/`compileTestJava` clean after the refactor.

Part of the plugin production-polish tracker 4160.