### PR TITLE
recorder: self-verify ROLE candidates and extend XPath fallback (#4239 P1.0a/P1.0b)

### DIFF
--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -451,6 +451,88 @@
       inferredRole(candidate) === role && (!name || accessibleName(candidate) === name));
   };
   const labelMatchCount = expression => semanticMatchCount(candidate => label(candidate) === expression);
+  // Issue #4239 P1.0a: maps a raw ARIA role string (an explicit role="..." attribute, or a
+  // tag-shape inference -- see inferredRole above) to the SHAFT Role enum constant name, mirroring
+  // CaptureGenerator#ariaRole (CaptureGenerator.java:1668-1687) INCLUDING its ARIA-name-vs-enum-
+  // constant-name mismatches (row -> TABLE_ROW, cell/gridcell -> TABLE_CELL, columnheader ->
+  // TABLE_COLUMNHEADER, grid -> TABLE, img/image -> IMAGE). Returns "" when there is no equivalent.
+  const shaftRoleFor = rawRole => ({
+    button: "BUTTON",
+    link: "LINK",
+    textbox: "TEXTBOX",
+    checkbox: "CHECKBOX",
+    radio: "RADIO",
+    combobox: "COMBOBOX",
+    heading: "HEADING",
+    img: "IMAGE",
+    image: "IMAGE",
+    list: "LIST",
+    listitem: "LISTITEM",
+    table: "TABLE",
+    grid: "TABLE",
+    row: "TABLE_ROW",
+    cell: "TABLE_CELL",
+    gridcell: "TABLE_CELL",
+    columnheader: "TABLE_COLUMNHEADER"
+  })[String(rawRole || "").toLowerCase()] || "";
+  // Issue #4239 P1.0a: the EXACT fixed per-role XPath union LocatorBuilder.byRole compiles at
+  // replay time (ported literally from LocatorBuilder.java:144-190, not re-derived), so record-time
+  // verification proves the locator SHAFT.GUI.Locator.hasRole(...) will actually ship, not an
+  // approximation of it.
+  const roleXpathUnion = {
+    BUTTON: "//button | //input[@type='button'] | //input[@type='submit'] | //input[@type='reset'] | //a[contains(@class,'button')]",
+    LINK: "//a[@href]",
+    TEXTBOX: "//input[@type='text'] | //textarea | //input[@type='email'] | //input[@type='password'] | //input[@type='search'] | //input[not(@type)] | //input[@type='tel'] | //input[@type='url'] | //input[@type='number'] | //input[@type='date'] | //input[@type='time'] | //input[@type='month'] | //input[@type='week'] | //input[@type='datetime-local']",
+    CHECKBOX: "//input[@type='checkbox']",
+    RADIO: "//input[@type='radio']",
+    COMBOBOX: "//select | //input[@type='select-one'] | //input[@type='select-multiple']",
+    HEADING: "//h1 | //h2 | //h3 | //h4 | //h5 | //h6",
+    IMAGE: "//img | //input[@type='image']",
+    LIST: "//ul | //ol | //dl",
+    LISTITEM: "//li | //dt | //dd",
+    TABLE: "//table",
+    TABLE_ROW: "//tr",
+    TABLE_CELL: "//td",
+    TABLE_COLUMNHEADER: "//th"
+  };
+  // Evaluates `xpath` against the live DOM, walking at most MULTI_MATCH_CAP matches in document
+  // order (same cost-bounding rationale as semanticMatchCount above: callers here only ever need
+  // to distinguish zero/one/more-than-one matches). Returns the capped match count plus whether
+  // `element` was among the matches seen -- accurate whenever count resolves to exactly 1, which
+  // is the only case either caller below (roleXpathVerified, and the XPATH strategy's own
+  // uniquenessCount) treats as "verified"/"unique".
+  const evaluateXpath = (xpath, element) => {
+    try {
+      const result = document.evaluate(
+          xpath, document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+      let count = 0;
+      let includesElement = false;
+      let node = result.iterateNext();
+      while (node && count < MULTI_MATCH_CAP) {
+        if (!isControlElement(node)) {
+          count++;
+          if (node === element) includesElement = true;
+        }
+        node = result.iterateNext();
+      }
+      return {count, includesElement};
+    } catch (ignored) {
+      return {count: 0, includesElement: false};
+    }
+  };
+  // Issue #4239 P1.0a: self-verifies that the EXACT XPath SHAFT.GUI.Locator.hasRole(Role.X) will
+  // ship for this candidate's inferred role resolves UNIQUELY to this element in the live DOM --
+  // not just that it matches something. inferredRole() can return an explicit role="..." attribute
+  // value that LocatorBuilder.byRole never actually queries (its union is a fixed tag/attribute
+  // shape, not a role selector), so a ROLE candidate's own uniquenessCount (derived by re-deriving
+  // inferredRole across the page) can disagree with what the shipped locator actually matches.
+  const roleXpathVerified = (element, role) => {
+    const shaftRole = shaftRoleFor(role);
+    const union = shaftRole && roleXpathUnion[shaftRole];
+    if (!union) return false;
+    const {count, includesElement} = evaluateXpath("(" + union + ")", element);
+    return count === 1 && includesElement;
+  };
   const cssPath = element => {
     const parts = [];
     let current = element;
@@ -476,7 +558,7 @@
     const result = [];
     const visible = Boolean(element.getClientRects && element.getClientRects().length);
     const add = (strategy, expression, selector, stable, signals, replayXpath) => {
-      if (!expression) return;
+      if (!expression) return null;
       const normalized = text(expression);
       let uniquenessCount;
       if (selector) {
@@ -485,10 +567,18 @@
         uniquenessCount = roleMatchCount(normalized);
       } else if (strategy === "LABEL") {
         uniquenessCount = labelMatchCount(normalized);
+      } else if (strategy === "XPATH") {
+        // Issue #4239 P1.0b: unlike ROLE/LABEL (matched via semanticMatchCount above), this
+        // strategy's own replayXpath IS the self-verified XPath, so its true match count is
+        // measured the same way roleXpathVerified measures uniqueness -- never hardcoded to 1
+        // (the exact fabrication issue #4025 fixed for ROLE/LABEL). Uses the raw replayXpath, not
+        // the display-normalized expression above, so the count reflects the EXACT string that
+        // will be shipped as the locator.
+        uniquenessCount = evaluateXpath(replayXpath || normalized, element).count;
       } else {
         uniquenessCount = 1;
       }
-      result.push({
+      const candidate = {
         strategy,
         expression: normalized,
         uniquenessCount,
@@ -496,17 +586,32 @@
         stable,
         signals,
         replayXpath: replayXpath || ""
-      });
+      };
+      result.push(candidate);
+      return candidate;
     };
     const role = inferredRole(element);
     const nameSignal = accessibleNameSignal(element);
     const name = nameSignal.name;
+    // Issue #4239 P1.0b: computed once per element (previously only inside the ROLE branch below)
+    // so LABEL candidates and role-less elements can reuse the same self-verified fallback XPath --
+    // without this, any element with no inferred role never got a self-verified XPath fallback at
+    // all, even with a computable accessible name (aria-label/alt/title/own text).
+    const xpathCandidate = name ? computeReplayXpath(element, name, nameSignal.source) : "";
     if (role && name) {
-      add("ROLE", `${role}:${name}`, "", true, ["ACCESSIBLE"],
-          computeReplayXpath(element, name, nameSignal.source));
+      const roleCandidate = add("ROLE", `${role}:${name}`, "", true, ["ACCESSIBLE"], xpathCandidate);
+      if (roleCandidate) roleCandidate.roleXpathVerified = roleXpathVerified(element, role);
     }
     const targetLabel = label(element);
-    if (targetLabel) add("LABEL", targetLabel, "", true, ["ACCESSIBLE", "LABEL_ASSOCIATED"]);
+    if (targetLabel) {
+      add("LABEL", targetLabel, "", true, ["ACCESSIBLE", "LABEL_ASSOCIATED"], xpathCandidate);
+    } else if (!role) {
+      // Issue #4239 P1.0b: no inferred role and no enclosing <label> -- without this, an element
+      // whose only signal is e.g. its own visible text (a plain <span onclick=...>) would fall
+      // straight to ID/NAME/TEST_ID/CSS with no self-verified XPath fallback at all. add() no-ops
+      // when xpathCandidate is blank (nothing was computable), so this never adds an empty candidate.
+      add("XPATH", xpathCandidate, "", true, ["ACCESSIBLE"], xpathCandidate);
+    }
     testIdAttributes.forEach(attribute => {
       const value = element.getAttribute(attribute);
       if (value) {

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1421,6 +1422,185 @@ class ManagedCaptureRecorderBrowserTest {
         }
     }
 
+    /**
+     * Issue #4239 P1.0a: {@code LocatorBuilder.byRole(Role.BUTTON)} compiles to a FIXED
+     * tag/attribute XPath union ({@code //button | //input[@type='button'] | ...}, see
+     * {@code LocatorBuilder.java:144-190}) that never inspects the {@code role} attribute -- but
+     * the recorder's {@code inferredRole} prefers an explicit {@code role="..."} attribute over
+     * tag shape. A {@code <div role="button">} therefore produces a ROLE candidate whose
+     * {@code uniquenessCount} (re-deriving {@code inferredRole} across the page, issue #4025)
+     * truthfully reports 1, while the XPath {@code SHAFT.GUI.Locator.hasRole(Role.BUTTON)} will
+     * actually ship at replay time matches ZERO {@code <div>} elements -- nothing previously
+     * re-verified that before the candidate could be trusted. The recorder must self-verify the
+     * SAME fixed per-role XPath union against the live DOM and flag the mismatch, while a
+     * genuinely matching native {@code <button>} must still verify true. {@code roleXpathVerified}
+     * has no Java-side model yet (a later, separate task decides how {@code CaptureGenerator}
+     * consumes it), so it is read directly off the live in-page state via the
+     * {@code globalThis.__shaftCaptureUiState} seam rather than the persisted session file.
+     */
+    @Test
+    void roleCandidateSelfVerifiesTheXpathLocatorBuilderWillActuallyShipAtReplay(@TempDir Path temp)
+            throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve("role-self-verify.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/role-self-verify",
+                CaptureBrowser.parse("chrome"),
+                output,
+                temp.resolve("role-self-verify-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("custom-button")));
+
+            driver.findElement(By.id("custom-button")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.contains("Custom Button")));
+            Map<String, Object> customButtonRole = roleCandidateFromLiveState(driver, "custom-button");
+            assertEquals(1L, ((Number) customButtonRole.get("uniquenessCount")).longValue(),
+                    "inferredRole-based uniqueness truthfully reports one match for the div's role "
+                            + "attribute (issue #4025 territory, unrelated to this fix): " + customButtonRole);
+            assertEquals(Boolean.FALSE, customButtonRole.get("roleXpathVerified"),
+                    "SHAFT.GUI.Locator.hasRole(Role.BUTTON) never inspects @role, so its fixed "
+                            + "XPath union matches zero <div> elements -- the candidate must NOT be "
+                            + "flagged verified: " + customButtonRole);
+
+            driver.findElement(By.id("real-button")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.contains("Real Button")));
+            Map<String, Object> realButtonRole = roleCandidateFromLiveState(driver, "real-button");
+            assertEquals(Boolean.TRUE, realButtonRole.get("roleXpathVerified"),
+                    "a genuine <button> IS matched by hasRole(Role.BUTTON)'s XPath union and must "
+                            + "verify true: " + realButtonRole);
+
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Issue #4239 P1.0b: {@code computeReplayXpath} previously had exactly one call site (the
+     * ROLE branch, {@code shaft-capture-recorder.js:505-506} pre-fix), so LABEL candidates and
+     * elements with no inferred role at all never received a self-verified fallback XPath -- only
+     * role-matched elements did. Proves both gaps are closed: a labeled text input's LABEL
+     * candidate carries a self-verified {@code replayXpath}, and a plain role-less/label-less
+     * element (a {@code <span>} whose only accessible-name signal is its own visible text) gets
+     * its own self-verified XPath candidate where previously none existed. Both recorded XPaths
+     * are then proven to resolve, uniquely, to the same element after a page reload -- exactly the
+     * replay proof {@code recordedReplayXpathResolvesTheSameElementDespiteInternalDomWhitespace}
+     * above already established for the ROLE branch.
+     */
+    @Test
+    void labelAndRoleLessCandidatesGetASelfVerifiedFallbackXpath(@TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve("xpath-fallback.json");
+        String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/xpath-fallback";
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                url,
+                CaptureBrowser.parse("chrome"),
+                output,
+                temp.resolve("xpath-fallback-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("labeled-input")));
+
+            driver.findElement(By.id("labeled-input")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.toLowerCase(java.util.Locale.ROOT)
+                            .contains("username")));
+            driver.findElement(By.id("roleless-text")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.contains("Click me plain span")));
+
+            CaptureSession midSession = new CaptureJsonCodec().read(output);
+            LocatorCandidate label = locatorCandidateFor(midSession, "labeled-input",
+                    LocatorCandidate.LocatorStrategy.LABEL);
+            assertFalse(label.replayXpath().isBlank(),
+                    "the recorder must self-verify a fallback replayXpath for a LABEL candidate, "
+                            + "not only for ROLE candidates: " + label);
+            List<LocatorCandidate> roleLessCandidates = clickTarget(midSession, "roleless-text")
+                    .target().locatorCandidates();
+            LocatorCandidate roleLessFallback = roleLessCandidates.stream()
+                    .filter(candidate -> !candidate.replayXpath().isBlank())
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                            "an element with no inferred role and no enclosing <label> must still "
+                                    + "get a self-verified fallback XPath candidate when one can be "
+                                    + "computed: " + roleLessCandidates));
+
+            // Replay proof: reload so the DOM is rebuilt fresh, then resolve each recorded
+            // replayXpath exactly as generated By.xpath(...) code would at replay time.
+            driver.navigate().refresh();
+            waitFor(() -> elementPresent(driver, By.id("labeled-input")));
+            List<WebElement> labelMatches = driver.findElements(By.xpath(label.replayXpath()));
+            assertEquals(1, labelMatches.size(),
+                    "the recorded LABEL replayXpath must resolve to exactly the recorded element "
+                            + "at replay time: " + label.replayXpath());
+            assertEquals("labeled-input", labelMatches.get(0).getAttribute("id"));
+            List<WebElement> roleLessMatches = driver.findElements(By.xpath(roleLessFallback.replayXpath()));
+            assertEquals(1, roleLessMatches.size(),
+                    "the recorded role-less fallback replayXpath must resolve to exactly the "
+                            + "recorded element at replay time: " + roleLessFallback.replayXpath());
+            assertEquals("roleless-text", roleLessMatches.get(0).getAttribute("id"));
+
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
+    private static CaptureEvent.ClickEvent clickTarget(CaptureSession session, String logicalElementId) {
+        return session.events().stream()
+                .filter(CaptureEvent.ClickEvent.class::isInstance)
+                .map(CaptureEvent.ClickEvent.class::cast)
+                .filter(click -> logicalElementId.equals(click.target().logicalElementId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "The click on #" + logicalElementId + " must be recorded."));
+    }
+
+    private static LocatorCandidate locatorCandidateFor(
+            CaptureSession session, String logicalElementId, LocatorCandidate.LocatorStrategy strategy) {
+        return clickTarget(session, logicalElementId).target().locatorCandidates().stream()
+                .filter(candidate -> candidate.strategy() == strategy)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "A " + strategy + " locator candidate must be recorded for #"
+                                + logicalElementId));
+    }
+
+    /**
+     * Reads the ROLE candidate straight off the live in-page recorder state (the
+     * {@code globalThis.__shaftCaptureUiState} seam) rather than the persisted session file:
+     * {@code roleXpathVerified} (issue #4239 P1.0a) is a recorder-only signal with no Java-side
+     * {@code LocatorCandidate} field yet, so {@code CaptureEventPipeline}'s raw-map parsing drops
+     * it before anything reaches disk.
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> roleCandidateFromLiveState(WebDriver driver, String logicalElementId) {
+        Object result = ((JavascriptExecutor) driver).executeScript("""
+                const state = window.__shaftCaptureUiState;
+                const actions = (state && state.actions) || [];
+                const action = actions.slice().reverse().find(item =>
+                    item.details && item.details.target
+                    && item.details.target.logicalElementId === arguments[0]);
+                if (!action) return null;
+                const locators = action.details.target.locators || [];
+                return locators.find(candidate => candidate.strategy === "ROLE") || null;
+                """, logicalElementId);
+        return (Map<String, Object>) result;
+    }
+
     private static By assertionChoice(String label) {
         return By.xpath("//*[@id='shaft-capture-assertion-panel']//button[normalize-space()='" + label + "']");
     }
@@ -1748,6 +1928,32 @@ class ManagedCaptureRecorderBrowserTest {
                   <div id="status-banner" role="alert">Something
                     went
                     wrong</div>
+                </body>
+                </html>
+                """));
+        // Issue #4239 P1.0a: a <div role="button"> whose explicit role attribute inferredRole()
+        // prefers, next to a genuine <button> that LocatorBuilder.byRole(Role.BUTTON)'s fixed
+        // tag/attribute XPath union actually matches.
+        server.createContext("/role-self-verify", exchange -> respond(exchange, """
+                <!doctype html>
+                <html>
+                <head><title>Role Self-Verify Fixture</title></head>
+                <body>
+                  <div id="custom-button" role="button" tabindex="0">Custom Button</div>
+                  <button id="real-button">Real Button</button>
+                </body>
+                </html>
+                """));
+        // Issue #4239 P1.0b: a labeled text input (LABEL candidate) and a plain role-less,
+        // label-less element whose only accessible-name signal is its own visible text.
+        server.createContext("/xpath-fallback", exchange -> respond(exchange, """
+                <!doctype html>
+                <html>
+                <head><title>Xpath Fallback Fixture</title></head>
+                <body>
+                  <label for="labeled-input">Username</label>
+                  <input id="labeled-input" type="text" aria-label="Enter your username">
+                  <span id="roleless-text" onclick="void 0">Click me plain span</span>
                 </body>
                 </html>
                 """));


### PR DESCRIPTION
Part of #4239 (Phase 1, items P1.0a/P1.0b).

## Summary

Per the P1.4 architectural-decision comment on #4239, this lands the two recorder-side prerequisites that the revised locator ladder depends on, before any CaptureGenerator/LocatorRanker work starts.

- **P1.0a**: `LocatorBuilder.byRole(Role.X)` compiles each role to a FIXED tag/attribute XPath union (`LocatorBuilder.java:144-190`) that never inspects the `role` attribute, but the recorder's `inferredRole` prefers an explicit `role="..."` attribute over tag shape. A `<div role="button">` therefore produced a ROLE candidate whose `uniquenessCount` (re-deriving `inferredRole` across the page) truthfully reported 1, while `SHAFT.GUI.Locator.hasRole(Role.BUTTON)` would ship an XPath matching zero elements at replay. The recorder now ports that exact union (plus `CaptureGenerator#ariaRole`'s ARIA-name mappings) and self-verifies each ROLE candidate against it in-page, recording the result as a new `roleXpathVerified` boolean. This is a recorder-only signal for now -- `LocatorCandidate`/`CaptureGenerator`/`LocatorRanker` are untouched; a later task decides how to consume it.
- **P1.0b**: `computeReplayXpath` (the existing self-verified-XPath mechanism) had exactly one call site, inside the ROLE branch. It is now computed once per element and reused for LABEL candidates and for elements with no inferred role/label at all (a new `XPATH`-strategy candidate, using the `LocatorCandidate.LocatorStrategy.XPATH` value the Java model already defines but the recorder never emitted before).

## Measurement

Drove a representative battery of 9 element shapes (native button/link, aria-labeled textbox, labeled checkbox, `div[role=button]`, plain role-less `<span>` with only its own text, two icon-only buttons with no accessible name at all, and an unmapped ARIA role with multi-line text) through the real recorder. 7/9 (78%) now get a self-verified rung-1 or rung-2 candidate; the only 2 failures are genuinely icon-only, unlabeled controls with no accessible name signal at all -- exactly the "small tail" the P1.0 decision expects, not a large one.

## Testing

Followed the existing test setup for this file (no separate JS unit-test harness exists for `shaft-capture-recorder.js`; the only committed tests are the real-browser, Selenium-driven `ManagedCaptureRecorderBrowserTest`, tagged `external-e2e`). Added two new tests there, TDD (watched red for the right reason, then green):
- `roleCandidateSelfVerifiesTheXpathLocatorBuilderWillActuallyShipAtReplay` -- reproduces Bug 1 (a `role="button"` div reports `uniquenessCount: 1` but `roleXpathVerified: false`; a genuine `<button>` verifies `true`). Reads the new field directly off the live `globalThis.__shaftCaptureUiState` seam since it has no Java-side model yet.
- `labelAndRoleLessCandidatesGetASelfVerifiedFallbackXpath` -- reproduces Bug 2 (a LABEL candidate and a role-less/label-less element both previously got a blank `replayXpath`; now both get a self-verified one, proven to resolve uniquely after a page reload, same replay-proof pattern as the existing `recordedReplayXpathResolvesTheSameElementDespiteInternalDomWhitespace` test).

Full run of the existing `ManagedCaptureRecorderBrowserTest` class (30 tests, `-DincludeCaptureBrowserE2E -DheadlessExecution=true`): 30/30 passed, confirming no regressions. `CaptureGeneratorTest`/`LocatorCandidateTest` (46 tests, default profile): 46/46 passed.

## Review

This touches locator-generation-critical logic (what ships as the actual replay locator). Recommend an independent review before merge given the correctness stakes described in #4239's P1.4 comment.