### PR TITLE
Wire the always-on deterministic re-suggestion ladder into resolve() (issue 4027)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -941,7 +941,11 @@ public final class CaptureGenerator {
         line(source, "        SHAFT.Properties.healing.set()");
         line(source, "                .strategy(\"shaft-heal\")");
         line(source, "                .historyPath(\"" + javaString(healingHistoryPath.toString()) + "\")");
-        line(source, "                .aiTrigger(\"below-threshold\");");
+        line(source, "                .aiTrigger(\"below-threshold\")");
+        // Issue #4027: always-on deterministic re-suggestion ladder with a 60s hard total budget
+        // for generated tests specifically, without touching the engine-wide default (0), which
+        // every other healing user keeps unless they explicitly raise it.
+        line(source, "                .ladderBudgetSeconds(60);");
         if (backend == CodegenBackend.WEBDRIVER) {
             line(source, "        driver = new SHAFT.GUI.WebDriver(DriverFactory.DriverType."
                     + driverType(session.browser().browserName()) + ");");

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorHealingSeedingTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorHealingSeedingTest.java
@@ -103,6 +103,9 @@ class CaptureGeneratorHealingSeedingTest {
         Path expectedHistoryPath = output.resolve(".shaft-heal/history.json").normalize();
         assertTrue(source.contains(".strategy(\"shaft-heal\")"), source);
         assertTrue(source.contains(".aiTrigger(\"below-threshold\")"), source);
+        // Issue #4027: generated tests get the deterministic re-suggestion ladder always-on (60s
+        // hard budget) without touching the engine-wide healing.ladder.budgetSeconds default (0).
+        assertTrue(source.contains(".ladderBudgetSeconds(60)"), source);
         assertTrue(Files.exists(expectedHistoryPath), "seeded history file should exist at the absolute path");
 
         // The SAME absolute path a later real run's setUp() would configure -- proves the history

--- a/shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java
+++ b/shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java
@@ -21,7 +21,8 @@ public class FormCompletedTest {
         SHAFT.Properties.healing.set()
                 .strategy("shaft-heal")
                 .historyPath("PLACEHOLDER")
-                .aiTrigger("below-threshold");
+                .aiTrigger("below-threshold")
+                .ladderBudgetSeconds(60);
         driver = new SHAFT.GUI.WebDriver(DriverFactory.DriverType.CHROME);
         testData = new SHAFT.TestData.JSON("form-completed-test.json");
         windows.put("window-1", driver.browser().getWindowHandle());

--- a/shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java
+++ b/shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java
@@ -18,12 +18,14 @@ import com.shaft.heal.model.LocatorFingerprint;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Default deterministic SHAFT Heal provider.
@@ -33,12 +35,27 @@ import java.util.concurrent.ConcurrentHashMap;
  * outcome through {@link #recordOutcome(HealingActionOutcome)}.</p>
  */
 public class ShaftHealingProvider implements HealingProvider {
+    // Issue #4027: delay between re-suggestion rungs once the hard total budget is engaged. Only
+    // relevant when healing.ladder.budgetSeconds > 0; the default (0) never reaches this loop.
+    private static final Duration LADDER_POLL_INTERVAL = Duration.ofSeconds(1);
     private final Map<String, PendingRecovery> pendingRecoveries = new ConcurrentHashMap<>();
+    private final ResuggestionLadder ladder;
 
     /**
      * Creates the ServiceLoader provider.
      */
     public ShaftHealingProvider() {
+        this(ResuggestionLadder.system());
+    }
+
+    /**
+     * Creates a provider with an injectable re-suggestion ladder (issue #4027), letting tests
+     * control the clock driving the hard total budget.
+     *
+     * @param ladder re-suggestion ladder
+     */
+    ShaftHealingProvider(ResuggestionLadder ladder) {
+        this.ladder = ladder;
     }
 
     @Override
@@ -73,26 +90,14 @@ public class ShaftHealingProvider implements HealingProvider {
                             false),
                     HealingReport.ProviderMetadata.disabled(),
                     false,
-                    false));
+                    false,
+                    HealingReport.LadderMetadata.disabled()));
             return Optional.empty();
         }
 
-        List<RankedCandidate> candidates = new CandidateExtractor(configuration)
-                .extract(
-                        request.driver(),
-                        retained.get().fingerprint(),
-                        request.frameLocator(),
-                        request.shadowHostLocator());
-        candidates = new VisualEvidenceService(configuration)
-                .apply(candidates, retained.get().visualReference());
-        HealingDecisionEngine.DecisionResult result = HealingDecisionEngine.decide(
-                candidates, configuration, request.visibilityRequired());
-        AiCandidateReranker.RerankResult reranked = rerankIfTriggered(
-                candidates, configuration, result.decision());
-        if (reranked.applied()) {
-            result = HealingDecisionEngine.decide(
-                    reranked.candidates(), configuration, request.visibilityRequired());
-        }
+        LadderRun run = runLadder(request, configuration, retained.get());
+        HealingDecisionEngine.DecisionResult result = run.attempt().result();
+        AiCandidateReranker.RerankResult reranked = run.attempt().reranked();
         HealingReport report = report(
                 attemptId,
                 request,
@@ -103,7 +108,9 @@ public class ShaftHealingProvider implements HealingProvider {
                 result.decision(),
                 reranked.metadata(),
                 reranked.remoteEvidenceSent(),
-                result.selected() != null);
+                result.selected() != null,
+                new HealingReport.LadderMetadata(
+                        run.rungs(), run.elapsed().toMillis(), configuration.ladderBudget().toSeconds()));
         writer.publish(report);
         if (result.selected() == null) {
             return Optional.empty();
@@ -119,6 +126,61 @@ public class ShaftHealingProvider implements HealingProvider {
                 attemptId,
                 List.of(result.selected().element()),
                 result.selected().locator()));
+    }
+
+    /**
+     * Runs the deterministic candidate-extraction-and-decision pass once, or -- when
+     * {@code healing.ladder.budgetSeconds} is positive -- repeatedly across
+     * {@link ResuggestionLadder} rungs until a candidate is accepted or the hard total budget is
+     * exhausted (issue #4027). {@code Duration#ZERO} (the default) never engages the ladder,
+     * preserving today's exact single-attempt behavior for every existing caller.
+     */
+    private LadderRun runLadder(
+            HealingRequest request, HealingConfiguration configuration, HistoryRecord retained) {
+        Duration budget = configuration.ladderBudget();
+        if (budget.isZero()) {
+            return new LadderRun(attempt(request, configuration, retained), 1, Duration.ZERO);
+        }
+        AtomicReference<AttemptResult> lastAttempt = new AtomicReference<>();
+        ResuggestionLadder.Result<AttemptResult> ladderResult = ladder.run(budget, LADDER_POLL_INTERVAL, () -> {
+            AttemptResult attemptResult = attempt(request, configuration, retained);
+            lastAttempt.set(attemptResult);
+            return attemptResult.result().selected() != null ? Optional.of(attemptResult) : Optional.empty();
+        });
+        AttemptResult finalAttempt = ladderResult.value().orElseGet(lastAttempt::get);
+        return new LadderRun(finalAttempt, ladderResult.rungs(), ladderResult.elapsed());
+    }
+
+    /**
+     * Runs exactly one deterministic re-suggestion rung: extract candidates from the retained
+     * fingerprint, apply optional visual evidence, decide, and rerank when triggered.
+     */
+    private static AttemptResult attempt(
+            HealingRequest request, HealingConfiguration configuration, HistoryRecord retained) {
+        List<RankedCandidate> candidates = new CandidateExtractor(configuration)
+                .extract(
+                        request.driver(),
+                        retained.fingerprint(),
+                        request.frameLocator(),
+                        request.shadowHostLocator());
+        candidates = new VisualEvidenceService(configuration)
+                .apply(candidates, retained.visualReference());
+        HealingDecisionEngine.DecisionResult result = HealingDecisionEngine.decide(
+                candidates, configuration, request.visibilityRequired());
+        AiCandidateReranker.RerankResult reranked = rerankIfTriggered(
+                candidates, configuration, result.decision());
+        if (reranked.applied()) {
+            result = HealingDecisionEngine.decide(
+                    reranked.candidates(), configuration, request.visibilityRequired());
+        }
+        return new AttemptResult(result, reranked);
+    }
+
+    private record AttemptResult(
+            HealingDecisionEngine.DecisionResult result, AiCandidateReranker.RerankResult reranked) {
+    }
+
+    private record LadderRun(AttemptResult attempt, int rungs, Duration elapsed) {
     }
 
     @Override
@@ -239,7 +301,8 @@ public class ShaftHealingProvider implements HealingProvider {
                 previous.decision(),
                 previous.provider(),
                 previous.privacy(),
-                action);
+                action,
+                previous.ladder());
         new HealingReportWriter(pending.configuration()).publish(updated);
         if (outcome.successful()) {
             HealingHistoryStore store = new HealingHistoryStore(pending.configuration());
@@ -276,7 +339,8 @@ public class ShaftHealingProvider implements HealingProvider {
             HealingDecision decision,
             HealingReport.ProviderMetadata provider,
             boolean remoteEvidenceSent,
-            boolean recoveryUsed) {
+            boolean recoveryUsed,
+            HealingReport.LadderMetadata ladder) {
         HealingReport.ActionMetadata action = new HealingReport.ActionMetadata(
                 request.action(),
                 recoveryUsed,
@@ -299,7 +363,8 @@ public class ShaftHealingProvider implements HealingProvider {
                         "Whitelist-only semantic evidence; values, cookies, authorization data, and full DOM are excluded.",
                         0,
                         remoteEvidenceSent),
-                action);
+                action,
+                ladder);
     }
 
     private static List<com.shaft.heal.model.HealingCandidate> rankedReports(List<RankedCandidate> candidates) {

--- a/shaft-heal/src/main/java/com/shaft/heal/model/HealingReport.java
+++ b/shaft-heal/src/main/java/com/shaft/heal/model/HealingReport.java
@@ -19,6 +19,7 @@ import java.util.Objects;
  * @param provider provider and fallback metadata
  * @param privacy minimization and redaction metadata
  * @param action action and post-action metadata
+ * @param ladder re-suggestion ladder metadata (issue #4027)
  */
 public record HealingReport(
         String schemaVersion,
@@ -33,11 +34,13 @@ public record HealingReport(
         HealingDecision decision,
         ProviderMetadata provider,
         PrivacyMetadata privacy,
-        ActionMetadata action) {
+        ActionMetadata action,
+        LadderMetadata ladder) {
     public static final String CURRENT_SCHEMA_VERSION = "2.0";
 
     /**
-     * Creates a backward-compatible report without structured context metadata.
+     * Creates a backward-compatible report without structured context metadata or re-suggestion
+     * ladder metadata.
      */
     public HealingReport(
             String schemaVersion,
@@ -64,6 +67,29 @@ public record HealingReport(
                         "",
                         ""),
                 candidates, decision, provider, privacy, action);
+    }
+
+    /**
+     * Creates a backward-compatible report without re-suggestion ladder metadata (issue #4027);
+     * the ladder was not engaged, matching today's one-shot behavior.
+     */
+    public HealingReport(
+            String schemaVersion,
+            String attemptId,
+            String timestamp,
+            String originalLocator,
+            String failureCategory,
+            String pageKey,
+            String context,
+            HealingContext contextMetadata,
+            List<HealingCandidate> candidates,
+            HealingDecision decision,
+            ProviderMetadata provider,
+            PrivacyMetadata privacy,
+            ActionMetadata action) {
+        this(schemaVersion, attemptId, timestamp, originalLocator, failureCategory, pageKey,
+                context, contextMetadata, candidates, decision, provider, privacy, action,
+                LadderMetadata.disabled());
     }
 
     /**
@@ -94,6 +120,7 @@ public record HealingReport(
         provider = provider == null ? ProviderMetadata.disabled() : provider;
         privacy = privacy == null ? PrivacyMetadata.minimized() : privacy;
         action = action == null ? ActionMetadata.pending("") : action;
+        ladder = ladder == null ? LadderMetadata.disabled() : ladder;
     }
 
     /**
@@ -211,6 +238,34 @@ public record HealingReport(
          */
         public static ActionMetadata pending(String name) {
             return new ActionMetadata(name, true, "PENDING", "UNVERIFIABLE", "");
+        }
+    }
+
+    /**
+     * Re-suggestion ladder metadata (issue #4027): how many deterministic rungs ran and how much
+     * total elapsed time they consumed against the configured hard budget, so the 60-second budget
+     * is observable in the report instead of only enforced silently.
+     *
+     * @param rungsAttempted how many deterministic re-suggestion attempts ran (always at least 1)
+     * @param elapsedMillis total elapsed time across every rung, in milliseconds
+     * @param budgetSeconds the configured hard total budget in seconds; {@code 0} means the ladder
+     *                       was not engaged (today's one-shot behavior)
+     */
+    public record LadderMetadata(int rungsAttempted, long elapsedMillis, long budgetSeconds) {
+        /**
+         * Creates safe ladder metadata.
+         */
+        public LadderMetadata {
+            rungsAttempted = Math.max(1, rungsAttempted);
+            elapsedMillis = Math.max(0, elapsedMillis);
+            budgetSeconds = Math.max(0, budgetSeconds);
+        }
+
+        /**
+         * @return metadata for a single-attempt resolution with the ladder not engaged
+         */
+        public static LadderMetadata disabled() {
+            return new LadderMetadata(1, 0, 0);
         }
     }
 }

--- a/shaft-heal/src/main/resources/schema/shaft-heal-report-2.0.schema.json
+++ b/shaft-heal/src/main/resources/schema/shaft-heal-report-2.0.schema.json
@@ -6,7 +6,7 @@
   "required": [
     "schemaVersion", "attemptId", "timestamp", "originalLocator",
     "failureCategory", "pageKey", "context", "contextMetadata",
-    "candidates", "decision", "provider", "privacy", "action"
+    "candidates", "decision", "provider", "privacy", "action", "ladder"
   ],
   "properties": {
     "schemaVersion": {"const": "2.0"},
@@ -57,6 +57,10 @@
       "required": [
         "name", "recoveryUsed", "outcome", "postActionVerification", "failure"
       ]
+    },
+    "ladder": {
+      "type": "object",
+      "required": ["rungsAttempted", "elapsedMillis", "budgetSeconds"]
     }
   },
   "additionalProperties": false

--- a/shaft-heal/src/test/java/com/shaft/heal/internal/MutableClock.java
+++ b/shaft-heal/src/test/java/com/shaft/heal/internal/MutableClock.java
@@ -1,0 +1,40 @@
+package com.shaft.heal.internal;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+/**
+ * Test-only clock with an explicitly advanceable instant, shared by every ladder-timing test
+ * (issue #4027): both {@code ResuggestionLadderTest} (unit tests the ladder in isolation) and
+ * {@code ShaftHealingProviderTest} (proves {@code resolve()} actually invokes it under budget)
+ * need the exact same fake-time behavior.
+ */
+final class MutableClock extends Clock {
+    private Instant instant;
+
+    MutableClock(Instant instant) {
+        this.instant = instant;
+    }
+
+    void advance(Duration duration) {
+        instant = instant.plus(duration);
+    }
+
+    @Override
+    public ZoneOffset getZone() {
+        return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Instant instant() {
+        return instant;
+    }
+}

--- a/shaft-heal/src/test/java/com/shaft/heal/internal/ResuggestionLadderTest.java
+++ b/shaft-heal/src/test/java/com/shaft/heal/internal/ResuggestionLadderTest.java
@@ -3,10 +3,8 @@ package com.shaft.heal.internal;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -73,32 +71,5 @@ public class ResuggestionLadderTest {
         Assert.assertTrue(
                 result.elapsed().compareTo(Duration.ofSeconds(90)) < 0,
                 "elapsed was " + result.elapsed());
-    }
-
-    private static final class MutableClock extends Clock {
-        private Instant instant;
-
-        private MutableClock(Instant instant) {
-            this.instant = instant;
-        }
-
-        private void advance(Duration duration) {
-            instant = instant.plus(duration);
-        }
-
-        @Override
-        public ZoneOffset getZone() {
-            return ZoneOffset.UTC;
-        }
-
-        @Override
-        public Clock withZone(java.time.ZoneId zone) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Instant instant() {
-            return instant;
-        }
     }
 }

--- a/shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java
+++ b/shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java
@@ -311,6 +311,92 @@ public class ShaftHealingProviderTest {
         Assert.assertTrue(resolution.get().selectedLocator().toString().contains("new-id-test"));
     }
 
+    @Test
+    public void zeroBudgetPreservesTodaysSingleAttemptBehavior() {
+        // Issue #4027: healing.ladder.budgetSeconds defaults to 0, which must keep every existing
+        // healing user on today's exact one-shot resolve() -- never a retry loop.
+        WebDriver driver = driver();
+        WebElement original = element("old-id", "Username");
+        WebElement candidate = element("new-id", "Username");
+        configureSearch(driver, List.of(candidate));
+        when(candidate.isEnabled()).thenReturn(false);
+        ShaftHealingProvider provider = new ShaftHealingProvider();
+        By originalLocator = By.id("old-id");
+        provider.observe(new HealingObservation(driver, originalLocator, original, "TYPE", null, null, null));
+
+        Optional<HealingResolution> resolution = provider.resolve(new HealingRequest(
+                driver, originalLocator, "TYPE", true, null, null, null));
+
+        Assert.assertTrue(resolution.isEmpty());
+        Assert.assertEquals(
+                ShaftHeal.lastReport().orElseThrow().decision().status(),
+                HealingDecision.Status.REJECTED_PRECONDITION);
+        com.shaft.heal.model.HealingReport.LadderMetadata ladder =
+                ShaftHeal.lastReport().orElseThrow().ladder();
+        Assert.assertEquals(ladder.rungsAttempted(), 1);
+        Assert.assertEquals(ladder.elapsedMillis(), 0L);
+        Assert.assertEquals(ladder.budgetSeconds(), 0L);
+    }
+
+    @Test
+    public void positiveBudgetRetriesUntilCandidateBecomesInteractable() {
+        // Issue #4027: a positive hard budget must retry the deterministic re-suggestion pass
+        // until the candidate is found interactable, using an injected clock so the retry/poll
+        // timing is proven without any real sleep.
+        SHAFT.Properties.healing.set().ladderBudgetSeconds(60);
+        WebDriver driver = driver();
+        WebElement original = element("old-id", "Username");
+        WebElement candidate = element("new-id", "Username");
+        configureSearch(driver, List.of(candidate));
+        MutableClock clock = new MutableClock(java.time.Instant.EPOCH);
+        when(candidate.isEnabled()).thenAnswer(invocation ->
+                !clock.instant().isBefore(java.time.Instant.EPOCH.plusSeconds(2)));
+        ResuggestionLadder ladder = new ResuggestionLadder(clock, millis -> clock.advance(java.time.Duration.ofMillis(millis)));
+        ShaftHealingProvider provider = new ShaftHealingProvider(ladder);
+        By originalLocator = By.id("old-id");
+        provider.observe(new HealingObservation(driver, originalLocator, original, "TYPE", null, null, null));
+
+        Optional<HealingResolution> resolution = provider.resolve(new HealingRequest(
+                driver, originalLocator, "TYPE", true, null, null, null));
+
+        Assert.assertTrue(resolution.isPresent());
+        com.shaft.heal.model.HealingReport.LadderMetadata ladderMetadata =
+                ShaftHeal.lastReport().orElseThrow().ladder();
+        Assert.assertTrue(ladderMetadata.rungsAttempted() >= 2,
+                "rungsAttempted was " + ladderMetadata.rungsAttempted());
+        Assert.assertEquals(ladderMetadata.budgetSeconds(), 60L);
+    }
+
+    @Test
+    public void positiveBudgetNeverExceedsTheHardTotalBudgetWhenCandidateNeverBecomesReady() {
+        // Issue #4027 acceptance: total elapsed time across all rungs is bounded at 60s, proven by
+        // a test with an injected clock -- the equivalent of ResuggestionLadderTest's own proof,
+        // one layer up through resolve() rather than the ladder in isolation.
+        SHAFT.Properties.healing.set().ladderBudgetSeconds(60);
+        WebDriver driver = driver();
+        WebElement original = element("old-id", "Username");
+        WebElement candidate = element("new-id", "Username");
+        configureSearch(driver, List.of(candidate));
+        when(candidate.isEnabled()).thenReturn(false);
+        MutableClock clock = new MutableClock(java.time.Instant.EPOCH);
+        ResuggestionLadder ladder = new ResuggestionLadder(clock, millis -> clock.advance(java.time.Duration.ofMillis(millis)));
+        ShaftHealingProvider provider = new ShaftHealingProvider(ladder);
+        By originalLocator = By.id("old-id");
+        provider.observe(new HealingObservation(driver, originalLocator, original, "TYPE", null, null, null));
+
+        Optional<HealingResolution> resolution = provider.resolve(new HealingRequest(
+                driver, originalLocator, "TYPE", true, null, null, null));
+
+        Assert.assertTrue(resolution.isEmpty());
+        com.shaft.heal.model.HealingReport.LadderMetadata ladderMetadata =
+                ShaftHeal.lastReport().orElseThrow().ladder();
+        Assert.assertTrue(ladderMetadata.elapsedMillis() <= 60_000L,
+                "elapsed was " + ladderMetadata.elapsedMillis());
+        Assert.assertEquals(ladderMetadata.budgetSeconds(), 60L);
+        Assert.assertTrue(ladderMetadata.rungsAttempted() >= 2,
+                "rungsAttempted was " + ladderMetadata.rungsAttempted());
+    }
+
     @Test(dataProvider = "nativePlatforms")
     public void nativeAccessibilityChangesShouldRecoverDeterministically(
             String platformName,


### PR DESCRIPTION
Closes #4027

This is a subtask of tracker #4024 (SHAFT Assistant record/replay/codegen overhaul); this PR lands the last real remaining piece, the always-on deterministic re-suggestion ladder.

## Summary

- `ShaftHealingProvider.resolve()` (`shaft-heal`) now retries the deterministic candidate-extraction-and-decision pass across `ResuggestionLadder` rungs whenever `healing.ladder.budgetSeconds` is positive, bounded by the hard total budget across the whole ladder (not a per-attempt timeout multiplied by N rungs). The default (`0`) keeps every existing caller on today's exact single-attempt behavior -- proven by test, not just asserted.
- `CaptureGenerator` now emits `.ladderBudgetSeconds(60)` into generated tests' `setUp()`, alongside the existing `.strategy("shaft-heal")`/`.historyPath(...)`/`.aiTrigger("below-threshold")` lines, so generated tests get the ladder always-on without touching the engine-wide default that every other healing user relies on.
- `HealingReport` gained a `LadderMetadata` field (`rungsAttempted`, `elapsedMillis`, `budgetSeconds`) so the 60s budget is observable in the report, not just enforced silently (explicit acceptance criterion). Schema `shaft-heal-report-2.0.schema.json` updated to match.

## What was split off, and why

The "low-trust deterministic scores escalate to the agent for an on-the-spot XPath, and emit a code comment marking that locator as needing optimization" half of the original acceptance criteria was investigated first (front-loaded as the riskiest unknown) and found to need a materially larger plumbing change than a small extension of the existing generation/replay flow:

- The "low trust" signal the issue means is shaft-heal's own `DeterministicScorer`/`HealingDecisionEngine`, but `shaft-capture` deliberately has zero production-time dependency on `shaft-heal` (test-scope only, a decision made when the fingerprint-seeding seam landed).
- The realistic low-trust moment is a *later* re-execution of the already-checked-in generated test, not generation time -- there's nothing to score as low-trust the moment a locator is freshly recorded and just confirmed by a passing replay.
- "Add a comment to the generated code" from that later run means patching an already-existing checked-in `.java` file, which this repo already has a deliberate, separate answer for: `shaft-doctor`'s `HealingLocatorProposalService`/`DoctorRepairAiService`, exposed only as the explicitly user-invoked MCP tool `doctor_propose_healed_locator`. Issue #2885's own closed acceptance criteria require "runtime healing never modifies source files, regardless of recovery success" -- auto-emitting a comment from a live `resolve()` outcome would cut against that already-decided boundary.
- The only existing AI-call surface in `CaptureGenerator` (`CaptureEnrichmentService`) explicitly forbids proposing locators in its schema/prompt today.

Filed as its own tracked follow-up: #4194, with the concrete evidence and a suggested scope for reusing the existing `shaft-doctor` proposal/review machinery instead of building a parallel one. This mirrors how issue #4161 was split from this same issue earlier.

## Test plan

- `ShaftHealingProviderTest` (new): `zeroBudgetPreservesTodaysSingleAttemptBehavior`, `positiveBudgetRetriesUntilCandidateBecomesInteractable`, `positiveBudgetNeverExceedsTheHardTotalBudgetWhenCandidateNeverBecomesReady` (injected-clock proof, mirroring `ResuggestionLadderTest`'s own shape one layer up through `resolve()`).
- `CaptureGeneratorHealingSeedingTest` (updated): asserts `.ladderBudgetSeconds(60)` is emitted into generated source.
- `golden-generated-session-1.java` fixture updated to match the new emitted line.
- Full `shaft-heal` + `shaft-capture` module test suites run together (avoids the stale-installed-jar `NoSuchMethodError` pitfall from omitting either module in `-pl`): 311/311 passed.

## Validation run

```
mvn -pl shaft-heal,shaft-capture test -DheadlessExecution=true -Dallure.automaticallyOpen=false
Total: 311 · Passed: 311 · Failed: 0 · Skipped: 0
```

Not armed for auto-merge and CI not watched per dispatch instructions -- reporting back for review.
