### PR TITLE
Group current-agent label + settings gear into one chip in ShaftAssistantPanel routeRow

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -208,6 +208,17 @@ final class ShaftAssistantPanel extends JPanel {
     private final JButton rerunLastPrompt;
     private final JLabel currentAgentConfiguration;
     private final JButton configure;
+    /**
+     * Bordered chip wrapping {@link #currentAgentConfiguration} + {@link #configure} together so
+     * the "which agent is this / configure it" pair reads as one grouped unit in {@code routeRow}
+     * instead of two unstyled controls lost among the surrounding dropdowns (issue #4316). Mirrors
+     * the {@link #allowSourceMutationChip} idiom, but with a neutral tint (reusing
+     * {@link ShaftStatusPresentation#progress()}, the same informational tint already used for
+     * {@link #status}) since this pair is purely informational, not a high-stakes toggle. Its
+     * visibility must mirror both wrapped controls' shared {@code lockedRoute} gate in
+     * {@link #updateControlVisibility()} so it never renders as an empty chip.
+     */
+    private final JPanel currentAgentChip;
     private final JProgressBar progress;
     private final JLabel status;
     private final ShaftSettingsState.Settings settings;
@@ -612,6 +623,21 @@ final class ShaftAssistantPanel extends JPanel {
         rerunLastPrompt.setEnabled(false);
         this.configure = button("Configure", "Open SHAFT MCP setup", event -> openSetup());
         ShaftIconButtons.apply(this.configure, ShaftIcons.SETTINGS);
+        // Neutral informational tint (progress(), also used for the "status" label at #3601 B3.4) --
+        // distinct from allowSourceMutationChip's warning tint, which is deliberately alarming for a
+        // high-stakes toggle. This pair is just "which agent is this / configure it".
+        currentAgentChip = new JPanel(new BorderLayout(4, 0));
+        currentAgentChip.setOpaque(true);
+        currentAgentChip.setBackground(ShaftStatusPresentation.tint(
+                javax.swing.UIManager.getColor("Panel.background") == null
+                        ? java.awt.Color.WHITE
+                        : javax.swing.UIManager.getColor("Panel.background"),
+                ShaftStatusPresentation.progress(), 0.08D));
+        currentAgentChip.setBorder(JBUI.Borders.compound(
+                JBUI.Borders.customLine(ShaftStatusPresentation.progress(), 1),
+                JBUI.Borders.empty(2, 6)));
+        currentAgentChip.add(currentAgentConfiguration, BorderLayout.CENTER);
+        currentAgentChip.add(this.configure, BorderLayout.EAST);
 
         mode.addActionListener(event -> onModeOrRouteSelectionChanged());
         providerType.addActionListener(event -> onModeOrRouteSelectionChanged());
@@ -661,8 +687,7 @@ final class ShaftAssistantPanel extends JPanel {
         routeRow.add(providerType);
         routeRow.add(assistantFamily);
         routeRow.add(assistantRuntime);
-        routeRow.add(currentAgentConfiguration);
-        routeRow.add(configure);
+        routeRow.add(currentAgentChip);
         routeRow.add(customCommand);
         routeRow.add(cloudProvider);
         routeRow.add(cloudModel);
@@ -3195,6 +3220,10 @@ final class ShaftAssistantPanel extends JPanel {
         currentAgentConfiguration.getAccessibleContext().setAccessibleDescription(currentAgentConfigurationText);
         currentAgentConfiguration.setToolTipText(currentAgentConfigurationTooltip());
         currentAgentConfiguration.setVisible(lockedRoute);
+        // Chip has no state of its own; it only needs to stay in lockstep with the label's and
+        // configure button's own shared lockedRoute gate below so it never renders as an empty
+        // colored box (mirrors the allowSourceMutationChip comment at #3601 B3.4).
+        currentAgentChip.setVisible(lockedRoute);
         customCommand.setVisible(advanced && !lockedRoute && localCli);
         customCommand.setEnabled(controlsEnabled && advanced && !lockedRoute && localCli);
         cloudProvider.setVisible(advanced && !lockedRoute && cloud);

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLayoutTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLayoutTest.java
@@ -3,10 +3,14 @@ package com.shaft.intellij.ui;
 import com.shaft.intellij.settings.ShaftSettingsState;
 import org.junit.jupiter.api.Test;
 
+import javax.swing.JComponent;
 import javax.swing.JPanel;
+import java.awt.Component;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -33,6 +37,40 @@ class ShaftAssistantPanelLayoutTest {
                         + "strip must not reserve any height above the chat header");
     }
 
+    /**
+     * Issue #4316: {@code currentAgentConfiguration} (the "Claude CLI"-style label) and
+     * {@code configure} (the settings gear) used to be added to {@code routeRow} as two bare
+     * controls, reading as clutter among the ~13 other dropdowns/checkboxes in that row. They now
+     * share one bordered chip, mirroring the {@code allowSourceMutationChip} idiom already used in
+     * this file for {@code allowSourceMutation}.
+     */
+    @Test
+    void currentAgentChipGroupsLabelAndGearButtonWhenRouteIsLocked() throws ReflectiveOperationException {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(
+                null, readySettingsForExistingProject(), ShaftAssistantChatState.getInstance(null), () -> { });
+
+        JPanel chip = currentAgentChipOf(panel);
+        Component label = fieldOf(panel, "currentAgentConfiguration");
+        Component gear = fieldOf(panel, "configure");
+
+        assertTrue(chip.isVisible(), "route is locked (MCP configured + setup flow present), so the chip "
+                + "grouping the current-agent label and settings gear must be visible");
+        assertTrue(containsComponent(chip, label), "chip must contain the current-agent-configuration label");
+        assertTrue(containsComponent(chip, gear), "chip must contain the configure/settings gear button");
+    }
+
+    /** Same route-locked gate {@code currentAgentConfiguration}/{@code configure} already used individually. */
+    @Test
+    void currentAgentChipHiddenWhenRouteIsNotLocked() throws ReflectiveOperationException {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(
+                null, new ShaftSettingsState.Settings(), ShaftAssistantChatState.getInstance(null));
+
+        JPanel chip = currentAgentChipOf(panel);
+
+        assertFalse(chip.isVisible(), "no setup flow/MCP configuration -- the route is not locked, so the "
+                + "grouped chip must stay hidden exactly like the two controls it wraps used to");
+    }
+
     /** MCP configured (hides the setup notice) with a {@code null} project (never "fresh", hides that notice too). */
     private static ShaftSettingsState.Settings readySettingsForExistingProject() {
         ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
@@ -45,5 +83,19 @@ class ShaftAssistantPanelLayoutTest {
         Field field = ShaftAssistantPanel.class.getDeclaredField("notices");
         field.setAccessible(true); // NOPMD - test-only field injection, matching the established pattern in ShaftPanelSetupTest
         return (JPanel) field.get(panel);
+    }
+
+    private static JPanel currentAgentChipOf(ShaftAssistantPanel panel) throws ReflectiveOperationException {
+        return (JPanel) fieldOf(panel, "currentAgentChip");
+    }
+
+    private static Component fieldOf(ShaftAssistantPanel panel, String name) throws ReflectiveOperationException {
+        Field field = ShaftAssistantPanel.class.getDeclaredField(name);
+        field.setAccessible(true); // NOPMD - test-only field injection, matching the established pattern in ShaftPanelSetupTest
+        return (Component) field.get(panel);
+    }
+
+    private static boolean containsComponent(JComponent container, Component target) {
+        return Arrays.stream(container.getComponents()).anyMatch(child -> child == target);
     }
 }


### PR DESCRIPTION
## Summary
- `currentAgentConfiguration` (the "Codex CLI"/"Claude CLI" label) and `configure` (the settings gear) used to sit as two bare controls in `routeRow`'s flat flow, unstyled among ~13 other dropdowns/checkboxes.
- They now share one bordered `currentAgentChip` `JPanel`, reusing the exact `allowSourceMutationChip` idiom already in this file (bordered, opaque, tinted `JPanel`), but with a **neutral** tint (`ShaftStatusPresentation.progress()`, the same tint already used for the informational `status` label) instead of the warning tint used for the high-stakes `allowSourceMutation` toggle.
- Conditional visibility (`lockedRoute`) is preserved exactly on both wrapped controls; the chip's own visibility is now set alongside them so it never renders as an empty box.
- Accessible names/descriptions/tooltips on both controls, and `configure`'s action listener/icon, are unchanged -- only relocated into the wrapper.

Fixes #4316

## Design decision (for sanity check)
`currentAgentChip = new JPanel(new BorderLayout(4, 0))`, label `CENTER`, gear `EAST`, background tinted 8% with `progress()` over the panel background, 1px `customLine(progress())` border + 2/6px padding -- same weight/thickness as `allowSourceMutationChip`, just a calmer blue instead of orange, so the two chips read as siblings in the row (one "info" chip, one "high-stakes toggle" chip) rather than clashing visual languages.

## Test plan
- [x] `ShaftAssistantPanelLayoutTest` (2 new tests, TDD: watched `NoSuchFieldException` red before the field/wiring existed): chip groups both controls and is visible when the route is locked; chip stays hidden when it's not.
- [x] `ShaftPluginScreenshotRendererTest` -- full scoped run green, both before and after the change (code was temporarily reverted via `git checkout HEAD~1 -- <file>` to render true BEFORE evidence, then restored).
- [x] Real BEFORE/AFTER PNG evidence rendered via `-Dshaft.intellij.screenshotDir=...` (light, dark, narrow-dark variants) -- not attached inline (no non-interactive image-upload path from this session); files handed to the requesting orchestrator with local paths for review.

Scoped Gradle run only (`shaft-intellij` is a Gradle module, not Maven -- see `.claude/skills/shaft-mastery/references/intellij-plugin.md`):
```
JAVA_HOME=<ms-21.0.11 JDK> ./gradlew test --tests "com.shaft.intellij.ui.ShaftAssistantPanelLayoutTest" --tests "com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest"
```
No full suite, no headed IntelliJ launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGdgmezM75NX62aMypA5jn