### PR TITLE
capture: locatorExpression honors rung-2 replayXpath for ID/NAME/CSS/TEST_ID (fixes #4264)

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -1637,10 +1637,31 @@ public final class CaptureGenerator {
         String name = !target.accessibleName().isBlank() ? target.accessibleName() : target.label();
         return switch (candidate.strategy()) {
             case ROLE, ACCESSIBLE_NAME, LABEL -> semanticLocator(target, name, candidate);
+            case TEST_ID, CSS, ID, NAME -> nonAriaLocatorExpression(candidate);
+            case XPATH -> "By.xpath(\"" + javaString(candidate.expression()) + "\")";
+        };
+    }
+
+    /**
+     * Issue #4264: {@code isLadderEligible} (see below) admits a TEST_ID/CSS/ID/NAME candidate as
+     * rung-2 eligible whenever it carries a non-blank self-verified {@code replayXpath}, exactly
+     * like any other strategy. But rendering used to switch on {@code strategy()} alone for these
+     * four and always emit the literal {@code SHAFT.GUI.Locator.id/name/cssSelector(...)} form,
+     * which the unconditional {@code NON_ARIA_LOCATOR} guardrail (GeneratedCodeGuardrails) bans
+     * regardless of ladder eligibility -- the two gates disagreed. A genuinely rung-2-eligible
+     * candidate must render via its self-verified replayXpath instead, exactly like
+     * {@link #semanticLocator} already does for ROLE/LABEL/ACCESSIBLE_NAME.
+     */
+    private static String nonAriaLocatorExpression(LocatorCandidate candidate) {
+        if (!candidate.replayXpath().isBlank()) {
+            return "By.xpath(\"" + javaString(candidate.replayXpath()) + "\")";
+        }
+        return switch (candidate.strategy()) {
             case TEST_ID, CSS -> "SHAFT.GUI.Locator.cssSelector(\"" + javaString(candidate.expression()) + "\")";
             case ID -> "SHAFT.GUI.Locator.id(\"" + javaString(candidate.expression()) + "\")";
             case NAME -> "SHAFT.GUI.Locator.name(\"" + javaString(candidate.expression()) + "\")";
-            case XPATH -> "By.xpath(\"" + javaString(candidate.expression()) + "\")";
+            default -> throw new IllegalStateException(
+                    "nonAriaLocatorExpression only handles TEST_ID/CSS/ID/NAME, got " + candidate.strategy());
         };
     }
 
@@ -1708,6 +1729,16 @@ public final class CaptureGenerator {
     private static boolean usesNativeBy(TargetPlan plan) {
         LocatorCandidate candidate = plan.selection().selected().candidate();
         if (candidate.strategy() == LocatorCandidate.LocatorStrategy.XPATH) {
+            return true;
+        }
+        // Issue #4264: must agree with nonAriaLocatorExpression() -- a TEST_ID/CSS/ID/NAME candidate
+        // with a self-verified replayXpath renders as By.xpath(...) there too, so the "import
+        // org.openqa.selenium.By;" line must be added or the generated source fails to compile.
+        if ((candidate.strategy() == LocatorCandidate.LocatorStrategy.TEST_ID
+                || candidate.strategy() == LocatorCandidate.LocatorStrategy.CSS
+                || candidate.strategy() == LocatorCandidate.LocatorStrategy.ID
+                || candidate.strategy() == LocatorCandidate.LocatorStrategy.NAME)
+                && !candidate.replayXpath().isBlank()) {
             return true;
         }
         if (candidate.strategy() == LocatorCandidate.LocatorStrategy.ROLE

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -952,6 +952,121 @@ class CaptureGeneratorTest {
                 Map.of());
     }
 
+    /**
+     * Issue #4264: {@code isLadderEligible} admits a TEST_ID/CSS/ID/NAME candidate as rung-2
+     * eligible whenever it carries a non-blank self-verified {@code replayXpath}, exactly like any
+     * other strategy -- but {@code locatorExpression} used to switch on {@code strategy()} alone
+     * for these four and always render the literal {@code SHAFT.GUI.Locator.id/name/cssSelector(...)}
+     * form, which the unconditional {@code NON_ARIA_LOCATOR} guardrail bans regardless of ladder
+     * eligibility: the two gates disagreed. A genuinely rung-2-eligible ID candidate must render via
+     * its self-verified replayXpath instead, exactly like ROLE/LABEL/ACCESSIBLE_NAME already do.
+     */
+    @Test
+    void idStrategyCandidateWithSelfVerifiedReplayXpathRendersAsByXpathNotNonAriaLocator() throws Exception {
+        Path session = session(idStrategyReplayXpathSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result = new CaptureGenerator()
+                .generate(request(session, temp.resolve("id-strategy-replay-xpath")));
+
+        assertGeneratedUnconfirmed(result);
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("By.xpath(\"//button[@id=\\\"login-button\\\"]\")"),
+                "a rung-2-eligible ID candidate must render its self-verified replayXpath: " + source);
+        assertFalse(source.contains("SHAFT.GUI.Locator.id("),
+                "must not fall back to the NON_ARIA_LOCATOR-banned literal ID builder once rung-2 "
+                        + "evidence is present: " + source);
+        assertTrue(source.contains("import org.openqa.selenium.By;"));
+    }
+
+    private static CaptureSession idStrategyReplayXpathSession() {
+        ElementSnapshot loginButton = new ElementSnapshot(
+                "login-button",
+                "button",
+                "button",
+                "",
+                "",
+                Map.of("id", "login-button"),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.ID,
+                        "login-button", 1, true, true,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.USER_PROVIDED),
+                        "//button[@id=\"login-button\"]")),
+                true,
+                true,
+                false);
+        return new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "id-strategy-replay-xpath-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(3),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), loginButton,
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+    }
+
+    /**
+     * Issue #4264 follow-up: the TEST_ID and CSS strategies share one switch arm with ID/NAME in
+     * {@code locatorExpression} -- this covers that arm too, so the fix is not accidentally scoped
+     * to only the ID case.
+     */
+    @Test
+    void cssStrategyCandidateWithSelfVerifiedReplayXpathRendersAsByXpathNotNonAriaLocator() throws Exception {
+        Path session = session(cssStrategyReplayXpathSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result = new CaptureGenerator()
+                .generate(request(session, temp.resolve("css-strategy-replay-xpath")));
+
+        assertGeneratedUnconfirmed(result);
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("By.xpath(\"//button[@data-testid=\\\"submit\\\"]\")"),
+                "a rung-2-eligible CSS candidate must render its self-verified replayXpath: " + source);
+        assertFalse(source.contains("SHAFT.GUI.Locator.cssSelector("),
+                "must not fall back to the NON_ARIA_LOCATOR-banned literal cssSelector builder once "
+                        + "rung-2 evidence is present: " + source);
+    }
+
+    private static CaptureSession cssStrategyReplayXpathSession() {
+        ElementSnapshot submitButton = new ElementSnapshot(
+                "submit-button",
+                "button",
+                "button",
+                "",
+                "",
+                Map.of("data-testid", "submit"),
+                List.of(new LocatorCandidate(LocatorCandidate.LocatorStrategy.CSS,
+                        "[data-testid=\"submit\"]", 1, true, true,
+                        java.util.Set.of(LocatorCandidate.LocatorSignal.TEST_ATTRIBUTE),
+                        "//button[@data-testid=\"submit\"]")),
+                true,
+                true,
+                false);
+        return new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "css-strategy-replay-xpath-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(3),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.ClickEvent(CaptureFixtures.context(2), submitButton,
+                                CaptureEvent.MouseButton.PRIMARY, 1)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+    }
+
     private static CaptureSession roleLocatorSessionWithoutAccessibleName() {
         ElementSnapshot iconButton = new ElementSnapshot(
                 "icon-button",


### PR DESCRIPTION
## Summary

Fixes #4264. `CaptureGenerator.isLadderEligible` (shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java:744-750) admits a TEST_ID/CSS/ID/NAME candidate as rung-2 eligible whenever it carries a non-blank self-verified `replayXpath`, exactly like any other strategy. But `locatorExpression` switched on `strategy()` alone for these four and always rendered the literal `SHAFT.GUI.Locator.id/name/cssSelector(...)` form — which the unconditional `NON_ARIA_LOCATOR` guardrail bans regardless of ladder eligibility. The two gates disagreed.

- Extracted the four-strategy switch arm into `nonAriaLocatorExpression()` (CaptureGenerator.java:1636-1659), which checks `replayXpath()` first and renders `By.xpath(...)` when present, falling back to the literal builder call only when absent — matching what `semanticLocator` already does for ROLE/LABEL/ACCESSIBLE_NAME.
- `usesNativeBy()` needed the matching companion fix (CaptureGenerator.java:1729-1741) — it gates the `import org.openqa.selenium.By;` line, and without the fix the rendered `By.xpath(...)` call would have had a missing import (a compile failure, not just a guardrail failure).
- Currently unreachable in production (`shaft-capture-recorder.js` never attaches an `xpathCandidate` to non-ROLE candidates) — same as the original defect this was blocking: issue #4262's option (c), teaching `McpPlaywrightCaptureAdapter`'s manual-recording flow to do genuine live-DOM self-verification.

Filed #4269 for an adjacent, structurally identical bug in `runtimeLocator()` (used only by `seedHealingHistory` to key SHAFT Heal fingerprints, not the compile/replay validation path) — out of scope here per #4264's explicit boundary, tracked separately.

## Test plan
- [x] Watched RED: two new `CaptureGeneratorTest` cases (one per distinct switch arm — ID for the single-strategy arms, CSS for the shared TEST_ID/CSS arm) failed with the exact `guardrail-NON_ARIA_LOCATOR` violation described in the issue, before the fix.
- [x] Watched GREEN: `mvn -pl shaft-capture test -Dtest=CaptureGeneratorTest#idStrategyCandidateWithSelfVerifiedReplayXpathRendersAsByXpathNotNonAriaLocator+cssStrategyCandidateWithSelfVerifiedReplayXpathRendersAsByXpathNotNonAriaLocator -DheadlessExecution=true` — 2/2 after the fix.
- [x] `mvn -pl shaft-capture test -DheadlessExecution=true` (full module) — 345/345 green, no regressions.
- [x] `mvn -pl shaft-mcp test -DheadlessExecution=true` (downstream consumer) — 488/488 green, no regressions.

Refs #4239, #4262.

https://claude.ai/code/session_019wEoJduy4Q4jfHWejcizCe