### PR TITLE
Fix #4206: delete the staged generated source on the exception path too

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -176,6 +176,11 @@ public final class CaptureGenerator {
         // JSON is restored/removed AFTER a failed validation rather than staged beforehand.
         byte[] previousDataBytes = null;
         boolean dataWritePendingValidation = false;
+        // The staged pre-validation copy of the generated source (issue #4166), hoisted here so a
+        // RuntimeException escaping compile()/replay() (issue #4206) can still find and delete it
+        // in the catch block below -- deleteStagedSourceQuietly() is a no-op if it was never
+        // created or was already cleaned up on the normal success/failure path.
+        Path stagedSource = null;
         // Names the pipeline phase reached when a RuntimeException escapes to the catch block below,
         // so a failure never collapses to a bare, stage-less message (issue #4029).
         String stage = "reading the capture session";
@@ -318,7 +323,7 @@ public final class CaptureGenerator {
             // written to its real path here -- the replay subprocess loads it by the deterministic
             // SHAFT.TestData.JSON(dataFileName(className)) convention, not from a staged location.
             stage = "writing generated artifacts to disk";
-            Path stagedSource = stagingSourcePath(outputRoot, request.packageName(), className);
+            stagedSource = stagingSourcePath(outputRoot, request.packageName(), className);
             atomicWrite(stagedSource, source);
             previousDataBytes = readDataSnapshot(paths.data());
             atomicWrite(paths.data(), dataJson);
@@ -401,6 +406,9 @@ public final class CaptureGenerator {
                     : paths;
             GenerationState failure = GenerationState.failure(
                     "Generation failed while " + stage + ": " + safeMessage(exception));
+            if (stagedSource != null) {
+                deleteStagedSourceQuietly(stagedSource);
+            }
             if (dataWritePendingValidation && paths != null) {
                 restoreOrRemoveDataFile(paths.data(), previousDataBytes, paths.root(), failure.warnings());
             }

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -1331,6 +1331,53 @@ class CaptureGeneratorTest {
                 result.report().warnings().toString());
     }
 
+    // Issue #4206: deleteStagedSourceQuietly(stagedSource) previously ran only on the normal
+    // success/failure control-flow path after compile/replay, never in the outer
+    // catch (RuntimeException) block -- so a RuntimeException escaping validator.compile()/
+    // validator.replay() (e.g. an unchecked JacksonException from a malformed/partially-flushed
+    // Allure result file, as from a killed replay JVM) leaked the staged .java source file under
+    // target/shaft-capture/staging/.
+    @Test
+    void replayThrowingRuntimeExceptionStillDeletesStagedSourceFile() throws Exception {
+        CaptureSession baseline = CaptureFixtures.representativeSession();
+        writeCaptureData("alice");
+        Path output = temp.resolve("staged-source-leak");
+
+        GeneratedTestValidator throwingReplayValidator = new GeneratedTestValidator() {
+            @Override
+            public CaptureGenerationReport.Validation compile(Path source, Path classesDirectory) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED, List.of(), 0);
+            }
+
+            @Override
+            public CaptureGenerationReport.Validation replay(
+                    String fullyQualifiedClassName,
+                    Path classesDirectory,
+                    Path resourcesDirectory,
+                    Path workDirectory,
+                    Duration timeout) {
+                throw new RuntimeException("Simulated malformed Allure-results parse failure.");
+            }
+        };
+        CaptureGenerationResult result = new CaptureGenerator(
+                new CaptureJsonCodec(), new LocatorRanker(), throwingReplayValidator, new CaptureEnrichmentService())
+                .generate(new CaptureGenerationRequest(
+                        session(baseline), output, "generated.capture", "StagedSourceLeakTest", true,
+                        true, true, Duration.ofMinutes(1),
+                        CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                        ApprovalPolicy.denyAll()));
+
+        assertFalse(result.successful());
+        Path stagedSource = output.toAbsolutePath().normalize()
+                .resolve("target/shaft-capture/staging")
+                .resolve("generated/capture")
+                .resolve("StagedSourceLeakTest.java")
+                .normalize();
+        assertFalse(Files.exists(stagedSource),
+                "staged source file should have been cleaned up after a RuntimeException from replay()");
+    }
+
     @Test
     void workspaceContainedFileUrlRecordingIsNotAPrivacyBlocker() throws Exception {
         CaptureSession base = CaptureFixtures.representativeSession();

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -1357,7 +1357,7 @@ class CaptureGeneratorTest {
                     Path resourcesDirectory,
                     Path workDirectory,
                     Duration timeout) {
-                throw new RuntimeException("Simulated malformed Allure-results parse failure.");
+                throw new IllegalStateException("Simulated malformed Allure-results parse failure.");
             }
         };
         CaptureGenerationResult result = new CaptureGenerator(


### PR DESCRIPTION
## Summary
- Fixes #4206: `CaptureGenerator.generate()` leaked the staged `.java` source file under `target/shaft-capture/staging/` when a `RuntimeException` escaped `validator.compile()`/`validator.replay()` -- e.g. an unchecked `JacksonException` from a malformed/partially-flushed Allure result file, as from a killed replay JVM -- because `deleteStagedSourceQuietly(stagedSource)` only ran on the normal success/failure control-flow path, never from the outer `catch (RuntimeException)` block.
- Fix: hoist the `stagedSource` local above the try block (same pattern as the `previousDataBytes`/`dataWritePendingValidation` guard PR #4213 added for the sibling data-JSON cleanup) and delete it in the catch block when non-null. `deleteStagedSourceQuietly()` is already an idempotent `Files.deleteIfExists`, so this composes cleanly alongside the data-file restore/remove logic without duplicating or touching it.

## Rebased onto main (post-#4213 merge)
PR #4213 merged (squashed) into `main` while this PR was open. Rebased this branch onto the current `origin/main` and force-pushed -- the diff now collapses to the true, minimal delta: 2 files changed, 56 insertions(+), 1 deletion(-) (just this fix, no longer showing #4213's changes too).

## Test plan
- [x] New regression test `replayThrowingRuntimeExceptionStillDeletesStagedSourceFile` (forces `replay()` to throw a `RuntimeException`): watched RED (staged file still present), then GREEN after the fix -- re-confirmed after the rebase.
- [x] Full `CaptureGeneratorTest`: 42/42 passed (re-run after rebase).
- [x] `CaptureGeneratorHealingSeedingTest` + `ApiCaptureGeneratorTest` (combined run): 17/17 passed, no regressions (re-run after rebase).
- [x] `mvn -pl shaft-capture compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false`: clean (re-run after rebase).

## Sequencing note (tracker #4214)
Tracker #4214 requires this issue to land before #4029 starts (both touch the same method's control flow). This PR is ready for that sequencing once merged.

Closes #4206

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH