### PR TITLE
Fix false-positive data-file restore on promotion-write failure

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -367,6 +367,11 @@ public final class CaptureGenerator {
                     : replay.status() == CaptureGenerationReport.Validation.ValidationStatus.PASSED
                     ? CaptureGenerationReport.Status.SUCCESS
                     : CaptureGenerationReport.Status.UNCONFIRMED;
+            // Issue #4217: reset the moment `generationOk` is known -- restoring/removing the data
+            // snapshot is only ever warranted by a compile/replay FAILURE, never by the unrelated
+            // source-promotion write below, so the flag must not still be true if that write throws
+            // and reaches the outer catch block.
+            dataWritePendingValidation = false;
             if (generationOk) {
                 stage = "promoting the validated generated source to its final path";
                 atomicWrite(paths.source(), source);
@@ -378,7 +383,6 @@ public final class CaptureGenerator {
                 }
                 restoreOrRemoveDataFile(paths.data(), previousDataBytes, paths.root(), state.warnings());
             }
-            dataWritePendingValidation = false;
             deleteStagedSourceQuietly(stagedSource);
             stage = "writing the generation report";
             CaptureGenerationReport report = report(

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -1377,6 +1377,57 @@ class CaptureGeneratorTest {
                 "staged source file should have been cleaned up after a RuntimeException from replay()");
     }
 
+    // Issue #4217: dataWritePendingValidation must be reset as soon as compile+replay determine
+    // `successful`, not after the later, unrelated atomicWrite(paths.source(), source) promotion
+    // write -- otherwise an I/O failure on that unrelated write (disk full, permission race) AFTER
+    // a fully successful validation reaches the outer catch block with the flag still true, which
+    // wrongly restores/removes the just-validated, correct data file as if compile/replay had
+    // failed.
+    @Test
+    void promotionWriteFailureAfterSuccessfulValidationDoesNotDiscardValidatedDataFile() throws Exception {
+        CaptureSession baseline = CaptureFixtures.representativeSession();
+        writeCaptureData("alice");
+        Path output = temp.resolve("promotion-write-failure");
+
+        // Block the directory the validated source would be promoted into, so the atomicWrite()
+        // call AFTER a successful compile+replay throws, while compile/replay themselves report
+        // PASSED -- isolating the promotion-write failure from an actual validation failure.
+        Files.createDirectories(output.resolve("src/test/java"));
+        Files.writeString(output.resolve("src/test/java/generated"), "not a directory");
+
+        GeneratedTestValidator passingValidator = new GeneratedTestValidator() {
+            @Override
+            public CaptureGenerationReport.Validation compile(Path source, Path classesDirectory) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED, List.of(), 0);
+            }
+
+            @Override
+            public CaptureGenerationReport.Validation replay(
+                    String fullyQualifiedClassName,
+                    Path classesDirectory,
+                    Path resourcesDirectory,
+                    Path workDirectory,
+                    Duration timeout) {
+                return new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED, List.of(), 0);
+            }
+        };
+        CaptureGenerationResult result = new CaptureGenerator(
+                new CaptureJsonCodec(), new LocatorRanker(), passingValidator, new CaptureEnrichmentService())
+                .generate(new CaptureGenerationRequest(
+                        session(baseline), output, "generated.capture", "PromotionWriteFailureTest", true,
+                        true, true, Duration.ofMinutes(1),
+                        CaptureGenerationRequest.EnrichmentMode.NONE, null, false,
+                        ApprovalPolicy.denyAll()));
+
+        assertFalse(result.successful());
+        assertTrue(Files.isRegularFile(result.testDataPath()),
+                "a validated data file must not be discarded by an unrelated later promotion-write failure");
+        assertTrue(Files.readString(result.testDataPath()).contains("\"username\" : \"alice\""),
+                Files.readString(result.testDataPath()));
+    }
+
     @Test
     void workspaceContainedFileUrlRecordingIsNotAPrivacyBlocker() throws Exception {
         CaptureSession base = CaptureFixtures.representativeSession();


### PR DESCRIPTION
## Summary
- `dataWritePendingValidation` was reset to `false` AFTER `atomicWrite(paths.source(), source)` (the source-promotion write) in `CaptureGenerator.generate()`. If compile+replay both PASSED but that unrelated promotion write then threw (disk full, permission race, etc.), the outer `catch (RuntimeException)` block saw the flag still `true` and wrongly restored/removed the already-validated data file, stamping a false "compilation or replay failed" warning.
- One-line reorder: the flag is now reset immediately after `generationOk` is computed, before it gates the `if (generationOk) {...} else {...}` branch — matching its actual meaning ("do we still need to restore/remove the snapshot," fully determined by compile/replay, not by the later promotion write).
- Related to #4202 / PR #4213 (which this is a non-blocking follow-up to) and #4029 (whose PR #4224 also touched this same status-computation block, renaming `successful` to `generationOk`/`status`).

## Test plan
- [x] Added `CaptureGeneratorTest#promotionWriteFailureAfterSuccessfulValidationDoesNotDiscardValidatedDataFile`: forces compile+replay to PASS via a stub `GeneratedTestValidator`, then blocks the source-promotion directory with a pre-created regular file so `atomicWrite(paths.source(), source)` throws after successful validation. Watched RED against the pre-fix code (data file was discarded); watched GREEN after the one-line fix.
- [x] `mvn -pl shaft-capture -Dtest=CaptureGeneratorTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` — 44/44 passed.

Closes #4217