### PR TITLE
Use IDE editor font in ShaftMcpSetupPanel instead of hardcoded Font.MONOSPACED

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -510,7 +510,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         details.setPreferredSize(JBUI.size(560, 180));
         details.getAccessibleContext().setAccessibleName("SHAFT MCP setup output");
         details.setEditable(false);
-        details.setFont(new Font(Font.MONOSPACED, Font.PLAIN, details.getFont() == null ? 12 : details.getFont().getSize()));
+        details.setFont(new Font(AssistantTranscriptView.monospacedFontFamily(), Font.PLAIN, details.getFont() == null ? 12 : details.getFont().getSize()));
         details.setBackground(UIManagerColors.background());
         details.setForeground(UIManagerColors.foreground());
         details.setBorder(JBUI.Borders.compound(JBUI.Borders.empty(6), JBUI.Borders.customLine(UIManagerColors.border(), 1)));
@@ -1015,7 +1015,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         area.setLineWrap(true);
         area.setWrapStyleWord(true);
         area.getAccessibleContext().setAccessibleName(accessibleName);
-        area.setFont(new Font(Font.MONOSPACED, Font.PLAIN, area.getFont() == null ? 12 : area.getFont().getSize()));
+        area.setFont(new Font(AssistantTranscriptView.monospacedFontFamily(), Font.PLAIN, area.getFont() == null ? 12 : area.getFont().getSize()));
         area.setMinimumSize(JBUI.size(360, Math.max(72, rows * 24)));
         return area;
     }
@@ -2670,7 +2670,7 @@ final class ShaftMcpSetupPanel extends JPanel {
 
     private SimpleAttributeSet consoleStyle(boolean success) {
         SimpleAttributeSet style = new SimpleAttributeSet();
-        StyleConstants.setFontFamily(style, details.getFont() == null ? Font.MONOSPACED : details.getFont().getFamily());
+        StyleConstants.setFontFamily(style, details.getFont() == null ? AssistantTranscriptView.monospacedFontFamily() : details.getFont().getFamily());
         StyleConstants.setFontSize(style, details.getFont() == null ? 12 : details.getFont().getSize());
         StyleConstants.setForeground(style, success ? ShaftStatusPresentation.success() : UIManagerColors.foreground());
         if (success) {


### PR DESCRIPTION
## Summary
Ports the font-fix half of external PR #4182 (contributor: @waterWang) directly, preserving authorship, because that PR was branched on top of #4181's commit and #4181 has a confirmed regression (see below) that this fix should not carry.

Closes #4179.

## What changed
Three `Font.MONOSPACED` sites in `ShaftMcpSetupPanel.java` now resolve through `AssistantTranscriptView.monospacedFontFamily()` (added in PR #4176), matching the mechanism issue 4179 asked for rather than introducing a second one.

## Why this landed separately instead of merging #4182 directly
#4182's branch includes #4181's commit as its parent. #4181 ("don't overwrite generated test source when compile/replay fails," closes #4166) moves the `atomicWrite` of the generated source/data files to *after* the compile+replay check, but `GeneratedTestValidator.compile()` reads the source from disk (`paths.source()`) rather than from the in-memory string -- so deferring the write means compile() either finds no file (first-time generation) or stale content from a prior run (regeneration), never the content actually being validated.

Verified empirically, not by inspection: test-merging #4181 against current `main` and running `CaptureGeneratorTest`/`CaptureGeneratorHealingSeedingTest` produces **23 failures + 1 file-not-found error** (`NoSuchFile ... ExampleFormTest.java`) out of 36 tests. This is a real, confirmed regression, not a hypothetical.

Left detailed review feedback on #4181 with this evidence and the correct fix shape (already scoped in issue 4166: write to a temporary location, validate against it, promote to the final path only on success). Did not merge #4181. #4182 is superseded by this PR for its font-fix half; a comment on #4182 points here.

## Verification
- `./gradlew compileJava compileTestJava` -- BUILD SUCCESSFUL.
- `./gradlew test --tests "com.shaft.intellij.ui.ShaftPanelSetupTest"` -- BUILD SUCCESSFUL, all green.

Co-Authored-By: waterWang <water@users.noreply.github.com>