### PR TITLE
Wire shaft-capture into the healing fingerprint-seeding seam (issue 4172)

### DIFF
--- a/shaft-capture/pom.xml
+++ b/shaft-capture/pom.xml
@@ -65,6 +65,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <!-- Test-only: proves the generation-time fingerprint seeding (issue #4172) actually
+                 satisfies a later shaft-heal history lookup, the same way
+                 ShaftHealingProviderTest#seededFingerprintShouldSatisfyHistoryLookupWithoutALiveElementOrDriver
+                 proves it at the shaft-heal layer. Production code never depends on shaft-heal,
+                 only the optional runtime ServiceLoader seam in shaft-engine (issue #4161). -->
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-heal</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -18,7 +18,13 @@ import com.shaft.capture.model.EventContext;
 import com.shaft.capture.model.ExternalTestDataReference;
 import com.shaft.capture.model.LocatorCandidate;
 import com.shaft.capture.privacy.CapturePrivacyClassifier;
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.internal.healing.HealingFingerprintObservation;
+import com.shaft.gui.internal.healing.HealingFingerprintSeed;
+import com.shaft.gui.internal.healing.HealingManager;
+import com.shaft.gui.internal.locator.Locator;
 import com.shaft.gui.internal.locator.Role;
+import org.openqa.selenium.By;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -75,6 +81,15 @@ public final class CaptureGenerator {
             .build();
     private static final DefaultPrettyPrinter PRINTER = printer();
     private static final BiConsumer<Double, String> NO_OP_PROGRESS = (fraction, message) -> { };
+    // The deterministic-source render is fingerprinted (SHA-256) to detect drift between a
+    // control-flow/enrichment PREVIEW and its later APPLY (issue #4172 introduced the only
+    // outputRoot-dependent line: the absolute healing.history.path). PREVIEW and APPLY are
+    // legitimately allowed to target different output directories (see
+    // CaptureGeneratorTest#approvedControlFlowPreviewGeneratesOptionalGuard), so the fingerprint
+    // must stay independent of outputRoot -- a stable placeholder is rendered here instead of the
+    // real absolute path; only the FINAL written source uses the true per-call healingHistoryPath.
+    private static final Path FINGERPRINT_HEALING_HISTORY_PATH =
+            Path.of("fingerprint-placeholder", ".shaft-heal", "history.json");
 
     private final CaptureJsonCodec codec;
     private final LocatorRanker locatorRanker;
@@ -147,6 +162,10 @@ public final class CaptureGenerator {
         CodegenBackend targetBackend = backend == null ? CodegenBackend.WEBDRIVER : backend;
         Path sessionPath = request.sessionPath().toAbsolutePath().normalize();
         Path outputRoot = request.outputDirectory().toAbsolutePath().normalize();
+        // Absolute, NOT under target/ -- issue #4172: mvn clean wipes target/, and the default
+        // healing.history.path is relative (resolved against whatever CWD a later run happens to
+        // have), so seeded evidence would be orphaned instead of found by that later run.
+        Path healingHistoryPath = outputRoot.resolve(".shaft-heal/history.json").normalize();
         Path privacyRoot = privacyAllowedRoot(sessionPath, outputRoot);
         Path reportPath = outputRoot.resolve("target/shaft-capture/generation-report.json");
         CaptureSession session = null;
@@ -167,7 +186,7 @@ public final class CaptureGenerator {
             Map<String, String> elementNames = defaultElementNames(state.targets());
             String deterministicSource = renderSource(session, request.packageName(), deterministicClassName,
                     deterministicMethodName, state.targets(), state.data(), elementNames, List.of(), targetBackend,
-                    request.fallbackLocators(), Set.of());
+                    request.fallbackLocators(), Set.of(), FINGERPRINT_HEALING_HISTORY_PATH);
             reporter.accept(0.5, "Generated deterministic test source for " + deterministicClassName);
             String fingerprint = fingerprint(codec.write(session), deterministicSource);
             Set<Long> appliedControlFlowGuards = Set.of();
@@ -251,7 +270,7 @@ public final class CaptureGenerator {
             }
             String source = renderSource(session, request.packageName(), className, methodName,
                     state.targets(), state.data(), finalElementNames, appliedProposal.assertions(), targetBackend,
-                    request.fallbackLocators(), appliedControlFlowGuards);
+                    request.fallbackLocators(), appliedControlFlowGuards, healingHistoryPath);
             String dataJson = writeJson(state.data().root());
 
             List<String> privacy = new ArrayList<>();
@@ -293,6 +312,9 @@ public final class CaptureGenerator {
                         outputRoot,
                         request.replayTimeout());
                 reporter.accept(0.9, "Replayed generated test: " + replay.status());
+                if (replay.status() == CaptureGenerationReport.Validation.ValidationStatus.PASSED) {
+                    seedHealingHistory(state.targets(), healingHistoryPath);
+                }
             } else if (request.replay()) {
                 replay = CaptureGenerationReport.Validation.skipped(
                         "Replay was skipped because compilation failed.");
@@ -872,7 +894,8 @@ public final class CaptureGenerator {
             List<CaptureEnrichmentPreview.AssertionSuggestion> extraAssertions,
             CodegenBackend backend,
             boolean fallbackLocators,
-            Set<Long> optionalGuardSequences) {
+            Set<Long> optionalGuardSequences,
+            Path healingHistoryPath) {
         boolean fallbackReplay = fallbackLocators && hasFallbackTargets(targets);
         StringBuilder source = new StringBuilder();
         line(source, "package " + packageName + ";");
@@ -911,6 +934,14 @@ public final class CaptureGenerator {
         line(source, "");
         line(source, "    @BeforeMethod");
         line(source, "    public void setUp() {");
+        // Issue #4172: points a later real run at the SAME absolute history file generation-time
+        // seeding wrote to, and re-enables SHAFT Heal so it is actually consulted. Emitted
+        // unconditionally, even under healing.strategy=disabled/maximumPerformanceMode -- an
+        // intentional, accepted side effect of using a SHAFT-Assistant-generated test (see PR body).
+        line(source, "        SHAFT.Properties.healing.set()");
+        line(source, "                .strategy(\"shaft-heal\")");
+        line(source, "                .historyPath(\"" + javaString(healingHistoryPath.toString()) + "\")");
+        line(source, "                .aiTrigger(\"below-threshold\");");
         if (backend == CodegenBackend.WEBDRIVER) {
             line(source, "        driver = new SHAFT.GUI.WebDriver(DriverFactory.DriverType."
                     + driverType(session.browser().browserName()) + ");");
@@ -1298,6 +1329,109 @@ public final class CaptureGenerator {
         String locator = locatorReference(target.get(), targets, fallbackReplay);
         renderVerification(source, verification, target.get(), null, suggestion.negated(),
                 event.context(), locator, null, backend);
+    }
+
+    /**
+     * Seeds SHAFT Heal history with every target's already-recorded evidence right after a PASSED
+     * replay (issue #4172/#4161): no live driver or element required, and shaft-capture never
+     * itself depends on shaft-heal -- the optional runtime {@link HealingManager#observeFingerprint}
+     * seam swallows this silently when shaft-heal is not on the classpath, matching every other
+     * {@code HealingManager} entry point. Deliberately ungated on {@code healing.strategy}, mirroring
+     * {@code HealingManager.recordOutcome()}'s existing precedent rather than {@code resolve()}'s
+     * gated one -- see the PR body for the consequence this accepts.
+     */
+    private static void seedHealingHistory(List<TargetPlan> targets, Path healingHistoryPath) {
+        SHAFT.Properties.healing.set().historyPath(healingHistoryPath.toString());
+        for (TargetPlan target : targets) {
+            HealingManager.observeFingerprint(new HealingFingerprintObservation(
+                    target.context().page().url(),
+                    runtimeLocator(target),
+                    "ELEMENT_RESOLUTION",
+                    fingerprintSeed(target.target())));
+        }
+    }
+
+    /**
+     * Maps shaft-capture's already-computed per-element DOM evidence onto shaft-heal's fingerprint
+     * fields (issue #4172): {@link ElementSnapshot}'s recorded attributes line up almost one-to-one
+     * with {@link HealingFingerprintSeed}.
+     */
+    private static HealingFingerprintSeed fingerprintSeed(ElementSnapshot target) {
+        Map<String, String> attributes = target.normalizedAttributes();
+        Map<String, String> testIds = new LinkedHashMap<>();
+        for (String attribute : SHAFT.Properties.healing.testIdAttributes().split(",")) {
+            String key = attribute.trim();
+            String value = attributes.getOrDefault(key, "");
+            if (!key.isEmpty() && !value.isBlank()) {
+                testIds.put(key, value);
+            }
+        }
+        Map<String, String> semanticAttributes = new LinkedHashMap<>();
+        for (String key : List.of("aria-label", "aria-labelledby", "alt", "autocomplete")) {
+            String value = attributes.getOrDefault(key, "");
+            if (!value.isBlank()) {
+                semanticAttributes.put(key, value);
+            }
+        }
+        return new HealingFingerprintSeed(
+                target.tagName(),
+                target.accessibleName(),
+                target.label(),
+                "",
+                attributes.getOrDefault("id", ""),
+                attributes.getOrDefault("name", ""),
+                target.role(),
+                attributes.getOrDefault("type", ""),
+                attributes.getOrDefault("placeholder", ""),
+                attributes.getOrDefault("title", ""),
+                testIds,
+                semanticAttributes,
+                target.visible(),
+                target.enabled(),
+                target.selected());
+    }
+
+    /**
+     * Builds the exact runtime {@link By} the generated code will resolve at replay time (issue
+     * #4172): mirrors {@link #locatorExpression(ElementSnapshot, LocatorCandidate)}/{@link
+     * #semanticLocator(ElementSnapshot, String, LocatorCandidate)} branch-for-branch, using the real
+     * {@link Locator}/{@code By} APIs instead of rendering source text.
+     */
+    private static By runtimeLocator(TargetPlan plan) {
+        return runtimeLocator(plan.target(), plan.selection().selected().candidate());
+    }
+
+    private static By runtimeLocator(ElementSnapshot target, LocatorCandidate candidate) {
+        String name = !target.accessibleName().isBlank() ? target.accessibleName() : target.label();
+        return switch (candidate.strategy()) {
+            case ROLE, ACCESSIBLE_NAME, LABEL -> runtimeSemanticLocator(target, name, candidate);
+            case TEST_ID, CSS -> Locator.cssSelector(candidate.expression());
+            case ID -> Locator.id(candidate.expression());
+            case NAME -> Locator.name(candidate.expression());
+            case XPATH -> By.xpath(candidate.expression());
+        };
+    }
+
+    private static By runtimeSemanticLocator(ElementSnapshot target, String name, LocatorCandidate candidate) {
+        String semanticName = semanticName(name, candidate);
+        if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE) {
+            Role ariaRole = ariaRole(target.role());
+            if (ariaRole != null) {
+                return semanticName.isBlank()
+                        ? Locator.hasRole(ariaRole).build()
+                        : Locator.hasRole(ariaRole).hasNormalizedText(semanticName).build();
+            }
+        }
+        if (!candidate.replayXpath().isBlank()) {
+            return By.xpath(candidate.replayXpath());
+        }
+        if (semanticName.isBlank()) {
+            return By.xpath(candidate.expression());
+        }
+        String tagName = target.tagName().isBlank() ? "*" : target.tagName();
+        return candidate.strategy() == LocatorCandidate.LocatorStrategy.LABEL
+                ? Locator.hasTagName(tagName).containsText(semanticName).build()
+                : Locator.hasTagName(tagName).hasAttribute("aria-label", semanticName).build();
     }
 
     private static String locatorExpression(TargetPlan plan) {

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorHealingSeedingTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorHealingSeedingTest.java
@@ -1,0 +1,125 @@
+package com.shaft.capture.generate;
+
+import com.shaft.capture.CaptureFixtures;
+import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.model.CaptureEvent;
+import com.shaft.capture.model.CaptureSession;
+import com.shaft.capture.model.RedactionSummary;
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.internal.healing.HealingRequest;
+import com.shaft.gui.internal.locator.Locator;
+import com.shaft.heal.ShaftHeal;
+import com.shaft.heal.internal.ShaftHealingProvider;
+import com.shaft.heal.model.HealingDecision;
+import com.shaft.pilot.ai.ApprovalPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #4172: shaft-capture must actually call the fingerprint-seeding seam that issue #4161 /
+ * PR #4173 shipped into shaft-engine/shaft-heal but left unreachable. This follows the same shape
+ * as {@code ShaftHealingProviderTest#seededFingerprintShouldSatisfyHistoryLookupWithoutALiveElementOrDriver}
+ * one layer up: a freshly generated test, compiled and replayed from a clean output directory, must
+ * leave recorded fingerprint history behind that a later lookup at the SAME absolute
+ * {@code healing.history.path} finds -- proven by asserting the lookup does not return NO_HISTORY.
+ */
+class CaptureGeneratorHealingSeedingTest {
+    @TempDir
+    Path temp;
+
+    @AfterEach
+    void cleanup() {
+        com.shaft.properties.internal.Properties.clearForCurrentThread();
+        ShaftHeal.clear();
+    }
+
+    @Test
+    void freshlyGeneratedTestLeavesFingerprintHistoryASubsequentReplayLookupFinds() throws Exception {
+        CaptureSession session = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "healing-seed-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(2),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), CaptureFixtures.target(),
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                RedactionSummary.empty(),
+                Map.of());
+        Path sessionPath = temp.resolve("capture.json");
+        new CaptureJsonCodec().write(sessionPath, session);
+        Path output = temp.resolve("gen");
+
+        GeneratedTestValidator fakePassingReplay = new GeneratedTestValidator() {
+            @Override
+            public CaptureGenerationReport.Validation compile(Path source, Path classesDirectory) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED, List.of(), 0);
+            }
+
+            @Override
+            public CaptureGenerationReport.Validation replay(
+                    String fullyQualifiedClassName,
+                    Path classesDirectory,
+                    Path resourcesDirectory,
+                    Path workDirectory,
+                    Duration timeout) {
+                // Fakes a PASSED replay without spawning a real subprocess/browser: this test proves
+                // the seeding wiring, not GeneratedTestValidator's own (already-covered) replay path.
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED, List.of(), 1);
+            }
+        };
+
+        CaptureGenerationResult result = new CaptureGenerator(
+                new CaptureJsonCodec(), new LocatorRanker(), fakePassingReplay, new CaptureEnrichmentService())
+                .generate(new CaptureGenerationRequest(
+                        sessionPath, output, "generated.capture", "HealingSeedTest", false,
+                        true, true, Duration.ofMinutes(1),
+                        CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                        ApprovalPolicy.denyAll()));
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        String source = Files.readString(result.sourcePath());
+        Path expectedHistoryPath = output.resolve(".shaft-heal/history.json").normalize();
+        assertTrue(source.contains(".strategy(\"shaft-heal\")"), source);
+        assertTrue(source.contains(".aiTrigger(\"below-threshold\")"), source);
+        assertTrue(Files.exists(expectedHistoryPath), "seeded history file should exist at the absolute path");
+
+        // The SAME absolute path a later real run's setUp() would configure -- proves the history
+        // lookup succeeds instead of short-circuiting to NO_HISTORY (issue #4161's own proof, one
+        // layer up: generation-time evidence must be visible to a later, independent resolve()).
+        SHAFT.Properties.healing.set()
+                .strategy("shaft-heal")
+                .historyPath(expectedHistoryPath.toString());
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.getCurrentUrl()).thenReturn("https://example.test/form");
+        By originalLocator = Locator.hasTagName("input").containsText("Username").build();
+        ShaftHealingProvider provider = new ShaftHealingProvider();
+
+        provider.resolve(new HealingRequest(driver, originalLocator, "TYPE", true, null, null, null));
+
+        assertNotEquals(
+                HealingDecision.Status.NO_HISTORY,
+                ShaftHeal.lastReport().orElseThrow().decision().status());
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -63,7 +63,13 @@ class CaptureGeneratorTest {
         assertTrue(blockers.stream()
                 .anyMatch(blocker -> blocker.contains("upload.avatar")
                         && blocker.contains("fixture")));
-        assertEquals(Files.readString(first.sourcePath()), Files.readString(second.sourcePath()));
+        // Issue #4172: the emitted healing.history.path is an ABSOLUTE path derived from each
+        // call's own output directory (by design -- a later real run must resolve it to the SAME
+        // location generation-time seeding wrote to), so "first" and "second" legitimately differ
+        // on that one line even though every other line is still a pure function of the session.
+        assertEquals(
+                withStableHealingHistoryPath(Files.readString(first.sourcePath())),
+                withStableHealingHistoryPath(Files.readString(second.sourcePath())));
         assertEquals(Files.readString(first.testDataPath()), Files.readString(second.testDataPath()));
         assertEquals(first.report(), second.report());
 
@@ -71,7 +77,7 @@ class CaptureGeneratorTest {
         String data = Files.readString(first.testDataPath());
         String golden = Files.readString(Path.of(
                 "src/test/resources/fixtures/golden-generated-session-1.java"));
-        assertEquals(normalizeLineEndings(golden), normalizeLineEndings(source));
+        assertEquals(normalizeLineEndings(golden), normalizeLineEndings(withStableHealingHistoryPath(source)));
         assertTrue(source.contains("@AfterMethod(alwaysRun = true)"));
         assertTrue(source.contains("driver.quit();"));
         assertTrue(source.contains("SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()"));
@@ -1439,6 +1445,18 @@ class CaptureGeneratorTest {
 
     private static String normalizeLineEndings(String value) {
         return value.replace("\r\n", "\n").replace('\r', '\n');
+    }
+
+    /**
+     * Redacts the ONE line of generated source that is legitimately output-directory-dependent
+     * (issue #4172's absolute {@code healing.history.path}), so byte-for-byte comparisons across
+     * different output directories -- or against a static golden fixture -- still hold for every
+     * other line, which remains a pure function of the captured session.
+     */
+    private static String withStableHealingHistoryPath(String source) {
+        return source.replaceAll(
+                "(?m)^(\\s*\\.historyPath\\(\")[^\"]*(\"\\)\\r?)$",
+                "$1PLACEHOLDER$2");
     }
 
     private static long count(String value, String needle) {

--- a/shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java
+++ b/shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java
@@ -18,6 +18,10 @@ public class FormCompletedTest {
 
     @BeforeMethod
     public void setUp() {
+        SHAFT.Properties.healing.set()
+                .strategy("shaft-heal")
+                .historyPath("PLACEHOLDER")
+                .aiTrigger("below-threshold");
         driver = new SHAFT.GUI.WebDriver(DriverFactory.DriverType.CHROME);
         testData = new SHAFT.TestData.JSON("form-completed-test.json");
         windows.put("window-1", driver.browser().getWindowHandle());


### PR DESCRIPTION
## Summary

Closes #4172.

Issue #4161 (PR #4173) shipped a narrow seam -- `HealingFingerprintSeed`/`HealingFingerprintObservation`, `HealingProvider.observeFingerprint`, `HealingManager.observeFingerprint`, `ShaftHealingProvider.observeFingerprint` -- that lets recorded element evidence be persisted into SHAFT Heal history without a live driver or element. Nothing in shaft-capture called it. This PR wires it up, per the sequencing tracked in issue 4024 (subtask 4027, the always-on re-suggestion ladder, needs this data present at replay time to have anything to work with).

`CaptureGenerator.generate()` now, right after a PASSED compile+replay:
1. Maps each target's already-recorded `ElementSnapshot`/`LocatorCandidate` evidence onto a `HealingFingerprintSeed` (`CaptureGenerator.fingerprintSeed`).
2. Builds the exact runtime `By` the generated code will resolve at replay time (`CaptureGenerator.runtimeLocator`/`runtimeSemanticLocator`), mirroring the existing `locatorExpression`/`semanticLocator` source-rendering branch-for-branch using the real `Locator`/`By` APIs instead of re-deriving strings.
3. Calls `HealingManager.observeFingerprint(...)` for each target.

The generated test's `setUp()` now also emits:
- An **absolute** `healing.history.path` (`outputRoot/.shaft-heal/history.json`, never under `target/`, since `mvn clean` wipes that and the default is CWD-relative) -- the SAME absolute path generation-time seeding wrote to, so a later real run of the checked-in test finds it.
- `healing.strategy=shaft-heal`.
- `healing.ai.trigger=below-threshold` per tracker 4024's owner policy, which already covers "agent finds a new XPath on the spot" with existing machinery.

New test `CaptureGeneratorHealingSeedingTest` (following #4161's own `ShaftHealingProviderTest` shape one layer up) proves the acceptance criterion: a freshly generated test, compiled+replayed from a clean output directory, leaves fingerprint history behind that a later `ShaftHealingProvider.resolve()` lookup at the SAME absolute path finds -- the lookup does not return `NO_HISTORY`.

## Two deliberate design decisions

**1. Seeding is ungated on `healing.strategy`.** `HealingManager.observeFingerprint` (shipped in #4173) has no `HealingStrategy` gate, matching `recordOutcome()`'s precedent rather than `observe()`/`resolve()`'s gated one. I kept this as-is rather than adding a gate in the new caller: recorded evidence is not an action, the same reasoning that keeps `recordOutcome()` ungated. **Consequence accepted**: once wired, seeding fires even when `healing.strategy=disabled`, populating history a gated `resolve()` won't read until healing is later enabled -- at which point generation-time evidence surfaces as if current. This is a deliberate choice, not an inherited default.

**2. The generated `setUp()` always emits the healing override, even under `maximumPerformanceMode`.** #4161's own test (`PropertiesHelperMaximumPerformanceModeUnitTest`) traced that `TestNGListener.onStart(ISuite)` forces `healing.strategy=disabled` at suite start, before any `@BeforeMethod`, so a generated test's `setUp()` override would win (last-write-wins on the `ThreadLocal`-backed store) and silently re-enable healing. That memory record was corrected during this issue's review: the `ThreadLocal` last-write-wins behavior is proven by a unit test, but that `TestNGListener.onStart` really fires before `@BeforeMethod` in a real running suite rests on a traced call chain plus TestNG's documented `ISuiteListener` contract, not a watched red/green integration test.

My design does not depend on which way that ordering resolves: the generated `setUp()` unconditionally emits `healing.strategy=shaft-heal`, treating re-enabling healing as an **accepted, intentional side effect** of using a SHAFT-Assistant-generated test, regardless of whether it wins or loses against `maximumPerformanceMode`. Since the decision doesn't hinge on the ordering, I did not add a new TestNG-suite-runner integration test to settle it -- that question stays open for whoever next needs the ordering to matter for their own design.

## Adjacent fix: fingerprint-stability regression

Embedding the absolute (per-outputRoot) `healingHistoryPath` into the "deterministic source" broke `CaptureGenerator`'s existing PREVIEW/APPLY drift-detection fingerprint (SHA-256 over that source), because control-flow/enrichment PREVIEW and APPLY are legitimately allowed to target different output directories (see `CaptureGeneratorTest#approvedControlFlowPreviewGeneratesOptionalGuard`). Fixed by rendering the fingerprint-only source with a stable placeholder history path (`FINGERPRINT_HEALING_HISTORY_PATH`); only the final, actually-written source uses the true per-call absolute path. Existing `representativeSessionGeneratesDeterministicCompilableSourceAndExternalData` (byte-for-byte first-vs-second-directory and golden-file comparisons) was updated to redact that one legitimately-varying line before comparing.

## Known external conflict risk (not touched, not reviewed)

PR #4181 (external contributor, open, unmerged as of this PR) also touches `CaptureGenerator.generate()`'s replay region -- it moves the `atomicWrite(paths.source(), source)`/`atomicWrite(paths.data(), dataJson)` calls to after compile+replay, gated on a new `successful` boolean, to fix issue 4166. My new `if (replay.status() == PASSED) { seedHealingHistory(...); }` call sits in the same neighborhood. If #4181 merges before this PR, expect a textual merge conflict requiring a rebase (the seeding call should key off whatever `successful`-equivalent boolean #4181 introduces, not `replay.status() == PASSED` alone). I did not modify or review #4181 itself.

Issue 4166 itself (generated source written before compile/replay, so a failed run can overwrite a working test) remains adjacent and out of scope here, per the issue brief.

## Validation

- `mvn -pl shaft-capture test -Dtest=CaptureGeneratorHealingSeedingTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- new test, watched RED (missing seeding/emission) then GREEN.
- `mvn -pl shaft-capture test -Dtest=CaptureGeneratorTest,CaptureGeneratorHealingSeedingTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 36/36 passed (fixed the 2 fingerprint-drift regressions + 1 golden/determinism update this PR's own change caused).
- `mvn -pl shaft-capture test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- full module, 311/311 passed, no other regressions.
- `shaft-heal` installed locally (`-DskipTests -Dgpg.skip=true`) only to resolve the new shaft-capture test-scope dependency; shaft-capture's production code still has zero compile-time dependency on shaft-heal.

Related: issue 4161 (shipped the seam), issue 4027 (the re-suggestion ladder this data unblocks), tracker 4024 (owner policy for `healing.ai.trigger`).