### PR TITLE
Fix mobile codegen/replay to report honest success (#4239 P0.2)

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpMobileRecordingService.java
@@ -286,7 +286,11 @@ final class McpMobileRecordingService {
         if (targetSource != null || !text(insertAfter).isBlank()) {
             blocks.addAll(targetInsertionBlocks(targetSource, insertAfter, pom));
         }
-        return new McpMobileReplayResult(path, true, 0, blocks, replayWarnings(stored));
+        // Pure codegen: this method never compiles or replays anything, so successful=false and
+        // replayedActionCount=0 are honest (matches web/API's UNCONFIRMED semantics for the
+        // analogous no-replay case, #4239 F4). No report/source/test-data paths exist to attach
+        // here since no generation attempt beyond copy-paste text rendering ever ran.
+        return new McpMobileReplayResult(path, false, 0, blocks, replayWarnings(stored));
     }
 
     private void persist() {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/MobileService.java
@@ -549,8 +549,10 @@ public class MobileService {
             replay(action);
             replayed++;
         }
+        boolean allActionsReplayed = replayed == recording.actions().size();
         McpMobileReplayResult blocks = recorder.codeBlocks(recordingPath, driverVariableName);
-        return new McpMobileReplayResult(blocks.recordingPath(), true, replayed, blocks.codeBlocks(), blocks.warnings());
+        return new McpMobileReplayResult(
+                blocks.recordingPath(), allActionsReplayed, replayed, blocks.codeBlocks(), blocks.warnings());
     }
 
     /**

--- a/shaft-mcp/src/test/java/com/shaft/mcp/MobileRecordingServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/MobileRecordingServiceTest.java
@@ -55,6 +55,31 @@ class MobileRecordingServiceTest {
     }
 
     @Test
+    void codeBlocksReportsUnconfirmedNotSuccessfulSinceNoReplayWasAttempted() {
+        McpMobileRecordingService service = new McpMobileRecordingService(McpWorkspacePolicy.of(temp));
+        Path recording = temp.resolve("unconfirmed.json");
+
+        service.start(recording.toString(), "native", false);
+        service.record(
+                "tap",
+                locatorStrategy.ACCESSIBILITY_ID,
+                "login",
+                Map.of(),
+                "driver.element().touch().tap(SHAFT.GUI.Locator.accessibilityId(\"login\"));",
+                "driver.element().touch().tap(SHAFT.GUI.Locator.accessibilityId(\"login\"));",
+                false);
+        service.stop(false);
+
+        McpMobileReplayResult result = service.codeBlocks(recording.toString(), "driver");
+
+        // codeBlocks() only renders copy-paste text; it never compiles or replays anything, so
+        // reporting successful=true here would lie about validation that never happened (#4239 F4),
+        // matching web/API's UNCONFIRMED semantics for the analogous no-replay case.
+        assertFalse(result.successful(), "Pure codegen without replay must not report successful=true");
+        assertEquals(0, result.replayedActionCount());
+    }
+
+    @Test
     void typedValueSensitivityIsClassifiedPerFieldLikeWebCapture() {
         assertTrue(MobileService.isSensitiveTypedValue("password_input", "hunter2"),
                 "Password-looking fields must stay redacted");

--- a/shaft-mcp/src/test/java/com/shaft/mcp/MobileServiceReplayTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/MobileServiceReplayTest.java
@@ -117,6 +117,9 @@ class MobileServiceReplayTest {
         }
 
         assertEquals(15, replay.replayedActionCount());
+        // #4239 F4: successful must be computed from replayed-vs-total, not a hardcoded literal;
+        // this full run is the one reachable case where that computation evaluates true today.
+        assertTrue(replay.successful());
         verify(touch).tap(any(By.class));
         verify(touch).doubleTap(any(By.class));
         verify(touch).longTap(any(By.class));


### PR DESCRIPTION
## Summary

Mobile's codegen/replay results reported `successful: true` for generated code that was never compiled, replayed, or validated (finding F4 in #4239), unlike web/API which already report `UNCONFIRMED`/`false` for the analogous no-replay case (#4029/#4220/#4230/#4231).

Two sites:

- `McpMobileRecordingService.java` (pure codegen, no replay attempted): `codeBlocks()` hardcoded `successful=true`, `replayedActionCount=0`. Now returns `successful=false` — honest, matches web's UNCONFIRMED semantics for the no-replay case. No report/source/test-data fields are fabricated (none exist for this path), consistent with how web behaves when nothing was actually validated.
- `MobileService.java` `replayRecording()` (does attempt replay): hardcoded `successful=true` regardless of outcome. Now computes `successful = (replayedActionCount == recording.actions().size())`, mirroring `PlaywrightService.replayRecording()`'s existing fix for the same bug.

`CaptureService.fromMobileResult()` maps `McpMobileReplayResult.successful()` straight into the shared `McpCaptureReplayResult`, so `capture_code_blocks`/`capture_record_at_target_code_blocks`/`capture_generate_replay` now report mobile honestly too, with no changes needed in `CaptureService` itself.

## Note on test coverage for the `replayRecording` fix

`MobileService.replay(action)`'s dispatch is fail-fast: any per-action failure (including the intentional "redacted sensitive value must throw" rule) propagates all the way out of `replayRecording`, so the method never returns normally with `replayedActionCount < recording.actions().size()` today — confirmed by reading `replay()`'s dispatch and by the existing `replayRejectsARedactedTypeActionWithoutRequiringAnActiveDriver` test, which asserts the throw-not-skip contract. Playwright's analogous fix is meaningfully testable because Playwright's redacted actions are silently *skipped* (`continue`), not thrown; mobile intentionally does not skip. So a genuine red-then-green test proving `successful=false` for a real partial replay isn't achievable without changing mobile's fail-fast dispatch into skip-and-continue — a bigger design change out of scope for this fix. The computed expression is still correct and matches the sibling pattern; I added a regression assertion (`assertTrue(replay.successful())`) to the existing full-success driver-backed test to lock in the now-computed value.

Part of #4239 (Phase 0, item P0.2)

## Test plan

- [x] `MobileRecordingServiceTest#codeBlocksReportsUnconfirmedNotSuccessfulSinceNoReplayWasAttempted` — new test, watched RED (asserted false, got true) then GREEN after the fix.
- [x] `MobileServiceReplayTest` — added `assertTrue(replay.successful())` regression assertion to the existing full-replay test; both tests in the class green.
- [x] Full regression sweep: `MobileServiceReplayTest, MobileRecordingServiceTest, MobileServiceDriverBackedTest, MobileServiceConfigurationTest, MobileSwipeDispatchTest, McpMobileInspectorRecordingServiceTest, CaptureServiceDispatchTest, McpResultRecordsTest, PlaywrightServiceDriverBackedTest, PlaywrightServiceReplayHonestyTest` — 81/81 passed.
- [x] `mvn -pl shaft-mcp -am compile` — reactor build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH