### PR TITLE
Fix LiveChatToolE2ESupport leaking a fake Application into the Gradle test JVM

### DIFF
--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/LiveChatToolE2ESupport.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/LiveChatToolE2ESupport.java
@@ -57,11 +57,16 @@ import static org.junit.jupiter.api.Assertions.fail;
  * {@code ShaftMcpInvocationServiceCacheTest#fakeProject}). {@code
  * ApplicationManager.setApplication(Application, Disposable)} is public platform API: it captures
  * whatever application was installed before (here, {@code null}) and registers a Disposer hook
- * that restores it once the given {@link Disposable} is disposed -- confirmed by decompiling
- * {@code ApplicationManager.class} (the two-arg overload registers a
- * {@code Disposer.register(parentDisposable, () -> ourApplication = previous)} callback before
- * swapping in the new instance). So installation here is fully reversible per test and never
- * leaks a fake {@code Application} into any other test class sharing the Gradle test JVM.</p>
+ * that restores it once the given {@link Disposable} is disposed -- but, confirmed by decompiling
+ * {@code ApplicationManager.class}, the two-arg overload's restore-on-dispose callback is {@code
+ * previous -> { if (previous != null) setApplication(previous); }}: it only reinstates a NON-null
+ * previous {@code Application}, and silently no-ops otherwise. This whole Gradle test JVM has no
+ * live {@code Application} before {@link #install} runs, so disposing {@code
+ * applicationDisposable} alone (issue #4242) would leave the fake {@code Application} installed
+ * as the JVM-wide singleton forever, corrupting every later test sharing this fork -- exactly the
+ * gap PR #4238/#4239 already hit and fixed for {@code AssistantTranscriptViewTest}. {@link #close}
+ * therefore explicitly calls {@code ApplicationManager.setApplication(null)} after disposing
+ * {@code applicationDisposable}, rather than relying on the disposer-based restore alone.</p>
  */
 final class LiveChatToolE2ESupport implements AutoCloseable {
     private static final Duration POLL_INTERVAL = Duration.ofMillis(150);
@@ -369,16 +374,22 @@ final class LiveChatToolE2ESupport implements AutoCloseable {
     }
 
     /**
-     * Restores the real (previously {@code null}) {@link Application} via {@link Disposer#dispose}
-     * and disposes the real {@link ShaftMcpInvocationService}/{@link ShaftPluginExecutor} instances
-     * so the spawned MCP server process and worker thread pool are shut down -- never left as
-     * orphaned processes/threads after the test.
+     * Disposes the real {@link ShaftMcpInvocationService}/{@link ShaftPluginExecutor} instances so
+     * the spawned MCP server process and worker thread pool are shut down -- never left as orphaned
+     * processes/threads after the test -- then restores the real (previously {@code null}) {@link
+     * Application}. {@link Disposer#dispose} alone is NOT sufficient for that last step (issue
+     * #4242): {@code ApplicationManager.setApplication(Application, Disposable)}'s restore-on-dispose
+     * callback only reinstates a NON-null previous {@code Application} (see the class-level javadoc),
+     * and this Gradle test JVM's previous {@code Application} was {@code null}, so an explicit {@code
+     * ApplicationManager.setApplication(null)} afterward is required to actually null the JVM-wide
+     * singleton back out instead of leaking the fake {@code Application} into later tests.
      */
     @Override
     public void close() {
         invocationService.dispose();
         pluginExecutor.dispose();
         Disposer.dispose(applicationDisposable);
+        ApplicationManager.setApplication(null);
     }
 
     /**

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/LiveChatToolE2ESupportTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/LiveChatToolE2ESupportTest.java
@@ -1,0 +1,40 @@
+package com.shaft.intellij.ui;
+
+import com.intellij.openapi.application.ApplicationManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Issue #4242: {@link LiveChatToolE2ESupport#install} calls {@code
+ * ApplicationManager.setApplication(fakeApplication, applicationDisposable)}, and {@link
+ * LiveChatToolE2ESupport#close} disposed {@code applicationDisposable} alone, on the same incorrect
+ * "fully reversible" premise the class-level javadoc used to state. Decompiling {@code
+ * ApplicationManager.class} shows the two-arg overload's restore-on-dispose callback is {@code
+ * previous -> { if (previous != null) setApplication(previous); }} -- it only reinstates a NON-null
+ * previous {@code Application}, so it silently no-ops here: this whole Gradle test JVM has no live
+ * {@code Application} (i.e. {@code ApplicationManager.getApplication() == null}) before {@link
+ * LiveChatToolE2ESupport#install} runs, exactly the gap PR #4238/#4239 already fixed for {@code
+ * AssistantTranscriptViewTest}. Every real caller of this fixture is gated behind
+ * {@code -Dshaft.intellij.liveToolE2E=true}-style flags never exercised by the normal PR-gate CI
+ * run, so this test exercises the lifecycle directly and unconditionally instead, with no live
+ * flags or MCP credentials required: {@code install}'s own constructor work (fake {@code
+ * Application}/{@code Project} plus a {@code ShaftMcpInvocationService} that spawns its MCP server
+ * process lazily, only on first tool call -- see that class's constructor) never touches a real
+ * process, so {@code close()} can be asserted against with no {@link
+ * LiveChatToolE2ESupport#send} ever invoked.
+ */
+class LiveChatToolE2ESupportTest {
+    @Test
+    void closeRestoresApplicationManagerToNullEvenThoughNoneExistedBeforeInstall(@TempDir Path workspace) {
+        LiveChatToolE2ESupport fixture = LiveChatToolE2ESupport.install(workspace, "\"java\" \"-version\"");
+
+        fixture.close();
+
+        assertNull(ApplicationManager.getApplication(),
+                "close() must not leak the fake Application into later tests sharing this JVM fork");
+    }
+}


### PR DESCRIPTION
## Summary
- `LiveChatToolE2ESupport.install()` calls `ApplicationManager.setApplication(fakeApplication, applicationDisposable)`, but `close()` only disposed `applicationDisposable`, relying on the platform's restore-on-dispose callback to reinstate the previous (null) `Application`. Decompiling `ApplicationManager.class` shows that callback is `previous -> { if (previous != null) setApplication(previous); }` -- it silently no-ops when the previous `Application` was `null`, exactly the shape of this Gradle test JVM. `close()` now explicitly calls `ApplicationManager.setApplication(null)` afterward.
- Corrected the class-level javadoc's incorrect "fully reversible, never leaks" claim to describe the actual null-guarded restore behavior, citing the same decompilation finding.
- This is the same latent gap PR #4238/#4239 already fixed for `AssistantTranscriptViewTest`; #4242 called it out here but left it unfixed since every real caller of this fixture is gated behind `-Dshaft.intellij.liveToolE2E=true`-style flags never exercised by normal PR-gate CI.

## Test plan
- [x] Added `LiveChatToolE2ESupportTest` (ungated, no live flags/MCP credentials needed -- `ShaftMcpInvocationService`'s constructor never eagerly spawns a process) exercising `install()` then `close()` directly and asserting `ApplicationManager.getApplication()` is `null` afterward.
- [x] Watched RED against the buggy `close()`: `AssertionFailedError` on the `assertNull` line, proving the leak is real.
- [x] Watched GREEN after the fix.
- [x] Re-ran the full `com.shaft.intellij.ui` package after the fix: 887 tests, 0 failures, 20 skipped (same skip count as before -- unaffected gated live tests) -- confirms no pollution from the new test itself.

Fixes #4242

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH