### PR TITLE
Fix advisory locator proposal picking an ineligible top-scored candidate

### DIFF
--- a/shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java
@@ -271,7 +271,8 @@ public final class HealingLocatorProposalService {
             }
         }
         throw new IllegalArgumentException(
-                "No candidate passed uniqueness/context-match preconditions for an advisory proposal.");
+                "No candidate passed uniqueness/context-match/interactability preconditions"
+                        + " for an advisory proposal.");
     }
 
     private static JsonNode selectedCandidate(JsonNode report) {

--- a/shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java
@@ -252,8 +252,18 @@ public final class HealingLocatorProposalService {
         if (!candidates.isArray() || candidates.isEmpty()) {
             throw new IllegalArgumentException("An advisory proposal requires at least one scored candidate.");
         }
-        // The report's candidates are already ranked highest score first (ShaftHealingProvider).
-        return candidates.get(0);
+        // The report's candidates are already ranked highest score first (ShaftHealingProvider),
+        // but that ranking alone doesn't re-derive HealingDecisionEngine's own eligibility gate
+        // (unique && contextMatched) -- the persisted decision.confidence came from that
+        // pre-filtered ranking, so the advisory must mirror it before picking a candidate
+        // (issue #4209).
+        for (JsonNode candidate : candidates) {
+            if (candidate.path("unique").asBoolean() && candidate.path("contextMatched").asBoolean()) {
+                return candidate;
+            }
+        }
+        throw new IllegalArgumentException(
+                "No candidate passed uniqueness/context-match preconditions for an advisory proposal.");
     }
 
     private static JsonNode selectedCandidate(JsonNode report) {

--- a/shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java
@@ -253,12 +253,20 @@ public final class HealingLocatorProposalService {
             throw new IllegalArgumentException("An advisory proposal requires at least one scored candidate.");
         }
         // The report's candidates are already ranked highest score first (ShaftHealingProvider),
-        // but that ranking alone doesn't re-derive HealingDecisionEngine's own eligibility gate
-        // (unique && contextMatched) -- the persisted decision.confidence came from that
-        // pre-filtered ranking, so the advisory must mirror it before picking a candidate
-        // (issue #4209).
+        // but that ranking alone doesn't re-derive HealingDecisionEngine's own eligibility gate --
+        // the persisted decision.confidence came from that engine's pre-filtered `eligible` list,
+        // so the advisory must approximate it before picking a candidate (issue #4209). This
+        // requires `interactable` unconditionally, even though the engine only applies it when
+        // visibilityRequired=true (the common case for real callers): the report has no field
+        // recording whether visibilityRequired applied to this attempt, so the advisory can't
+        // perfectly reconstruct the engine's exact gate. When the original attempt had
+        // visibilityRequired=false, this makes the advisory slightly more conservative than the
+        // engine -- a missed suggestion rather than a mismatched-confidence one, the safe
+        // direction to be wrong in.
         for (JsonNode candidate : candidates) {
-            if (candidate.path("unique").asBoolean() && candidate.path("contextMatched").asBoolean()) {
+            if (candidate.path("unique").asBoolean()
+                    && candidate.path("contextMatched").asBoolean()
+                    && candidate.path("interactable").asBoolean()) {
                 return candidate;
             }
         }

--- a/shaft-doctor/src/test/java/com/shaft/doctor/repair/HealingLocatorProposalServiceTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/repair/HealingLocatorProposalServiceTest.java
@@ -232,6 +232,79 @@ class HealingLocatorProposalServiceTest {
         assertTrue(failure.getMessage().contains("healing.sourcePatch.enabled"));
     }
 
+    @Test
+    void advisoryProposalSkipsAnIneligibleTopScoredCandidateForTheGenuinelyEligibleOne(
+            @TempDir Path repository) throws Exception {
+        // Issue #4209: candidates.get(0) is sorted by raw score alone and can be non-unique or
+        // off-context; the advisory must mirror HealingDecisionEngine's own eligibility gate
+        // (unique && contextMatched) before picking a candidate to suggest.
+        source(repository, "private static final By LOGIN = By.id(\"old-login\");");
+        Path report = multiCandidateReport(repository,
+                candidateJson("candidate-top", "By.id: duplicate-login", false, true),
+                candidateJson("candidate-eligible", "By.id: new-login", true, true));
+
+        HealingLocatorProposal proposal = new HealingLocatorProposalService().proposeAdvisory(
+                new HealingLocatorProposalRequest(
+                        repository,
+                        report,
+                        "src/test/java/example/LoginTest.java",
+                        true,
+                        repository.resolve("target/advisory-eligible")));
+
+        assertEquals("By.id(\"new-login\")", proposal.proposedExpression(),
+                "The advisory must pick the genuinely eligible candidate, not the raw top score.");
+    }
+
+    @Test
+    void advisoryProposalRejectsAReportWhereNoCandidateIsEligible(@TempDir Path repository)
+            throws Exception {
+        source(repository, "private static final By LOGIN = By.id(\"old-login\");");
+        Path report = multiCandidateReport(repository,
+                candidateJson("candidate-a", "By.id: duplicate-login", false, true),
+                candidateJson("candidate-b", "By.id: wrong-context", true, false));
+
+        assertThrows(IllegalArgumentException.class, () -> new HealingLocatorProposalService()
+                .proposeAdvisory(new HealingLocatorProposalRequest(
+                        repository,
+                        report,
+                        "src/test/java/example/LoginTest.java",
+                        true,
+                        repository.resolve("target/advisory-none-eligible"))));
+    }
+
+    private static ObjectNode candidateJson(
+            String candidateId, String proposedLocator, boolean unique, boolean contextMatched) {
+        ObjectNode candidate = JSON.createObjectNode();
+        candidate.put("candidateId", candidateId);
+        candidate.put("proposedLocator", proposedLocator);
+        candidate.put("unique", unique);
+        candidate.put("contextMatched", contextMatched);
+        candidate.putArray("evidence").add("test-id exact match");
+        return candidate;
+    }
+
+    private static Path multiCandidateReport(Path repository, ObjectNode... candidates) throws Exception {
+        ObjectNode report = JSON.createObjectNode();
+        report.put("schemaVersion", "2.0");
+        report.put("attemptId", "attempt-multi");
+        report.put("originalLocator", "By.id: old-login");
+        var candidatesArray = report.putArray("candidates");
+        for (ObjectNode candidate : candidates) {
+            candidatesArray.add(candidate);
+        }
+        ObjectNode decision = report.putObject("decision");
+        decision.put("status", "BELOW_THRESHOLD");
+        decision.put("selectedCandidateId", "");
+        decision.put("confidence", 0.42);
+        ObjectNode action = report.putObject("action");
+        action.put("outcome", "NOT_EXECUTED");
+        action.put("postActionVerification", "FAILED");
+        Path path = repository.resolve("healing-report-multi.json");
+        Files.writeString(path, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(report),
+                StandardCharsets.UTF_8);
+        return path;
+    }
+
     private static Path source(Path repository, String locatorLine) throws Exception {
         Path source = repository.resolve("src/test/java/example/LoginTest.java");
         Files.createDirectories(source.getParent());

--- a/shaft-doctor/src/test/java/com/shaft/doctor/repair/HealingLocatorProposalServiceTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/repair/HealingLocatorProposalServiceTest.java
@@ -240,8 +240,8 @@ class HealingLocatorProposalServiceTest {
         // (unique && contextMatched) before picking a candidate to suggest.
         source(repository, "private static final By LOGIN = By.id(\"old-login\");");
         Path report = multiCandidateReport(repository,
-                candidateJson("candidate-top", "By.id: duplicate-login", false, true),
-                candidateJson("candidate-eligible", "By.id: new-login", true, true));
+                candidateJson("candidate-top", "By.id: duplicate-login", false, true, true),
+                candidateJson("candidate-eligible", "By.id: new-login", true, true, true));
 
         HealingLocatorProposal proposal = new HealingLocatorProposalService().proposeAdvisory(
                 new HealingLocatorProposalRequest(
@@ -260,8 +260,8 @@ class HealingLocatorProposalServiceTest {
             throws Exception {
         source(repository, "private static final By LOGIN = By.id(\"old-login\");");
         Path report = multiCandidateReport(repository,
-                candidateJson("candidate-a", "By.id: duplicate-login", false, true),
-                candidateJson("candidate-b", "By.id: wrong-context", true, false));
+                candidateJson("candidate-a", "By.id: duplicate-login", false, true, true),
+                candidateJson("candidate-b", "By.id: wrong-context", true, false, true));
 
         assertThrows(IllegalArgumentException.class, () -> new HealingLocatorProposalService()
                 .proposeAdvisory(new HealingLocatorProposalRequest(
@@ -272,13 +272,42 @@ class HealingLocatorProposalServiceTest {
                         repository.resolve("target/advisory-none-eligible"))));
     }
 
+    @Test
+    void advisoryProposalSkipsANonInteractableTopScoredCandidateForAnInteractableOne(
+            @TempDir Path repository) throws Exception {
+        // Issue #4209 (round 2): HealingDecisionEngine's eligible list also filters on
+        // interactable whenever visibilityRequired=true (the common case for real callers), so a
+        // higher-scored candidate that is unique/contextMatched but not interactable can still
+        // mismatch the persisted decision.confidence. Require interactable too, unconditionally --
+        // a deliberate approximation since the report never records whether visibilityRequired
+        // applied to this attempt.
+        source(repository, "private static final By LOGIN = By.id(\"old-login\");");
+        Path report = multiCandidateReport(repository,
+                candidateJson("candidate-top", "By.id: not-interactable-login", true, true, false),
+                candidateJson("candidate-eligible", "By.id: new-login", true, true, true));
+
+        HealingLocatorProposal proposal = new HealingLocatorProposalService().proposeAdvisory(
+                new HealingLocatorProposalRequest(
+                        repository,
+                        report,
+                        "src/test/java/example/LoginTest.java",
+                        true,
+                        repository.resolve("target/advisory-interactable")));
+
+        assertEquals("By.id(\"new-login\")", proposal.proposedExpression(),
+                "The advisory must pick the interactable candidate, not a higher-scored"
+                        + " non-interactable one.");
+    }
+
     private static ObjectNode candidateJson(
-            String candidateId, String proposedLocator, boolean unique, boolean contextMatched) {
+            String candidateId, String proposedLocator, boolean unique, boolean contextMatched,
+            boolean interactable) {
         ObjectNode candidate = JSON.createObjectNode();
         candidate.put("candidateId", candidateId);
         candidate.put("proposedLocator", proposedLocator);
         candidate.put("unique", unique);
         candidate.put("contextMatched", contextMatched);
+        candidate.put("interactable", interactable);
         candidate.putArray("evidence").add("test-id exact match");
         return candidate;
     }
@@ -350,6 +379,7 @@ class HealingLocatorProposalServiceTest {
         candidate.put("proposedLocator", proposedLocator);
         candidate.put("unique", unique);
         candidate.put("contextMatched", true);
+        candidate.put("interactable", true);
         candidate.putArray("evidence").add("test-id exact match");
         ObjectNode decision = report.putObject("decision");
         decision.put("status", decisionStatus);

--- a/shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/DoctorServiceTest.java
@@ -713,7 +713,8 @@ class DoctorServiceTest {
                     "proposedLocator": "By.id: new-login",
                     "evidence": ["test-id partial match"],
                     "unique": true,
-                    "contextMatched": true
+                    "contextMatched": true,
+                    "interactable": true
                   }],
                   "decision": {
                     "status": "BELOW_THRESHOLD",


### PR DESCRIPTION
## Summary

- `HealingLocatorProposalService.validateAdvisoryReport` picked `candidates.get(0)` -- sorted purely by raw score -- with no check of `unique`/`contextMatched`/`interactable`. The persisted `decision.confidence` on a `BELOW_THRESHOLD` report comes from `HealingDecisionEngine.decide()`'s pre-filtered `eligible` list (unique && contextMatched && interactable-if-`visibilityRequired`), so a duplicate-matching, off-context, or non-interactable candidate could outscore the genuinely eligible one and surface as the advisory suggestion paired with a confidence value belonging to a different candidate.
- Fixed by filtering for `unique && contextMatched && interactable` before picking the top-ranked candidate in `validateAdvisoryReport`. This **approximates** `HealingDecisionEngine`'s eligibility gate rather than mirroring it exactly: the engine only applies the `interactable` filter when `visibilityRequired=true`, but `HealingCandidate`/the persisted report has no field recording whether `visibilityRequired` applied to a given attempt -- so the advisory can't reconstruct which gate the engine actually used. Requiring `interactable` unconditionally is a deliberate, safe-direction approximation: in the rare case the original attempt had `visibilityRequired=false`, this makes the advisory *more* conservative than the engine (a missed/no-suggestion outcome), never reproducing the mismatched-confidence bug class on the common path (real callers pass `visibilityRequired=true` almost everywhere -- `Actions.java:1225`, `TouchActions.java:1367`, `ElementActionsHelper.java:241-244`).
- No schema/model change -- re-derives eligibility from data already present on each candidate (`unique`, `contextMatched`, `interactable` -- `HealingCandidate.java:16,25-27`).
- When no candidate is eligible, the advisory throws `IllegalArgumentException` ("No candidate passed uniqueness/context-match preconditions...") instead of silently falling back to an ineligible one, mirroring the existing not-found handling pattern in `selectedCandidate()`.
- `validateReport()`/`propose()` (the confirmed `RECOVERED` path) are untouched -- diff verified scoped to `validateAdvisoryReport` only across both commits.

**Known follow-up (not fixed here, tracked separately): #4215** -- the `visibilityRequired=false` approximation risk above; persisting the flag on the report so the advisory can reconstruct the engine's exact gate instead of approximating it.

Related: issue #4194 (advisory architecture), PR #4208 (original advisory implementation this gap was found in review of).

## Test plan

- Added `advisoryProposalSkipsAnIneligibleTopScoredCandidateForTheGenuinelyEligibleOne`: multi-candidate report, top-scored candidate non-unique, second one eligible. Watched RED (picked the ineligible candidate) before the fix, GREEN after.
- Added `advisoryProposalRejectsAReportWhereNoCandidateIsEligible`: all candidates ineligible. Watched RED (nothing thrown), then GREEN (`IllegalArgumentException`).
- Added `advisoryProposalSkipsANonInteractableTopScoredCandidateForAnInteractableOne` (round 2): top-scored candidate unique/contextMatched but not interactable, a lower-scored one is fully eligible. Watched RED against round-1 code (picked the non-interactable candidate) for the right reason, then GREEN after requiring `interactable` too.
- `HealingLocatorProposalServiceTest` full class: 13/13 passed.
- `mvn -pl shaft-doctor compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false`: clean.
- `shaft-mcp` `DoctorServiceTest#advisoryLocatorToolCreatesReviewableProposalWithoutChangingSource` + `#advisoryLocatorToolRejectsRecoveredReports` (end-to-end advisory path via the MCP tool): 2/2 passed (fixture updated to include `interactable: true`, matching a real report's shape).
- No `shaft-heal` tests reference the advisory path (checked via grep) -- nothing further to rerun there.

Closes #4209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH