### PR TITLE
shaft-intellij: pending-answer indicator on Cancelled/Killed bubbles

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantChatState.java
@@ -45,6 +45,17 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
     public static final String KIND_RAW_VERBOSE = "raw-verbose";
     public static final String KIND_MILESTONE = "milestone";
     public static final String KIND_USER = "user";
+    // Issue #4210: the pending-answer caption ShaftAssistantPanel stapled onto a live Cancelled/Killed
+    // Message#markdown is gated only by an in-memory CompletableFuture that does NOT survive a
+    // project/IDE restart -- if a save (getState(), fired by IntelliJ's periodic workspace autosave,
+    // not just an explicit user action) lands while that future is still unresolved, nothing would
+    // otherwise ever strip the caption back out, leaving a permanent, false "still recovering" claim
+    // on a run that structurally can never resolve after reload. Declared here (not in
+    // ShaftAssistantPanel) so the single literal is shared between the panel (which appends/removes it
+    // on the LIVE message while a real future is pending) and normalizeMessage below (which strips any
+    // surviving copy at every load/save round-trip, exactly like redactSecrets already does for
+    // secrets).
+    static final String PENDING_ANSWER_INDICATOR = "\n\n_Recovering final answer..._";
     private static final String SECOND_PERSON_LABEL = String.valueOf(new char[]{'Y', 'o', 'u'});
     private static final Pattern KEY_VALUE_SECRET = Pattern.compile(
             "(?iu)([\"']?\\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|authorization|cookie|set-cookie)\\b[\"']?\\s*[:=]\\s*)([\"']?)[^\\s`'\",}]+([\"']?)");
@@ -300,9 +311,20 @@ public final class ShaftAssistantChatState implements PersistentStateComponent<S
         Message copy = new Message();
         copy.role = source.role == null ? "" : source.role;
         copy.kind = resolveKind(source.kind, copy.role);
-        copy.markdown = redactSecrets(source.markdown);
+        copy.markdown = redactSecrets(stripPendingAnswerIndicator(source.markdown));
         copy.createdAt = source.createdAt == null ? "" : source.createdAt;
         return copy;
+    }
+
+    /**
+     * Issue #4210: strips a surviving {@link #PENDING_ANSWER_INDICATOR} caption from a message at
+     * every load/save round-trip -- the in-memory {@code CompletableFuture} gating that caption on
+     * the live panel does not survive a project/IDE restart, so this is the only place guaranteed to
+     * run regardless of what happened to that future (mirrors {@link #redactSecrets}'s own
+     * at-load/at-save enforcement, right beside it).
+     */
+    private static String stripPendingAnswerIndicator(String value) {
+        return value.contains(PENDING_ANSWER_INDICATOR) ? value.replace(PENDING_ANSWER_INDICATOR, "") : value;
     }
 
     /**

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -2112,7 +2112,12 @@ final class ShaftAssistantPanel extends JPanel {
             // Schedule a guarded, in-place-only upgrade for later (see scheduleTerminalAnswerUpgrade),
             // the same pattern already used for Kill.
             showAgentCancelled(streamToken, currentStream, killed, partialOutput);
+            // Read before scheduleTerminalAnswerUpgrade nulls the field (issue #4210): purely for the
+            // pending-answer indicator below, which only ever OBSERVES this same future via its own
+            // whenComplete -- never scheduleTerminalAnswerUpgrade's thenAccept or its guard clauses.
+            CompletableFuture<String> pendingForIndicator = pendingTerminalAnswer;
             scheduleTerminalAnswerUpgrade(lastLocalAgentFinalizedMessage, killed ? "_Killed._" : "_Cancelled._");
+            schedulePendingAnswerIndicator(lastLocalAgentFinalizedMessage, pendingForIndicator);
             return;
         }
         showAgentToolResult(streamToken, currentStream, success, result, error, captureIntegrationRun, partialOutput);
@@ -2634,7 +2639,11 @@ final class ShaftAssistantPanel extends JPanel {
             replaceLocalAgentStreamPlaceholder("assistant", finalized, true);
             ShaftAssistantChatState.Message finalizedMessage = messageAt(localAgentStreamPlaceholderMessageIndex);
             localAgentStreamPlaceholderMessageIndex = -1;
+            // See the matching comment in showAgentResult (issue #4210): read before
+            // scheduleTerminalAnswerUpgrade nulls the field, purely for the indicator's own observer.
+            CompletableFuture<String> pendingForIndicator = pendingTerminalAnswer;
             scheduleTerminalAnswerUpgrade(finalizedMessage, "_Killed._");
+            schedulePendingAnswerIndicator(finalizedMessage, pendingForIndicator);
         }
         activeLocalAgentStreamToken = -1;
         localAgentOutput = null;
@@ -2714,6 +2723,64 @@ final class ShaftAssistantPanel extends JPanel {
         message.markdown = upgraded;
         if (messageIndex == active.messages.size() - 1) {
             transcript.replaceLast(message.role, upgraded, message.kind);
+        } else {
+            transcript.setMessages(active.messages);
+        }
+    }
+
+    // Issue #4210: subtle caption shown on a Cancelled/Killed bubble for as long as its companion
+    // terminal-answer future is still pending, so the user can tell an in-place change may still
+    // land instead of the bubble looking indistinguishable from a genuinely final state.
+    private static final String PENDING_ANSWER_INDICATOR = "\n\n_Recovering final answer..._";
+
+    /**
+     * Issue #4210 (fast-follow to #3962): a purely observational UI affordance layered on top of the
+     * identity-based upgrade mechanism above -- never touches {@link #upgradeFinalizedLocalAgentMessage}'s
+     * guard clauses or control flow, only watches the SAME {@code pending} future via a second,
+     * independent {@code whenComplete} (registered separately from {@link
+     * #scheduleTerminalAnswerUpgrade}'s own {@code thenAccept}). Shows {@link
+     * #PENDING_ANSWER_INDICATOR} on {@code message} immediately, then clears it once {@code pending}
+     * resolves -- however it resolves: a real answer (folded into the upgraded content by the
+     * mechanism above, which already overwrites this caption along with the rest of the bubble), a
+     * {@code null} answer (the upgrade above intentionally no-ops, so this clears the caption on its
+     * own), or the run's own process-timeout path -- {@code AssistantLocalAgentRunner#run}'s {@code
+     * finally} block notifies this companion from every exit path (issue #3962), so {@code pending}
+     * always eventually completes and bounds how long the caption can show without any separate
+     * timer. A {@code null} message/pending, or a future already resolved by the time this runs, is a
+     * no-op (nothing to show).
+     */
+    private void schedulePendingAnswerIndicator(
+            ShaftAssistantChatState.Message message, CompletableFuture<String> pending) {
+        if (message == null || pending == null || pending.isDone()) {
+            return;
+        }
+        setPendingAnswerIndicatorVisible(message, true);
+        pending.whenComplete((answer, error) -> runOnEdt(() -> setPendingAnswerIndicatorVisible(message, false)));
+    }
+
+    /**
+     * Mirrors {@link #upgradeFinalizedLocalAgentMessage}'s own identity/session guard (found by
+     * reference in the CURRENTLY active session, never a captured index) so this never mutates or
+     * re-renders a message that has scrolled out of the active session in the meantime.
+     */
+    private void setPendingAnswerIndicatorVisible(ShaftAssistantChatState.Message message, boolean visible) {
+        ShaftAssistantChatState.Session active = chatState.activeSession();
+        if (active == null || active.messages == null) {
+            return;
+        }
+        int index = active.messages.indexOf(message);
+        if (index < 0 || message.markdown == null) {
+            return;
+        }
+        boolean showing = message.markdown.contains(PENDING_ANSWER_INDICATOR);
+        if (visible == showing) {
+            return;
+        }
+        message.markdown = visible
+                ? message.markdown + PENDING_ANSWER_INDICATOR
+                : message.markdown.replace(PENDING_ANSWER_INDICATOR, "");
+        if (index == active.messages.size() - 1) {
+            transcript.replaceLast(message.role, message.markdown, message.kind);
         } else {
             transcript.setMessages(active.messages);
         }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -2728,26 +2728,25 @@ final class ShaftAssistantPanel extends JPanel {
         }
     }
 
-    // Issue #4210: subtle caption shown on a Cancelled/Killed bubble for as long as its companion
-    // terminal-answer future is still pending, so the user can tell an in-place change may still
-    // land instead of the bubble looking indistinguishable from a genuinely final state.
-    private static final String PENDING_ANSWER_INDICATOR = "\n\n_Recovering final answer..._";
-
     /**
      * Issue #4210 (fast-follow to #3962): a purely observational UI affordance layered on top of the
      * identity-based upgrade mechanism above -- never touches {@link #upgradeFinalizedLocalAgentMessage}'s
      * guard clauses or control flow, only watches the SAME {@code pending} future via a second,
      * independent {@code whenComplete} (registered separately from {@link
      * #scheduleTerminalAnswerUpgrade}'s own {@code thenAccept}). Shows {@link
-     * #PENDING_ANSWER_INDICATOR} on {@code message} immediately, then clears it once {@code pending}
-     * resolves -- however it resolves: a real answer (folded into the upgraded content by the
-     * mechanism above, which already overwrites this caption along with the rest of the bubble), a
-     * {@code null} answer (the upgrade above intentionally no-ops, so this clears the caption on its
-     * own), or the run's own process-timeout path -- {@code AssistantLocalAgentRunner#run}'s {@code
-     * finally} block notifies this companion from every exit path (issue #3962), so {@code pending}
-     * always eventually completes and bounds how long the caption can show without any separate
-     * timer. A {@code null} message/pending, or a future already resolved by the time this runs, is a
-     * no-op (nothing to show).
+     * ShaftAssistantChatState#PENDING_ANSWER_INDICATOR} on {@code message} immediately, then clears it
+     * once {@code pending} resolves -- however it resolves: a real answer (folded into the upgraded
+     * content by the mechanism above, which already overwrites this caption along with the rest of
+     * the bubble), a {@code null} answer (the upgrade above intentionally no-ops, so this clears the
+     * caption on its own), or the run's own process-timeout path -- {@code
+     * AssistantLocalAgentRunner#run}'s {@code finally} block notifies this companion from every exit
+     * path (issue #3962), so {@code pending} always eventually completes and bounds how long the
+     * caption can show without any separate timer. A {@code null} message/pending, or a future already
+     * resolved by the time this runs, is a no-op (nothing to show). Note this caption is gated purely
+     * by this in-memory future, which does not survive a project/IDE restart -- {@code
+     * ShaftAssistantChatState}'s {@code normalizeMessage} is the backstop that strips any surviving
+     * copy at every persisted load/save round-trip, so a restart mid-wait can never bake in a
+     * permanently stale claim.
      */
     private void schedulePendingAnswerIndicator(
             ShaftAssistantChatState.Message message, CompletableFuture<String> pending) {
@@ -2772,13 +2771,13 @@ final class ShaftAssistantPanel extends JPanel {
         if (index < 0 || message.markdown == null) {
             return;
         }
-        boolean showing = message.markdown.contains(PENDING_ANSWER_INDICATOR);
+        boolean showing = message.markdown.contains(ShaftAssistantChatState.PENDING_ANSWER_INDICATOR);
         if (visible == showing) {
             return;
         }
         message.markdown = visible
-                ? message.markdown + PENDING_ANSWER_INDICATOR
-                : message.markdown.replace(PENDING_ANSWER_INDICATOR, "");
+                ? message.markdown + ShaftAssistantChatState.PENDING_ANSWER_INDICATOR
+                : message.markdown.replace(ShaftAssistantChatState.PENDING_ANSWER_INDICATOR, "");
         if (index == active.messages.size() - 1) {
             transcript.replaceLast(message.role, message.markdown, message.kind);
         } else {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -4764,6 +4764,60 @@ class ShaftPanelSetupTest {
     }
 
     /**
+     * Issue #4210 (independent-review finding): the pending-answer indicator above is gated purely by
+     * an in-memory {@code CompletableFuture} that does NOT survive a project/IDE restart. If IntelliJ's
+     * workspace autosave calls {@code getState()} while the companion is still unresolved -- entirely
+     * plausible during a run's up-to-several-minutes process-timeout window -- and the project is then
+     * reopened (simulated here by feeding that {@code StateData} into a brand-new {@code
+     * ShaftAssistantChatState}, standing in for a fresh IDE instance with no live future for the old
+     * run), nothing must leave the caption baked into the reloaded transcript permanently: the run it
+     * refers to structurally can never resolve after reload, so the caption would otherwise become a
+     * permanent, false claim. The underlying terminal marker itself must still survive the round-trip.
+     */
+    @Test
+    void assistantCancelledBubblePendingAnswerIndicatorDoesNotSurviveAStateRoundTripWhileCompanionIsUnresolved()
+            throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 423);
+        appendLocalAgentOutput(panel, 423, "a line streamed before cancel");
+
+        // Deliberately never completed -- the companion is still pending when the "restart" below
+        // happens, exactly like the real up-to-several-minutes process-timeout window.
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel);
+        showAgentResult(panel, 423, null, new CancellationException("cancelled"));
+        assertTrue(transcriptMarkdown(panel).toLowerCase(java.util.Locale.ROOT)
+                .contains("recovering final answer"),
+                "sanity: the indicator must be showing before the simulated restart");
+
+        ShaftAssistantChatState chatState = (ShaftAssistantChatState) getField(panel, "chatState");
+        // Simulates IntelliJ's workspace autosave firing while the companion is still unresolved.
+        ShaftAssistantChatState.StateData persisted = chatState.getState();
+
+        // Simulates a fresh IDE/project instance after restart: a new ShaftAssistantChatState has no
+        // live pendingTerminalAnswer field tied to the old run at all.
+        ShaftAssistantChatState reloaded = new ShaftAssistantChatState();
+        reloaded.loadState(persisted);
+
+        String reloadedMarkdown = reloaded.activeMarkdown();
+        assertAll(
+                () -> assertTrue(reloadedMarkdown.contains("Cancelled"),
+                        "the underlying terminal marker must survive the round-trip: " + reloadedMarkdown),
+                () -> assertFalse(reloadedMarkdown.toLowerCase(java.util.Locale.ROOT)
+                                .contains("recovering final answer"),
+                        "a stray pending-answer caption must never survive a save/reload round-trip -- "
+                                + "the run it refers to can never resolve after reload: " + reloadedMarkdown));
+    }
+
+    /**
      * Issue #3962 (second-review finding F2/F3): reproduces the exact scenario the reviewer found --
      * at {@link ShaftAssistantChatState#MAX_MESSAGES_PER_SESSION}, appending the run's own cancelled
      * bubble trips {@code trim()}'s {@code remove(0)}, shifting that bubble's real index down by one

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -4640,6 +4640,130 @@ class ShaftPanelSetupTest {
     }
 
     /**
+     * Issue #4210 (fast-follow to #3962/PR #4204): while a Cancelled bubble's companion terminal-
+     * answer future is still unresolved, the bubble must carry a subtle "recovering final answer"
+     * caption so the user can tell a change may still land -- today it sits indistinguishable from a
+     * genuinely final Cancelled state for as long as the run takes to actually finish shutting down.
+     * The caption must disappear the moment the companion resolves with a real answer (folded into
+     * the upgraded content, never left stapled on).
+     */
+    @Test
+    void assistantCancelledBubbleShowsPendingAnswerIndicatorWhileCompanionIsUnresolved() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 420);
+        appendLocalAgentOutput(panel, 420, "a line streamed before cancel");
+
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel);
+        showAgentResult(panel, 420, null, new CancellationException("cancelled"));
+
+        String whilePending = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(whilePending.contains("Cancelled"), whilePending),
+                () -> assertTrue(whilePending.toLowerCase(java.util.Locale.ROOT)
+                                .contains("recovering final answer"),
+                        "an unresolved companion must show a pending-answer indicator: " + whilePending));
+
+        pendingTerminalAnswer.complete("The finished answer.");
+        pumpEdt();
+
+        String afterResolve = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(afterResolve.contains("The finished answer."), afterResolve),
+                () -> assertFalse(afterResolve.toLowerCase(java.util.Locale.ROOT)
+                                .contains("recovering final answer"),
+                        "the indicator must be gone once the upgrade lands: " + afterResolve));
+    }
+
+    /**
+     * Same as above for the case the companion resolves with no answer at all (the run never
+     * produced a terminal event -- e.g. it failed before completing): {@link
+     * #upgradeFinalizedLocalAgentMessage} intentionally no-ops here (nothing to upgrade to), but the
+     * pending-answer indicator must still clear -- the companion HAS resolved, so there is nothing
+     * left to wait for, and the bubble must not be stuck advertising a change that will never come.
+     */
+    @Test
+    void assistantCancelledBubblePendingAnswerIndicatorClearsWhenCompanionResolvesWithNoAnswer() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 421);
+        appendLocalAgentOutput(panel, 421, "a line streamed before cancel");
+
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel);
+        showAgentResult(panel, 421, null, new CancellationException("cancelled"));
+        assertTrue(transcriptMarkdown(panel).toLowerCase(java.util.Locale.ROOT)
+                .contains("recovering final answer"));
+
+        pendingTerminalAnswer.complete(null);
+        pumpEdt();
+
+        String after = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(after.contains("Cancelled"), after),
+                () -> assertFalse(after.toLowerCase(java.util.Locale.ROOT).contains("recovering final answer"),
+                        "resolving with no answer must still clear the indicator: " + after));
+    }
+
+    /**
+     * Kill-side counterpart of {@link
+     * #assistantCancelledBubbleShowsPendingAnswerIndicatorWhileCompanionIsUnresolved} (issue #4210):
+     * {@code stopLocalAgentStreaming} finalizes the "_Killed._" bubble synchronously, before {@code
+     * ShaftMcpInvocation#kill()} even runs, so its companion is essentially guaranteed unresolved at
+     * that point -- the indicator must show there too, and clear once the upgrade lands.
+     */
+    @Test
+    void assistantKilledBubbleShowsPendingAnswerIndicatorWhileCompanionIsUnresolved() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        ShaftMcpInvocation invocation = new ShaftMcpInvocation(
+                new CompletableFuture<>(), () -> {
+        }, () -> {
+        });
+        setField(panel, "currentInvocation", invocation);
+        panel.setRunning(true, "Thinking...");
+        appendStreamingLocalAgentBubble(panel, 422);
+
+        CompletableFuture<String> pendingTerminalAnswer = new CompletableFuture<>();
+        setField(panel, "pendingTerminalAnswer", pendingTerminalAnswer);
+
+        cancelOrKillCurrent(panel); // Cancel
+        cancelOrKillCurrent(panel); // escalate to Kill -- calls stopLocalAgentStreaming synchronously
+
+        String whilePending = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(whilePending.contains("Killed"), whilePending),
+                () -> assertTrue(whilePending.toLowerCase(java.util.Locale.ROOT)
+                                .contains("recovering final answer"),
+                        "an unresolved companion must show a pending-answer indicator: " + whilePending));
+
+        pendingTerminalAnswer.complete("The finished answer, parsed before kill won the race.");
+        pumpEdt();
+
+        String afterResolve = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(afterResolve.contains("The finished answer, parsed before kill won the race."),
+                        afterResolve),
+                () -> assertFalse(afterResolve.toLowerCase(java.util.Locale.ROOT)
+                                .contains("recovering final answer"),
+                        "the indicator must be gone once the upgrade lands: " + afterResolve));
+    }
+
+    /**
      * Issue #3962 (second-review finding F2/F3): reproduces the exact scenario the reviewer found --
      * at {@link ShaftAssistantChatState#MAX_MESSAGES_PER_SESSION}, appending the run's own cancelled
      * bubble trips {@code trim()}'s {@code remove(0)}, shifting that bubble's real index down by one

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -164,6 +164,8 @@ class ShaftPluginScreenshotRendererTest {
         Path assistantToolResultRawOutputScreenshot = outputPath.resolve("intellij-plugin-assistant-tool-result-raw-output.png");
         Path assistantCancelledScreenshot = outputPath.resolve("intellij-plugin-assistant-cancelled.png");
         Path assistantKilledScreenshot = outputPath.resolve("intellij-plugin-assistant-killed.png");
+        Path assistantCancelledPendingAnswerScreenshot =
+                outputPath.resolve("intellij-plugin-assistant-cancelled-pending-answer.png");
         Path assistantApprovalPromptScreenshot = outputPath.resolve("intellij-plugin-assistant-approval-prompt.png");
         Path assistantModelFallbackScreenshot = outputPath.resolve("intellij-plugin-assistant-model-fallback.png");
         Path assistantSlashCommandsScreenshot = outputPath.resolve("intellij-plugin-assistant-slash-commands.png");
@@ -209,6 +211,7 @@ class ShaftPluginScreenshotRendererTest {
         write(assistantToolResultRawOutputScreenshot, renderAssistantToolResultRawOutput(LIGHT_THEME, false));
         write(assistantCancelledScreenshot, renderAssistantCancelled(LIGHT_THEME, false));
         write(assistantKilledScreenshot, renderAssistantKilled(LIGHT_THEME, false));
+        write(assistantCancelledPendingAnswerScreenshot, renderAssistantCancelledPendingAnswer(LIGHT_THEME, false));
         write(assistantApprovalPromptScreenshot, renderApprovalPrompt(LIGHT_THEME, false));
         write(assistantModelFallbackScreenshot, renderAssistantModelFallback(LIGHT_THEME, false));
         write(assistantSlashCommandsScreenshot, renderAssistantSlashCommands(LIGHT_THEME, false));
@@ -255,6 +258,8 @@ class ShaftPluginScreenshotRendererTest {
                         assistantFailureRecoveryCardScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantCancelledScreenshot) > 0, assistantCancelledScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantKilledScreenshot) > 0, assistantKilledScreenshot + " should be non-empty"),
+                () -> assertTrue(Files.size(assistantCancelledPendingAnswerScreenshot) > 0,
+                        assistantCancelledPendingAnswerScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantApprovalPromptScreenshot) > 0, assistantApprovalPromptScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantModelFallbackScreenshot) > 0, assistantModelFallbackScreenshot + " should be non-empty"),
                 () -> assertTrue(Files.size(assistantSlashCommandsScreenshot) > 0, assistantSlashCommandsScreenshot + " should be non-empty"),
@@ -1022,6 +1027,37 @@ class ShaftPluginScreenshotRendererTest {
     private static BufferedImage renderAssistantKilled(String lookAndFeelClassName, boolean dark)
             throws InterruptedException, InvocationTargetException {
         return renderAssistantTerminalState(lookAndFeelClassName, dark, "Killed");
+    }
+
+    /**
+     * Issue #4210: same "Cancelled" composition as {@link #renderAssistantCancelled}, plus the
+     * subtle pending-answer caption {@code ShaftAssistantPanel#PENDING_ANSWER_INDICATOR} appends
+     * while the run's companion terminal-answer future is still unresolved -- visual evidence the
+     * caption reads as a legible, non-intrusive aside rather than crowding the terminal marker.
+     */
+    private static BufferedImage renderAssistantCancelledPendingAnswer(String lookAndFeelClassName, boolean dark)
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<BufferedImage> image = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(lookAndFeelClassName, dark);
+            ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+            chatState.append("user", "/codegen recordings/demo-recording.json", "");
+            ShaftSettingsState.Settings settings = defaultSettings();
+            ShaftAssistantPanel component = new ShaftAssistantPanel(screenshotProject(), settings, chatState,
+                    () -> {
+                    });
+            String partialOutput = "Reading pom.xml...\nAnalyzing dependency tree for shaft-mcp...";
+            String markdown = "```text\n" + partialOutput + "\n```\n\n_Cancelled._ (partial output above)"
+                    + "\n\n_Recovering final answer..._";
+            component.simulateAppendForTest("assistant", markdown, "");
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, !dark);
+            image.set(render(component, WIDTH, HEIGHT));
+        });
+        return image.get();
     }
 
     private static BufferedImage renderAssistantTerminalState(String lookAndFeelClassName, boolean dark, String label)


### PR DESCRIPTION
## Summary

Closes #4210 (fast-follow from the #3962/PR #4204 hardening work, subtask of tracker #4214).

While a soft Cancel's (or Kill's) recovered terminal answer is still pending, the already-rendered `_Cancelled._`/`_Killed._` bubble now shows a subtle `_Recovering final answer..._` caption, so the user can tell an in-place change may still land instead of the bubble looking indistinguishable from a genuinely final state. The caption disappears the moment the companion future resolves — whether it lands a real answer (folded into the upgraded content), resolves with nothing (the run never produced a terminal event), or the run's own process-timeout path completes (`AssistantLocalAgentRunner#run`'s `finally` notifies the companion from every exit path, so it always eventually resolves — no separate timer needed for the "or times out" case).

**What I deliberately did NOT touch**: the identity-based upgrade mechanism from #3962/PR #4204 — `scheduleTerminalAnswerUpgrade`, `upgradeFinalizedLocalAgentMessage`, and the `lastLocalAgentFinalizedMessage` object-reference/guard clauses — is byte-for-byte unchanged. The two new methods (`schedulePendingAnswerIndicator`, `setPendingAnswerIndicatorVisible`) only *observe* the same companion `CompletableFuture` via an independent `whenComplete` callback (registered separately from the existing `thenAccept`), and mirror the exact same identity/active-session guard the upgrade method already uses, so the indicator can never mutate or render a message that has scrolled out of the active session — the same safety property the reviewed code establishes. The only two call sites touched (`showAgentResult`'s cancel branch, `stopLocalAgentStreaming`) get one extra line each: capture the pending future *before* `scheduleTerminalAnswerUpgrade` nulls it, then hand it to the new indicator scheduler — no change to their existing control flow or ordering.

**Scope call**: did not add the optional scroll-position guard for the `transcript.setMessages(...)` full resync (issue's second bullet says "your call") — kept this PR to just the indicator, per the ponytail minimal-diff constraint.

**Screenshot evidence**: added one new screenshot scenario (`intellij-plugin-assistant-cancelled-pending-answer.png`, via `ShaftPluginScreenshotRendererTest`) since this is a visible UI change (per the shaft-intellij testing convention) — inspected it: the caption renders as a legible, single-line italic aside under the terminal marker, not crowding it.

## Test plan

- [x] New tests written first and watched RED before implementation:
  - `assistantCancelledBubbleShowsPendingAnswerIndicatorWhileCompanionIsUnresolved`
  - `assistantCancelledBubblePendingAnswerIndicatorClearsWhenCompanionResolvesWithNoAnswer`
  - `assistantKilledBubbleShowsPendingAnswerIndicatorWhileCompanionIsUnresolved`
- [x] All three watched GREEN after implementation.
- [x] Full `ShaftPanelSetupTest` (includes every existing Cancel/Kill/terminal-answer-upgrade test, e.g. `assistantCancelUpgradeStillLandsAfterAnUnrelatedAppendShiftsItsIndexAtTheCap`, `assistantTwoCancelledRunsAtTheCapNeverCrossContaminateEachOthersBubble`, `assistantKillTerminalAnswerUpgradeIsSkippedIfTheUserSwitchedSessionsMeanwhile`): 275 tests, 0 failures — all unchanged and green.
- [x] `AssistantLocalAgentRunnerTerminalAnswerCompanionTest` (2 tests) and `AssistantLocalAgentRunnerCancellationTest` (3 tests): green, untouched (no changes to `AssistantLocalAgentRunner.java`).
- [x] `ShaftPluginScreenshotRendererTest` regenerated with `-Dshaft.intellij.screenshotDir=...`: 6 tests, 0 failures; new screenshot visually inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH