### PR TITLE
Gate ApiCaptureGenerator success on a real replay pass, not a skipped one

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiCaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiCaptureGenerator.java
@@ -348,11 +348,18 @@ public final class ApiCaptureGenerator {
                         classesDirectory, testDataDirectory.getParent(), outputRoot, Duration.ofMinutes(2))
                 : CaptureGenerationReport.Validation.skipped("Replay was not requested.");
 
-        boolean failed = compilation.status() == CaptureGenerationReport.Validation.ValidationStatus.FAILED
-                || replay.status() == CaptureGenerationReport.Validation.ValidationStatus.FAILED;
-        CaptureGenerationReport.Status status = failed
+        // Issue #4220 (adjacent finding from #4029): neither compile nor replay failing outright
+        // means the generated artifacts are safe to report, but "safe to report" is not the same
+        // claim as "proven to run" -- an actual replay pass is required for SUCCESS, a skipped/
+        // not-requested replay is UNCONFIRMED (never bare success), and either validation actually
+        // failing is FAILED. Mirrors CaptureGenerator.generate()'s generationOk/status split.
+        boolean generationOk = compilation.status() != CaptureGenerationReport.Validation.ValidationStatus.FAILED
+                && replay.status() != CaptureGenerationReport.Validation.ValidationStatus.FAILED;
+        CaptureGenerationReport.Status status = !generationOk
                 ? CaptureGenerationReport.Status.FAILED
-                : CaptureGenerationReport.Status.SUCCESS;
+                : replay.status() == CaptureGenerationReport.Validation.ValidationStatus.PASSED
+                ? CaptureGenerationReport.Status.SUCCESS
+                : CaptureGenerationReport.Status.UNCONFIRMED;
 
         CaptureGenerationReport report = new CaptureGenerationReport(
                 CaptureGenerationReport.CURRENT_SCHEMA_VERSION,

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiCaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/api/ApiCaptureGeneratorTest.java
@@ -53,7 +53,7 @@ class ApiCaptureGeneratorTest {
                 sessionPath, outputRoot, "tests.generated", "",
                 ApiCodegenStyle.SCENARIO, ApiValidationDepth.SCHEMA, true, false, true));
 
-        assertEquals(CaptureGenerationReport.Status.SUCCESS, result.report().status(),
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, result.report().status(),
                 "Unsupported events: " + result.report().unsupportedEvents());
         assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED, result.report().compilation().status(),
                 "Compile diagnostics: " + result.report().compilation().diagnostics());
@@ -62,6 +62,32 @@ class ApiCaptureGeneratorTest {
         assertTrue(Files.isDirectory(result.testDataDirectory()));
         assertTrue(Files.list(result.testDataDirectory()).findAny().isPresent(), "Schema artifacts should be written");
         assertTrue(Files.exists(result.reportPath()));
+    }
+
+    /**
+     * Issue #4220 (adjacent finding from #4029): {@code ApiCaptureGenerator} must never report
+     * {@code Status.SUCCESS} when replay was never requested -- a compiled-but-unreplayed
+     * generation is a distinct, honest {@code UNCONFIRMED} status, mirroring the fix #4029 applied
+     * to {@code CaptureGenerator}.
+     */
+    @Test
+    void generateWithSkippedReplayIsNotReportedSuccessful() throws Exception {
+        Path outputRoot = Files.createDirectories(tempDir.resolve("project-unconfirmed"));
+        Path sessionPath = writeRecordedSession(outputRoot, "session-api-unconfirmed");
+
+        ApiCaptureGenerationResult result = new ApiCaptureGenerator().generate(new ApiCaptureGenerationRequest(
+                sessionPath, outputRoot, "tests.generated", "",
+                ApiCodegenStyle.SCENARIO, ApiValidationDepth.SCHEMA, true, false, true));
+
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, result.report().status(),
+                "a skipped replay must never report bare Status.SUCCESS");
+        assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                result.report().compilation().status(),
+                "Compile diagnostics: " + result.report().compilation().diagnostics());
+        assertEquals(CaptureGenerationReport.Validation.ValidationStatus.SKIPPED,
+                result.report().replay().status());
+        assertTrue(Files.isRegularFile(result.sourcePath()),
+                "compiled-but-unconfirmed generation must still write the generated source");
     }
 
     @Test
@@ -78,7 +104,7 @@ class ApiCaptureGeneratorTest {
                 sessionPath, outputRoot, "tests.generated", "",
                 ApiCodegenStyle.SCENARIO, ApiValidationDepth.STATUS, true, false, true, specPath));
 
-        assertEquals(CaptureGenerationReport.Status.SUCCESS, result.report().status());
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, result.report().status());
         CaptureGenerationReport.OpenApiCoverage coverage = result.report().openApiCoverage();
         assertTrue(coverage.loadable(), "Coverage load failure: " + coverage.loadFailureReason());
         assertEquals(3, coverage.totalDeclaredOperations());
@@ -115,7 +141,7 @@ class ApiCaptureGeneratorTest {
                 ApiCodegenStyle.HYBRID_UI_API, ApiValidationDepth.STATUS, true, false, true, null,
                 CaptureGenerationRequest.EnrichmentMode.NONE, null, false, null));
 
-        assertEquals(CaptureGenerationReport.Status.SUCCESS, result.report().status(),
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, result.report().status(),
                 "Unsupported: " + result.report().unsupportedEvents());
         assertEquals(CaptureGenerationReport.Enrichment.EnrichmentStatus.NOT_REQUESTED,
                 result.report().enrichment().status());
@@ -137,7 +163,7 @@ class ApiCaptureGeneratorTest {
                 CaptureGenerationRequest.EnrichmentMode.PREVIEW, previewPath, false,
                 new ApprovalPolicy(true, true, Set.of(EvidenceCategory.TEXT))));
 
-        assertEquals(CaptureGenerationReport.Status.SUCCESS, result.report().status(),
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, result.report().status(),
                 "Unsupported: " + result.report().unsupportedEvents());
         assertEquals(CaptureGenerationReport.Enrichment.EnrichmentStatus.PREVIEWED,
                 result.report().enrichment().status());
@@ -161,14 +187,14 @@ class ApiCaptureGeneratorTest {
                 ApiCodegenStyle.HYBRID_UI_API, ApiValidationDepth.STATUS, true, false, true, null,
                 CaptureGenerationRequest.EnrichmentMode.PREVIEW, previewPath, false,
                 new ApprovalPolicy(true, true, Set.of(EvidenceCategory.TEXT))));
-        assertEquals(CaptureGenerationReport.Status.SUCCESS, previewResult.report().status());
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, previewResult.report().status());
 
         ApiCaptureGenerationResult applied = generator.generate(new ApiCaptureGenerationRequest(
                 sessionPath, outputRoot, "tests.generated", "",
                 ApiCodegenStyle.HYBRID_UI_API, ApiValidationDepth.STATUS, true, false, true, null,
                 CaptureGenerationRequest.EnrichmentMode.APPLY, previewPath, true, ApprovalPolicy.denyAll()));
 
-        assertEquals(CaptureGenerationReport.Status.SUCCESS, applied.report().status(),
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, applied.report().status(),
                 "Unsupported: " + applied.report().unsupportedEvents());
         assertEquals(CaptureGenerationReport.Enrichment.EnrichmentStatus.APPLIED,
                 applied.report().enrichment().status());
@@ -215,7 +241,7 @@ class ApiCaptureGeneratorTest {
                 outputRoot.resolve("preview.json"), false,
                 new ApprovalPolicy(true, true, Set.of(EvidenceCategory.TEXT))));
 
-        assertEquals(CaptureGenerationReport.Status.SUCCESS, result.report().status());
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, result.report().status());
         assertEquals(CaptureGenerationReport.Enrichment.EnrichmentStatus.NOT_REQUESTED,
                 result.report().enrichment().status());
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/GuidedWorkflowLiveE2ETest.java
@@ -201,7 +201,11 @@ class GuidedWorkflowLiveE2ETest {
 
                 JsonObject generated = mcp.invoke(apiGenerate(outputPath), TOOL_TIMEOUT);
                 String code = generated.toString();
-                assertTrue(generated.get("successful").getAsBoolean(), code);
+                // Issue #4220 (adjacent finding from #4029): capture_api_generate defaults to
+                // replay=false (unsafe to auto-replay non-idempotent HTTP methods) -- a genuinely
+                // working generation now reports report.status=UNCONFIRMED, never bare
+                // successful=true, since replay was never proven to run.
+                assertEquals("UNCONFIRMED", generated.get("report").getAsJsonObject().get("status").getAsString(), code);
                 assertTrue(code.contains("new SHAFT.API("), code);
                 assertTrue(code.contains("setTargetStatusCode(200)"), code);
                 assertTrue(code.contains("assertThatResponse().matchesSchema("), code);

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceApiToolsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceApiToolsTest.java
@@ -3,6 +3,7 @@ package com.shaft.mcp;
 import com.shaft.capture.control.CaptureControlFiles;
 import com.shaft.capture.control.CaptureControlServer;
 import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.generate.CaptureGenerationReport;
 import com.shaft.capture.model.BrowserMetadata;
 import com.shaft.capture.model.CaptureEvent;
 import com.shaft.capture.model.CaptureSession;
@@ -208,7 +209,7 @@ class CaptureServiceApiToolsTest {
                     "recordings/session-mcp.json", "generated", "tests.generated", "",
                     "SCENARIO", "STATUS", true, false, "openapi.json", List.of(), List.of());
 
-            assertTrue(result.successful(), "Generation report: " + result.report());
+            assertGeneratedUnconfirmed(result);
             assertNotNull(result.report().openApiCoverage());
             assertTrue(result.report().openApiCoverage().loadable(),
                     "Coverage load failure: " + result.report().openApiCoverage().loadFailureReason());
@@ -231,7 +232,7 @@ class CaptureServiceApiToolsTest {
                     "recordings/session-mcp.json", "generated", "tests.generated", "",
                     "SCENARIO", "STATUS", true, false, "", List.of(), List.of());
 
-            assertTrue(result.successful(), "Generation report: " + result.report());
+            assertGeneratedUnconfirmed(result);
             assertFalse(result.report().openApiCoverage().loadable());
         } finally {
             service.close();
@@ -253,7 +254,7 @@ class CaptureServiceApiToolsTest {
                     "recordings/session-mcp-two.json", "generated-excluded", "tests.generated", "",
                     "SCENARIO", "STATUS", true, false, "", List.of("tx-2"), List.of());
 
-            assertTrue(result.successful(), "Generation report: " + result.report());
+            assertGeneratedUnconfirmed(result);
             String source = Files.readString(result.sourcePath());
             assertTrue(source.contains("/orders"), "Included transaction missing from generated source: " + source);
             assertFalse(source.contains("/admin"), "Excluded transaction leaked into generated source: " + source);
@@ -280,7 +281,7 @@ class CaptureServiceApiToolsTest {
                     "recordings/session-mcp-two.json", "generated-pinned", "tests.generated", "",
                     "SCENARIO", "BUSINESS", true, false, "", List.of(), List.of("$.id"));
 
-            assertTrue(result.successful(), "Generation report: " + result.report());
+            assertGeneratedUnconfirmed(result);
             String source = Files.readString(result.sourcePath());
             assertTrue(source.contains("/orders"), "Generated source missing recorded transaction: " + source);
         } finally {
@@ -430,6 +431,16 @@ class CaptureServiceApiToolsTest {
         Map<String, String> headers = new TreeMap<>();
         headers.put("content-type", "application/json");
         return headers;
+    }
+
+    /**
+     * Issue #4220 (adjacent finding from #4029): {@code capture_api_generate} never replays by
+     * default (unsafe to do automatically for non-idempotent HTTP methods), so a caller-supplied
+     * {@code replay=false} must resolve to {@code UNCONFIRMED}, never bare {@code SUCCESS}.
+     */
+    private static void assertGeneratedUnconfirmed(McpCaptureReplayResult result) {
+        assertEquals(CaptureGenerationReport.Status.UNCONFIRMED, result.report().status(),
+                "Generation report: " + result.report());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adjacent finding from issue #4029 (which fixed the identical bug in
`CaptureGenerator`/`CaptureCli`/`capture_generate_replay` for the UI-recording
generator). `ApiCaptureGenerator.compileAndReport()` had the exact same shape:
a skipped/not-requested replay was folded into bare `Status.SUCCESS`, so every
default (no `replay`) `capture_api_generate` call reported `successful=true`
without ever proving the recorded scenario runs.

- `shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiCaptureGenerator.java:351-359`:
  mirrors #4029's exact `generationOk`/`status` split -- promotion/rollback
  still gates on compile+replay not FAILED (unchanged), but the reported
  `Status` now requires an actual `PASSED` replay for `SUCCESS`, resolving a
  skipped replay to `UNCONFIRMED` instead.
- No forced `replay=true` anywhere: `capture_api_generate`'s real callers
  (`ApiRecordingSessionPanel.generateCode()`, `AssistantCommand.apiCaptureGenerate()`)
  both already default `replay=false` -- unlike #4029's `capture_generate_replay`,
  whose only real caller always passed `replay=true` -- so per the issue's own
  guidance this does not flip that default, only makes the reported status honest.
- `CaptureService.generateApi()` (`shaft-mcp/.../CaptureService.java:712`) needed
  no change: its existing `status() == SUCCESS` check was already
  comparison-correct, it just never saw `UNCONFIRMED` before because the
  generator never produced it.
- No separate `ApiCaptureGenerationReport` model exists (contrary to the
  issue's speculation) -- `ApiCaptureGenerationResult` already reuses
  `CaptureGenerationReport`/`Status`, so no new type was needed.
- Updates 7 existing `ApiCaptureGeneratorTest` assertions and 4
  `CaptureServiceApiToolsTest` assertions that asserted `SUCCESS`/`successful()`
  off the no-replay default (all tested source rendering/compilation, not
  replay confirmation) to assert `UNCONFIRMED` instead, via a new
  `assertGeneratedUnconfirmed` helper mirroring `CaptureServiceTest`'s #4029
  helper. Adds a dedicated regression test.
- Also fixes shaft-intellij's `GuidedWorkflowLiveE2ETest` (Gradle module, live
  MCP infra required -- verified by `compileTestJava` only, cannot run the
  live suite here), whose `apiRecorderCapturesNetworkTrafficAndGeneratesShaftApiCode`
  asserted bare `successful=true` off the same `replay=false` shape.

Closes #4220

## Test plan

- [x] `mvn -pl shaft-capture -Dtest=ApiCaptureGeneratorTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 16/16 green (new regression test watched RED then GREEN)
- [x] `mvn -pl shaft-mcp -Dtest=CaptureServiceApiToolsTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 21/21 green
- [x] `shaft-intellij`: `./gradlew.bat compileTestJava -Dorg.gradle.java.home=<jdk21>` -- BUILD SUCCESSFUL (live E2E suite requires live MCP infra, not runnable here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH