### PR TITLE
shaft-mcp: warn immediately on CSS-strategy Playwright locator recordings (#4291)

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpPlaywrightCaptureAdapter.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpPlaywrightCaptureAdapter.java
@@ -247,11 +247,14 @@ final class McpPlaywrightCaptureAdapter {
      * constructed {@code //*[@name="..."]} expression, independently re-verified live) locators, so
      * {@code LocatorPolicy}'s {@code Tier.VERIFIED_XPATH} admits those two strategies as well. {@code
      * CSS}-strategy recordings still hard-fail codegen -- a general CSS-to-XPath conversion is a
-     * separate, larger change, tracked as a follow-up issue. This adapter simply relays whatever
-     * genuine evidence {@link PlaywrightService} computed instead of fabricating it -- unverified
-     * actions (non-Playwright models, CSS/other unhandled strategies, or recordings captured before
-     * this evidence existed) still carry the honest {@code 0}/{@code false}/{@code ""} default, so
-     * {@code LocatorPolicy} admits only what was actually observed live.
+     * separate, larger change, deliberately not pursued here (issue #4291). This adapter simply
+     * relays whatever genuine evidence {@link PlaywrightService} computed instead of fabricating it
+     * -- unverified actions (non-Playwright models, CSS/other unhandled strategies, or recordings
+     * captured before this evidence existed) still carry the honest {@code 0}/{@code false}/{@code ""}
+     * default, so {@code LocatorPolicy} admits only what was actually observed live. Issue #4291 does
+     * not change that refusal, but ensures the caller learns about it immediately instead of only
+     * when codegen runs: {@link PlaywrightService} now surfaces a non-blocking warning the moment a
+     * CSS-strategy locator is recorded.
      */
     private LocatorCandidate locator(McpMobileRecordedAction action, String name, boolean semantic) {
         LocatorCandidate.LocatorStrategy strategy = locatorStrategy(action.locatorStrategy(), semantic);

--- a/shaft-mcp/src/main/java/com/shaft/mcp/PlaywrightService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/PlaywrightService.java
@@ -724,6 +724,10 @@ public class PlaywrightService {
                 warnings);
     }
 
+    static final String CSS_LOCATOR_CODEGEN_WARNING = "CSS-strategy locators cannot be used for SHAFT "
+            + "test-code generation; codegen will fail for this action later. Use an ID, NAME, XPath, or "
+            + "role-based locator strategy instead if you need generated code.";
+
     private static List<String> actionWarnings(
             String action,
             locatorStrategy locatorStrategy,
@@ -732,6 +736,9 @@ public class PlaywrightService {
         if (McpAppiumLocatorSuggester.isCoordinateFallback(action, locatorStrategy)) {
             warnings.add(McpAppiumLocatorSuggester.COORDINATE_FALLBACK_WARNING);
         }
+        if (isCssLocatorStrategy(locatorStrategy)) {
+            warnings.add(CSS_LOCATOR_CODEGEN_WARNING);
+        }
         if (recorded == null) {
             warnings.add("Ignored: recording is not active — call capture_start (with the Playwright engine "
                     + "active) to capture this step.");
@@ -739,6 +746,19 @@ public class PlaywrightService {
             warnings.addAll(recorded.warnings());
         }
         return List.copyOf(warnings);
+    }
+
+    /**
+     * True for the locator strategies {@link McpPlaywrightCaptureAdapter#locator} maps to CSS for
+     * codegen purposes ({@code CSS}/{@code CSSSELECTOR}/{@code SELECTOR}). {@code LocatorPolicy}
+     * (shaft-capture) has no admission path for CSS-strategy locators, so recording one always
+     * fails codegen later (issue #4291) -- surfacing that immediately here, instead of leaving the
+     * caller to discover it only when they later call codegen, is this method's entire purpose.
+     */
+    private static boolean isCssLocatorStrategy(locatorStrategy strategy) {
+        return strategy == locatorStrategy.CSS
+                || strategy == locatorStrategy.CSSSELECTOR
+                || strategy == locatorStrategy.SELECTOR;
     }
 
     private McpCodeBlock actionBlock(String action, String javaCode) {

--- a/shaft-mcp/src/test/java/com/shaft/mcp/PlaywrightServiceDriverBackedTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/PlaywrightServiceDriverBackedTest.java
@@ -239,6 +239,54 @@ class PlaywrightServiceDriverBackedTest {
     }
 
     @Test
+    void cssStrategyLocatorRecordingWarnsThatCodegenWillFailButStillSucceeds() throws Exception {
+        // Issue #4291: LocatorPolicy (shaft-capture) has no admission path for CSS-strategy
+        // locators, so codegen honestly refuses CSS recordings later, deep inside CaptureGenerator
+        // (#4262). Recording a CSS-strategy action must surface that fact immediately as a
+        // non-blocking warning -- same contract as the existing coordinate-fallback warning -- not
+        // change whether the action itself succeeds.
+        PlaywrightService service = new PlaywrightService(McpWorkspacePolicy.of(temp));
+        ElementActions element = mock(ElementActions.class);
+        inject(service, mockDriver(mock(BrowserActions.class), element, mock(Page.class)));
+        service.recordStart(temp.resolve("recordings/css.json").toString(), "playwright", false);
+
+        McpMobileActionResult click = service.click(locatorStrategy.CSS, "#login");
+        McpMobileActionResult clickCssSelector = service.click(locatorStrategy.CSSSELECTOR, "#login");
+        McpMobileActionResult clickSelector = service.click(locatorStrategy.SELECTOR, "#login");
+
+        assertTrue(click.recorded());
+        assertTrue(click.warnings().stream().anyMatch(warning -> warning.contains("codegen")),
+                click.warnings().toString());
+        assertTrue(clickCssSelector.recorded());
+        assertTrue(clickCssSelector.warnings().stream().anyMatch(warning -> warning.contains("codegen")),
+                clickCssSelector.warnings().toString());
+        assertTrue(clickSelector.recorded());
+        assertTrue(clickSelector.warnings().stream().anyMatch(warning -> warning.contains("codegen")),
+                clickSelector.warnings().toString());
+    }
+
+    @Test
+    void nonCssStrategyLocatorRecordingDoesNotCarryTheCssCodegenWarning() throws Exception {
+        // No false positives (#4291): ID/NAME/XPATH-strategy and semantic (role-based, null
+        // strategy) actions have a genuine LocatorPolicy admission path, so they must never carry
+        // the CSS-only codegen warning.
+        PlaywrightService service = new PlaywrightService(McpWorkspacePolicy.of(temp));
+        ElementActions element = mock(ElementActions.class);
+        inject(service, mockDriver(mock(BrowserActions.class), element, mock(Page.class)));
+        service.recordStart(temp.resolve("recordings/non-css.json").toString(), "playwright", false);
+
+        McpMobileActionResult id = service.click(locatorStrategy.ID, "submit");
+        McpMobileActionResult name = service.click(locatorStrategy.NAME, "submit");
+        McpMobileActionResult xpath = service.click(locatorStrategy.XPATH, "//button");
+
+        assertFalse(id.warnings().stream().anyMatch(warning -> warning.contains("codegen")), id.warnings().toString());
+        assertFalse(name.warnings().stream().anyMatch(warning -> warning.contains("codegen")),
+                name.warnings().toString());
+        assertFalse(xpath.warnings().stream().anyMatch(warning -> warning.contains("codegen")),
+                xpath.warnings().toString());
+    }
+
+    @Test
     void driverBackedIsDisplayedAndIsEnabledResolvePlaywrightLocator() throws Exception {
         PlaywrightService service = new PlaywrightService(McpWorkspacePolicy.of(temp));
         Page page = mock(Page.class);


### PR DESCRIPTION
## Summary

Closes #4291.

Issue #4291 was filed as a deliberately-scoped-out follow-up of #4262/#4273: `LocatorPolicy.plan` (shaft-capture, untouched by this PR) has exactly three admission paths (ID, ROLE, self-verified XPath/NAME), and CSS-strategy manual Playwright MCP recordings have never had a genuine admission path into any of them. Codegen still hard-fails deep inside `CaptureGenerator` (`unplannable`/`state.unsupported()`) for CSS-strategy recordings -- discovered only when the caller later tries to generate code, not at the moment they recorded the action.

The issue explicitly listed three possible directions and left the choice open ("not decided -- architectural, needs sign-off like #4262 did"):
- (a) a general xpath-synthesis engine derived from the live DOM element a CSS selector resolves to
- (b) adopting a CSS-to-XPath translation library
- (c) formally accepting CSS-strategy manual recordings as unsupported for codegen and having the MCP tool surface a clear, immediate, caller-facing warning instead of a deep, opaque codegen failure

This PR implements **(c)**: (a) needs a materially larger and riskier general xpath-synthesis engine than this narrow follow-up warrants, and (b) adds a new dependency for a niche, low-frequency path. (c) directly fixes the actual pain -- an opaque, deep, late-discovered failure -- with no new locator-evidence machinery, and is trivially revertible if a future issue wants to pursue (a)/(b) instead.

## Changes

- `PlaywrightService.actionWarnings` (shaft-mcp/src/main/java/com/shaft/mcp/PlaywrightService.java) now adds a new `CSS_LOCATOR_CODEGEN_WARNING` to the returned warnings whenever a locator-bearing action is recorded with `locatorStrategy` `CSS`, `CSSSELECTOR`, or `SELECTOR` -- the three enum values `McpPlaywrightCaptureAdapter.locator()`'s existing strategy mapping already treats as CSS-equivalent for codegen purposes. This is purely additive: it does not change whether the action succeeds (`McpMobileActionResult.recorded()`/`.success()` are unaffected) or what code is returned, using the exact same non-blocking-warning contract as the pre-existing coordinate-fallback warning (`McpAppiumLocatorSuggester.COORDINATE_FALLBACK_WARNING`).
- `McpPlaywrightCaptureAdapter.locator()`'s javadoc updated to note that issue #4291 makes the caller aware of the CSS honest-refusal default immediately (at record time), while codegen itself still refuses CSS exactly as before.
- `LocatorPolicy.java` (shaft-capture) is **not** touched -- confirmed via `git diff --stat -- '**/LocatorPolicy.java'` (empty).

## Test plan

- [x] New failing test first (RED), watched fail for the right reason (no CSS warning existed yet): `PlaywrightServiceDriverBackedTest#cssStrategyLocatorRecordingWarnsThatCodegenWillFailButStillSucceeds` -- proves recording a CSS/CSSSELECTOR/SELECTOR-strategy click still succeeds (`recorded()==true`) while now carrying a warning containing "codegen".
- [x] New test proving no false positives: `PlaywrightServiceDriverBackedTest#nonCssStrategyLocatorRecordingDoesNotCarryTheCssCodegenWarning` -- ID/NAME/XPATH-strategy actions carry no such warning.
- [x] Both watched GREEN after the minimal implementation.
- [x] Full regression: `mvn -pl shaft-mcp -DheadlessExecution=true test` -- 509 tests, 0 failures, 0 errors (rebased onto latest `origin/main`, which already includes #4262's merged PR #4292 touching the same files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wEoJduy4Q4jfHWejcizCe