### PR TITLE
shaft-intellij: fix tool approval prompt text silently clipped at ordinary width

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolApprovalPromptPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolApprovalPromptPanel.java
@@ -284,5 +284,20 @@ final class ToolApprovalPromptPanel extends JPanel {
         public Dimension getMaximumSize() {
             return getPreferredSize();
         }
+
+        /**
+         * Without this override, {@link javax.swing.plaf.basic.BasicTextAreaUI#getMinimumSize}
+         * reports roughly one row's height regardless of the real wrapped content -- when an
+         * ancestor's actual available height falls short of the true sum of preferred heights (e.g.
+         * two of these areas stacked via {@link BoxLayout}), the layout manager shrinks a child
+         * toward its minimum before its preferred size, silently clipping every line past the first
+         * with no ellipsis or scroll affordance. Locking minimum to the full wrapped {@link
+         * #getPreferredSize()} (mirroring {@link #getMaximumSize()} above) means this area can never
+         * be compressed smaller than the text it must show in full.
+         */
+        @Override
+        public Dimension getMinimumSize() {
+            return getPreferredSize();
+        }
     }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPluginScreenshotRendererTest.java
@@ -25,6 +25,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollBar;
+import javax.swing.JTextArea;
 import javax.swing.JViewport;
 import javax.swing.LookAndFeel;
 import javax.swing.SwingUtilities;
@@ -719,6 +720,80 @@ class ShaftPluginScreenshotRendererTest {
                         + "visible width at NARROW_WIDTH -- panel right edge "
                         + (boundsInView.x + boundsInView.width) + "px, viewport width "
                         + viewport.getWidth() + "px.");
+    }
+
+    /**
+     * Reproduces a visual clipping defect found while reviewing {@code
+     * intellij-plugin-assistant-approval-prompt.png} evidence: at the ORDINARY (non-narrow) tool
+     * window width this renderer already uses for {@link #renderApprovalPrompt}, the approval
+     * prompt's plain-language summary ("This will run with targetUrl: ...") and its raw-JSON
+     * arguments dump are both cut off mid-word with no ellipsis or scroll affordance -- the same
+     * silent-clip failure mode as issue #4174's welcome-bubble paragraph crop, but in {@link
+     * ToolApprovalPromptPanel} instead. {@code ToolApprovalPromptPanelTest#argumentsSummaryRendersFullJsonWithoutTruncation}
+     * only asserts the underlying {@link JTextArea#getText()} model string is never
+     * character-truncated; it never lays the panel out inside the real {@link ShaftAssistantPanel}
+     * transcript and checks whether every rendered line is actually painted within the text area's
+     * own allocated bounds, which is what this test drives instead, using the exact same {@code
+     * captureStartArguments()} payload and {@code WIDTH}/{@code HEIGHT} {@link #renderApprovalPrompt}
+     * already renders screenshot evidence for.
+     */
+    @Test
+    void toolApprovalPromptArgumentsTextIsNotVerticallyClippedAtOrdinaryWidth()
+            throws InterruptedException, InvocationTargetException {
+        AtomicReference<JTextArea> plainLanguageArea = new AtomicReference<>();
+        AtomicReference<JTextArea> argumentsArea = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            configureLookAndFeel(LIGHT_THEME, false);
+            ShaftAssistantChatState chatState = new ShaftAssistantChatState();
+            chatState.append("user", "/record-web https://example.com", "");
+            ShaftSettingsState.Settings settings = defaultSettings();
+            settings.defaultAutobotMode = "AGENT";
+            ShaftAssistantPanel component = new ShaftAssistantPanel(screenshotProject(), settings, chatState,
+                    () -> {
+                    });
+            selectButton(component, "Allow source edits");
+            invokeStartMcpInvocation(component, AssistantCommand.Invocation.tool(
+                    "capture_start", captureStartArguments()));
+            component.setSize(new Dimension(WIDTH, HEIGHT));
+            component.setPreferredSize(new Dimension(WIDTH, HEIGHT));
+            SwingUtilities.updateComponentTreeUI(component);
+            component.doLayout();
+            layout(component, true);
+
+            plainLanguageArea.set(findByAccessibleName(
+                    component, "Tool approval plain-language summary", JTextArea.class));
+            argumentsArea.set(findByAccessibleName(component, "Tool approval arguments", JTextArea.class));
+        });
+
+        assertNotNull(plainLanguageArea.get(),
+                "The tool approval prompt's plain-language summary must render at ordinary tool window width");
+        assertNotNull(argumentsArea.get(),
+                "The tool approval prompt's raw-JSON arguments summary must render at ordinary tool window width");
+        assertTextAreaFullyPainted(plainLanguageArea.get(), "plain-language summary");
+        assertTextAreaFullyPainted(argumentsArea.get(), "raw-JSON arguments summary");
+    }
+
+    /**
+     * Asserts the last character of {@code area}'s full text model is painted within the text
+     * area's own allocated height -- the same {@code modelToView2D}-based technique {@link
+     * #firstRunWelcomeTrailingParagraphIsNotClippedAtNarrowWidth} already uses for a {@link
+     * JEditorPane}, applied here to a {@link JTextArea}.
+     */
+    private static void assertTextAreaFullyPainted(JTextArea area, String label) {
+        int length = area.getDocument().getLength();
+        assertTrue(length > 0, "The " + label + " text area must contain rendered text");
+        try {
+            java.awt.geom.Rectangle2D bounds2D = area.modelToView2D(length - 1);
+            assertNotNull(bounds2D, "The " + label + " text area's last character must resolve a caret rectangle");
+            Rectangle bounds = bounds2D.getBounds();
+            assertTrue(bounds.y + bounds.height <= area.getHeight(),
+                    "The " + label + " text area's final characters must be painted inside its own bounds "
+                            + "(height=" + area.getHeight() + "), not silently clipped with no ellipsis or "
+                            + "scroll affordance -- last character bottom edge was "
+                            + (bounds.y + bounds.height) + "px, full text was: " + area.getText());
+        } catch (BadLocationException exception) {
+            throw new IllegalStateException(exception);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Assistant view UI/UX audit (scoped to `ShaftAssistantPanel` and its supporting rendering classes) found one real, reproducible bug via empirical screenshot evidence:

- `shaft-intellij/src/main/java/com/shaft/intellij/ui/ToolApprovalPromptPanel.java:283-299` (`WrappingArgumentsArea`, the tool-approval bubble's plain-language and raw-JSON argument text): the class overrode `getMaximumSize()` to lock itself at its full wrapped-content size, but never overrode `getMinimumSize()`. `BasicTextAreaUI`'s default minimum size (~1 row) let ancestor layout (a `BoxLayout` stacking the two wrapping text areas) shrink either one down toward that tiny minimum whenever the ancestor's actual available height fell short of their combined true preferred height — silently clipping every wrapped line past the first, with no ellipsis or scroll affordance. Visible at ordinary (non-narrow) tool-window width, rendering a real `capture_start` approval prompt: both the plain-language summary ("This will run with targetUrl: ...") and the raw JSON arguments cut off mid-word.
  - Fix: override `getMinimumSize()` to also return `getPreferredSize()`, mirroring the existing `getMaximumSize()` override two lines above it — the text area can never be compressed below the height its own content needs.

## How this was found and verified

- Rendered real screenshot evidence via `ShaftPluginScreenshotRendererTest -Dshaft.intellij.screenshotDir=...` (the repo's documented UI-evidence path for this plugin) and inspected each PNG, including cropped/zoomed regions, rather than reading code alone.
- Wrote a failing regression test first (`ShaftPluginScreenshotRendererTest#toolApprovalPromptArgumentsTextIsNotVerticallyClippedAtOrdinaryWidth`) that drives the real `ShaftAssistantPanel` approval-prompt embedding at the same width/arguments the screenshot renderer already uses, and asserts (via `modelToView2D` on the last text offset, the same technique the existing `firstRunWelcomeTrailingParagraphIsNotClippedAtNarrowWidth` test uses for a sibling clipping bug) that the text area's last character is painted inside its own bounds.
  - Watched RED: `AssertionFailedError: ... final characters must be painted inside its own bounds (height=34) ... last character bottom edge was 102px`.
  - Applied the one-method fix, watched GREEN.
  - Re-rendered the screenshot and visually confirmed both the plain-language summary and raw JSON now render in full with no clipping.
- Ran `ShaftPluginScreenshotRendererTest`, `ToolApprovalPromptPanelTest`, `ShaftPanelSetupTest`, `ShaftAssistantChatStateTest`, and `LookAndFeelIsolationExtensionTest` (every test file referencing `ToolApprovalPromptPanel`, plus the chat-state persistence tests) together — all green.

## Other findings (investigated, not changed)

Several other candidate "bugs" were investigated via the same screenshot-evidence process and ruled out as intentional/already-covered, so nothing further was touched in this pass:
- Ragged mid-word wrapping of long code strings/URLs inside fenced code blocks — deliberate (`overflow-wrap: anywhere` in `AssistantTranscriptView`'s CSS), prevents horizontal overflow.
- Attachment chip truncation note only in the tooltip, not the visible chip label — matches an existing, deliberately-scoped test (`ShaftPanelSetupTest` asserting only the tooltip) and the icon-only-button tooltip convention already documented in this file.
- A perceived "empty box" above short cancelled/killed code-block bubbles — a zoomed re-crop showed the toolbar+code content was fully and correctly enclosed by the bordered code-block box; false alarm caught before making any change.

No architectural or scope-exceeding issues were found, so no GitHub issue was filed for this session.

## Test plan
- [x] `gradlew --offline test --tests ShaftPluginScreenshotRendererTest --tests ToolApprovalPromptPanelTest --tests ShaftPanelSetupTest --tests ShaftAssistantChatStateTest --tests LookAndFeelIsolationExtensionTest -DheadlessExecution=true` — green
- [x] `gradlew --offline compileJava compileTestJava` — clean
- [x] Visual re-render of `intellij-plugin-assistant-approval-prompt.png` confirms the fix

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH