### PR TITLE
Snapshot/restore generated test-data JSON on failed compile/replay (issue 4202)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -170,6 +170,12 @@ public final class CaptureGenerator {
         Path reportPath = outputRoot.resolve("target/shaft-capture/generation-report.json");
         CaptureSession session = null;
         ArtifactPaths paths = null;
+        // Snapshot of paths.data() taken right before this call overwrites it, and whether that
+        // overwrite has happened yet without being resolved (issue #4202): compile/replay must
+        // still read the real, convention-based path, so unlike the staged .java source, the data
+        // JSON is restored/removed AFTER a failed validation rather than staged beforehand.
+        byte[] previousDataBytes = null;
+        boolean dataWritePendingValidation = false;
         // Names the pipeline phase reached when a RuntimeException escapes to the catch block below,
         // so a failure never collapses to a bare, stage-less message (issue #4029).
         String stage = "reading the capture session";
@@ -314,7 +320,9 @@ public final class CaptureGenerator {
             stage = "writing generated artifacts to disk";
             Path stagedSource = stagingSourcePath(outputRoot, request.packageName(), className);
             atomicWrite(stagedSource, source);
+            previousDataBytes = readDataSnapshot(paths.data());
             atomicWrite(paths.data(), dataJson);
+            dataWritePendingValidation = true;
             stage = "compiling the generated test";
             CaptureGenerationReport.Validation compilation = request.compile()
                     ? validator.compile(stagedSource, paths.classes())
@@ -347,11 +355,15 @@ public final class CaptureGenerator {
             if (successful) {
                 stage = "promoting the validated generated source to its final path";
                 atomicWrite(paths.source(), source);
-            } else if (Files.exists(paths.source())) {
-                state.warnings().add("Generated test source was not written: compilation or replay failed, "
-                        + "so the existing file at " + relative(paths.root(), paths.source())
-                        + " was left unchanged.");
+            } else {
+                if (Files.exists(paths.source())) {
+                    state.warnings().add("Generated test source was not written: compilation or replay failed, "
+                            + "so the existing file at " + relative(paths.root(), paths.source())
+                            + " was left unchanged.");
+                }
+                restoreOrRemoveDataFile(paths.data(), previousDataBytes, paths.root(), state.warnings());
             }
+            dataWritePendingValidation = false;
             deleteStagedSourceQuietly(stagedSource);
             stage = "writing the generation report";
             CaptureGenerationReport report = report(
@@ -389,6 +401,9 @@ public final class CaptureGenerator {
                     : paths;
             GenerationState failure = GenerationState.failure(
                     "Generation failed while " + stage + ": " + safeMessage(exception));
+            if (dataWritePendingValidation && paths != null) {
+                restoreOrRemoveDataFile(paths.data(), previousDataBytes, paths.root(), failure.warnings());
+            }
             CaptureGenerationReport report = report(
                     sessionId,
                     safePaths,
@@ -2464,6 +2479,47 @@ public final class CaptureGenerator {
         } catch (IOException ignored) {
             // Best-effort cleanup of an unpublished staged artifact under target/; never reaches
             // the user and is safe to leave for the next `mvn clean`.
+        }
+    }
+
+    /**
+     * Snapshot of {@code paths.data()} taken immediately before this generation overwrites it
+     * (issue #4202). {@code null} means no previous data file existed at that path -- this is the
+     * first generation for that target.
+     */
+    private static byte[] readDataSnapshot(Path dataPath) {
+        try {
+            return Files.exists(dataPath) ? Files.readAllBytes(dataPath) : null;
+        } catch (IOException exception) {
+            throw new IllegalStateException("Previous generated test data could not be read.", exception);
+        }
+    }
+
+    /**
+     * Restores the pre-generation test-data JSON after a failed compile/replay (issue #4202),
+     * mirroring how a failed regeneration leaves {@code paths.source()} untouched (issue #4166):
+     * the replay subprocess reads {@code paths.data()} by its fixed, convention-based filename, so
+     * that real path can't be staged the way the source is -- a previous file is restored
+     * byte-for-byte instead, and a first-time generation removes the unvalidated file rather than
+     * leaving it in place.
+     */
+    private static void restoreOrRemoveDataFile(
+            Path dataPath, byte[] previousBytes, Path root, List<String> warnings) {
+        try {
+            if (previousBytes != null) {
+                Files.write(dataPath, previousBytes);
+                warnings.add("Generated test data was not written: compilation or replay failed, "
+                        + "so the existing file at " + relative(root, dataPath) + " was left unchanged.");
+            } else {
+                Files.deleteIfExists(dataPath);
+                warnings.add("Generated test data was not written: compilation or replay failed, and no "
+                        + "previous data file existed, so the unvalidated file at " + relative(root, dataPath)
+                        + " was removed.");
+            }
+        } catch (IOException exception) {
+            String message = exception.getMessage();
+            warnings.add("Generated test data could not be restored after a failed compile or replay: "
+                    + (message == null || message.isBlank() ? exception.getClass().getSimpleName() : message));
         }
     }
 

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -1226,6 +1226,111 @@ class CaptureGeneratorTest {
                 second.report().warnings().toString());
     }
 
+    // Issue #4202: the same overwrite-before-validate exposure #4166/PR #4201 fixed for the
+    // generated .java source is also present for the generated test-data JSON -- a failed
+    // compile/replay must never leave unvalidated data at paths.data() either. Staging under a
+    // temp name (as #4166 did for source) is not viable here: the replay subprocess loads test
+    // data from paths.data() by the fixed SHAFT.TestData.JSON(dataFileName(className)) convention
+    // baked into the generated test itself, so the fix is snapshot/restore instead.
+    @Test
+    void failedReplayLeavesPreviouslyGeneratedDataUnchanged() throws Exception {
+        CaptureSession baseline = CaptureFixtures.representativeSession();
+        writeCaptureData("alice");
+        Path output = temp.resolve("data-overwrite-protection");
+
+        CaptureGenerationResult first = new CaptureGenerator().generate(new CaptureGenerationRequest(
+                session(baseline), output, "generated.capture", "DataOverwriteProtectionTest", true,
+                true, false, Duration.ofMinutes(1),
+                CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                ApprovalPolicy.denyAll()));
+        assertTrue(first.successful(), first.report().unsupportedEvents().toString());
+        String originalDataJson = Files.readString(first.testDataPath());
+
+        // Same session (so analysis/compile would still be valid), but the referenced
+        // capture-data.json now has a different username value, so the regenerated dataJson is
+        // provably different text from the original -- otherwise a byte-identical regeneration
+        // could pass even with the bug still present.
+        writeCaptureData("bob");
+
+        GeneratedTestValidator failingReplayValidator = new GeneratedTestValidator() {
+            @Override
+            public CaptureGenerationReport.Validation compile(Path source, Path classesDirectory) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED, List.of(), 0);
+            }
+
+            @Override
+            public CaptureGenerationReport.Validation replay(
+                    String fullyQualifiedClassName,
+                    Path classesDirectory,
+                    Path resourcesDirectory,
+                    Path workDirectory,
+                    Duration timeout) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.FAILED,
+                        List.of("Simulated replay failure for regression coverage."), 1);
+            }
+        };
+        CaptureGenerationResult second = new CaptureGenerator(
+                new CaptureJsonCodec(), new LocatorRanker(), failingReplayValidator, new CaptureEnrichmentService())
+                .generate(new CaptureGenerationRequest(
+                        session(baseline), output, "generated.capture", "DataOverwriteProtectionTest", true,
+                        true, true, Duration.ofMinutes(1),
+                        CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                        ApprovalPolicy.denyAll()));
+
+        assertFalse(second.successful());
+        assertEquals(first.testDataPath(), second.testDataPath());
+        assertEquals(originalDataJson, Files.readString(second.testDataPath()));
+        assertTrue(second.report().warnings().stream()
+                        .anyMatch(warning -> warning.contains("test data") && warning.contains("left unchanged")),
+                second.report().warnings().toString());
+    }
+
+    // Issue #4202: a FIRST generation that fails compile/replay has no previous data file to
+    // restore, so the just-written, unvalidated data file must be removed instead of left in
+    // place.
+    @Test
+    void failedReplayOnFirstGenerationRemovesUnvalidatedDataFile() throws Exception {
+        CaptureSession baseline = CaptureFixtures.representativeSession();
+        writeCaptureData("alice");
+        Path output = temp.resolve("data-first-generation-failure");
+
+        GeneratedTestValidator failingReplayValidator = new GeneratedTestValidator() {
+            @Override
+            public CaptureGenerationReport.Validation compile(Path source, Path classesDirectory) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED, List.of(), 0);
+            }
+
+            @Override
+            public CaptureGenerationReport.Validation replay(
+                    String fullyQualifiedClassName,
+                    Path classesDirectory,
+                    Path resourcesDirectory,
+                    Path workDirectory,
+                    Duration timeout) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.FAILED,
+                        List.of("Simulated replay failure for regression coverage."), 1);
+            }
+        };
+        CaptureGenerationResult result = new CaptureGenerator(
+                new CaptureJsonCodec(), new LocatorRanker(), failingReplayValidator, new CaptureEnrichmentService())
+                .generate(new CaptureGenerationRequest(
+                        session(baseline), output, "generated.capture", "FirstGenerationFailureTest", true,
+                        true, true, Duration.ofMinutes(1),
+                        CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                        ApprovalPolicy.denyAll()));
+
+        assertFalse(result.successful());
+        assertFalse(Files.exists(result.testDataPath()),
+                "Unvalidated first-generation data file should have been removed.");
+        assertTrue(result.report().warnings().stream()
+                        .anyMatch(warning -> warning.contains("test data") && warning.contains("removed")),
+                result.report().warnings().toString());
+    }
+
     @Test
     void workspaceContainedFileUrlRecordingIsNotAPrivacyBlocker() throws Exception {
         CaptureSession base = CaptureFixtures.representativeSession();


### PR DESCRIPTION
## Summary

- `CaptureGenerator.generate()` wrote the generated test-data JSON via `atomicWrite(paths.data(), dataJson)` to its real path before compile/replay validated it, and never rolled it back on failure. Same overwrite-before-validate exposure PR #4201 handled for the generated `.java` source, but staging was not viable here: the replay subprocess loads test data from the real path via the fixed, convention-based `SHAFT.TestData.JSON(dataFileName(className))` filename baked into the generated test's own code.
- Fix: snapshot the previous bytes at `paths.data()` (or `null` for a first-time generation) right before overwriting it. On a failed compile, failed replay, or an escaping `RuntimeException`, restore those bytes -- or delete the just-written file when there was no previous one -- and add a report warning: "...was left unchanged" (restore case) or "...was removed" (first-generation case), reusing the same `state.warnings()` reporting path PR #4201 wired for the source-rollback case.
- No behavior change on the success path; only what happens to `paths.data()` on a failed generation changed.

## Test plan

- [x] `mvn -pl shaft-capture -Dtest=CaptureGeneratorTest#failedReplayLeavesPreviouslyGeneratedDataUnchanged+failedReplayOnFirstGenerationRemovesUnvalidatedDataFile test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- watched RED (current data left overwritten with the failed-replay's data, unvalidated file not removed) then GREEN after the fix.
- [x] `mvn -pl shaft-capture -Dtest=CaptureGeneratorTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 41/41 passed.
- [x] `mvn -pl shaft-capture -Dtest=CaptureGeneratorHealingSeedingTest,ApiCaptureGeneratorTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 17/17 passed, no regressions.
- [x] `mvn -pl shaft-capture compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- clean compile.

Closes #4202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH
