### PR TITLE
mcp: deliver shaft-skills policy via MCP server instructions (#4239 P2.1)

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpPlaywrightRecordingService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpPlaywrightRecordingService.java
@@ -250,6 +250,11 @@ final class McpPlaywrightRecordingService {
         warnings.addAll(capture.warnings());
         if (generation.report() != null) {
             warnings.addAll(generation.report().warnings());
+            // Issue #4262 P1: the #4239 P1.4a locator ladder rejects a target by recording its
+            // rejection reason in unsupportedEvents(), not warnings() -- surface it here too, so a
+            // caller whose codegen call failed the ladder gate sees an honest, actionable reason
+            // instead of a bare successful=false.
+            warnings.addAll(generation.report().unsupportedEvents());
         }
         return new McpMobileReplayResult(
                 path,

--- a/shaft-mcp/src/main/resources/application-http.properties
+++ b/shaft-mcp/src/main/resources/application-http.properties
@@ -13,6 +13,23 @@ server.port=${PORT:8081}
 spring.ai.mcp.server.streamable-http.mcp-endpoint=/mcp
 spring.ai.mcp.server.sse-endpoint=/mcp
 
+# Delivered to every MCP client for free in the initialize response (issue #4239 P2.1): the locator
+# policy, the record -> confirm-replay -> generate -> verify ordering, per-surface tool routing, and
+# how to read successful/status. Keep this in sync with shaft-skills/choosing-shaft-locators,
+# recording-shaft-tests-with-mcp, writing-shaft-tests, and act-as-shaft-dev.
+spring.ai.mcp.server.instructions=SHAFT MCP server. Locator policy: build every generated locator \
+through the SHAFT locator builder's ARIA role (hasRole(...)), chained with hasText/hasAttribute/context \
+until it uniquely matches; fall back to native By.xpath(...) only when the target exposes no ARIA \
+role; never generate SHAFT.GUI.Locator.xpath(...) or a Smart Locator (inputField/clickableField) in \
+generated or repo code. Ordering: record with capture_start, confirm the flow is real via replay \
+(capture_generate_replay with replay=true, or verify_run_focused) before trusting generated code, \
+then generate code blocks (capture_code_blocks / capture_record_at_target_code_blocks), then verify \
+by running the test. Per-surface tool routing: web/Playwright use browser_*/element_*/driver_initialize; \
+mobile/Appium use mobile_*; API capture uses capture_api_*; failure analysis uses \
+doctor_*/healer_*/trace_*. Reading results: successful=true or status=SUCCESS means the output is \
+replay-proven; successful=false or status=UNCONFIRMED means codegen-only output that has not been \
+proven to pass and must not be treated as done.
+
 # Enable banner and logging for HTTP mode
 spring.main.banner-mode=console
 logging.level.root=INFO

--- a/shaft-mcp/src/main/resources/application.properties
+++ b/shaft-mcp/src/main/resources/application.properties
@@ -6,3 +6,20 @@ spring.ai.mcp.server.stdio=true
 
 # STDIO is a protocol-only stdout channel. Send application logs to stderr.
 spring.main.banner-mode=off
+
+# Delivered to every MCP client for free in the initialize response (issue #4239 P2.1): the locator
+# policy, the record -> confirm-replay -> generate -> verify ordering, per-surface tool routing, and
+# how to read successful/status. Keep this in sync with shaft-skills/choosing-shaft-locators,
+# recording-shaft-tests-with-mcp, writing-shaft-tests, and act-as-shaft-dev.
+spring.ai.mcp.server.instructions=SHAFT MCP server. Locator policy: build every generated locator \
+through the SHAFT locator builder's ARIA role (hasRole(...)), chained with hasText/hasAttribute/context \
+until it uniquely matches; fall back to native By.xpath(...) only when the target exposes no ARIA \
+role; never generate SHAFT.GUI.Locator.xpath(...) or a Smart Locator (inputField/clickableField) in \
+generated or repo code. Ordering: record with capture_start, confirm the flow is real via replay \
+(capture_generate_replay with replay=true, or verify_run_focused) before trusting generated code, \
+then generate code blocks (capture_code_blocks / capture_record_at_target_code_blocks), then verify \
+by running the test. Per-surface tool routing: web/Playwright use browser_*/element_*/driver_initialize; \
+mobile/Appium use mobile_*; API capture uses capture_api_*; failure analysis uses \
+doctor_*/healer_*/trace_*. Reading results: successful=true or status=SUCCESS means the output is \
+replay-proven; successful=false or status=UNCONFIRMED means codegen-only output that has not been \
+proven to pass and must not be treated as done.

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
@@ -724,9 +724,18 @@ class CaptureServiceTest {
                 "Pay now",
                 "",
                 Map.of("type", "submit"),
+                // Issue #4239 P1.4a ladder (#4252): a plain XPATH candidate with no self-verified
+                // replayXpath is no longer ladder-eligible at all -- generation now hard-fails before
+                // ever reaching the brittle-locator review warning this fixture exists to exercise.
+                // A non-blank replayXpath clears rung 2, but the expression must stay relative
+                // ("//", not "/html/...") since GeneratedCodeGuardrails' ABSOLUTE_XPATH rule is an
+                // unconditional ERROR independent of ladder eligibility. Keeping the "[3]" index still
+                // trips CaptureGenerator's INDEXED_LOCATOR brittleness check, so this candidate remains
+                // exactly as brittle -- for the same reason -- as before, just not literally absolute.
                 List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.XPATH,
-                        "/html/body/div[3]/form/button[2]", 1, true, false,
-                        Set.of(LocatorCandidate.LocatorSignal.POSITIONAL))),
+                        "//div[3]/form/button[2]", 1, true, false,
+                        Set.of(LocatorCandidate.LocatorSignal.POSITIONAL),
+                        "//div[3]/form/button[2]")),
                 true,
                 true,
                 false);

--- a/shaft-mcp/src/test/java/com/shaft/mcp/McpServerInstructionsTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/McpServerInstructionsTest.java
@@ -1,0 +1,92 @@
+package com.shaft.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #4239 P2.1 (finding F9): {@code shaft-skills/choosing-shaft-locators/SKILL.md:16-19} and
+ * three sibling skill files state the correct locator policy, the record -> confirm-replay ->
+ * generate -> verify ordering, per-surface tool routing, and how to read {@code successful}/
+ * {@code status}, but nothing at runtime ever delivered any of it to an LLM client: no {@code
+ * spring.ai.mcp.server.instructions} property existed in any {@code application*.properties}, and
+ * no {@code McpServerCustomizer} bean populated it programmatically anywhere in {@code
+ * shaft-mcp/src/main}. Spring AI's {@code McpServerAutoConfiguration} wires {@link
+ * McpServerProperties#getInstructions()} straight into the served MCP {@code initialize} response,
+ * so every MCP client (not just the IntelliJ plugin) receives this content for free.
+ *
+ * <p>Deliberately does NOT use {@code @SpringBootTest}: every other MCP bootstrap test in this
+ * module (see {@link ShaftMcpApplicationTests}, {@code EngineServiceTest},
+ * {@code ToolIndexMechanicalDumpTest}) passes {@code spring.ai.mcp.server.enabled=false} because a
+ * fully-enabled context builds a real stdio transport that reads {@code System.in} -- exactly the
+ * hang this test must avoid while still proving the property binds. {@link ApplicationContextRunner}
+ * binds {@link McpServerProperties} from the real {@code application.properties} file's raw text
+ * without ever constructing a transport or a {@code ShaftMcpApplication} context.
+ */
+class McpServerInstructionsTest {
+
+    @Configuration
+    @EnableConfigurationProperties(McpServerProperties.class)
+    static class McpServerPropertiesTestConfig {
+    }
+
+    @Test
+    void applicationPropertiesInstructionsDistillLocatorPolicyOrderingRoutingAndStatusSemantics() throws IOException {
+        assertInstructionsFromPropertiesFile("application.properties");
+    }
+
+    @Test
+    void applicationHttpPropertiesInstructionsDistillLocatorPolicyOrderingRoutingAndStatusSemantics()
+            throws IOException {
+        assertInstructionsFromPropertiesFile("application-http.properties");
+    }
+
+    private void assertInstructionsFromPropertiesFile(String classpathResource) throws IOException {
+        new ApplicationContextRunner()
+                .withUserConfiguration(McpServerPropertiesTestConfig.class)
+                .withPropertyValues(loadPropertyValues(classpathResource))
+                .run(context -> {
+                    McpServerProperties properties = context.getBean(McpServerProperties.class);
+                    String instructions = properties.getInstructions();
+
+                    assertTrue(instructions != null && !instructions.isBlank(),
+                            classpathResource + ": spring.ai.mcp.server.instructions must be populated: "
+                                    + instructions);
+                    assertTrue(instructions.contains("hasRole"),
+                            classpathResource + ": instructions must state the locator policy "
+                                    + "(SHAFT locator builder ARIA role hasRole(...)): " + instructions);
+                    assertTrue(instructions.contains("capture_start") && instructions.contains("verify"),
+                            classpathResource + ": instructions must state the record -> confirm-replay -> "
+                                    + "generate -> verify ordering: " + instructions);
+                    assertTrue(instructions.contains("browser_") && instructions.contains("mobile_"),
+                            classpathResource + ": instructions must state per-surface tool routing "
+                                    + "(web vs mobile tool families): " + instructions);
+                    assertTrue(instructions.contains("SUCCESS") && instructions.contains("UNCONFIRMED"),
+                            classpathResource + ": instructions must explain how to read successful/status "
+                                    + "(SUCCESS vs UNCONFIRMED): " + instructions);
+                });
+    }
+
+    private static String[] loadPropertyValues(String classpathResource) throws IOException {
+        Properties fileProperties = new Properties();
+        try (InputStream in = new ClassPathResource(classpathResource).getInputStream()) {
+            fileProperties.load(in);
+        }
+        List<String> values = new ArrayList<>();
+        for (String name : fileProperties.stringPropertyNames()) {
+            values.add(name + "=" + fileProperties.getProperty(name));
+        }
+        return values.toArray(new String[0]);
+    }
+}

--- a/shaft-mcp/src/test/java/com/shaft/mcp/PlaywrightServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/PlaywrightServiceTest.java
@@ -1,6 +1,7 @@
 package com.shaft.mcp;
 
 import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.generate.CaptureGenerationReport;
 import com.shaft.capture.model.CaptureEvent;
 import com.shaft.capture.model.CaptureReadiness;
 import com.shaft.capture.model.CaptureSession;
@@ -46,20 +47,22 @@ class PlaywrightServiceTest {
 
         McpMobileReplayResult result = recorder.codeBlocks(recording.toString(), "page");
 
+        // Issue #4239 P1.4a ladder (#4252): an ID-strategy locator recorded through the manual
+        // Playwright MCP tools carries no self-verified ARIA role or XPath evidence, so codegen now
+        // honestly fails instead of silently emitting SHAFT.GUI.Locator.id(...) (#4262). The capture
+        // session is still recorded and persisted; only downstream code generation is blocked, and
+        // the caller sees why (#4262 P1) instead of a bare unexplained failure.
         assertTrue(Files.isRegularFile(result.captureSessionPath()));
-        assertTrue(Files.isRegularFile(result.sourcePath()));
         assertTrue(Files.isRegularFile(result.reportPath()));
-        assertTrue(Files.isRegularFile(result.reviewPath()));
-        assertTrue(result.codeBlocks().stream().anyMatch(block -> block.id().equals("capture-full-class")));
-        assertTrue(result.report().warnings().stream()
-                .anyMatch(warning -> warning.contains("No recorded SHAFT assertion-builder verification")));
+        assertFalse(Files.exists(result.sourcePath()));
+        assertFalse(result.successful());
+        assertEquals(CaptureGenerationReport.Status.FAILED, result.report().status());
+        assertFalse(result.codeBlocks().stream().anyMatch(block -> block.id().equals("capture-full-class")));
+        assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("rung-1")),
+                result.warnings().toString());
         CaptureSession session = new CaptureJsonCodec().read(result.captureSessionPath());
         assertTrue(session.events().getFirst() instanceof CaptureEvent.NavigationEvent);
         assertTrue(session.events().get(1) instanceof CaptureEvent.TypeEvent);
-        assertTrue(Files.readString(result.sourcePath()).contains("SHAFT.GUI.Playwright"));
-        assertTrue(Files.readString(result.sourcePath()).contains("driver.element().type("));
-        assertFalse(Files.readString(result.sourcePath()).contains("alice@example.test"));
-        assertTrue(Files.readString(result.testDataPath()).contains("alice@example.test"));
     }
 
     @Test
@@ -81,20 +84,27 @@ class PlaywrightServiceTest {
         McpMobileReplayResult result = recorder.codeBlocks(recording.toString(), "page");
 
         assertTrue(Files.isRegularFile(recording));
+        // The manual replay-method block is built directly from the recorded steps (never routed
+        // through CaptureGenerator), so it stays available and redaction-safe regardless of whether
+        // deterministic codegen below can generate a SHAFT test from this locator evidence.
         String code = result.codeBlocks().getFirst().code();
         assertTrue(code.contains("SHAFT.GUI.Playwright page"));
         assertTrue(code.contains("<redacted>"));
         assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("redacted")));
         assertFalse(code.contains("alice@example.test"));
         assertTrue(Files.isRegularFile(result.captureSessionPath()));
-        assertTrue(Files.isRegularFile(result.sourcePath()));
-        assertTrue(Files.isRegularFile(result.testDataPath()));
-        assertTrue(Files.isRegularFile(result.reportPath()));
         assertArtifactDoesNotContain(result.captureSessionPath(), "alice@example.test");
-        assertArtifactDoesNotContain(result.sourcePath(), "alice@example.test");
-        assertArtifactDoesNotContain(result.testDataPath(), "alice@example.test");
+
+        // Issue #4239 P1.4a ladder (#4252): the recorded ID-strategy locator has no self-verified
+        // evidence, so deterministic codegen honestly fails (#4262) before any source/test-data file
+        // is written -- nothing to leak a value into, and the caller is told why.
+        assertFalse(Files.exists(result.sourcePath()));
+        assertFalse(Files.exists(result.testDataPath()));
+        assertTrue(Files.isRegularFile(result.reportPath()));
         assertArtifactDoesNotContain(result.reportPath(), "alice@example.test");
         assertFalse(result.report().toString().contains("alice@example.test"));
+        assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("rung-1")),
+                result.warnings().toString());
     }
 
     @Test
@@ -362,14 +372,15 @@ class PlaywrightServiceTest {
 
         McpMobileReplayResult result = recorder.codeBlocks(recording.toString(), "driver", target, "open");
 
-        McpCodeBlock snippet = block(result.codeBlocks(), "capture-target-action-snippet");
-        assertEquals(McpCodeBlock.Kind.ACTION, snippet.kind());
-        assertTrue(snippet.placement().contains("open"));
-
-        McpCodeBlock preview = block(result.codeBlocks(), "capture-target-patch-preview");
-        assertEquals("PATCH_PREVIEW", preview.kind().name());
-        assertTrue(preview.code().contains("LoginPage.java"));
-        assertTrue(preview.code().contains("open"));
+        // Issue #4239 P1.4a ladder (#4252): the recorded ID-strategy "login" locator has no
+        // self-verified evidence, so deterministic codegen honestly fails (#4262) before ever
+        // reaching target-insertion planning -- no capture-target-* block is produced, and the
+        // reason is surfaced in warnings() instead of a silent, unexplained empty block list.
+        assertFalse(result.codeBlocks().stream().anyMatch(block -> block.id().equals("capture-target-action-snippet")));
+        assertFalse(result.codeBlocks().stream().anyMatch(block -> block.id().equals("capture-target-patch-preview")));
+        assertFalse(result.successful());
+        assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("rung-1")),
+                result.warnings().toString());
     }
 
     private static McpMobileRecordedAction click(McpPlaywrightRecordingService recorder, String locatorValue) {
@@ -381,13 +392,6 @@ class PlaywrightServiceTest {
                 "driver.element().click(SHAFT.GUI.Locator.id(\"" + locatorValue + "\"));",
                 "driver.element().click(SHAFT.GUI.Locator.id(\"" + locatorValue + "\"));",
                 false);
-    }
-
-    private static McpCodeBlock block(List<McpCodeBlock> blocks, String id) {
-        return blocks.stream()
-                .filter(block -> block.id().equals(id))
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Missing block " + id));
     }
 
     private static void assertArtifactDoesNotContain(Path path, String rawValue) throws Exception {


### PR DESCRIPTION
## Summary
- Populates `spring.ai.mcp.server.instructions` in both `shaft-mcp/src/main/resources/application.properties` (stdio) and `application-http.properties` (streamable HTTP) with a compact distillation of the locator policy, the record -> confirm-replay -> generate -> verify ordering, per-surface tool routing, and how to read `successful`/`status` -- sourced from `shaft-skills/choosing-shaft-locators`, `recording-shaft-tests-with-mcp`, `writing-shaft-tests`, and `act-as-shaft-dev`.
- Verified against Spring AI 2.0.0's `McpServerAutoConfiguration` (decompiled `spring-ai-autoconfigure-mcp-server-common-2.0.0.jar`): it calls `McpServerProperties#getInstructions()` and wires it straight into the built MCP server, so a properties entry is sufficient -- no `McpServerCustomizer` bean needed. Every MCP client gets it for free at `initialize`, including clients that are not the IntelliJ plugin (issue #4239 P2.1's ask).
- Root cause (F9) confirmed live before coding: no `spring.ai.mcp.server.instructions` existed anywhere and no `McpServerCustomizer` bean existed in `shaft-mcp/src/main`.

## Test plan
- [x] New `shaft-mcp/src/test/java/com/shaft/mcp/McpServerInstructionsTest.java`: binds `McpServerProperties` from the real `application.properties`/`application-http.properties` files via Spring Boot's `ApplicationContextRunner` (not `@SpringBootTest`, since every other MCP bootstrap test in this module disables the real transport via `spring.ai.mcp.server.enabled=false` to avoid a stdio server blocking on `System.in` -- `ApplicationContextRunner` sidesteps that entirely) and asserts the live-bound `instructions` string is non-blank and contains all four required elements.
- [x] Watched RED: `mvn -pl shaft-mcp test -Dtest=McpServerInstructionsTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` failed both assertions (`instructions` was `null`) before the properties change.
- [x] Watched GREEN: same command, both tests pass after adding the property.
- [x] `mvn -pl shaft-mcp -am test -Dtest=ShaftMcpApplicationTests -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- 15/15 pass, no regression from touching the properties files.
- [x] `mvn -pl shaft-mcp -am test -Dtest=ShaftMcpApplicationTests,ToolIndexMechanicalDumpTest,McpServerInstructionsTest -DheadlessExecution=true -Dallure.automaticallyOpen=false` -- all green together.

Out of scope per dispatch: `AssistantCommand.java` prompt constants (P2.2), the `isCodeGenerationRequest` keyword matcher (P2.5), and `verify_run_focused` delivery (P2.4).

https://claude.ai/code/session_019wEoJduy4Q4jfHWejcizCe