### PR TITLE
refactor(mcp,capture): extract guardrail rules into shaft-capture library (P1.2)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/guardrail/GeneratedCodeGuardrails.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/guardrail/GeneratedCodeGuardrails.java
@@ -1,0 +1,274 @@
+package com.shaft.capture.guardrail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Lexical guardrail rules for generated or agent-authored SHAFT test code, shared by any caller
+ * (MCP tools, capture code generation) that needs to check generated code without depending on
+ * shaft-mcp.
+ */
+public final class GeneratedCodeGuardrails {
+    private static final Pattern THREAD_SLEEP = Pattern.compile("\\bThread\\s*\\.\\s*sleep\\s*\\(");
+    private static final Pattern SHAFT_LOCATOR_XPATH = Pattern.compile(
+            "\\bSHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.\\s*xpath\\s*\\(");
+    private static final Pattern SMART_LOCATOR = Pattern.compile(
+            "\\bSHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.\\s*(?:clickableField|inputField)\\s*\\(");
+    private static final Pattern CLASS_BOUNDARY = Pattern.compile("\\bclass\\s+\\w+");
+    private static final Pattern TEST_ANNOTATION = Pattern.compile("@Test\\b");
+    private static final Pattern LOCATOR_DECLARATION = Pattern.compile(
+            "\\bBy\\s+\\w+\\s*=\\s*(?:SHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.|By\\s*\\.\\s*xpath\\s*\\()");
+    private static final Pattern BY_XPATH = Pattern.compile("\\bBy\\s*\\.\\s*xpath\\s*\\(\\s*\"((?:\\\\.|[^\"\\\\])*)\"");
+    private static final Pattern PAGE_FACTORY = Pattern.compile("(?:@FindBy\\b|\\bPageFactory\\b)");
+    private static final Pattern IMPLICIT_WAIT = Pattern.compile(
+            "\\.\\s*manage\\s*\\(\\s*\\)\\s*\\.\\s*timeouts\\s*\\(\\s*\\)\\s*\\.\\s*implicitlyWait\\s*\\(");
+    private static final Pattern RAW_FIND_ELEMENT = Pattern.compile("\\bdriver\\s*\\.\\s*findElements?\\s*\\(");
+    private static final Pattern HEADED_BROWSER = Pattern.compile(
+            "(?:\\.\\s*setHeadless\\s*\\(\\s*false\\s*\\)|--headed\\b|--headless\\s*=\\s*false|\\bheadless\\s*=\\s*false\\b)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern DIRECT_SYSTEM_PROPERTY = Pattern.compile("\\bSystem\\s*\\.\\s*getProperty\\s*\\(");
+    private static final Pattern HARDCODED_SECRET_ASSIGNMENT = Pattern.compile(
+            "\\b\\w*(?:password|passwd|pwd|secret|token|apikey|api_key|authorization|clientsecret|client_secret"
+                    + "|accesstoken|access_token)\\w*\\s*=\\s*\"((?:\\\\.|[^\"\\\\]){8,})\"",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern HARDCODED_SECRET_HEADER = Pattern.compile(
+            "\\b(?:put|header|setHeader|addHeader)\\s*\\(\\s*\"[^\"]*(?:authorization|token|password|secret"
+                    + "|api[-_ ]?key)[^\"]*\"\\s*,\\s*\"((?:\\\\.|[^\"\\\\]){8,})\"",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern HARDCODED_SECRET_SETTER = Pattern.compile(
+            "\\b(?:setPassword|setToken|setSecret|setApiKey|setAuthorization|bearerToken|basicAuth)\\s*\\("
+                    + "\\s*\"((?:\\\\.|[^\"\\\\]){8,})\"",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern STRING_LITERAL = Pattern.compile("\"(?:\\\\.|[^\"\\\\])*\"");
+    private static final String NO_SLEEP = "Do not generate Thread.sleep; use SHAFT waits/actions/assertions.";
+    private static final String NO_ABSOLUTE_XPATH = "Do not generate absolute XPath; prefer role-based locators,"
+            + " then the SHAFT.GUI.Locator XPath builder.";
+    private static final String NO_SHAFT_LOCATOR_XPATH = "Do not generate SHAFT.GUI.Locator.xpath; use role-based"
+            + " locators, the SHAFT locator builder, or By.xpath only as a last fallback.";
+    private static final String NO_IMPLICIT_WAIT = "Avoid Selenium implicit waits; use SHAFT waits/actions/assertions.";
+    private static final String NO_RAW_FIND_ELEMENT = "Avoid direct driver.findElement/findElements calls in generated"
+            + " SHAFT tests; route actions through SHAFT facades or page objects.";
+    private static final String NO_HEADED_BROWSER = "Do not hard-code headed browser setup; keep generated tests"
+            + " headless-configurable.";
+    private static final String NO_DIRECT_SYSTEM_PROPERTY = "Avoid direct System.getProperty() in SHAFT-like snippets;"
+            + " use SHAFT properties or injected configuration.";
+    private static final String NO_HARDCODED_SECRET = "Do not hard-code obvious header, token, or password secrets.";
+    private static final String NO_SMART_LOCATOR = "Avoid generating SHAFT.GUI.Locator.clickableField/inputField"
+            + " (intent-based smart locators); prefer role-based locators or the SHAFT locator builder instead.";
+    private static final String NO_POM_VIOLATION = "Do not declare locators (SHAFT.GUI.Locator.* or By.xpath) inside a"
+            + " class that also has @Test methods; move locators/actions into a Page Object class and keep"
+            + " orchestration in the test.";
+
+    private GeneratedCodeGuardrails() {
+    }
+
+    /**
+     * Checks generated or agent-authored code for SHAFT guardrails.
+     *
+     * @param code source code to check
+     * @return guardrail check result
+     */
+    public static GuardrailCheckResult check(String code) {
+        String source = code == null ? "" : code;
+        List<GuardrailViolation> violations = new ArrayList<>();
+        addThreadSleepViolations(source, violations);
+        addShaftLocatorXpathViolations(source, violations);
+        addSmartLocatorViolations(source, violations);
+        addPageObjectModelViolations(source, violations);
+        addAbsoluteXpathViolations(source, violations);
+        addPageFactoryWarnings(source, violations);
+        addImplicitWaitWarnings(source, violations);
+        addRawFindElementWarnings(source, violations);
+        addHeadedBrowserWarnings(source, violations);
+        addDirectSystemPropertyWarnings(source, violations);
+        addHardcodedSecretViolations(source, violations);
+        boolean passed = violations.stream().noneMatch(violation -> "ERROR".equals(violation.severity()));
+        return new GuardrailCheckResult(passed, violations);
+    }
+
+    private static void addThreadSleepViolations(String source, List<GuardrailViolation> violations) {
+        addPatternViolations(source, violations, THREAD_SLEEP, "THREAD_SLEEP", "ERROR", NO_SLEEP);
+    }
+
+    private static void addShaftLocatorXpathViolations(String source, List<GuardrailViolation> violations) {
+        addPatternViolations(source, violations, SHAFT_LOCATOR_XPATH, "SHAFT_LOCATOR_XPATH", "ERROR",
+                NO_SHAFT_LOCATOR_XPATH);
+    }
+
+    private static void addSmartLocatorViolations(String source, List<GuardrailViolation> violations) {
+        addPatternViolations(source, violations, SMART_LOCATOR, "SMART_LOCATOR", "ERROR", NO_SMART_LOCATOR);
+    }
+
+    private static void addPageObjectModelViolations(String source, List<GuardrailViolation> violations) {
+        List<Integer> boundaries = classBoundaries(source);
+        for (int i = 0; i < boundaries.size() - 1; i++) {
+            int start = boundaries.get(i);
+            String classBody = source.substring(start, boundaries.get(i + 1));
+            Matcher locatorMatcher = LOCATOR_DECLARATION.matcher(classBody);
+            if (!locatorMatcher.find() || !TEST_ANNOTATION.matcher(classBody).find()) {
+                continue;
+            }
+            int offset = start + locatorMatcher.start();
+            if (isCommentOnlyLine(source, offset)) {
+                continue;
+            }
+            violations.add(violation("POM_VIOLATION", "ERROR", NO_POM_VIOLATION, source, offset));
+        }
+    }
+
+    private static List<Integer> classBoundaries(String source) {
+        List<Integer> boundaries = new ArrayList<>();
+        Matcher classMatcher = CLASS_BOUNDARY.matcher(source);
+        while (classMatcher.find()) {
+            boundaries.add(classMatcher.start());
+        }
+        boundaries.add(source.length());
+        return boundaries;
+    }
+
+    private static void addAbsoluteXpathViolations(String source, List<GuardrailViolation> violations) {
+        Matcher matcher = BY_XPATH.matcher(source);
+        while (matcher.find()) {
+            if (isCommentOnlyLine(source, matcher.start())) {
+                continue;
+            }
+            String xpath = matcher.group(1).replace("\\\"", "\"").trim();
+            if (isAbsoluteXpath(xpath)) {
+                violations.add(violation(
+                        "ABSOLUTE_XPATH",
+                        "ERROR",
+                        NO_ABSOLUTE_XPATH,
+                        source,
+                        matcher.start()));
+            }
+        }
+    }
+
+    private static void addPageFactoryWarnings(String source, List<GuardrailViolation> violations) {
+        addPatternViolations(source, violations, PAGE_FACTORY, "PAGE_FACTORY", "WARNING",
+                "Prefer Selenium By objects and SHAFT.GUI.Locator instead of @FindBy or PageFactory.");
+    }
+
+    private static void addImplicitWaitWarnings(String source, List<GuardrailViolation> violations) {
+        addPatternViolations(source, violations, IMPLICIT_WAIT, "IMPLICIT_WAIT", "WARNING", NO_IMPLICIT_WAIT);
+    }
+
+    private static void addRawFindElementWarnings(String source, List<GuardrailViolation> violations) {
+        addPatternViolations(source, violations, RAW_FIND_ELEMENT, "RAW_FIND_ELEMENT", "WARNING", NO_RAW_FIND_ELEMENT);
+    }
+
+    private static void addHeadedBrowserWarnings(String source, List<GuardrailViolation> violations) {
+        addPatternViolations(source, violations, HEADED_BROWSER, "HEADED_BROWSER", "WARNING", NO_HEADED_BROWSER);
+    }
+
+    private static void addDirectSystemPropertyWarnings(String source, List<GuardrailViolation> violations) {
+        addPatternViolations(source, violations, DIRECT_SYSTEM_PROPERTY, "DIRECT_SYSTEM_PROPERTY", "WARNING",
+                NO_DIRECT_SYSTEM_PROPERTY);
+    }
+
+    private static void addHardcodedSecretViolations(String source, List<GuardrailViolation> violations) {
+        addSecretViolations(source, violations, HARDCODED_SECRET_ASSIGNMENT);
+        addSecretViolations(source, violations, HARDCODED_SECRET_HEADER);
+        addSecretViolations(source, violations, HARDCODED_SECRET_SETTER);
+    }
+
+    private static void addPatternViolations(
+            String source,
+            List<GuardrailViolation> violations,
+            Pattern pattern,
+            String kind,
+            String severity,
+            String message) {
+        Matcher matcher = pattern.matcher(source);
+        while (matcher.find()) {
+            if (isCommentOnlyLine(source, matcher.start())) {
+                continue;
+            }
+            violations.add(violation(kind, severity, message, source, matcher.start()));
+        }
+    }
+
+    private static void addSecretViolations(
+            String source,
+            List<GuardrailViolation> violations,
+            Pattern pattern) {
+        Matcher matcher = pattern.matcher(source);
+        while (matcher.find()) {
+            if (isCommentOnlyLine(source, matcher.start()) || !isSuspiciousSecretLiteral(matcher.group(1))) {
+                continue;
+            }
+            violations.add(secretViolation(source, matcher.start()));
+        }
+    }
+
+    private static boolean isAbsoluteXpath(String xpath) {
+        return (xpath.startsWith("/") && !xpath.startsWith("//")) || xpath.startsWith("(/");
+    }
+
+    private static boolean isSuspiciousSecretLiteral(String literal) {
+        String value = literal == null ? "" : literal.trim();
+        if (value.length() < 8 || value.contains("${")) {
+            return false;
+        }
+        String lower = value.toLowerCase(Locale.ROOT);
+        if (lower.contains("example") || lower.contains("sample") || lower.contains("dummy")
+                || lower.contains("placeholder") || lower.contains("redacted") || lower.contains("changeme")
+                || lower.contains("change-me") || lower.contains("your_") || lower.contains("your-")) {
+            return false;
+        }
+        String compact = lower.replaceAll("[^a-z0-9]+", "");
+        return switch (compact) {
+            case "authorization", "apikey", "token", "accesstoken", "password", "passwd", "pwd", "secret",
+                    "clientsecret" -> false;
+            default -> true;
+        };
+    }
+
+    private static boolean isCommentOnlyLine(String source, int offset) {
+        int lineStart = source.lastIndexOf('\n', Math.max(0, offset - 1)) + 1;
+        String prefix = source.substring(lineStart, Math.min(offset, source.length())).trim();
+        return prefix.startsWith("//") || prefix.startsWith("/*") || prefix.startsWith("*");
+    }
+
+    private static GuardrailViolation violation(
+            String kind,
+            String severity,
+            String message,
+            String source,
+            int offset) {
+        return new GuardrailViolation(kind, severity, message, lineNumber(source, offset), lineSnippet(source, offset));
+    }
+
+    private static GuardrailViolation secretViolation(String source, int offset) {
+        return new GuardrailViolation(
+                "HARDCODED_SECRET",
+                "ERROR",
+                NO_HARDCODED_SECRET,
+                lineNumber(source, offset),
+                STRING_LITERAL.matcher(lineSnippet(source, offset)).replaceAll("\"[REDACTED]\""));
+    }
+
+    private static int lineNumber(String source, int offset) {
+        int line = 1;
+        int length = Math.min(offset, source.length());
+        for (int index = 0; index < length; index++) {
+            if (source.charAt(index) == '\n') {
+                line++;
+            }
+        }
+        return line;
+    }
+
+    private static String lineSnippet(String source, int offset) {
+        int start = source.lastIndexOf('\n', Math.max(0, offset - 1)) + 1;
+        int end = source.indexOf('\n', offset);
+        if (end < 0) {
+            end = source.length();
+        }
+        String snippet = source.substring(start, end).trim();
+        return snippet.length() > 160 ? snippet.substring(0, 157) + "..." : snippet;
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/guardrail/GuardrailCheckResult.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/guardrail/GuardrailCheckResult.java
@@ -1,0 +1,18 @@
+package com.shaft.capture.guardrail;
+
+import java.util.List;
+
+/**
+ * Result of checking generated or agent-authored code against SHAFT guardrails.
+ *
+ * @param passed whether no blocking (ERROR severity) findings were detected
+ * @param violations blocking and advisory findings
+ */
+public record GuardrailCheckResult(boolean passed, List<GuardrailViolation> violations) {
+    /**
+     * Creates an immutable guardrail check result.
+     */
+    public GuardrailCheckResult {
+        violations = violations == null ? List.of() : List.copyOf(violations);
+    }
+}

--- a/shaft-capture/src/main/java/com/shaft/capture/guardrail/GuardrailViolation.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/guardrail/GuardrailViolation.java
@@ -1,0 +1,32 @@
+package com.shaft.capture.guardrail;
+
+/**
+ * Code guardrail finding produced by {@link GeneratedCodeGuardrails}.
+ *
+ * @param kind stable violation kind
+ * @param severity ERROR for blocking findings, WARNING for advisory findings
+ * @param message safe human-readable message
+ * @param line one-based line number, or 0 when unavailable
+ * @param snippet short source excerpt
+ */
+public record GuardrailViolation(
+        String kind,
+        String severity,
+        String message,
+        int line,
+        String snippet) {
+    /**
+     * Creates an immutable guardrail violation.
+     */
+    public GuardrailViolation {
+        kind = text(kind);
+        severity = severity == null || severity.isBlank() ? "ERROR" : severity.trim();
+        message = text(message);
+        line = Math.max(0, line);
+        snippet = text(snippet);
+    }
+
+    private static String text(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/guardrail/GeneratedCodeGuardrailsTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/guardrail/GeneratedCodeGuardrailsTest.java
@@ -1,0 +1,207 @@
+package com.shaft.capture.guardrail;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GeneratedCodeGuardrailsTest {
+
+    @Test
+    void rejectsThreadSleepAndAbsoluteXpath() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("""
+                import org.openqa.selenium.By;
+
+                class LoginTest {
+                    void waitsWrong() throws Exception {
+                        Thread.sleep(1000);
+                        By login = By.xpath("/html/body/div/form/button");
+                        By fallback = SHAFT.GUI.Locator.xpath("//button[@type='submit']");
+                    }
+                }
+                """);
+
+        assertFalse(result.passed());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("THREAD_SLEEP")));
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("ABSOLUTE_XPATH")));
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("SHAFT_LOCATOR_XPATH")));
+    }
+
+    @Test
+    void allowsPreferredLocatorsAndWarnsOnPageFactory() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("""
+                import com.shaft.driver.SHAFT;
+                import com.shaft.gui.internal.locator.Role;
+                import org.openqa.selenium.By;
+                import org.openqa.selenium.support.FindBy;
+
+                class LoginPage {
+                    @FindBy(id = "legacy")
+                    private Object legacy;
+                    private final By email = SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build();
+                    private final By login = SHAFT.GUI.Locator.hasRole(Role.BUTTON).build();
+                    private final By scopedFallback = By.xpath("//button[@type='submit']");
+                }
+                """);
+
+        assertTrue(result.passed());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("PAGE_FACTORY")
+                && violation.severity().equals("WARNING")));
+    }
+
+    @Test
+    void warnsOnRawSeleniumWaitsDriverCallsHeadedSetupAndSystemProperties() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("""
+                import org.openqa.selenium.By;
+                import org.openqa.selenium.WebDriver;
+                import org.openqa.selenium.chrome.ChromeOptions;
+
+                class GeneratedLoginTest {
+                    void antiPatterns(WebDriver driver) {
+                        driver.manage().timeouts().implicitlyWait(java.time.Duration.ofSeconds(5));
+                        driver.findElement(By.id("login")).click();
+                        driver.findElements(By.cssSelector(".error"));
+                        ChromeOptions options = new ChromeOptions();
+                        options.setHeadless(false);
+                        String baseUrl = System.getProperty("base.url");
+                    }
+                }
+                """);
+
+        assertTrue(result.passed());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("IMPLICIT_WAIT")
+                && violation.severity().equals("WARNING") && violation.line() == 7));
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("RAW_FIND_ELEMENT")
+                && violation.severity().equals("WARNING") && violation.line() == 8));
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("RAW_FIND_ELEMENT")
+                && violation.severity().equals("WARNING") && violation.line() == 9));
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("HEADED_BROWSER")
+                && violation.severity().equals("WARNING") && violation.line() == 11));
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("DIRECT_SYSTEM_PROPERTY")
+                && violation.severity().equals("WARNING") && violation.line() == 12));
+    }
+
+    @Test
+    void rejectsHardcodedSecretsAndRedactsSecretSnippet() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("""
+                import java.util.Map;
+
+                class GeneratedApiTest {
+                    void leaksSecret(Map<String, String> headers) {
+                        headers.put("Authorization", "Bearer sk_live_1234567890abcdef");
+                    }
+                }
+                """);
+
+        assertFalse(result.passed());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("HARDCODED_SECRET")
+                && violation.severity().equals("ERROR")
+                && violation.line() == 5
+                && violation.snippet().contains("[REDACTED]")
+                && !violation.snippet().contains("sk_live_1234567890abcdef")));
+    }
+
+    @Test
+    void allowsShaftFacadeAndRoleBasedLocatorUsage() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("""
+                import com.shaft.driver.SHAFT;
+                import com.shaft.gui.internal.locator.Role;
+                import org.openqa.selenium.By;
+
+                class LoginPage {
+                    private final By email = SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build();
+                    private final By submit = SHAFT.GUI.Locator.hasRole(Role.BUTTON).build();
+
+                    void login(SHAFT.GUI.WebDriver browser) {
+                        browser.element().type(email, "user@example.com");
+                        browser.element().click(submit);
+                    }
+                }
+                """);
+
+        assertTrue(result.passed());
+        assertTrue(result.violations().isEmpty());
+    }
+
+    @Test
+    void rejectsIntentBasedSmartLocatorUsage() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("""
+                import com.shaft.driver.SHAFT;
+                import org.openqa.selenium.By;
+
+                class LoginPage {
+                    private final By email = SHAFT.GUI.Locator.inputField("Email");
+                    private final By submit = SHAFT.GUI.Locator.clickableField("Sign In");
+                }
+                """);
+
+        assertFalse(result.passed());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("SMART_LOCATOR")
+                && violation.severity().equals("ERROR") && violation.line() == 5));
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("SMART_LOCATOR")
+                && violation.severity().equals("ERROR") && violation.line() == 6));
+    }
+
+    @Test
+    void rejectsLocatorDeclaredInsideTestAnnotatedClass() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("""
+                import com.shaft.driver.SHAFT;
+                import com.shaft.gui.internal.locator.Role;
+                import org.openqa.selenium.By;
+                import org.testng.annotations.Test;
+
+                class CheckoutTest {
+                    private final By checkoutButton = SHAFT.GUI.Locator.hasRole(Role.BUTTON)
+                            .hasText("Checkout").build();
+
+                    @Test
+                    void checkout(SHAFT.GUI.WebDriver driver) {
+                        driver.element().click(checkoutButton);
+                    }
+                }
+                """);
+
+        assertFalse(result.passed());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("POM_VIOLATION")
+                && violation.severity().equals("ERROR")));
+    }
+
+    @Test
+    void allowsLocatorsDeclaredInSeparatePageObjectFromTestClass() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("""
+                import com.shaft.driver.SHAFT;
+                import com.shaft.gui.internal.locator.Role;
+                import org.openqa.selenium.By;
+                import org.testng.annotations.Test;
+
+                public final class LoginPage {
+                    private final By email = SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build();
+                    private final By submit = SHAFT.GUI.Locator.hasRole(Role.BUTTON).build();
+
+                    public LoginPage login(SHAFT.GUI.WebDriver driver, String user, String password) {
+                        driver.element().type(email, user);
+                        driver.element().click(submit);
+                        return this;
+                    }
+                }
+
+                class LoginTest {
+                    @Test
+                    void login(SHAFT.GUI.WebDriver driver) {
+                        new LoginPage(driver).login(driver, "user@example.com", "secret123");
+                    }
+                }
+                """);
+
+        assertTrue(result.passed());
+        assertTrue(result.violations().stream().noneMatch(violation -> violation.kind().equals("POM_VIOLATION")));
+    }
+
+    @Test
+    void noCodeSuppliedYieldsNoViolationsAndPasses() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("");
+
+        assertTrue(result.passed());
+        assertTrue(result.violations().isEmpty());
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/TestAutomationService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/TestAutomationService.java
@@ -1,12 +1,14 @@
 package com.shaft.mcp;
 
+import com.shaft.capture.guardrail.GeneratedCodeGuardrails;
+import com.shaft.capture.guardrail.GuardrailCheckResult;
+import com.shaft.capture.guardrail.GuardrailViolation;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -16,37 +18,6 @@ import java.util.regex.Pattern;
 public class TestAutomationService {
     private static final int MAX_RESULTS = 50;
     private static final Pattern TOKEN_SPLIT = Pattern.compile("[^a-z0-9]+");
-    private static final Pattern THREAD_SLEEP = Pattern.compile("\\bThread\\s*\\.\\s*sleep\\s*\\(");
-    private static final Pattern SHAFT_LOCATOR_XPATH = Pattern.compile(
-            "\\bSHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.\\s*xpath\\s*\\(");
-    private static final Pattern SMART_LOCATOR = Pattern.compile(
-            "\\bSHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.\\s*(?:clickableField|inputField)\\s*\\(");
-    private static final Pattern CLASS_BOUNDARY = Pattern.compile("\\bclass\\s+\\w+");
-    private static final Pattern TEST_ANNOTATION = Pattern.compile("@Test\\b");
-    private static final Pattern LOCATOR_DECLARATION = Pattern.compile(
-            "\\bBy\\s+\\w+\\s*=\\s*(?:SHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.|By\\s*\\.\\s*xpath\\s*\\()");
-    private static final Pattern BY_XPATH = Pattern.compile("\\bBy\\s*\\.\\s*xpath\\s*\\(\\s*\"((?:\\\\.|[^\"\\\\])*)\"");
-    private static final Pattern PAGE_FACTORY = Pattern.compile("(?:@FindBy\\b|\\bPageFactory\\b)");
-    private static final Pattern IMPLICIT_WAIT = Pattern.compile(
-            "\\.\\s*manage\\s*\\(\\s*\\)\\s*\\.\\s*timeouts\\s*\\(\\s*\\)\\s*\\.\\s*implicitlyWait\\s*\\(");
-    private static final Pattern RAW_FIND_ELEMENT = Pattern.compile("\\bdriver\\s*\\.\\s*findElements?\\s*\\(");
-    private static final Pattern HEADED_BROWSER = Pattern.compile(
-            "(?:\\.\\s*setHeadless\\s*\\(\\s*false\\s*\\)|--headed\\b|--headless\\s*=\\s*false|\\bheadless\\s*=\\s*false\\b)",
-            Pattern.CASE_INSENSITIVE);
-    private static final Pattern DIRECT_SYSTEM_PROPERTY = Pattern.compile("\\bSystem\\s*\\.\\s*getProperty\\s*\\(");
-    private static final Pattern HARDCODED_SECRET_ASSIGNMENT = Pattern.compile(
-            "\\b\\w*(?:password|passwd|pwd|secret|token|apikey|api_key|authorization|clientsecret|client_secret"
-                    + "|accesstoken|access_token)\\w*\\s*=\\s*\"((?:\\\\.|[^\"\\\\]){8,})\"",
-            Pattern.CASE_INSENSITIVE);
-    private static final Pattern HARDCODED_SECRET_HEADER = Pattern.compile(
-            "\\b(?:put|header|setHeader|addHeader)\\s*\\(\\s*\"[^\"]*(?:authorization|token|password|secret"
-                    + "|api[-_ ]?key)[^\"]*\"\\s*,\\s*\"((?:\\\\.|[^\"\\\\]){8,})\"",
-            Pattern.CASE_INSENSITIVE);
-    private static final Pattern HARDCODED_SECRET_SETTER = Pattern.compile(
-            "\\b(?:setPassword|setToken|setSecret|setApiKey|setAuthorization|bearerToken|basicAuth)\\s*\\("
-                    + "\\s*\"((?:\\\\.|[^\"\\\\]){8,})\"",
-            Pattern.CASE_INSENSITIVE);
-    private static final Pattern STRING_LITERAL = Pattern.compile("\"(?:\\\\.|[^\"\\\\])*\"");
     private static final String NO_SLEEP = "Do not generate Thread.sleep; use SHAFT waits/actions/assertions.";
     private static final String NO_ABSOLUTE_XPATH = "Do not generate absolute XPath; prefer role-based locators,"
             + " then the SHAFT.GUI.Locator XPath builder.";
@@ -59,12 +30,6 @@ public class TestAutomationService {
             + " headless-configurable.";
     private static final String NO_DIRECT_SYSTEM_PROPERTY = "Avoid direct System.getProperty() in SHAFT-like snippets;"
             + " use SHAFT properties or injected configuration.";
-    private static final String NO_HARDCODED_SECRET = "Do not hard-code obvious header, token, or password secrets.";
-    private static final String NO_SMART_LOCATOR = "Avoid generating SHAFT.GUI.Locator.clickableField/inputField"
-            + " (intent-based smart locators); prefer role-based locators or the SHAFT locator builder instead.";
-    private static final String NO_POM_VIOLATION = "Do not declare locators (SHAFT.GUI.Locator.* or By.xpath) inside a"
-            + " class that also has @Test methods; move locators/actions into a Page Object class and keep"
-            + " orchestration in the test.";
     private static final List<String> GUIDANCE_RULES = List.of(
             "Call shaft_guide_search before writing SHAFT API, GUI, mobile, CLI, DB, or troubleshooting code.",
             "Keep MCP as guidance and inspection; the calling agent writes repository files and runs validation.",
@@ -150,211 +115,28 @@ public class TestAutomationService {
                     + " raw driver calls, headed setup, direct system properties, and obvious secrets")
     public McpCodeGuardrailResult checkGeneratedCode(String language, String code) {
         String source = code == null ? "" : code;
-        List<McpCodeGuardrailViolation> violations = new ArrayList<>();
-        addThreadSleepViolations(source, violations);
-        addShaftLocatorXpathViolations(source, violations);
-        addSmartLocatorViolations(source, violations);
-        addPageObjectModelViolations(source, violations);
-        addAbsoluteXpathViolations(source, violations);
-        addPageFactoryWarnings(source, violations);
-        addImplicitWaitWarnings(source, violations);
-        addRawFindElementWarnings(source, violations);
-        addHeadedBrowserWarnings(source, violations);
-        addDirectSystemPropertyWarnings(source, violations);
-        addHardcodedSecretViolations(source, violations);
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check(source);
+        List<McpCodeGuardrailViolation> violations = result.violations().stream()
+                .map(TestAutomationService::toMcpViolation)
+                .toList();
         List<String> warnings = source.isBlank()
                 ? List.of("No code was supplied.")
                 : List.of("Lexical guardrail check only; compile/runtime validation is still required.");
-        boolean passed = violations.stream().noneMatch(violation -> "ERROR".equals(violation.severity()));
         return new McpCodeGuardrailResult(
                 McpCodeGuardrailResult.CURRENT_SCHEMA_VERSION,
                 language,
-                passed,
+                result.passed(),
                 violations,
                 warnings);
     }
 
-    private static void addThreadSleepViolations(String source, List<McpCodeGuardrailViolation> violations) {
-        addPatternViolations(source, violations, THREAD_SLEEP, "THREAD_SLEEP", "ERROR", NO_SLEEP);
-    }
-
-    private static void addShaftLocatorXpathViolations(String source, List<McpCodeGuardrailViolation> violations) {
-        addPatternViolations(source, violations, SHAFT_LOCATOR_XPATH, "SHAFT_LOCATOR_XPATH", "ERROR",
-                NO_SHAFT_LOCATOR_XPATH);
-    }
-
-    private static void addSmartLocatorViolations(String source, List<McpCodeGuardrailViolation> violations) {
-        addPatternViolations(source, violations, SMART_LOCATOR, "SMART_LOCATOR", "ERROR", NO_SMART_LOCATOR);
-    }
-
-    private static void addPageObjectModelViolations(String source, List<McpCodeGuardrailViolation> violations) {
-        List<Integer> boundaries = classBoundaries(source);
-        for (int i = 0; i < boundaries.size() - 1; i++) {
-            int start = boundaries.get(i);
-            String classBody = source.substring(start, boundaries.get(i + 1));
-            Matcher locatorMatcher = LOCATOR_DECLARATION.matcher(classBody);
-            if (!locatorMatcher.find() || !TEST_ANNOTATION.matcher(classBody).find()) {
-                continue;
-            }
-            int offset = start + locatorMatcher.start();
-            if (isCommentOnlyLine(source, offset)) {
-                continue;
-            }
-            violations.add(violation("POM_VIOLATION", "ERROR", NO_POM_VIOLATION, source, offset));
-        }
-    }
-
-    private static List<Integer> classBoundaries(String source) {
-        List<Integer> boundaries = new ArrayList<>();
-        Matcher classMatcher = CLASS_BOUNDARY.matcher(source);
-        while (classMatcher.find()) {
-            boundaries.add(classMatcher.start());
-        }
-        boundaries.add(source.length());
-        return boundaries;
-    }
-
-    private static void addAbsoluteXpathViolations(String source, List<McpCodeGuardrailViolation> violations) {
-        Matcher matcher = BY_XPATH.matcher(source);
-        while (matcher.find()) {
-            if (isCommentOnlyLine(source, matcher.start())) {
-                continue;
-            }
-            String xpath = matcher.group(1).replace("\\\"", "\"").trim();
-            if (isAbsoluteXpath(xpath)) {
-                violations.add(violation(
-                        "ABSOLUTE_XPATH",
-                        "ERROR",
-                        NO_ABSOLUTE_XPATH,
-                        source,
-                        matcher.start()));
-            }
-        }
-    }
-
-    private static void addPageFactoryWarnings(String source, List<McpCodeGuardrailViolation> violations) {
-        addPatternViolations(source, violations, PAGE_FACTORY, "PAGE_FACTORY", "WARNING",
-                "Prefer Selenium By objects and SHAFT.GUI.Locator instead of @FindBy or PageFactory.");
-    }
-
-    private static void addImplicitWaitWarnings(String source, List<McpCodeGuardrailViolation> violations) {
-        addPatternViolations(source, violations, IMPLICIT_WAIT, "IMPLICIT_WAIT", "WARNING", NO_IMPLICIT_WAIT);
-    }
-
-    private static void addRawFindElementWarnings(String source, List<McpCodeGuardrailViolation> violations) {
-        addPatternViolations(source, violations, RAW_FIND_ELEMENT, "RAW_FIND_ELEMENT", "WARNING", NO_RAW_FIND_ELEMENT);
-    }
-
-    private static void addHeadedBrowserWarnings(String source, List<McpCodeGuardrailViolation> violations) {
-        addPatternViolations(source, violations, HEADED_BROWSER, "HEADED_BROWSER", "WARNING", NO_HEADED_BROWSER);
-    }
-
-    private static void addDirectSystemPropertyWarnings(String source, List<McpCodeGuardrailViolation> violations) {
-        addPatternViolations(source, violations, DIRECT_SYSTEM_PROPERTY, "DIRECT_SYSTEM_PROPERTY", "WARNING",
-                NO_DIRECT_SYSTEM_PROPERTY);
-    }
-
-    private static void addHardcodedSecretViolations(String source, List<McpCodeGuardrailViolation> violations) {
-        addSecretViolations(source, violations, HARDCODED_SECRET_ASSIGNMENT);
-        addSecretViolations(source, violations, HARDCODED_SECRET_HEADER);
-        addSecretViolations(source, violations, HARDCODED_SECRET_SETTER);
-    }
-
-    private static void addPatternViolations(
-            String source,
-            List<McpCodeGuardrailViolation> violations,
-            Pattern pattern,
-            String kind,
-            String severity,
-            String message) {
-        Matcher matcher = pattern.matcher(source);
-        while (matcher.find()) {
-            if (isCommentOnlyLine(source, matcher.start())) {
-                continue;
-            }
-            violations.add(violation(kind, severity, message, source, matcher.start()));
-        }
-    }
-
-    private static void addSecretViolations(
-            String source,
-            List<McpCodeGuardrailViolation> violations,
-            Pattern pattern) {
-        Matcher matcher = pattern.matcher(source);
-        while (matcher.find()) {
-            if (isCommentOnlyLine(source, matcher.start()) || !isSuspiciousSecretLiteral(matcher.group(1))) {
-                continue;
-            }
-            violations.add(secretViolation(source, matcher.start()));
-        }
-    }
-
-    private static boolean isAbsoluteXpath(String xpath) {
-        return (xpath.startsWith("/") && !xpath.startsWith("//")) || xpath.startsWith("(/");
-    }
-
-    private static boolean isSuspiciousSecretLiteral(String literal) {
-        String value = literal == null ? "" : literal.trim();
-        if (value.length() < 8 || value.contains("${")) {
-            return false;
-        }
-        String lower = value.toLowerCase(Locale.ROOT);
-        if (lower.contains("example") || lower.contains("sample") || lower.contains("dummy")
-                || lower.contains("placeholder") || lower.contains("redacted") || lower.contains("changeme")
-                || lower.contains("change-me") || lower.contains("your_") || lower.contains("your-")) {
-            return false;
-        }
-        String compact = lower.replaceAll("[^a-z0-9]+", "");
-        return switch (compact) {
-            case "authorization", "apikey", "token", "accesstoken", "password", "passwd", "pwd", "secret",
-                    "clientsecret" -> false;
-            default -> true;
-        };
-    }
-
-    private static boolean isCommentOnlyLine(String source, int offset) {
-        int lineStart = source.lastIndexOf('\n', Math.max(0, offset - 1)) + 1;
-        String prefix = source.substring(lineStart, Math.min(offset, source.length())).trim();
-        return prefix.startsWith("//") || prefix.startsWith("/*") || prefix.startsWith("*");
-    }
-
-    private static McpCodeGuardrailViolation violation(
-            String kind,
-            String severity,
-            String message,
-            String source,
-            int offset) {
-        return new McpCodeGuardrailViolation(kind, severity, message, lineNumber(source, offset), lineSnippet(source, offset));
-    }
-
-    private static McpCodeGuardrailViolation secretViolation(String source, int offset) {
+    private static McpCodeGuardrailViolation toMcpViolation(GuardrailViolation violation) {
         return new McpCodeGuardrailViolation(
-                "HARDCODED_SECRET",
-                "ERROR",
-                NO_HARDCODED_SECRET,
-                lineNumber(source, offset),
-                STRING_LITERAL.matcher(lineSnippet(source, offset)).replaceAll("\"[REDACTED]\""));
-    }
-
-    private static int lineNumber(String source, int offset) {
-        int line = 1;
-        int length = Math.min(offset, source.length());
-        for (int index = 0; index < length; index++) {
-            if (source.charAt(index) == '\n') {
-                line++;
-            }
-        }
-        return line;
-    }
-
-    private static String lineSnippet(String source, int offset) {
-        int start = source.lastIndexOf('\n', Math.max(0, offset - 1)) + 1;
-        int end = source.indexOf('\n', offset);
-        if (end < 0) {
-            end = source.length();
-        }
-        String snippet = source.substring(start, end).trim();
-        return snippet.length() > 160 ? snippet.substring(0, 157) + "..." : snippet;
+                violation.kind(),
+                violation.severity(),
+                violation.message(),
+                violation.line(),
+                violation.snippet());
     }
 
     private static boolean matchesIntent(McpTestAutomationScenario scenario, String intent) {


### PR DESCRIPTION
Part of #4239 (Phase 1, item P1.2).

## Summary

- Extracts the lexical guardrail rules (`SMART_LOCATOR`, `SHAFT_LOCATOR_XPATH`, `ABSOLUTE_XPATH`, `POM_VIOLATION`, `THREAD_SLEEP`, secrets detection, etc.) out of `TestAutomationService.checkGeneratedCode` (shaft-mcp) into a new `com.shaft.capture.guardrail` package in shaft-capture: `GeneratedCodeGuardrails` (checker), `GuardrailCheckResult`, `GuardrailViolation`.
- Extraction is verbatim: same regexes, same severities, same detection order, same helper logic (`isCommentOnlyLine`, `isAbsoluteXpath`, `isSuspiciousSecretLiteral`, line/snippet computation).
- `TestAutomationService.checkGeneratedCode` is now a thin wrapper: delegates to `GeneratedCodeGuardrails.check(source)` and maps `GuardrailViolation` -> the existing `McpCodeGuardrailViolation` MCP DTO. Public method signature and return shape are unchanged, so no caller of `TestAutomationService` needs to change.

## Why here, not the reverse

`shaft-mcp` already depends on `shaft-capture` (`shaft-mcp/pom.xml`), and `shaft-capture` depends only on `shaft-engine`/`shaft-pilot-core` -- putting the library in shaft-mcp and having shaft-capture depend on it would be circular. Putting it in shaft-capture lets `CaptureGenerator` (also in shaft-capture) call the same guardrails later (P1.3) with no new dependency edge.

## Scope

This is P1.2 only: a pure library extraction. It does **not**:
- wire the new library into `CaptureGenerator` (that's P1.3, separate task -- `CaptureGenerator` does not import or reference the new type in this PR)
- change P1.1's rule severities or P1.5's marker-comment behavior
- touch `shaft-capture-recorder.js` (P1.0a/P1.0b, already merged in #4248 on a different branch)

No user-visible behavior changes.

## Test plan

- [x] Baseline: `TestAutomationServiceTest` (shaft-mcp) green before the change -- 12/12 passed.
- [x] New direct unit tests against the extracted type: `GeneratedCodeGuardrailsTest` (shaft-capture) -- 9/9 passed (mirrors the 8 guardrail-specific cases from `TestAutomationServiceTest` plus one no-code-supplied case).
- [x] Post-extraction: `TestAutomationServiceTest` re-run through the new thin wrapper -- still 12/12 passed, identical results.
- [x] Full `shaft-capture` test suite (44 test classes) -- all green, zero regressions.
- [x] `mvn -pl shaft-capture,shaft-mcp -am package -DskipTests` -- clean compile/package, confirming the dependency direction (shaft-mcp -> shaft-capture) resolves without a cycle.
- [x] Rebased onto latest `origin/main` (through #4248) and re-ran the affected tests green.