### PR TITLE
Fix fingerprint-seeding fidelity gaps: recorder attributes, fallback-chain seeding

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -333,7 +333,8 @@ public final class CaptureGenerator {
                         request.replayTimeout());
                 reporter.accept(0.9, "Replayed generated test: " + replay.status());
                 if (replay.status() == CaptureGenerationReport.Validation.ValidationStatus.PASSED) {
-                    seedHealingHistory(state.targets(), healingHistoryPath);
+                    seedHealingHistory(state.targets(), healingHistoryPath,
+                            request.fallbackLocators() && hasFallbackTargets(state.targets()));
                 }
             } else if (request.replay()) {
                 replay = CaptureGenerationReport.Validation.skipped(
@@ -1384,15 +1385,33 @@ public final class CaptureGenerator {
      * {@code HealingManager} entry point. Deliberately ungated on {@code healing.strategy}, mirroring
      * {@code HealingManager.recordOutcome()}'s existing precedent rather than {@code resolve()}'s
      * gated one -- see the PR body for the consequence this accepts.
+     *
+     * <p>Issue #4188 gap B: when {@code fallbackReplay} is true, the generated code calls {@code
+     * captureReplayLocator(primary, alt1, ...)} (see {@link #locatorExpression(TargetPlan, boolean)}),
+     * which can resolve to an alternate candidate at runtime if the primary has degraded. {@code
+     * HealingSupport.locator()} keys its history lookup by exact {@code By.toString()}, so every
+     * candidate in the fallback chain -- not just the primary -- gets its own seeded fingerprint here,
+     * keeping whichever one actually resolves at replay time already covered.
      */
-    private static void seedHealingHistory(List<TargetPlan> targets, Path healingHistoryPath) {
+    private static void seedHealingHistory(
+            List<TargetPlan> targets, Path healingHistoryPath, boolean fallbackReplay) {
         SHAFT.Properties.healing.set().historyPath(healingHistoryPath.toString());
         for (TargetPlan target : targets) {
+            HealingFingerprintSeed seed = fingerprintSeed(target.target());
             HealingManager.observeFingerprint(new HealingFingerprintObservation(
                     target.context().page().url(),
                     runtimeLocator(target),
                     "ELEMENT_RESOLUTION",
-                    fingerprintSeed(target.target())));
+                    seed));
+            if (fallbackReplay) {
+                for (LocatorRanker.ScoredLocator alternative : target.selection().alternatives()) {
+                    HealingManager.observeFingerprint(new HealingFingerprintObservation(
+                            target.context().page().url(),
+                            runtimeLocator(target.target(), alternative.candidate()),
+                            "ELEMENT_RESOLUTION",
+                            seed));
+                }
+            }
         }
     }
 

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -722,7 +722,7 @@
     if (isControlElement(element)) return null;
     const attributes = {};
     ["id", "name", "type", "placeholder", "autocomplete", "data-testid",
-      "data-test", "data-qa", "aria-label", "role"].forEach(name => {
+      "data-test", "data-qa", "aria-label", "role", "title", "alt", "aria-labelledby"].forEach(name => {
       if (element.hasAttribute && element.hasAttribute(name)) {
         attributes[name] = text(element.getAttribute(name));
       }

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorHealingSeedingTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorHealingSeedingTest.java
@@ -125,4 +125,85 @@ class CaptureGeneratorHealingSeedingTest {
                 HealingDecision.Status.NO_HISTORY,
                 ShaftHeal.lastReport().orElseThrow().decision().status());
     }
+
+    /**
+     * Issue #4188 gap B: {@code runtimeLocator(TargetPlan)} seeded history only under the primary
+     * candidate's {@code By.toString()}, never the fallback chain. But when {@code
+     * request.fallbackLocators()==true}, the generated code calls {@code
+     * captureReplayLocator(primary, alt1, ...)}, which can resolve to an alternate at runtime if the
+     * primary degrades -- and {@code HealingSupport.locator()} keys its history lookup by exact
+     * {@code By.toString()}. {@link CaptureFixtures#target()} carries two locator candidates (a
+     * higher-scored LABEL one and a lower-scored CSS one), so the CSS one is always the unselected
+     * fallback alternative here. This proves seeding now covers that alternate, not just the primary.
+     */
+    @Test
+    void fallbackCandidateAlsoLeavesFingerprintHistoryASubsequentReplayLookupFinds() throws Exception {
+        CaptureSession session = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "healing-seed-fallback-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(2),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), CaptureFixtures.target(),
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                RedactionSummary.empty(),
+                Map.of());
+        Path sessionPath = temp.resolve("capture.json");
+        new CaptureJsonCodec().write(sessionPath, session);
+        Path output = temp.resolve("gen");
+
+        GeneratedTestValidator fakePassingReplay = new GeneratedTestValidator() {
+            @Override
+            public CaptureGenerationReport.Validation compile(Path source, Path classesDirectory) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED, List.of(), 0);
+            }
+
+            @Override
+            public CaptureGenerationReport.Validation replay(
+                    String fullyQualifiedClassName,
+                    Path classesDirectory,
+                    Path resourcesDirectory,
+                    Path workDirectory,
+                    Duration timeout) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED, List.of(), 1);
+            }
+        };
+
+        CaptureGenerationResult result = new CaptureGenerator(
+                new CaptureJsonCodec(), new LocatorRanker(), fakePassingReplay, new CaptureEnrichmentService())
+                .generate(new CaptureGenerationRequest(
+                        sessionPath, output, "generated.capture", "HealingSeedFallbackTest", false,
+                        true, true, Duration.ofMinutes(1),
+                        CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                        ApprovalPolicy.denyAll(), true));
+
+        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        Path expectedHistoryPath = output.resolve(".shaft-heal/history.json").normalize();
+        assertTrue(Files.exists(expectedHistoryPath), "seeded history file should exist at the absolute path");
+
+        SHAFT.Properties.healing.set()
+                .strategy("shaft-heal")
+                .historyPath(expectedHistoryPath.toString());
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.getCurrentUrl()).thenReturn("https://example.test/form");
+        // The lower-scored CSS candidate from CaptureFixtures#target() -- never the primary
+        // (LABEL) By, but exactly what captureReplayLocator() falls back to at replay time if the
+        // primary degrades. Mirrors runtimeLocator()'s own CSS branch: Locator.cssSelector(expression).
+        By alternateLocator = Locator.cssSelector("form input:nth-child(1)");
+        ShaftHealingProvider provider = new ShaftHealingProvider();
+
+        provider.resolve(new HealingRequest(driver, alternateLocator, "TYPE", true, null, null, null));
+
+        assertNotEquals(
+                HealingDecision.Status.NO_HISTORY,
+                ShaftHeal.lastReport().orElseThrow().decision().status());
+    }
 }

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -161,6 +161,25 @@ class CaptureGeneratorTest {
         }
     }
 
+    /**
+     * Issue #4188 gap A: {@code fingerprintSeed()} reads {@code title} from {@code
+     * normalizedAttributes} and folds {@code alt}/{@code aria-labelledby} into {@code
+     * semanticAttributes}, but the recorder never preserved those as raw attributes -- only as a
+     * name-computation fallback -- so every real capture session left them structurally blank.
+     */
+    @Test
+    void recorderAttributeAllowlistCapturesTitleAltAndAriaLabelledby() throws Exception {
+        try (InputStream stream = CaptureGeneratorTest.class
+                .getResourceAsStream("/browser/shaft-capture-recorder.js")) {
+            assertTrue(stream != null, "Recorder resource should be available on the test classpath.");
+            String recorder = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+
+            assertTrue(recorder.contains(
+                    "\"aria-label\", \"role\", \"title\", \"alt\", \"aria-labelledby\"].forEach(name => {"),
+                    recorder);
+        }
+    }
+
     @Test
     void generatedNamesAndCommentsUseRecorderIntentBeforeOpaqueSessionIds() throws Exception {
         EventContext navigation = new EventContext(


### PR DESCRIPTION
## Summary

Two non-blocking gaps hostile review found in PR #4185's capture-to-healing
fingerprint-seeding wiring:

- **Gap A** -- `fingerprintSeed()` (`CaptureGenerator.java`) reads `title` and
  folds `alt`/`aria-labelledby` into `semanticAttributes`, but the recorder's
  attribute allowlist (`shaft-capture-recorder.js`) never captured those three
  into `normalizedAttributes` at all -- they only fed a name-computation
  fallback. Real capture sessions always produced blank values for these
  fields. Fixed by extending the allowlist.
- **Gap B** -- `seedHealingHistory()` derived the seeded `By` solely from each
  target's primary locator candidate. When `fallbackLocators()==true` and the
  primary degrades at replay time, the generated code's
  `captureReplayLocator(primary, alt1, ...)` can resolve to an alternate whose
  fingerprint was never seeded -- reproducing the exact `NO_HISTORY` failure
  the seeding path exists to prevent, in a real (non-default) configuration.
  Fixed by seeding one fingerprint per candidate in the fallback chain
  (primary + every alternative), entirely inside shaft-capture's seeding
  logic -- `HealingSupport`'s lookup-by-`By.toString()` contract is untouched.

Closes #4188

## Test plan
- [x] RED: `CaptureGeneratorTest#recorderAttributeAllowlistCapturesTitleAltAndAriaLabelledby` failed before the allowlist fix (`expected true but was false`).
- [x] RED: `CaptureGeneratorHealingSeedingTest#fallbackCandidateAlsoLeavesFingerprintHistoryASubsequentReplayLookupFinds` failed before the fix (`NO_HISTORY`).
- [x] GREEN: both pass after the fix; `mvn -pl shaft-capture -Dtest=CaptureGeneratorTest,CaptureGeneratorHealingSeedingTest test` -- 41/41 passed, no regressions.
- [x] `mvn -pl shaft-capture compile test-compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH