### PR TITLE
Record shaft-intellij -Werror/modelToView compile gotcha

### DIFF
--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -498,3 +498,4 @@
 {"actor":"agent","event":"memory.updated","id":"gotcha.testnglistener-suite-start-postprocessing-runs-before-setup-later-same-thread-healing-strategy-override-wins-over-maximumperformancemode-disable","timestamp":"2026-07-26T20:37:00+03:00"}
 {"actor":"agent","event":"memory.created","id":"gotcha.single-frame-swing-screenshot-evidence-cannot-confirm-scrollable-content-clipping-claims-verify-the-live-jviewport-before-treating-them-as-defects","timestamp":"2026-07-26T20:45:21+03:00"}
 {"actor":"agent","event":"memory.updated","id":"gotcha.shaft-intellij-gradle-unit-tests-have-no-live-intellij-application-guard-every-applicationmanager-touch","timestamp":"2026-07-26T20:45:21+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.shaft-intellij-werror-bans-jtextcomponent-modeltoview-int-use-modeltoview2d-int-for-pixel-position-swing-test-assertions","timestamp":"2026-07-27T00:18:39+03:00"}

--- a/.memory/memory/gotchas/shaft-intellij-werror-bans-jtextcomponent-modeltoview-int-use-modeltoview2d-int-for-pixel-position-swing-test-assertions.json
+++ b/.memory/memory/gotchas/shaft-intellij-werror-bans-jtextcomponent-modeltoview-int-use-modeltoview2d-int-for-pixel-position-swing-test-assertions.json
@@ -1,0 +1,33 @@
+{
+  "body_path": "memory/gotchas/shaft-intellij-werror-bans-jtextcomponent-modeltoview-int-use-modeltoview2d-int-for-pixel-position-swing-test-assertions.md",
+  "content_hash": "sha256:522835e07d09d9825d0898d8f757bbd352e2386e2f1aa5687111769f4cb2401e",
+  "created_at": "2026-07-27T00:18:39+03:00",
+  "evidence": [],
+  "facets": {
+    "category": "gotcha"
+  },
+  "id": "gotcha.shaft-intellij-werror-bans-jtextcomponent-modeltoview-int-use-modeltoview2d-int-for-pixel-position-swing-test-assertions",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "shaft-intellij -Werror deprecation gotcha for Swing pixel-position tests (issue 4174)"
+  },
+  "status": "active",
+  "tags": [
+    "shaft-intellij",
+    "gradle",
+    "werror",
+    "deprecation",
+    "swing",
+    "modeltoview",
+    "compile-failure"
+  ],
+  "title": "shaft-intellij -Werror bans JTextComponent#modelToView(int) -- use modelToView2D(int) for pixel-position Swing test assertions",
+  "type": "gotcha",
+  "updated_at": "2026-07-27T00:18:39+03:00"
+}

--- a/.memory/memory/gotchas/shaft-intellij-werror-bans-jtextcomponent-modeltoview-int-use-modeltoview2d-int-for-pixel-position-swing-test-assertions.md
+++ b/.memory/memory/gotchas/shaft-intellij-werror-bans-jtextcomponent-modeltoview-int-use-modeltoview2d-int-for-pixel-position-swing-test-assertions.md
@@ -1,0 +1,5 @@
+shaft-intellij/build.gradle.kts:140 sets `options.compilerArgs.addAll(listOf("-Xlint:deprecation", "-Werror"))` on the `JavaCompile` task type, so any deprecation warning in shaft-intellij (test or production code) is a compile failure, not a warning.
+
+Consequence: `javax.swing.text.JTextComponent#modelToView(int)` is deprecated in the JDK and cannot be called anywhere under shaft-intellij, including in Swing tests that measure whether a rendered character's y-coordinate falls inside a pane's bounds. Discovered while writing such a pixel-position assertion for issue 4174.
+
+Fix: use `#modelToView2D(int)` instead -- same purpose, but returns `Rectangle2D` (not `Rectangle`), so callers that need integer bounds must convert (e.g. `.getBounds()` on the `Rectangle2D`, or round the double fields) rather than assigning directly to a `Rectangle`.


### PR DESCRIPTION
## Summary
- Records a durable memory gotcha: shaft-intellij's `-Werror` deprecation gate (`shaft-intellij/build.gradle.kts:140`) turns any use of `JTextComponent#modelToView(int)` into a compile failure; `modelToView2D(int)` is the required replacement.
- Discovered while writing a Swing pixel-position test for issue 4174.

## Test plan
- [x] `memory check` -- passed clean
- [x] `py -3 scripts/ci/validate_agent_setup.py` -- passed clean

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH