### PR TITLE
Print UNCONFIRMED banner after the JSON dump in capture generate

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/cli/CaptureCli.java
@@ -231,13 +231,6 @@ public final class CaptureCli {
         CaptureGenerationReport.Status status = result.report() == null
                 ? CaptureGenerationReport.Status.FAILED
                 : result.report().status();
-        if (status == CaptureGenerationReport.Status.UNCONFIRMED) {
-            // Issue #4029: the default (no --replay) quick-start flow keeps its fast, exit-0
-            // contract -- but must never let that read as a proven-working test. Loud and
-            // impossible to miss in the human-facing output, not buried in the JSON status field.
-            OUTPUT.println("UNCONFIRMED: the generated test compiled but replay was not requested, "
-                    + "so the recorded scenario was NOT proven to run. Pass --replay to confirm it.");
-        }
         if (options.values().containsKey("target-source") || options.values().containsKey("insert-after")) {
             if (!options.values().containsKey("target-source") || !options.values().containsKey("insert-after")) {
                 throw new IllegalArgumentException(
@@ -254,6 +247,17 @@ public final class CaptureCli {
                     "Capture record-at-target result could not be serialized.");
         } else {
             print(result);
+        }
+        if (status == CaptureGenerationReport.Status.UNCONFIRMED) {
+            // Issue #4029: the default (no --replay) quick-start flow keeps its fast, exit-0
+            // contract -- but must never let that read as a proven-working test. Loud and
+            // impossible to miss in the human-facing output, not buried in the JSON status field.
+            // Issue #4225: printed AFTER the JSON dump -- whatever prints last is what stays
+            // visible in a real terminal without scrolling back, and the JSON dump of a
+            // non-trivial CaptureGenerationReport can be long enough to push an earlier banner
+            // off-screen.
+            OUTPUT.println("UNCONFIRMED: the generated test compiled but replay was not requested, "
+                    + "so the recorded scenario was NOT proven to run. Pass --replay to confirm it.");
         }
         return status == CaptureGenerationReport.Status.FAILED ? 1 : 0;
     }

--- a/shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/cli/CaptureCliTest.java
@@ -296,6 +296,16 @@ class CaptureCliTest {
         assertEquals(0, process.exitValue(), "a skipped replay must keep the exit-0 quick-start contract: " + stdout);
         assertTrue(stdout.contains("UNCONFIRMED"),
                 "stdout must loudly state the result is unconfirmed/not replay-verified: " + stdout);
+
+        // Issue #4225: whatever prints LAST is what stays visible in a real terminal without
+        // scrolling back. The JSON dump of CaptureGenerationReport is one large unstructured line,
+        // so the banner must come after it -- not before it -- to stay unmissable.
+        int jsonIndex = stdout.indexOf("{");
+        int bannerIndex = stdout.indexOf("UNCONFIRMED:");
+        assertTrue(jsonIndex >= 0, "expected a JSON result dump in stdout: " + stdout);
+        assertTrue(bannerIndex > jsonIndex,
+                "UNCONFIRMED banner must print AFTER the JSON dump so it's the last line a developer "
+                        + "sees without scrolling: " + stdout);
     }
 
     private static Path repositoryRoot() {


### PR DESCRIPTION
## Summary

- Non-blocking finding from hostile review of PR #4224 (issue #4029): `CaptureCli.generate()` printed the `UNCONFIRMED:` banner BEFORE `print(result)`/`printJson(...)`, so a large `CaptureGenerationReport` JSON dump could scroll the banner off-screen above the tail of a real terminal's output.
- Moved the banner print to after the JSON dump (both the plain `print(result)` branch and the `--target-source`/`--insert-after` `printJson(...)` branch) so it is the last thing a developer sees without scrolling back.
- Exit code contract and the machine-readable `"status":"UNCONFIRMED"` JSON field are unchanged -- this is purely an output-ordering fix.

## Test plan
- [x] Extended `CaptureCliTest#generateCommandExitsZeroButPrintsUnconfirmedWhenReplayIsSkipped` to assert the banner's index in captured stdout is after the JSON dump's opening brace.
- [x] Watched it fail (RED) against the old ordering, then applied the fix and watched it pass (GREEN).
- [x] `mvn -pl shaft-capture -Dtest=CaptureCliTest test -DheadlessExecution=true -Dallure.automaticallyOpen=false` -> 6/6 passed.

Closes #4225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH