### PR TITLE
Name the failing stage and recorded step in codegen failures (issue 4029)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -170,9 +170,13 @@ public final class CaptureGenerator {
         Path reportPath = outputRoot.resolve("target/shaft-capture/generation-report.json");
         CaptureSession session = null;
         ArtifactPaths paths = null;
+        // Names the pipeline phase reached when a RuntimeException escapes to the catch block below,
+        // so a failure never collapses to a bare, stage-less message (issue #4029).
+        String stage = "reading the capture session";
         try {
             session = codec.read(sessionPath);
             reporter.accept(0.1, "Read capture session " + sessionPath.getFileName());
+            stage = "validating generation request inputs";
             validatePackage(request.packageName());
             String deterministicClassName = request.className().isBlank()
                     ? defaultClassName(session)
@@ -181,15 +185,19 @@ public final class CaptureGenerator {
             String deterministicMethodName = defaultMethodName(session);
             paths = artifactPaths(outputRoot, request.packageName(), deterministicClassName);
 
+            stage = "analyzing captured events";
             GenerationState state = analyze(session, sessionPath, targetBackend);
             reporter.accept(0.3, "Analyzed " + session.events().size() + " captured event(s)");
             Map<String, String> elementNames = defaultElementNames(state.targets());
+            stage = "rendering deterministic test source";
             String deterministicSource = renderSource(session, request.packageName(), deterministicClassName,
                     deterministicMethodName, state.targets(), state.data(), elementNames, List.of(), targetBackend,
                     request.fallbackLocators(), Set.of(), FINGERPRINT_HEALING_HISTORY_PATH);
             reporter.accept(0.5, "Generated deterministic test source for " + deterministicClassName);
+            stage = "computing the drift-detection fingerprint";
             String fingerprint = fingerprint(codec.write(session), deterministicSource);
             Set<Long> appliedControlFlowGuards = Set.of();
+            stage = "processing the control-flow preview/apply request";
             if (request.controlFlowMode() == CaptureGenerationRequest.ControlFlowMode.PREVIEW) {
                 writeControlFlowPreview(
                         request.controlFlowPreviewPath().toAbsolutePath().normalize(),
@@ -213,6 +221,7 @@ public final class CaptureGenerator {
 
             CaptureGenerationReport.Enrichment enrichment = CaptureGenerationReport.Enrichment.notRequested();
             CaptureEnrichmentPreview.Proposal appliedProposal = CaptureEnrichmentPreview.Proposal.empty();
+            stage = "processing the enrichment preview/apply request";
             if (request.enrichmentMode() == CaptureGenerationRequest.EnrichmentMode.PREVIEW) {
                 CaptureEnrichmentPreview preview = enrichmentService.preview(
                         session,
@@ -268,11 +277,13 @@ public final class CaptureGenerator {
             if (!className.equals(deterministicClassName)) {
                 paths = artifactPaths(outputRoot, request.packageName(), className);
             }
+            stage = "rendering the final test source";
             String source = renderSource(session, request.packageName(), className, methodName,
                     state.targets(), state.data(), finalElementNames, appliedProposal.assertions(), targetBackend,
                     request.fallbackLocators(), appliedControlFlowGuards, healingHistoryPath);
             String dataJson = writeJson(state.data().root());
 
+            stage = "checking generated artifacts for privacy findings and validating output paths";
             List<String> privacy = new ArrayList<>();
             privacy.addAll(privacyFindings(codec.write(session), privacyRoot));
             privacy.addAll(privacyFindings(source, privacyRoot));
@@ -295,12 +306,15 @@ public final class CaptureGenerator {
                         request.enrichmentPreviewPath(), report);
             }
 
+            stage = "writing generated artifacts to disk";
             atomicWrite(paths.source(), source);
             atomicWrite(paths.data(), dataJson);
+            stage = "compiling the generated test";
             CaptureGenerationReport.Validation compilation = request.compile()
                     ? validator.compile(paths.source(), paths.classes())
                     : CaptureGenerationReport.Validation.skipped("Compilation was not requested.");
             reporter.accept(request.replay() ? 0.75 : 0.9, "Compiled generated test: " + compilation.status());
+            stage = "replaying the generated test";
             CaptureGenerationReport.Validation replay = CaptureGenerationReport.Validation.skipped(
                     "Replay was not requested.");
             if (request.replay()
@@ -320,6 +334,7 @@ public final class CaptureGenerator {
                         "Replay was skipped because compilation failed.");
                 reporter.accept(0.9, "Replay skipped: compilation failed");
             }
+            stage = "writing the generation report";
             boolean successful = compilation.status()
                     != CaptureGenerationReport.Validation.ValidationStatus.FAILED
                     && replay.status() != CaptureGenerationReport.Validation.ValidationStatus.FAILED;
@@ -356,7 +371,8 @@ public final class CaptureGenerator {
             ArtifactPaths safePaths = paths == null
                     ? artifactPaths(outputRoot, "generated.capture", "CapturedJourneyTest")
                     : paths;
-            GenerationState failure = GenerationState.failure(safeMessage(exception));
+            GenerationState failure = GenerationState.failure(
+                    "Generation failed while " + stage + ": " + safeMessage(exception));
             CaptureGenerationReport report = report(
                     sessionId,
                     safePaths,
@@ -404,8 +420,18 @@ public final class CaptureGenerator {
                             + " has no locator evidence. Re-record the step with a visible target.");
                     return;
                 }
-                LocatorRanker.LocatorSelection selection =
-                        locatorRanker.select(target, event.context(), interaction(event));
+                LocatorRanker.LocatorSelection selection;
+                try {
+                    selection = locatorRanker.select(target, event.context(), interaction(event));
+                } catch (RuntimeException cause) {
+                    // Names the failing recorded step and element (issue #4029) instead of letting a
+                    // bare, step-less exception message reach the generation report.
+                    throw new IllegalStateException(
+                            "Locator analysis failed for " + eventId + " (element "
+                                    + target.logicalElementId() + "). Re-record the step or report this as a "
+                                    + "SHAFT codegen defect: " + safeMessage(cause),
+                            cause);
+                }
                 MutableTargetPlan existing = targets.computeIfAbsent(
                         target.logicalElementId(),
                         ignored -> new MutableTargetPlan(target, event.context(), selection));
@@ -2800,7 +2826,9 @@ public final class CaptureGenerator {
 
     private static String safeMessage(RuntimeException exception) {
         String message = exception.getMessage();
-        return message == null || message.isBlank() ? "Generation failed." : message;
+        return message == null || message.isBlank()
+                ? "an unhandled " + exception.getClass().getSimpleName() + " with no further detail"
+                : message;
     }
 
     private static void line(StringBuilder source, String value) {

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -1539,4 +1539,118 @@ class CaptureGeneratorTest {
                 List.of(),
                 Map.of());
     }
+
+    /**
+     * Issue #4029: a recording broken deep enough to trip an unexpected {@link RuntimeException}
+     * (here, a malformed capture file that fails schema validation on its THIRD event) must not
+     * collapse to a generic, stage-less "Generation failed." string -- the failure must name which
+     * pipeline stage was reached.
+     */
+    @Test
+    void malformedRecordingReportsWhichPipelineStageFailed() throws Exception {
+        CaptureSession valid = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "broken-recording-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(3),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), CaptureFixtures.target(),
+                                CaptureEvent.MouseButton.PRIMARY, 1),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(3), CaptureFixtures.target(),
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+        String json = new CaptureJsonCodec().write(valid);
+        var tree = JSON.readTree(json);
+        // Strip the required "context" object from the THIRD recorded event (index 2) -- schema
+        // validation names it "$.events[2].context is required.", so the corruption is scoped to
+        // one specific recorded step rather than the whole file.
+        ((tools.jackson.databind.node.ObjectNode) tree.path("events").get(2)).remove("context");
+        Path brokenSession = temp.resolve("broken-recording.json");
+        Files.writeString(brokenSession,
+                JSON.writerWithDefaultPrettyPrinter().writeValueAsString(tree), StandardCharsets.UTF_8);
+
+        CaptureGenerationResult result = new CaptureGenerator().generate(request(brokenSession, temp.resolve("out")));
+
+        assertFalse(result.successful());
+        assertEquals(CaptureGenerationReport.Status.FAILED, result.report().status());
+        assertTrue(result.report().unsupportedEvents().stream()
+                        .anyMatch(message -> message.contains("reading the capture session")
+                                && message.contains("events[2]")),
+                result.report().unsupportedEvents().toString());
+    }
+
+    /**
+     * Issue #4029: when a recorded step's element evidence is corrupt enough to trip an unexpected
+     * exception during locator analysis, the failure must identify WHICH recorded step (event)
+     * broke -- not just re-surface a bare, step-less exception message.
+     */
+    @Test
+    void brokenLocatorEvidenceReportsWhichRecordedStepFailed() throws Exception {
+        ElementSnapshot workingTarget = CaptureFixtures.target();
+        ElementSnapshot corruptTarget = new ElementSnapshot(
+                "checkout-button",
+                "button",
+                "button",
+                "Checkout",
+                "Checkout",
+                Map.of(),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.CSS,
+                        "button.checkout", 1, true, true,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE))),
+                true,
+                true,
+                false);
+        CaptureSession session = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "broken-locator-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(3),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), workingTarget,
+                                CaptureEvent.MouseButton.PRIMARY, 1),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(3), corruptTarget,
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+        Path sessionPath = session(session);
+        LocatorRanker realRanker = new LocatorRanker();
+        LocatorRanker ranker = org.mockito.Mockito.mock(LocatorRanker.class);
+        org.mockito.Mockito.when(ranker.select(
+                        org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.anyBoolean()))
+                .thenAnswer(invocation -> {
+                    ElementSnapshot target = invocation.getArgument(0);
+                    if ("checkout-button".equals(target.logicalElementId())) {
+                        throw new IllegalStateException("simulated corrupted locator evidence");
+                    }
+                    return realRanker.select(
+                            invocation.getArgument(0), invocation.getArgument(1), invocation.getArgument(2));
+                });
+
+        CaptureGenerationResult result = new CaptureGenerator(
+                new CaptureJsonCodec(), ranker, new GeneratedTestValidator(), new CaptureEnrichmentService())
+                .generate(request(sessionPath, temp.resolve("out")));
+
+        assertFalse(result.successful());
+        assertTrue(result.report().unsupportedEvents().stream()
+                        .anyMatch(message -> message.contains("event-3") && message.contains("checkout-button")),
+                result.report().unsupportedEvents().toString());
+        assertTrue(result.report().unsupportedEvents().stream()
+                        .noneMatch(message -> message.contains("event-2")),
+                result.report().unsupportedEvents().toString());
+    }
 }


### PR DESCRIPTION
## Summary

- `CaptureGenerator.generate()` enumerated: every path that can terminate the method was read end to end. The unsupported-events early return, the compile/replay report, and the privacy-failure return already surface specific, actionable reasons. The one genuine gap: the top-level `catch (RuntimeException exception)` collapsed ANY unexpected failure into a single generic string -- as bare as "Generation failed." for an exception with a blank message -- with no indication of which pipeline stage was reached, and a per-target locator-analysis exception was re-surfaced verbatim with no reference to which recorded event triggered it.
- Fix: track the reached pipeline stage through `generate()` (reading the session, analyzing events, rendering source, computing the fingerprint, control-flow/enrichment processing, writing artifacts, compiling, replaying, writing the report) and fold it into the top-level failure message. Wrap the per-event locator-selection call in `analyze()` so a failure names the specific `event-N` and element, with the same remedy wording already used elsewhere in this file ("re-record the step" / "report this as a SHAFT codegen defect").
- No behavior change to write ordering, compile/replay gating, or public API -- purely additive diagnostics.

Subtask of tracker #4024 (SHAFT Assistant record/replay/codegen overhaul).

## Scope note (post-review correction)

Independent review confirmed this PR only satisfies the first half of #4029's acceptance criteria (loud, diagnosable failure messages naming the stage/step). The second half -- codegen success gated on a confirmed-working replay, with the CLI's `--replay` flag and the MCP `capture_generate_replay` tool currently defaulting to unverified "success" -- is untouched by this diff. #4029 is being kept open, narrowed to that remaining half, instead of being closed here. See that issue for the corrected scope.

## Entanglement check (issue 4166)

Issue 4166 is about the generated source file being overwritten with unvalidated content before compile/replay complete (`atomicWrite(paths.source(), source)` runs before `validator.compile()`/`validator.replay()`). This PR does not touch that ordering -- it only adds stage-tracking commentary/assignments around the existing calls and wraps one per-event exception path. Verified via `git diff` that the write-then-validate sequence is byte-for-byte unchanged; no entanglement found.

## Test plan

- [x] `mvn -pl shaft-capture -Dtest=CaptureGeneratorTest#malformedRecordingReportsWhichPipelineStageFailed+brokenLocatorEvidenceReportsWhichRecordedStepFailed test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- watched RED (both failed for the expected reason: message present but missing stage/step context) then GREEN after the fix.
- [x] `mvn -pl shaft-capture -Dtest=CaptureGeneratorTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 37/37 passed.
- [x] `mvn -pl shaft-capture -Dtest=CaptureGeneratorHealingSeedingTest,ApiCaptureGeneratorTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 16/16 passed.
- [x] `mvn -pl shaft-capture compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- clean.

Addresses part of #4029 (diagnosability half); does not close it.

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH
