### PR TITLE
Persist visibilityRequired on HealingReport for exact advisory eligibility mirror

### DIFF
--- a/shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java
@@ -255,18 +255,17 @@ public final class HealingLocatorProposalService {
         // The report's candidates are already ranked highest score first (ShaftHealingProvider),
         // but that ranking alone doesn't re-derive HealingDecisionEngine's own eligibility gate --
         // the persisted decision.confidence came from that engine's pre-filtered `eligible` list,
-        // so the advisory must approximate it before picking a candidate (issue #4209). This
-        // requires `interactable` unconditionally, even though the engine only applies it when
-        // visibilityRequired=true (the common case for real callers): the report has no field
-        // recording whether visibilityRequired applied to this attempt, so the advisory can't
-        // perfectly reconstruct the engine's exact gate. When the original attempt had
-        // visibilityRequired=false, this makes the advisory slightly more conservative than the
-        // engine -- a missed suggestion rather than a mismatched-confidence one, the safe
-        // direction to be wrong in.
+        // so the advisory must reproduce that exact gate before picking a candidate (issue #4209).
+        // HealingDecisionEngine.java:29-33 only requires `interactable` when the original attempt
+        // had visibilityRequired=true; the persisted `visibilityRequired` flag (issue #4215) lets
+        // this branch the same way instead of requiring `interactable` unconditionally. A legacy
+        // report predating that field defaults to visibilityRequired=true, preserving the previous
+        // safe-direction approximation.
+        boolean visibilityRequired = report.path("visibilityRequired").asBoolean(true);
         for (JsonNode candidate : candidates) {
             if (candidate.path("unique").asBoolean()
                     && candidate.path("contextMatched").asBoolean()
-                    && candidate.path("interactable").asBoolean()) {
+                    && (!visibilityRequired || candidate.path("interactable").asBoolean())) {
                 return candidate;
             }
         }

--- a/shaft-doctor/src/test/java/com/shaft/doctor/repair/HealingLocatorProposalServiceTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/repair/HealingLocatorProposalServiceTest.java
@@ -239,7 +239,7 @@ class HealingLocatorProposalServiceTest {
         // off-context; the advisory must mirror HealingDecisionEngine's own eligibility gate
         // (unique && contextMatched) before picking a candidate to suggest.
         source(repository, "private static final By LOGIN = By.id(\"old-login\");");
-        Path report = multiCandidateReport(repository,
+        Path report = multiCandidateReport(repository, true,
                 candidateJson("candidate-top", "By.id: duplicate-login", false, true, true),
                 candidateJson("candidate-eligible", "By.id: new-login", true, true, true));
 
@@ -259,7 +259,7 @@ class HealingLocatorProposalServiceTest {
     void advisoryProposalRejectsAReportWhereNoCandidateIsEligible(@TempDir Path repository)
             throws Exception {
         source(repository, "private static final By LOGIN = By.id(\"old-login\");");
-        Path report = multiCandidateReport(repository,
+        Path report = multiCandidateReport(repository, true,
                 candidateJson("candidate-a", "By.id: duplicate-login", false, true, true),
                 candidateJson("candidate-b", "By.id: wrong-context", true, false, true));
 
@@ -275,14 +275,12 @@ class HealingLocatorProposalServiceTest {
     @Test
     void advisoryProposalSkipsANonInteractableTopScoredCandidateForAnInteractableOne(
             @TempDir Path repository) throws Exception {
-        // Issue #4209 (round 2): HealingDecisionEngine's eligible list also filters on
-        // interactable whenever visibilityRequired=true (the common case for real callers), so a
-        // higher-scored candidate that is unique/contextMatched but not interactable can still
-        // mismatch the persisted decision.confidence. Require interactable too, unconditionally --
-        // a deliberate approximation since the report never records whether visibilityRequired
-        // applied to this attempt.
+        // Issue #4209 (round 2) / #4215: HealingDecisionEngine's eligible list only filters on
+        // interactable when visibilityRequired=true. This report's attempt had
+        // visibilityRequired=true, so a higher-scored candidate that is unique/contextMatched but
+        // not interactable must still be skipped in favor of the interactable one.
         source(repository, "private static final By LOGIN = By.id(\"old-login\");");
-        Path report = multiCandidateReport(repository,
+        Path report = multiCandidateReport(repository, true,
                 candidateJson("candidate-top", "By.id: not-interactable-login", true, true, false),
                 candidateJson("candidate-eligible", "By.id: new-login", true, true, true));
 
@@ -299,6 +297,31 @@ class HealingLocatorProposalServiceTest {
                         + " non-interactable one.");
     }
 
+    @Test
+    void advisoryProposalAcceptsANonInteractableCandidateWhenVisibilityWasNotRequired(
+            @TempDir Path repository) throws Exception {
+        // Issue #4215: when the original attempt had visibilityRequired=false,
+        // HealingDecisionEngine's own eligible list (HealingDecisionEngine.java:29-33) never
+        // required interactable for that attempt. The advisory must branch on the persisted
+        // visibilityRequired flag exactly the same way, instead of unconditionally requiring
+        // interactable (the safe-direction approximation from #4209 round 2).
+        source(repository, "private static final By LOGIN = By.id(\"old-login\");");
+        Path report = multiCandidateReport(repository, false,
+                candidateJson("candidate-top", "By.id: new-login", true, true, false));
+
+        HealingLocatorProposal proposal = new HealingLocatorProposalService().proposeAdvisory(
+                new HealingLocatorProposalRequest(
+                        repository,
+                        report,
+                        "src/test/java/example/LoginTest.java",
+                        true,
+                        repository.resolve("target/advisory-visibility-not-required")));
+
+        assertEquals("By.id(\"new-login\")", proposal.proposedExpression(),
+                "When visibilityRequired=false, a unique+contextMatched candidate must be accepted"
+                        + " even when not interactable, exactly mirroring HealingDecisionEngine.");
+    }
+
     private static ObjectNode candidateJson(
             String candidateId, String proposedLocator, boolean unique, boolean contextMatched,
             boolean interactable) {
@@ -312,11 +335,13 @@ class HealingLocatorProposalServiceTest {
         return candidate;
     }
 
-    private static Path multiCandidateReport(Path repository, ObjectNode... candidates) throws Exception {
+    private static Path multiCandidateReport(
+            Path repository, boolean visibilityRequired, ObjectNode... candidates) throws Exception {
         ObjectNode report = JSON.createObjectNode();
         report.put("schemaVersion", "2.0");
         report.put("attemptId", "attempt-multi");
         report.put("originalLocator", "By.id: old-login");
+        report.put("visibilityRequired", visibilityRequired);
         var candidatesArray = report.putArray("candidates");
         for (ObjectNode candidate : candidates) {
             candidatesArray.add(candidate);

--- a/shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java
+++ b/shaft-heal/src/main/java/com/shaft/heal/internal/ShaftHealingProvider.java
@@ -91,7 +91,8 @@ public class ShaftHealingProvider implements HealingProvider {
                     HealingReport.ProviderMetadata.disabled(),
                     false,
                     false,
-                    HealingReport.LadderMetadata.disabled()));
+                    HealingReport.LadderMetadata.disabled(),
+                    request.visibilityRequired()));
             return Optional.empty();
         }
 
@@ -110,7 +111,8 @@ public class ShaftHealingProvider implements HealingProvider {
                 reranked.remoteEvidenceSent(),
                 result.selected() != null,
                 new HealingReport.LadderMetadata(
-                        run.rungs(), run.elapsed().toMillis(), configuration.ladderBudget().toSeconds()));
+                        run.rungs(), run.elapsed().toMillis(), configuration.ladderBudget().toSeconds()),
+                request.visibilityRequired());
         writer.publish(report);
         if (result.selected() == null) {
             return Optional.empty();
@@ -302,7 +304,8 @@ public class ShaftHealingProvider implements HealingProvider {
                 previous.provider(),
                 previous.privacy(),
                 action,
-                previous.ladder());
+                previous.ladder(),
+                previous.visibilityRequired());
         new HealingReportWriter(pending.configuration()).publish(updated);
         if (outcome.successful()) {
             HealingHistoryStore store = new HealingHistoryStore(pending.configuration());
@@ -340,7 +343,8 @@ public class ShaftHealingProvider implements HealingProvider {
             HealingReport.ProviderMetadata provider,
             boolean remoteEvidenceSent,
             boolean recoveryUsed,
-            HealingReport.LadderMetadata ladder) {
+            HealingReport.LadderMetadata ladder,
+            boolean visibilityRequired) {
         HealingReport.ActionMetadata action = new HealingReport.ActionMetadata(
                 request.action(),
                 recoveryUsed,
@@ -364,7 +368,8 @@ public class ShaftHealingProvider implements HealingProvider {
                         0,
                         remoteEvidenceSent),
                 action,
-                ladder);
+                ladder,
+                visibilityRequired);
     }
 
     private static List<com.shaft.heal.model.HealingCandidate> rankedReports(List<RankedCandidate> candidates) {

--- a/shaft-heal/src/main/java/com/shaft/heal/model/HealingReport.java
+++ b/shaft-heal/src/main/java/com/shaft/heal/model/HealingReport.java
@@ -20,6 +20,9 @@ import java.util.Objects;
  * @param privacy minimization and redaction metadata
  * @param action action and post-action metadata
  * @param ladder re-suggestion ladder metadata (issue #4027)
+ * @param visibilityRequired whether this attempt required the selected candidate to be visible
+ *                            and enabled, mirroring {@code HealingDecisionEngine}'s own
+ *                            eligibility gate (issue #4215)
  */
 public record HealingReport(
         String schemaVersion,
@@ -35,7 +38,8 @@ public record HealingReport(
         ProviderMetadata provider,
         PrivacyMetadata privacy,
         ActionMetadata action,
-        LadderMetadata ladder) {
+        LadderMetadata ladder,
+        boolean visibilityRequired) {
     public static final String CURRENT_SCHEMA_VERSION = "2.0";
 
     /**
@@ -90,6 +94,31 @@ public record HealingReport(
         this(schemaVersion, attemptId, timestamp, originalLocator, failureCategory, pageKey,
                 context, contextMetadata, candidates, decision, provider, privacy, action,
                 LadderMetadata.disabled());
+    }
+
+    /**
+     * Creates a backward-compatible report without a persisted visibility-required flag
+     * (issue #4215); defaults to {@code true}, preserving the previous safe-direction assumption
+     * that a candidate must be interactable.
+     */
+    public HealingReport(
+            String schemaVersion,
+            String attemptId,
+            String timestamp,
+            String originalLocator,
+            String failureCategory,
+            String pageKey,
+            String context,
+            HealingContext contextMetadata,
+            List<HealingCandidate> candidates,
+            HealingDecision decision,
+            ProviderMetadata provider,
+            PrivacyMetadata privacy,
+            ActionMetadata action,
+            LadderMetadata ladder) {
+        this(schemaVersion, attemptId, timestamp, originalLocator, failureCategory, pageKey,
+                context, contextMetadata, candidates, decision, provider, privacy, action, ladder,
+                true);
     }
 
     /**

--- a/shaft-heal/src/main/resources/schema/shaft-heal-report-2.0.schema.json
+++ b/shaft-heal/src/main/resources/schema/shaft-heal-report-2.0.schema.json
@@ -6,7 +6,8 @@
   "required": [
     "schemaVersion", "attemptId", "timestamp", "originalLocator",
     "failureCategory", "pageKey", "context", "contextMetadata",
-    "candidates", "decision", "provider", "privacy", "action", "ladder"
+    "candidates", "decision", "provider", "privacy", "action", "ladder",
+    "visibilityRequired"
   ],
   "properties": {
     "schemaVersion": {"const": "2.0"},
@@ -61,7 +62,8 @@
     "ladder": {
       "type": "object",
       "required": ["rungsAttempted", "elapsedMillis", "budgetSeconds"]
-    }
+    },
+    "visibilityRequired": {"type": "boolean"}
   },
   "additionalProperties": false
 }

--- a/shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java
+++ b/shaft-heal/src/test/java/com/shaft/heal/internal/ShaftHealingProviderTest.java
@@ -124,6 +124,34 @@ public class ShaftHealingProviderTest {
     }
 
     @Test
+    public void reportPersistsTheRequestsVisibilityRequiredFlagAcrossRecordOutcome() throws Exception {
+        // Issue #4215: HealingLocatorProposalService.validateAdvisoryReport needs to know whether
+        // visibilityRequired applied to the attempt that produced the report, to mirror
+        // HealingDecisionEngine.java:29-33's eligibility gate exactly instead of approximating it.
+        WebDriver driver = driver();
+        WebElement original = element("old-id", "Username");
+        WebElement candidate = element("new-id", "Username");
+        configureSearch(driver, List.of(candidate));
+        ShaftHealingProvider provider = new ShaftHealingProvider();
+        By originalLocator = By.id("old-id");
+        provider.observe(new HealingObservation(
+                driver, originalLocator, original, "TYPE", null, null, null));
+
+        HealingResolution resolution = provider.resolve(new HealingRequest(
+                        driver, originalLocator, "TYPE", false, null, null, null))
+                .orElseThrow();
+
+        Assert.assertFalse(ShaftHeal.lastReport().orElseThrow().visibilityRequired());
+
+        provider.recordOutcome(new HealingActionOutcome(
+                driver, resolution.attemptId(), originalLocator, resolution.selectedLocator(),
+                "TYPE", true, "UNVERIFIABLE", ""));
+
+        Assert.assertFalse(ShaftHeal.lastReport().orElseThrow().visibilityRequired(),
+                "recordOutcome must preserve the originally persisted visibilityRequired flag.");
+    }
+
+    @Test
     public void serviceLoadedProviderShouldRetainPendingOutcomeState() {
         WebDriver driver = driver();
         WebElement original = element("old-id", "Username");


### PR DESCRIPTION
## Summary

Follow-up from hostile review of PR #4212 (issue #4209): `HealingLocatorProposalService.validateAdvisoryReport` could not exactly mirror `HealingDecisionEngine`'s eligibility gate (`unique && contextMatched && (!visibilityRequired || interactable)`, `HealingDecisionEngine.java:29-33`) because the persisted `HealingReport` never recorded whether `visibilityRequired` applied to the attempt that produced it. PR #4212's round 2 worked around this by unconditionally requiring `interactable` -- a safe-direction approximation that is stricter than the engine when the original attempt had `visibilityRequired=false`.

- Added a `visibilityRequired` field to `HealingReport` (`shaft-heal/src/main/java/com/shaft/heal/model/HealingReport.java`), threaded from `HealingRequest.visibilityRequired()` via `ShaftHealingProvider` and preserved across `recordOutcome`'s report rebuild; a new backward-compatible constructor defaults it to `true` for callers built against the previous shape.
- `HealingLocatorProposalService.validateAdvisoryReport` (`shaft-doctor/src/main/java/com/shaft/doctor/repair/HealingLocatorProposalService.java:264-269`) now reads the persisted `visibilityRequired` flag (defaulting to `true` for legacy reports lacking it) and branches exactly like `HealingDecisionEngine.java:29-33`, instead of requiring `interactable` unconditionally.
- Updated `shaft-heal-report-2.0.schema.json` to include the new required `visibilityRequired` boolean field.

## Test plan

- [x] `mvn -pl shaft-doctor -Dtest=HealingLocatorProposalServiceTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- watched RED (new test `advisoryProposalAcceptsANonInteractableCandidateWhenVisibilityWasNotRequired` failed with the expected `IllegalArgumentException` against the old unconditional-interactable check), then GREEN (14/14 passed) after the fix.
- [x] `mvn -pl shaft-heal -Dtest=ShaftHealingProviderTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- watched RED (compile failure: `cannot find symbol: method visibilityRequired()`) for the new test `reportPersistsTheRequestsVisibilityRequiredFlagAcrossRecordOutcome`, then GREEN (18/18 passed) after adding the field, including the existing schema-validation test.
- [x] `mvn -pl shaft-heal -Dtest=WebDomHealingAcceptanceTest,AiCandidateRerankerTest,DeterministicScorerTest,HealingHistoryStoreTest,ResuggestionLadderTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 20/20 passed (no regression in neighboring shaft-heal tests).
- [x] `mvn -pl shaft-heal,shaft-doctor compile test-compile -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- BUILD SUCCESS.

Closes #4215

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH
