### PR TITLE
Gate codegen success on a real replay pass, not a skipped one

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
@@ -5,6 +5,7 @@ import tools.jackson.databind.json.JsonMapper;
 import com.shaft.capture.control.CaptureControlClient;
 import com.shaft.capture.control.CaptureControlFiles;
 import com.shaft.capture.control.CaptureControlServer;
+import com.shaft.capture.generate.CaptureGenerationReport;
 import com.shaft.capture.generate.CaptureGenerationRequest;
 import com.shaft.capture.generate.CaptureGenerationResult;
 import com.shaft.capture.generate.CaptureGenerator;
@@ -227,12 +228,22 @@ public final class CaptureCli {
                         controlFlowMode,
                         controlFlowPreview),
                 generationBackend(options));
+        CaptureGenerationReport.Status status = result.report() == null
+                ? CaptureGenerationReport.Status.FAILED
+                : result.report().status();
+        if (status == CaptureGenerationReport.Status.UNCONFIRMED) {
+            // Issue #4029: the default (no --replay) quick-start flow keeps its fast, exit-0
+            // contract -- but must never let that read as a proven-working test. Loud and
+            // impossible to miss in the human-facing output, not buried in the JSON status field.
+            OUTPUT.println("UNCONFIRMED: the generated test compiled but replay was not requested, "
+                    + "so the recorded scenario was NOT proven to run. Pass --replay to confirm it.");
+        }
         if (options.values().containsKey("target-source") || options.values().containsKey("insert-after")) {
             if (!options.values().containsKey("target-source") || !options.values().containsKey("insert-after")) {
                 throw new IllegalArgumentException(
                         "Capture record-at-target requires both --target-source and --insert-after.");
             }
-            CaptureTargetInsertionPlan insertion = result.successful()
+            CaptureTargetInsertionPlan insertion = status != CaptureGenerationReport.Status.FAILED
                     ? new CaptureTargetInsertionPlanner().plan(
                             result.sourcePath(),
                             options.pathRequired("target-source"),
@@ -244,7 +255,7 @@ public final class CaptureCli {
         } else {
             print(result);
         }
-        return result.successful() ? 0 : 1;
+        return status == CaptureGenerationReport.Status.FAILED ? 1 : 0;
     }
 
     private static int features() {

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationReport.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerationReport.java
@@ -90,6 +90,12 @@ public record CaptureGenerationReport(
      */
     public enum Status {
         SUCCESS,
+        /**
+         * Compilation passed but replay was never requested or was skipped (issue #4029): the
+         * recorded scenario was never proven to actually run, so this must never be treated as
+         * {@code SUCCESS} by any caller.
+         */
+        UNCONFIRMED,
         FAILED
     }
 

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -354,10 +354,20 @@ public final class CaptureGenerator {
                         "Replay was skipped because compilation failed.");
                 reporter.accept(0.9, "Replay skipped: compilation failed");
             }
-            boolean successful = compilation.status()
-                    != CaptureGenerationReport.Validation.ValidationStatus.FAILED
+            // Issue #4029: compile/replay neither failed outright, so the generated artifacts are
+            // safe to promote -- but "safe to promote" is not the same claim as "proven to run".
+            // generationOk gates promotion/rollback exactly as `successful` used to; `status` is
+            // the separate, honest report of WHAT was proven: an actual replay pass is required for
+            // SUCCESS, a skipped/not-requested replay is UNCONFIRMED (never bare success), and either
+            // validation actually failing is FAILED.
+            boolean generationOk = compilation.status() != CaptureGenerationReport.Validation.ValidationStatus.FAILED
                     && replay.status() != CaptureGenerationReport.Validation.ValidationStatus.FAILED;
-            if (successful) {
+            CaptureGenerationReport.Status status = !generationOk
+                    ? CaptureGenerationReport.Status.FAILED
+                    : replay.status() == CaptureGenerationReport.Validation.ValidationStatus.PASSED
+                    ? CaptureGenerationReport.Status.SUCCESS
+                    : CaptureGenerationReport.Status.UNCONFIRMED;
+            if (generationOk) {
                 stage = "promoting the validated generated source to its final path";
                 atomicWrite(paths.source(), source);
             } else {
@@ -375,7 +385,7 @@ public final class CaptureGenerator {
                     session,
                     paths,
                     state,
-                    successful ? CaptureGenerationReport.Status.SUCCESS : CaptureGenerationReport.Status.FAILED,
+                    status,
                     compilation,
                     replay,
                     enrichment);
@@ -396,7 +406,7 @@ public final class CaptureGenerator {
                         request.enrichmentPreviewPath(), privacyFailure);
             }
             atomicWrite(reportPath, reportJson);
-            reporter.accept(1.0, "Generation complete: " + (successful ? "SUCCESS" : "FAILED"));
+            reporter.accept(1.0, "Generation complete: " + status);
             return result(paths.source(), paths.data(), reportPath,
                     request.enrichmentPreviewPath(), report);
         } catch (RuntimeException exception) {

--- a/shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java
@@ -8,8 +8,12 @@ import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -252,6 +256,57 @@ class CaptureCliTest {
         String argsFileContent = java.nio.file.Files.readString(Path.of(argsFileArgument.substring(1)));
         assertTrue(argsFileContent.contains("-cp"));
         assertTrue(argsFileContent.contains(CaptureCli.class.getName()));
+    }
+
+    /**
+     * Issue #4029: the promoted, documented quick-start flow ({@code shaft-cli codegen} /
+     * {@code capture generate} with no {@code --replay}) must keep its exit-0 contract for scripts
+     * that grep {@code $?} -- but stdout must carry an unmissable line stating the result is
+     * UNCONFIRMED, since a skipped replay never proves the recorded scenario actually runs.
+     * Runs the CLI as a real child process: {@code CaptureCli}'s {@code OUTPUT}/{@code ERROR}
+     * writers bind directly to {@link java.io.FileDescriptor#out}/{@code err}, bypassing
+     * {@code System.out} entirely, so only a real process's captured stdout proves what a user
+     * actually sees.
+     */
+    @Test
+    void generateCommandExitsZeroButPrintsUnconfirmedWhenReplayIsSkipped() throws Exception {
+        Path session = temp.resolve("capture.json");
+        Files.copy(repositoryRoot().resolve(
+                "shaft-capture/src/test/resources/fixtures/golden-session-1.0.json"), session);
+        Path output = temp.resolve("generated");
+
+        List<String> command = new ArrayList<>();
+        command.add(ProcessHandle.current().info().command().orElseThrow());
+        command.add("-cp");
+        command.add(System.getProperty("java.class.path"));
+        command.add(CaptureCli.class.getName());
+        command.add("generate");
+        command.add("--session");
+        command.add(session.toString());
+        command.add("--output-dir");
+        command.add(output.toString());
+
+        Process process = new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start();
+        String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        boolean finished = process.waitFor(60, TimeUnit.SECONDS);
+
+        assertTrue(finished, "generate command did not finish in time: " + stdout);
+        assertEquals(0, process.exitValue(), "a skipped replay must keep the exit-0 quick-start contract: " + stdout);
+        assertTrue(stdout.contains("UNCONFIRMED"),
+                "stdout must loudly state the result is unconfirmed/not replay-verified: " + stdout);
+    }
+
+    private static Path repositoryRoot() {
+        Path current = Path.of("").toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml")) && Files.isDirectory(current.resolve("shaft-capture"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Repository root could not be resolved.");
     }
 
     private static Object invokeStatic(String methodName, Class<?>[] parameterTypes, Object... arguments)

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -46,7 +46,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult first = new CaptureGenerator().generate(request(session, temp.resolve("first")));
         CaptureGenerationResult second = new CaptureGenerator().generate(request(session, temp.resolve("second")));
 
-        assertTrue(first.successful(), first.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(first);
         assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
                 first.report().compilation().status());
         assertTrue(Files.isRegularFile(first.reviewPath()));
@@ -114,7 +114,7 @@ class CaptureGeneratorTest {
                     messages.add(message);
                 });
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertTrue(fractions.size() >= 2,
                 "expected at least two progress milestones, got: " + messages);
         assertTrue(messages.stream().anyMatch(message -> !message.isBlank()));
@@ -236,7 +236,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result =
                 new CaptureGenerator().generate(request(session(capture), temp.resolve("intent-names")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(result.sourcePath().getFileName().toString().contains("CheckoutHappyPathTest.java"));
         assertTrue(source.contains("public class CheckoutHappyPathTest"));
@@ -265,7 +265,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result =
                 new CaptureGenerator().generate(request(session, temp.resolve("goal-session")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("// Capture review: readiness="));
         assertTrue(source.contains("// Capture goal: record checkout happy path"));
@@ -294,7 +294,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result =
                 new CaptureGenerator().generate(request(session, temp.resolve("goal-naming")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("public class LogInAsAValidUserTest"), source);
         assertTrue(source.contains("public void logInAsAValidUser()"), source);
@@ -329,7 +329,7 @@ class CaptureGeneratorTest {
         assertTrue(result.report().unsupportedEvents().stream()
                         .noneMatch(message -> message.startsWith("privacy:")),
                 result.report().unsupportedEvents().toString());
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
     }
 
     @Test
@@ -372,7 +372,7 @@ class CaptureGeneratorTest {
         new CaptureJsonCodec().write(path, recorded);
         CaptureGenerationResult result =
                 new CaptureGenerator().generate(request(path, temp.resolve(outputName)));
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         return Files.readString(result.sourcePath());
     }
 
@@ -502,7 +502,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result =
                 new CaptureGenerator().generate(request(session, temp.resolve("segmented")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("        loginAsAdmin();"));
         assertTrue(source.contains("    private void loginAsAdmin() throws Exception {"));
@@ -535,7 +535,7 @@ class CaptureGeneratorTest {
                 request(session, temp.resolve("playwright")),
                 CaptureGenerator.CodegenBackend.PLAYWRIGHT);
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
                 result.report().compilation().status());
         String source = Files.readString(result.sourcePath());
@@ -579,7 +579,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result =
                 new CaptureGenerator().generate(request(session, temp.resolve("verification")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("driver.browser().assertThat().title().contains(requiredData(\"username\"));"));
         assertTrue(source.contains("driver.browser().assertThat().text().contains(requiredData(\"username\"));"));
@@ -616,7 +616,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result =
                 new CaptureGenerator().generate(request(session, temp.resolve("aria-screenshot-verification")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains(
                 "driver.element().assertThat(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build())"
@@ -704,7 +704,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result = new CaptureGenerator()
                 .generate(request(session, temp.resolve("attribute-assertion")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains(
                 "driver.element().assertThat(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()).attribute(\"autocomplete\")"
@@ -722,7 +722,7 @@ class CaptureGeneratorTest {
                 CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
                 ApprovalPolicy.denyAll(), true));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("import org.openqa.selenium.By;"));
         assertTrue(source.contains("private By captureReplayLocator(By primary, By... alternatives)"));
@@ -752,8 +752,7 @@ class CaptureGeneratorTest {
         assertTrue(source.contains("import com.shaft.gui.internal.locator.Role;"),
                 "generated source uses Role.BUTTON but never imports Role: " + source);
         assertTrue(source.contains("Role.BUTTON"), source);
-        assertTrue(result.successful(),
-                "generation must compile a ROLE-strategy locator: " + result.report().compilation());
+        assertGeneratedUnconfirmed(result);
         assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
                 result.report().compilation().status(),
                 result.report().compilation().diagnostics().toString());
@@ -786,7 +785,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result = new CaptureGenerator()
                 .generate(request(session, temp.resolve("role-name")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("SHAFT.GUI.Locator.hasRole(Role.BUTTON).hasNormalizedText(\"Log in\").build()"),
                 "generated ROLE locator must chain the recorded accessible name via hasNormalizedText so "
@@ -809,7 +808,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result = new CaptureGenerator()
                 .generate(request(session, temp.resolve("role-blank-name")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("SHAFT.GUI.Locator.hasRole(Role.BUTTON).build()"), source);
     }
@@ -867,7 +866,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result = new CaptureGenerator()
                 .generate(request(session, temp.resolve("unmapped-role-replay-xpath")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains(
                         "By.xpath(\"//div[normalize-space(.)=\\\"Something  went wrong\\\"]\")"),
@@ -956,7 +955,7 @@ class CaptureGeneratorTest {
                 ApprovalPolicy.denyAll(), false,
                 CaptureGenerationRequest.ControlFlowMode.PREVIEW, preview));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertTrue(Files.isRegularFile(preview));
         List<CaptureGenerationReport.ControlFlowKind> kinds = result.report().controlFlowSuggestions().stream()
                 .map(CaptureGenerationReport.ControlFlowSuggestion::kind)
@@ -991,7 +990,7 @@ class CaptureGeneratorTest {
                 ApprovalPolicy.denyAll(), false,
                 CaptureGenerationRequest.ControlFlowMode.APPLY, preview));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("if (driver.element().getElementsCount(SHAFT.GUI.Locator.cssSelector(\"[aria-label='Close cookie banner']\")) > 0)"));
         assertFalse(source.contains("private boolean isCaptureElementDisplayed(By locator)"));
@@ -1064,7 +1063,7 @@ class CaptureGeneratorTest {
         CaptureGenerationResult result =
                 new CaptureGenerator().generate(request(session, temp.resolve("review")));
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         var review = JSON.readTree(result.reviewPath().toFile());
         List<String> categories = new java.util.ArrayList<>();
         review.path("findings").forEach(finding -> categories.add(finding.path("category").asText()));
@@ -1179,7 +1178,7 @@ class CaptureGeneratorTest {
                 true, false, Duration.ofMinutes(1),
                 CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
                 ApprovalPolicy.denyAll()));
-        assertTrue(first.successful(), first.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(first);
         String originalSource = Files.readString(first.sourcePath());
 
         // Same events (so analysis/compile would still be valid) but a different sessionGoal, so
@@ -1243,7 +1242,7 @@ class CaptureGeneratorTest {
                 true, false, Duration.ofMinutes(1),
                 CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
                 ApprovalPolicy.denyAll()));
-        assertTrue(first.successful(), first.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(first);
         String originalDataJson = Files.readString(first.testDataPath());
 
         // Same session (so analysis/compile would still be valid), but the referenced
@@ -1405,7 +1404,7 @@ class CaptureGeneratorTest {
         assertTrue(result.report().unsupportedEvents().stream()
                         .noneMatch(message -> message.startsWith("privacy:")),
                 result.report().unsupportedEvents().toString());
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
     }
 
     @Test
@@ -1440,7 +1439,7 @@ class CaptureGeneratorTest {
         assertTrue(result.report().unsupportedEvents().stream()
                         .noneMatch(message -> message.startsWith("privacy:")),
                 result.report().unsupportedEvents().toString());
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
     }
 
     @Test
@@ -1539,8 +1538,8 @@ class CaptureGeneratorTest {
         CaptureGenerationResult retried =
                 new CaptureGenerator().generate(request(healthySession, output));
 
-        assertTrue(retried.successful(), retried.report().unsupportedEvents().toString());
-        assertEquals("SUCCESS", JSON.readTree(retried.reportPath().toFile()).path("status").asText(),
+        assertGeneratedUnconfirmed(retried);
+        assertEquals("UNCONFIRMED", JSON.readTree(retried.reportPath().toFile()).path("status").asText(),
                 "Retry must refresh the status report");
     }
 
@@ -1584,7 +1583,7 @@ class CaptureGeneratorTest {
                 true, false, Duration.ofMinutes(1),
                 CaptureGenerationRequest.EnrichmentMode.PREVIEW, preview, false,
                 new ApprovalPolicy(true, true, java.util.Set.of(com.shaft.pilot.ai.EvidenceCategory.TEXT))));
-        assertTrue(previewResult.successful());
+        assertGeneratedUnconfirmed(previewResult);
         assertTrue(Files.readString(preview).contains("EnrichedJourneyTest"));
 
         CaptureGenerationResult applied = generator.generate(new CaptureGenerationRequest(
@@ -1593,7 +1592,7 @@ class CaptureGeneratorTest {
                 CaptureGenerationRequest.EnrichmentMode.APPLY, preview, true,
                 ApprovalPolicy.denyAll()));
 
-        assertTrue(applied.successful(), applied.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(applied);
         assertEquals(CaptureGenerationReport.Enrichment.EnrichmentStatus.APPLIED,
                 applied.report().enrichment().status());
         String source = Files.readString(applied.sourcePath());
@@ -1659,6 +1658,34 @@ class CaptureGeneratorTest {
                 Map.of("username-input", "USERNAME_INPUT_LOCATOR"),
                 new ApprovalPolicy(true, true,
                         java.util.Set.of(com.shaft.pilot.ai.EvidenceCategory.TEXT))));
+    }
+
+    /**
+     * Issue #4029: {@code CaptureGenerator} must never report {@code successful=true} when replay
+     * was never requested -- a compiled-but-unreplayed generation is a distinct, honest
+     * {@code UNCONFIRMED} status, not folded into bare {@code SUCCESS}.
+     */
+    @Test
+    void generateWithSkippedReplayIsNotReportedSuccessful() throws Exception {
+        Path session = session(CaptureFixtures.representativeSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result =
+                new CaptureGenerator().generate(request(session, temp.resolve("unconfirmed")));
+
+        assertFalse(result.successful(), "a skipped replay must never report successful=true");
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, result.report().status());
+        assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                result.report().compilation().status());
+        assertEquals(CaptureGenerationReport.Validation.ValidationStatus.SKIPPED,
+                result.report().replay().status());
+        assertTrue(Files.isRegularFile(result.sourcePath()),
+                "compiled-but-unconfirmed generation must still write the generated source");
+    }
+
+    private static void assertGeneratedUnconfirmed(CaptureGenerationResult result) {
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, result.report().status(),
+                result.report().unsupportedEvents().toString());
     }
 
     private CaptureGenerationRequest request(Path session, Path output) {

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -124,7 +124,11 @@ class CaptureEventPipelineTest {
                 false, false, Duration.ofMinutes(1),
                 CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
                 ApprovalPolicy.denyAll()));
-        assertTrue(generated.successful(),
+        // Issue #4029: replay was not requested, so a genuinely working generation now reports
+        // UNCONFIRMED, never bare SUCCESS -- this test's own intent (the pipeline output is valid
+        // for this session shape) is what UNCONFIRMED-not-FAILED proves.
+        assertEquals(com.shaft.capture.generate.CaptureGenerationReport.Status.UNCONFIRMED,
+                generated.report().status(),
                 "Codegen must succeed for a single-tab async-typed session: "
                         + generated.report().unsupportedEvents());
     }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -751,7 +751,12 @@ class ManagedCaptureRecorderBrowserTest {
                                 com.shaft.capture.generate.CaptureGenerationRequest.EnrichmentMode.NONE,
                                 null, false,
                                 com.shaft.pilot.ai.ApprovalPolicy.denyAll()));
-        assertTrue(generated.successful(),
+        // Issue #4029: replay was not requested (compile wasn't either, here), so a genuinely
+        // working generation now reports UNCONFIRMED, never bare SUCCESS -- this test's own intent
+        // (recorded-event/navigation-dedup correctness, proven below via navigateCalls) is what
+        // UNCONFIRMED-not-FAILED verifies, not replay confirmation.
+        assertEquals(com.shaft.capture.generate.CaptureGenerationReport.Status.UNCONFIRMED,
+                generated.report().status(),
                 "Codegen must succeed for the recorded search journey: "
                         + generated.report().unsupportedEvents());
         String source = Files.readString(generated.sourcePath(), StandardCharsets.UTF_8);

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
@@ -80,7 +80,11 @@ class GuidedWorkflowLiveE2ETest {
 
             JsonObject generated = mcp.invoke(panel.click("Review code"), TOOL_TIMEOUT);
             String code = generated.toString();
-            assertTrue(generated.get("successful").getAsBoolean(), code);
+            // Issue #4029: "Review code" dispatches to capture_code_blocks, which never replays by
+            // design (it is the deliberately fast, unproven-draft sibling of capture_generate_replay)
+            // -- a genuinely working generation now reports report.status=UNCONFIRMED, never bare
+            // successful=true, since replay was never proven to run.
+            assertEquals("UNCONFIRMED", generated.get("report").getAsJsonObject().get("status").getAsString(), code);
             assertTrue(code.contains("GeneratedShaftTest"), code);
             assertTrue(code.contains("driver.element()"), code);
             assertTrue(code.contains("typeSecure"),

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
@@ -1,6 +1,7 @@
 package com.shaft.mcp;
 
 import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.generate.CaptureGenerationReport;
 import com.shaft.capture.model.BrowserMetadata;
 import com.shaft.capture.model.CaptureEvent;
 import com.shaft.capture.model.CaptureSession;
@@ -59,7 +60,7 @@ class CaptureServiceTest {
             service.close();
         }
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertTrue(Files.isRegularFile(result.sourcePath()));
         assertTrue(Files.isRegularFile(result.reviewUiPath()));
         assertTrue(result.codeBlocks().stream()
@@ -108,7 +109,7 @@ class CaptureServiceTest {
             service.close();
         }
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertFalse(result.codeBlocks().stream()
                 .anyMatch(block -> block.kind() == McpCodeBlock.Kind.PROVIDER_ADVISORY));
         assertTrue(result.codeBlocks().stream()
@@ -144,7 +145,7 @@ class CaptureServiceTest {
             service.close();
         }
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertTrue(Files.readString(result.sourcePath()).contains("SHAFT.GUI.Playwright"));
         assertTrue(result.codeBlocks().stream()
                 .anyMatch(block -> block.id().equals("capture-test-method")
@@ -173,7 +174,7 @@ class CaptureServiceTest {
             service.close();
         }
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("review/LOCATOR")),
                 result.warnings().toString());
         assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("review/ASSERTION")),
@@ -526,8 +527,7 @@ class CaptureServiceTest {
             service.close();
         }
 
-        assertTrue(result.successful(),
-                result.report() == null ? "no report" : result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertTrue(result.codeBlocks().stream()
                 .anyMatch(block -> block.kind() == McpCodeBlock.Kind.FULL_CLASS
                         && block.code().contains("class DefaultSessionTest")));
@@ -556,9 +556,48 @@ class CaptureServiceTest {
             service.close();
         }
 
-        assertTrue(result.successful(),
-                result.report() == null ? "no report" : result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertTrue(Files.isRegularFile(result.sourcePath()));
+    }
+
+    /**
+     * Issue #4029: {@code capture_generate_replay} is named and documented as the "replay-proven"
+     * tool (as opposed to its sibling {@code capture_code_blocks}'s "faster, unproven draft") --
+     * a caller-supplied {@code replay=false} on THIS tool must resolve to {@code UNCONFIRMED}, not
+     * silent {@code successful=true}, closing the "no server-side floor" gap the issue named.
+     */
+    @Test
+    void generateReplayToolWithReplayFalseReportsUnconfirmedNotSuccess() throws Exception {
+        Path session = temp.resolve("capture.json");
+        Files.copy(repositoryRoot().resolve(
+                "shaft-capture/src/test/resources/fixtures/golden-session-1.0.json"), session);
+
+        CaptureService service = service();
+        McpCaptureReplayResult result;
+        try {
+            result = service.generateReplay(
+                    session.toString(),
+                    temp.resolve("generated-replay-false").toString(),
+                    "generated.capture",
+                    "GoldenSessionTest",
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    "driver");
+        } finally {
+            service.close();
+        }
+
+        assertFalse(result.successful(),
+                "capture_generate_replay must never report successful=true when replay=false: "
+                        + result.report());
+        assertGeneratedUnconfirmed(result);
+        assertEquals(CaptureGenerationReport.Validation.ValidationStatus.SKIPPED,
+                result.report().replay().status());
+        assertTrue(Files.isRegularFile(result.sourcePath()),
+                "compiled-but-unconfirmed generation must still return a usable source file");
     }
 
     @Test
@@ -600,7 +639,7 @@ class CaptureServiceTest {
             service.close();
         }
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertTrue(Files.isRegularFile(result.sourcePath()));
         assertTrue(result.codeBlocks().stream()
                 .anyMatch(block -> block.kind() == McpCodeBlock.Kind.FULL_CLASS
@@ -634,13 +673,23 @@ class CaptureServiceTest {
             service.close();
         }
 
-        assertTrue(result.successful(), result.report().unsupportedEvents().toString());
+        assertGeneratedUnconfirmed(result);
         assertTrue(Files.isRegularFile(result.sourcePath()));
         assertTrue(result.codeBlocks().stream()
                 .anyMatch(block -> block.kind() == McpCodeBlock.Kind.FULL_CLASS
                         && block.code().contains("class RecordedFlowTest")
                         && block.code().contains("package tests.generated")),
                 "Generated code should contain default class RecordedFlowTest and package tests.generated when blank strings provided");
+    }
+
+    /**
+     * Issue #4029: {@code capture_code_blocks} never replays by design (it is the deliberately
+     * fast, unproven-draft sibling of {@code capture_generate_replay}), so its result must report
+     * {@code UNCONFIRMED}, never bare {@code SUCCESS}.
+     */
+    private static void assertGeneratedUnconfirmed(McpCaptureReplayResult result) {
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, result.report().status(),
+                result.report() == null ? "no report" : result.report().unsupportedEvents().toString());
     }
 
     private CaptureService service() {


### PR DESCRIPTION
## Summary
- `CaptureGenerator.generate()` folded a skipped/not-requested replay into bare `Status.SUCCESS`, so every default (no `--replay`) generate call reported `successful=true` without ever proving the recorded scenario runs. Adds `CaptureGenerationReport.Status.UNCONFIRMED` ("compiled, replay never proved it") and requires an actual `PASSED` replay for `SUCCESS`; a genuinely failed compile/replay still resolves to `FAILED` exactly as before, and the artifact promotion/rollback gate is unchanged.
- `CaptureCli`/`shaft-cli codegen` keeps its `--replay`-false default and exit-0 quick-start contract (per owner decision: the fast, documented path stays fast), but now prints an unmissable `UNCONFIRMED: ...` line to stdout instead of silently claiming success.
- `capture_generate_replay`'s MCP tool gets the same status-honesty fix with no forced default flip — its only real caller (the shaft-intellij Assistant) already always passes `replay=true` explicitly, and the tool's own docs already promise "replay-proven" as its contract.
- Updates ~30 existing assertions across `CaptureGeneratorTest`, `CaptureServiceTest`, and `CaptureEventPipelineTest` that asserted bare `successful()==true` off the no-replay default; all of them were actually testing source rendering/compilation, not replay confirmation, so they now assert the honest `UNCONFIRMED` status instead.
- The adjacent `ApiCaptureGenerator`/`capture_api_generate` finding (same shape, different tool) is tracked separately as issue #4220 and is intentionally untouched here to keep this PR's scope to exactly what #4029 names.

Closes #4029

## Test plan
- [x] `CaptureGeneratorTest#generateWithSkippedReplayIsNotReportedSuccessful` — new, watched RED then GREEN
- [x] Full `CaptureGeneratorTest` (43 tests) green
- [x] `CaptureCliTest#generateCommandExitsZeroButPrintsUnconfirmedWhenReplayIsSkipped` — new real-subprocess test (CaptureCli's stdout binds directly to `FileDescriptor.out`, bypassing `System.out`), watched RED then GREEN; full `CaptureCliTest` (6 tests) green
- [x] `CaptureServiceTest#generateReplayToolWithReplayFalseReportsUnconfirmedNotSuccess` — new; full `CaptureServiceTest` (23), `CaptureServiceDispatchTest` (15), `CaptureServiceApiToolsTest` (21) green
- [x] Full `shaft-capture` `Capture*`-scoped suite (174 tests) green, including `ApiCaptureGeneratorTest` (out-of-scope adjacent, unaffected)
- [x] `shaft-cli`'s `CodegenCommandTest` (4 tests) green, unaffected
- [x] `mvn compile test-compile` clean across shaft-capture, shaft-mcp, shaft-cli (no exhaustive-switch/compile breakage from the new enum value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH