### PR TITLE
THROWAWAY: verify font-install fix against PR 4184's welcome-bubble change (do not merge)

### DIFF
--- a/.github/actions/intellij-verify/action.yml
+++ b/.github/actions/intellij-verify/action.yml
@@ -37,6 +37,16 @@ runs:
       uses: gradle/actions/setup-gradle@v6
       with:
         gradle-version: '9.0.0'
+    # ubuntu-22.04 runner images ship only fonts-noto-color-emoji (no DejaVu/
+    # Liberation/any general text font). Without a real text font present,
+    # JVM/Swing logical-font substitution for Dialog/sans-serif on that image
+    # resolves to something with no relationship to any real desktop, which
+    # makes headless Swing layout tests (font metrics, text wrapping) unstable
+    # relative to local/production rendering. No-op on non-Linux runners.
+    - name: Install text fonts for headless Swing rendering
+      if: runner.os == 'Linux'
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends fonts-dejavu-core fonts-liberation
     - name: Validate Marketplace secrets
       if: inputs.publish == 'true'
       shell: bash

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
@@ -1168,10 +1168,13 @@ final class AssistantTranscriptView extends JPanel {
         bubble.putClientProperty(TRANSCRIPT_BUBBLE_PROPERTY, UNKNOWN_ROLE);
         bubble.getAccessibleContext().setAccessibleName(accessibleName);
         JEditorPane htmlPane = fallbackHtmlPane(convertMarkdown(markdown), foreground, background);
-        // JEditorPane under-reports the preferred height of a trailing HTML list by roughly its last
-        // item's bottom margin, which cropped the final "Review code into a test" step against the
-        // actions row below. Reserve extra bottom room so BorderLayout gives the pane enough height.
-        htmlPane.setBorder(JBUI.Borders.emptyBottom(JBUI.scale(10)));
+        // JEditorPane under-reports the preferred height of trailing wrapped content -- originally
+        // seen with a trailing HTML list (cropping the final "Review code into a test" step against
+        // the actions row below), and, at narrow tool-window widths, also with a trailing wrapped
+        // plain paragraph (issue #4174: the welcome message's last sentence painted below the pane's
+        // own bounds and was silently dropped, with no ellipsis). Reserve extra bottom room so
+        // BorderLayout gives the pane enough height to cover both shapes.
+        htmlPane.setBorder(JBUI.Borders.emptyBottom(JBUI.scale(30)));
         htmlPane.putClientProperty(TRANSCRIPT_ROLE_PROPERTY, UNKNOWN_ROLE);
         // Unlike a persisted fallbackMessage() pane, this one can exist in the tree of a freshly
         // constructed, otherwise message-less panel (the welcome shows before any real message
@@ -1700,9 +1703,7 @@ final class AssistantTranscriptView extends JPanel {
         Lexer lexer = highlighter.getHighlightingLexer();
         lexer.start(code);
         StringBuilder highlighted = new StringBuilder();
-        EditorColorsScheme scheme = EditorColorsManager.getInstance() == null
-                ? null
-                : EditorColorsManager.getInstance().getGlobalScheme();
+        EditorColorsScheme scheme = currentEditorColorsSchemeOrNull();
         boolean styled = false;
         while (lexer.getTokenType() != null) {
             String token = code.substring(lexer.getTokenStart(), lexer.getTokenEnd());
@@ -1720,6 +1721,21 @@ final class AssistantTranscriptView extends JPanel {
             lexer.advance();
         }
         return styled ? highlighted.toString() : "";
+    }
+
+    /**
+     * Issue #4175: {@code EditorColorsManager.getInstance()} unconditionally dereferences {@code
+     * ApplicationManager.getApplication()} with no null guard of its own, so it throws rather than
+     * returning {@code null} once there is no live {@code Application} -- guarding on its own return
+     * value (the previous shape here) was dead code that could never catch anything. Mirrors {@link
+     * #monospacedFontFamily()}'s corrected guard: check {@link ApplicationManager#getApplication()}
+     * itself first, and only call {@code EditorColorsManager.getInstance()} once an {@code
+     * Application} actually exists.
+     */
+    static EditorColorsScheme currentEditorColorsSchemeOrNull() {
+        return ApplicationManager.getApplication() == null
+                ? null
+                : EditorColorsManager.getInstance().getGlobalScheme();
     }
 
     private static TextAttributes attributesFor(TextAttributesKey[] keys, EditorColorsScheme scheme) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantTranscriptView.java
@@ -1161,8 +1161,12 @@ final class AssistantTranscriptView extends JPanel {
         Color foreground = resolvedColor("TextArea.foreground", new Color(0x202020));
         Color stroke = resolvedColor("Component.borderColor", new Color(0xD0D7DE));
         RoundedBubblePanel bubble = new RoundedBubblePanel(background, stroke, 18);
-        bubble.setLayout(new BorderLayout(0, 8));
-        bubble.setBorder(JBUI.Borders.empty(9, 11));
+        // A tighter vgap (was 8) and bottom outer margin (was 9) claim back a few px of the
+        // otherwise-fixed vertical budget a narrow tool window gives this bubble, independent of the
+        // htmlPane height reservation below -- see that reservation's comment for why the two must
+        // not share the same budget (issue #4174).
+        bubble.setLayout(new BorderLayout(0, 4));
+        bubble.setBorder(JBUI.Borders.empty(9, 11, 5, 11));
         bubble.setBackground(background);
         bubble.setForeground(foreground);
         bubble.putClientProperty(TRANSCRIPT_BUBBLE_PROPERTY, UNKNOWN_ROLE);
@@ -1170,11 +1174,20 @@ final class AssistantTranscriptView extends JPanel {
         JEditorPane htmlPane = fallbackHtmlPane(convertMarkdown(markdown), foreground, background);
         // JEditorPane under-reports the preferred height of trailing wrapped content -- originally
         // seen with a trailing HTML list (cropping the final "Review code into a test" step against
-        // the actions row below), and, at narrow tool-window widths, also with a trailing wrapped
-        // plain paragraph (issue #4174: the welcome message's last sentence painted below the pane's
-        // own bounds and was silently dropped, with no ellipsis). Reserve extra bottom room so
-        // BorderLayout gives the pane enough height to cover both shapes.
-        htmlPane.setBorder(JBUI.Borders.emptyBottom(JBUI.scale(30)));
+        // the actions row below), and (issue #4174) also with a trailing wrapped plain paragraph at
+        // narrow tool-window widths, by roughly one line's worth. A fixed pixel constant tuned to one
+        // platform's font rendering is fragile (issue #4174's PR history: a value that looked
+        // comfortable locally left only single-digit pixels of margin once the button-reachability
+        // test below was checked against its own real geometry). Reserve three body lines' worth
+        // instead, derived from the live font metrics actually in effect via bodyLineHeight(), so the
+        // reservation is proportional to whatever font metrics are live on the current platform
+        // rather than a guess tuned for one. This and the actions row below necessarily share this
+        // bubble's fixed vertical budget once laid out in the transcript's scroll viewport (growing
+        // one pushes the other down by the same amount); the vgap/margin trims above claim back
+        // independent room so this reservation doesn't have to fight the "Got it" button's own
+        // reachability margin (firstRunWelcomeDismissButtonIsVisibleWithoutScrollingAtNarrowDarkWidth)
+        // down to a razor-thin margin by itself.
+        htmlPane.setBorder(JBUI.Borders.emptyBottom(bodyLineHeight() * 3));
         htmlPane.putClientProperty(TRANSCRIPT_ROLE_PROPERTY, UNKNOWN_ROLE);
         // Unlike a persisted fallbackMessage() pane, this one can exist in the tree of a freshly
         // constructed, otherwise message-less panel (the welcome shows before any real message

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantTranscriptViewTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantTranscriptViewTest.java
@@ -117,6 +117,23 @@ class AssistantTranscriptViewTest {
         assertEquals(java.awt.Font.MONOSPACED, AssistantTranscriptView.monospacedFontFamily());
     }
 
+    /**
+     * Issue #4175: {@code highlightedByLexer}'s {@code EditorColorsScheme} lookup guarded itself with
+     * {@code EditorColorsManager.getInstance() == null ? null : ...} -- dead code, since {@code
+     * EditorColorsManager.getInstance()} unconditionally dereferences {@code
+     * ApplicationManager.getApplication()} with no null guard of its own, so it throws rather than
+     * ever returning {@code null} for the {@code == null} check to catch. This module builds no live
+     * {@code Application} in its tests (same rationale as {@code
+     * monospacedFontFamilyFallsBackToLogicalMonospacedWithoutALiveEditorColorsScheme} above), so
+     * calling the guarded lookup here must return {@code null} instead of throwing -- mirroring
+     * {@code monospacedFontFamily()}'s corrected {@code ApplicationManager.getApplication() == null}
+     * guard shape.
+     */
+    @Test
+    void currentEditorColorsSchemeOrNullReturnsNullWithoutALiveApplicationInsteadOfThrowing() {
+        assertNull(AssistantTranscriptView.currentEditorColorsSchemeOrNull());
+    }
+
     @Test
     void rawEvidenceNeverLeaksIntoTranscriptMarkdown() {
         AssistantTranscriptView view = new AssistantTranscriptView();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -19,6 +19,7 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
+import javax.swing.JEditorPane;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
@@ -29,6 +30,7 @@ import javax.swing.LookAndFeel;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.plaf.ColorUIResource;
+import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreeNode;
@@ -583,6 +585,67 @@ class ShaftPluginScreenshotRendererTest {
                 () -> assertTrue(reachableAfterScrollingToBottom.get(),
                         "The Got it button must stay fully inside the viewport when the transcript is "
                                 + "scrolled to the bottom -- it must never become orphaned by scrolling."));
+    }
+
+    /**
+     * Issue #4174 (tracker #4160 area B): investigating #4163's sibling "Got it" button-clip claim
+     * (see {@link #firstRunWelcomeDismissButtonIsVisibleWithoutScrollingAtNarrowDarkWidth} above,
+     * which did NOT reproduce) turned up a real, different defect in the same welcome bubble: at
+     * narrow tool-window widths the trailing paragraph -- "...the ones you'll reach for first are
+     * New chat, Send, and Copy response." -- is silently cut off mid-sentence, with no ellipsis or
+     * other signal that content is missing. Swing clips painting to a component's own bounds, so a
+     * character laid out below {@link JEditorPane#getHeight()} is never painted; this drives the
+     * exact same narrow/dark construction and proves the pane's own allocated height (after real
+     * layout) falls short of where the paragraph's final characters are positioned -- the same
+     * height-under-reporting mechanism {@code assistantBubbleWithActions}'s existing trailing-list-
+     * crop fix comment documents for a different (list, not paragraph) content shape.
+     */
+    @Test
+    void firstRunWelcomeTrailingParagraphIsNotClippedAtNarrowWidth() throws InterruptedException, InvocationTargetException {
+        AtomicReference<JEditorPane> welcomePane = new AtomicReference<>();
+        AtomicReference<Rectangle> tailCharacterBounds = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(DARK_THEME, true);
+            ShaftSettingsState.Settings settings = defaultSettings();
+            JComponent component = new ShaftToolWindowPanel(
+                    screenshotProject(), settings, AssistantLocalAgentRunner::readiness, new ShaftAssistantChatState());
+            component.setSize(new Dimension(NARROW_WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(NARROW_WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, false);
+
+            JEditorPane pane = findByAccessibleName(component, "Assistant welcome message content", JEditorPane.class);
+            welcomePane.set(pane);
+            if (pane == null) {
+                return;
+            }
+            try {
+                String rendered = pane.getDocument().getText(0, pane.getDocument().getLength());
+                String tail = "Copy response.";
+                int tailStart = rendered.indexOf(tail);
+                if (tailStart < 0) {
+                    return;
+                }
+                int lastOffset = tailStart + tail.length() - 1;
+                java.awt.geom.Rectangle2D bounds2D = pane.modelToView2D(lastOffset);
+                tailCharacterBounds.set(bounds2D == null ? null : bounds2D.getBounds());
+            } catch (BadLocationException exception) {
+                throw new IllegalStateException(exception);
+            }
+        });
+
+        assertNotNull(welcomePane.get(),
+                "The welcome bubble's message pane must render at a narrow dark tool window width");
+        assertNotNull(tailCharacterBounds.get(),
+                "The welcome message's trailing paragraph must contain the full onboarding sentence, "
+                        + "including its final \"Copy response.\" clause, in the rendered document");
+        Rectangle bounds = tailCharacterBounds.get();
+        assertTrue(bounds.y + bounds.height <= welcomePane.get().getHeight(),
+                "The trailing paragraph's final characters (\"Copy response.\") must be painted "
+                        + "inside the welcome message pane's own bounds at NARROW_WIDTH -- Swing clips "
+                        + "paint to component bounds, so text laid out below getHeight() is silently "
+                        + "dropped with no ellipsis, reproducing issue #4174.");
     }
 
     /**

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -641,11 +641,18 @@ class ShaftPluginScreenshotRendererTest {
                 "The welcome message's trailing paragraph must contain the full onboarding sentence, "
                         + "including its final \"Copy response.\" clause, in the rendered document");
         Rectangle bounds = tailCharacterBounds.get();
-        assertTrue(bounds.y + bounds.height <= welcomePane.get().getHeight(),
+        int margin = welcomePane.get().getHeight() - (bounds.y + bounds.height);
+        // A margin that merely clears zero is exactly what regressed here once already (a shared
+        // htmlPane border reservation tuned against one platform's font metrics left only 1px of
+        // slack on a real run): require real headroom, not a razor-thin pass, so a future edit that
+        // erodes this back down gets caught here instead of on a CI runner with different font
+        // metrics.
+        assertTrue(margin >= 10,
                 "The trailing paragraph's final characters (\"Copy response.\") must be painted "
-                        + "inside the welcome message pane's own bounds at NARROW_WIDTH -- Swing clips "
-                        + "paint to component bounds, so text laid out below getHeight() is silently "
-                        + "dropped with no ellipsis, reproducing issue #4174.");
+                        + "inside the welcome message pane's own bounds at NARROW_WIDTH with a real "
+                        + "safety margin (>=10px), not a razor-thin pass -- Swing clips paint to "
+                        + "component bounds, so text laid out below getHeight() is silently dropped "
+                        + "with no ellipsis, reproducing issue #4174. Actual margin: " + margin + "px.");
     }
 
     /**


### PR DESCRIPTION
Disposable verification PR only, not for merging. Combines PR 4184's tip commit c0bf2de9d9 (issue 4174 welcome-bubble height fix) with the font-install fix from #4189, purely to observe whether firstRunWelcomeDismissButtonIsVisibleWithoutScrollingAtNarrowDarkWidth now passes on ubuntu-22.04 CI with real text fonts installed. Will be closed and the branch deleted once CI reports a result. See #4189 for the real fix.