### PR TITLE
Stage generated test source until compile/replay pass, never overwrite it early

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -306,12 +306,18 @@ public final class CaptureGenerator {
                         request.enrichmentPreviewPath(), report);
             }
 
+            // Issue #4166: compile() and replay() run against a STAGED copy of the source, never
+            // against paths.source() itself, so a failed regeneration can never clobber a
+            // previously-good generated test the user already had. The test-data JSON must still be
+            // written to its real path here -- the replay subprocess loads it by the deterministic
+            // SHAFT.TestData.JSON(dataFileName(className)) convention, not from a staged location.
             stage = "writing generated artifacts to disk";
-            atomicWrite(paths.source(), source);
+            Path stagedSource = stagingSourcePath(outputRoot, request.packageName(), className);
+            atomicWrite(stagedSource, source);
             atomicWrite(paths.data(), dataJson);
             stage = "compiling the generated test";
             CaptureGenerationReport.Validation compilation = request.compile()
-                    ? validator.compile(paths.source(), paths.classes())
+                    ? validator.compile(stagedSource, paths.classes())
                     : CaptureGenerationReport.Validation.skipped("Compilation was not requested.");
             reporter.accept(request.replay() ? 0.75 : 0.9, "Compiled generated test: " + compilation.status());
             stage = "replaying the generated test";
@@ -334,10 +340,19 @@ public final class CaptureGenerator {
                         "Replay was skipped because compilation failed.");
                 reporter.accept(0.9, "Replay skipped: compilation failed");
             }
-            stage = "writing the generation report";
             boolean successful = compilation.status()
                     != CaptureGenerationReport.Validation.ValidationStatus.FAILED
                     && replay.status() != CaptureGenerationReport.Validation.ValidationStatus.FAILED;
+            if (successful) {
+                stage = "promoting the validated generated source to its final path";
+                atomicWrite(paths.source(), source);
+            } else if (Files.exists(paths.source())) {
+                state.warnings().add("Generated test source was not written: compilation or replay failed, "
+                        + "so the existing file at " + relative(paths.root(), paths.source())
+                        + " was left unchanged.");
+            }
+            deleteStagedSourceQuietly(stagedSource);
+            stage = "writing the generation report";
             CaptureGenerationReport report = report(
                     session,
                     paths,
@@ -2409,6 +2424,27 @@ public final class CaptureGenerator {
             return java.net.URLDecoder.decode(value.replace("+", "%2B"), StandardCharsets.UTF_8);
         } catch (IllegalArgumentException malformedEscape) {
             return value;
+        }
+    }
+
+    /**
+     * Path for the pre-validation copy of the generated source (issue #4166). Compilation and
+     * replay run against this path -- never against {@code paths.source()} -- so a failed
+     * regeneration never overwrites a previously-good generated test at the real output path.
+     */
+    private static Path stagingSourcePath(Path outputRoot, String packageName, String className) {
+        return outputRoot.resolve("target/shaft-capture/staging")
+                .resolve(packageName.replace('.', '/'))
+                .resolve(className + ".java")
+                .normalize();
+    }
+
+    private static void deleteStagedSourceQuietly(Path stagedSource) {
+        try {
+            Files.deleteIfExists(stagedSource);
+        } catch (IOException ignored) {
+            // Best-effort cleanup of an unpublished staged artifact under target/; never reaches
+            // the user and is safe to leave for the next `mvn clean`.
         }
     }
 

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -1146,6 +1146,67 @@ class CaptureGeneratorTest {
                 .anyMatch(warning -> warning.contains("#3065")), result.report().warnings().toString());
     }
 
+    // Issue #4166: a failed compile/replay must never destroy a previously-good generated test
+    // file already sitting at the same output path -- only a validated regeneration may be
+    // promoted to paths.source().
+    @Test
+    void failedReplayLeavesPreviouslyGeneratedSourceUnchanged() throws Exception {
+        CaptureSession baseline = CaptureFixtures.representativeSession();
+        writeCaptureData("alice");
+        Path output = temp.resolve("overwrite-protection");
+
+        CaptureGenerationResult first = new CaptureGenerator().generate(new CaptureGenerationRequest(
+                session(baseline), output, "generated.capture", "OverwriteProtectionTest", true,
+                true, false, Duration.ofMinutes(1),
+                CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                ApprovalPolicy.denyAll()));
+        assertTrue(first.successful(), first.report().unsupportedEvents().toString());
+        String originalSource = Files.readString(first.sourcePath());
+
+        // Same events (so analysis/compile would still be valid) but a different sessionGoal, so
+        // the deterministically-rendered source is provably different text from the original --
+        // otherwise a byte-identical regeneration could pass even with the bug still present.
+        CaptureSession regenerated = new CaptureSession(
+                baseline.schemaVersion(), baseline.sessionId(), baseline.status(), baseline.startedAt(),
+                baseline.endedAt(), baseline.browser(), baseline.events(), baseline.checkpoints(),
+                baseline.dataReferences(), baseline.redactionSummary(),
+                Map.of("sessionGoal", JSON.getNodeFactory().textNode("Regenerated after a forced replay failure")));
+
+        GeneratedTestValidator failingReplayValidator = new GeneratedTestValidator() {
+            @Override
+            public CaptureGenerationReport.Validation compile(Path source, Path classesDirectory) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED, List.of(), 0);
+            }
+
+            @Override
+            public CaptureGenerationReport.Validation replay(
+                    String fullyQualifiedClassName,
+                    Path classesDirectory,
+                    Path resourcesDirectory,
+                    Path workDirectory,
+                    Duration timeout) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.FAILED,
+                        List.of("Simulated replay failure for regression coverage."), 1);
+            }
+        };
+        CaptureGenerationResult second = new CaptureGenerator(
+                new CaptureJsonCodec(), new LocatorRanker(), failingReplayValidator, new CaptureEnrichmentService())
+                .generate(new CaptureGenerationRequest(
+                        session(regenerated), output, "generated.capture", "OverwriteProtectionTest", true,
+                        true, true, Duration.ofMinutes(1),
+                        CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                        ApprovalPolicy.denyAll()));
+
+        assertFalse(second.successful());
+        assertEquals(first.sourcePath(), second.sourcePath());
+        assertEquals(originalSource, Files.readString(second.sourcePath()));
+        assertTrue(second.report().warnings().stream()
+                        .anyMatch(warning -> warning.contains("left unchanged")),
+                second.report().warnings().toString());
+    }
+
     @Test
     void workspaceContainedFileUrlRecordingIsNotAPrivacyBlocker() throws Exception {
         CaptureSession base = CaptureFixtures.representativeSession();


### PR DESCRIPTION
## Summary
- `CaptureGenerator.generate()` wrote the generated `.java` source to its final output path (`paths.source()`) before `compile()` and `replay()` ran, with no rollback on failure. Combined with `/codegen` defaulting `overwrite=true`, a failed regeneration silently destroyed a previously-good generated test the user already had.
- Compile and replay now run against a staged copy of the source under `target/shaft-capture/staging/`; the real path is only written once both pass. On failure the previously-existing file is left completely untouched.
- When a previously-existing file was left unchanged, the generation report's `warnings` now say so explicitly, reusing the same report-warnings path the stage-tracking work (issue 4029, PR 4196) already threads through `generate()`, rather than a parallel message channel.
- Rebased on current `main` (post issue 4029/PR 4196, which added pipeline-stage tracking through this same method) -- the fix composes with that tracking rather than reverting or duplicating it.

## Adjacent finding (reported, not fixed -- out of scope for this PR)
`atomicWrite(paths.data(), dataJson)` (the generated test-data JSON) is still written to its real path before compile/replay run, with the identical overwrite-before-validate exposure this issue describes for the source file. It could not be staged the same way: the replay subprocess loads test data from the real path by the deterministic `SHAFT.TestData.JSON(dataFileName(className))` convention, so true staging isn't a drop-in fix there. Worth a follow-up issue if the team wants the same protection extended to the data file.

## Test plan
- [x] `mvn -pl shaft-capture -Dtest=CaptureGeneratorTest#failedReplayLeavesPreviouslyGeneratedSourceUnchanged test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- watched RED (asserted original content, got the clobbered regenerated content) then GREEN after the fix.
- [x] `mvn -pl shaft-capture -Dtest=CaptureGeneratorTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 38/38 passed (37 pre-existing + the new regression test).
- [x] `mvn -pl shaft-capture compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- clean.

Closes #4166