### PR TITLE
fix(intellij): stop recommending Smart Locators in two more Assistant prompts

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -2665,7 +2665,7 @@ final class AssistantCommand {
                 - Inspect the current project structure before editing.
                 - Move stable locators into page object classes.
                 - Move replay actions into intent-named page methods.
-                - Do not use SHAFT.GUI.Locator.xpath; use smart locators, the locator builder, or By.xpath only as a last fallback.
+                - Do not use SHAFT.GUI.Locator.xpath; build locators with the SHAFT locator builder's ARIA-role strategy, SHAFT.GUI.Locator.hasRole(...), falling back to native By.xpath(...) only when the element exposes no ARIA role.
                 - Keep the TestNG test focused on scenario orchestration and final assertions.
                 - Do not duplicate existing locators, page actions, tests, or classes.
                 - Preserve the recorded browser journey; do not collapse it to only opening the start page or a generic title check.

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java
@@ -1568,7 +1568,7 @@ final class AssistantMarkdown {
                 - For broad test or page-object design, call `test_automation_scenarios` to learn the matching SHAFT coding pattern.
                 - Call `test_code_guardrails_check` on the final Java snippet before returning it.
                 - Use `SHAFT.GUI.WebDriver`, `driver.browser()`, `driver.element()`, `driver.element().touch()`, and `SHAFT.GUI.Locator`.
-                - Do not use `SHAFT.GUI.Locator.xpath(...)`; use Smart Locators, the SHAFT locator builder, or `By.xpath(...)` only as a last fallback.
+                - Do not use `SHAFT.GUI.Locator.xpath(...)`; build locators with the SHAFT locator builder's ARIA-role strategy, `SHAFT.GUI.Locator.hasRole(...)`, falling back to native `By.xpath(...)` only when the element exposes no ARIA role.
                 - Do not return native navigation calls, direct element lookup calls, WebElement actions, browser-driver constructors, or other raw Selenium code.
                 """.strip();
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -666,4 +666,30 @@ class AssistantCommandTest {
                 () -> assertTrue(codegenPrompt.contains(
                         "By.xpath(...) only when the element exposes no ARIA role"), codegenPrompt));
     }
+
+    /**
+     * Issue #4239 (Phase 0, item P0.1b): two more occurrences of the same "smart locators" fallback
+     * recommendation fixed by P0.1/#4240 were flagged out of that PR's scope -- one of them is the
+     * post-approval file-creation prompt built by {@code captureIntegrationPrompt} and dispatched
+     * through {@code approvedCaptureIntegration}. Same policy as the rest of the file: SHAFT locator
+     * builder ARIA-role strategy ({@code SHAFT.GUI.Locator.hasRole(...)}) first, native
+     * {@code By.xpath(...)} only when the element exposes no ARIA role, never Smart Locators.
+     */
+    @Test
+    void captureIntegrationPromptStatesAriaRoleFirstLocatorPolicyAndNeverRecommendsSmartLocators() {
+        AssistantCommand.Invocation invocation = AssistantCommand.approvedCaptureIntegration(
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "C:/work/project",
+                "",
+                "Reviewed capture markdown",
+                "{}");
+
+        String prompt = invocation.arguments().get("prompt").getAsString();
+
+        assertAll(
+                () -> assertFalse(prompt.toLowerCase(Locale.ROOT).contains("smart locator"), prompt),
+                () -> assertTrue(prompt.contains("SHAFT.GUI.Locator.hasRole("), prompt),
+                () -> assertTrue(prompt.contains(
+                        "By.xpath(...) only when the element exposes no ARIA role"), prompt));
+    }
 }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantMarkdownTest.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -1026,6 +1027,25 @@ class AssistantMarkdownTest {
                 () -> assertEquals("", AssistantMarkdown.readinessLabel(unknown)),
                 () -> assertEquals("", AssistantMarkdown.readinessLabel(new JsonObject())),
                 () -> assertEquals("", AssistantMarkdown.readinessLabel(null)));
+    }
+
+    /**
+     * Issue #4239 (Phase 0, item P0.1b): two more occurrences of the same "smart locators" fallback
+     * recommendation fixed by P0.1/#4240 were flagged out of that PR's scope -- one of them is this
+     * user-facing rejection message shown when generated Java uses native Selenium or a rejected
+     * SHAFT locator fallback. Same policy as the rest of the codebase: SHAFT locator builder
+     * ARIA-role strategy ({@code SHAFT.GUI.Locator.hasRole(...)}) first, native {@code By.xpath(...)}
+     * only when the element exposes no ARIA role, never Smart Locators.
+     */
+    @Test
+    void nativeSeleniumRejectionMarkdownStatesAriaRoleFirstLocatorPolicyAndNeverRecommendsSmartLocators() {
+        String markdown = AssistantMarkdown.nativeSeleniumRejectionMarkdown();
+
+        assertAll(
+                () -> assertFalse(markdown.toLowerCase(Locale.ROOT).contains("smart locator"), markdown),
+                () -> assertTrue(markdown.contains("SHAFT.GUI.Locator.hasRole("), markdown),
+                () -> assertTrue(markdown.contains("By.xpath(...)"), markdown),
+                () -> assertTrue(markdown.contains("only when the element exposes no ARIA role"), markdown));
     }
 
     private static String mcpText(String text) {


### PR DESCRIPTION
## Summary
- Part of #4239 (Phase 0, item P0.1b -- remaining occurrences flagged during P0.1). PR #4240 fixed the two main locator-policy prompt strings in `AssistantCommand.java` but flagged two more occurrences of the identical bad recommendation as out of scope for that PR.
- `AssistantCommand.captureIntegrationPrompt` (`shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java:2668`, the post-approval file-creation prompt) and `AssistantMarkdown.nativeSeleniumRejectionMarkdown` (`shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantMarkdown.java:1571`, the user-facing rejection message) both told the model/user to "use smart locators ... By.xpath only as a last fallback" -- the same policy contradiction P0.1 already fixed everywhere else.
- Applied the same already-reconciled policy used in #4240: build locators through the SHAFT locator builder's ARIA-role strategy (`SHAFT.GUI.Locator.hasRole(...)`), falling back to native `By.xpath(...)` only when the element exposes no ARIA role -- no mention of Smart Locators.

## Test plan
- [x] Added `AssistantCommandTest#captureIntegrationPromptStatesAriaRoleFirstLocatorPolicyAndNeverRecommendsSmartLocators`, watched it fail red against the pre-fix prompt text, then green after the fix.
- [x] Added `AssistantMarkdownTest#nativeSeleniumRejectionMarkdownStatesAriaRoleFirstLocatorPolicyAndNeverRecommendsSmartLocators`, watched it fail red against the pre-fix markdown text, then green after the fix.
- [x] `gradlew test --tests "com.shaft.intellij.ui.AssistantCommandTest" --tests "com.shaft.intellij.ui.AssistantMarkdownTest"` -- `BUILD SUCCESSFUL`, no regressions.
- [x] Repo-wide `grep -rn "smart locator" -i shaft-intellij/src/main` now returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B77p5FMfqraiw1amwJGgVH