### PR TITLE
docs: converge the modular-era feature catalog (774 -> 514 lines)

### DIFF
--- a/modular-era-feature-catalog.md
+++ b/modular-era-feature-catalog.md
@@ -2,11 +2,17 @@
 
 SHAFT is now a modular Java 25 automation framework with a lean core, opt-in power modules, and evidence-first tooling for browser, mobile, API, Playwright, MCP, IntelliJ IDEA, SikuliX desktop image automation, capture, reporting, diagnosis, and healing.
 
-This catalog is written for framework users who want to know what changed, what they can adopt now, and which command or API gets them started.
+This catalog is written for framework users who want to know what they can adopt
+now, and which command or API gets them started.
 
-- Baseline: `35d51c56289af07a4204cc52d2ee30e55be172e3` (`Shaft modularization (#2839)`)
-- Catalog source: current PR branch based on `origin/main` at `465fb54942`
-- Fresh evidence captured: `2026-07-04`
+For the release-by-release history behind these capabilities, see the
+[GitHub releases](https://github.com/ShaftHQ/SHAFT_ENGINE/releases). For
+installation, configuration, and full API reference, see the
+[user guide](https://shafthq.github.io/docs/start/overview).
+
+Screenshots in this catalog are real repository evidence under
+`shaft-engine/src/main/resources/modular-era-feature-catalog/`, shown beside the
+feature each one proves.
 
 ## Start Here
 
@@ -19,279 +25,46 @@ This catalog is written for framework users who want to know what changed, what 
 | Make Android/Appium setup and recording less coordinate-driven. | [Mobile automation](#mobile-automation) | Toolchain diagnostics and locator-first Inspector recording show the exact device, locator, and fallback state. |
 | Debug failed tests from evidence instead of guessing. | [Doctor, Heal, Trace, and reporting](#doctor-heal-trace-and-reporting) | Failure briefs, traces, locator health, healing decisions, and report UI give a shorter path from failure to fix. |
 
-### IntelliJ Assistant browser control
-
-Assistant chat now routes browser-control requests directly to sequenced SHAFT MCP tools. WebDriver is the default for natural prompts such as `open https://example.com and inspect the sign in link`. The generated sequence calls `driver_initialize` before `browser_open_intent`, keeps DOM output bounded, and returns locator candidates with evidence.
-
-Browser-control requests can inspect DOM, title, URL, screenshots, navigation, window state, and session cleanup. Screenshot requests write workspace evidence files and omit base64 by default. Playwright remains available only through explicit wording in natural prompts.
-
-## Screenshot Proof Gallery
-
-Every screenshot in this catalog is real repository evidence under `shaft-engine/src/main/resources/modular-era-feature-catalog/`.
-
-### IntelliJ plugin screenshots
-
-- `shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-assistant.png`
-- `shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-assistant-empty.png`
-- `shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-assistant-live-output-dark.png`
-- `shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-assistant-narrow-dark.png`
-- `shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-mcp-setup.png`
-- `shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-mcp-setup-narrow-dark.png`
-- `shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-mcp-setup-success.png`
-- `shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-mcp-setup-error-dark.png`
-- `shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-settings.png`
-
-<table>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-assistant.png" alt="SHAFT IntelliJ IDEA plugin Assistant tab" width="620">
-      <br><strong>IntelliJ Assistant</strong>
-      <br>Copilot-style composer with visible Ask/Plan/Agent mode switching, Local/Cloud provider type, family/runtime, prompt, and transcript.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-assistant-dark.png" alt="SHAFT IntelliJ IDEA plugin Assistant tab in dark theme" width="620">
-      <br><strong>Assistant (dark)</strong>
-      <br>Assistant workflow view in IntelliJ dark theme for the same prompt/action path.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-assistant-live-output-dark.png" alt="SHAFT IntelliJ IDEA plugin Assistant tab while a local agent is running" width="620">
-      <br><strong>Assistant live output</strong>
-      <br>Local agent execution keeps transcript output, progress, cancellation, and copy controls visible in the tool window.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-assistant-narrow-dark.png" alt="SHAFT IntelliJ IDEA plugin Assistant tab in a narrow dark tool window" width="620">
-      <br><strong>Assistant narrow panel</strong>
-      <br>The same Assistant controls stay usable in a narrow right-side IntelliJ tool window.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-guided.png" alt="SHAFT IntelliJ IDEA plugin Guided tab" width="620">
-      <br><strong>Guided workflows</strong>
-      <br>Recorder, locator, and guardrail actions prepare reviewed SHAFT MCP requests.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-triage.png" alt="SHAFT IntelliJ IDEA plugin Triage tab" width="620">
-      <br><strong>Triage</strong>
-      <br>Doctor, Trace, Healer, and locator proposal requests are prepared from one evidence workflow.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-recorder.png" alt="SHAFT IntelliJ IDEA plugin Recorder tab" width="620">
-      <br><strong>Recorder</strong>
-      <br>Editable capture templates, checkpoints, Playwright/native replay settings, and request/result state.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-inspector.png" alt="SHAFT IntelliJ IDEA plugin Inspector tab" width="620">
-      <br><strong>Inspector</strong>
-      <br>Inspector-backed status and MCP request inspection during capture and mobile tool workflows.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-evidence.png" alt="SHAFT IntelliJ IDEA plugin Evidence Tools tab" width="620">
-      <br><strong>Evidence Tools</strong>
-      <br>Evidence and repair-oriented outputs, including locator and failure-context helpers.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-projects.png" alt="SHAFT IntelliJ IDEA plugin Projects tab" width="620">
-      <br><strong>Projects</strong>
-      <br>Project and upgrade actions, migration checkers, and project tool execution surfaces.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-advanced-tools.png" alt="SHAFT IntelliJ IDEA plugin Advanced Tools tab" width="620">
-      <br><strong>Advanced Tools (light)</strong>
-      <br>Curated MCP template families and lower-frequency operational tool access.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-advanced-tools-dark.png" alt="SHAFT IntelliJ IDEA plugin Advanced Tools tab in dark theme" width="620">
-      <br><strong>Advanced Tools (dark)</strong>
-      <br>Same curated MCP families in IntelliJ dark theme.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-mcp-setup.png" alt="SHAFT IntelliJ IDEA plugin first-run MCP setup flow" width="620">
-      <br><strong>First-run MCP setup</strong>
-      <br>A simple click-through workflow highlights one action at a time: pick agent, copy command, open terminal, then check setup.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-settings.png" alt="SHAFT IntelliJ IDEA plugin Settings panel with MCP and provider controls" width="620">
-      <br><strong>Settings and providers</strong>
-      <br>Post-setup controls for Local/Cloud routing, cloud model selection, selected-key passing, and provider key storage.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-mcp-setup-success.png" alt="SHAFT IntelliJ IDEA plugin MCP setup success flow" width="620">
-      <br><strong>MCP setup success</strong>
-      <br>Successful setup stays clean: SHAFT verifies the runtime, hides managed MCP wiring, and reveals Start chatting.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-mcp-setup-error-dark.png" alt="SHAFT IntelliJ IDEA plugin MCP setup error state in dark theme" width="620">
-      <br><strong>MCP setup error</strong>
-      <br>Probe failures stay inline with categorized diagnostics, client-specific next steps, retry actions, and copyable diagnostic output.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-mcp-setup-narrow-dark.png" alt="SHAFT IntelliJ IDEA plugin MCP setup flow in a narrow dark tool window" width="620">
-      <br><strong>MCP setup narrow panel</strong>
-      <br>Status labels and runtime controls remain readable in a 360 px right-side tool window.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/intellij-plugin-settings-dark.png" alt="SHAFT IntelliJ IDEA plugin Settings panel in dark theme" width="620">
-      <br><strong>Settings (dark)</strong>
-      <br>Provider routing, selected-key passing, and stored-key controls remain readable in IntelliJ dark theme.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/android-recorder-working.png" alt="Android recorder resolving gestures to accessibility id and resource id locators" width="620">
-      <br><strong>Android recorder with real locators</strong>
-      <br>Inspector gestures are resolved to `ACCESSIBILITY_ID` and `ID` locators before falling back to coordinates.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/android-recorder-locator-details.png" alt="Mobile Inspector locator details and coordinate fallback warning" width="620">
-      <br><strong>Locator details and fallback warning</strong>
-      <br>Shows the locator order, recorded action details, and warning-only coordinate fallback path.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/android-toolchain-status.png" alt="Android Appium toolchain status after setup" width="620">
-      <br><strong>Android toolchain status</strong>
-      <br>Confirms SDK, emulator, Appium, UiAutomator2, Inspector plugin, and readiness checks from one diagnostic surface.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/android-emulator-device.png" alt="Android emulator device used for evidence capture" width="620">
-      <br><strong>Fresh emulator evidence</strong>
-      <br>Shows the real Android emulator target used while validating the mobile recorder path.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/mcp-tools.png" alt="shaft-mcp tool manifest and tool families" width="620">
-      <br><strong>MCP tool manifest</strong>
-      <br>WebDriver, Playwright, mobile, capture, target discovery, backend comparison, evidence packs, Doctor, Heal, Trace, guide search, scenario catalog, and guardrails in one manifest.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/capture-catalog.png" alt="Capture and code generation feature catalog" width="620">
-      <br><strong>Capture/codegen capability map</strong>
-      <br>Session storage, in-panel checkpoints, step reorder, session goals, replay generation, privacy, locator fallback, patch previews, backend comparison, evidence manifests, workbench review sections, and Page Object drafts are visible in source.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/playwright-surface.png" alt="Playwright facade and MCP tool surface" width="620">
-      <br><strong>Playwright surface beside WebDriver</strong>
-      <br>Browser actions, element actions, assertions, tracing, replay, screenshots, and Doctor hooks share the SHAFT workflow.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/doctor-heal-trace.png" alt="Doctor Heal and Trace tools" width="620">
-      <br><strong>Doctor, Heal, and Trace</strong>
-      <br>Failure analysis, trace summaries, locator recovery, and reviewed repair suggestions stay connected to test evidence.
-    </td>
-  </tr>
-  <tr>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/api-reporting.png" alt="API contract reporting and observability APIs" width="620">
-      <br><strong>API, contracts, and reporting</strong>
-      <br>GraphQL, retries, typed JSON mapping, contract replay, locator health, trace reporting, and evidence profiles are grouped together.
-    </td>
-    <td width="50%">
-      <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/module-map.png" alt="SHAFT module map from current reactor POMs" width="620">
-      <br><strong>Module map</strong>
-      <br>Current reactor POMs show the lean core, BOM, relocation artifact, and optional module split.
-    </td>
-  </tr>
-</table>
-
 ## What Changed
 
-| Area | Framework-user value | Proof |
+| Area | What you can adopt now | Proof |
 | --- | --- | --- |
 | Lean modular core | Adopt the core engine first, then add BrowserStack, visual, video, SikuliX desktop image automation, AI, Doctor, Heal, Capture, or MCP only when a project needs them. | `module-map.png` |
-| MCP automation surface | Drive WebDriver, Playwright, mobile, recording, coding-partner planning, target discovery, guide search, generated-code review, evidence manifests, and failure triage through one local server. | `mcp-tools.png` |
-| IntelliJ IDEA plugin | First-run MCP setup now opens as a simple vertical click-through: pick the agent, copy the installer command, run it in the IntelliJ terminal, and check setup while the plugin uses installer defaults to find and persist the local SHAFT MCP launch command automatically. Guided now includes a Partner section that plans repository-aware work from intent, current source, selected code, and evidence before codegen starts; the Assistant restores safe project chats, uses a compact `Codex CLI` agent label with the full agent tooltip, keeps action/timeline chrome hidden until useful, uses a taller prompt composer with a concise placeholder, keeps Copy, Clear, and Rerun available as compact transcript icons when useful, renders code blocks with theme-aware light/dark palettes, keeps status text accessible, supports Ctrl+Enter / Command+Enter send plus Escape cancel, and keeps reviewed recorder/codegen actions, Inspector checks, Triage, Evidence Tools, project actions, settings/provider controls, and live-refresh Advanced Tools behind the same verified MCP setup gate. | `intellij-plugin-mcp-setup.png`, `intellij-plugin-mcp-setup-success.png`, `intellij-plugin-mcp-setup-error-dark.png`, `intellij-plugin-mcp-setup-narrow-dark.png`, `intellij-plugin-assistant.png`, `intellij-plugin-assistant-empty.png`, `intellij-plugin-assistant-dark.png`, `intellij-plugin-guided.png`, `intellij-plugin-triage.png`, `intellij-plugin-advanced-tools.png`, `intellij-plugin-settings.png`, `intellij-plugin-settings-dark.png` |
-| IntelliJ Assistant fix for issue #3188 | Chat transcript messages are now role-rendered (user/assistant bubbles), sessions persist and restore correctly, and the route/runtime controls lock with a visible configure recovery path once MCP is configured. | `intellij-plugin-assistant.png`, `intellij-plugin-mcp-setup.png` |
-| IntelliJ Assistant fix for issue #3237 | Local Agent completion callbacks now clear the running state even when the streaming token was already reset, and approved capture generation tells the Agent to preserve the recorded journey, open the first search result, and assert the final page title or page-specific text. | `intellij-plugin-assistant-live-output-dark.png`, `intellij-plugin-assistant-narrow-dark.png` |
-| IntelliJ Assistant chat polish | Newly sent user prompts scroll into view immediately, while SHAFT-owned icon buttons and Assistant bubbles use borderless surfaces so chat feedback reads clearly in light, dark, and narrow tool windows. | `intellij-plugin-assistant.png`, `intellij-plugin-assistant-dark.png`, `intellij-plugin-assistant-narrow-dark.png` |
-| IntelliJ and MCP hardening for issue #3244 | Onboarding preflight now validates Windows JDK21 `JAVA_HOME` state and auto-creates `%JAVA_HOME%\\Packages` when possible, then reports clear missing/invalid/unwritable diagnostics; recorder re-record flows map discard to `capture_stop` with `discard=true`; and `shaft_project_create` supports optional `shaftVersion` with blank/null defaulting to the latest published stable `shaft-engine` while bundled example POMs remain reactor-versioned. | `intellij-plugin-mcp-setup.png`, `intellij-plugin-mcp-setup-error-dark.png`, `intellij-plugin-recorder.png`, `mcp-tools.png` |
-| Non-SHAFT-project hardening for issues #3396/#3397 | Every SHAFT-only Assistant action now gates on a real SHAFT dependency: tool approvals ("approve once/tool/all") persist per project instead of application-wide, the MCP connection heartbeat no longer polls in non-SHAFT projects, and mutating Assistant tools (`shaft_project_upgrade`, `verify_run_focused`, healer/doctor triage) return an onboarding nudge toward Create/Upgrade SHAFT Project instead of running. Settings > SHAFT "Test Connection" now probes the open project's workspace instead of the IDE process's own working directory. `healer_run_failed_test` fails fast with a guardrail message instead of burning guarded Maven builds when the target repository has no SHAFT dependency, and SHAFT MCP workspace errors for a missing Allure/report path now read as "no SHAFT setup found here" instead of a sandbox-escape message. | `intellij-plugin-assistant.png`, `intellij-plugin-assistant-approval-prompt.png`, `intellij-plugin-settings.png`, `intellij-plugin-settings-dark.png` |
-| IntelliJ trust/polish for issue #3601 (remaining scope) | Setup wizard: finished steps collapse to a compact line once a later step is active (click or Enter/Space to re-expand), the Target/Runtime line reads as a de-emphasized caption with "MCP" spelled out on first mention, the six steps are threaded by a connecting rule, raw probe output on failure hides behind a "Show details" toggle, and a non-destructive "Connection & agents" button re-checks readiness without the "Reset everything" factory reset. Settings: the MCP stdio command field is read-only once a wizard-set command exists, with an "Edit manually" gate before direct editing. Assistant: the first-run welcome no longer uses list-item emoji and now orients first-time users to the icon-only toolbar, "Allow source edits" gets a distinct bordered treatment from the neutral Verbose/Auto-compact toggles, a dismissible hint points fresh (non-SHAFT) projects at the "Create a new SHAFT project" template, and tool results now show narrative Markdown with a per-message "Show raw output" disclosure toggle for the underlying raw evidence (A5) instead of only a bulk transcript-export appendix. Guided: a dismissible soft prompt nudges collapsed-view users toward Advanced options for templates/backend controls. Accessibility: informational labels across the setup wizard, Assistant, Settings, and Guided panels now expose their live, dynamically-updated text to screen readers via an accessible description that tracks every `setText` update, not just a static category name (issue #3603; remaining same-shape labels tracked separately as #3605). | `intellij-plugin-mcp-setup.png`, `intellij-plugin-mcp-setup-success.png`, `intellij-plugin-mcp-setup-error-dark.png`, `intellij-plugin-mcp-setup-narrow-dark.png`, `intellij-plugin-assistant.png`, `intellij-plugin-assistant-empty.png`, `intellij-plugin-assistant-dark.png`, `intellij-plugin-assistant-tool-result-raw-output.png`, `intellij-plugin-guided.png`, `intellij-plugin-settings.png`, `intellij-plugin-settings-dark.png` |
-| IntelliJ Phase 4/5 hardening for issues #3634-#3642 | Success status color now passes WCAG contrast in dark themes; the Pin Response Fields dialog is a proper modal `DialogWrapper`; the selected workflow view and feature-panel split position persist across restarts; day-to-day action buttons carry per-action notification titles instead of a generic "SHAFT" banner; the API recording session panel (the last panel with visible-text buttons, now that every other one is icon-only) gets Alt-reachable mnemonics for Stop/Pin Fields/Generate/Copy CA Certificate; Guided's recorded-step list gains Delete/Move Up/Move Down for Playwright and Mobile recordings (shown below); the SHAFT Tests tab gains double-click Run and Ctrl+double-click Navigate on any row; watch mode now correlates a saved file against the last run's target class before replaying, offering a "Run `<Class>`" action on a mismatch instead of silently rerunning a stale test; and Doctor/Healer evidence screenshots render inline in the assistant transcript instead of requiring a separate file open. | `intellij-plugin-guided.png` |
-| IntelliJ per-run execution overrides for issue #3659 | Adds a `RunConfigurationExtension`-backed "SHAFT" tab to IntelliJ's own TestNG/JUnit run-configuration editor, so a single run configuration can override `targetBrowserName`/`headlessExecution`/extra `-D` args without editing `custom.properties`; state round-trips through the run configuration's own saved XML and survives "Copy Configuration". First step of the IntelliJ plugin UX program tracked by issue #3666. | `intellij-plugin-run-config-shaft-tab.png` |
-| IntelliJ SHAFT Tests discovery tree for issue #3663 | Replaces the flat, run-history-only "SHAFT Tests" list with a package/class/@Test-method tree built from real project-wide PSI discovery (`ShaftTestDiscovery`), so every SHAFT-runnable test is visible up front instead of only ones that happened to already run; recorded pass/fail/last-run-time layers on as a decoration where available. Second step of the IntelliJ plugin UX program (issue #3666), foundational for the live-status follow-up (#3664). | `intellij-plugin-shaft-tests.png`, `intellij-plugin-shaft-tests-dark.png` |
-| IntelliJ Settings/Recorder curation for issue #3665, setup wizard Connect agent | A "Test Execution" Settings section reads/writes `custom.properties` directly (line-based, never destroys comments/formatting); the Recorder tab gets a curated WebDriver Quick Start with the raw-JSON tool catalog demoted to an Advanced fallback; the first-run setup wizard's Ready step gets a one-click `Connect agent` retry instead of a skip-only dead end. Fourth step of the IntelliJ plugin UX program (issue #3666). | `intellij-plugin-settings.png`, `intellij-plugin-settings-dark.png`, `intellij-plugin-recorder.png` |
-| MCP locator-generation policy | `capture_target_candidates`, `capture_pick_locator`, `test_plan_explore`, and the recording-to-code pipeline (`capture_code_blocks`/`capture_generate_replay`) no longer generate intent-based `SHAFT.GUI.Locator.clickableField`/`inputField` calls; locators are chosen in strict tier order -- a unique, stable, author-written id (`hasId`) first, role-based locators (`hasRole`) second, a self-verified, non-absolute XPath (native `By.xpath`) third and only as a last resort; anything else is refused rather than emitted. `capture_start`'s `targetUrl`/`browser`/`outputPath`/`sessionGoal` are now genuinely optional in its MCP schema (matching its own javadoc), fixing a validation error that blocked starting a goal-less recording. | -- |
-| IntelliJ Guided recorder browser picker for issue #3660 | Replaces the recorder's hardcoded `"Chrome"`/`"CHROME"` literals with a real Browser picker (Chrome/Edge, the only two values `capture_start` and `mobile_initialize_web_emulation` actually accept server-side); moves the Browser and Headless controls out from behind "Advanced options" onto the always-visible primary surface, mirroring Playwright's VS Code extension; and gives the existing team-policy headless lock (`.shaft/recorder-policy.json`) a visible "Locked by team policy" hint instead of a tooltip-only signal. Third step of the IntelliJ plugin UX program (issue #3666). | `intellij-plugin-guided.png` |
-| IntelliJ Assistant run timeline retired for issue #3695 | Removes the separately-scrollable "Run timeline" list (and its label) that used to duplicate chat content below the composer; every tool-call milestone, streamed progress notification, and terminal Completed/Failed/Cancelled/Killed signal now renders as its own chat bubble in the main transcript instead, still filtered to drop internal meta-tool noise like `ToolSearch` (issue #3672). Below the chat, a single-line status label (spinner + text, no "Run timeline" caption) is the only run-status element left. | `intellij-plugin-assistant-progress-milestones.png`, `intellij-plugin-assistant-live-output-dark.png` |
-| SikuliX desktop automation | Desktop image automation lives in `shaft-sikulix`, so projects opt into `com.sikulix:sikulixapi` only when they need image-based desktop flows. | `tools/modularization/consumer-fixtures/sikulix/pom.xml`, `tests/scripts/test_sikulix_module_boundary.py` |
-| Recorder-to-code workflow | Capture real user actions, preserve edited step intent and checkpoints, plan reuse with `shaft_coding_partner_plan`, then generate TestNG replay snippets, setup/assertion/control-flow review blocks, locator/action summaries, patch previews, backend comparisons, evidence manifests, and Page Object insertions. | `web-recorder.png`, `capture-catalog.png`, `intellij-plugin-guided.png` |
+| MCP automation surface | Drive WebDriver, Playwright, mobile, recording, coding-partner planning, guide search, generated-code review, evidence manifests, and failure triage through one local server. | `mcp-tools.png` |
+| IntelliJ IDEA plugin | First-run setup is a four-step click-through (pick agent, copy command, run in terminal, check setup). Assistant and Guided then plan repository-aware work from intent, current source, selected code, and evidence before codegen starts. | `intellij-plugin-mcp-setup.png`, `intellij-plugin-assistant.png` |
+| Recorder-to-code workflow | Capture real user actions, preserve edited step intent and checkpoints, plan reuse with `shaft_coding_partner_plan`, then generate TestNG replay snippets, review blocks, patch previews, evidence manifests, and Page Object insertions. | `web-recorder.png`, `capture-catalog.png` |
 | Locator-first mobile recording | Resolve Appium Inspector pointer gestures through the accessibility tree, then generate ranked locator inventories, Page Object drafts, and record-at-target snippets before using coordinate fallback. | `android-recorder-working.png`, `android-recorder-locator-details.png` |
 | Evidence-led failure work | Combine Allure failure briefs, traces, locator health, healing reports, and optional reviewed AI advice. | `doctor-heal-trace.png`, `api-reporting.png` |
+| SikuliX desktop automation | `shaft-sikulix` owns the `com.sikulix:sikulixapi` dependency, keeping image-based desktop flows out of the lean engine artifact. | `module-map.png` |
 
-## IntelliJ Coding Partner Top 10 Implementation
+Release-by-release detail, including the issue numbers behind each change, lives
+in the [GitHub releases](https://github.com/ShaftHQ/SHAFT_ENGINE/releases).
 
-The recorder/codegen handoff is now a three-iteration coding-partner loop before
-any source edit: plan the working set and user steps, reuse the recommended Java
-owner and insertion anchor, avoid duplicate locators/actions/classes, prove
-missing browser steps, inspect the patch preview, collect evidence, then verify
-locally. Generated code picks locators in strict tier order: a unique,
-stable, author-written id (`hasAnyTagName().hasId(...)`) first, the SHAFT
-locator builder's ARIA-role locators (`hasRole(...)`) second, native
-`By.xpath(...)` only as a last resort when the element has neither; it must
-not emit `SHAFT.GUI.Locator.xpath(...)`, the raw `id`/`name`/`cssSelector`/
-`className`/`tagName(...)` factories, or a Smart Locator
-(`inputField`/`clickableField`).
+## Generated-Code Locator Policy
+
+Every SHAFT code generator — `capture_target_candidates`, `capture_pick_locator`,
+`test_plan_explore`, `capture_code_blocks`, and `capture_generate_replay` — picks
+locators in strict tier order:
+
+1. A unique, stable, author-written id: `hasAnyTagName().hasId(...)`.
+2. An ARIA-role locator: `hasRole(...)`.
+3. A self-verified, non-absolute `By.xpath(...)`, and only when the element has
+   neither of the above.
+
+Anything else is refused rather than emitted. Generators never produce
+`SHAFT.GUI.Locator.xpath(...)`, the raw `id`/`name`/`cssSelector`/`className`/
+`tagName(...)` factories, or a Smart Locator (`inputField`/`clickableField`).
+
+## Coding Partner Workflow
+
+The recorder/codegen handoff is a review loop, not a one-shot generator: plan the
+working set and user steps, reuse the recommended Java owner and insertion
+anchor, avoid duplicate locators/actions/classes, inspect the patch preview,
+collect evidence, then verify locally.
 
 The public entry point is IntelliJ, not raw MCP: Assistant `/partner` and Guided
 `Plan coding partner` gather the IDE context, then MCP returns the reuse plan,
-reviewed code blocks, and focused verification command.
-
-```mermaid
-flowchart LR
-    IDE[IntelliJ Assistant / Guided] --> Plan[shaft_coding_partner_plan]
-    Plan --> Reuse[Existing target + insertion anchor]
-    Reuse --> Review[Reviewed code blocks / patch preview]
-    Review --> Verify[Focused local verification]
-```
-
-| Rank | Enhancement | Why users feel it immediately |
-| --- | --- | --- |
-| 1 | Coding Partner Workspace | Guided exposes `Plan coding partner` and Assistant exposes `/partner`, so intent, backend, current Java source, selected text, and evidence paths become one preview-only MCP request. |
-| 2 | Repository Reuse Scanner | `shaft_coding_partner_plan` and `capture_target_candidates` return existing tests/page objects with driver variables, anchors, locator summaries, and action summaries. |
-| 3 | Duplicate Prevention Plan | The plan separates `reuseMatches` from `missingCodeItems` and returns `recommendedTargetSourcePath` plus `recommendedInsertionAnchor`, so agents extend existing owners before creating new page objects or generated tests. |
-| 4 | Context Plan Generator | `workingSetSummary` records the active intent, backend, source path, candidate count, and evidence count; `stepPlan` breaks the user request into proofable browser/code steps. |
-| 5 | Live Browser Step Runner | Suggested calls route WebDriver work through `browser_open_intent` and Playwright work through `playwright_browser_get_page_dom` before publishing locators. |
-| 6 | Missing-Code Generator | `missingCodeItems` calls out raw Selenium conversion, missing stable locators, missing Java targets, or absent user intent before generation. |
-| 7 | Patch Preview And Apply | `capture_record_at_target_code_blocks` and `mobile_record_at_target_code_blocks` still return preview-only diff blocks with apply order; existing locator fields and duplicate action lines are reused or skipped before IntelliJ approval. |
-| 8 | Focused Verification | The plan returns the smallest useful verification command, then Capture/Doctor evidence links compile or replay failures back to source and recording context. |
-| 9 | Failure Repair Loop | Failure skills now route Doctor, trace, and healer evidence through the coding-partner plan before changing shared page/test code. |
-| 10 | Evidence Pack And PR UX | `capture_evidence_pack` plus refreshed IntelliJ screenshots provide local source/report/review/screenshot evidence without zipping or uploading artifacts. |
-
-## IntelliJ + MCP UX Enhancements (Next Wave)
-
-Building on the coding-partner loop, this wave tightens the last-mile experience:
-plan to applied code to verified result, with a simpler default command surface
-and sharper trust signals.
-
-| Enhancement | What users get | Entry point |
-| --- | --- | --- |
-| Minimal command surface | The Assistant shows only five core commands by default — `/record-web`, `/record-mobile`, `/codegen`, `/doctor`, `/upgrade`. Everything else (including the new `/verify` and `/skills`) moves behind Expert mode, which is the existing advanced-UI switch. Natural-language intents still work in both modes. | Assistant composer; `Settings -> SHAFT` Expert mode |
-| Preview-only patch diff | `shaft_coding_partner_diff` turns reviewed SHAFT code blocks into a unified diff against an existing Java target and anchor, without writing files. | `shaft_coding_partner_diff` |
-| Focused verification runner | `verify_run_focused` runs the plan's smallest Maven verification command headlessly through the Healer allowlist and returns a bounded pass/fail summary; the Expert `/verify` command routes to it. | `verify_run_focused`, `/verify` |
-| Provider readiness | `autobot_provider_status` reports the configured provider, model, API-key presence (never the value), and structured-output support for an at-a-glance readiness view. | `autobot_provider_status` |
-| Structured cloud codegen | `autobot_provider_chat` now returns a structured JSON-schema codegen response — summary, per-block code with target path/anchor, cited SHAFT guide URLs, unverified locator assumptions, and a guardrail status computed by running SHAFT guardrails on the returned code. | `autobot_provider_chat` |
-| Readable tool output | The Assistant renders the coding-partner plan, diff preview, verification result, provider status, and structured codegen as clean markdown with inline citations and locator-assumption warnings instead of raw JSON. | `Assistant` tab |
-| Fix Failing Test | The Triage panel adds a one-click button that routes the Allure/trace evidence and locator source into `shaft_coding_partner_plan`, bridging analyze -> plan -> verify. | `Triage` tab |
-| Optimized authoring skills | The `shaft-skills` set gains `verifying-and-applying-shaft-changes` (review -> diff -> apply -> guardrails -> verify) and the existing skills point their apply/verify step at the new tools; the Expert `/skills` command lists them in-panel. | `shaft-skills/`, `/skills` |
+reviewed code blocks, and a focused verification command.
 
 ```mermaid
 flowchart LR
@@ -304,24 +77,18 @@ flowchart LR
     Triage --> Plan
 ```
 
-### Settling Pass: Audit + UI/UX Polish
-
-A follow-up pass re-audited this wave's own gap-analysis fixes (all confirmed intact) and closed the remaining
-professionalism gaps the first audit didn't reach — no new features, all reused-vocabulary polish.
-
-| Enhancement | What users get | Entry point |
+| Step | Tool | What you get |
 | --- | --- | --- |
-| Unified status presentation | One shared `ShaftStatusPresentation` class now owns every status color and glyph (success/pending/progress/error, plus the warning glyph) that three panels used to reimplement independently. | Settings, MCP setup, Assistant |
-| Colored, iconed run milestones | The Assistant's agent-milestone chat bubbles (issue #3695; formerly a separate "Run timeline" list) show a checkmark/hourglass/cross before Completed/Running/Failed steps instead of plain text, reusing the same shared vocabulary. | `Assistant` chat transcript |
-| Consistent section headers | Guided Workflows and Evidence Triage's intro captions, and the Workflow selector's field label, now get the same bold-header treatment Settings already had. | `Guided`, `Triage` tabs |
-| Field tooltips | Evidence Triage's six input fields (Allure, Trace, Repository, Sources, Locator source, Command) now show a tooltip, matching every other panel in the plugin. | `Triage` tab |
-| Iconed workflow selector | The Workflow selector — the plugin's primary navigation control across all 8 destinations — now shows an icon per destination instead of bare text. | `Workflow` selector |
-| Hardened narrow layout | The Assistant status row now trims safely at the 360px narrow tool-window width instead of risking a clip, keeping the full text in a tooltip. | `Assistant` tab, narrow layout |
-| Muted empty state | The tool catalog's "No tool template matches the current filter" message now renders muted/disabled, matching the plugin's established empty-state treatment. | `Advanced` tools tab |
-| Unified transient confirmation | The Assistant's transient status label now uses the same bordered, tinted "chip" look as the MCP setup toast, instead of two different visual languages for the same concept. | `Assistant` tab, `Settings \| SHAFT MCP` setup |
-| Explicit icon wiring | Guided Workflows' and Evidence Triage's buttons now receive their icon explicitly at construction instead of an icon lookup keyed on the button's display text, so a future label edit can't silently point at the wrong icon. | `Guided`, `Triage` tabs |
-| Collapsing notices strip | The Assistant's setup/fresh-project banner strip no longer reserves blank height for hidden banners, closing the gap between the panel header and the "New chat" chat-history dropdown so the transcript below it fills the remaining space. | `Assistant` tab, chat header |
-| Scope-colored approval buttons | The tool-approval prompt's three approval buttons now render with equal visual weight and are color-coded by scope breadth -- green for "Approve all tools", blue for "Approve tool always", yellow for "Approve once" -- nudging toward broader scopes instead of dimming them. | `Assistant` tab, tool approval prompt |
+| Plan | `shaft_coding_partner_plan` | `workingSetSummary`, a `stepPlan`, `reuseMatches` versus `missingCodeItems`, plus `recommendedTargetSourcePath` and `recommendedInsertionAnchor`, so agents extend existing owners instead of creating new page objects. |
+| Preview | `shaft_coding_partner_diff` | A unified diff against an existing Java target and anchor, without writing files. |
+| Guard | `test_code_guardrails_check` | Runs SHAFT guardrails over generated code before it is applied. |
+| Verify | `verify_run_focused` | Runs the plan's smallest Maven verification command headlessly and returns a bounded pass/fail summary. |
+| Triage | `Fix Failing Test` | Routes Allure/trace evidence and locator source back into the plan, closing the analyze, plan, verify loop. |
+
+The Assistant shows five core commands by default — `/record-web`,
+`/record-mobile`, `/codegen`, `/doctor`, and `/upgrade`. Everything else,
+including `/verify` and `/skills`, sits behind Expert mode. Natural-language
+intents work in both modes.
 
 ## Modular Adoption
 
@@ -340,6 +107,21 @@ Use the new reactor split when you want SHAFT as a framework base, not a monolit
 ## MCP and Agent Workflows
 
 `shaft-mcp` turns SHAFT into an agent-friendly local automation server. Framework users get direct tools for browser sessions, Playwright sessions, mobile devices, recorder sessions, coding-partner planning, guide search, scenario discovery, generated-code guardrails, trace reading, Doctor analysis, and Heal workflows.
+
+### Assistant browser control
+
+IntelliJ Assistant chat routes browser-control requests to sequenced SHAFT MCP
+tools. WebDriver is the default for natural prompts such as
+`open https://example.com and inspect the sign in link`: the generated sequence
+calls `driver_initialize` before `browser_open_intent`, keeps DOM output
+bounded, and returns locator candidates with evidence. Playwright is used only
+when a prompt asks for it explicitly.
+
+Browser-control requests can inspect DOM, title, URL, screenshots, navigation,
+window state, and session cleanup. Screenshot requests write workspace evidence
+files and omit base64 by default.
+
+### Workflows
 
 | Workflow | What it gives users | Entry point |
 | --- | --- | --- |
@@ -638,15 +420,6 @@ SHAFT.Properties.reporting.set()
   </tr>
 </table>
 
-## Release and Developer Experience Guardrails
-
-The modular-era work also tightened release and developer workflows: release guards, modular upgrader coverage, MCP runtime path fixes, generated-code guardrails, documentation consolidation, graph assets, and memory guidance now sit beside the feature surface instead of after it.
-
-```powershell
-py -3 scripts/ci/validate_agent_setup.py
-py -3 scripts/ci/validate_shaft_mcp_transports.py
-```
-
 ## Relationship Map
 
 ```mermaid
@@ -738,7 +511,7 @@ sequenceDiagram
 
 ```mermaid
 flowchart TB
-    A[134 registered MCP tools] --> B[WebDriver browser + element]
+    A[90 registered MCP tools] --> B[WebDriver browser + element]
     A --> C[Playwright browser + element + semantic]
     A --> D[Capture start/status/stop/generate]
     A --> E[Mobile native, web emulation, inspector, screenshots]
@@ -747,28 +520,3 @@ flowchart TB
 ```
 
 </details>
-
-## Fresh Capture Commands
-
-```powershell
-# Build the current remote/main code used by the MCP server.
-mvn -pl shaft-mcp -am package '-DskipTests' '-Dallure.automaticallyOpen=false' '-Dallure.open=false'
-mvn -pl shaft-mcp dependency:copy-dependencies '-DincludeScope=runtime' '-Dallure.automaticallyOpen=false' '-Dallure.open=false'
-
-# Validate browser_open_intent and the synchronized MCP tool manifest.
-mvn -pl shaft-mcp -am '-Dtest=McpServiceHelperTest,ShaftMcpApplicationTests#contextRegistersExpectedLeanMcpToolApi' '-Dallure.automaticallyOpen=false' '-Dallure.open=false' test
-
-# Start the shaft-mcp HTTP server from the merged build.
-java -cp "shaft-mcp\target\shaft-mcp-10.2.20260623.jar;shaft-mcp\target\dependency\*" com.shaft.mcp.ShaftMcpApplication --spring.profiles.active=http --server.port=8093
-```
-
-```powershell
-# Install Android SDK pieces used for the fresh emulator screenshot.
-C:\Users\Mohab\android-tools\cmdline-tools\latest\bin\sdkmanager.bat --sdk_root=C:\Users\Mohab\android-tools `
-  'platform-tools' 'emulator' 'platforms;android-36' 'system-images;android-36;google_apis;x86_64'
-
-# Appium tool cache versions used by current SHAFT internal defaults.
-appium@3.5.2
-appium-uiautomator2-driver@7.6.2
-appium-inspector-plugin@2026.5.1
-```


### PR DESCRIPTION
## Description

`modular-era-feature-catalog.md` says it is "written for framework users who want to know what they can adopt now", but it had accumulated release-by-release history and read as a per-issue changelog. This keeps the adoption guidance, removes the duplication, and fixes the stale facts. 774 -> 514 lines, no adoption guidance lost.

Companion to #4295, which covers the other root docs. Independent — either can merge first.

## Type of Change

- [x] Documentation update

## The duplication

**The "Screenshot Proof Gallery" was a second copy of the whole image set (187 lines).** Every PNG in it is already rendered beside the feature it proves, in the IntelliJ, Capture, Mobile, Playwright, Doctor, Modular Adoption, and MCP sections. Several images appeared **three** times in one document. The gallery's captions restated the section tables. Removed; the images stay where they carry meaning.

**Per-issue retrospectives collapsed into one capability table.** "What Changed" carried rows titled after issues 3188, 3237, 3244, 3396/3397, 3601, 3634-3642, 3659, 3663, 3665, and 3695 — several a single unbroken 200-word cell — plus the "IntelliJ Coding Partner Top 10", "Next Wave", and "Settling Pass: Audit + UI/UX Polish" sections. That is development history, not adoption guidance, and it is already in the release notes.

Behaviour a user still needs was kept and promoted into two focused sections rather than deleted:

- **Generated-Code Locator Policy** — the strict `hasId` -> `hasRole` -> `By.xpath` tier order and what the generators refuse to emit. This was buried in a changelog cell and restated in a second section.
- **Coding Partner Workflow** — plan/preview/guard/verify/triage, with the entry-point tools and the five default Assistant commands.

Per-issue history now points at the [releases](https://github.com/ShaftHQ/SHAFT_ENGINE/releases).

## The stale facts

| Claim | Reality | Verified against |
|---|---|---|
| "134 registered MCP tools" | **90** | `shaft-skills/references/shaft-mcp-tools.md` header *and*, independently, the raw `@Tool` annotation count in `shaft-mcp/src/main/java` |
| `shaft-mcp-10.2.20260623.jar` hardcoded on a classpath | reactor is `10.3.20260727` | root `pom.xml` |
| `intellij-plugin-assistant-approval-prompt.png` | **does not exist** | listed in a Proof column; absent from the resources dir |
| Pinned to PR branch `465fb54942`, "evidence captured 2026-07-04" | branch long merged | stale provenance header |
| `C:\Users\Mohab\android-tools\...` | a maintainer's personal absolute path | in a user-facing doc |

The last two lived in a "Fresh Capture Commands" section documenting how the screenshots were captured — maintainer provenance, not adoption guidance — so it is removed rather than patched. "Release and Developer Experience Guardrails" is likewise removed: it listed contributor validators that CONTRIBUTING.md already owns.

Also moved "IntelliJ Assistant browser control" out of the Start Here navigation table, where it sat as a stray `###`, into the MCP section.

> The missing-PNG and stale-count findings are why this was checked rather than assumed: an automated link check reported "0 missing", because those filenames appear as backticked text in table cells, not as Markdown image syntax.

## Evidence

After the rewrite, checked programmatically:

```
every remaining image reference        -> resolves on disk (0 missing)
all 6 "Start Here" anchors             -> match a real heading
py -3 scripts/ci/validate_documentation_boundaries.py
  Documentation boundary is valid (432 tracked Markdown files).
git diff --check                       -> clean
```

Line endings unchanged (pure LF, as in the original).

## Documentation Site

- Documentation not required because: this is an in-repo catalog. No public API or product behaviour changes, and the trimmed content was development history already published in the GitHub release notes.

## Additional Notes

`intellij-plugin-tools.png` and `intellij-plugin-tools-dark.png` are unreferenced by this document. They were already unreferenced before this change, so I left them in place rather than widen the diff — worth a look if they are genuinely dead assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wEoJduy4Q4jfHWejcizCe
