### PR TITLE
Fix #4308: revert unverified FlutterTest enablement in Android_Native_BrowserStack nightly

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -28,16 +28,18 @@ on:
           Opt-in flag for the Android_Flutter_Emulator_E2E job (issue #4197).
           Renamed from enableFlutterE2E (issue #4294) to stop colliding in
           name with the unrelated -Dshaft.enableFlutterE2E Maven system
-          property that gates FlutterTest.java (FlutterTest.java:24,31-36) --
-          that property is now permanently hardcoded true in the
-          Android_Native_BrowserStack job instead of being driven by any
-          workflow input, so this input only ever means one thing: opt in to
-          THIS emulator smoke-check job. This job never runs on the nightly
-          schedule (schedule triggers can't supply inputs); set to 'true' on
-          a manual dispatch to run it. It only proves an Appium session opens
-          against the real, pinned demo-app on an emulator -- it does not run
-          FlutterTest.java and does not exercise the fluent Flutter API (see
-          job comment).
+          property that gates FlutterTest.java (FlutterTest.java:24,31-36).
+          #4303 briefly hardcoded that property true in Android_Native_BrowserStack;
+          reverted back to self-skip by the fix for issue #4308 (the checked-in
+          flutter-demo.apk was never actually built with the required Flutter
+          Integration Driver server -- see issue #4313 for the real fix). The
+          rename stands regardless, so this input still only ever means one
+          thing: opt in to THIS emulator smoke-check job. This job never runs
+          on the nightly schedule (schedule triggers can't supply inputs); set
+          to 'true' on a manual dispatch to run it. It only proves an Appium
+          session opens against the real, pinned demo-app on an emulator -- it
+          does not run FlutterTest.java and does not exercise the fluent
+          Flutter API (see job comment).
         required: false
         default: 'false'
 
@@ -596,15 +598,24 @@ jobs:
       - name: Run tests
         continue-on-error: true
         timeout-minutes: 40
-        # -Dshaft.enableFlutterE2E=true unskips FlutterTest.java's flutter-group tests
-        # (FlutterTest.java:24,31-36) so they actually execute here instead of
-        # self-skipping every run (issue #4294). This job's shaft-engine reactor
-        # module (pulled in via -am) already matches FlutterTest.* through the
-        # -Dtest selector below and already opens BrowserStack sessions strictly
-        # sequentially (TestNG defaults setParallel=NONE/setThreadCount=1, never
-        # overridden here), so adding it is a same-job subset, not a new
-        # concurrent-session risk.
-        run: mvn -pl shaft-browserstack -am -e test "-Dshaft.enableFlutterE2E=true" "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=60" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.platformVersion=13.0" "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*ndroid.*], %regex[.*FlutterTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]' }}"
+        # -Dshaft.enableFlutterE2E=true is intentionally NOT passed here. #4303/#4294
+        # hardcoded it, unskipping FlutterTest.java's flutter-group tests
+        # (FlutterTest.java:24,31-36) on the assumption that the checked-in
+        # shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk already
+        # had the Appium Flutter Integration Driver server wired in -- that premise was
+        # never actually verified (no workflow_dispatch run against it before merge) and
+        # was proven false by the first real nightly run (issue #4308, run 30327817291):
+        # FlutterTest.setupFlutterDriver failed immediately with "Flutter server is not
+        # started", because flutter-demo.apk is a plain Flutter build with no such
+        # server embedded (confirmed via `unzip -l` -- no flutter_driver/integration
+        # markers). Reverted back to self-skip (the pre-#4303 default) until issue #4313
+        # replaces flutter-demo.apk with one actually built via the same
+        # Ptarget=.../integration_test/appium.dart pipeline Android_Flutter_Emulator_E2E
+        # already uses, and that rebuild is verified with a real workflow_dispatch run
+        # before re-enabling this flag -- the exact verification step #4294 skipped.
+        # The -Dtest selector below still deliberately matches FlutterTest.* (harmless
+        # while self-skipping) so re-enabling later is a one-line change again.
+        run: mvn -pl shaft-browserstack -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=60" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=browserstack" "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2" "-DbrowserStack.platformVersion=13.0" "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl=" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '%regex[.*ndroid.*], %regex[.*FlutterTest.*], %regex[.*BrowserStackPropertiesUnitTest.*], %regex[.*BrowserStackHelperUnitTest.*], %regex[.*BrowserStackSdkHelperCoverageUnitTest.*]' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -675,10 +686,13 @@ jobs:
 
   # Issue #4197: proves a real Appium session can be opened against a Flutter
   # app built with the driver's own required server wiring, on a real CI
-  # runner. This job deliberately does NOT touch FlutterTest.java or run it
-  # -- that class is now actually enabled and running for real in the
-  # Android_Native_BrowserStack job instead (issue #4294), against a
-  # BrowserStack-hosted prebuilt APK rather than a locally-built/emulated one.
+  # runner. This job deliberately does NOT touch FlutterTest.java or run it.
+  # #4303/#4294 briefly enabled FlutterTest.java for real in the
+  # Android_Native_BrowserStack job against a BrowserStack-hosted prebuilt APK,
+  # but that APK (flutter-demo.apk) was never actually built with the driver's
+  # server wiring -- proven by the resulting nightly failure, issue #4308 --
+  # so that enablement was reverted back to self-skip pending issue #4313
+  # (build a correctly-wired demo app the same way THIS job already does).
   # What this job proves: the demo-app/emulator/Appium pipeline boots and a
   # session opens locally. What it does NOT prove: that any of the fluent
   # API's calls behave correctly against a live Flutter widget tree -- wiring


### PR DESCRIPTION
## 📋 Description

PR #4303 (closing issue #4294) hardcoded `-Dshaft.enableFlutterE2E=true` into `Android_Native_BrowserStack`'s Maven args, unskipping `FlutterTest.java`'s flutter-group tests in the nightly job for the first time. That PR's own body admitted the premise was never verified: "Not locally verifiable ... Issue #4294's own plan calls for a real workflow_dispatch run scoped to jobs=Android_Native_BrowserStack ... that has not been run as part of this change."

The first real nightly run after merge (run [30327817291](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30327817291), tracked by #4308) failed immediately:

```
[ERROR] testPackage.appium.FlutterTest.setupFlutterDriver -- Time elapsed: 485.1 s <<< FAILURE!
[ERROR] Run 1: FlutterTest.setupFlutterDriver:59 » Runtime Driver Factory Action "setRemoteDriverInstance" failed.
  Root cause: SessionNotCreatedException: ... "Flutter server is not started. Please make sure the
  application under test is configured properly."
```

**Root cause:** `shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk` (checked in years ago in an unrelated bulk-fixture commit, `c623638cd5`) is a plain Flutter build — `unzip -l` shows only standard `libflutter.so`/notification/kotlin resources, no Appium Flutter Integration Driver server extension. Compare `Android_Flutter_Emulator_E2E` (same workflow file), which builds its own demo app fresh every run specifically to embed that server via `flutter build apk --debug && gradlew app:assembleDebug -Ptarget=.../integration_test/appium.dart`. `flutter-demo.apk` was never built that way, so `FlutterTest` fails deterministically, not intermittently — it will fail on every future nightly run until the app is fixed.

## Fix

Reverts **only** the forced-enable premise: removes `-Dshaft.enableFlutterE2E=true` from `Android_Native_BrowserStack`'s Maven args, restoring `FlutterTest`'s self-skip (the pre-#4303 default). Confirmed the restored `run:` line is byte-identical to the pre-#4303 commit (`79acbbf756~1`).

Everything else from #4303/#4294 is kept intact, per design:
- The `-Dtest` selector still matches `FlutterTest.*` (harmless while self-skipping; re-enabling later is a one-line change).
- The `enableFlutterEmulatorE2E` workflow_dispatch input rename is kept (still needed to avoid the original naming collision regardless of enablement state).

Updated the surrounding comments in `.github/workflows/e2eTests.yml` so they no longer claim the property is "permanently hardcoded true" (no longer true) or that FlutterTest is "actually enabled and running for real" (also no longer true), and cross-referenced #4308/#4313.

## 🔗 Related Issue(s)

- Fixes #4308
- Reverts the enablement half of #4303 / #4294 (both already closed on GitHub — no reopen needed, just cross-linked)
- Follow-up (the real permanent fix): #4313 — build `Android_Native_BrowserStack` a demo app actually wired with the Flutter Integration Driver server, the same way `Android_Flutter_Emulator_E2E` already does, with the `workflow_dispatch` verification run this time before re-enabling.

## 🗂️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 CI/CD or infrastructure change

## ✅ Pre-Submission Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md) and this PR follows its guidelines.
- [x] Documentation/agent-only changes pass their deterministic validators: `py -3 scripts/ci/validate_workflow_timeouts.py` → "All workflow jobs declare timeout-minutes."
- [x] YAML re-parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2eTests.yml'))"`).
- [ ] Behavior changes have focused automated coverage. — this is CI-workflow YAML only, same as #4303; no Java changed. Acceptance criterion is the next nightly/`workflow_dispatch` run of `Android_Native_BrowserStack` showing `FlutterTest` skipped again (not failed).
- [x] I have not introduced any hardcoded credentials, secrets, or sensitive data.
- [x] I have not broken backward compatibility.

## 🧪 How to Test

1. Dispatch `e2eTests.yml` manually scoped to `jobs=Android_Native_BrowserStack`, or wait for the next nightly schedule run.
2. Confirm the job's TestNG output shows `FlutterTest`'s 4 flutter-group methods **skipped** again (not failed) — restoring the state before #4303.
3. Confirm all other `Android_Native_BrowserStack` tests (native Android, BrowserStack unit tests) are unaffected.

## Evidence

- Root-cause log excerpt from run 30327817291 above.
- `unzip -l shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk` — no `flutter_driver`/`integration`/Appium-server markers, just `lib/{arm64-v8a,x86_64}/libflutter.so` + standard Flutter/Kotlin/notification resources.
- Diff confirms restored Maven args line is byte-identical to `79acbbf756~1` (pre-#4303).
- `py -3 scripts/ci/validate_workflow_timeouts.py` passes.