### PR TITLE
Add Flutter demo-app + emulator E2E pipeline to e2eTests.yml

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -23,6 +23,21 @@ on:
           selector unchanged.
         required: false
         default: ''
+      enableFlutterE2E:
+        description: >-
+          Opt-in flag for the Android_Flutter_Emulator_E2E job (issue #4197).
+          Mirrors the existing -Dshaft.enableFlutterE2E Maven system property
+          that already gates FlutterTest.java (SkipException unless set,
+          FlutterTest.java:24,34-37) -- reused here as a workflow_dispatch
+          input instead of a dotted property key because GitHub Actions
+          expression syntax can't address a literal dot in an input name.
+          This job never runs on the nightly schedule (schedule triggers
+          can't supply inputs); set to 'true' on a manual dispatch to run
+          it. It only proves an Appium session opens against the real,
+          pinned demo-app on an emulator -- it does not run FlutterTest.java
+          and does not exercise the fluent Flutter API (see job comment).
+        required: false
+        default: 'false'
 
 permissions:
   contents: read
@@ -77,6 +92,7 @@ jobs:
       - Android_Native_BrowserStack
       - iOS_Web_SAFARI_BrowserStack
       - Android_Web_Chrome_BrowserStack
+      - Android_Flutter_Emulator_E2E
       - MacOSX_Safari_BrowserStack
       - Ubuntu_Chrome_Cucumber_Grid
       - MacOSX_Safari_Cucumber_BrowserStack
@@ -647,6 +663,130 @@ jobs:
           job-name: Android_Web_Chrome_BrowserStack
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+  # Issue #4197: proves a real Appium session can be opened against a Flutter
+  # app built with the driver's own required server wiring, on a real CI
+  # runner -- something FlutterTest.java (permanently SkipException-gated,
+  # FlutterTest.java:24,34-37) has never had a CI leg to prove. This job
+  # deliberately does NOT touch FlutterTest.java or run it: issue #4017 is
+  # concurrently adding the fluent Flutter API and its own gated test stubs
+  # in that exact file. What this job proves: the demo-app/emulator/Appium
+  # pipeline boots and a session opens. What it does NOT prove: that any of
+  # the fluent API's calls behave correctly against a live Flutter widget
+  # tree -- wiring that is explicitly deferred to a fast-follow ticket once
+  # both this job and issue 4017 have landed. Gated behind the
+  # enableFlutterE2E workflow_dispatch input above (never runs on the
+  # nightly schedule) -- see that input's description for why it mirrors
+  # -Dshaft.enableFlutterE2E instead of duplicating the gating concept.
+  Android_Flutter_Emulator_E2E:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.enableFlutterE2E == 'true' && (github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Flutter_Emulator_E2E,'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          java-version: '17'
+          node-version: '20'
+      - name: Setup Flutter 3.22.1
+        uses: subosito/flutter-action@v2.23.0
+        with:
+          flutter-version: 3.22.1
+          channel: stable
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v4.0.1
+      - name: Checkout pinned appium-flutter-server demo-app
+        uses: actions/checkout@v7
+        with:
+          repository: AppiumTestDistribution/appium-flutter-server
+          # Pinned commit, verified current HEAD of main at ticket time (issue #4197) --
+          # never track a moving branch; there is no permanently-hosted prebuilt APK,
+          # the upstream project's own CI builds fresh from source every run too.
+          ref: 78ba97a6146091b944335d0db3330f74416f3ac7
+          path: appium-flutter-server
+          sparse-checkout: |
+            demo-app
+      - name: Build demo-app debug APK wired for the Appium Flutter Integration Server
+        # Recipe taken verbatim from appium-flutter-server's own
+        # .github/workflows/main.yml at the pinned commit -- their CI runs this
+        # exact sequence successfully today.
+        run: |
+          set -euo pipefail
+          cd appium-flutter-server/demo-app
+          dart pub global activate rps --version 0.8.0
+          flutter build apk --debug
+          cd android && ./gradlew app:assembleDebug -Ptarget="$(pwd)/../integration_test/appium.dart"
+      - name: Install Appium and the Flutter Integration Driver
+        run: |
+          set -euo pipefail
+          npm install -g appium@3.5.2
+          appium driver install --source npm appium-flutter-integration-driver
+      - name: Boot emulator and assert an Appium Flutter session opens
+        uses: reactivecircus/android-emulator-runner@v2.38.0
+        with:
+          api-level: 30
+          target: google_apis
+          arch: x86_64
+          script: |
+            set -euo pipefail
+            APK_PATH="$GITHUB_WORKSPACE/appium-flutter-server/demo-app/build/app/outputs/apk/debug/app-debug.apk"
+            ls -l "$APK_PATH"
+            adb devices
+
+            # The Appium server and the session-open assertion MUST run in the same
+            # step/script: a server started via a background job in an earlier step
+            # gets torn down when that step's shell exits, so nothing is listening by
+            # the time a later step tries to connect (see e2eLocalTests.yml's
+            # Windows_Appium_Desktop_Local job comment, issue #3806, for the same
+            # gotcha discovered the hard way there). Co-locating start + assertion
+            # here keeps the server alive for the whole session-creation window.
+            appiumLog="$RUNNER_TEMP/appium-server.log"
+            appium --address 127.0.0.1 --port 4723 --log-level info --log "$appiumLog" &
+            APPIUM_PID=$!
+            trap 'kill "$APPIUM_PID" 2>/dev/null || true' EXIT
+
+            ready=false
+            for i in $(seq 1 60); do
+              if curl --max-time 2 -fsS http://127.0.0.1:4723/status >/dev/null 2>&1; then
+                ready=true
+                break
+              fi
+              sleep 1
+            done
+            if [ "$ready" != true ]; then
+              echo "::error::Appium server did not become ready."
+              cat "$appiumLog" || true
+              exit 1
+            fi
+
+            SESSION_PAYLOAD=$(jq -n --arg app "$APK_PATH" '{capabilities: {alwaysMatch: {platformName: "Android", "appium:automationName": "FlutterIntegration", "appium:app": $app, "appium:noReset": true}}}')
+
+            RESPONSE=$(curl --max-time 120 -fsS -X POST -H "Content-Type: application/json" -d "$SESSION_PAYLOAD" http://127.0.0.1:4723/session)
+            echo "$RESPONSE"
+            SESSION_ID=$(echo "$RESPONSE" | jq -r '.value.sessionId // empty')
+            if [ -z "$SESSION_ID" ]; then
+              echo "::error::Appium session did not open -- no sessionId in response."
+              cat "$appiumLog" || true
+              exit 1
+            fi
+            echo "Appium Flutter session opened: $SESSION_ID"
+            curl --max-time 30 -fsS -X DELETE "http://127.0.0.1:4723/session/$SESSION_ID" || true
+      - name: Upload Appium server log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: Android_Flutter_Emulator_E2E_appium_log
+          path: ${{ runner.temp }}/appium-server.log
+          if-no-files-found: ignore
+
   MacOSX_Safari_BrowserStack:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_BrowserStack,')
     runs-on: ubuntu-latest
@@ -938,7 +1078,7 @@ jobs:
 
   notify_e2e_tests_failure:
     name: Notify on nightly failure
-    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack, Ubuntu_JUnit_E2E ]
+    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, Android_Flutter_Emulator_E2E, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack, Ubuntu_JUnit_E2E ]
     if: always()
     runs-on: ubuntu-22.04
     timeout-minutes: 5

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -683,6 +683,14 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+    outputs:
+      job: ${{ steps.post_test_report.outputs.job }}
+      total: ${{ steps.post_test_report.outputs.total }}
+      passed: ${{ steps.post_test_report.outputs.passed }}
+      failed: ${{ steps.post_test_report.outputs.failed }}
+      broken: ${{ steps.post_test_report.outputs.broken }}
+      skipped: ${{ steps.post_test_report.outputs.skipped }}
+      duration: ${{ steps.post_test_report.outputs.duration }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -786,6 +794,13 @@ jobs:
           name: Android_Flutter_Emulator_E2E_appium_log
           path: ${{ runner.temp }}/appium-server.log
           if-no-files-found: ignore
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: Android_Flutter_Emulator_E2E
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Safari_BrowserStack:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_BrowserStack,')


### PR DESCRIPTION
## Summary

Adds `Android_Flutter_Emulator_E2E` to `.github/workflows/e2eTests.yml`: a new
CI job that builds the real `AppiumTestDistribution/appium-flutter-server`
`demo-app` from a pinned upstream commit, boots a hardware-accelerated Android
emulator, starts Appium with the Flutter Integration Driver installed, and
asserts that an Appium session actually opens against the built app. This is
CI-workflow-only infrastructure -- no Java/test code is touched.

Closes #4197

## Why this job, and why here

Issue 4017 (the fluent Flutter wait/gesture/camera API) named its own biggest
gap plainly: no CI coverage was possible, so it shipped blind. `FlutterTest.java`
has been permanently `SkipException`-gated (`shaft.enableFlutterE2E`) with no
CI leg that ever un-gates it. This PR is the CI-infrastructure fix for that gap:
proof, on a real GitHub Actions runner, that an Appium session can be opened
against a real Flutter app built with the driver's own required server wiring
-- something this repo has never had CI evidence for.

Issue 4017 is being worked concurrently and is adding the fluent API plus its
own gated test stubs directly in `FlutterTest.java`. This PR deliberately never
touches that file or any other Java test code -- the scope here is the CI
pipeline that will eventually make `-Dshaft.enableFlutterE2E=true` meaningful,
not the fluent API itself.

**Home for the job:** `e2eTests.yml`, not `pr-gate.yml` -- it already has the
right shape (nightly `schedule` + `workflow_dispatch` with a selectable `jobs`
input) and already carries the `Workflow_Summary` / `notify_e2e_tests_failure`
consolidation pattern the new job rides for free. A separate workflow file
would have needed its own copy of both, for no benefit -- so the job lives
alongside the other `Android_*` jobs (`Android_Native_BrowserStack`,
`Android_Web_Chrome_BrowserStack`) rather than in a bespoke file.

## Gating

The job is gated behind a new `enableFlutterE2E` `workflow_dispatch` input,
opt-in (`default: 'false'`), never runs on the nightly `schedule` trigger
(schedule events carry no inputs), and only runs on a manual dispatch with
`enableFlutterE2E: 'true'`. This mirrors the existing
`-Dshaft.enableFlutterE2E` Maven system property that already gates
`FlutterTest.java` (`FlutterTest.java:24,34-37`) rather than inventing a
second, competing gating concept -- it's the same name adapted to
`workflow_dispatch` input syntax, which can't contain a literal dot.

## What this proves, and what it does not

**Proven by a green run of this job:** the demo-app builds from source with the
Appium Flutter server wired in, an Android emulator boots on a GitHub-hosted
runner, Appium starts with the Flutter Integration Driver installed, and a
real Appium session opens against the built app (`platformName: Android`,
`appium:automationName: FlutterIntegration`). That is the entire proof
surface -- no UI interaction is driven.

**Not proven:** that the 8 fluent-API calls issue 4017 is adding behave
correctly against a live Flutter widget tree. A session opening is not the
same as the fluent API working. Wiring the actual fluent-API assertions
against this real app/pipeline is an intentional fast-follow once both this
job and the 4017 work have landed -- filing that follow-up ticket is a
separate action outside this PR's diff.

## Build recipe and pins

- Upstream fixture: `AppiumTestDistribution/appium-flutter-server` (MIT
  licensed), pinned to commit `78ba97a6146091b944335d0db3330f74416f3ac7` --
  verified as the current HEAD of `main` at the time of writing. Checked out
  via a sparse checkout of just `demo-app/` into a separate path so it never
  touches the SHAFT_ENGINE tree.
- Build steps replicate that repo's own `.github/workflows/main.yml` verbatim:
  Flutter 3.22.1 (stable channel, `subosito/flutter-action@v2.23.0`), JDK 17,
  Android SDK setup (`android-actions/setup-android@v4.0.1`),
  `dart pub global activate rps --version 0.8.0`, `flutter build apk --debug`,
  then `./gradlew app:assembleDebug -Ptarget=.../integration_test/appium.dart`.
- Emulator: `reactivecircus/android-emulator-runner@v2.38.0` (the current
  release; researched as the standard, actively maintained action for exactly
  this on GitHub-hosted runners -- no prior art for this existed in the repo).
  API level 30, `google_apis`, `x86_64`, with the KVM-enabling udev step its
  own README documents as required on Linux runners for hardware
  acceleration.
- Appium: pinned to `appium@3.5.2`, the same version already validated
  elsewhere in this repo (`e2eLocalTests.yml`'s `Windows_Appium_Desktop_Local`
  job) -- plus the `appium-flutter-integration-driver` npm driver
  (`appium driver install --source npm appium-flutter-integration-driver`).
  The Appium server and the session-open assertion run in the same shell
  script for the same reason documented in that existing Windows job's
  comment (issue #3806): a server backgrounded in one step is torn down
  before a later step can reach it.
- `timeout-minutes: 60` -- generous headroom over the emulator boot + fresh
  Flutter/Gradle toolchain download + APK build, which is genuinely slow on a
  cold cache.

## Validation performed (and its limits)

- `py -3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2eTests.yml'))"` --
  passes, structurally valid YAML.
- `py -3 scripts/ci/validate_workflow_timeouts.py` -- passes.
- `py -3 scripts/ci/validate_agent_setup.py` -- passes (unrelated guidance/memory
  guard, run as a general sanity check).
- **This is the ceiling of what could be verified locally.** This machine has
  no Flutter SDK, no configured AVD, and per this repo's own safety
  convention, mobile emulator/inspector tooling is not launched interactively
  in an agent session. No emulator, Appium server, or Flutter build was run
  locally. The only real proof that this pipeline works is a green run of
  this job on GitHub Actions once merged -- that has not happened yet as of
  this PR.

Related to (but does not close) issue 4017.
