### PR TITLE
Recover a cancelled/killed local-agent run's terminal answer

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -197,12 +197,38 @@ final class AssistantLocalAgentRunner {
             LocalAgentApprovalBridge.ApprovalRequestHandler approvalHandler,
             ApprovalBridgeLauncher bridgeLauncher,
             boolean verbose) {
+        return start(invocation, outputConsumer, processLauncher, requireCommandAvailable, approvalHandler,
+                bridgeLauncher, verbose, null);
+    }
+
+    /**
+     * Same as the 7-arg overload above, plus {@code terminalAnswerConsumer} (issue #3962). {@code
+     * ShaftMcpInvocation.cancel()}/{@code kill()} call {@code future.cancel(true)} <em>before</em>
+     * running their cancel/kill action (issue #3758/#3768's validated ordering, untouched here) -- so
+     * once that call wins, the JDK's own {@code Future} contract silently discards whatever {@link
+     * #run} later returns or throws, even a real parsed terminal answer. {@code
+     * terminalAnswerConsumer}, when non-null, is notified exactly once from {@code run()}'s own
+     * {@code finally} block (see the canonical {@link #run} overload) with the parsed terminal answer
+     * -- or {@code null} if the structured stream never produced one -- regardless of {@code
+     * future.cancel(true)}, since it is a side channel the primary future's cancellation cannot touch.
+     * {@code null} (the default via the 7-arg overload) means "no one is listening"; every existing
+     * caller is unaffected.
+     */
+    static ShaftMcpInvocation start(
+            AssistantCommand.Invocation invocation,
+            Consumer<String> outputConsumer,
+            ProcessLauncher processLauncher,
+            boolean requireCommandAvailable,
+            LocalAgentApprovalBridge.ApprovalRequestHandler approvalHandler,
+            ApprovalBridgeLauncher bridgeLauncher,
+            boolean verbose,
+            Consumer<String> terminalAnswerConsumer) {
         JsonObject arguments = invocation.arguments();
         AtomicReference<Process> processReference = new AtomicReference<>();
         AtomicBoolean cancellationRequested = new AtomicBoolean();
         CompletableFuture<ShaftMcpToolResult> future = CompletableFuture.supplyAsync(() -> run(
                 arguments, processReference, cancellationRequested, outputConsumer, processLauncher,
-                requireCommandAvailable, approvalHandler, bridgeLauncher, verbose),
+                requireCommandAvailable, approvalHandler, bridgeLauncher, verbose, terminalAnswerConsumer),
                 ShaftPluginExecutor.getInstance().executor());
         return new ShaftMcpInvocation(
                 future,
@@ -275,6 +301,24 @@ final class AssistantLocalAgentRunner {
             Consumer<String> outputConsumer,
             LocalAgentApprovalBridge.ApprovalRequestHandler approvalHandler,
             boolean verbose) {
+        return startWithOptionalCompact(invocation, autoCompactEnabled, outputConsumer, approvalHandler, verbose, null);
+    }
+
+    /**
+     * Same as the 5-arg overload above, plus {@code terminalAnswerConsumer} (issue #3962) -- see the
+     * matching {@link #start(AssistantCommand.Invocation, Consumer, ProcessLauncher, boolean,
+     * LocalAgentApprovalBridge.ApprovalRequestHandler, ApprovalBridgeLauncher, boolean, Consumer)}
+     * overload for what it is notified with and when. {@link ShaftAssistantPanel} calls this overload
+     * for its local-agent runs so it can recover a cancelled/killed run's parsed terminal answer,
+     * which {@code future.cancel(true)} would otherwise discard unconditionally.
+     */
+    static ShaftMcpInvocation startWithOptionalCompact(
+            AssistantCommand.Invocation invocation,
+            boolean autoCompactEnabled,
+            Consumer<String> outputConsumer,
+            LocalAgentApprovalBridge.ApprovalRequestHandler approvalHandler,
+            boolean verbose,
+            Consumer<String> terminalAnswerConsumer) {
         if (autoCompactEnabled) {
             ShaftMcpToolResult compactResult = runCompactPreamble(invocation.arguments());
             if (outputConsumer != null && compactResult.output() != null && !compactResult.output().isBlank()) {
@@ -282,7 +326,7 @@ final class AssistantLocalAgentRunner {
             }
         }
         return start(invocation, outputConsumer, AssistantLocalAgentRunner::launchProcess, true, approvalHandler,
-                LocalAgentApprovalBridge::start, verbose);
+                LocalAgentApprovalBridge::start, verbose, terminalAnswerConsumer);
     }
 
     /**
@@ -528,7 +572,7 @@ final class AssistantLocalAgentRunner {
             ProcessLauncher processLauncher,
             boolean requireCommandAvailable) {
         return run(arguments, processReference, cancellationRequested, outputConsumer, processLauncher,
-                requireCommandAvailable, null, LocalAgentApprovalBridge::start, true);
+                requireCommandAvailable, null, LocalAgentApprovalBridge::start, true, null);
     }
 
     private static ShaftMcpToolResult run(
@@ -540,7 +584,8 @@ final class AssistantLocalAgentRunner {
             boolean requireCommandAvailable,
             LocalAgentApprovalBridge.ApprovalRequestHandler approvalHandler,
             ApprovalBridgeLauncher bridgeLauncher,
-            boolean verbose) {
+            boolean verbose,
+            Consumer<String> terminalAnswerConsumer) {
         Duration timeout = Duration.ofSeconds(intValue(arguments, "timeoutSeconds", DEFAULT_TIMEOUT_SECONDS));
         LocalAgentApprovalBridge.ApprovalRequestHandler narratingApprovalHandler =
                 narrateApproval(approvalHandler, outputConsumer);
@@ -563,6 +608,11 @@ final class AssistantLocalAgentRunner {
                 }
             }
         }
+        // Declared here (not inside the try below) so the outer finally can always reach it -- issue
+        // #3962's terminalAnswerConsumer notification below must fire from every exit path of this
+        // method, including the early-return guard clauses at the top of the try that run before a
+        // structured stream parser is even created.
+        StructuredStreamParser streamParser = null;
         try {
             List<String> command = commandFor(arguments, bridge);
             if (command.isEmpty()) {
@@ -580,7 +630,7 @@ final class AssistantLocalAgentRunner {
             String stdin = string(arguments, "prompt", "");
             Path workingDirectory = workingDirectory(arguments);
             boolean isDefaultCommand = defaultCommand(arguments);
-            StructuredStreamParser streamParser = isDefaultCommand ? structuredStreamParser(command) : null;
+            streamParser = isDefaultCommand ? structuredStreamParser(command) : null;
             Consumer<String> effectiveConsumer =
                     effectiveConsumer(outputConsumer, streamParser, isDefaultCommand);
             OutputStream stdinStream = null;
@@ -656,6 +706,20 @@ final class AssistantLocalAgentRunner {
                 processReference.set(null);
             }
         } finally {
+            // Issue #3962: notified exactly once, from every exit path of this method (normal return,
+            // timeout, a thrown exception, or a cancellation the checks above turned into a thrown
+            // CancellationException) -- unconditionally, regardless of whether cancellationRequested
+            // was ever observed. This runs strictly before this method returns/throws to the
+            // supplyAsync wrapper that completes the primary future, so by the time any caller's
+            // future.whenComplete callback can possibly observe this run's outcome, this notification
+            // has already happened -- closing the race #3758/#3768 exploit differently (this side
+            // channel is never subject to future.cancel(true), which only ever affects the primary
+            // future's own stored result).
+            if (terminalAnswerConsumer != null) {
+                terminalAnswerConsumer.accept(streamParser != null && streamParser.hasTerminalEvent()
+                        ? streamParser.finalOutput()
+                        : null);
+            }
             if (bridge != null) {
                 bridge.close();
             }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -706,22 +706,27 @@ final class AssistantLocalAgentRunner {
                 processReference.set(null);
             }
         } finally {
-            // Issue #3962: notified exactly once, from every exit path of this method (normal return,
-            // timeout, a thrown exception, or a cancellation the checks above turned into a thrown
-            // CancellationException) -- unconditionally, regardless of whether cancellationRequested
-            // was ever observed. This runs strictly before this method returns/throws to the
-            // supplyAsync wrapper that completes the primary future, so by the time any caller's
-            // future.whenComplete callback can possibly observe this run's outcome, this notification
-            // has already happened -- closing the race #3758/#3768 exploit differently (this side
-            // channel is never subject to future.cancel(true), which only ever affects the primary
-            // future's own stored result).
-            if (terminalAnswerConsumer != null) {
-                terminalAnswerConsumer.accept(streamParser != null && streamParser.hasTerminalEvent()
-                        ? streamParser.finalOutput()
-                        : null);
-            }
-            if (bridge != null) {
-                bridge.close();
+            try {
+                // Issue #3962: notified exactly once, from every exit path of this method (normal
+                // return, timeout, a thrown exception, or a cancellation the checks above turned into a
+                // thrown CancellationException) -- unconditionally, regardless of whether
+                // cancellationRequested was ever observed. This runs strictly before this method
+                // returns/throws to the supplyAsync wrapper that completes the primary future, so by the
+                // time any caller's future.whenComplete callback can possibly observe this run's
+                // outcome, this notification has already happened -- closing the race #3758/#3768
+                // exploit differently (this side channel is never subject to future.cancel(true), which
+                // only ever affects the primary future's own stored result).
+                if (terminalAnswerConsumer != null) {
+                    terminalAnswerConsumer.accept(streamParser != null && streamParser.hasTerminalEvent()
+                            ? streamParser.finalOutput()
+                            : null);
+                }
+            } finally {
+                // Nested so a misbehaving terminalAnswerConsumer (e.g. a caller's completion callback
+                // throwing) can never suppress closing the approval bridge's HTTP server underneath it.
+                if (bridge != null) {
+                    bridge.close();
+                }
             }
         }
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -84,6 +84,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -2085,22 +2086,27 @@ final class ShaftAssistantPanel extends JPanel {
         if (cancelled) {
             String terminalStep = killed ? "Killed" : "Cancelled";
             setStatus(terminalStep);
-            // Issue #3962: a genuine Kill already finalized synchronously in stopLocalAgentStreaming
-            // (handleKilledOrStaleAgentStream short-circuited above before this branch could ever run
-            // for that same stream token), so pendingTerminalAnswer only ever matters for a soft
-            // Cancel reaching here -- wait for it (bounded: AssistantLocalAgentRunner#run's own
-            // finally always completes it, one way or another) instead of immediately rendering the
-            // bare "_Cancelled._" placeholder and permanently losing a terminal answer that was
-            // already parsed the instant it resolves.
-            CompletableFuture<String> pending = pendingTerminalAnswer;
-            pendingTerminalAnswer = null;
-            if (pending == null) {
-                showAgentCancelled(streamToken, currentStream, killed, partialOutput);
-            } else {
-                pending.whenComplete((terminalAnswer, ignoredError) -> runOnEdt(() -> showAgentCancelled(
-                        streamToken, streamToken == activeLocalAgentStreamToken, killed, partialOutput,
-                        terminalAnswer)));
-            }
+            // Issue #3962 (hostile-review correction): render the "_Cancelled._"/partial-buffer bubble
+            // synchronously, exactly like before this fix -- mirrors stopLocalAgentStreaming's Kill
+            // path, which never waited on the companion either. Waiting here would (a) leave the user
+            // with no terminal bubble at all for as long as AssistantLocalAgentRunner#run's own
+            // finally takes to run (unbounded from this method's perspective -- up to the process
+            // timeout/approval extension), and (b) re-reading activeLocalAgentStreamToken inside a
+            // deferred callback after this same method already reset it to -1 a few lines above is
+            // unconditionally false, silently routing the deferred render down
+            // persistAndAppendResponse's append-a-new-message path instead of replacing this one --
+            // rendering the run twice. Capture the index/session this synchronous render just wrote to
+            // -- BEFORE calling it, since a currentStream reply replaces
+            // localAgentStreamPlaceholderMessageIndex and then resets it to -1 -- and schedule a
+            // guarded, in-place-only upgrade for later (see scheduleTerminalAnswerUpgrade), the same
+            // pattern already used for Kill.
+            ShaftAssistantChatState.Session activeBeforeRender = chatState.activeSession();
+            String sessionId = activeBeforeRender == null ? null : activeBeforeRender.id;
+            int targetMessageIndex = currentStream
+                    ? nextLocalAgentStreamPlaceholderTargetIndex()
+                    : currentSessionMessageCount();
+            showAgentCancelled(streamToken, currentStream, killed, partialOutput);
+            scheduleTerminalAnswerUpgrade(targetMessageIndex, sessionId, killed ? "_Killed._" : "_Cancelled._");
             return;
         }
         showAgentToolResult(streamToken, currentStream, success, result, error, captureIntegrationRun, partialOutput);
@@ -2260,32 +2266,15 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void showAgentCancelled(int streamToken, boolean currentStream, boolean killed, String partialOutput) {
-        showAgentCancelled(streamToken, currentStream, killed, partialOutput, null);
-    }
-
-    /**
-     * Same as the 4-arg overload above, plus {@code terminalAnswer} (issue #3962): when non-blank, the
-     * structured stream had already produced a real, composed answer before the cancellation raced
-     * it -- rendered here instead of the bare "_Cancelled._"/"_Killed._" marker or the raw partial
-     * buffer, both of which would otherwise be all that is left once {@code future.cancel(true)}
-     * discards the run's actual return value.
-     */
-    private void showAgentCancelled(
-            int streamToken, boolean currentStream, boolean killed, String partialOutput, String terminalAnswer) {
         String label = killed ? "Killed" : "Cancelled";
-        String canceledResponse;
-        if (terminalAnswer != null && !terminalAnswer.isBlank()) {
-            canceledResponse = AssistantMarkdown.normalizeMarkdown(
-                    AssistantLocalAgentRunner.stripTrailingUsageMetadata(terminalAnswer))
-                    + "\n\n_" + label + "._ (the run had already finished)";
-        } else if (partialOutput == null || partialOutput.isBlank()) {
-            canceledResponse = "_" + label + "._";
-        } else {
-            canceledResponse = formatLocalAgentStreamingResponse(partialOutput) + "\n\n_" + label
-                    + "._ (partial output above)";
-        }
+        String canceledResponse = partialOutput == null || partialOutput.isBlank()
+                ? "_" + label + "._"
+                : formatLocalAgentStreamingResponse(partialOutput) + "\n\n_" + label + "._ (partial output above)";
         // A user-initiated Cancel/Kill is a tool-event outcome, not a genuine failure -- mirrors
-        // showTerminalSequenceResult's cancelled branch for the MCP-tool-sequence path.
+        // showTerminalSequenceResult's cancelled branch for the MCP-tool-sequence path. A recovered
+        // terminal answer (issue #3962) is never rendered here -- only via the guarded, in-place
+        // upgrade scheduled right after this call returns (see scheduleTerminalAnswerUpgrade), so this
+        // synchronous render and that later upgrade can never both write a message.
         showAgentResponse(streamToken, currentStream, canceledResponse, "", ShaftAssistantChatState.KIND_TOOL_EVENT);
     }
 
@@ -2334,6 +2323,27 @@ final class ShaftAssistantPanel extends JPanel {
     private int currentSessionMessageCount() {
         ShaftAssistantChatState.Session active = chatState.activeSession();
         return active == null || active.messages == null ? 0 : active.messages.size();
+    }
+
+    /**
+     * The exact index {@link #replaceLocalAgentStreamPlaceholder} is about to write to, computed the
+     * same way it decides internally: {@link #localAgentStreamPlaceholderMessageIndex} when it still
+     * points inside the active session's current message list (a live placeholder bubble exists to
+     * replace in place), otherwise {@link #currentSessionMessageCount()} (its append-fresh fallback
+     * appends there). Needed by {@link #showAgentResult}'s cancelled branch (issue #3962) to capture
+     * -- BEFORE calling {@link #showAgentCancelled}, which is what actually resets {@link
+     * #localAgentStreamPlaceholderMessageIndex} -- exactly where the cancelled bubble is about to
+     * land, since a non-Verbose run with no live placeholder yet (only compact milestone bubbles
+     * appended so far, see {@link #appendLocalAgentOutput}) leaves {@link
+     * #localAgentStreamPlaceholderMessageIndex} at {@code -1} right up until this same call appends
+     * fresh -- naively trusting a {@code -1}/stale value here would point the later terminal-answer
+     * upgrade at the wrong message (or no message at all).
+     */
+    private int nextLocalAgentStreamPlaceholderTargetIndex() {
+        int currentCount = currentSessionMessageCount();
+        return localAgentStreamPlaceholderMessageIndex >= 0 && localAgentStreamPlaceholderMessageIndex < currentCount
+                ? localAgentStreamPlaceholderMessageIndex
+                : currentCount;
     }
 
     private void appendLocalAgentOutput(int streamToken, String line) {
@@ -2618,7 +2628,9 @@ final class ShaftAssistantPanel extends JPanel {
             replaceLocalAgentStreamPlaceholder("assistant", finalized, true);
             int finalizedMessageIndex = localAgentStreamPlaceholderMessageIndex;
             localAgentStreamPlaceholderMessageIndex = -1;
-            scheduleKilledTerminalAnswerUpgrade(finalizedMessageIndex);
+            ShaftAssistantChatState.Session activeAfterFinalize = chatState.activeSession();
+            String sessionId = activeAfterFinalize == null ? null : activeAfterFinalize.id;
+            scheduleTerminalAnswerUpgrade(finalizedMessageIndex, sessionId, "_Killed._");
         }
         activeLocalAgentStreamToken = -1;
         localAgentOutput = null;
@@ -2626,55 +2638,69 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     /**
-     * Issue #3962: a Kill finalizes the "_Killed._" bubble synchronously above, before {@link
-     * ShaftMcpInvocation#kill()} even runs -- so {@link #pendingTerminalAnswer} (if this run has one)
-     * cannot possibly be resolved yet, and waiting for it here would delay the existing instant Kill
-     * feedback. Instead, this schedules a one-time, guarded in-place upgrade of the exact message just
-     * finalized (at {@code finalizedMessageIndex}) for whenever -- if ever -- the companion resolves
-     * with a real answer, without delaying or duplicating the render above.
+     * Issue #3962: both Cancel ({@link #showAgentResult}) and Kill ({@link #stopLocalAgentStreaming})
+     * render their terminal "_Cancelled._"/"_Killed._" bubble synchronously -- neither one waits on
+     * {@link #pendingTerminalAnswer} before that first render (Kill cannot: it finalizes before {@code
+     * ShaftMcpInvocation#kill()} even runs, so the companion is essentially guaranteed unresolved;
+     * Cancel could, but doing so would leave no terminal bubble at all for as long as the run takes to
+     * actually finish, and would have to re-read mutable instance state like {@code
+     * activeLocalAgentStreamToken} from inside a deferred callback after this same code path has
+     * already changed it). Instead, this schedules a one-time, guarded in-place upgrade of the exact
+     * message just finalized (at {@code messageIndex}, in the session {@code sessionId}) for whenever
+     * -- if ever -- the companion resolves with a real answer, without delaying or duplicating either
+     * render.
      */
-    private void scheduleKilledTerminalAnswerUpgrade(int finalizedMessageIndex) {
+    private void scheduleTerminalAnswerUpgrade(int messageIndex, String sessionId, String terminalMarker) {
         CompletableFuture<String> pending = pendingTerminalAnswer;
         pendingTerminalAnswer = null;
         if (pending == null) {
             return;
         }
         pending.thenAccept(terminalAnswer -> runOnEdt(
-                () -> upgradeKilledLocalAgentMessage(finalizedMessageIndex, terminalAnswer)));
+                () -> upgradeFinalizedLocalAgentMessage(messageIndex, sessionId, terminalMarker, terminalAnswer)));
     }
 
     /**
-     * Guarded upgrade for {@link #scheduleKilledTerminalAnswerUpgrade}: replaces the "_Killed._"
+     * Guarded upgrade for {@link #scheduleTerminalAnswerUpgrade}: replaces the {@code terminalMarker}
      * message at {@code messageIndex} in place with {@code terminalAnswer}'s polished text, but only
      * if all of the following still hold at the time this actually runs (which may be immediately, or
-     * after other transcript activity has happened in the meantime):
+     * after other activity -- including the user switching chats -- has happened in the meantime):
      * <ul>
-     *   <li>{@code terminalAnswer} is non-blank -- a killed run whose stream never produced a
-     *   terminal event has nothing to upgrade to, and the existing marker stands unchanged;</li>
-     *   <li>{@code messageIndex} still points inside the active session's message list -- guards
-     *   against a shape change (e.g. the transcript's cap-trim eviction of the oldest bubbles);</li>
-     *   <li>that exact message still carries the {@code "_Killed._"} marker -- guards against the
-     *   same index now belonging to unrelated content, so this can only ever replace the message it
-     *   finalized, never a different one.</li>
+     *   <li>{@code terminalAnswer} is non-blank -- a run whose stream never produced a terminal event
+     *   has nothing to upgrade to, and the existing marker stands unchanged;</li>
+     *   <li>the currently active session's id still matches {@code sessionId} -- guards against the
+     *   user switching to a different chat (re-enabled by {@code setRunning(false, ...)} before this
+     *   is even scheduled): a coincidentally same-shaped message in a DIFFERENT session must never be
+     *   touched, even if it happens to carry the exact same marker at the exact same index;</li>
+     *   <li>{@code messageIndex} still points inside that session's message list -- guards against a
+     *   shape change (e.g. the transcript's cap-trim eviction of the oldest bubbles);</li>
+     *   <li>that exact message still carries {@code terminalMarker} -- guards against the same index
+     *   now belonging to unrelated content, so this can only ever replace the message it finalized,
+     *   never a different one.</li>
      * </ul>
      * Never appends a new message: this is always a replace of the single already-rendered bubble, so
-     * a killed run's answer can be upgraded at most once and is never shown twice.
+     * a run's answer can be upgraded at most once and is never shown twice.
      */
-    private void upgradeKilledLocalAgentMessage(int messageIndex, String terminalAnswer) {
+    private void upgradeFinalizedLocalAgentMessage(
+            int messageIndex, String sessionId, String terminalMarker, String terminalAnswer) {
         if (terminalAnswer == null || terminalAnswer.isBlank()) {
             return;
         }
         ShaftAssistantChatState.Session active = chatState.activeSession();
-        if (active == null || active.messages == null || messageIndex < 0 || messageIndex >= active.messages.size()) {
+        if (active == null || !Objects.equals(active.id, sessionId)) {
+            return;
+        }
+        if (active.messages == null || messageIndex < 0 || messageIndex >= active.messages.size()) {
             return;
         }
         ShaftAssistantChatState.Message target = active.messages.get(messageIndex);
-        if (target.markdown == null || !target.markdown.contains("_Killed._")) {
+        if (target.markdown == null || !target.markdown.contains(terminalMarker)) {
             return;
         }
+        String label = terminalMarker.contains("Killed") ? "Killed" : "Cancelled";
         String upgraded = AssistantMarkdown.normalizeMarkdown(
                 AssistantLocalAgentRunner.stripTrailingUsageMetadata(terminalAnswer))
-                + "\n\n_Killed._ (the run had already finished)";
+                + "\n\n_" + label + "._ (the run had already finished)";
         target.markdown = upgraded;
         if (messageIndex == active.messages.size() - 1) {
             transcript.replaceLast(target.role, upgraded, target.kind);

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -236,6 +236,15 @@ final class ShaftAssistantPanel extends JPanel {
      * unlike a plain "replace the last message", which those milestone bubbles would otherwise
      * shadow. -1 while no local-agent stream is active. */
     private int localAgentStreamPlaceholderMessageIndex = -1;
+    /** Issue #3962 (second-review finding F2/F3): the REAL index {@link #finishLocalAgentResponse} or
+     * {@link #persistAndAppendResponse} just wrote a terminal local-agent response to, captured right
+     * as it becomes known (after {@code ShaftAssistantChatState}'s own {@code trim()} at the {@code
+     * MAX_MESSAGES_PER_SESSION} cap has already run, not predicted beforehand -- a prediction cannot
+     * know in advance whether THIS call's own append will trip the cap and shift the landing index).
+     * {@code showAgentResult}'s cancelled branch reads this immediately after calling {@link
+     * #showAgentCancelled}, before anything else on the (single-threaded EDT) call stack can overwrite
+     * it, to schedule the terminal-answer upgrade against the message that was actually written. */
+    private int lastLocalAgentFinalizedMessageIndex = -1;
     private StringBuilder localAgentOutput;
     /** Issue #3918: false for a buffered/custom-command local-agent run (Copilot's default command, or
      * any hand-typed custom command) -- such a run's entire live stream is raw CLI passthrough with no
@@ -2086,26 +2095,23 @@ final class ShaftAssistantPanel extends JPanel {
         if (cancelled) {
             String terminalStep = killed ? "Killed" : "Cancelled";
             setStatus(terminalStep);
-            // Issue #3962 (hostile-review correction): render the "_Cancelled._"/partial-buffer bubble
-            // synchronously, exactly like before this fix -- mirrors stopLocalAgentStreaming's Kill
-            // path, which never waited on the companion either. Waiting here would (a) leave the user
-            // with no terminal bubble at all for as long as AssistantLocalAgentRunner#run's own
-            // finally takes to run (unbounded from this method's perspective -- up to the process
-            // timeout/approval extension), and (b) re-reading activeLocalAgentStreamToken inside a
-            // deferred callback after this same method already reset it to -1 a few lines above is
-            // unconditionally false, silently routing the deferred render down
-            // persistAndAppendResponse's append-a-new-message path instead of replacing this one --
-            // rendering the run twice. Capture the index/session this synchronous render just wrote to
-            // -- BEFORE calling it, since a currentStream reply replaces
-            // localAgentStreamPlaceholderMessageIndex and then resets it to -1 -- and schedule a
-            // guarded, in-place-only upgrade for later (see scheduleTerminalAnswerUpgrade), the same
-            // pattern already used for Kill.
-            ShaftAssistantChatState.Session activeBeforeRender = chatState.activeSession();
-            String sessionId = activeBeforeRender == null ? null : activeBeforeRender.id;
-            int targetMessageIndex = currentStream
-                    ? nextLocalAgentStreamPlaceholderTargetIndex()
-                    : currentSessionMessageCount();
+            // Issue #3962 (hostile-review correction; refined again per second review F2/F3): render
+            // the "_Cancelled._"/partial-buffer bubble synchronously, exactly like before this fix --
+            // mirrors stopLocalAgentStreaming's Kill path, which never waited on the companion either.
+            // Waiting here would leave the user with no terminal bubble at all for as long as
+            // AssistantLocalAgentRunner#run's own finally takes to run. Read the REAL index/session
+            // this synchronous render just wrote to -- AFTER calling it, from {@link
+            // #lastLocalAgentFinalizedMessageIndex} (stashed by finishLocalAgentResponse/
+            // persistAndAppendResponse the moment each knows its own post-trim value) -- rather than
+            // predicting it beforehand: a beforehand prediction cannot know whether THIS call's own
+            // append will trip ShaftAssistantChatState's MAX_MESSAGES_PER_SESSION trim() and shift the
+            // landing index down by one, which silently dropped the recovered answer at the cap.
+            // Schedule a guarded, in-place-only upgrade for later (see scheduleTerminalAnswerUpgrade),
+            // the same pattern already used for Kill.
             showAgentCancelled(streamToken, currentStream, killed, partialOutput);
+            int targetMessageIndex = lastLocalAgentFinalizedMessageIndex;
+            ShaftAssistantChatState.Session activeAfterRender = chatState.activeSession();
+            String sessionId = activeAfterRender == null ? null : activeAfterRender.id;
             scheduleTerminalAnswerUpgrade(targetMessageIndex, sessionId, killed ? "_Killed._" : "_Cancelled._");
             return;
         }
@@ -2325,27 +2331,6 @@ final class ShaftAssistantPanel extends JPanel {
         return active == null || active.messages == null ? 0 : active.messages.size();
     }
 
-    /**
-     * The exact index {@link #replaceLocalAgentStreamPlaceholder} is about to write to, computed the
-     * same way it decides internally: {@link #localAgentStreamPlaceholderMessageIndex} when it still
-     * points inside the active session's current message list (a live placeholder bubble exists to
-     * replace in place), otherwise {@link #currentSessionMessageCount()} (its append-fresh fallback
-     * appends there). Needed by {@link #showAgentResult}'s cancelled branch (issue #3962) to capture
-     * -- BEFORE calling {@link #showAgentCancelled}, which is what actually resets {@link
-     * #localAgentStreamPlaceholderMessageIndex} -- exactly where the cancelled bubble is about to
-     * land, since a non-Verbose run with no live placeholder yet (only compact milestone bubbles
-     * appended so far, see {@link #appendLocalAgentOutput}) leaves {@link
-     * #localAgentStreamPlaceholderMessageIndex} at {@code -1} right up until this same call appends
-     * fresh -- naively trusting a {@code -1}/stale value here would point the later terminal-answer
-     * upgrade at the wrong message (or no message at all).
-     */
-    private int nextLocalAgentStreamPlaceholderTargetIndex() {
-        int currentCount = currentSessionMessageCount();
-        return localAgentStreamPlaceholderMessageIndex >= 0 && localAgentStreamPlaceholderMessageIndex < currentCount
-                ? localAgentStreamPlaceholderMessageIndex
-                : currentCount;
-    }
-
     private void appendLocalAgentOutput(int streamToken, String line) {
         if (streamToken != activeLocalAgentStreamToken || localAgentOutput == null) {
             return;
@@ -2505,6 +2490,12 @@ final class ShaftAssistantPanel extends JPanel {
         String displayResponse = withLocalAgentTokenUsage(response, rawResponse);
         ResolvedQuestion resolved = resolveQuestion(displayResponse, rawResponse);
         replaceLocalAgentStreamPlaceholder("assistant", resolved.toPersist(), true, kind);
+        // Issue #3962 (F2/F3): stash the REAL index replaceLocalAgentStreamPlaceholder just used --
+        // already correct post-trim whether it replaced in place or appended fresh -- before resetting
+        // the placeholder-tracking field below. A caller (showAgentResult's cancelled branch) that
+        // needs to know where this exact response landed reads lastLocalAgentFinalizedMessageIndex
+        // right after this call returns, instead of trying to predict it beforehand.
+        lastLocalAgentFinalizedMessageIndex = localAgentStreamPlaceholderMessageIndex;
         localAgentStreamPlaceholderMessageIndex = -1;
         lastResponse = resolved.toPersist();
         lastRawResponse = rawResponse == null ? "" : rawResponse;
@@ -2698,9 +2689,14 @@ final class ShaftAssistantPanel extends JPanel {
             return;
         }
         String label = terminalMarker.contains("Killed") ? "Killed" : "Cancelled";
-        String upgraded = AssistantMarkdown.normalizeMarkdown(
+        String composed = AssistantMarkdown.normalizeMarkdown(
                 AssistantLocalAgentRunner.stripTrailingUsageMetadata(terminalAnswer))
                 + "\n\n_" + label + "._ (the run had already finished)";
+        // Issue #3962 (second-review finding F1): every other terminal local-agent response is routed
+        // through withLocalAgentTokenUsage (see finishLocalAgentResponse) -- bypassing it here silently
+        // dropped the "**Token usage:**..." disclaimer the moment a recovered answer upgraded the
+        // bubble in place, even though the pinned no-companion cancelled/killed path still carried it.
+        String upgraded = withLocalAgentTokenUsage(composed, "");
         target.markdown = upgraded;
         if (messageIndex == active.messages.size() - 1) {
             transcript.replaceLast(target.role, upgraded, target.kind);
@@ -2868,6 +2864,10 @@ final class ShaftAssistantPanel extends JPanel {
         // append() clears any showing widget first, so a detected question's answer chips are only
         // shown AFTER the persisted append -- otherwise this call would immediately wipe them again.
         append("assistant", resolved.toPersist(), rawResponse, kind);
+        // Issue #3962 (F2/F3): mirrors finishLocalAgentResponse's own capture -- the just-appended
+        // message's real, post-trim index (append() -> chatState.append() -> trim() already ran by the
+        // time currentSessionMessageCount() is read here).
+        lastLocalAgentFinalizedMessageIndex = currentSessionMessageCount() - 1;
         if (resolved.question() != null) {
             showAssistantQuestionOptions(resolved.question());
         }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -251,6 +251,14 @@ final class ShaftAssistantPanel extends JPanel {
     // terminal render reads localAgentOutput, so a run's very last streamed lines are never lost or
     // silently delayed past the terminal state.
     private LocalAgentOutputCoalescer localAgentOutputCoalescer;
+    /** Issue #3962: the current local-agent run's parsed terminal answer, carried on a side channel
+     * {@code future.cancel(true)} cannot touch -- {@link AssistantLocalAgentRunner#run}'s own {@code
+     * finally} block completes this exactly once per run (with {@code null} if the structured stream
+     * never produced a terminal event), regardless of whether the primary future ({@link
+     * #currentInvocation}) was cancelled first. {@code null} while no local-agent run is active or
+     * once a run's completion has consumed it. See {@link #showAgentResult} (soft Cancel) and {@link
+     * #stopLocalAgentStreaming} (Kill) for the two ways it is used. */
+    private CompletableFuture<String> pendingTerminalAnswer;
     private final Deque<Runnable> queuedLocalAgentApprovalPrompts = new ArrayDeque<>();
     private boolean localAgentApprovalPromptShowing;
     private final List<ToolEvidence> toolEvidence = new ArrayList<>();
@@ -1438,12 +1446,14 @@ final class ShaftAssistantPanel extends JPanel {
                         timer.setRepeats(false);
                         timer.start();
                     });
+            pendingTerminalAnswer = new CompletableFuture<>();
             currentInvocation = AssistantLocalAgentRunner.startWithOptionalCompact(
                     invocation,
                     autoCompact.isSelected(),
                     localAgentOutputCoalescer::enqueue,
                     localAgentApprovalHandler(streamToken),
-                    verboseLocalAgentOutput());
+                    verboseLocalAgentOutput(),
+                    pendingTerminalAnswer::complete);
             currentInvocation.future().whenComplete((result, error) -> ApplicationManager.getApplication().invokeLater(
                     () -> showAgentResult(streamToken, result, error)));
             return;
@@ -2074,8 +2084,23 @@ final class ShaftAssistantPanel extends JPanel {
         finishCaptureIntegrationIfRunning(success, result);
         if (cancelled) {
             String terminalStep = killed ? "Killed" : "Cancelled";
-            showAgentCancelled(streamToken, currentStream, killed, partialOutput);
             setStatus(terminalStep);
+            // Issue #3962: a genuine Kill already finalized synchronously in stopLocalAgentStreaming
+            // (handleKilledOrStaleAgentStream short-circuited above before this branch could ever run
+            // for that same stream token), so pendingTerminalAnswer only ever matters for a soft
+            // Cancel reaching here -- wait for it (bounded: AssistantLocalAgentRunner#run's own
+            // finally always completes it, one way or another) instead of immediately rendering the
+            // bare "_Cancelled._" placeholder and permanently losing a terminal answer that was
+            // already parsed the instant it resolves.
+            CompletableFuture<String> pending = pendingTerminalAnswer;
+            pendingTerminalAnswer = null;
+            if (pending == null) {
+                showAgentCancelled(streamToken, currentStream, killed, partialOutput);
+            } else {
+                pending.whenComplete((terminalAnswer, ignoredError) -> runOnEdt(() -> showAgentCancelled(
+                        streamToken, streamToken == activeLocalAgentStreamToken, killed, partialOutput,
+                        terminalAnswer)));
+            }
             return;
         }
         showAgentToolResult(streamToken, currentStream, success, result, error, captureIntegrationRun, partialOutput);
@@ -2235,10 +2260,30 @@ final class ShaftAssistantPanel extends JPanel {
     }
 
     private void showAgentCancelled(int streamToken, boolean currentStream, boolean killed, String partialOutput) {
+        showAgentCancelled(streamToken, currentStream, killed, partialOutput, null);
+    }
+
+    /**
+     * Same as the 4-arg overload above, plus {@code terminalAnswer} (issue #3962): when non-blank, the
+     * structured stream had already produced a real, composed answer before the cancellation raced
+     * it -- rendered here instead of the bare "_Cancelled._"/"_Killed._" marker or the raw partial
+     * buffer, both of which would otherwise be all that is left once {@code future.cancel(true)}
+     * discards the run's actual return value.
+     */
+    private void showAgentCancelled(
+            int streamToken, boolean currentStream, boolean killed, String partialOutput, String terminalAnswer) {
         String label = killed ? "Killed" : "Cancelled";
-        String canceledResponse = partialOutput == null || partialOutput.isBlank()
-                ? "_" + label + "._"
-                : formatLocalAgentStreamingResponse(partialOutput) + "\n\n_" + label + "._ (partial output above)";
+        String canceledResponse;
+        if (terminalAnswer != null && !terminalAnswer.isBlank()) {
+            canceledResponse = AssistantMarkdown.normalizeMarkdown(
+                    AssistantLocalAgentRunner.stripTrailingUsageMetadata(terminalAnswer))
+                    + "\n\n_" + label + "._ (the run had already finished)";
+        } else if (partialOutput == null || partialOutput.isBlank()) {
+            canceledResponse = "_" + label + "._";
+        } else {
+            canceledResponse = formatLocalAgentStreamingResponse(partialOutput) + "\n\n_" + label
+                    + "._ (partial output above)";
+        }
         // A user-initiated Cancel/Kill is a tool-event outcome, not a genuine failure -- mirrors
         // showTerminalSequenceResult's cancelled branch for the MCP-tool-sequence path.
         showAgentResponse(streamToken, currentStream, canceledResponse, "", ShaftAssistantChatState.KIND_TOOL_EVENT);
@@ -2571,11 +2616,71 @@ final class ShaftAssistantPanel extends JPanel {
                             + "\n\n_Killed._ (partial output above)"
                     : "_Killed._";
             replaceLocalAgentStreamPlaceholder("assistant", finalized, true);
+            int finalizedMessageIndex = localAgentStreamPlaceholderMessageIndex;
             localAgentStreamPlaceholderMessageIndex = -1;
+            scheduleKilledTerminalAnswerUpgrade(finalizedMessageIndex);
         }
         activeLocalAgentStreamToken = -1;
         localAgentOutput = null;
         clearPendingLocalAgentApprovalPrompt();
+    }
+
+    /**
+     * Issue #3962: a Kill finalizes the "_Killed._" bubble synchronously above, before {@link
+     * ShaftMcpInvocation#kill()} even runs -- so {@link #pendingTerminalAnswer} (if this run has one)
+     * cannot possibly be resolved yet, and waiting for it here would delay the existing instant Kill
+     * feedback. Instead, this schedules a one-time, guarded in-place upgrade of the exact message just
+     * finalized (at {@code finalizedMessageIndex}) for whenever -- if ever -- the companion resolves
+     * with a real answer, without delaying or duplicating the render above.
+     */
+    private void scheduleKilledTerminalAnswerUpgrade(int finalizedMessageIndex) {
+        CompletableFuture<String> pending = pendingTerminalAnswer;
+        pendingTerminalAnswer = null;
+        if (pending == null) {
+            return;
+        }
+        pending.thenAccept(terminalAnswer -> runOnEdt(
+                () -> upgradeKilledLocalAgentMessage(finalizedMessageIndex, terminalAnswer)));
+    }
+
+    /**
+     * Guarded upgrade for {@link #scheduleKilledTerminalAnswerUpgrade}: replaces the "_Killed._"
+     * message at {@code messageIndex} in place with {@code terminalAnswer}'s polished text, but only
+     * if all of the following still hold at the time this actually runs (which may be immediately, or
+     * after other transcript activity has happened in the meantime):
+     * <ul>
+     *   <li>{@code terminalAnswer} is non-blank -- a killed run whose stream never produced a
+     *   terminal event has nothing to upgrade to, and the existing marker stands unchanged;</li>
+     *   <li>{@code messageIndex} still points inside the active session's message list -- guards
+     *   against a shape change (e.g. the transcript's cap-trim eviction of the oldest bubbles);</li>
+     *   <li>that exact message still carries the {@code "_Killed._"} marker -- guards against the
+     *   same index now belonging to unrelated content, so this can only ever replace the message it
+     *   finalized, never a different one.</li>
+     * </ul>
+     * Never appends a new message: this is always a replace of the single already-rendered bubble, so
+     * a killed run's answer can be upgraded at most once and is never shown twice.
+     */
+    private void upgradeKilledLocalAgentMessage(int messageIndex, String terminalAnswer) {
+        if (terminalAnswer == null || terminalAnswer.isBlank()) {
+            return;
+        }
+        ShaftAssistantChatState.Session active = chatState.activeSession();
+        if (active == null || active.messages == null || messageIndex < 0 || messageIndex >= active.messages.size()) {
+            return;
+        }
+        ShaftAssistantChatState.Message target = active.messages.get(messageIndex);
+        if (target.markdown == null || !target.markdown.contains("_Killed._")) {
+            return;
+        }
+        String upgraded = AssistantMarkdown.normalizeMarkdown(
+                AssistantLocalAgentRunner.stripTrailingUsageMetadata(terminalAnswer))
+                + "\n\n_Killed._ (the run had already finished)";
+        target.markdown = upgraded;
+        if (messageIndex == active.messages.size() - 1) {
+            transcript.replaceLast(target.role, upgraded, target.kind);
+        } else {
+            transcript.setMessages(active.messages);
+        }
     }
 
     /**

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -84,7 +84,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -236,15 +235,19 @@ final class ShaftAssistantPanel extends JPanel {
      * unlike a plain "replace the last message", which those milestone bubbles would otherwise
      * shadow. -1 while no local-agent stream is active. */
     private int localAgentStreamPlaceholderMessageIndex = -1;
-    /** Issue #3962 (second-review finding F2/F3): the REAL index {@link #finishLocalAgentResponse} or
-     * {@link #persistAndAppendResponse} just wrote a terminal local-agent response to, captured right
-     * as it becomes known (after {@code ShaftAssistantChatState}'s own {@code trim()} at the {@code
-     * MAX_MESSAGES_PER_SESSION} cap has already run, not predicted beforehand -- a prediction cannot
-     * know in advance whether THIS call's own append will trip the cap and shift the landing index).
-     * {@code showAgentResult}'s cancelled branch reads this immediately after calling {@link
+    /** Issue #3962 (third-review finding 2/3): the {@link ShaftAssistantChatState.Message} object a
+     * terminal local-agent response (a Cancel's "_Cancelled._"/partial-buffer bubble, or a normal
+     * completion routed through {@link #persistAndAppendResponse}) was just written to -- captured by
+     * REFERENCE, not by index. An {@code int} index goes silently stale the instant any later append
+     * trims the session again (at {@code ShaftAssistantChatState.MAX_MESSAGES_PER_SESSION}, every
+     * append shifts every earlier index down by one, whether or not it belongs to this run); object
+     * identity survives any number of trims, so a later terminal-answer upgrade can always find the
+     * exact same message again via {@code indexOf}, or correctly discover it is gone. {@code
+     * showAgentResult}'s cancelled branch reads this immediately after calling {@link
      * #showAgentCancelled}, before anything else on the (single-threaded EDT) call stack can overwrite
-     * it, to schedule the terminal-answer upgrade against the message that was actually written. */
-    private int lastLocalAgentFinalizedMessageIndex = -1;
+     * it, to schedule the upgrade against the message that was actually written. {@link
+     * #stopLocalAgentStreaming} (Kill) captures its own equivalent locally, the same way. */
+    private ShaftAssistantChatState.Message lastLocalAgentFinalizedMessage;
     private StringBuilder localAgentOutput;
     /** Issue #3918: false for a buffered/custom-command local-agent run (Copilot's default command, or
      * any hand-typed custom command) -- such a run's entire live stream is raw CLI passthrough with no
@@ -2095,24 +2098,21 @@ final class ShaftAssistantPanel extends JPanel {
         if (cancelled) {
             String terminalStep = killed ? "Killed" : "Cancelled";
             setStatus(terminalStep);
-            // Issue #3962 (hostile-review correction; refined again per second review F2/F3): render
-            // the "_Cancelled._"/partial-buffer bubble synchronously, exactly like before this fix --
+            // Issue #3962 (refined through three review passes): render the
+            // "_Cancelled._"/partial-buffer bubble synchronously, exactly like before this fix --
             // mirrors stopLocalAgentStreaming's Kill path, which never waited on the companion either.
             // Waiting here would leave the user with no terminal bubble at all for as long as
-            // AssistantLocalAgentRunner#run's own finally takes to run. Read the REAL index/session
+            // AssistantLocalAgentRunner#run's own finally takes to run. Read the actual Message object
             // this synchronous render just wrote to -- AFTER calling it, from {@link
-            // #lastLocalAgentFinalizedMessageIndex} (stashed by finishLocalAgentResponse/
-            // persistAndAppendResponse the moment each knows its own post-trim value) -- rather than
-            // predicting it beforehand: a beforehand prediction cannot know whether THIS call's own
-            // append will trip ShaftAssistantChatState's MAX_MESSAGES_PER_SESSION trim() and shift the
-            // landing index down by one, which silently dropped the recovered answer at the cap.
+            // #lastLocalAgentFinalizedMessage} (stashed by finishLocalAgentResponse/
+            // persistAndAppendResponse the moment each knows it) -- rather than an int index: an index
+            // captured here could go stale later (from this call's own MAX_MESSAGES_PER_SESSION trim,
+            // or any later, unrelated append trimming again before the companion resolves), silently
+            // losing the recovered answer or -- worse -- landing it on a different message entirely.
             // Schedule a guarded, in-place-only upgrade for later (see scheduleTerminalAnswerUpgrade),
             // the same pattern already used for Kill.
             showAgentCancelled(streamToken, currentStream, killed, partialOutput);
-            int targetMessageIndex = lastLocalAgentFinalizedMessageIndex;
-            ShaftAssistantChatState.Session activeAfterRender = chatState.activeSession();
-            String sessionId = activeAfterRender == null ? null : activeAfterRender.id;
-            scheduleTerminalAnswerUpgrade(targetMessageIndex, sessionId, killed ? "_Killed._" : "_Cancelled._");
+            scheduleTerminalAnswerUpgrade(lastLocalAgentFinalizedMessage, killed ? "_Killed._" : "_Cancelled._");
             return;
         }
         showAgentToolResult(streamToken, currentStream, success, result, error, captureIntegrationRun, partialOutput);
@@ -2331,6 +2331,20 @@ final class ShaftAssistantPanel extends JPanel {
         return active == null || active.messages == null ? 0 : active.messages.size();
     }
 
+    /**
+     * The active session's message at {@code index}, or {@code null} if there is no active session or
+     * the index is out of bounds. Used immediately after a write whose real (post-trim) index is
+     * already known, purely to grab a stable object reference (see {@link
+     * #lastLocalAgentFinalizedMessage}) -- never stored or reused as an index itself.
+     */
+    private ShaftAssistantChatState.Message messageAt(int index) {
+        ShaftAssistantChatState.Session active = chatState.activeSession();
+        if (active == null || active.messages == null || index < 0 || index >= active.messages.size()) {
+            return null;
+        }
+        return active.messages.get(index);
+    }
+
     private void appendLocalAgentOutput(int streamToken, String line) {
         if (streamToken != activeLocalAgentStreamToken || localAgentOutput == null) {
             return;
@@ -2490,12 +2504,13 @@ final class ShaftAssistantPanel extends JPanel {
         String displayResponse = withLocalAgentTokenUsage(response, rawResponse);
         ResolvedQuestion resolved = resolveQuestion(displayResponse, rawResponse);
         replaceLocalAgentStreamPlaceholder("assistant", resolved.toPersist(), true, kind);
-        // Issue #3962 (F2/F3): stash the REAL index replaceLocalAgentStreamPlaceholder just used --
-        // already correct post-trim whether it replaced in place or appended fresh -- before resetting
-        // the placeholder-tracking field below. A caller (showAgentResult's cancelled branch) that
-        // needs to know where this exact response landed reads lastLocalAgentFinalizedMessageIndex
-        // right after this call returns, instead of trying to predict it beforehand.
-        lastLocalAgentFinalizedMessageIndex = localAgentStreamPlaceholderMessageIndex;
+        // Issue #3962 (third-review finding 2/3): grab the actual Message object at the REAL index
+        // replaceLocalAgentStreamPlaceholder just used (already correct post-trim, whether it replaced
+        // in place or appended fresh) -- before resetting the placeholder-tracking field below. A
+        // caller (showAgentResult's cancelled branch) that needs to know which message this response
+        // landed on reads lastLocalAgentFinalizedMessage right after this call returns; the reference
+        // stays valid even if a later, unrelated append trims the session again.
+        lastLocalAgentFinalizedMessage = messageAt(localAgentStreamPlaceholderMessageIndex);
         localAgentStreamPlaceholderMessageIndex = -1;
         lastResponse = resolved.toPersist();
         lastRawResponse = rawResponse == null ? "" : rawResponse;
@@ -2617,11 +2632,9 @@ final class ShaftAssistantPanel extends JPanel {
                             + "\n\n_Killed._ (partial output above)"
                     : "_Killed._";
             replaceLocalAgentStreamPlaceholder("assistant", finalized, true);
-            int finalizedMessageIndex = localAgentStreamPlaceholderMessageIndex;
+            ShaftAssistantChatState.Message finalizedMessage = messageAt(localAgentStreamPlaceholderMessageIndex);
             localAgentStreamPlaceholderMessageIndex = -1;
-            ShaftAssistantChatState.Session activeAfterFinalize = chatState.activeSession();
-            String sessionId = activeAfterFinalize == null ? null : activeAfterFinalize.id;
-            scheduleTerminalAnswerUpgrade(finalizedMessageIndex, sessionId, "_Killed._");
+            scheduleTerminalAnswerUpgrade(finalizedMessage, "_Killed._");
         }
         activeLocalAgentStreamToken = -1;
         localAgentOutput = null;
@@ -2634,72 +2647,73 @@ final class ShaftAssistantPanel extends JPanel {
      * {@link #pendingTerminalAnswer} before that first render (Kill cannot: it finalizes before {@code
      * ShaftMcpInvocation#kill()} even runs, so the companion is essentially guaranteed unresolved;
      * Cancel could, but doing so would leave no terminal bubble at all for as long as the run takes to
-     * actually finish, and would have to re-read mutable instance state like {@code
-     * activeLocalAgentStreamToken} from inside a deferred callback after this same code path has
-     * already changed it). Instead, this schedules a one-time, guarded in-place upgrade of the exact
-     * message just finalized (at {@code messageIndex}, in the session {@code sessionId}) for whenever
-     * -- if ever -- the companion resolves with a real answer, without delaying or duplicating either
-     * render.
+     * actually finish). Instead, this schedules a one-time, guarded in-place upgrade of {@code message}
+     * -- the exact object just finalized -- for whenever, if ever, the companion resolves with a real
+     * answer, without delaying or duplicating either render. A {@code null} message (the render this
+     * run's index/lookup failed to resolve to anything, which should not normally happen) is a no-op.
      */
-    private void scheduleTerminalAnswerUpgrade(int messageIndex, String sessionId, String terminalMarker) {
+    private void scheduleTerminalAnswerUpgrade(ShaftAssistantChatState.Message message, String terminalMarker) {
         CompletableFuture<String> pending = pendingTerminalAnswer;
         pendingTerminalAnswer = null;
-        if (pending == null) {
+        if (pending == null || message == null) {
             return;
         }
         pending.thenAccept(terminalAnswer -> runOnEdt(
-                () -> upgradeFinalizedLocalAgentMessage(messageIndex, sessionId, terminalMarker, terminalAnswer)));
+                () -> upgradeFinalizedLocalAgentMessage(message, terminalMarker, terminalAnswer)));
     }
 
     /**
-     * Guarded upgrade for {@link #scheduleTerminalAnswerUpgrade}: replaces the {@code terminalMarker}
-     * message at {@code messageIndex} in place with {@code terminalAnswer}'s polished text, but only
-     * if all of the following still hold at the time this actually runs (which may be immediately, or
-     * after other activity -- including the user switching chats -- has happened in the meantime):
+     * Guarded upgrade for {@link #scheduleTerminalAnswerUpgrade}: replaces {@code message}'s markdown
+     * in place with {@code terminalAnswer}'s polished text, but only if all of the following still
+     * hold at the time this actually runs (which may be immediately, or after other activity --
+     * including the user switching chats, or further messages trimming the session -- in the
+     * meantime):
      * <ul>
      *   <li>{@code terminalAnswer} is non-blank -- a run whose stream never produced a terminal event
      *   has nothing to upgrade to, and the existing marker stands unchanged;</li>
-     *   <li>the currently active session's id still matches {@code sessionId} -- guards against the
-     *   user switching to a different chat (re-enabled by {@code setRunning(false, ...)} before this
-     *   is even scheduled): a coincidentally same-shaped message in a DIFFERENT session must never be
-     *   touched, even if it happens to carry the exact same marker at the exact same index;</li>
-     *   <li>{@code messageIndex} still points inside that session's message list -- guards against a
-     *   shape change (e.g. the transcript's cap-trim eviction of the oldest bubbles);</li>
-     *   <li>that exact message still carries {@code terminalMarker} -- guards against the same index
-     *   now belonging to unrelated content, so this can only ever replace the message it finalized,
-     *   never a different one.</li>
+     *   <li>{@code message} is still found (by reference, via {@code indexOf}) in the CURRENTLY active
+     *   session's message list. This single identity-based lookup replaces what used to be two
+     *   separate checks against a captured {@code int} index: a session-id match (a {@code Message}
+     *   only ever belongs to one session, so finding it in the active session's own list already
+     *   proves it's the right session) and an index-bounds check (an index goes stale the moment ANY
+     *   later append trims the session again -- even one unrelated to this run -- while an object
+     *   reference stays valid, or is correctly reported missing, regardless of how many trims happen
+     *   in between);</li>
+     *   <li>that message still carries {@code terminalMarker} -- guards against extremely unlikely
+     *   reuse/mutation of the same object for unrelated content between scheduling and this call.</li>
      * </ul>
      * Never appends a new message: this is always a replace of the single already-rendered bubble, so
      * a run's answer can be upgraded at most once and is never shown twice.
      */
     private void upgradeFinalizedLocalAgentMessage(
-            int messageIndex, String sessionId, String terminalMarker, String terminalAnswer) {
+            ShaftAssistantChatState.Message message, String terminalMarker, String terminalAnswer) {
         if (terminalAnswer == null || terminalAnswer.isBlank()) {
             return;
         }
         ShaftAssistantChatState.Session active = chatState.activeSession();
-        if (active == null || !Objects.equals(active.id, sessionId)) {
+        if (active == null || active.messages == null) {
             return;
         }
-        if (active.messages == null || messageIndex < 0 || messageIndex >= active.messages.size()) {
+        int messageIndex = active.messages.indexOf(message);
+        if (messageIndex < 0) {
             return;
         }
-        ShaftAssistantChatState.Message target = active.messages.get(messageIndex);
-        if (target.markdown == null || !target.markdown.contains(terminalMarker)) {
+        if (message.markdown == null || !message.markdown.contains(terminalMarker)) {
             return;
         }
         String label = terminalMarker.contains("Killed") ? "Killed" : "Cancelled";
         String composed = AssistantMarkdown.normalizeMarkdown(
                 AssistantLocalAgentRunner.stripTrailingUsageMetadata(terminalAnswer))
                 + "\n\n_" + label + "._ (the run had already finished)";
-        // Issue #3962 (second-review finding F1): every other terminal local-agent response is routed
-        // through withLocalAgentTokenUsage (see finishLocalAgentResponse) -- bypassing it here silently
-        // dropped the "**Token usage:**..." disclaimer the moment a recovered answer upgraded the
-        // bubble in place, even though the pinned no-companion cancelled/killed path still carried it.
-        String upgraded = withLocalAgentTokenUsage(composed, "");
-        target.markdown = upgraded;
+        // Issue #3962 (second-review finding F1, corrected again per third review): the ACTUAL
+        // terminalAnswer -- which always carries a real usage trailer (see
+        // AssistantLocalAgentRunner#composeOutput) -- must be passed through, not "" (a blank
+        // rawResponse always renders "not available", even though the real numbers were one line
+        // earlier, before stripTrailingUsageMetadata discarded them).
+        String upgraded = withLocalAgentTokenUsage(composed, terminalAnswer);
+        message.markdown = upgraded;
         if (messageIndex == active.messages.size() - 1) {
-            transcript.replaceLast(target.role, upgraded, target.kind);
+            transcript.replaceLast(message.role, upgraded, message.kind);
         } else {
             transcript.setMessages(active.messages);
         }
@@ -2864,10 +2878,11 @@ final class ShaftAssistantPanel extends JPanel {
         // append() clears any showing widget first, so a detected question's answer chips are only
         // shown AFTER the persisted append -- otherwise this call would immediately wipe them again.
         append("assistant", resolved.toPersist(), rawResponse, kind);
-        // Issue #3962 (F2/F3): mirrors finishLocalAgentResponse's own capture -- the just-appended
-        // message's real, post-trim index (append() -> chatState.append() -> trim() already ran by the
-        // time currentSessionMessageCount() is read here).
-        lastLocalAgentFinalizedMessageIndex = currentSessionMessageCount() - 1;
+        // Issue #3962 (third-review finding 2/3): mirrors finishLocalAgentResponse's own capture --
+        // grabs the just-appended Message object itself (append() -> chatState.append() -> trim()
+        // already ran by the time currentSessionMessageCount() is read here, so this is its real,
+        // post-trim position) rather than storing that position as an int that could go stale later.
+        lastLocalAgentFinalizedMessage = messageAt(currentSessionMessageCount() - 1);
         if (resolved.question() != null) {
             showAssistantQuestionOptions(resolved.question());
         }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerTerminalAnswerCompanionTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerTerminalAnswerCompanionTest.java
@@ -1,0 +1,204 @@
+package com.shaft.intellij.ui;
+
+import com.shaft.intellij.approval.LocalAgentApprovalBridge;
+import com.shaft.intellij.mcp.ShaftMcpInvocation;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #3962: {@code ShaftMcpInvocation.cancel()}/{@code kill()} call {@code future.cancel(true)}
+ * <em>before</em> running their cancel/kill action (issue #3758/#3768's own validated ordering,
+ * unchanged here) -- so once that call wins, any value {@link AssistantLocalAgentRunner#run}
+ * eventually returns or throws is silently discarded by the JDK's own {@code Future} contract, even
+ * when the structured stream parser had already captured a real terminal answer. A
+ * {@code terminalAnswerConsumer} passed to {@link AssistantLocalAgentRunner#start} exists precisely
+ * to survive that discard: {@code run()}'s own {@code finally} block notifies it exactly once, with
+ * the parsed terminal answer (or {@code null} if none was ever captured), regardless of whether the
+ * primary future was cancelled first -- a side channel {@code future.cancel(true)} cannot touch.
+ *
+ * <p>Mirrors {@link AssistantLocalAgentRunnerCancellationTest}'s {@code BlockingStubProcess} pattern:
+ * the stub blocks inside {@code waitFor} until killed, exactly like a real long-running CLI process.
+ */
+class AssistantLocalAgentRunnerTerminalAnswerCompanionTest {
+
+    @Test
+    void terminalAnswerConsumerReceivesTheParsedAnswerEvenWhenKillWinsTheRace() throws Exception {
+        CountDownLatch stdoutFullyRead = new CountDownLatch(1);
+        TerminalEventStubProcess process = new TerminalEventStubProcess(
+                claudeResultEvent("The finished answer"), stdoutFullyRead);
+        List<String> terminalAnswers = new CopyOnWriteArrayList<>();
+        // kill() only cancels the primary future and unblocks the background run() thread -- it does
+        // NOT wait for that thread to actually reach its own finally block and notify the companion,
+        // so asserting on terminalAnswers right after kill() returns would be a race. This latch makes
+        // "the companion has fired" an observable, awaited event instead.
+        CountDownLatch companionNotified = new CountDownLatch(1);
+        Consumer<String> terminalAnswerConsumer = answer -> {
+            terminalAnswers.add(answer);
+            companionNotified.countDown();
+        };
+
+        ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
+                claudeAskInvocation(), line -> { }, (command, workingDirectory, environment) -> process,
+                false, null, LocalAgentApprovalBridge::start, false, terminalAnswerConsumer);
+
+        assertTrue(process.enteredWaitFor.await(5, TimeUnit.SECONDS),
+                "The stub process must be blocked inside waitFor before killing, or the race is nondeterministic");
+        assertTrue(stdoutFullyRead.await(5, TimeUnit.SECONDS),
+                "The terminal event must already be parsed before kill() races it, matching the issue's scenario");
+
+        boolean acknowledged = running.kill();
+
+        // The PRIMARY future is still cancelled deterministically first -- #3758's own invariant,
+        // untouched by this change (asserted here as a guard the fix must never regress).
+        assertTrue(running.future().isCancelled(),
+                "kill() must still mark the future cancelled synchronously via future.cancel(true)");
+        assertTrue(companionNotified.await(5, TimeUnit.SECONDS),
+                "The companion must fire even though kill() itself does not wait for run()'s own finally block");
+
+        assertAll(
+                () -> assertTrue(acknowledged),
+                () -> assertEquals(1, terminalAnswers.size(),
+                        "The companion consumer must fire exactly once even though the primary future discarded "
+                                + "its value: " + terminalAnswers),
+                () -> assertTrue(terminalAnswers.get(0).contains("The finished answer"),
+                        "The companion must carry the real parsed terminal answer: " + terminalAnswers));
+    }
+
+    @Test
+    void terminalAnswerConsumerReceivesNullWhenTheRunIsKilledBeforeAnyTerminalEvent() throws Exception {
+        CountDownLatch stdoutFullyRead = new CountDownLatch(1);
+        // No terminal event on stdout at all -- just an empty stream, so hasTerminalEvent() stays
+        // false for the whole run.
+        TerminalEventStubProcess process = new TerminalEventStubProcess("", stdoutFullyRead);
+        List<String> terminalAnswers = new CopyOnWriteArrayList<>();
+        CountDownLatch companionNotified = new CountDownLatch(1);
+        Consumer<String> terminalAnswerConsumer = answer -> {
+            terminalAnswers.add(answer);
+            companionNotified.countDown();
+        };
+
+        ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
+                claudeAskInvocation(), line -> { }, (command, workingDirectory, environment) -> process,
+                false, null, LocalAgentApprovalBridge::start, false, terminalAnswerConsumer);
+
+        assertTrue(process.enteredWaitFor.await(5, TimeUnit.SECONDS),
+                "The stub process must be blocked inside waitFor before killing, or the race is nondeterministic");
+
+        running.kill();
+
+        assertTrue(companionNotified.await(5, TimeUnit.SECONDS),
+                "The companion must fire even though kill() itself does not wait for run()'s own finally block");
+        assertEquals(Collections.singletonList(null), terminalAnswers,
+                "The companion must still fire (with null) so a caller waiting on it is never left hanging: "
+                        + terminalAnswers);
+    }
+
+    private static AssistantCommand.Invocation claudeAskInvocation() {
+        return AssistantCommand.fromPrompt("Explain this failure", "CLAUDE_CODE", "ASK", ".", "", false);
+    }
+
+    private static String claudeResultEvent(String result) {
+        return "{\"type\":\"result\",\"result\":\"" + result + "\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}";
+    }
+
+    /**
+     * Blocks inside {@link #waitFor(long, TimeUnit)} until {@link #destroyForcibly()} is called
+     * (mirrors {@code AssistantLocalAgentRunnerCancellationTest.BlockingStubProcess}), but replays a
+     * real structured-stream terminal event on stdout first, signalling {@code stdoutFullyRead} once
+     * every line has actually been drained -- the background reader thread (started before the main
+     * run() thread even reaches {@code awaitProcessWithApprovalExtension}) processes each line
+     * through {@code StructuredStreamParser.accept} synchronously as it reads, so EOF is proof the
+     * terminal event was already parsed.
+     */
+    private static final class TerminalEventStubProcess extends Process {
+        private final CountDownLatch enteredWaitFor = new CountDownLatch(1);
+        private final CountDownLatch destroyLatch = new CountDownLatch(1);
+        private final InputStream stdout;
+
+        TerminalEventStubProcess(String stdoutContent, CountDownLatch stdoutFullyRead) {
+            byte[] bytes = (stdoutContent + "\n").getBytes(StandardCharsets.UTF_8);
+            InputStream raw = new ByteArrayInputStream(bytes);
+            this.stdout = new InputStream() {
+                @Override
+                public int read() throws IOException {
+                    int value = raw.read();
+                    if (value == -1) {
+                        stdoutFullyRead.countDown();
+                    }
+                    return value;
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len) throws IOException {
+                    int count = raw.read(b, off, len);
+                    if (count == -1) {
+                        stdoutFullyRead.countDown();
+                    }
+                    return count;
+                }
+            };
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return OutputStream.nullOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return stdout;
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public int waitFor() {
+            return 0;
+        }
+
+        @Override
+        public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+            enteredWaitFor.countDown();
+            return destroyLatch.await(timeout, unit);
+        }
+
+        @Override
+        public int exitValue() {
+            return 0;
+        }
+
+        @Override
+        public void destroy() {
+            destroyLatch.countDown();
+        }
+
+        @Override
+        public Process destroyForcibly() {
+            destroyLatch.countDown();
+            return this;
+        }
+
+        @Override
+        public boolean isAlive() {
+            return destroyLatch.getCount() > 0;
+        }
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -4523,6 +4523,92 @@ class ShaftPanelSetupTest {
                 () -> assertFalse(markdown.contains("Killed"), markdown));
     }
 
+    /**
+     * Issue #3962: a soft Cancel reaches {@code showAgentResult} asynchronously (unlike Kill, which
+     * finalizes synchronously in {@code stopLocalAgentStreaming} before the invocation is even asked
+     * to cancel) -- so when the run's terminal-answer companion ({@code pendingTerminalAnswer}) is
+     * still unresolved at that moment, the fix waits for it instead of immediately rendering the bare
+     * "_Cancelled._" placeholder and losing the real answer forever once the companion does resolve.
+     * Exercises the real waiting/rendering sequencing (a not-yet-completed {@link CompletableFuture},
+     * resolved only after {@code showAgentResult} has already run), not just a direct method call.
+     */
+    @Test
+    void assistantCancelWaitsForPendingTerminalAnswerAndRendersItInsteadOfBarePlaceholder() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 401);
+
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel);
+        showAgentResult(panel, 401, null, new CancellationException("cancelled"));
+
+        // Not resolved yet -- the cancelled placeholder must not have been finalized while the run's
+        // real terminal answer is still pending, or it would be lost the instant it does arrive.
+        String beforeResolution = transcriptMarkdown(panel);
+        assertFalse(beforeResolution.contains("Cancelled"), beforeResolution);
+
+        pendingTerminalAnswer.complete("The finished answer, parsed before cancel won the race.");
+        pumpEdt();
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("The finished answer, parsed before cancel won the race."),
+                        markdown),
+                () -> assertEquals(1,
+                        countOccurrences(markdown, "The finished answer, parsed before cancel won the race."),
+                        "the terminal answer must render exactly once: " + markdown));
+    }
+
+    /**
+     * Issue #3962, Kill side: unlike Cancel, {@code stopLocalAgentStreaming} finalizes the "_Killed._"
+     * bubble synchronously at button-click time -- before {@code ShaftMcpInvocation#kill()} even runs
+     * -- so the companion cannot be waited on there without delaying the existing instant feedback.
+     * Instead the same already-finalized message is upgraded in place once the companion resolves.
+     * Proves both halves of the anti-duplication requirement: the message count never grows (no
+     * second bubble) and the upgrade only fires once real content exists.
+     */
+    @Test
+    void assistantKillUpgradesTheSameFinalizedMessageOnceTerminalAnswerArrives() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 402);
+
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel); // Cancel
+        cancelOrKillCurrent(panel); // escalate to Kill -- calls stopLocalAgentStreaming synchronously
+
+        String immediately = transcriptMarkdown(panel);
+        assertTrue(immediately.contains("Killed"), immediately);
+        int messageCountAfterKill = currentSessionMessageCount(panel);
+
+        pendingTerminalAnswer.complete("The finished answer, parsed before kill won the race.");
+        pumpEdt();
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("The finished answer, parsed before kill won the race."),
+                        markdown),
+                () -> assertEquals(messageCountAfterKill, currentSessionMessageCount(panel),
+                        "the upgrade must replace the same message in place, never append a second one"),
+                () -> assertEquals(1,
+                        countOccurrences(markdown, "The finished answer, parsed before kill won the race."),
+                        "the terminal answer must render exactly once: " + markdown));
+    }
+
     @Test
     void assistantKillRequestTerminalEntryIsKilledNotCancelled() throws Exception {
         // Issue #3919: no "Killing..."/terminal "Killed (Ns)" milestone bubbles in the transcript any
@@ -7165,6 +7251,23 @@ class ShaftPanelSetupTest {
         Field field = target.getClass().getDeclaredField(name);
         field.setAccessible(true);
         return field.get(target);
+    }
+
+    private static int currentSessionMessageCount(ShaftAssistantPanel panel) throws Exception {
+        ShaftAssistantChatState chatState = (ShaftAssistantChatState) getField(panel, "chatState");
+        return chatState.activeSession().messages.size();
+    }
+
+    /** Flushes the real AWT Event Dispatch Thread's queue: a no-op {@code invokeAndWait} only returns
+     * once every {@code invokeLater}/{@code runOnEdt} action already queued ahead of it has run,
+     * making otherwise-async EDT continuations (e.g. a {@code CompletableFuture.whenComplete} callback
+     * that hops onto the EDT via {@code runOnEdt}) observable deterministically in a headless test. */
+    private static void pumpEdt() {
+        try {
+            SwingUtilities.invokeAndWait(() -> { });
+        } catch (Exception pumpFailure) {
+            Thread.currentThread().interrupt();
+        }
     }
 
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -4524,16 +4524,18 @@ class ShaftPanelSetupTest {
     }
 
     /**
-     * Issue #3962: a soft Cancel reaches {@code showAgentResult} asynchronously (unlike Kill, which
-     * finalizes synchronously in {@code stopLocalAgentStreaming} before the invocation is even asked
-     * to cancel) -- so when the run's terminal-answer companion ({@code pendingTerminalAnswer}) is
-     * still unresolved at that moment, the fix waits for it instead of immediately rendering the bare
-     * "_Cancelled._" placeholder and losing the real answer forever once the companion does resolve.
-     * Exercises the real waiting/rendering sequencing (a not-yet-completed {@link CompletableFuture},
-     * resolved only after {@code showAgentResult} has already run), not just a direct method call.
+     * Issue #3962 (hostile-review finding): a soft Cancel renders the "_Cancelled._" bubble
+     * synchronously (matching Kill's shape -- neither one waits on the companion before the FIRST
+     * render, since the run may already have streamed content the user must see immediately). The
+     * companion is only ever consulted afterward, to upgrade that exact already-rendered message in
+     * place once (if) it resolves with a real answer -- mirroring {@link
+     * #assistantKillUpgradesTheSameFinalizedMessageOnceTerminalAnswerArrives}. Streams a line BEFORE
+     * cancelling (the earlier version of this test never did, so it could not distinguish an in-place
+     * replace from an appended duplicate) and asserts the message count never grows across the
+     * upgrade -- the exact regression a broken token re-read inside the deferred callback produced.
      */
     @Test
-    void assistantCancelWaitsForPendingTerminalAnswerAndRendersItInsteadOfBarePlaceholder() throws Exception {
+    void assistantCancelUpgradesTheSameFinalizedMessageOnceTerminalAnswerArrives() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         ShaftMcpInvocation invocation = new ShaftMcpInvocation(
                 new CompletableFuture<>(), () -> {
@@ -4542,6 +4544,7 @@ class ShaftPanelSetupTest {
         setField(panel, "currentInvocation", invocation);
         panel.setRunning(true, "Thinking...");
         appendStreamingLocalAgentBubble(panel, 401);
+        appendLocalAgentOutput(panel, 401, "a line streamed before cancel");
 
         CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
         setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
@@ -4549,10 +4552,9 @@ class ShaftPanelSetupTest {
         cancelOrKillCurrent(panel);
         showAgentResult(panel, 401, null, new CancellationException("cancelled"));
 
-        // Not resolved yet -- the cancelled placeholder must not have been finalized while the run's
-        // real terminal answer is still pending, or it would be lost the instant it does arrive.
-        String beforeResolution = transcriptMarkdown(panel);
-        assertFalse(beforeResolution.contains("Cancelled"), beforeResolution);
+        String immediately = transcriptMarkdown(panel);
+        assertTrue(immediately.contains("Cancelled"), immediately);
+        int messageCountAfterCancel = currentSessionMessageCount(panel);
 
         pendingTerminalAnswer.complete("The finished answer, parsed before cancel won the race.");
         pumpEdt();
@@ -4561,9 +4563,42 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertTrue(markdown.contains("The finished answer, parsed before cancel won the race."),
                         markdown),
+                () -> assertEquals(messageCountAfterCancel, currentSessionMessageCount(panel),
+                        "the upgrade must replace the same message in place, never append a second one"),
                 () -> assertEquals(1,
                         countOccurrences(markdown, "The finished answer, parsed before cancel won the race."),
                         "the terminal answer must render exactly once: " + markdown));
+    }
+
+    /**
+     * Same regression as above, for the case the companion resolves with {@code null} (the run never
+     * produced a terminal event -- e.g. it failed before completing). The message count must still
+     * never grow: no upgrade should happen, and critically no *second* rendering attempt either.
+     */
+    @Test
+    void assistantCancelAfterStreamingDoesNotDuplicateWhenCompanionResolvesWithNoAnswer() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 403);
+        appendLocalAgentOutput(panel, 403, "a line streamed before cancel");
+
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel);
+        showAgentResult(panel, 403, null, new CancellationException("cancelled"));
+        int messageCountAfterCancel = currentSessionMessageCount(panel);
+
+        pendingTerminalAnswer.complete(null);
+        pumpEdt();
+
+        assertEquals(messageCountAfterCancel, currentSessionMessageCount(panel),
+                "resolving with no answer must never append (or otherwise duplicate) a message");
     }
 
     /**
@@ -4607,6 +4642,58 @@ class ShaftPanelSetupTest {
                 () -> assertEquals(1,
                         countOccurrences(markdown, "The finished answer, parsed before kill won the race."),
                         "the terminal answer must render exactly once: " + markdown));
+    }
+
+    /**
+     * Issue #3962 (hostile-review finding 3): {@code setRunning(false, ...)} re-enables chat
+     * switching before the deferred upgrade runs, so a user who switches to a different chat in that
+     * window must never have the recovered terminal answer land there. Deliberately fabricates the
+     * worst case the reviewer described: the now-active OTHER session's message at the exact same
+     * index also happens to carry the "_Killed._" marker -- so an index-and-marker check alone (with
+     * no session identity check) would be fooled into overwriting it. The upgrade must guard on the
+     * session id captured at schedule time, not whatever session happens to be active when the
+     * companion resolves.
+     */
+    @Test
+    void assistantKillTerminalAnswerUpgradeIsSkippedIfTheUserSwitchedSessionsMeanwhile() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 404);
+        appendLocalAgentOutput(panel, 404, "a line streamed before kill");
+
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel); // Cancel
+        cancelOrKillCurrent(panel); // escalate to Kill
+
+        ShaftAssistantChatState chatState = (ShaftAssistantChatState) getField(panel, "chatState");
+        int killedMessageIndex = chatState.activeSession().messages.size() - 1;
+        assertTrue(chatState.activeSession().messages.get(killedMessageIndex).markdown.contains("_Killed._"));
+
+        // The user leaves this chat for a different one whose message at that SAME index also
+        // happens to carry the "_Killed._" marker -- a coincidence the fix must not be fooled by.
+        chatState.newSession();
+        for (int i = 0; i < killedMessageIndex; i++) {
+            chatState.append("assistant", "filler message " + i, "");
+        }
+        chatState.append("assistant", "_Killed._", "");
+        String otherSessionId = chatState.activeSession().id;
+
+        pendingTerminalAnswer.complete("The finished answer, arriving after the user left this chat.");
+        pumpEdt();
+
+        ShaftAssistantChatState.Session otherSessionAfter = chatState.activeSession();
+        assertAll(
+                () -> assertEquals(otherSessionId, otherSessionAfter.id),
+                () -> assertEquals("_Killed._", otherSessionAfter.messages.get(killedMessageIndex).markdown,
+                        "the recovered answer must never overwrite a different session's message, even one "
+                                + "coincidentally shaped like the finalized marker"));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -4688,6 +4688,119 @@ class ShaftPanelSetupTest {
     }
 
     /**
+     * Issue #3962 (third-review finding 2a): capturing an {@code int} index at render time (rather
+     * than the {@link ShaftAssistantChatState.Message} object itself) goes stale the moment ANY later
+     * append trims the session again -- even one completely unrelated to this run, like the user's
+     * next message. At {@link ShaftAssistantChatState#MAX_MESSAGES_PER_SESSION}, every append shifts
+     * every earlier index down by one. The recovered answer must still land correctly even after such
+     * a shift happens between the synchronous cancelled render and the companion resolving.
+     */
+    @Test
+    void assistantCancelUpgradeStillLandsAfterAnUnrelatedAppendShiftsItsIndexAtTheCap() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+
+        ShaftAssistantChatState chatState = (ShaftAssistantChatState) getField(panel, "chatState");
+        for (int i = 0; i < ShaftAssistantChatState.MAX_MESSAGES_PER_SESSION; i++) {
+            chatState.append("assistant", "filler " + i, "");
+        }
+
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 410);
+        appendLocalAgentOutput(panel, 410, "a line streamed before cancel");
+
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel);
+        showAgentResult(panel, 410, null, new CancellationException("cancelled"));
+
+        // Before the companion resolves, an unrelated later message is appended (e.g. the user's next
+        // prompt) -- at the cap, this trims the oldest message, shifting the just-cancelled bubble's
+        // real position down by one from wherever it landed right after the synchronous render.
+        chatState.append("user", "an unrelated later message", "");
+        assertEquals(ShaftAssistantChatState.MAX_MESSAGES_PER_SESSION, chatState.activeSession().messages.size());
+
+        pendingTerminalAnswer.complete("The recovered final answer despite the later shift.");
+        pumpEdt();
+
+        String markdown = transcriptMarkdown(panel);
+        assertTrue(markdown.contains("The recovered final answer despite the later shift."),
+                "the recovered answer must still land after an unrelated append shifts its real index "
+                        + "out from under a captured int: " + markdown);
+    }
+
+    /**
+     * Issue #3962 (third-review finding 2b -- a genuinely new defect introduced by the F2/F3 fix, not
+     * merely an old symptom recurring): two runs cancelled back-to-back at the session cap. Run A's
+     * companion stays unresolved while run B starts, streams, and is itself cancelled -- run B's own
+     * cancelled-bubble append trims the session again, shifting run A's already-captured index. If
+     * that capture is a stale {@code int}, run A's late-resolving companion would target whatever
+     * message now sits at that index -- run B's own cancelled bubble -- and silently overwrite it
+     * with run A's answer: wrong content landing in the wrong bubble, not just a lost update. Each
+     * run's recovered answer must land only in its own bubble, exactly once, never the other's.
+     */
+    @Test
+    void assistantTwoCancelledRunsAtTheCapNeverCrossContaminateEachOthersBubble() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftAssistantChatState chatState = (ShaftAssistantChatState) getField(panel, "chatState");
+        for (int i = 0; i < ShaftAssistantChatState.MAX_MESSAGES_PER_SESSION; i++) {
+            chatState.append("assistant", "filler " + i, "");
+        }
+
+        // Run A: starts, streams, is cancelled -- its companion is deliberately left unresolved,
+        // simulating a slow CLI that hasn't produced a terminal event yet.
+        ShaftMcpInvocation invocationA = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocationA);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 411);
+        appendLocalAgentOutput(panel, 411, "run A streamed line");
+        CompletableFuture<String> pendingA = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingA);
+        cancelOrKillCurrent(panel);
+        showAgentResult(panel, 411, null, new CancellationException("cancelled"));
+
+        // Run B: a new prompt sent right after cancelling A, also streamed and cancelled -- at the
+        // cap, its own cancelled-bubble append trims the session again, shifting A's bubble down by
+        // one more from wherever it was captured.
+        ShaftMcpInvocation invocationB = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocationB);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 412);
+        appendLocalAgentOutput(panel, 412, "run B streamed line");
+        CompletableFuture<String> pendingB = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingB);
+        cancelOrKillCurrent(panel);
+        showAgentResult(panel, 412, null, new CancellationException("cancelled"));
+
+        // Run A's companion resolves LATE, after run B has already landed its own cancelled bubble.
+        pendingA.complete("Run A's recovered answer.");
+        pumpEdt();
+        pendingB.complete("Run B's recovered answer.");
+        pumpEdt();
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("Run A's recovered answer."), markdown),
+                () -> assertTrue(markdown.contains("Run B's recovered answer."), markdown),
+                () -> assertEquals(1, countOccurrences(markdown, "Run A's recovered answer."),
+                        "run A's answer must land exactly once, in its own bubble: " + markdown),
+                () -> assertEquals(1, countOccurrences(markdown, "Run B's recovered answer."),
+                        "run B's answer must land exactly once, in its own bubble, never overwritten "
+                                + "by run A's late-resolving companion: " + markdown));
+    }
+
+    /**
      * Issue #3962, Kill side: unlike Cancel, {@code stopLocalAgentStreaming} finalizes the "_Killed._"
      * bubble synchronously at button-click time -- before {@code ShaftMcpInvocation#kill()} even runs
      * -- so the companion cannot be waited on there without delaying the existing instant feedback.

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -4602,6 +4602,92 @@ class ShaftPanelSetupTest {
     }
 
     /**
+     * Issue #3962 (second-review finding F1): the recovered terminal answer written by the Cancel
+     * upgrade must still carry the same "**Token usage:**..." disclaimer every other terminal
+     * local-agent response gets (see the pinned {@code
+     * assistantLocalAgentCancelledWithoutUsageMetadataStatesTokenUsageNotAvailable}, which never
+     * resolves a companion so it could not catch this regression) -- the upgrade must route through
+     * {@code withLocalAgentTokenUsage} exactly like {@code finishLocalAgentResponse} already does for
+     * the ordinary (non-recovered) cancelled/killed text.
+     */
+    @Test
+    void assistantCancelUpgradeStillIncludesTokenUsageStatement() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 405);
+        appendLocalAgentOutput(panel, 405, "a line streamed before cancel");
+
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel);
+        showAgentResult(panel, 405, null, new CancellationException("cancelled"));
+
+        pendingTerminalAnswer.complete("The recovered final answer.");
+        pumpEdt();
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains("The recovered final answer."), markdown),
+                () -> assertTrue(markdown.toLowerCase(java.util.Locale.ROOT).contains("token usage"),
+                        "the token-usage disclaimer must survive the upgrade, not just the original "
+                                + "bare marker: " + markdown));
+    }
+
+    /**
+     * Issue #3962 (second-review finding F2/F3): reproduces the exact scenario the reviewer found --
+     * at {@link ShaftAssistantChatState#MAX_MESSAGES_PER_SESSION}, appending the run's own cancelled
+     * bubble trips {@code trim()}'s {@code remove(0)}, shifting that bubble's real index down by one
+     * from wherever a caller predicted it would land ahead of time. The fix (recording the REAL
+     * post-trim index {@code replaceLocalAgentStreamPlaceholder} used, instead of predicting it
+     * beforehand) must land the recovered answer correctly even here -- not silently no-op and leave
+     * the bare "_Cancelled._" marker forever, which would reproduce #3962's own original symptom.
+     */
+    @Test
+    void assistantCancelUpgradeStillLandsWhenTheStreamedBubbleTripsTheSessionCap() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+
+        ShaftAssistantChatState chatState = (ShaftAssistantChatState) getField(panel, "chatState");
+        for (int i = 0; i < ShaftAssistantChatState.MAX_MESSAGES_PER_SESSION; i++) {
+            chatState.append("assistant", "filler " + i, "");
+        }
+        assertEquals(ShaftAssistantChatState.MAX_MESSAGES_PER_SESSION, chatState.activeSession().messages.size());
+
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 406);
+        // Non-verbose: lands as its own compact milestone message (see appendLocalAgentOutput), which
+        // alone already trips the cap's trim() once.
+        appendLocalAgentOutput(panel, 406, "a line streamed before cancel");
+
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel);
+        showAgentResult(panel, 406, null, new CancellationException("cancelled"));
+
+        assertEquals(ShaftAssistantChatState.MAX_MESSAGES_PER_SESSION, chatState.activeSession().messages.size(),
+                "the session must still be capped after the cancelled bubble's own append/trim");
+
+        pendingTerminalAnswer.complete("The recovered final answer despite the cap trim.");
+        pumpEdt();
+
+        String markdown = transcriptMarkdown(panel);
+        assertTrue(markdown.contains("The recovered final answer despite the cap trim."),
+                "the recovered answer must land even when trim() shifted the cancelled bubble's real "
+                        + "index out from under a beforehand prediction: " + markdown);
+    }
+
+    /**
      * Issue #3962, Kill side: unlike Cancel, {@code stopLocalAgentStreaming} finalizes the "_Killed._"
      * bubble synchronously at button-click time -- before {@code ShaftMcpInvocation#kill()} even runs
      * -- so the companion cannot be waited on there without delaying the existing instant feedback.


### PR DESCRIPTION
## Summary

Closes #3962.

- `ShaftMcpInvocation.cancel()`/`kill()` call `future.cancel(true)` **before** running their cancel/kill action (the ordering issue #3758/#3768 stress-validated across 500 runs — untouched by this PR). Once that call wins, the JDK `Future` contract silently discards whatever `AssistantLocalAgentRunner.run()` later returns, including an already-parsed terminal answer. A prior attempt to fix this by guarding the `CancellationException` throw on `streamParser.hasTerminalEvent()` was dead code for exactly this reason — the guard runs *after* the future is already done, so it can never be observed.
- Adds a `terminalAnswerConsumer` side channel: new additive overloads of `AssistantLocalAgentRunner.start`/`startWithOptionalCompact`/`run` (existing overloads unchanged, delegate with `null`). `run()`'s own `finally` block notifies this consumer exactly once per invocation — with the parsed terminal answer, or `null` if the structured stream never produced one — regardless of whether cancellation raced it. This channel is never subject to `future.cancel(true)`, since it isn't the primary future at all.
- `ShaftAssistantPanel` wires this into a new per-run `pendingTerminalAnswer` field:
  - **Soft Cancel** reaches `showAgentResult` asynchronously already (no existing synchronous UX to preserve), so it now waits on the companion before rendering, instead of immediately showing the bare `_Cancelled._` placeholder and permanently losing the answer the instant it *does* resolve.
  - **Kill** finalizes `_Killed._` synchronously in `stopLocalAgentStreaming`, at button-click time — before `ShaftMcpInvocation.kill()` even runs, so the companion is essentially guaranteed not to be resolved yet. Delaying that existing instant feedback felt like a bigger, riskier behavior change than the issue asked for, so instead the same already-rendered message is upgraded in place once (if) the companion resolves with a real answer.

## Why this doesn't touch #3758's invariant

`future.cancel(true)` is called at the exact same place, in the exact same order, as before in both `cancel()` and `kill()`. The new companion channel is a parallel, independent completion (`run()`'s own `finally`) that the primary future's cancellation cannot see or affect either way.

## Anti-duplication proof

- **Cancel path**: exactly one call site (`showAgentResult`'s `cancelled` branch) renders the cancelled bubble, gated by an `if (pending == null) { render now } else { render once the companion resolves }` — mutually exclusive by construction, so it can never render from both branches.
- **Kill path**: the synchronous finalize (existing code, unchanged) always renders first; the async upgrade only ever *replaces* that same message's `markdown` in place (never appends), and only when its content still contains the exact `_Killed._` marker it was finalized with — otherwise it's a documented no-op (the transcript moved on in the meantime; the narrower fallback the design review flagged as acceptable, "Approach B"-style, only for this edge case).
- Covered by new tests:
  - `AssistantLocalAgentRunnerTerminalAnswerCompanionTest#terminalAnswerConsumerReceivesTheParsedAnswerEvenWhenKillWinsTheRace` — reproduces the exact race (stub process blocks in `waitFor`, terminal event fully parsed via a latch on stdout EOF, *then* `kill()` races it) and asserts the primary future is still cancelled (guarding #3758) while the companion still carries the parsed answer.
  - `...ReceivesNullWhenTheRunIsKilledBeforeAnyTerminalEvent` — the companion always fires (with `null`), so a waiting caller is never left hanging.
  - `ShaftPanelSetupTest#assistantCancelWaitsForPendingTerminalAnswerAndRendersItInsteadOfBarePlaceholder` — drives the real deferred-render path with a not-yet-completed `CompletableFuture`, asserts nothing renders before it resolves, then asserts the answer renders exactly once.
  - `ShaftPanelSetupTest#assistantKillUpgradesTheSameFinalizedMessageOnceTerminalAnswerArrives` — asserts the message count never grows across the upgrade (no second bubble) and the answer appears exactly once.

## What a reviewer should re-check

- The existing `AssistantLocalAgentRunnerCancellationTest` suite (#3758's own regression coverage) is unchanged and still green — worth independently confirming the ordering assertions (`future().isCancelled()`, `destroy()` vs `destroyForcibly()`) still hold, since that's the invariant this PR must never regress.
- `terminalResultEventsAreConsumedIntoTheFinalAnswerNotEchoedRaw` (pins that a terminal event is never echoed into the live stream) is untouched — this PR deliberately does not forward anything into the live `outputConsumer`, unlike the originally-considered "Approach A" the linked design review rejected.
- The message-index + marker-content guard in `upgradeKilledLocalAgentMessage` is the one genuinely new piece of transcript-mutation logic — worth tracing `replaceLocalAgentStreamPlaceholder`'s existing index-tracking gotcha (a milestone bubble appended after the placeholder shifts the index) against this new path, since it reads `chatState.activeSession()` fresh at upgrade time rather than trusting a stale snapshot.
- A real 500-run-style stress pass isn't practical here, but the specific thing to hammer is: `kill()` immediately followed (before the background thread's `finally` runs) by starting a *new* run — confirming the new run's own `pendingTerminalAnswer` is never confused with the previous run's late-arriving companion (this PR captures the old reference into a local variable and nulls the field before scheduling, specifically to avoid that).

## Design context

This follows an independent architectural review already recorded on #3962 (Approach C: a companion future that cancel/kill never touch, completed in a `finally`) and confirms via `#3976` (already shipped, closed) that the adjacent normal-completion Verbose-buffer gap does **not** share a mechanism with this one and was correctly split into its own PR.

Related: #3920, #3758, #3768 (all read for context; no closing keywords used against them intentionally).

## Test plan
- [x] `AssistantLocalAgentRunnerTerminalAnswerCompanionTest` (new) — watched red (no 8-arg `start` overload), then green.
- [x] `ShaftPanelSetupTest#assistantCancelWaitsForPendingTerminalAnswerAndRendersItInsteadOfBarePlaceholder` / `#assistantKillUpgradesTheSameFinalizedMessageOnceTerminalAnswerArrives` (new) — watched red (`NoSuchFieldException: pendingTerminalAnswer`), then green.
- [x] Full `com.shaft.intellij.ui.*` package: 872 tests, 0 failures, 0 errors — run twice in a row (plus 5 repeats of the new companion test alone) after finding and fixing one race in the new test itself (`kill()` returning doesn't wait for the background thread's own `finally`).
- [x] `compileJava`/`compileTestJava` clean.
- [ ] Not run: full module `gradlew test` (guard-hooked off per repo policy) or IntelliJ screenshot renderer (no visible UI change — same Swing components, only text content differs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH