### PR TITLE
Wire commit-message autoclose scanning into pr-gate.yml

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -430,15 +430,36 @@ jobs:
   # it auto-closed #3930 from PR #4009's "Does not fix #3930's original macOS
   # OOM", overriding a human's manual reopen 7 minutes earlier. Runs
   # unconditionally on every pull_request (like dependency-review below, it
-  # concerns PR body text, not changed files, so no `changes` path leg gates
-  # it) and reads the live PR body via `github.event.pull_request.body`,
+  # concerns PR body/commit text, not changed files, so no `changes` path leg
+  # gates it) and reads the live PR body via `github.event.pull_request.body`,
   # which only exists on the pull_request event.
+  #
+  # Issue #4146/#4237: GitHub's scanner also reads individual commit messages
+  # pushed to the default branch, not just the final PR body -- confirmed via
+  # #3930's timeline, whose second auto-close carried a squash-merge commit
+  # SHA with a clean PR body. #4157 wired this once, then reverted the whole
+  # file for an unrelated reason (its `edited`-trigger concurrency hazard),
+  # leaving this job body-only until now. Commits come from the REST API, not
+  # `git log` (this job's checkout is unauthenticated for an arbitrary
+  # base..head range and shallow by default), with `--paginate` from the
+  # start: issue #4159 found the prior attempt capped at the default 100-item
+  # page with no `--paginate`, silently dropping the rest of a >100-commit PR.
+  # The jq filter deliberately does NOT wrap each page in `[...]`: verified
+  # empirically that `gh api --paginate` applies `--jq` per page and
+  # concatenates each page's raw output, so an array-per-page filter emits
+  # back-to-back JSON arrays that are not one valid document. Emitting a bare
+  # object per commit and slurping the whole stream with a separate
+  # `jq -s -c '.'` merges every page into the single JSON array
+  # `parse_commits_json` expects, regardless of page count.
   pr-body-autoclose-guard:
-    name: PR Body Autoclose Guard
+    name: PR Body & Commit Autoclose Guard
     needs: changes
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -446,11 +467,20 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: "3.13"
+      - name: Fetch PR commit messages
+        id: pr-commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          commits_json=$(gh api -X GET "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
+            --paginate -f per_page=100 --jq '.[] | {sha: .sha, message: .commit.message}' | jq -s -c '.')
+          echo "commits_json=${commits_json}" >> "$GITHUB_OUTPUT"
       - name: Run PR body autoclose guard unit tests
         run: python3 -m unittest tests.scripts.test_validate_pr_closing_keywords -v
-      - name: Validate PR body has no negated closing-keyword references
+      - name: Validate PR body and commit messages have no negated closing-keyword references
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_COMMITS_JSON: ${{ steps.pr-commits.outputs.commits_json }}
         run: python3 scripts/ci/validate_pr_closing_keywords.py
 
   # Moved from security.yml's dependency-review job. Runs unconditionally on

--- a/tests/scripts/test_validate_pr_closing_keywords.py
+++ b/tests/scripts/test_validate_pr_closing_keywords.py
@@ -231,6 +231,39 @@ class ParseCommitsJsonTest(unittest.TestCase):
         )
 
 
+class GhApiCommitsShapeRoundTripTest(unittest.TestCase):
+    """Issue #4237: pins the mapping `.github/workflows/pr-gate.yml`'s
+    `pr-body-autoclose-guard` job performs on the raw `gh api
+    repos/{owner}/{repo}/pulls/{number}/commits` response (each element nests the message
+    under `commit.message`) before handing it to this script. The CI step's jq filter
+    (`.[] | {sha: .sha, message: .commit.message}`, slurped across pages with a separate
+    `jq -s -c '.'`) is mirrored here in Python so a mismatch between that shape and what
+    `parse_commits_json` expects fails a fast local test instead of only in CI."""
+
+    @staticmethod
+    def _pr_gate_jq_equivalent(raw_commits_api_response):
+        """Mirror `.[] | {sha: .sha, message: .commit.message}` piped through `jq -s -c '.'`."""
+        return json.dumps(
+            [
+                {"sha": entry["sha"], "message": entry["commit"]["message"]}
+                for entry in raw_commits_api_response
+            ]
+        )
+
+    def test_real_gh_api_shape_round_trips_and_flags_the_hazardous_commit(self):
+        raw_commits_api_response = [
+            {"sha": "aaaaaaaaaaaa", "commit": {"message": "Add a helper method\n"}},
+            {"sha": "bbbbbbbbbbbb", "commit": {"message": "This doesn't close #10 by itself.\n"}},
+            {"sha": "cccccccccccc", "commit": {"message": "Closes #20\n"}},
+        ]
+        commits_json = self._pr_gate_jq_equivalent(raw_commits_api_response)
+        commits = parse_commits_json(commits_json)
+        errors = find_negated_autocloses_in_commits(commits)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("bbbbbbbbbbbb", errors[0]["path"])
+        self.assertIn("#10", errors[0]["message"])
+
+
 class MainCLIIntegrationTest(unittest.TestCase):
     """Exercises the actual CLI entry point CI invokes: PR_BODY + PR_COMMITS_JSON env vars."""
 


### PR DESCRIPTION
Fixes #4237

## Summary
- `validate_pr_closing_keywords.py`'s commit-message scanning path (`find_negated_autocloses_in_commits`/`parse_commits_json`, consuming `PR_COMMITS_JSON`) already existed and was unit-tested, but `pr-gate.yml`'s `pr-body-autoclose-guard` job only ever called it with `PR_BODY` — individual commit messages went completely unscanned.
- Adds a "Fetch PR commit messages" step that calls `gh api repos/{owner}/{repo}/pulls/{number}/commits --paginate -f per_page=100 --jq '.[] | {sha: .sha, message: .commit.message}'`, piped through a separate `jq -s -c '.'`, and feeds the result to the script via `PR_COMMITS_JSON`.
- `--paginate` is included from the start (issue #4159: the previously-reverted attempt used `-f per_page=100` with no `--paginate`, silently capping at 100 commits).
- Adds job-level `permissions: contents: read, pull-requests: read` (needed for the `pulls/{number}/commits` REST call; the workflow only grants `contents: read` globally).

## A real gotcha found and fixed while wiring this up
Verified empirically (`gh api ... --paginate --jq '[.[] | ...]'` against a real 2-commit PR forced into 2 pages via `per_page=1`) that `gh api --paginate` applies `--jq` **per page** and concatenates each page's raw output — an array-wrapping filter (`[.[] | ...]`) therefore emits multiple back-to-back JSON arrays once a PR spans more than one page, which is not valid as a single JSON document and would make `parse_commits_json`'s `json.loads()` raise on any >100-commit PR. Fixed by emitting one bare object per commit (no wrapping) and slurping the full stream with a separate `jq -s -c '.'` step, which merges correctly regardless of page count. Confirmed against the real PR #4157 commits both ways (wrapped: 2 concatenated arrays, unwrapped+slurped: 1 valid 2-element array).

## Scope decision
Issue #4145 (re-running the guard on an `edited` PR body with no new commit) is **explicitly out of scope** here — it's a separate, already-closed issue (accepted limitation) about the trigger's activity types, unrelated to the commit-scanning gap this PR fixes. No trigger change is made.

## Verification
- `python3 -m unittest tests.scripts.test_validate_pr_closing_keywords -v` — 22/22 pass (21 pre-existing + 1 new regression test pinning the GitHub API's nested `commit.message` shape -> `{sha, message}` mapping through `parse_commits_json`).
- `python3 -m unittest tests.scripts.test_validate_workflow_timeouts -v` and `python3 scripts/ci/validate_workflow_timeouts.py` — pass (new job still declares `timeout-minutes`).
- YAML parsed with PyYAML to confirm the job structure is well-formed.
- Live `gh api` calls against real PR #4157 to confirm both the correct commit shape and the pagination/jq interaction described above.
- Self-scanned this PR's own body/commit message with `find_negated_autocloses` — no accidental negated closes.

## Review
This touches a CI safety-guard workflow (auto-close prevention) — recommend independent review before merge given the security/safety-relevant nature of the change, even though the underlying Python logic is unchanged.