### PR TITLE
test: migrate MultipleElementsFailureTest off data: URL to TestPageServer

### DIFF
--- a/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
@@ -6,10 +6,11 @@ import org.openqa.selenium.By;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import testPackage.TestPageServer;
 
 public class MultipleElementsFailureTest {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
-    String mockedHTML = "data:text/html,<input/><input/><input/><script>var result;</script><button ${HIDDEN} alt='Google' onclick='result=\"Clicked\"'>Go</button>";
+    String mockedHTML = TestPageServer.url("multipleElementsFixture.html");
 
 
     @Test(expectedExceptions = {RuntimeException.class})

--- a/shaft-engine/src/test/resources/testDataFiles/multipleElementsFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/multipleElementsFixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT Multiple Elements Fixture</title>
+</head>
+<body>
+<input/>
+<input/>
+<input/>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Migrates `MultipleElementsFailureTest`'s mocked HTML off the `data:text/html,...` literal to a served-file fixture (`multipleElementsFixture.html`) via `TestPageServer`, matching the existing pattern in `E2ECoverageTests`.
- Drops the dead `${HIDDEN}` placeholder token and the `<button>`/`<script>` it decorated -- neither was ever substituted or referenced by any assertion in this file.

Related to #4300.

## Why

The nightly `Local E2E Tests` / `MacOSX_Safari_Local` job reports `MultipleElementsFailureTest.type/click/clickUsingJS` as BROKEN -- Safari never throws `MultipleElementsFoundException` for a `//input` xpath that matches 3 `<input/>` elements on the test's `data:text/html,...` page, while the same test passes 3/3 on headless Chrome. Issue #4300's investigation concluded this is most likely a genuine SafariDriver/WebKit `data:`-URL handling quirk, not a SHAFT logic bug (SHAFT's own uniqueness-detection logic in `Actions.java` is plain, browser-agnostic Java with no Safari-specific override), but that could not be confirmed without a live Safari session.

This PR implements the issue's own suggested next step: eliminate the `data:`-URL variable by swapping to a served-file URL, so a future Safari nightly run isolates whether the failure is `data:`-URL-specific or something else. **It is not itself a fix for the Safari behavior** -- only the next `MacOSX_Safari_Local` nightly run can confirm whether removing the `data:` URL changes the outcome.

## What changed
- `shaft-engine/src/test/resources/testDataFiles/multipleElementsFixture.html` (new): 3 `<input/>` elements, nothing else.
- `shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java`: `mockedHTML` field now resolves via `TestPageServer.url("multipleElementsFixture.html")` instead of the inline `data:` literal. Same 3 `<input/>` elements, same 3 test methods/assertions, same `expectedExceptions = {RuntimeException.class}` (`MultipleElementsFoundException`) expectation.

The dropped `${HIDDEN}` token was never substituted anywhere in the file (confirmed via `rg '\$\{HIDDEN\}'`), and the `<button>`/`<script>` it decorated were never targeted by any of the three test methods (all three only ever locate `By.xpath("//input")`) -- so removing them is a pure dead-code cleanup, not a behavior change.

## Test plan
- **Baseline (before this change, headless Chrome):** `mvn -pl shaft-engine -Dtest=MultipleElementsFailureTest -Dallure.automaticallyOpen=false -DheadlessExecution=true test` → `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`, all 3 throwing `MultipleElementsFoundException` as expected.
- **After migration (same command):** identical result -- `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`, all 3 still throwing `MultipleElementsFoundException` with the same root-cause stack.
- This confirms the migration is behavior-preserving on Chrome. **It does not and cannot confirm anything about Safari** -- whether this change actually resolves the `MacOSX_Safari_Local` nightly failures can only be confirmed by that next nightly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wEoJduy4Q4jfHWejcizCe
