### PR TITLE
capture: make locator policy a real gate, hard ban non-ARIA fallback (issue #4239 P1.1/P1.3/P1.4a/P1.5)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -1611,7 +1611,7 @@ public final class CaptureGenerator {
         if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE && candidate.roleXpathVerified()) {
             Role ariaRole = ariaRole(target.role());
             if (ariaRole != null) {
-                return semanticName.isBlank()
+                return semanticName.isBlank() || !tagCanCarryOwnText(target.tagName())
                         ? Locator.hasRole(ariaRole).build()
                         : Locator.hasRole(ariaRole).hasNormalizedText(semanticName).build();
             }
@@ -1668,6 +1668,26 @@ public final class CaptureGenerator {
      */
     private static boolean isVerifiedRoleCandidate(LocatorCandidate candidate) {
         return candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE && candidate.roleXpathVerified();
+    }
+
+    private static final Set<String> TAGS_WITHOUT_OWN_TEXT = Set.of("input", "textarea", "select");
+
+    /**
+     * Issue #4239 P1.4a follow-up: true unless {@code tagName} is a void-of-text-children HTML form
+     * control (input/textarea/select). These tags can never carry their own visible text content, so
+     * pairing a verified ROLE locator with {@code hasNormalizedText(...)} -- which compiles to a
+     * literal {@code normalize-space(.)} predicate on the matched element itself, per {@link
+     * com.shaft.gui.internal.locator.LocatorBuilder#hasNormalizedText} -- is unconditionally
+     * unsatisfiable for them, regardless of where their accessible name actually came from (an
+     * associated {@code <label>}, {@code aria-label}, {@code placeholder}, ...): the generated code
+     * would compile fine but throw {@code NoSuchElementException} at replay, every time. {@code
+     * roleXpathVerified} alone already proves the bare role union matches this element uniquely
+     * (see {@link LocatorCandidate#roleXpathVerified()}), so omitting the name predicate for these
+     * tags costs only extra future-drift resilience -- never today's correctness -- while a
+     * button/link/heading/etc. (own text IS a legitimate name source) keeps the narrower locator.
+     */
+    private static boolean tagCanCarryOwnText(String tagName) {
+        return !TAGS_WITHOUT_OWN_TEXT.contains(tagName.toLowerCase(Locale.ROOT));
     }
 
     /**
@@ -1750,7 +1770,7 @@ public final class CaptureGenerator {
             Role ariaRole = ariaRole(target.role());
             if (ariaRole != null) {
                 String roleLocator = "SHAFT.GUI.Locator.hasRole(Role." + ariaRole.name() + ")";
-                return semanticName.isBlank()
+                return semanticName.isBlank() || !tagCanCarryOwnText(target.tagName())
                         ? roleLocator + ".build()"
                         : roleLocator + ".hasNormalizedText(\"" + javaString(semanticName) + "\").build()";
             }

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -9,6 +9,8 @@ import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ObjectNode;
 import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.guardrail.GeneratedCodeGuardrails;
+import com.shaft.capture.guardrail.GuardrailViolation;
 import com.shaft.capture.model.CaptureEvent;
 import com.shaft.capture.model.CaptureReadiness;
 import com.shaft.capture.model.CaptureSession;
@@ -300,6 +302,12 @@ public final class CaptureGenerator {
             privacy.addAll(privacyFindings(source, privacyRoot));
             privacy.addAll(privacyFindings(dataJson, privacyRoot));
             privacy.stream().distinct().forEach(state.unsupported()::add);
+            // Issue #4239 P1.3: belt-and-braces, not primary enforcement -- the P1.4-decision ladder
+            // (see the per-target rung-1/rung-2 filtering above) already makes a locator-strategy
+            // guardrail violation unreachable by construction. This defends the OTHER shared rules
+            // (Thread.sleep, POM violations, hardcoded secrets, ...) against a future regression in
+            // codegen ever rendering something the guardrail library would reject.
+            guardrailUnsupportedFindings(source).forEach(state.unsupported()::add);
             validateOutputs(paths, request.overwrite(), state.unsupported());
 
             if (!state.unsupported().isEmpty()) {
@@ -485,14 +493,27 @@ public final class CaptureGenerator {
                                     + "SHAFT codegen defect: " + safeMessage(cause),
                             cause);
                 }
+                Optional<LocatorRanker.LocatorSelection> laddered = ladderSelection(selection);
+                if (laddered.isEmpty()) {
+                    // Issue #4239 P1.4-decision ladder, rung 3: nothing in the recorded evidence is a
+                    // self-verified ARIA role (rung 1) or a self-verified XPath (rung 2) -- refuse to
+                    // fall back to .id/.name/.cssSelector rather than silently emitting a locator this
+                    // policy no longer trusts.
+                    unsupported.add(eventId + ": element " + target.logicalElementId()
+                            + " has no rung-1 (self-verified ARIA role) or rung-2 (self-verified XPath) "
+                            + "locator evidence. Re-record with a stable ARIA role or accessible name/label "
+                            + "so the recorder can compute a self-verified locator.");
+                    return;
+                }
+                LocatorRanker.LocatorSelection ladderedSelection = laddered.get();
                 MutableTargetPlan existing = targets.computeIfAbsent(
                         target.logicalElementId(),
-                        ignored -> new MutableTargetPlan(target, event.context(), selection));
+                        ignored -> new MutableTargetPlan(target, event.context(), ladderedSelection));
                 existing.eventIds.add(eventId);
-                if (selection.selected().score() > existing.selection.selected().score()) {
+                if (ladderedSelection.selected().score() > existing.selection.selected().score()) {
                     existing.target = target;
                     existing.context = event.context();
-                    existing.selection = selection;
+                    existing.selection = ladderedSelection;
                 }
             });
         }
@@ -660,6 +681,72 @@ public final class CaptureGenerator {
                 || verification == CaptureEvent.VerificationKind.SCREENSHOT_MATCHES) && negated) {
             unsupported.add(eventId + ": " + verification + " does not support negated verification.");
         }
+    }
+
+    /**
+     * Issue #4239 P1.3: checks {@code source} against the shared {@link GeneratedCodeGuardrails}
+     * library (the P1.2 extraction) and renders its ERROR-severity findings as actionable
+     * unsupported-generation messages. WARNING-severity findings are intentionally not gated here --
+     * only ERROR findings block generation, matching {@link GeneratedCodeGuardrails#check}'s own
+     * {@code passed} semantics. Package-private so it is directly unit-testable: the P1.4-decision
+     * ladder makes a locator-strategy violation unreachable through a full {@code generate()} call,
+     * so the wiring itself is proven in isolation rather than end-to-end.
+     *
+     * @param source rendered generated test source
+     * @return actionable messages for each ERROR-severity guardrail violation, empty when none
+     */
+    static List<String> guardrailUnsupportedFindings(String source) {
+        return GeneratedCodeGuardrails.check(source).violations().stream()
+                .filter(violation -> "ERROR".equals(violation.severity()))
+                .map(CaptureGenerator::guardrailUnsupportedMessage)
+                .toList();
+    }
+
+    private static String guardrailUnsupportedMessage(GuardrailViolation violation) {
+        return "guardrail-" + violation.kind() + " (line " + violation.line() + "): " + violation.message()
+                + " -- " + violation.snippet();
+    }
+
+    /**
+     * Issue #4239 P1.4-decision ladder: filters {@code raw}'s fully-ranked candidate list (selected
+     * candidate plus alternatives, already deterministically ordered by {@link LocatorRanker}) down
+     * to only rung-1 (self-verified ARIA role) or rung-2 (self-verified XPath) eligible candidates,
+     * preserving relative order, and returns the highest-ranked survivor as the new selection. Empty
+     * when nothing in the recorded evidence clears either rung -- callers must treat that as
+     * generation-blocking (rung 3: {@code state.unsupported()}), never fall back to the raw
+     * ranker output.
+     *
+     * @param raw the ranker's unfiltered selection
+     * @return the ladder-filtered selection, or empty when no candidate is rung-1/rung-2 eligible
+     */
+    private static Optional<LocatorRanker.LocatorSelection> ladderSelection(LocatorRanker.LocatorSelection raw) {
+        List<LocatorRanker.ScoredLocator> ranked = new ArrayList<>();
+        ranked.add(raw.selected());
+        ranked.addAll(raw.alternatives());
+        List<LocatorRanker.ScoredLocator> eligible = ranked.stream()
+                .filter(CaptureGenerator::isLadderEligible)
+                .toList();
+        if (eligible.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new LocatorRanker.LocatorSelection(
+                eligible.getFirst(), eligible.subList(1, eligible.size())));
+    }
+
+    /**
+     * True when {@code scored}'s candidate clears rung 1 (a ROLE candidate whose recorder-verified
+     * {@code roleXpathVerified} flag confirms {@code SHAFT.GUI.Locator.hasRole(...)}'s fixed XPath
+     * union will actually resolve uniquely to this element -- see {@link LocatorCandidate#roleXpathVerified()})
+     * or rung 2 (any candidate carrying a non-blank self-verified {@code replayXpath}). Every other
+     * strategy -- TEST_ID, ID, NAME, CSS, or a ROLE/LABEL/ACCESSIBLE_NAME candidate with neither
+     * signal -- is never ladder-eligible, regardless of its ranker score or uniqueness count.
+     */
+    private static boolean isLadderEligible(LocatorRanker.ScoredLocator scored) {
+        LocatorCandidate candidate = scored.candidate();
+        if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE && candidate.roleXpathVerified()) {
+            return true;
+        }
+        return !candidate.replayXpath().isBlank();
     }
 
     private static Optional<String> brittleLocatorWarning(TargetPlan target) {
@@ -1149,6 +1236,12 @@ public final class CaptureGenerator {
         if (!userDescription.isBlank()) {
             line(source, "        // Captured step: " + safeComment(userDescription));
         }
+        // Issue #4239 P1.5 (F12): a rung-2 selection (self-verified XPath, no verified ARIA role)
+        // is still ladder-eligible and gets generated, but the trust degradation was previously
+        // visible only in report.flakySteps() -- never where a human reading the generated code
+        // would see it. Disclose it right on the line that uses the degraded locator.
+        target(event).filter(target -> isRungTwoSelection(target, targets)).ifPresent(ignored ->
+                line(source, "        // SHAFT: no verified ARIA role, using recorded XPath"));
         if (optionalGuardSequences.contains(event.context().sequence())
                 && event instanceof CaptureEvent.ClickEvent value) {
             renderOptionalGuardedClick(source, value, targets, fallbackReplay);
@@ -1515,7 +1608,7 @@ public final class CaptureGenerator {
 
     private static By runtimeSemanticLocator(ElementSnapshot target, String name, LocatorCandidate candidate) {
         String semanticName = semanticName(name, candidate);
-        if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE) {
+        if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE && candidate.roleXpathVerified()) {
             Role ariaRole = ariaRole(target.role());
             if (ariaRole != null) {
                 return semanticName.isBlank()
@@ -1562,8 +1655,34 @@ public final class CaptureGenerator {
      * if the generated source actually references {@link Role}.
      */
     private static boolean needsRoleImport(List<TargetPlan> targets) {
-        return targets.stream().anyMatch(plan -> plan.selection().selected().candidate().strategy()
-                == LocatorCandidate.LocatorStrategy.ROLE && ariaRole(plan.target().role()) != null);
+        return targets.stream().anyMatch(plan -> isVerifiedRoleCandidate(plan.selection().selected().candidate())
+                && ariaRole(plan.target().role()) != null);
+    }
+
+    /**
+     * True only for a ROLE candidate that cleared rung 1's self-verification (issue #4239 ladder):
+     * {@code roleXpathVerified() == true}. A ROLE-strategy candidate can still be ladder-eligible via
+     * rung 2 (its self-verified {@code replayXpath}) when its role failed self-verification -- e.g. a
+     * {@code <div role="button">} -- in which case it must render as {@code By.xpath(...)}, never
+     * {@code hasRole(...)}, even though its {@code strategy()} is still {@code ROLE}.
+     */
+    private static boolean isVerifiedRoleCandidate(LocatorCandidate candidate) {
+        return candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE && candidate.roleXpathVerified();
+    }
+
+    /**
+     * Issue #4239 P1.5 (F12): true when {@code target}'s emitted locator is a rung-2 selection --
+     * ladder-eligible (it survived {@link #isLadderEligible}) but not a verified ARIA role. Looks up
+     * the already-selected candidate on {@code targets} rather than re-deriving it, mirroring {@link
+     * #locatorReference}; a target absent from {@code targets} (defensive fallback only) is treated
+     * as not degraded since no selection was made for it.
+     */
+    private static boolean isRungTwoSelection(ElementSnapshot target, List<TargetPlan> targets) {
+        return targets.stream()
+                .filter(plan -> plan.logicalElementId().equals(target.logicalElementId()))
+                .findFirst()
+                .map(plan -> !isVerifiedRoleCandidate(plan.selection().selected().candidate()))
+                .orElse(false);
     }
 
     private static boolean usesNativeBy(TargetPlan plan) {
@@ -1574,8 +1693,7 @@ public final class CaptureGenerator {
         if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE
                 || candidate.strategy() == LocatorCandidate.LocatorStrategy.ACCESSIBLE_NAME
                 || candidate.strategy() == LocatorCandidate.LocatorStrategy.LABEL) {
-            if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE
-                    && ariaRole(plan.target().role()) != null) {
+            if (isVerifiedRoleCandidate(candidate) && ariaRole(plan.target().role()) != null) {
                 // Resolves to SHAFT.GUI.Locator.hasRole(...), not By.xpath -- see semanticLocator().
                 return false;
             }
@@ -1628,7 +1746,7 @@ public final class CaptureGenerator {
             String name,
             LocatorCandidate candidate) {
         String semanticName = semanticName(name, candidate);
-        if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE) {
+        if (isVerifiedRoleCandidate(candidate)) {
             Role ariaRole = ariaRole(target.role());
             if (ariaRole != null) {
                 String roleLocator = "SHAFT.GUI.Locator.hasRole(Role." + ariaRole.name() + ")";

--- a/shaft-capture/src/main/java/com/shaft/capture/guardrail/GeneratedCodeGuardrails.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/guardrail/GeneratedCodeGuardrails.java
@@ -17,6 +17,14 @@ public final class GeneratedCodeGuardrails {
             "\\bSHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.\\s*xpath\\s*\\(");
     private static final Pattern SMART_LOCATOR = Pattern.compile(
             "\\bSHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.\\s*(?:clickableField|inputField)\\s*\\(");
+    // Issue #4239 P1.1: with CaptureGenerator's emission-time ladder (rung 1 verified ARIA role,
+    // rung 2 self-verified XPath, rung 3 FAILED) now the primary enforcement, this rule is the
+    // regression-catching backstop -- unconditional ERROR, no "only when an ARIA candidate existed"
+    // qualifier (unimplementable in a text lint: it cannot see recorded candidates, only emitted
+    // code). Deliberately excludes hasTagName/hasRole -- the SHAFT locator BUILDER methods, not these
+    // raw Selenium-strategy factories.
+    private static final Pattern NON_ARIA_LOCATOR = Pattern.compile(
+            "\\bSHAFT\\s*\\.\\s*GUI\\s*\\.\\s*Locator\\s*\\.\\s*(?:id|name|cssSelector|className|tagName)\\s*\\(");
     private static final Pattern CLASS_BOUNDARY = Pattern.compile("\\bclass\\s+\\w+");
     private static final Pattern TEST_ANNOTATION = Pattern.compile("@Test\\b");
     private static final Pattern LOCATOR_DECLARATION = Pattern.compile(
@@ -58,6 +66,9 @@ public final class GeneratedCodeGuardrails {
     private static final String NO_HARDCODED_SECRET = "Do not hard-code obvious header, token, or password secrets.";
     private static final String NO_SMART_LOCATOR = "Avoid generating SHAFT.GUI.Locator.clickableField/inputField"
             + " (intent-based smart locators); prefer role-based locators or the SHAFT locator builder instead.";
+    private static final String NO_NON_ARIA_LOCATOR = "Do not generate SHAFT.GUI.Locator.id/name/cssSelector/"
+            + "className/tagName; use a self-verified ARIA role (hasRole) or, when no role is available, a "
+            + "self-verified By.xpath.";
     private static final String NO_POM_VIOLATION = "Do not declare locators (SHAFT.GUI.Locator.* or By.xpath) inside a"
             + " class that also has @Test methods; move locators/actions into a Page Object class and keep"
             + " orchestration in the test.";
@@ -77,6 +88,7 @@ public final class GeneratedCodeGuardrails {
         addThreadSleepViolations(source, violations);
         addShaftLocatorXpathViolations(source, violations);
         addSmartLocatorViolations(source, violations);
+        addNonAriaLocatorViolations(source, violations);
         addPageObjectModelViolations(source, violations);
         addAbsoluteXpathViolations(source, violations);
         addPageFactoryWarnings(source, violations);
@@ -100,6 +112,10 @@ public final class GeneratedCodeGuardrails {
 
     private static void addSmartLocatorViolations(String source, List<GuardrailViolation> violations) {
         addPatternViolations(source, violations, SMART_LOCATOR, "SMART_LOCATOR", "ERROR", NO_SMART_LOCATOR);
+    }
+
+    private static void addNonAriaLocatorViolations(String source, List<GuardrailViolation> violations) {
+        addPatternViolations(source, violations, NON_ARIA_LOCATOR, "NON_ARIA_LOCATOR", "ERROR", NO_NON_ARIA_LOCATOR);
     }
 
     private static void addPageObjectModelViolations(String source, List<GuardrailViolation> violations) {

--- a/shaft-capture/src/main/java/com/shaft/capture/model/LocatorCandidate.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/model/LocatorCandidate.java
@@ -16,6 +16,15 @@ import java.util.Set;
  *                    candidate (issue #4026), or blank when none was computed. When present,
  *                    it is the exact string the engine resolves at replay -- record and replay
  *                    share one artifact instead of independently deriving the same locator twice.
+ * @param roleXpathVerified whether the recorder self-verified that {@code SHAFT.GUI.Locator.hasRole(...)}'s
+ *                    EXACT fixed per-role XPath union (issue #4239 P1.0a/ladder) resolves uniquely to
+ *                    this element in the live DOM. Only meaningful for {@link LocatorStrategy#ROLE}
+ *                    candidates: {@code uniquenessCount} on a ROLE candidate is derived by re-deriving
+ *                    {@code inferredRole} across the page, which can disagree with what the fixed XPath
+ *                    union {@code hasRole(...)} actually ships (e.g. a {@code <div role="button">}
+ *                    truthfully has {@code uniquenessCount == 1} yet matches zero elements via
+ *                    {@code hasRole(Role.BUTTON)}'s tag-shape union) -- this is the only signal that
+ *                    tells the two apart, so codegen's rung-1 emission gate must check it explicitly.
  */
 public record LocatorCandidate(
         LocatorStrategy strategy,
@@ -24,10 +33,12 @@ public record LocatorCandidate(
         boolean visible,
         boolean stable,
         Set<LocatorSignal> signals,
-        String replayXpath) {
+        String replayXpath,
+        boolean roleXpathVerified) {
     /**
-     * Creates immutable locator evidence with no recorded {@code replayXpath} (additive
-     * backward-compatible overload; existing 6-arg call sites keep compiling unchanged).
+     * Creates immutable locator evidence with no recorded {@code replayXpath} and
+     * {@code roleXpathVerified} defaulted to {@code false} (additive backward-compatible overload;
+     * existing 6-arg call sites keep compiling unchanged).
      *
      * @param strategy locator strategy
      * @param expression raw locator expression
@@ -43,7 +54,30 @@ public record LocatorCandidate(
             boolean visible,
             boolean stable,
             Set<LocatorSignal> signals) {
-        this(strategy, expression, uniquenessCount, visible, stable, signals, "");
+        this(strategy, expression, uniquenessCount, visible, stable, signals, "", false);
+    }
+
+    /**
+     * Creates immutable locator evidence with {@code roleXpathVerified} defaulted to {@code false}
+     * (additive backward-compatible overload; existing 7-arg call sites keep compiling unchanged).
+     *
+     * @param strategy locator strategy
+     * @param expression raw locator expression
+     * @param uniquenessCount number of matching elements observed
+     * @param visible whether the target was visible
+     * @param stable whether the evidence appeared stable
+     * @param signals additional deterministic scoring signals
+     * @param replayXpath self-verified replay XPath, or blank when none was computed
+     */
+    public LocatorCandidate(
+            LocatorStrategy strategy,
+            String expression,
+            int uniquenessCount,
+            boolean visible,
+            boolean stable,
+            Set<LocatorSignal> signals,
+            String replayXpath) {
+        this(strategy, expression, uniquenessCount, visible, stable, signals, replayXpath, false);
     }
     /**
      * Supported locator evidence strategies.

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -755,7 +755,8 @@ final class CaptureEventPipeline implements AutoCloseable {
                         bool(raw.get("visible")),
                         bool(raw.get("stable")),
                         locatorSignals(raw.get("signals")),
-                        replayXpath.value()));
+                        replayXpath.value(),
+                        bool(raw.get("roleXpathVerified"))));
             }
         }
         String targetId = logicalId.value().isBlank()

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -298,6 +298,16 @@
     if (alt) return {name: alt, source: "alt"};
     const title = text(element.getAttribute("title"));
     if (title) return {name: title, source: "title"};
+    // Issue #4239 P1.4a follow-up: an unlabeled form control's placeholder is a real, if weaker,
+    // accessible-name source (WAI-ARIA Accessible Name and Description Computation 1.2, step 2F) --
+    // browsers' own accessibility trees already expose it. Without this, every plain
+    // <input placeholder="Search"> with no <label>/aria-label (a very common real-world search-box
+    // shape) had NO accessible name at all, so the ROLE candidate below never got recorded and the
+    // hard-ban ladder had nothing to select -- not because no legitimate locator existed, but because
+    // this signal was missing. Checked below "title" and above plain text content, mirroring its
+    // fallback standing in the AccName algorithm.
+    const placeholder = text(element.getAttribute("placeholder"));
+    if (placeholder) return {name: placeholder, source: "placeholder"};
     const innerText = text(element.innerText);
     if (innerText) return {name: innerText, source: "text"};
     return {name: "", source: ""};
@@ -314,6 +324,7 @@
     "aria-label": name => `normalize-space(@aria-label)=${xpathLiteral(name)}`,
     "alt": name => `normalize-space(@alt)=${xpathLiteral(name)}`,
     "title": name => `normalize-space(@title)=${xpathLiteral(name)}`,
+    "placeholder": name => `normalize-space(@placeholder)=${xpathLiteral(name)}`,
     "text": name => `normalize-space(.)=${xpathLiteral(name)}`
   };
   // Computes and self-verifies a literal XPath for a ROLE candidate against the LIVE DOM (issue

--- a/shaft-capture/src/test/java/com/shaft/capture/CaptureFixtures.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/CaptureFixtures.java
@@ -47,6 +47,16 @@ public final class CaptureFixtures {
                                 "form input:nth-child(1)", 1, true, false,
                                 Set.of(LocatorCandidate.LocatorSignal.GENERATED,
                                         LocatorCandidate.LocatorSignal.POSITIONAL)),
+                        // Issue #4239 P1.4-decision ladder: a plain <input> with no explicit "type"
+                        // attribute genuinely matches LocatorBuilder.byRole(Role.TEXTBOX)'s fixed XPath
+                        // union (//input[not(@type)] among others), so a real recorder self-verifies
+                        // roleXpathVerified=true here -- rung 1 is the realistic, expected outcome for
+                        // this native form control (contrast the LABEL candidate below, whose accessible
+                        // name comes from an associated <label>, a signal computeReplayXpath cannot
+                        // express as a self-verified XPath -- see shaft-capture-recorder.js:289-291).
+                        new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
+                                "textbox:Username", 1, true, true,
+                                Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE), "", true),
                         new LocatorCandidate(LocatorCandidate.LocatorStrategy.LABEL,
                                 "Username", 1, true, true,
                                 Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE,

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java
@@ -89,9 +89,29 @@ class CaptureGeneratedReplayBrowserTest {
     private CaptureSession session(String url) {
         ExternalTestDataReference username = reference("data.username", "username");
         ExternalTestDataReference expected = reference("data.expected-message", "expected-message");
-        ElementSnapshot input = target("username", "input", "textbox", "Username");
-        ElementSnapshot button = target("submit", "button", "button", "Submit");
-        ElementSnapshot message = target("message", "p", "", "");
+        // Issue #4239 P1.4-decision ladder: this fixture drives a REAL generate+replay against the
+        // HTML above, so each ElementSnapshot's locator evidence must mirror what the real recorder
+        // would actually capture for that markup, not just an ID candidate the ladder now refuses to
+        // emit. <input id="username"> has a genuine <label for="username">, so a real recorder infers
+        // role=textbox and self-verifies SHAFT.GUI.Locator.hasRole(Role.TEXTBOX) resolves uniquely
+        // (rung 1); <button id="submit">Submit</button> similarly self-verifies role=button (rung 1).
+        // <p id="message"> has no ARIA role and no label, but by verification time its text content is
+        // the replayed username ("Alice", per writeData() below) -- a real recorder would self-verify
+        // a text-based XPath fallback (rung 2) exactly like this.
+        ElementSnapshot input = target("username", "input", "textbox", "Username",
+                new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
+                        "textbox:Username", 1, true, true,
+                        Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE), "", true));
+        ElementSnapshot button = target("submit", "button", "button", "Submit",
+                new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
+                        "button:Submit", 1, true, true,
+                        Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE),
+                        "//button[normalize-space(.)=\"Submit\"]", true));
+        ElementSnapshot message = target("message", "p", "", "",
+                new LocatorCandidate(LocatorCandidate.LocatorStrategy.XPATH,
+                        "//p[normalize-space(.)=\"Alice\"]", 1, true, true,
+                        Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE),
+                        "//p[normalize-space(.)=\"Alice\"]"));
         List<CaptureEvent> events = List.of(
                 new CaptureEvent.NavigationEvent(
                         CaptureFixtures.context(1),
@@ -132,7 +152,8 @@ class CaptureGeneratedReplayBrowserTest {
             String id,
             String tag,
             String role,
-            String accessibleName) {
+            String accessibleName,
+            LocatorCandidate primaryCandidate) {
         return new ElementSnapshot(
                 id,
                 tag,
@@ -140,7 +161,7 @@ class CaptureGeneratedReplayBrowserTest {
                 accessibleName,
                 accessibleName,
                 Map.of("id", id),
-                List.of(new LocatorCandidate(
+                List.of(primaryCandidate, new LocatorCandidate(
                         LocatorCandidate.LocatorStrategy.ID,
                         id,
                         1,

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorHealingSeedingTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorHealingSeedingTest.java
@@ -116,7 +116,8 @@ class CaptureGeneratorHealingSeedingTest {
                 .historyPath(expectedHistoryPath.toString());
         WebDriver driver = mock(WebDriver.class);
         when(driver.getCurrentUrl()).thenReturn("https://example.test/form");
-        By originalLocator = Locator.hasTagName("input").containsText("Username").build();
+        By originalLocator = Locator.hasRole(com.shaft.gui.internal.locator.Role.TEXTBOX)
+                .hasNormalizedText("Username").build();
         ShaftHealingProvider provider = new ShaftHealingProvider();
 
         provider.resolve(new HealingRequest(driver, originalLocator, "TYPE", true, null, null, null));
@@ -132,12 +133,37 @@ class CaptureGeneratorHealingSeedingTest {
      * request.fallbackLocators()==true}, the generated code calls {@code
      * captureReplayLocator(primary, alt1, ...)}, which can resolve to an alternate at runtime if the
      * primary degrades -- and {@code HealingSupport.locator()} keys its history lookup by exact
-     * {@code By.toString()}. {@link CaptureFixtures#target()} carries two locator candidates (a
-     * higher-scored LABEL one and a lower-scored CSS one), so the CSS one is always the unselected
-     * fallback alternative here. This proves seeding now covers that alternate, not just the primary.
+     * {@code By.toString()}. This proves seeding now covers that alternate, not just the primary.
+     *
+     * <p>Issue #4239 P1.4-decision ladder: the fallback alternative must itself clear rung 1 or rung
+     * 2 (a {@link CaptureFixtures#target()}'s lower-scored CSS candidate no longer qualifies, since
+     * CSS is never ladder-eligible), so this uses a bespoke element with a second, independently
+     * ladder-eligible {@code ACCESSIBLE_NAME} candidate carrying its own self-verified
+     * {@code replayXpath} instead.
      */
     @Test
     void fallbackCandidateAlsoLeavesFingerprintHistoryASubsequentReplayLookupFinds() throws Exception {
+        com.shaft.capture.model.ElementSnapshot usernameInput = new com.shaft.capture.model.ElementSnapshot(
+                "username-input",
+                "input",
+                "textbox",
+                "Username",
+                "Username",
+                Map.of("autocomplete", "username", "name", "username"),
+                List.of(
+                        new com.shaft.capture.model.LocatorCandidate(
+                                com.shaft.capture.model.LocatorCandidate.LocatorStrategy.ROLE,
+                                "textbox:Username", 1, true, true,
+                                java.util.Set.of(com.shaft.capture.model.LocatorCandidate.LocatorSignal.ACCESSIBLE),
+                                "", true),
+                        new com.shaft.capture.model.LocatorCandidate(
+                                com.shaft.capture.model.LocatorCandidate.LocatorStrategy.ACCESSIBLE_NAME,
+                                "Username", 1, true, true,
+                                java.util.Set.of(com.shaft.capture.model.LocatorCandidate.LocatorSignal.ACCESSIBLE),
+                                "//input[normalize-space(@aria-label)=\"Username\"]")),
+                true,
+                true,
+                false);
         CaptureSession session = new CaptureSession(
                 CaptureSession.CURRENT_SCHEMA_VERSION,
                 "healing-seed-fallback-session",
@@ -148,7 +174,7 @@ class CaptureGeneratorHealingSeedingTest {
                 List.of(
                         new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
                                 CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
-                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), CaptureFixtures.target(),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), usernameInput,
                                 CaptureEvent.MouseButton.PRIMARY, 1)),
                 List.of(),
                 List.of(),
@@ -194,10 +220,10 @@ class CaptureGeneratorHealingSeedingTest {
                 .historyPath(expectedHistoryPath.toString());
         WebDriver driver = mock(WebDriver.class);
         when(driver.getCurrentUrl()).thenReturn("https://example.test/form");
-        // The lower-scored CSS candidate from CaptureFixtures#target() -- never the primary
-        // (LABEL) By, but exactly what captureReplayLocator() falls back to at replay time if the
-        // primary degrades. Mirrors runtimeLocator()'s own CSS branch: Locator.cssSelector(expression).
-        By alternateLocator = Locator.cssSelector("form input:nth-child(1)");
+        // The lower-scored ACCESSIBLE_NAME candidate -- never the primary (verified ROLE) By, but
+        // exactly what captureReplayLocator() falls back to at replay time if the primary degrades.
+        // Mirrors runtimeLocator()'s own replayXpath branch: By.xpath(candidate.replayXpath()).
+        By alternateLocator = By.xpath("//input[normalize-space(@aria-label)=\"Username\"]");
         ShaftHealingProvider provider = new ShaftHealingProvider();
 
         provider.resolve(new HealingRequest(driver, alternateLocator, "TYPE", true, null, null, null));

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorHealingSeedingTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorHealingSeedingTest.java
@@ -116,8 +116,12 @@ class CaptureGeneratorHealingSeedingTest {
                 .historyPath(expectedHistoryPath.toString());
         WebDriver driver = mock(WebDriver.class);
         when(driver.getCurrentUrl()).thenReturn("https://example.test/form");
-        By originalLocator = Locator.hasRole(com.shaft.gui.internal.locator.Role.TEXTBOX)
-                .hasNormalizedText("Username").build();
+        // Issue #4239 P1.4a follow-up: the "username-input" fixture's ROLE candidate carries no
+        // self-verified replayXpath (its accessible name comes from an associated <label>, per
+        // CaptureFixtures.target()), and its tag ("input") structurally cannot satisfy a
+        // hasNormalizedText(...) own-text predicate -- CaptureGenerator now renders (and the runtime
+        // healing seed must key against) the bare verified-role locator instead.
+        By originalLocator = Locator.hasRole(com.shaft.gui.internal.locator.Role.TEXTBOX).build();
         ShaftHealingProvider provider = new ShaftHealingProvider();
 
         provider.resolve(new HealingRequest(driver, originalLocator, "TYPE", true, null, null, null));

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -80,8 +80,8 @@ class CaptureGeneratorTest {
         assertEquals(normalizeLineEndings(golden), normalizeLineEndings(withStableHealingHistoryPath(source)));
         assertTrue(source.contains("@AfterMethod(alwaysRun = true)"));
         assertTrue(source.contains("driver.quit();"));
-        assertTrue(source.contains("SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()"));
-        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).text()"));
+        assertTrue(source.contains("SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()"));
+        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()).text()"));
         assertFalse(source.contains("alice"));
         assertTrue(data.contains("\"username\" : \"alice\""));
         assertFalse(data.toLowerCase().contains("password"));
@@ -507,7 +507,7 @@ class CaptureGeneratorTest {
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("        loginAsAdmin();"));
         assertTrue(source.contains("    private void loginAsAdmin() throws Exception {"));
-        assertEquals(1, count(source, "driver.element().type(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()"));
+        assertEquals(1, count(source, "driver.element().type(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()"));
         assertTrue(source.indexOf("        loginAsAdmin();")
                 < source.indexOf("    private void loginAsAdmin() throws Exception {"));
         assertFalse(source.contains("FLOW_START"));
@@ -542,7 +542,7 @@ class CaptureGeneratorTest {
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("private SHAFT.GUI.Playwright driver;"));
         assertTrue(source.contains("driver = new SHAFT.GUI.Playwright();"));
-        assertTrue(source.contains("driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build());"));
+        assertTrue(source.contains("driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build());"));
         assertFalse(source.contains("DriverFactory"));
         assertFalse(source.contains("ExpectedConditions"));
     }
@@ -584,8 +584,8 @@ class CaptureGeneratorTest {
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("driver.browser().assertThat().title().contains(requiredData(\"username\"));"));
         assertTrue(source.contains("driver.browser().assertThat().text().contains(requiredData(\"username\"));"));
-        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).matchesReferenceImage();"));
-        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).doesNotMatchReferenceImage();"));
+        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()).matchesReferenceImage();"));
+        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()).doesNotMatchReferenceImage();"));
     }
 
     @Test
@@ -620,10 +620,10 @@ class CaptureGeneratorTest {
         assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains(
-                "driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build())"
+                "driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build())"
                         + ".matchesAriaSnapshot(requiredData(\"username\"));"));
         assertTrue(source.contains(
-                "driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).matchesScreenshot();"));
+                "driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()).matchesScreenshot();"));
     }
 
     @Test
@@ -708,7 +708,7 @@ class CaptureGeneratorTest {
         assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains(
-                "driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).attribute(\"autocomplete\")"
+                "driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()).attribute(\"autocomplete\")"
                         + ".isEqualTo(requiredData(\"username\"));"));
     }
 
@@ -767,7 +767,7 @@ class CaptureGeneratorTest {
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("import org.openqa.selenium.By;"));
         assertTrue(source.contains("private By captureReplayLocator(By primary, By... alternatives)"));
-        assertTrue(source.contains("captureReplayLocator(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()"),
+        assertTrue(source.contains("captureReplayLocator(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()"),
                 source);
         assertTrue(result.report().fallbackLocators().stream()
                 .anyMatch(fallback -> fallback.contains("username-input")));
@@ -1700,7 +1700,7 @@ class CaptureGeneratorTest {
         assertTrue(source.contains("public class EnrichedJourneyTest"));
         assertTrue(source.contains("public void completeCheckout()"));
         assertFalse(source.contains("private static final By USERNAME_FIELD"));
-        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).isVisible();"));
+        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()).isVisible();"));
         assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
                 applied.report().compilation().status());
     }

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -80,8 +80,8 @@ class CaptureGeneratorTest {
         assertEquals(normalizeLineEndings(golden), normalizeLineEndings(withStableHealingHistoryPath(source)));
         assertTrue(source.contains("@AfterMethod(alwaysRun = true)"));
         assertTrue(source.contains("driver.quit();"));
-        assertTrue(source.contains("SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()"));
-        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()).text()"));
+        assertTrue(source.contains("SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()"));
+        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).text()"));
         assertFalse(source.contains("alice"));
         assertTrue(data.contains("\"username\" : \"alice\""));
         assertFalse(data.toLowerCase().contains("password"));
@@ -209,9 +209,10 @@ class CaptureGeneratorTest {
                 "Pay now",
                 "",
                 Map.of("type", "submit"),
-                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.CSS,
-                        "button[type='submit']", 1, true, true,
-                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE))),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
+                        "button:Pay now", 1, true, true,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE),
+                        "", true)),
                 true,
                 true,
                 false);
@@ -506,7 +507,7 @@ class CaptureGeneratorTest {
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("        loginAsAdmin();"));
         assertTrue(source.contains("    private void loginAsAdmin() throws Exception {"));
-        assertEquals(1, count(source, "driver.element().type(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()"));
+        assertEquals(1, count(source, "driver.element().type(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()"));
         assertTrue(source.indexOf("        loginAsAdmin();")
                 < source.indexOf("    private void loginAsAdmin() throws Exception {"));
         assertFalse(source.contains("FLOW_START"));
@@ -541,7 +542,7 @@ class CaptureGeneratorTest {
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("private SHAFT.GUI.Playwright driver;"));
         assertTrue(source.contains("driver = new SHAFT.GUI.Playwright();"));
-        assertTrue(source.contains("driver.element().click(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build());"));
+        assertTrue(source.contains("driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build());"));
         assertFalse(source.contains("DriverFactory"));
         assertFalse(source.contains("ExpectedConditions"));
     }
@@ -583,8 +584,8 @@ class CaptureGeneratorTest {
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("driver.browser().assertThat().title().contains(requiredData(\"username\"));"));
         assertTrue(source.contains("driver.browser().assertThat().text().contains(requiredData(\"username\"));"));
-        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()).matchesReferenceImage();"));
-        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()).doesNotMatchReferenceImage();"));
+        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).matchesReferenceImage();"));
+        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).doesNotMatchReferenceImage();"));
     }
 
     @Test
@@ -619,10 +620,10 @@ class CaptureGeneratorTest {
         assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains(
-                "driver.element().assertThat(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build())"
+                "driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build())"
                         + ".matchesAriaSnapshot(requiredData(\"username\"));"));
         assertTrue(source.contains(
-                "driver.element().assertThat(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()).matchesScreenshot();"));
+                "driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).matchesScreenshot();"));
     }
 
     @Test
@@ -707,14 +708,54 @@ class CaptureGeneratorTest {
         assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains(
-                "driver.element().assertThat(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()).attribute(\"autocomplete\")"
+                "driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).attribute(\"autocomplete\")"
                         + ".isEqualTo(requiredData(\"username\"));"));
     }
 
+    /**
+     * Issue #4239 P1.4-decision ladder: a fallback ALTERNATIVE must clear rung 1 or rung 2 exactly
+     * like the primary candidate does -- the ladder filters {@code target.locatorCandidates()} down
+     * to only eligible entries before ranking, so a genuinely fallback-worthy element needs a SECOND
+     * independently ladder-eligible candidate (here, a distinct {@code ACCESSIBLE_NAME} candidate
+     * carrying its own self-verified {@code replayXpath}), not merely a second recorded strategy.
+     */
     @Test
     void fallbackLocatorReplayOptionEmitsCompactHelperOnlyWhenFallbacksExist() throws Exception {
-        Path session = session(CaptureFixtures.representativeSession());
-        writeCaptureData("alice");
+        ElementSnapshot usernameInput = new ElementSnapshot(
+                "username-input",
+                "input",
+                "textbox",
+                "Username",
+                "Username",
+                Map.of("autocomplete", "username", "name", "username"),
+                List.of(
+                        new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
+                                "textbox:Username", 1, true, true,
+                                java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE), "", true),
+                        new LocatorCandidate(LocatorCandidate.LocatorStrategy.ACCESSIBLE_NAME,
+                                "Username", 1, true, true,
+                                java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE),
+                                "//input[normalize-space(@aria-label)=\"Username\"]")),
+                true,
+                true,
+                false);
+        CaptureSession fallbackSession = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "fallback-locator-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(2),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), usernameInput,
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+        Path session = session(fallbackSession);
 
         CaptureGenerationResult result = new CaptureGenerator().generate(new CaptureGenerationRequest(
                 session, temp.resolve("fallback-replay"), "generated.capture", "", false,
@@ -726,7 +767,8 @@ class CaptureGeneratorTest {
         String source = Files.readString(result.sourcePath());
         assertTrue(source.contains("import org.openqa.selenium.By;"));
         assertTrue(source.contains("private By captureReplayLocator(By primary, By... alternatives)"));
-        assertTrue(source.contains("captureReplayLocator(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()"));
+        assertTrue(source.contains("captureReplayLocator(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()"),
+                source);
         assertTrue(result.report().fallbackLocators().stream()
                 .anyMatch(fallback -> fallback.contains("username-input")));
     }
@@ -823,7 +865,7 @@ class CaptureGeneratorTest {
                 Map.of(),
                 List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
                         "button:Log in", 1, true, true,
-                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE))),
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE), "", true)),
                 true,
                 true,
                 false);
@@ -920,7 +962,7 @@ class CaptureGeneratorTest {
                 Map.of(),
                 List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
                         "button:", 1, true, true,
-                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE))),
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE), "", true)),
                 true,
                 true,
                 false);
@@ -967,8 +1009,12 @@ class CaptureGeneratorTest {
                 .anyMatch(warning -> warning.contains("review/CONTROL_FLOW")), result.report().warnings().toString());
 
         String source = Files.readString(result.sourcePath());
-        assertTrue(source.contains("driver.element().click(SHAFT.GUI.Locator.cssSelector(\"[aria-label='Close cookie banner']\"));"));
-        assertFalse(source.contains("if (driver.element().getElementsCount(SHAFT.GUI.Locator.cssSelector(\"[aria-label='Close cookie banner']\")) > 0)"));
+        assertTrue(source.contains(
+                "driver.element().click(SHAFT.GUI.Locator.hasRole(Role.BUTTON)"
+                        + ".hasNormalizedText(\"Close cookie banner\").build());"));
+        assertFalse(source.contains(
+                "if (driver.element().getElementsCount(SHAFT.GUI.Locator.hasRole(Role.BUTTON)"
+                        + ".hasNormalizedText(\"Close cookie banner\").build()) > 0)"));
     }
 
     @Test
@@ -992,7 +1038,9 @@ class CaptureGeneratorTest {
 
         assertGeneratedUnconfirmed(result);
         String source = Files.readString(result.sourcePath());
-        assertTrue(source.contains("if (driver.element().getElementsCount(SHAFT.GUI.Locator.cssSelector(\"[aria-label='Close cookie banner']\")) > 0)"));
+        assertTrue(source.contains(
+                "if (driver.element().getElementsCount(SHAFT.GUI.Locator.hasRole(Role.BUTTON)"
+                        + ".hasNormalizedText(\"Close cookie banner\").build()) > 0)"));
         assertFalse(source.contains("private boolean isCaptureElementDisplayed(By locator)"));
         assertTrue(result.report().controlFlowSuggestions().stream()
                 .anyMatch(suggestion -> suggestion.kind() == CaptureGenerationReport.ControlFlowKind.OPTIONAL_GUARD
@@ -1016,8 +1064,9 @@ class CaptureGeneratorTest {
                 "Card number",
                 Map.of("name", "card"),
                 List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.XPATH,
-                        "/html/body/div[3]/form/input[1]", 1, true, false,
-                        java.util.Set.of(LocatorCandidate.LocatorSignal.POSITIONAL))),
+                        "//div[3]/form/input[1]", 1, true, false,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.POSITIONAL),
+                        "//div[3]/form/input[1]")),
                 true,
                 true,
                 false);
@@ -1029,8 +1078,9 @@ class CaptureGeneratorTest {
                 "",
                 Map.of("type", "submit"),
                 List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.XPATH,
-                        "/html/body/div[3]/form/button[2]", 1, true, false,
-                        java.util.Set.of(LocatorCandidate.LocatorSignal.POSITIONAL))),
+                        "//div[3]/form/button[2]", 1, true, false,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.POSITIONAL),
+                        "//div[3]/form/button[2]")),
                 true,
                 true,
                 false);
@@ -1650,7 +1700,7 @@ class CaptureGeneratorTest {
         assertTrue(source.contains("public class EnrichedJourneyTest"));
         assertTrue(source.contains("public void completeCheckout()"));
         assertFalse(source.contains("private static final By USERNAME_FIELD"));
-        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasTagName(\"input\").containsText(\"Username\").build()).isVisible();"));
+        assertTrue(source.contains("driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText(\"Username\").build()).isVisible();"));
         assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
                 applied.report().compilation().status());
     }
@@ -1789,9 +1839,9 @@ class CaptureGeneratorTest {
                 "Close cookie banner",
                 "Close",
                 Map.of("aria-label", "Close cookie banner", "class", "cookie-banner-close"),
-                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.CSS,
-                        "[aria-label='Close cookie banner']", 1, true, true,
-                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE))),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
+                        "button:Close cookie banner", 1, true, true,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE), "", true)),
                 true,
                 true,
                 false);
@@ -1802,9 +1852,9 @@ class CaptureGeneratorTest {
                 "Submit",
                 "",
                 Map.of("type", "submit"),
-                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.CSS,
-                        "button[type='submit']", 1, true, true,
-                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE))),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
+                        "button:Submit", 1, true, true,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE), "", true)),
                 true,
                 true,
                 false);
@@ -1962,5 +2012,194 @@ class CaptureGeneratorTest {
         assertTrue(result.report().unsupportedEvents().stream()
                         .noneMatch(message -> message.contains("event-2")),
                 result.report().unsupportedEvents().toString());
+    }
+
+    /**
+     * Issue #4239 P1.4-decision ladder, rung 1 refusal: {@code inferredRole()} prefers an explicit
+     * {@code role="button"} attribute over tag shape, so a {@code <div role="button">} produces a
+     * ROLE candidate whose {@code uniquenessCount} (re-derived via {@code inferredRole}) truthfully
+     * reports 1 -- but {@code SHAFT.GUI.Locator.hasRole(Role.BUTTON)}'s fixed XPath union
+     * ({@code //button | //input[@type='button'] | ...}) never inspects the {@code role} attribute
+     * and matches ZERO {@code <div>} elements. {@code roleXpathVerified=false} is the recorder's
+     * signal that this mismatch was caught, so rung 1 must be refused and generation must fall
+     * through to rung 2 (the self-verified {@code replayXpath}) instead of emitting the broken
+     * {@code hasRole(...)} -- and must never fall back further to the ID candidate that also exists.
+     */
+    @Test
+    void customRoleAttributeDivIsRefusedForRungOneAndFallsThroughToSelfVerifiedXpath() throws Exception {
+        Path session = session(customRoleButtonSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result = new CaptureGenerator()
+                .generate(request(session, temp.resolve("custom-role-button")));
+
+        assertGeneratedUnconfirmed(result);
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("By.xpath(\"//div[normalize-space(.)=\\\"Custom Button\\\"]\")"),
+                "a role=\"button\" div whose hasRole(...) union does not verify must fall through to "
+                        + "the self-verified recorded XPath (rung 2): " + source);
+        assertFalse(source.contains("hasRole(Role.BUTTON)"),
+                "must never emit hasRole(...) for a ROLE candidate that failed self-verification: " + source);
+        assertFalse(source.contains(".id(\"custom-button\")"),
+                "must never fall back to the ID candidate even though it also exists and is unique: "
+                        + source);
+    }
+
+    private static CaptureSession customRoleButtonSession() {
+        ElementSnapshot customButton = new ElementSnapshot(
+                "custom-button",
+                "div",
+                "button",
+                "Custom Button",
+                "",
+                Map.of("role", "button"),
+                List.of(
+                        new LocatorCandidate(LocatorCandidate.LocatorStrategy.ROLE,
+                                "button:Custom Button", 1, true, true,
+                                java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE),
+                                "//div[normalize-space(.)=\"Custom Button\"]", false),
+                        new LocatorCandidate(LocatorCandidate.LocatorStrategy.ID,
+                                "custom-button", 1, true, true,
+                                java.util.Set.of(LocatorCandidate.LocatorSignal.STABLE_ATTRIBUTE))),
+                true,
+                true,
+                false);
+        return new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "custom-role-button-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(3),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), customButton,
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+    }
+
+    /**
+     * Issue #4239 P1.4-decision ladder, rung 3: a role-less {@code <div id="x">} with no accessible
+     * name has no ROLE candidate (no role inferred) and no self-verified {@code replayXpath} (no
+     * computable name to build one from) -- only an ID candidate. The ladder must refuse to fall
+     * back to it and must FAIL generation with an actionable message instead of silently emitting
+     * {@code SHAFT.GUI.Locator.id("x")}.
+     */
+    @Test
+    void roleLessUnlabeledDivWithNoTextFailsGenerationInsteadOfFallingBackToId() throws Exception {
+        ElementSnapshot plainDiv = new ElementSnapshot(
+                "plain-div",
+                "div",
+                "",
+                "",
+                "",
+                Map.of("id", "x"),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.ID,
+                        "x", 1, true, true,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.STABLE_ATTRIBUTE))),
+                true,
+                true,
+                false);
+        CaptureSession captureSession = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "role-less-div-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(3),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), plainDiv,
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+        Path session = session(captureSession);
+
+        CaptureGenerationResult result = new CaptureGenerator()
+                .generate(request(session, temp.resolve("role-less-div")));
+
+        assertFalse(result.successful());
+        assertEquals(CaptureGenerationReport.Status.FAILED, result.report().status());
+        assertTrue(result.report().unsupportedEvents().stream()
+                        .anyMatch(message -> message.contains("plain-div")),
+                result.report().unsupportedEvents().toString());
+    }
+
+    /**
+     * Issue #4239 P1.3: {@code GeneratedCodeGuardrails} (the P1.2 extraction) is wired into
+     * {@code CaptureGenerator.generate}'s existing {@code state.unsupported()} gate as
+     * belt-and-braces. The P1.4-decision ladder makes locator-strategy guardrail violations
+     * unreachable by construction (rung 3 refuses generation before any {@code .id/.name/.cssSelector}
+     * could ever be rendered), so this is a regression-catcher for the OTHER rules the shared
+     * guardrail library also enforces (e.g. {@code Thread.sleep}), tested here directly against the
+     * wiring helper rather than through a full {@code generate()} call that no legitimate input can
+     * reach a violation through.
+     */
+    @Test
+    void guardrailUnsupportedFindingsFlagsErrorSeverityViolationsOnly() {
+        List<String> errorFindings = CaptureGenerator.guardrailUnsupportedFindings("""
+                class GeneratedTest {
+                    void step() throws InterruptedException {
+                        Thread.sleep(1000);
+                    }
+                }
+                """);
+        assertFalse(errorFindings.isEmpty(), errorFindings.toString());
+        assertTrue(errorFindings.stream().anyMatch(message -> message.contains("THREAD_SLEEP")), errorFindings.toString());
+
+        List<String> warningOnlyFindings = CaptureGenerator.guardrailUnsupportedFindings("""
+                class GeneratedTest {
+                    void step(org.openqa.selenium.WebDriver driver) {
+                        driver.manage().timeouts().implicitlyWait(java.time.Duration.ofSeconds(5));
+                    }
+                }
+                """);
+        assertTrue(warningOnlyFindings.isEmpty(), warningOnlyFindings.toString());
+    }
+
+    /**
+     * Issue #4239 P1.5 (F12): once a target degrades to rung 2 (self-verified XPath, no verified
+     * ARIA role), the generated line must disclose that -- "no verified ARIA role, using recorded
+     * XPath" -- since the F12 finding was that this information existed only in
+     * {@code report.flakySteps()}, never where a human reading the generated code would see it.
+     * Triggers on rung 2 itself (a ROLE candidate that failed self-verification, per the
+     * {@code customRoleAttributeDivIsRefusedForRungOneAndFallsThroughToSelfVerifiedXpath} fixture),
+     * not on a role+index composition -- that fallback no longer exists in this design.
+     */
+    @Test
+    void rungTwoSelectionEmitsLowTrustMarkerCommentDisclosingNoVerifiedAriaRole() throws Exception {
+        Path session = session(customRoleButtonSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result = new CaptureGenerator()
+                .generate(request(session, temp.resolve("rung-two-marker")));
+
+        assertGeneratedUnconfirmed(result);
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("// SHAFT: no verified ARIA role, using recorded XPath"), source);
+    }
+
+    /**
+     * Issue #4239 P1.5: a rung-1 (verified ARIA role) selection with a healthy score must NOT carry
+     * the rung-2 disclosure -- the marker is signal, not noise on every generated line.
+     */
+    @Test
+    void rungOneSelectionWithHealthyScoreEmitsNoLowTrustMarker() throws Exception {
+        Path session = session(CaptureFixtures.representativeSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result = new CaptureGenerator()
+                .generate(request(session, temp.resolve("rung-one-no-marker")));
+
+        assertGeneratedUnconfirmed(result);
+        String source = Files.readString(result.sourcePath());
+        assertFalse(source.contains("// SHAFT: no verified ARIA role"), source);
     }
 }

--- a/shaft-capture/src/test/java/com/shaft/capture/guardrail/GeneratedCodeGuardrailsTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/guardrail/GeneratedCodeGuardrailsTest.java
@@ -218,4 +218,55 @@ class GeneratedCodeGuardrailsTest {
         assertTrue(result.passed());
         assertTrue(result.violations().stream().noneMatch(violation -> violation.kind().equals("HARDCODED_SECRET")));
     }
+
+    /**
+     * Issue #4239 P1.1: with the emission-time ladder in {@code CaptureGenerator} now the primary
+     * enforcement (rung 1 verified ARIA role, rung 2 self-verified XPath, rung 3 FAILED), this lint
+     * rule is the regression-catching backstop -- unconditional ERROR, no "only when an ARIA
+     * candidate existed" qualifier (that qualifier is unimplementable in a text lint: it cannot see
+     * what candidates were recorded, only the emitted code). Every one of
+     * {@code id/name/cssSelector/className/tagName} is checked; {@code hasTagName}/{@code hasRole}
+     * (the SHAFT locator BUILDER, not these raw Selenium-strategy factories) must stay clean.
+     */
+    @Test
+    void rejectsNonAriaLocatorFactoriesUnconditionally() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("""
+                import com.shaft.driver.SHAFT;
+                import org.openqa.selenium.By;
+
+                class GeneratedLoginTest {
+                    By byId = SHAFT.GUI.Locator.id("login");
+                    By byName = SHAFT.GUI.Locator.name("login");
+                    By byCss = SHAFT.GUI.Locator.cssSelector(".login");
+                    By byClassName = SHAFT.GUI.Locator.className("login-form");
+                    By byTagName = SHAFT.GUI.Locator.tagName("button");
+                }
+                """);
+
+        assertFalse(result.passed());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("NON_ARIA_LOCATOR")
+                && violation.severity().equals("ERROR") && violation.line() == 5), result.violations().toString());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("NON_ARIA_LOCATOR")
+                && violation.severity().equals("ERROR") && violation.line() == 6), result.violations().toString());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("NON_ARIA_LOCATOR")
+                && violation.severity().equals("ERROR") && violation.line() == 7), result.violations().toString());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("NON_ARIA_LOCATOR")
+                && violation.severity().equals("ERROR") && violation.line() == 8), result.violations().toString());
+        assertTrue(result.violations().stream().anyMatch(violation -> violation.kind().equals("NON_ARIA_LOCATOR")
+                && violation.severity().equals("ERROR") && violation.line() == 9), result.violations().toString());
+    }
+
+    @Test
+    void hasTagNameBuilderIsNotConfusedWithTheRawTagNameFactory() {
+        GuardrailCheckResult result = GeneratedCodeGuardrails.check("""
+                import com.shaft.driver.SHAFT;
+
+                class LoginPage {
+                    private final By label = SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build();
+                }
+                """);
+
+        assertTrue(result.violations().stream().noneMatch(violation -> violation.kind().equals("NON_ARIA_LOCATOR")),
+                result.violations().toString());
+    }
 }

--- a/shaft-capture/src/test/java/com/shaft/capture/model/LocatorCandidateTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/model/LocatorCandidateTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Issue #4026: {@code replayXpath} carries the literal XPath the in-page recorder computed and
@@ -30,5 +32,32 @@ class LocatorCandidateTest {
                 Set.of(), "//div[normalize-space(.)=\"Something went wrong\"]");
 
         assertEquals("//div[normalize-space(.)=\"Something went wrong\"]", candidate.replayXpath());
+    }
+
+    @Test
+    void sevenArgConstructorDefaultsRoleXpathVerifiedToFalse() {
+        LocatorCandidate candidate = new LocatorCandidate(
+                LocatorCandidate.LocatorStrategy.ROLE, "alert:Something went wrong", 1, true, true,
+                Set.of(), "//div[normalize-space(.)=\"Something went wrong\"]");
+
+        assertFalse(candidate.roleXpathVerified());
+    }
+
+    /**
+     * Issue #4239 P1.0a/ladder: {@code roleXpathVerified} records whether the recorder self-verified
+     * that {@code SHAFT.GUI.Locator.hasRole(...)}'s EXACT fixed per-role XPath union (not the
+     * candidate's own {@code inferredRole}-based uniquenessCount) resolves uniquely to this element
+     * in the live DOM. A {@code <div role="button">} truthfully has {@code uniquenessCount == 1} via
+     * inferredRole re-derivation, yet {@code hasRole(Role.BUTTON)} matches zero {@code <div>}
+     * elements -- this flag is the only signal that can tell the two apart, so the ladder
+     * (CaptureGenerator) must be able to gate rung 1 on it.
+     */
+    @Test
+    void eightArgConstructorCarriesTheRecordedRoleXpathVerifiedFlag() {
+        LocatorCandidate candidate = new LocatorCandidate(
+                LocatorCandidate.LocatorStrategy.ROLE, "button:Real Button", 1, true, true,
+                Set.of(), "", true);
+
+        assertTrue(candidate.roleXpathVerified());
     }
 }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -104,8 +104,23 @@ class CaptureEventPipelineTest {
         pipeline.accept(signalFromContext(
                 "navigation", START.plusMillis(50), realContextId, Map.of(),
                 Map.of("action", "OPEN"), Map.of("url", "https://example.test/login")));
+        // Issue #4239 P1.4-decision ladder: usernameTarget()'s shared ID-only locator payload is no
+        // longer codegen-eligible (rung 3), which is orthogonal to what THIS test proves (window/context
+        // resolution) -- so this target carries its own self-verified ROLE candidate instead, mirroring
+        // what a real recorder emits for a plain, natively-typed <input> (matches
+        // LocatorBuilder.byRole(Role.TEXTBOX)'s fixed union unconditionally).
+        Map<String, Object> ladderEligibleUsernameTarget = target("username", "input", "textbox",
+                Map.of("name", "username", "autocomplete", "username"),
+                List.of(Map.of(
+                        "strategy", "ROLE",
+                        "expression", "textbox:username",
+                        "uniquenessCount", 1,
+                        "visible", true,
+                        "stable", true,
+                        "signals", List.of("ACCESSIBLE"),
+                        "roleXpathVerified", true)));
         pipeline.accept(signalFromContext(
-                "input", START.plusSeconds(3), "loopback", usernameTarget(),
+                "input", START.plusSeconds(3), "loopback", ladderEligibleUsernameTarget,
                 Map.of("value", "shaft.user", "committed", true), Map.of()));
         pipeline.close();
 
@@ -895,6 +910,57 @@ class CaptureEventPipelineTest {
         assertEquals("//div[normalize-space(.)=\"Something went wrong\"]", role.replayXpath(),
                 "the recorded replayXpath must survive the pipeline unchanged instead of being "
                         + "dropped: " + role);
+    }
+
+    /**
+     * Issue #4239 P1.0a/ladder: the in-page recorder self-verifies whether {@code hasRole(...)}'s
+     * fixed per-role XPath union resolves uniquely to a ROLE candidate's element, and sends it as
+     * {@code roleXpathVerified} on that locator payload entry. Until now nothing in the pipeline's
+     * raw-map parsing read that field, so it was silently dropped before reaching disk (see
+     * {@code ManagedCaptureRecorderBrowserTest#roleCandidateFromLiveState}'s javadoc) -- the ladder in
+     * {@code CaptureGenerator} needs it to gate rung-1 {@code hasRole(...)} emission, so it must
+     * survive the pipeline unchanged like {@code replayXpath} already does.
+     */
+    @Test
+    void threadsRecordedRoleXpathVerifiedFromLocatorPayloadOntoTheCandidate(@TempDir Path temp) {
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        Map<String, Object> target = Map.of(
+                "logicalElementId", "real-button",
+                "tagName", "button",
+                "role", "button",
+                "accessibleName", "Real Button",
+                "label", "",
+                "attributes", Map.of(),
+                "locators", List.of(Map.of(
+                        "strategy", "ROLE",
+                        "expression", "button:Real Button",
+                        "uniquenessCount", 1,
+                        "visible", true,
+                        "stable", true,
+                        "signals", List.of("ACCESSIBLE"),
+                        "roleXpathVerified", true)),
+                "visible", true,
+                "enabled", true,
+                "selected", false);
+        pipeline.accept(signal("click", START, target, Map.of("button", 0, "clickCount", 1), Map.of()));
+        pipeline.close();
+
+        CaptureEvent.ClickEvent click = assertInstanceOf(
+                CaptureEvent.ClickEvent.class, store.read().events().get(0));
+        LocatorCandidate role = click.target().locatorCandidates().stream()
+                .filter(candidate -> candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "A ROLE locator candidate must be recorded: " + click.target()));
+        assertTrue(role.roleXpathVerified(),
+                "the recorded roleXpathVerified flag must survive the pipeline unchanged instead of "
+                        + "being dropped: " + role);
     }
 
     @Test

--- a/shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java
+++ b/shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java
@@ -32,20 +32,20 @@ public class FormCompletedTest {
     @Test
     public void replayFormCompleted() throws Exception {
         driver.browser().navigateToURL("https://example.test/form");
-        driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build());
-        driver.element().type(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build(), requiredData("username"));
-        driver.element().clear(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build());
-        driver.element().select(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build(), requiredData("username"));
-        driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build());
-        driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build());
-        driver.element().typeFileLocationForUpload(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build(), Path.of("src/test/resources/test-data/uploads/avatar.png").toString());
+        driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build());
+        driver.element().type(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build(), requiredData("username"));
+        driver.element().clear(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build());
+        driver.element().select(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build(), requiredData("username"));
+        driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build());
+        driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build());
+        driver.element().typeFileLocationForUpload(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build(), Path.of("src/test/resources/test-data/uploads/avatar.png").toString());
         // Targeted keyboard shortcut omitted by SHAFT-only codegen.
         driver.browser().openNewTab("about:blank");
         windows.put("window-2", driver.browser().getWindowHandle());
-        driver.element().switchToIframe(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build());
+        driver.element().switchToIframe(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build());
         driver.browser().typeIntoPromptAlert(requiredData("username"));
-        driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build()).isVisible();
-        driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build()).text().isEqualTo(requiredData("username"));
+        driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()).isVisible();
+        driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).build()).text().isEqualTo(requiredData("username"));
         // Recorded checkpoint checkpoint-1 (ASSERTION). Form completed
     }
 

--- a/shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java
+++ b/shaft-capture/src/test/resources/fixtures/golden-generated-session-1.java
@@ -2,6 +2,7 @@ package generated.capture;
 
 import com.shaft.driver.DriverFactory;
 import com.shaft.driver.SHAFT;
+import com.shaft.gui.internal.locator.Role;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -11,7 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class FormCompletedTest {
-    // Capture review: readiness=READY, events=14, fallback locators=1.
+    // Capture review: readiness=READY, events=14, fallback locators=0.
     private SHAFT.GUI.WebDriver driver;
     private SHAFT.TestData.JSON testData;
     private final Map<String, String> windows = new HashMap<>();
@@ -31,20 +32,20 @@ public class FormCompletedTest {
     @Test
     public void replayFormCompleted() throws Exception {
         driver.browser().navigateToURL("https://example.test/form");
-        driver.element().click(SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build());
-        driver.element().type(SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build(), requiredData("username"));
-        driver.element().clear(SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build());
-        driver.element().select(SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build(), requiredData("username"));
-        driver.element().click(SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build());
-        driver.element().click(SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build());
-        driver.element().typeFileLocationForUpload(SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build(), Path.of("src/test/resources/test-data/uploads/avatar.png").toString());
+        driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build());
+        driver.element().type(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build(), requiredData("username"));
+        driver.element().clear(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build());
+        driver.element().select(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build(), requiredData("username"));
+        driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build());
+        driver.element().click(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build());
+        driver.element().typeFileLocationForUpload(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build(), Path.of("src/test/resources/test-data/uploads/avatar.png").toString());
         // Targeted keyboard shortcut omitted by SHAFT-only codegen.
         driver.browser().openNewTab("about:blank");
         windows.put("window-2", driver.browser().getWindowHandle());
-        driver.element().switchToIframe(SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build());
+        driver.element().switchToIframe(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build());
         driver.browser().typeIntoPromptAlert(requiredData("username"));
-        driver.element().assertThat(SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build()).isVisible();
-        driver.element().assertThat(SHAFT.GUI.Locator.hasTagName("input").containsText("Username").build()).text().isEqualTo(requiredData("username"));
+        driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build()).isVisible();
+        driver.element().assertThat(SHAFT.GUI.Locator.hasRole(Role.TEXTBOX).hasNormalizedText("Username").build()).text().isEqualTo(requiredData("username"));
         // Recorded checkpoint checkpoint-1 (ASSERTION). Form completed
     }
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of issue #4239's architecture plan (locator policy enforcement) -- P1.1, P1.3, P1.4(a), P1.5 -- building on the P1.0a/P1.0b recorder self-verification (#4248) and the P1.2 guardrail-library extraction (#4249). Issue #4239 remains open: Phases 2/3 (mobile routing, etc.) are separate follow-on work.

**The ladder mechanism (P1.4, decision (a) "hard ban"):** `CaptureGenerator` now filters each target's fully-ranked locator candidate list through an emission-time ladder before rendering:

- **Rung 1** -- a `ROLE` candidate whose `roleXpathVerified` flag confirms `SHAFT.GUI.Locator.hasRole(...)`'s fixed per-role XPath union actually resolves uniquely to the element (not just that `uniquenessCount` re-derived via `inferredRole` says so -- a `<div role="button">` can satisfy the latter while `hasRole(Role.BUTTON)` matches zero `<div>`s).
- **Rung 2** -- any candidate carrying a non-blank self-verified `replayXpath`, rendered as `By.xpath(...)`.
- **Rung 3** -- neither exists: generation is refused via `state.unsupported()` with an actionable message. The ladder never falls back to `.id()/.name()/.cssSelector()`.

**P1.1** -- a new `NON_ARIA_LOCATOR` ERROR-severity rule in `GeneratedCodeGuardrails` catches `SHAFT.GUI.Locator.id/name/cssSelector/className/tagName(...)`, a regression backstop since the ladder makes this unreachable by construction through normal generation.

**P1.3** -- wires that guardrail check into `CaptureGenerator.generate` as belt-and-braces, defending the *other* shared rules (`Thread.sleep`, POM violations, secrets, ...) against a future codegen regression.

**P1.5 (F12)** -- once a target degrades to rung 2, the generated line now carries `// SHAFT: no verified ARIA role, using recorded XPath`, surfacing trust degradation that previously only lived in `report.flakySteps()`.

A new `roleXpathVerified` boolean field on `LocatorCandidate` (additive/backward-compatible constructor overloads) threads the recorder's self-verification signal through `CaptureEventPipeline` into the ladder.

## Test plan
- [x] `mvn -o -pl shaft-capture test-compile` -- BUILD SUCCESS
- [x] `mvn -o -pl shaft-capture test -DheadlessExecution=true -Dtest=CaptureGeneratorTest,CaptureGeneratorHealingSeedingTest,GeneratedCodeGuardrailsTest,LocatorCandidateTest,CaptureEventPipelineTest` -- 94/94 passed

Part of #4239 (Phase 1 items P1.1, P1.3, P1.4(a), P1.5 -- issue stays open for later phases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcDusFExgWXGEySD34aRXT