### PR TITLE
Add test for activateInjectedImage negative branch coverage

### DIFF
--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -871,6 +871,18 @@ public class AndroidTouchActionsCoverageUnitTest {
         verify(elementActionsHelper).failAction(eq(driver), anyString(), isNull(By.class));
     }
 
+    @Test
+    public void activateInjectedImageWithNonFlutterDriverShouldFailAction() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+
+        touchActions.activateInjectedImage("mock-image-123");
+
+        verify(elementActionsHelper).failAction(eq(driver), anyString(), isNull(By.class));
+    }
+
     private AndroidDriver createMockAndroidDriver() {
         AndroidDriver driver = mock(AndroidDriver.class);
         WebDriver.Options options = mock(WebDriver.Options.class);


### PR DESCRIPTION
## Summary
Add coverage test for the non-Flutter driver path of `activateInjectedImage`. This test mirrors the existing `injectMockImageWithNonFlutterDriverShouldFailActionAndReturnNull` pattern and verifies the method calls `failAction` when invoked against a non-Flutter driver.

## Test Details
- **Test added**: `activateInjectedImageWithNonFlutterDriverShouldFailAction` (lines 874-884)
- **Pattern**: Matches sibling negative-branch test for `injectMockImage`
- **Verification**: Confirms failAction is called with driver, test data string, and null By
- **Result**: Test passes; production code already implements the expected pattern

## Test Run
- **Total**: 33 tests (32 existing + 1 new)
- **Passed**: 33
- **Failed**: 0

Closes #4203