### PR TITLE
fix(intellij): stop recommending Smart Locators in Assistant prompts (#4239 P0.1)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -96,7 +96,7 @@ final class AssistantCommand {
                     Never start an interactive user-driven recording (capture_start, which dispatches to whichever engine -- WebDriver, Playwright, or mobile -- is active): your MCP session ends with this turn and would kill the recording seconds after it starts. Tell the user to ask the SHAFT panel to record instead.
                     A scripted capture_start session (its optional nested codegenOptions carries the full Playwright-codegen-compatible request) that you drive and capture_stop within this same turn is allowed.
                     Generated Java code must use SHAFT syntax only: SHAFT.GUI.WebDriver, driver.browser(), driver.element(), driver.element().touch(), and SHAFT.GUI.Locator.
-                    Never generate SHAFT.GUI.Locator.xpath(...); use smart locators, the SHAFT locator builder, or By.xpath only as a last fallback.
+                    Never generate SHAFT.GUI.Locator.xpath(...); build locators with the SHAFT locator builder's ARIA-role strategy, SHAFT.GUI.Locator.hasRole(...), falling back to native By.xpath(...) only when the element exposes no ARIA role.
                     Never generate raw Selenium code such as WebDriver, ChromeDriver, driver.get(...), driver.findElement(...), or direct WebElement actions.
                     For repeated search-result anchors, scope the locator to the first result container; for Wikipedia use By.id("searchInput") for the search box and `(//div[contains(@class,'mw-search-result-heading')])[1]//a` for the first result.
                     """.stripIndent().trim() + "\n" + SHAFT_OPTIONS_HINT;
@@ -118,7 +118,7 @@ final class AssistantCommand {
                     - For any requested site/action, preserve the user's requested target. Never substitute a different URL, domain, or example page in code or screenshot evidence.
                     - If the user asks for code only, a draft, or says not to run/open a browser, do not call live browser tools.
                     - Do not publish locators as verified unless a live browser session actually checked them.
-                    - Never generate SHAFT.GUI.Locator.xpath(...); prefer smart locators and the locator builder, then By.xpath only as a last fallback.
+                    - Never generate SHAFT.GUI.Locator.xpath(...); build locators with the SHAFT locator builder's ARIA-role strategy, SHAFT.GUI.Locator.hasRole(...), falling back to native By.xpath(...) only when the element exposes no ARIA role.
                     - Use native Playwright locators only as a last fallback in SHAFT Playwright-specific code.
                     - Call test_code_guardrails_check on the final Java snippet.
                     - Do not print full repository files or broad file dumps. Cite inspected files by path and include only the generated or changed code needed for the answer.

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -624,4 +624,46 @@ class AssistantCommandTest {
         assertEquals("C:/work/project", invocation.arguments().get("workingDirectory").getAsString());
         assertFalse(invocation.arguments().get("allowSourceMutation").getAsBoolean());
     }
+
+    /**
+     * Issue #4239 (Phase 0, item P0.1 / finding F1): SHAFT's own lint
+     * ({@code TestAutomationService.NO_SMART_LOCATOR}) rates Smart Locator usage in generated code
+     * as ERROR, but the prompts delivered to the LLM used to actively recommend "smart locators" as
+     * a preferred or fallback strategy in both {@code SHAFT_MCP_USAGE_HINT} and
+     * {@code SHAFT_CODEGEN_TOOL_GUIDANCE}. The real policy (already reconciled everywhere else in
+     * PR #4031) is: SHAFT locator builder ARIA-role strategy ({@code SHAFT.GUI.Locator.hasRole(...)})
+     * first, native {@code By.xpath(...)} only when the element exposes no ARIA role, and Smart
+     * Locator is never recommended in generated code.
+     */
+    @Test
+    void localAgentPromptsStateAriaRoleFirstLocatorPolicyAndNeverRecommendSmartLocators() {
+        AssistantCommand.Invocation nonCodegen = AssistantCommand.fromPrompt(
+                "open wikipedia and search for SHAFT Engine",
+                "CODEX",
+                "AGENT",
+                ".",
+                "",
+                true);
+        AssistantCommand.Invocation codegen = AssistantCommand.fromPrompt(
+                "generate a Java login test with a page object",
+                "CODEX",
+                "AGENT",
+                ".",
+                "",
+                true);
+
+        String nonCodegenPrompt = nonCodegen.arguments().get("prompt").getAsString();
+        String codegenPrompt = codegen.arguments().get("prompt").getAsString();
+
+        assertAll(
+                () -> assertFalse(nonCodegenPrompt.toLowerCase(Locale.ROOT).contains("smart locator"),
+                        nonCodegenPrompt),
+                () -> assertTrue(nonCodegenPrompt.contains("SHAFT.GUI.Locator.hasRole("), nonCodegenPrompt),
+                () -> assertTrue(nonCodegenPrompt.contains(
+                        "By.xpath(...) only when the element exposes no ARIA role"), nonCodegenPrompt),
+                () -> assertFalse(codegenPrompt.toLowerCase(Locale.ROOT).contains("smart locator"), codegenPrompt),
+                () -> assertTrue(codegenPrompt.contains("SHAFT.GUI.Locator.hasRole("), codegenPrompt),
+                () -> assertTrue(codegenPrompt.contains(
+                        "By.xpath(...) only when the element exposes no ARIA role"), codegenPrompt));
+    }
 }


### PR DESCRIPTION
## Summary

Part of #4239 (Phase 0, item P0.1) -- finding F1 (CRITICAL).

The owner policy: generated locator code must use only the SHAFT locator builder's ARIA-role strategy (`SHAFT.GUI.Locator.hasRole(...)`), with native `By.xpath(...)` as the only permitted fallback when no ARIA role exists. Smart Locators are never permitted in generated code -- shaft-mcp's own lint (`TestAutomationService.NO_SMART_LOCATOR`) rates Smart Locator usage as ERROR.

But the prompt text actually delivered to the LLM on every Assistant request said the opposite, in `shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java`:

- `SHAFT_MCP_USAGE_HINT`: "Never generate SHAFT.GUI.Locator.xpath(...); **use smart locators**, the SHAFT locator builder, or By.xpath only as a last fallback."
- `SHAFT_CODEGEN_TOOL_GUIDANCE`: "Never generate SHAFT.GUI.Locator.xpath(...); **prefer smart locators** and the locator builder, then By.xpath only as a last fallback."

Both actively steered the LLM toward output shaft-mcp's own lint rejects. This PR rewrites both to state the real policy -- ARIA-role builder first, `By.xpath(...)` fallback only when no ARIA role exists, no mention of Smart Locators as a strategy.

## Adjacent findings (not fixed here, out of this PR's scope)

Two more prompt strings carry the exact same "use smart locators ... By.xpath only as a last fallback" language and were not part of the assigned P0.1 scope (only the two constants above were in scope):
- `AssistantCommand.java`'s `captureIntegrationPrompt` (around what is currently line 2668)
- `AssistantMarkdown.java`'s `nativeSeleniumRejectionMarkdown()` (around what is currently line 1571)

Flagging for the orchestrator to decide whether these get folded into a follow-up P0 item or a new ticket.

## Test plan
- [x] New test `AssistantCommandTest.localAgentPromptsStateAriaRoleFirstLocatorPolicyAndNeverRecommendSmartLocators` added, watched RED against the buggy strings (6 assertion failures, all for the right reason), then GREEN after the fix.
- [x] `gradle -p shaft-intellij test --tests "com.shaft.intellij.ui.AssistantCommand*Test"` -- all green, no regressions in the other two AssistantCommand test classes.