### PR TITLE
Fix targetless iframe locator guardrail violation and add shaft-capture to CI unit-test matrix

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -97,8 +97,12 @@ jobs:
               - 'shaft-mcp/src/main/java/com/shaft/mcp/ShaftProjectService.java'
               - 'shaft-mcp/src/test/java/com/shaft/mcp/ShaftProjectServiceTest.java'
             # Core Java modules with a unit-test leg (issue #3849): shaft-engine and
-            # its downstream Pilot-family modules. shaft-capture/shaft-cli/shaft-intellij
-            # already have dedicated legs above and are intentionally not repeated here.
+            # its downstream Pilot-family modules. shaft-cli/shaft-intellij already have
+            # dedicated legs above and are intentionally not repeated here. shaft-capture
+            # is deliberately NOT listed here even though it has its own unit-test matrix
+            # entry below (issue #4280) -- it already has a dedicated `capture` filter
+            # above (used by capture-e2e), and the unit-tests job's `if` condition also
+            # checks that filter directly rather than duplicating its paths into javacore.
             javacore:
               - 'shaft-engine/**'
               - 'shaft-pilot-core/**'
@@ -266,11 +270,13 @@ jobs:
   # gets its dependencies installed first (mirrors capture-e2e's install-step
   # pattern above) because pr-gate has no earlier install step for this set.
   #
-  # shaft-pilot-core/shaft-doctor/shaft-ai/shaft-heal/shaft-mcp run their full
-  # `mvn test` suite unfiltered -- the same invocation shaft-pilot-release.yml
-  # already runs on every release-relevant PR and calls "deterministic" (no
-  # live browser/grid/device; the one opt-in browser suite, shaft-capture's,
-  # stays gated behind -DincludeCaptureBrowserE2E and is not part of this set).
+  # shaft-pilot-core/shaft-doctor/shaft-ai/shaft-heal/shaft-mcp/shaft-capture run
+  # their full `mvn test` suite unfiltered -- the same invocation
+  # shaft-pilot-release.yml already runs on every release-relevant PR and calls
+  # "deterministic" (no live browser/grid/device). shaft-capture's own opt-in
+  # browser suite stays excluded by default (its pom's `excludedGroups`
+  # setting) and is gated separately behind -DincludeCaptureBrowserE2E in the
+  # capture-e2e job above -- not part of this set (issue #4280).
   #
   # shaft-engine cannot reuse that unfiltered pattern: outside its own
   # `testPackage.unitTests` package it also has nightly-only live-browser
@@ -292,13 +298,15 @@ jobs:
   unit-tests:
     name: Unit Tests (${{ matrix.module }})
     needs: changes
-    if: needs.changes.outputs.javacore == 'true' || needs.changes.outputs.infra == 'true'
+    if: >-
+      needs.changes.outputs.javacore == 'true' || needs.changes.outputs.capture == 'true'
+      || needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        module: [ shaft-engine, shaft-pilot-core, shaft-doctor, shaft-ai, shaft-heal, shaft-mcp ]
+        module: [ shaft-engine, shaft-pilot-core, shaft-doctor, shaft-ai, shaft-heal, shaft-mcp, shaft-capture ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/CaptureGenerator.java
@@ -1316,8 +1316,8 @@ public final class CaptureGenerator {
             } else if (value.target() != null) {
                 line(source, "        driver.element().switchToIframe(" + locator + ");");
             } else {
-                line(source, "        driver.element().switchToIframe(SHAFT.GUI.Locator.id(\""
-                        + javaString(value.logicalFrameId()) + "\"));");
+                line(source, "        driver.element().switchToIframe(SHAFT.GUI.Locator.hasAnyTagName().hasId(\""
+                        + javaString(value.logicalFrameId()) + "\").build());");
             }
         } else if (event instanceof CaptureEvent.AlertEvent value) {
             renderAlert(source, value, data, backend);

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -880,6 +880,51 @@ class CaptureGeneratorTest {
     }
 
     /**
+     * Issue #4278: a targetless {@code FrameEvent} (a recorder-observed frame switch with a logical
+     * frame id but no captured element snapshot) rendered the frame id through the literal
+     * {@code SHAFT.GUI.Locator.id(...)} builder call -- exactly the non-ARIA form its own
+     * {@code NON_ARIA_LOCATOR} guardrail unconditionally rejects, hard-failing generation for a
+     * switch the user cannot influence by re-recording. A frame id is not an element locator at all,
+     * but SHAFT's {@code switchToIframe} only accepts a {@code By}/{@code ShaftLocator}, so the fix
+     * routes it through the same policy-clean {@code hasAnyTagName().hasId(...)} builder chain
+     * #4271 already established for unique author-written element ids.
+     */
+    @Test
+    void targetlessFrameSwitchGeneratesTheShaftLocatorBuilderIdFormAndClearsEveryGuardrail() throws Exception {
+        Path session = session(targetlessFrameSwitchSession());
+        writeCaptureData("alice");
+
+        CaptureGenerationResult result = new CaptureGenerator()
+                .generate(request(session, temp.resolve("targetless-frame")));
+
+        assertGeneratedUnconfirmed(result);
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("SHAFT.GUI.Locator.hasAnyTagName().hasId(\"payment-frame\").build()"), source);
+        assertFalse(source.contains("SHAFT.GUI.Locator.id("), source);
+        assertTrue(CaptureGenerator.guardrailUnsupportedFindings(source).isEmpty(),
+                CaptureGenerator.guardrailUnsupportedFindings(source).toString());
+    }
+
+    private static CaptureSession targetlessFrameSwitchSession() {
+        return new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "targetless-frame-switch-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(2),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/form"),
+                        new CaptureEvent.FrameEvent(CaptureFixtures.context(2),
+                                CaptureEvent.FrameAction.ENTER, "payment-frame", null)),
+                List.of(),
+                List.of(),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+    }
+
+    /**
      * Issue #4271 review finding 2: {@code LocatorRanker} ranks candidates lexicographically by
      * (tier, score) <em>within one element snapshot</em>, but when the same logical element is seen
      * again on a later event, {@code CaptureGenerator} merged the two selections by raw additive


### PR DESCRIPTION
## Summary

Two small, unrelated, file-disjoint fixes bundled in one PR (grouped per orchestrator's call since both touch shaft-capture-adjacent config/code):

- **#4278**: `CaptureGenerator` rendered a targetless `FrameEvent`'s logical frame id through the literal `SHAFT.GUI.Locator.id("<frameId>")` builder call, which its own `NON_ARIA_LOCATOR` guardrail unconditionally rejects -- hard-failing generation for an iframe switch the user cannot influence by re-recording. A frame id is not an element locator, but `switchToIframe` only accepts a `By`/`ShaftLocator`, so it now routes through `SHAFT.GUI.Locator.hasAnyTagName().hasId("<frameId>").build()` -- the same guardrail-clean builder chain #4271 already established for unique author-written element ids.
- **#4280**: shaft-capture's unit test suite (370+ tests) never executed in CI. Added `shaft-capture` to `pr-gate.yml`'s `Unit Tests` matrix (same unfiltered `mvn test` invocation as its sibling modules; its own opt-in browser E2E suite stays excluded by default via the pom's `excludedGroups`). Also widened the job's `if` condition to fire on the existing `capture` path filter (previously only `javacore`/`infra`), since `shaft-capture/**` was never in `javacore` -- without that, capture-only PRs would still get zero unit-test signal even with the module added to the matrix.

## Test plan

- [x] `CaptureGeneratorTest#targetlessFrameSwitchGeneratesTheShaftLocatorBuilderIdFormAndClearsEveryGuardrail` written first, watched RED (`guardrail-NON_ARIA_LOCATOR ... SHAFT.GUI.Locator.id("payment-frame")`), then GREEN after the one-line fix.
- [x] Full `CaptureGeneratorTest` class: 60/60 passed.
- [x] Full shaft-capture unit suite, `mvn -pl shaft-capture test -DheadlessExecution=true` (no `-am`): 370/370 passed, no regressions.
- [x] `py -3 scripts/ci/validate_workflow_timeouts.py` and `validate_orphaned_suite_files.py` pass against the edited workflow.
- [x] PyYAML parse confirms the edited `unit-tests` job's `if`/matrix syntax is valid and includes `shaft-capture`.
- [ ] Confirm in this PR's own CI that the `Unit Tests (shaft-capture)` job appears and passes (the actual point of #4280).

Closes #4278
Closes #4280