### PR TITLE
docs: fix inaccurate facts and converge the root entry docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,7 +36,7 @@
 - [ ] I have read the [Contributing Guide](../CONTRIBUTING.md) and this PR follows its guidelines.
 - [ ] Documentation/agent-only changes pass their deterministic validators and `git diff --check`.
 - [ ] Behavior changes have focused automated coverage.
-- [ ] Affected tests pass: `mvn -pl shaft-engine -am test -Dtest=<AffectedTestClass>`.
+- [ ] Affected tests pass: `mvn -pl shaft-engine -am test -Dtest=<AffectedTestClass> -DheadlessExecution=true`.
 - [ ] Code/build changes compile once with `mvn clean install -DskipTests -Dgpg.skip`.
 - [ ] New `public` methods and classes have JavaDoc comments with `@param` / `@return` / `@throws` tags.
 - [ ] I have not introduced any hardcoded credentials, secrets, or sensitive data.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,10 +121,12 @@ py -3 scripts/ci/validate_documentation_boundaries.py
 git diff --check
 ```
 
-For localized code changes, run the affected test first:
+For localized code changes, run the affected test first. Always scope the run
+with `-Dtest=` and force headless execution, so a browser-capable test cannot
+open a real window on your machine:
 
 ```bash
-mvn -pl shaft-engine -am test "-Dtest=TestClassName"
+mvn -pl shaft-engine -am test "-Dtest=TestClassName" "-DheadlessExecution=true"
 ```
 
 Then run one compile/package pass appropriate to the change. For broad API,

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Java 25 automation framework for Web, Mobile, API, CLI, and Database testing.
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=flat-square&logo=apachemaven)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
-[![Build](https://img.shields.io/github/actions/workflow/status/ShaftHQ/SHAFT_ENGINE/e2eTests.yml?branch=main&style=flat-square&label=tests)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/e2eTests.yml)
+[![PR Gate](https://img.shields.io/github/actions/workflow/status/ShaftHQ/SHAFT_ENGINE/pr-gate.yml?branch=main&style=flat-square&label=build)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/pr-gate.yml)
 [![Docs](https://img.shields.io/badge/docs-live-5b4bff?style=flat-square)](https://shafthq.github.io/docs/start/overview)
 
 **[Open the User Guide](https://shafthq.github.io/docs/start/overview)**
@@ -22,19 +22,7 @@ automation plumbing in one place: drivers, synchronization, assertions,
 configuration, test data, reporting, evidence, and optional agent-assisted
 workflows.
 
-## Why SHAFT
-
-- Java and Maven first, with TestNG, JUnit, and Cucumber integration.
-- One workflow for Web, Mobile, API, CLI, Database, accessibility, reporting,
-  and evidence.
-- Configuration-first defaults for local, grid, cloud, and CI execution.
-- Optional modules and tools for BrowserStack, Capture, Doctor, Heal, MCP, AI,
-  IntelliJ IDEA, video, and visual testing.
-- IntelliJ IDEA is the front-door workflow for coding partners: plan from the
-  SHAFT tool window, reuse existing code, review generated blocks, and verify
-  locally.
-
-## Feature Overview
+## What You Get
 
 | Area | Built in |
 |---|---|
@@ -43,20 +31,26 @@ workflows.
 | System coverage | CLI and Database actions for end-to-end validation beyond the browser. |
 | Test design | Assertions, validations, test data handling, and configuration overrides. |
 | Reporting | Allure-ready evidence, attachments, execution logs, and accessibility artifacts. |
-| Extensions | Optional modules and tools for cloud execution, capture, diagnostics, healing, MCP, AI, IntelliJ IDEA, video, and visual checks. |
+| Extensions | Opt-in modules for cloud execution, capture, diagnostics, healing, MCP, AI, video, and visual checks, plus an IntelliJ IDEA plugin. |
 
-SHAFT is built for Java teams that want consistent APIs, repeatable
-configuration, and useful run artifacts across the full automation suite.
+Java and Maven first, with TestNG, JUnit, and Cucumber integration, and
+configuration-first defaults for local, grid, cloud, and CI execution. The
+IntelliJ IDEA plugin is the front door for agent-assisted work: plan from the
+SHAFT tool window, reuse existing code, review generated blocks, verify locally.
 
-## User Guide
+## Documentation
 
 - Start: [overview](https://shafthq.github.io/docs/start/overview), [installation](https://shafthq.github.io/docs/start/installation), [upgrade](https://shafthq.github.io/docs/start/upgrade).
 - Testing: [web](https://shafthq.github.io/docs/testing/web), [mobile](https://shafthq.github.io/docs/testing/mobile), [API](https://shafthq.github.io/docs/testing/api).
 - Agentic workflows: [IntelliJ IDEA plugin](https://shafthq.github.io/docs/agentic/intellij), [MCP](https://shafthq.github.io/docs/agentic/mcp), [Doctor](https://shafthq.github.io/docs/agentic/doctor), [Heal](https://shafthq.github.io/docs/agentic/heal).
+- [Modular-era feature catalog](modular-era-feature-catalog.md) — which optional
+  module or command to adopt, with screenshots.
 
 ## Contributing
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, validation, and pull
-request guidance.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — local setup, validation, and pull requests.
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — community expectations.
+- [SECURITY.md](SECURITY.md) — report a vulnerability privately, never as a
+  public issue.
 
 MIT licensed. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,44 +2,37 @@
 
 ## Supported Versions
 
-SHAFT Engine follows a **latest-release-only** support model. Security fixes are applied to the most recent release exclusively.
+SHAFT Engine follows a **latest-release-only** support model. Security fixes are
+applied to the most recent release exclusively.
 
 | Version | Supported |
 |---------|-----------|
-| Latest  | ✅ |
-| Older   | ❌ |
+| Latest | Yes |
+| Older | No |
 
-If you are affected by a vulnerability on an older version, please upgrade to the latest release first.  
-Check the current version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/SHAFT_ENGINE?style=flat-square&label=latest%20version)](https://central.sonatype.com/artifact/io.github.shafthq/SHAFT_ENGINE)
-
----
+If a vulnerability affects you on an older version, upgrade to the latest
+release first:
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=flat-square&label=latest%20version)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
 
 ## Reporting a Vulnerability
 
-**Please do NOT open a public GitHub issue for security vulnerabilities.**  
-Public disclosure before a fix is available puts all users at risk.
+**Do not open a public GitHub issue for a security vulnerability.** Public
+disclosure before a fix is available puts every user at risk.
 
-### Preferred: GitHub Private Security Advisory
+**Preferred —
+[report a vulnerability privately](https://github.com/ShaftHQ/SHAFT_ENGINE/security/advisories/new).**
+This opens a private discussion with the maintainers and stays confidential
+until a fix ships.
 
-Use GitHub's built-in private reporting channel:
+**Alternative** — if you cannot use GitHub advisories, email
+**mohabmohie@gmail.com**.
 
-👉 **[Report a vulnerability privately](https://github.com/ShaftHQ/SHAFT_ENGINE/security/advisories/new)**
+Include in your report:
 
-This creates a private discussion between you and the maintainers. Your report remains confidential until a fix is released.
-
-### Alternative: Email
-
-If you cannot use GitHub's advisory system, email the maintainer directly:
-
-📧 **mohabmohie@gmail.com**
-
-Include the following in your report:
-- A clear description of the vulnerability
-- Steps to reproduce (minimal code or configuration)
-- Potential impact and affected versions
-- Any suggested mitigations or patches (optional but appreciated)
-
----
+- A clear description of the vulnerability.
+- Steps to reproduce, with minimal code or configuration.
+- Potential impact and affected versions.
+- Suggested mitigations or patches (optional, appreciated).
 
 ## Response Timeline
 
@@ -49,33 +42,34 @@ Include the following in your report:
 | Initial assessment | Within **5 business days** |
 | Fix released | Depends on severity — critical issues are prioritized |
 
-You will be credited in the release notes (unless you prefer to remain anonymous).
-
----
+You will be credited in the release notes unless you prefer to stay anonymous.
 
 ## Scope
 
-The following are **in scope** for security reports:
+**In scope:**
 
-- Vulnerabilities in SHAFT Engine's own source code (`shaft-engine/src/main/java/`)
-- Unsafe defaults in configuration or properties that could expose user data
-- Dependency vulnerabilities that have a direct exploitable path through SHAFT's public API
+- Vulnerabilities in SHAFT Engine's own source code (`shaft-engine/src/main/java/`).
+- Unsafe configuration or property defaults that could expose user data.
+- Dependency vulnerabilities with a direct exploitable path through SHAFT's
+  public API.
 
-The following are **out of scope**:
+**Out of scope:**
 
-- Vulnerabilities in test code (`shaft-engine/src/test/java/`) — these are example tests, not production code
-- Issues in third-party libraries where no exploitable path through SHAFT exists (report these upstream)
-- Social engineering or phishing attacks
-
----
+- Vulnerabilities in test code (`shaft-engine/src/test/java/`) — these are
+  example tests, not production code.
+- Third-party library issues with no exploitable path through SHAFT; report
+  those upstream.
+- Social engineering or phishing.
 
 ## Dependency Security
 
-SHAFT Engine uses **Dependabot** for automated daily dependency updates and **CodeQL** for continuous static analysis on every pull request. This significantly reduces the window of exposure for known CVEs in transitive dependencies.
+SHAFT Engine runs **Dependabot** on a daily schedule and **CodeQL** static
+analysis on every pull request, which shortens the exposure window for known
+CVEs in transitive dependencies.
 
-Security-related dependency updates are tracked through Dependabot pull requests and are reflected in each [release's changelog](https://github.com/ShaftHQ/SHAFT_ENGINE/releases) when applicable.
-
----
+Security-related dependency updates land as Dependabot pull requests and appear
+in the relevant
+[release changelog](https://github.com/ShaftHQ/SHAFT_ENGINE/releases).
 
 ## Disclosure Policy
 


### PR DESCRIPTION
## Description

Quality pass over the root human-facing docs, focused on accuracy. Every factual claim was checked against the live repo rather than assumed; this PR fixes the ones that were wrong. Companion PR for the feature catalog is separate.

## Type of Change

- [x] Documentation update

## What was wrong, and the evidence

**README build badge pointed at a workflow that never runs on `main`.**
The badge used `e2eTests.yml?branch=main`, but that workflow triggers only on `schedule` and `workflow_dispatch` (`.github/workflows/e2eTests.yml:7-10`), so a branch-scoped badge on it could never reflect main's health. Repointed at `pr-gate.yml`, which its own header calls "the single path-conditioned gate for this repository" and which triggers on `pull_request` + push to `main`. Live-checked: the new badge renders **build | passing**.

**SECURITY.md sent readers to the deprecated Maven coordinate.**
Its version badge and link used artifactId `SHAFT_ENGINE`, while README used `shaft-engine`. That coordinate does resolve, so this was not a broken link — but `legacy-shaft-engine/pom.xml` publishes it as a **relocation POM** whose own message reads *"SHAFT Engine moved to io.github.shafthq:shaft-engine"*. A reader told to "check the current version" landed on the legacy coordinate. Both files now use `shaft-engine`, matching `shaft-engine/pom.xml:10`.

**CONTRIBUTING.md and the PR template documented a command the repo's own guard rejects.**
Both said `mvn -pl shaft-engine -am test -Dtest=<Class>` with no `-DheadlessExecution=true`. `.claude/hooks/guard.py:264-273` blocks any Maven test command missing that flag, and without it a browser-capable test opens a real window on the contributor's machine. Added the flag to both, so the documented command matches the enforced one.

**`shaft-intellij` was described as an optional module.** It is a Gradle build (`shaft-intellij/build.gradle.kts`) and is not a `<module>` in the root pom, so it is now described as a plugin.

## Convergence

- Linked `modular-era-feature-catalog.md` from README. No human-facing doc referenced it — a 774-line user-facing catalog reachable only by browsing the repo root.
- Merged README's "Why SHAFT" bullets into the feature table; the two restated the same module/extension list.
- Added CODE_OF_CONDUCT.md and SECURITY.md to README so the root docs form one navigable set.
- Dropped SECURITY.md's emoji and horizontal-rule styling, the only root doc using them.

## Verified correct and deliberately left alone

| Claim | Checked against |
|---|---|
| Java 25 | `pom.xml:57`, `.java-version`, `.sdkmanrc` — all agree |
| Maven 3.9.0+ | `pom.xml:59` and the `requireMavenVersion` enforcer rule |
| `@aictx/memory@0.1.55` pin | `scripts/ci/validate_agent_setup.py:30` |
| Dependabot daily | `.github/dependabot.yml` |
| CodeQL on every PR | `.github/workflows/security.yml` `on: pull_request` |
| SECURITY.md scope paths | both `shaft-engine/src/{main,test}/java/` exist |
| Every referenced script/path/relative link | resolves on disk |

`CODE_OF_CONDUCT.md` is untouched — see the note below.

## Evidence

```
py -3 scripts/ci/validate_documentation_boundaries.py
  Documentation boundary is valid (432 tracked Markdown files).
py -3 scripts/ci/validate_agent_setup.py   -> exit 0
git diff --check                           -> clean
```

Every relative link and image across all seven root docs was resolved against disk programmatically; all pass. Both badges were fetched live.

## Documentation Site

- Documentation not required because: this changes only in-repo entry documentation (README, contributing, security policy, PR template). No public API, product behaviour, or user-guide route is affected.

## Additional Notes

Two things I found but deliberately did **not** change, as they are policy calls for the maintainer rather than doc fixes:

1. **`CODE_OF_CONDUCT.md` is Contributor Covenant v1.4**, correctly attributed. v2.1 is current and adds an enforcement-ladder section. Upgrading is a governance decision, not a docs cleanup, so I left it.
2. **Two different contact addresses**: `Mohab.MohieElDeen@outlook.com` for conduct reports (`CODE_OF_CONDUCT.md:58`) and `mohabmohie@gmail.com` for security (`SECURITY.md`). Plausibly intentional, since they route different report types, and I could not verify which is preferred — so I changed neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wEoJduy4Q4jfHWejcizCe