### PR TITLE
test: drop dead ${HIDDEN} placeholder and unused button/script in NoSuchElementFailureTest

### DIFF
--- a/shaft-engine/src/test/java/testPackage/mockedTests/NoSuchElementFailureTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/NoSuchElementFailureTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 
 public class NoSuchElementFailureTest {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
-    String mockedHTML = "data:text/html,<input/><input/><input/><script>var result;</script><button ${HIDDEN} alt='Google' onclick='result=\"Clicked\"'>Go</button>";
+    String mockedHTML = "data:text/html,<input/><input/><input/>";
 
 
     @Test(expectedExceptions = {RuntimeException.class})


### PR DESCRIPTION
## Summary
- Drops the dead `${HIDDEN}` placeholder token and the unused `<button>`/`<script>` it decorated from `NoSuchElementFailureTest.java` — same copy-paste dead-code pattern PR #4309 cleaned up in `MultipleElementsFailureTest.java`.
- `${HIDDEN}` was never substituted anywhere in the file; the `<button>`/`<script>` were never targeted by any of the three test methods, which all query a nonexistent `input[@id='noSuchElement']` to trigger `NoSuchElementException`.
- Scope intentionally narrower than #4309: issue #4310's body explicitly defers the `data:` URL → `TestPageServer` fixture migration as "a separate judgment call" pending a check of this test's own nightly-run status (that migration in #4309 was specifically to isolate a Safari nightly signal for #4300's test). Not performed here — reported back to the orchestrator as a follow-up decision, not assumed.

Fixes #4310

## Test plan
- [x] Baseline: `mvn test -pl shaft-engine -Dtest=testPackage.mockedTests.NoSuchElementFailureTest -DheadlessExecution=true` → 3/3 passed before edit.
- [x] Same command after edit → 3/3 passed, identical result.
- [x] Confirmed via `grep` that no `HIDDEN`/`button`/`script` (dead-code) tokens remain in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGdgmezM75NX62aMypA5jn