### PR TITLE
mcp: surface honest ladder-rejection reason from Playwright manual-recording codegen (#4262 P1)

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpPlaywrightRecordingService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpPlaywrightRecordingService.java
@@ -250,6 +250,11 @@ final class McpPlaywrightRecordingService {
         warnings.addAll(capture.warnings());
         if (generation.report() != null) {
             warnings.addAll(generation.report().warnings());
+            // Issue #4262 P1: the #4239 P1.4a locator ladder rejects a target by recording its
+            // rejection reason in unsupportedEvents(), not warnings() -- surface it here too, so a
+            // caller whose codegen call failed the ladder gate sees an honest, actionable reason
+            // instead of a bare successful=false.
+            warnings.addAll(generation.report().unsupportedEvents());
         }
         return new McpMobileReplayResult(
                 path,

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
@@ -724,9 +724,18 @@ class CaptureServiceTest {
                 "Pay now",
                 "",
                 Map.of("type", "submit"),
+                // Issue #4239 P1.4a ladder (#4252): a plain XPATH candidate with no self-verified
+                // replayXpath is no longer ladder-eligible at all -- generation now hard-fails before
+                // ever reaching the brittle-locator review warning this fixture exists to exercise.
+                // A non-blank replayXpath clears rung 2, but the expression must stay relative
+                // ("//", not "/html/...") since GeneratedCodeGuardrails' ABSOLUTE_XPATH rule is an
+                // unconditional ERROR independent of ladder eligibility. Keeping the "[3]" index still
+                // trips CaptureGenerator's INDEXED_LOCATOR brittleness check, so this candidate remains
+                // exactly as brittle -- for the same reason -- as before, just not literally absolute.
                 List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.XPATH,
-                        "/html/body/div[3]/form/button[2]", 1, true, false,
-                        Set.of(LocatorCandidate.LocatorSignal.POSITIONAL))),
+                        "//div[3]/form/button[2]", 1, true, false,
+                        Set.of(LocatorCandidate.LocatorSignal.POSITIONAL),
+                        "//div[3]/form/button[2]")),
                 true,
                 true,
                 false);

--- a/shaft-mcp/src/test/java/com/shaft/mcp/PlaywrightServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/PlaywrightServiceTest.java
@@ -1,6 +1,7 @@
 package com.shaft.mcp;
 
 import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.generate.CaptureGenerationReport;
 import com.shaft.capture.model.CaptureEvent;
 import com.shaft.capture.model.CaptureReadiness;
 import com.shaft.capture.model.CaptureSession;
@@ -46,20 +47,22 @@ class PlaywrightServiceTest {
 
         McpMobileReplayResult result = recorder.codeBlocks(recording.toString(), "page");
 
+        // Issue #4239 P1.4a ladder (#4252): an ID-strategy locator recorded through the manual
+        // Playwright MCP tools carries no self-verified ARIA role or XPath evidence, so codegen now
+        // honestly fails instead of silently emitting SHAFT.GUI.Locator.id(...) (#4262). The capture
+        // session is still recorded and persisted; only downstream code generation is blocked, and
+        // the caller sees why (#4262 P1) instead of a bare unexplained failure.
         assertTrue(Files.isRegularFile(result.captureSessionPath()));
-        assertTrue(Files.isRegularFile(result.sourcePath()));
         assertTrue(Files.isRegularFile(result.reportPath()));
-        assertTrue(Files.isRegularFile(result.reviewPath()));
-        assertTrue(result.codeBlocks().stream().anyMatch(block -> block.id().equals("capture-full-class")));
-        assertTrue(result.report().warnings().stream()
-                .anyMatch(warning -> warning.contains("No recorded SHAFT assertion-builder verification")));
+        assertFalse(Files.exists(result.sourcePath()));
+        assertFalse(result.successful());
+        assertEquals(CaptureGenerationReport.Status.FAILED, result.report().status());
+        assertFalse(result.codeBlocks().stream().anyMatch(block -> block.id().equals("capture-full-class")));
+        assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("rung-1")),
+                result.warnings().toString());
         CaptureSession session = new CaptureJsonCodec().read(result.captureSessionPath());
         assertTrue(session.events().getFirst() instanceof CaptureEvent.NavigationEvent);
         assertTrue(session.events().get(1) instanceof CaptureEvent.TypeEvent);
-        assertTrue(Files.readString(result.sourcePath()).contains("SHAFT.GUI.Playwright"));
-        assertTrue(Files.readString(result.sourcePath()).contains("driver.element().type("));
-        assertFalse(Files.readString(result.sourcePath()).contains("alice@example.test"));
-        assertTrue(Files.readString(result.testDataPath()).contains("alice@example.test"));
     }
 
     @Test
@@ -81,20 +84,27 @@ class PlaywrightServiceTest {
         McpMobileReplayResult result = recorder.codeBlocks(recording.toString(), "page");
 
         assertTrue(Files.isRegularFile(recording));
+        // The manual replay-method block is built directly from the recorded steps (never routed
+        // through CaptureGenerator), so it stays available and redaction-safe regardless of whether
+        // deterministic codegen below can generate a SHAFT test from this locator evidence.
         String code = result.codeBlocks().getFirst().code();
         assertTrue(code.contains("SHAFT.GUI.Playwright page"));
         assertTrue(code.contains("<redacted>"));
         assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("redacted")));
         assertFalse(code.contains("alice@example.test"));
         assertTrue(Files.isRegularFile(result.captureSessionPath()));
-        assertTrue(Files.isRegularFile(result.sourcePath()));
-        assertTrue(Files.isRegularFile(result.testDataPath()));
-        assertTrue(Files.isRegularFile(result.reportPath()));
         assertArtifactDoesNotContain(result.captureSessionPath(), "alice@example.test");
-        assertArtifactDoesNotContain(result.sourcePath(), "alice@example.test");
-        assertArtifactDoesNotContain(result.testDataPath(), "alice@example.test");
+
+        // Issue #4239 P1.4a ladder (#4252): the recorded ID-strategy locator has no self-verified
+        // evidence, so deterministic codegen honestly fails (#4262) before any source/test-data file
+        // is written -- nothing to leak a value into, and the caller is told why.
+        assertFalse(Files.exists(result.sourcePath()));
+        assertFalse(Files.exists(result.testDataPath()));
+        assertTrue(Files.isRegularFile(result.reportPath()));
         assertArtifactDoesNotContain(result.reportPath(), "alice@example.test");
         assertFalse(result.report().toString().contains("alice@example.test"));
+        assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("rung-1")),
+                result.warnings().toString());
     }
 
     @Test
@@ -362,14 +372,15 @@ class PlaywrightServiceTest {
 
         McpMobileReplayResult result = recorder.codeBlocks(recording.toString(), "driver", target, "open");
 
-        McpCodeBlock snippet = block(result.codeBlocks(), "capture-target-action-snippet");
-        assertEquals(McpCodeBlock.Kind.ACTION, snippet.kind());
-        assertTrue(snippet.placement().contains("open"));
-
-        McpCodeBlock preview = block(result.codeBlocks(), "capture-target-patch-preview");
-        assertEquals("PATCH_PREVIEW", preview.kind().name());
-        assertTrue(preview.code().contains("LoginPage.java"));
-        assertTrue(preview.code().contains("open"));
+        // Issue #4239 P1.4a ladder (#4252): the recorded ID-strategy "login" locator has no
+        // self-verified evidence, so deterministic codegen honestly fails (#4262) before ever
+        // reaching target-insertion planning -- no capture-target-* block is produced, and the
+        // reason is surfaced in warnings() instead of a silent, unexplained empty block list.
+        assertFalse(result.codeBlocks().stream().anyMatch(block -> block.id().equals("capture-target-action-snippet")));
+        assertFalse(result.codeBlocks().stream().anyMatch(block -> block.id().equals("capture-target-patch-preview")));
+        assertFalse(result.successful());
+        assertTrue(result.warnings().stream().anyMatch(warning -> warning.contains("rung-1")),
+                result.warnings().toString());
     }
 
     private static McpMobileRecordedAction click(McpPlaywrightRecordingService recorder, String locatorValue) {
@@ -381,13 +392,6 @@ class PlaywrightServiceTest {
                 "driver.element().click(SHAFT.GUI.Locator.id(\"" + locatorValue + "\"));",
                 "driver.element().click(SHAFT.GUI.Locator.id(\"" + locatorValue + "\"));",
                 false);
-    }
-
-    private static McpCodeBlock block(List<McpCodeBlock> blocks, String id) {
-        return blocks.stream()
-                .filter(block -> block.id().equals(id))
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Missing block " + id));
     }
 
     private static void assertArtifactDoesNotContain(Path path, String rawValue) throws Exception {


### PR DESCRIPTION
## Summary

PR 1 of the staged #4262 fix (per independent architecture review). `McpPlaywrightRecordingService.codeBlocks` merged `generation.report().warnings()` into the caller-visible result but silently dropped `generation.report().unsupportedEvents()` — the list the #4239 P1.4a locator ladder (#4252) uses to record *why* a target failed rung 1 (self-verified ARIA role) / rung 2 (self-verified XPath). Every manually-recorded Playwright locator (ID/NAME/CSS/XPATH — that recording flow has no self-verification step) now hard-fails the ladder, so callers got a bare `successful=false` with no stated reason. Same failure shape PR #4241 fixed for mobile codegen/replay honesty.

- Merge `unsupportedEvents()` into the same warnings list (`McpPlaywrightRecordingService.java:249-256`).
- Does **not** touch `isLadderEligible`/`locatorExpression`, and does **not** attempt live-DOM self-verification for the Playwright adapter — that's PR 2, deferred to its own issue (referenced from #4262).
- Flipped the 3 `PlaywrightServiceTest` assertions that encoded the old pre-#4252 pass-through behavior to instead assert the new honest contract: generation fails (`successful()==false`, `status()==FAILED`), no source/test-data/code-block artifacts are produced, and `result.warnings()` states the rung-1/rung-2 reason. The manual replay-method block (built directly from recorded steps, never routed through `CaptureGenerator`) and its redaction guarantees are unaffected and still verified.

## Test plan
- [x] Watched RED: reverted `PlaywrightServiceTest` assertions failed with the expected reason (missing "rung-1" text in `result.warnings()`) before the production fix.
- [x] Watched GREEN: `mvn -pl shaft-mcp test -Dtest=PlaywrightServiceTest -DheadlessExecution=true` — 14/14 after the fix.
- [x] `mvn -pl shaft-mcp test -DheadlessExecution=true` (full module) — 486 tests, only the 2 pre-existing `CaptureServiceTest` failures remain (already fixed on the separate, unmerged #4263 branch — unrelated to this PR); no other regressions.

Refs #4239, #4262. Combined with #4263, resolves PR #4254's shaft-mcp CI failures.

https://claude.ai/code/session_019wEoJduy4Q4jfHWejcizCe