### PR TITLE
[Docs] Update stale hardcoded '89-tool' prose references to '90-tool'

### DIFF
--- a/shaft-cli/src/test/java/com/shaft/commandline/ShaftCliLiveE2ETest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/ShaftCliLiveE2ETest.java
@@ -35,10 +35,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * environment variable ({@code McpLauncherLocator.tryEnvOverride}, checked first, before the
  * per-user installed-versions directory). Skipping that override matters: this machine has a
  * pre-existing {@code %LOCALAPPDATA%\ShaftHQ\shaft-mcp\versions\} installation from BEFORE the
- * 89-tool sweep (confirmed by inspecting its {@code tools} output -- it still lists deleted names
+ * 90-tool sweep (confirmed by inspecting its {@code tools} output -- it still lists deleted names
  * like {@code natural_act}/{@code playwright_initialize} as separate tools), so leaving {@code
  * SHAFT_MCP_JAR} unset would silently validate a stale catalog instead of this PR's current
- * 89-tool build.
+ * 90-tool build.
  */
 class ShaftCliLiveE2ETest {
 
@@ -52,7 +52,7 @@ class ShaftCliLiveE2ETest {
         ProcessResult result = runShaftCli(tempDir, Map.of(), "tools", "--cached");
         assertEquals(0, result.exitCode, "tools --cached should succeed: " + result.stderr);
         assertTrue(result.stdout.contains("browser_navigate"),
-                "tools --cached should list the current 89-tool catalog: " + result.stdout);
+                "tools --cached should list the current 90-tool catalog: " + result.stdout);
 
         recordExample(tempDir, "tools-cached", "tools --cached", result);
     }
@@ -65,7 +65,7 @@ class ShaftCliLiveE2ETest {
         ProcessResult result = runShaftCli(tempDir, serverEnv, "tools");
         assertEquals(0, result.exitCode, "tools should succeed against the live server: " + result.stderr);
         assertTrue(result.stdout.contains("browser_navigate") && result.stdout.contains("element_click"),
-                "tools (live) should list the current 89-tool catalog: " + result.stdout);
+                "tools (live) should list the current 90-tool catalog: " + result.stdout);
         assertTrue(!result.stdout.contains("natural_act") && !result.stdout.contains("mobile_natural_act"),
                 "tools (live) must not list the tools deleted by the sweep: " + result.stdout);
 

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/CaptureCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/CaptureCommandTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Curated {@code capture} aliases must stay in sync with the 89-tool catalog (tracker #3866
+ * Curated {@code capture} aliases must stay in sync with the 90-tool catalog (tracker #3866
  * T3/#3869): {@code capture_step_delete}/{@code capture_step_reorder} (W1 commit 3) had no curated
  * shortcut yet.
  */

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -1919,7 +1919,7 @@ final class AssistantCommand {
 
     // Deterministic-first routing (design doc Decision 5, issue #3870/#3866 T4 goal 3-4): a call
     // verb is optional -- "element_click ..." and "call element_click ..." both resolve -- so every
-    // one of the 89 surviving tools is directly addressable by name, not only the handful with a
+    // one of the 90 surviving tools is directly addressable by name, not only the handful with a
     // bespoke natural-language recognizer elsewhere in this file.
     private static final List<String> EXPLICIT_TOOL_CALL_VERBS =
             List.of("call ", "run ", "invoke ", "use ", "execute ");

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandToolIndexRoutingTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandToolIndexRoutingTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Covers issue #3870/#3866 T4: {@link AssistantCommand}'s routing wired to the canonical
  * {@link ToolCatalogIndex} instead of a second hand-maintained keyword table (design doc
  * Decision 5, amendment A7), plus the deterministic-first "explicit tool mention" routing this
- * task adds so every one of the 89 surviving tools -- not just the handful with a bespoke
+ * task adds so every one of the 90 surviving tools -- not just the handful with a bespoke
  * natural-language recognizer -- is directly addressable without falling back to the local-AI
  * agent (design doc Decision 5 / goal 3-4).
  */
@@ -202,10 +202,10 @@ class AssistantCommandToolIndexRoutingTest {
     }
 
     // ---- Routing-accuracy suite (design doc Decision 5 last bullet): parameterized from the real
-    // bundled index, not a hand-picked sample, across every surviving tool in the 89-tool catalog. ----
+    // bundled index, not a hand-picked sample, across every surviving tool in the 90-tool catalog. ----
 
     // Named exception allowlist for any future, deliberately-accepted exclusion from 100% explicit
-    // -tool-mention routing (PR #3882 review, Finding 2). Empty today: the full 89-tool catalog
+    // -tool-mention routing (PR #3882 review, Finding 2). Empty today: the full 90-tool catalog
     // routes deterministically with no exceptions. Add a tool name here only with a comment
     // explaining why it cannot route deterministically -- never to silence a real regression.
     private static final Set<String> TOOL_MENTION_ROUTING_EXCEPTIONS = Set.of();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLiveToolE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLiveToolE2ETest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>Prompts use the {@code /mcp <toolName> [json]} slash command (issue #3870/#3866 T4, {@code
  * AssistantCommand#rawMcp}): it is the one deterministic router that reaches every one of the
- * 89 surviving tools directly, so a representative call per service group needs no guessing at
+ * 90 surviving tools directly, so a representative call per service group needs no guessing at
  * natural-language phrasing -- {@code AssistantCommand#fromPrompt} parses it into an {@code
  * Invocation.tool(toolName, parsedJson)} with zero ambiguity, verified separately and exhaustively
  * by {@code AssistantCommandRoutingTest}/{@code ShaftAssistantPromptRoutingTest}. This class exists

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolTemplatesTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolTemplatesTest.java
@@ -64,7 +64,7 @@ class ToolTemplatesTest {
 
     @Test
     void workflowTemplatesExposePlaywrightAndInspectorCoverage() {
-        // Tool sweep W1 (89-tool catalog): Playwright no longer has its own tool names -- it is
+        // Tool sweep W1 (90-tool catalog): Playwright no longer has its own tool names -- it is
         // reached through the same capture_*/browser_* tools as WebDriver and Mobile, dispatching
         // on whichever engine is active (or an explicit backend:"playwright" argument). Coverage
         // for Playwright is therefore proven by the presence of a "backend":"playwright" template,

--- a/shaft-skills/references/shaft-cli-commands.md
+++ b/shaft-skills/references/shaft-cli-commands.md
@@ -50,7 +50,7 @@ prefer the cached `shaft-mcp-tools.md` to save tokens. `shaft-cli tools --cached
 [--json]` instead reads a bundled offline snapshot with no MCP server involved
 at all (not even a one-shot child process) — the fastest discovery path when
 you don't need live server state. The snapshot is a stop-gap assembled from
-the frozen 89-tool catalog (`mcp-tool-manifest.json` +
+the frozen 90-tool catalog (`mcp-tool-manifest.json` +
 `shaft-mcp-tools.md`); it will move onto the canonical `tool-index.json`
 generated for #3868 once that lands, so treat it as "recent", not
 "authoritative live state".


### PR DESCRIPTION
## Summary

Fix remaining non-executable prose mentions (comments, Javadoc, markdown) of the old 89-tool catalog count after the MCP tool count changed to 90 with the addition of `doctor_propose_advisory_locator` (issue #4194). 

The executable sentinels (test assertions in `ShaftMcpApplicationTests.java`, `test_generate_shaft_skills_tool_catalog.py`, `ToolCatalogIndexTest.java`, `ToolsCommandCachedTest.java`) were already corrected to 90 in PR #4208.

## Scope

- **7 files changed**
- **12 stale "89" references updated to "90"**
- All changes are in comments and documentation only (no functional code changes)

### Files Changed

1. **shaft-cli/src/test/java/com/shaft/commandline/command/CaptureCommandTest.java:15**
   - Line 15: `89-tool catalog` → `90-tool catalog`

2. **shaft-cli/src/test/java/com/shaft/commandline/ShaftCliLiveE2ETest.java**
   - Line 38: `89-tool sweep` → `90-tool sweep`
   - Line 41: `89-tool build` → `90-tool build`
   - Line 55: `89-tool catalog` → `90-tool catalog`
   - Line 68: `89-tool catalog` → `90-tool catalog`

3. **shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java**
   - Line 1922: `89 surviving tools` → `90 surviving tools`

4. **shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandToolIndexRoutingTest.java**
   - Line 18: `89 surviving tools` → `90 surviving tools`
   - Line 205: `89-tool catalog` → `90-tool catalog`
   - Line 208: `89-tool catalog` → `90-tool catalog`

5. **shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLiveToolE2ETest.java**
   - Line 30: `89 surviving tools` → `90 surviving tools`

6. **shaft-intellij/src/test/java/com/shaft/intellij/ui/ToolTemplatesTest.java**
   - Line 67: `89-tool catalog` → `90-tool catalog`

7. **shaft-skills/references/shaft-cli-commands.md**
   - Line 53: `89-tool catalog` → `90-tool catalog`

## Verification

- Verified actual current tool count is 90 (from test_generate_shaft_skills_tool_catalog.py line 217)
- Performed repo-wide grep for stale references: no remaining "89-tool" or "89 surviving tools" references remain
- All changes are prose-only (comments, Javadoc, markdown) with no test assertion changes (those were fixed in #4208)

Closes #4211