### PR TITLE
Stop telling cloud-chat codegen to call MCP tools it can't invoke (#4258)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -116,10 +116,16 @@ final class AssistantCommand {
     // match SHAFT_MCP_USAGE_HINT_LOCAL_AGENT; that would silently drop guidance cloud users have no
     // other way to receive. A future P2.3 build-time consistency check must cover this constant
     // against shaft-skills/ in addition to the P2.1 instructions properties.
+    //
+    // Issue #4258 (adjacent finding filed during #4256): this constant used to also tell the model
+    // to "call driver_initialize before browser_* tools" -- an unactionable tool-invocation
+    // directive for the same reason as #4256's SHAFT_CODEGEN_TOOL_GUIDANCE_CLOUD fix, since
+    // autobot_provider_chat has no tool-calling loop. The WebDriver-vs-Playwright engine preference
+    // it conveyed is restated below without naming a tool to call.
     private static final String SHAFT_MCP_USAGE_HINT_CLOUD =
             """
                     If this request requires interacting with a browser, page element, or mobile app, use shaft-mcp.
-                    For WebDriver browser tasks, call driver_initialize before browser_* tools; do not use Playwright unless requested.
+                    For WebDriver browser tasks, default to WebDriver-based SHAFT code; do not use Playwright unless requested.
                     Never start an interactive user-driven recording (capture_start, which dispatches to whichever engine -- WebDriver, Playwright, or mobile -- is active): your MCP session ends with this turn and would kill the recording seconds after it starts. Tell the user to ask the SHAFT panel to record instead.
                     A scripted capture_start session (its optional nested codegenOptions carries the full Playwright-codegen-compatible request) that you drive and capture_stop within this same turn is allowed.
                     Generated Java code must use SHAFT syntax only: SHAFT.GUI.WebDriver, driver.browser(), driver.element(), driver.element().touch(), and SHAFT.GUI.Locator.
@@ -185,11 +191,24 @@ final class AssistantCommand {
                     - Put every code snippet in fenced code blocks with the correct language.
                     - Return only SHAFT-syntax Java; never return raw Selenium code.
                     """.stripIndent().trim();
-    private static final String SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE =
+    private static final String SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE_LOCAL_AGENT =
             """
                     Live browser verification was explicitly requested:
                     - Open a real browser session; call driver_initialize and browser_open_intent with the confirmed targetUrl and userIntent to inspect the live page and locator candidates.
                     - Verify each selected locator by performing the actual action with shaft-mcp element_type or element_click before returning it.
+                    """.stripIndent().trim();
+    // Issue #4258 (adjacent finding filed during #4256): unlike the local-agent variant above --
+    // which really is an MCP client and can call driver_initialize/browser_open_intent/
+    // element_type/element_click -- SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE used to be shared verbatim with
+    // the cloud-chat path regardless of the `cloud` flag passed to codeGenerationGuidance.
+    // autobot_provider_chat / AutobotService.runProviderChat is a plain text-completion call with no
+    // tool-calling loop at all, so it can never open a real browser session or invoke any of those
+    // tools. Restate the requested outcome without naming a tool to call.
+    private static final String SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE_CLOUD =
+            """
+                    Live browser verification was explicitly requested, but this chat has no way to open a real browser session or perform a live action:
+                    - Never claim a live browser check happened, and never present a returned locator as live-verified or replay-proven.
+                    - Base each selected locator on the page structure the user described or attached, applying the same locator policy as any other request.
                     """.stripIndent().trim();
     private static final CommandDefinition COMMAND_HELP = new CommandDefinition("/commands", "Show command help",
             List.of("/help", "/mcp-help", "/shaft-help"),
@@ -2986,11 +3005,17 @@ final class AssistantCommand {
     // SHAFT_CODEGEN_TOOL_GUIDANCE_* split (see their declarations) this call site needs -- cloudPrompt
     // passes true (no MCP instructions channel, keep the full policy text), localAgentPrompt passes
     // false (the spawned CLI is an MCP client and gets that content from P2.1 instead).
+    // Issue #4258: the same {@code cloud} flag also selects which half of the
+    // SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE_* split applies -- this constant used to be appended
+    // unconditionally regardless of {@code cloud} even though only the local-agent path can act on
+    // its tool-invocation directives.
     private static String codeGenerationGuidance(String text, boolean cloud) {
         String base = cloud ? SHAFT_CODEGEN_TOOL_GUIDANCE_CLOUD : SHAFT_CODEGEN_TOOL_GUIDANCE_LOCAL_AGENT;
-        return shouldUseLiveCodegenTools(text)
-                ? base + "\n" + SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE
-                : base;
+        if (!shouldUseLiveCodegenTools(text)) {
+            return base;
+        }
+        String liveGuidance = cloud ? SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE_CLOUD : SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE_LOCAL_AGENT;
+        return base + "\n" + liveGuidance;
     }
 
     private static boolean shouldUseLiveCodegenTools(String text) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -411,9 +411,41 @@ class AssistantCommandTest {
                 () -> assertTrue(prompt.contains("browser_open_intent"), prompt),
                 // "element_type, element_click" (comma-joined) used to also match the ordering
                 // bullet trimmed by issue #4239 P2.2; the real source of this phrase is
-                // SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE's "or"-joined wording, asserted here directly.
+                // SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE_LOCAL_AGENT's "or"-joined wording (issue #4258
+                // split this constant into local-agent/cloud variants), asserted here directly.
                 () -> assertTrue(prompt.contains("element_type or element_click"), prompt),
                 () -> assertTrue(prompt.contains("Return only SHAFT-syntax Java"), prompt));
+    }
+
+    /**
+     * Issue #4258 (adjacent finding filed during #4256): {@code SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE}
+     * used to be shared verbatim between the local-agent and cloud-chat codegen prompts regardless
+     * of the {@code cloud} flag passed to {@code codeGenerationGuidance}, unlike the
+     * {@code SHAFT_MCP_USAGE_HINT_*}/{@code SHAFT_CODEGEN_TOOL_GUIDANCE_*} pair split by issue #4239
+     * P2.2. The cloud-chat path ({@code autobot_provider_chat} /
+     * {@code AutobotService.runProviderChat}) is a plain text-completion call with no tool-calling
+     * loop at all, so it was being told to "call driver_initialize and browser_open_intent" and
+     * verify locators "with shaft-mcp element_type or element_click" -- directives it structurally
+     * cannot act on, the same class of bug as #4256's {@code SHAFT_CODEGEN_TOOL_GUIDANCE_CLOUD} fix.
+     */
+    @Test
+    void cloudCodegenPromptWithLiveVerificationRequestDoesNotNameToolsToCall() {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "generate code to login to https://example.com and verify locators live",
+                AssistantCommand.Selection.cloud("openai", "gpt-5"),
+                "ASK",
+                ".",
+                "",
+                false);
+
+        String prompt = invocation.arguments().get("prompt").getAsString();
+
+        assertAll(
+                () -> assertTrue(prompt.contains("Live browser verification was explicitly requested"), prompt),
+                () -> assertFalse(prompt.contains("call driver_initialize"), prompt),
+                () -> assertFalse(prompt.contains("browser_open_intent"), prompt),
+                () -> assertFalse(prompt.contains("element_type or element_click"), prompt),
+                () -> assertTrue(prompt.contains("never present a returned locator as live-verified"), prompt));
     }
 
     @Test
@@ -741,7 +773,13 @@ class AssistantCommandTest {
                 () -> assertFalse(codegenPrompt.contains("healer_run_failed_test"), codegenPrompt),
                 () -> assertFalse(codegenPrompt.contains("Call test_code_guardrails_check"), codegenPrompt),
                 () -> assertTrue(codegenPrompt.contains("MUST follow the Page Object Model"), codegenPrompt),
-                () -> assertTrue(codegenPrompt.contains("Return only SHAFT-syntax Java"), codegenPrompt));
+                () -> assertTrue(codegenPrompt.contains("Return only SHAFT-syntax Java"), codegenPrompt),
+                // Issue #4258: SHAFT_MCP_USAGE_HINT_CLOUD's own "call driver_initialize before
+                // browser_* tools" directive has the same unactionable-tool-call problem as the
+                // SHAFT_CODEGEN_TOOL_GUIDANCE_CLOUD directives above; the WebDriver-vs-Playwright
+                // engine preference it conveys stays, restated without naming a tool to call.
+                () -> assertFalse(codegenPrompt.contains("call driver_initialize"), codegenPrompt),
+                () -> assertTrue(codegenPrompt.contains("do not use Playwright unless requested"), codegenPrompt));
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #4258 — two remaining prompt-guidance fragments in `AssistantCommand.java` still told the tool-incapable cloud-chat codegen path (`AutobotService.runProviderChat`, a plain text-completion call with no MCP tool-calling loop) to "call" MCP tools it structurally cannot invoke. Same class of bug already fixed twice in this file (#4256, #4239 P2.2).

- `SHAFT_MCP_USAGE_HINT_CLOUD` (`shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java:122`): dropped "call `driver_initialize` before `browser_*` tools", restated as a WebDriver-vs-Playwright code-output expectation instead.
- `SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE` (`AssistantCommand.java:188`): was shared verbatim between local-agent and cloud-chat prompts regardless of the `cloud` flag. Split into `SHAFT_LIVE_CODEGEN_TOOL_GUIDANCE_LOCAL_AGENT`/`_CLOUD`, matching the established split pattern; `codeGenerationGuidance` (`AssistantCommand.java:3011`) now selects the right half from its existing `cloud` boolean.

## Test plan
- [x] TDD: added failing tests first (RED), watched them fail for the expected reason, then made the minimal fix (GREEN).
  - `cloudCodegenPromptDropsUnactionableToolCallDirectivesButKeepsLocatorPolicy` (fragment 1 assertions added)
  - `cloudCodegenPromptWithLiveVerificationRequestDoesNotNameToolsToCall` (new, fragment 2)
- [x] `AssistantCommandTest` — 26/26 passing (`./gradlew test --tests "com.shaft.intellij.ui.AssistantCommandTest"`)
- [x] `AssistantCommandRoutingTest` — 46/46 passing, unchanged
- [x] Full `shaft-intellij` module suite — `./gradlew test` BUILD SUCCESSFUL, 113 test report files, zero failures/errors anywhere in the module

Claude-Session: https://claude.ai/code/session_019wEoJduy4Q4jfHWejcizCe