### PR TITLE
Add typed FlutterDriverOptions arm to OptionsManager

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
@@ -202,7 +202,13 @@ public class OptionsManager {
                     flutterOptions.setFlutterSystemPort(SHAFT.Properties.mobile.flutterSystemPort());
                 }
                 flutterOptions.setFlutterEnableMockCamera(SHAFT.Properties.mobile.flutterEnableMockCamera());
-                appiumCapabilities = new DesiredCapabilities(flutterOptions.merge(PropertyFileManager.getCustomWebDriverDesiredCapabilities()).merge(customDriverOptions));
+                //merge customWebDriverCapabilities.properties
+                flutterOptions = flutterOptions.merge(PropertyFileManager.getCustomWebDriverDesiredCapabilities());
+                //merge hardcoded custom options
+                if (customDriverOptions != null) {
+                    flutterOptions = flutterOptions.merge(customDriverOptions);
+                }
+                appiumCapabilities = new DesiredCapabilities(flutterOptions);
             }
             case APPIUM_MOBILE_NATIVE, APPIUM_SAMSUNG_BROWSER, APPIUM_CHROME, APPIUM_CHROMIUM, APPIUM_WINDOWS ->
                     appiumCapabilities = new DesiredCapabilities(PropertyFileManager.getCustomWebDriverDesiredCapabilities().merge(customDriverOptions));

--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java
@@ -10,6 +10,7 @@ import com.shaft.tools.internal.support.JavaHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.MobileTraceMetadata;
 import com.shaft.tools.io.internal.TraceEventRecorder;
+import io.appium.java_client.flutter.FlutterDriverOptions;
 import io.appium.java_client.remote.options.UnhandledPromptBehavior;
 import lombok.Getter;
 import lombok.Setter;
@@ -189,7 +190,21 @@ public class OptionsManager {
                 applyRemoteVideoCapabilities(sfOptions);
                 ReportManager.logDiscrete(sfOptions.toString());
             }
-            case APPIUM_MOBILE_NATIVE, APPIUM_SAMSUNG_BROWSER, APPIUM_CHROME, APPIUM_CHROMIUM, APPIUM_FLUTTER, APPIUM_WINDOWS ->
+            case APPIUM_FLUTTER -> {
+                var flutterOptions = new FlutterDriverOptions();
+                if (SHAFT.Properties.mobile.flutterElementWaitTimeout() > 0) {
+                    flutterOptions.setFlutterElementWaitTimeout(Duration.ofSeconds(SHAFT.Properties.mobile.flutterElementWaitTimeout()));
+                }
+                if (SHAFT.Properties.mobile.flutterServerLaunchTimeout() > 0) {
+                    flutterOptions.setFlutterServerLaunchTimeout(Duration.ofSeconds(SHAFT.Properties.mobile.flutterServerLaunchTimeout()));
+                }
+                if (SHAFT.Properties.mobile.flutterSystemPort() > 0) {
+                    flutterOptions.setFlutterSystemPort(SHAFT.Properties.mobile.flutterSystemPort());
+                }
+                flutterOptions.setFlutterEnableMockCamera(SHAFT.Properties.mobile.flutterEnableMockCamera());
+                appiumCapabilities = new DesiredCapabilities(flutterOptions.merge(PropertyFileManager.getCustomWebDriverDesiredCapabilities()).merge(customDriverOptions));
+            }
+            case APPIUM_MOBILE_NATIVE, APPIUM_SAMSUNG_BROWSER, APPIUM_CHROME, APPIUM_CHROMIUM, APPIUM_WINDOWS ->
                     appiumCapabilities = new DesiredCapabilities(PropertyFileManager.getCustomWebDriverDesiredCapabilities().merge(customDriverOptions));
             default ->
                     DriverFactoryHelper.failAction("Unsupported Driver Type \"" + JavaHelper.convertToSentenceCase(driverType.getValue()) + "\".");

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Mobile.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Mobile.java
@@ -71,6 +71,22 @@ public interface Mobile extends EngineProperties<Mobile> {
     @DefaultValue("")
     String bundleId();
 
+    @Key("mobile_flutterElementWaitTimeout")
+    @DefaultValue("0")
+    int flutterElementWaitTimeout();
+
+    @Key("mobile_flutterServerLaunchTimeout")
+    @DefaultValue("0")
+    int flutterServerLaunchTimeout();
+
+    @Key("mobile_flutterSystemPort")
+    @DefaultValue("0")
+    int flutterSystemPort();
+
+    @Key("mobile_flutterEnableMockCamera")
+    @DefaultValue("false")
+    boolean flutterEnableMockCamera();
+
     default SetProperty set() {
         return new SetProperty();
     }
@@ -142,6 +158,26 @@ public interface Mobile extends EngineProperties<Mobile> {
 
         public SetProperty bundleId(String value) {
             setProperty("mobile_bundleId", value);
+            return this;
+        }
+
+        public SetProperty flutterElementWaitTimeout(int value) {
+            setProperty("mobile_flutterElementWaitTimeout", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty flutterServerLaunchTimeout(int value) {
+            setProperty("mobile_flutterServerLaunchTimeout", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty flutterSystemPort(int value) {
+            setProperty("mobile_flutterSystemPort", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty flutterEnableMockCamera(boolean value) {
+            setProperty("mobile_flutterEnableMockCamera", String.valueOf(value));
             return this;
         }
     }

--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Map;
 
 @Test(singleThreaded = true)
@@ -249,6 +250,24 @@ public class OptionsManagerCoverageUnitTest {
         Assert.assertEquals(String.valueOf(manager.getAppiumCapabilities().getCapability(CapabilityType.PLATFORM_NAME)).toLowerCase(), "windows");
         Assert.assertEquals(manager.getAppiumCapabilities().getCapability("appium:automationName"), "Windows");
         Assert.assertEquals(manager.getAppiumCapabilities().getCapability("appium:app"), "C:\\Windows\\System32\\notepad.exe");
+    }
+
+    @Test
+    public void shouldBuildTypedFlutterDriverOptionsForFlutterSessions() {
+        SHAFT.Properties.platform.set().targetPlatform("android");
+        SHAFT.Properties.mobile.set().browserName("")
+                .flutterElementWaitTimeout(5)
+                .flutterServerLaunchTimeout(20)
+                .flutterSystemPort(8300)
+                .flutterEnableMockCamera(true);
+
+        OptionsManager manager = new OptionsManager();
+        manager.setDriverOptions(DriverFactory.DriverType.APPIUM_FLUTTER, new MutableCapabilities());
+
+        Assert.assertEquals(manager.getAppiumCapabilities().getCapability("appium:flutterElementWaitTimeout"), Duration.ofSeconds(5).toMillis());
+        Assert.assertEquals(manager.getAppiumCapabilities().getCapability("appium:flutterServerLaunchTimeout"), Duration.ofSeconds(20).toMillis());
+        Assert.assertEquals(manager.getAppiumCapabilities().getCapability("appium:flutterSystemPort"), 8300);
+        Assert.assertEquals(manager.getAppiumCapabilities().getCapability("appium:flutterEnableMockCamera"), true);
     }
 
 }

--- a/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/driver/internal/DriverFactory/OptionsManagerCoverageUnitTest.java
@@ -270,4 +270,15 @@ public class OptionsManagerCoverageUnitTest {
         Assert.assertEquals(manager.getAppiumCapabilities().getCapability("appium:flutterEnableMockCamera"), true);
     }
 
+    @Test
+    public void shouldBuildFlutterCapabilitiesWhenCustomDriverOptionsIsNull() {
+        SHAFT.Properties.platform.set().targetPlatform("android");
+        SHAFT.Properties.mobile.set().browserName("");
+
+        OptionsManager manager = new OptionsManager();
+        manager.setDriverOptions(DriverFactory.DriverType.APPIUM_FLUTTER, null);
+
+        Assert.assertNotNull(manager.getAppiumCapabilities());
+    }
+
 }


### PR DESCRIPTION
## Summary

- `OptionsManager.setDriverOptions` (`shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/OptionsManager.java:193-205`) previously lumped `APPIUM_FLUTTER` into the generic Appium arm shared with native/chrome/chromium/windows sessions, building a bare `DesiredCapabilities`. Verified in the actual switch statement before starting -- there is no typed per-platform arm for ANY Appium type today (no `UiAutomator2Options`/`XCUITestOptions` arms exist either); Flutter was simply grouped with the rest.
- Added a dedicated `case APPIUM_FLUTTER ->` arm that builds a typed `io.appium.java_client.flutter.FlutterDriverOptions` (java-client 10.1.1, confirmed via `javap` against the vendored jar) and wires it through `SupportsFlutterElementWaitTimeoutOption#setFlutterElementWaitTimeout`, `SupportsFlutterServerLaunchTimeoutOption#setFlutterServerLaunchTimeout`, `SupportsFlutterSystemPortOption#setFlutterSystemPort`, and `SupportsFlutterEnableMockCamera#setFlutterEnableMockCamera`.
- Added four new `mobile_*` config properties to `Mobile.java` (`flutterElementWaitTimeout`, `flutterServerLaunchTimeout`, `flutterSystemPort`, `flutterEnableMockCamera`, all with `SetProperty` fluent setters) following the exact `@Key`/`@DefaultValue` convention already used for the other `mobile_*` capabilities in that file. The three numeric ones are only applied when configured (`> 0`) so an unconfigured session keeps the java-client library's own defaults; the boolean is always applied (matches its own `false` default, so no behavior change when unset).
- The Flutter arm still merges `PropertyFileManager.getCustomWebDriverDesiredCapabilities()` then `customDriverOptions` on top -- same raw-capability passthrough precedence the sibling Appium arm already has, so no expressiveness is lost. `FlutterDriverOptions extends BaseOptions<T> extends MutableCapabilities`, so `.merge(...)` works exactly like the browser-typed arms (Firefox/IE/Safari) already do.
- No other case arm touched. Non-Flutter sessions still build capabilities on the exact same line as before.

## Context (for reviewers)

Item 2 of #4001's original proposal. #4001 was closed by PR #4023 (driver construction, item 1), which explicitly carved this item out as "cut -- doesn't type-fit DesiredCapabilities and narrows capability expressiveness vs. existing mobile_* passthrough." I verified that concern does not apply to this implementation: `FlutterDriverOptions` merges into the same `DesiredCapabilities` field via `MutableCapabilities#merge`, so raw `mobile_*`/custom-capability passthrough for Flutter sessions is fully preserved -- nothing is narrowed. Item 3 (fluent wait/gesture/camera API) landed in #4017 (PR #4198).

## Test plan

- [x] New test `OptionsManagerCoverageUnitTest#shouldBuildTypedFlutterDriverOptionsForFlutterSessions` -- watched RED (compile failure: `Mobile.SetProperty` had no `flutterElementWaitTimeout` etc.), then GREEN after implementation.
- [x] `mvn -pl shaft-engine test -Dtest=OptionsManagerCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 7/7 passed.
- [x] `mvn -pl shaft-engine test -Dtest=DriverFactoryHelperCoverageUnitTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 43/43 passed (adjacent Flutter-driver-construction coverage, unaffected).
- [x] `mvn -pl shaft-engine compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- clean.

## Not validated

No real Flutter/Appium environment in this repo's CI (same constraint as #4017/#4198); this is unit-level coverage of the typed-options construction only, not a live session.

Closes #4199