### PR TITLE
Fix #4319: local-agent approval selector never showed, final answer duplicated

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/approval/LocalAgentApprovalBridge.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/approval/LocalAgentApprovalBridge.java
@@ -277,9 +277,17 @@ public final class LocalAgentApprovalBridge implements AutoCloseable {
         try {
             return future.get(decisionTimeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (TimeoutException exception) {
+            // Issue #4319 bug 1: give up locally AND tell the handler side this request is
+            // abandoned by cancelling the same future it handed out -- otherwise the caller (SHAFT's
+            // ShaftAssistantPanel) has no signal this request will never resolve, and its own
+            // "a prompt is currently showing" bookkeeping stays stuck forever, silently queuing every
+            // later approval request in the same run (e.g. a retry via a different tool) behind one
+            // that will never show or resolve.
+            future.cancel(true);
             return Decision.deny("No user decision arrived before the run's timeout.");
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
+            future.cancel(true);
             return Decision.deny("Interrupted while awaiting a user decision.");
         } catch (ExecutionException exception) {
             return Decision.deny("Approval failed: " + exception.getMessage());

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -285,6 +285,16 @@ final class ShaftAssistantPanel extends JPanel {
     private CompletableFuture<String> pendingTerminalAnswer;
     private final Deque<Runnable> queuedLocalAgentApprovalPrompts = new ArrayDeque<>();
     private boolean localAgentApprovalPromptShowing;
+    /**
+     * The bridge-facing future for whichever local-agent approval request is currently showing its
+     * widget, or {@code null} when none is. Issue #4319 bug 1: lets {@link
+     * #localAgentApprovalHandler} tell a genuinely abandoned request (the bridge gave up on its own
+     * timeout with no user decision -- see {@link LocalAgentApprovalBridge#awaitDecision}, which now
+     * cancels this same future when that happens) apart from one still waiting in {@link
+     * #queuedLocalAgentApprovalPrompts} that simply hasn't been shown yet, so only the request that
+     * is actually stuck on screen gets cleaned up.
+     */
+    private CompletableFuture<LocalAgentApprovalBridge.Decision> showingLocalAgentApprovalFuture;
     private final List<ToolEvidence> toolEvidence = new ArrayList<>();
     private String activeCaptureRecordingPath = AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH;
     private String activePlaywrightRecordingPath = AssistantCommand.DEFAULT_PLAYWRIGHT_RECORDING_PATH;
@@ -2326,6 +2336,20 @@ final class ShaftAssistantPanel extends JPanel {
      */
     private void showAgentResponse(
             int streamToken, boolean currentStream, String response, String output, String kind) {
+        // Issue #4319 bug 2: Claude Code's own final "text" block streams in as a dimmed
+        // KIND_MILESTONE bubble the moment the assistant event arrives (see
+        // ClaudeStreamEventMapper#describeAssistantEvent), moments before the terminal event that
+        // carries the identical text on a normal completion. Neither terminal branch below has a
+        // streaming-placeholder index to replace in place when that happens (only Verbose mode's
+        // appendLocalAgentOutput branch ever establishes one), so both would otherwise append this
+        // text as a second, duplicate bubble. Retract that redundant milestone first -- but only when
+        // there is no real placeholder to replace in place already (Verbose mode's own in-place
+        // update is untouched) -- so whichever branch below runs lands as the sole bubble, exactly as
+        // if the milestone had never streamed. A milestone showing genuinely different text is left
+        // alone; only an exact match is ever retracted.
+        if (localAgentStreamPlaceholderMessageIndex < 0) {
+            retractRedundantTrailingMilestone(response);
+        }
         if (currentStream) {
             finishLocalAgentResponse(streamToken, response, output, kind);
         } else {
@@ -2335,6 +2359,35 @@ final class ShaftAssistantPanel extends JPanel {
             // (issue #3703), which withLocalAgentTokenUsage does.
             persistAndAppendResponse(withLocalAgentTokenUsage(response, output), output, kind);
         }
+    }
+
+    /**
+     * Removes the transcript's last message when it is a {@link ShaftAssistantChatState#KIND_MILESTONE}
+     * bubble whose text exactly matches {@code response} (issue #4319 bug 2) -- resyncing {@code
+     * transcript} from {@code chatState} afterward, the same already-used pattern {@link
+     * #replaceLocalAgentStreamPlaceholder} relies on whenever it mutates {@code chatState} out from
+     * under the view directly (see the two-message-graph note on {@link #append}). Deliberately exact-
+     * match only and scoped to milestone bubbles specifically: a milestone showing different text (a
+     * tool call, a "Thinking:" line, ...) must never be retracted, and neither must a user bubble or
+     * any other kind that happens to share the same words.
+     */
+    private void retractRedundantTrailingMilestone(String response) {
+        if (response == null || response.isBlank()) {
+            return;
+        }
+        ShaftAssistantChatState.Session active = chatState.activeSession();
+        if (active == null || active.messages == null || active.messages.isEmpty()) {
+            return;
+        }
+        int lastIndex = active.messages.size() - 1;
+        ShaftAssistantChatState.Message last = active.messages.get(lastIndex);
+        if (!ShaftAssistantChatState.KIND_MILESTONE.equals(last.kind)
+                || last.markdown == null
+                || !last.markdown.strip().equals(response.strip())) {
+            return;
+        }
+        active.messages.remove(lastIndex);
+        transcript.setMessages(active.messages);
     }
 
     /**
@@ -2828,6 +2881,17 @@ final class ShaftAssistantPanel extends JPanel {
     private LocalAgentApprovalBridge.ApprovalRequestHandler localAgentApprovalHandler(int streamToken) {
         return (toolName, input) -> {
             CompletableFuture<LocalAgentApprovalBridge.Decision> future = new CompletableFuture<>();
+            // Issue #4319 bug 1: a cancelled/exceptionally-completed future means the BRIDGE gave up
+            // on this request (its own decision timeout fired with no user decision, e.g. the CLI
+            // moved on to a different tool call) -- not a normal resolution, which always completes
+            // this future normally via resolveLocalAgentApproval below. Only that abandonment case
+            // needs reacting to here; a normal completion is already fully handled at its own call
+            // site and must not be double-processed.
+            future.whenComplete((decision, error) -> {
+                if (error != null) {
+                    runOnEdt(() -> handleAbandonedLocalAgentApproval(future));
+                }
+            });
             runOnEdt(() -> handleLocalAgentApprovalRequest(streamToken, toolName, input, future));
             return future;
         };
@@ -2877,6 +2941,7 @@ final class ShaftAssistantPanel extends JPanel {
             int streamToken, String toolName, JsonObject input,
             CompletableFuture<LocalAgentApprovalBridge.Decision> future) {
         localAgentApprovalPromptShowing = true;
+        showingLocalAgentApprovalFuture = future;
         setStatus("Awaiting approval for " + toolName + "...");
         CompletableFuture<ToolApprovalDecision> decisionFuture = new CompletableFuture<>();
         ToolApprovalPromptPanel approvalPanel = new ToolApprovalPromptPanel(
@@ -2899,6 +2964,7 @@ final class ShaftAssistantPanel extends JPanel {
             CompletableFuture<LocalAgentApprovalBridge.Decision> future) {
         transcript.clearWidget();
         localAgentApprovalPromptShowing = false;
+        showingLocalAgentApprovalFuture = null;
         String key = LOCAL_AGENT_APPROVAL_KEY_PREFIX + toolName;
         String outcomeLine;
         if (decision == null || decision == ToolApprovalDecision.DENY) {
@@ -2921,6 +2987,37 @@ final class ShaftAssistantPanel extends JPanel {
             appendLocalAgentOutput(streamToken, outcomeLine);
             setStatus("Thinking...");
         }
+        advanceLocalAgentApprovalQueue();
+    }
+
+    /**
+     * Issue #4319 bug 1: reacts to a local-agent approval request the BRIDGE has abandoned (its own
+     * decision timeout fired -- see {@link LocalAgentApprovalBridge#awaitDecision} -- with no user
+     * decision ever arriving), which completes {@code abandonedFuture} exceptionally instead of
+     * through {@link #resolveLocalAgentApproval}'s normal path. Only cleans up when {@code
+     * abandonedFuture} is the request actually on screen right now ({@link
+     * #showingLocalAgentApprovalFuture}): a request still waiting in {@link
+     * #queuedLocalAgentApprovalPrompts} that gets abandoned before ever being shown is left alone --
+     * its own {@code showPrompt} still runs once its turn comes, harmlessly rendering a widget whose
+     * decision will complete an already-cancelled future as a no-op. Without this, {@link
+     * #localAgentApprovalPromptShowing} stays stuck {@code true} forever once a request is abandoned,
+     * silently queuing every later approval request in the same run behind one that will never
+     * resolve or show -- the exact "no approval selector, ever" symptom reported live: the model's
+     * retry via a different tool after the first call timed out.
+     */
+    private void handleAbandonedLocalAgentApproval(
+            CompletableFuture<LocalAgentApprovalBridge.Decision> abandonedFuture) {
+        if (abandonedFuture != showingLocalAgentApprovalFuture) {
+            return;
+        }
+        transcript.clearWidget();
+        localAgentApprovalPromptShowing = false;
+        showingLocalAgentApprovalFuture = null;
+        advanceLocalAgentApprovalQueue();
+    }
+
+    /** Shows the next queued local-agent approval prompt, if any, else restores composer focus. */
+    private void advanceLocalAgentApprovalQueue() {
         Runnable next = queuedLocalAgentApprovalPrompts.poll();
         if (next != null) {
             next.run();
@@ -2933,6 +3030,7 @@ final class ShaftAssistantPanel extends JPanel {
         if (localAgentApprovalPromptShowing) {
             transcript.clearWidget();
             localAgentApprovalPromptShowing = false;
+            showingLocalAgentApprovalFuture = null;
         }
         queuedLocalAgentApprovalPrompts.clear();
     }
@@ -3050,10 +3148,19 @@ final class ShaftAssistantPanel extends JPanel {
         // Any real message (user or assistant) ends the first-run welcome (issue #3540): the
         // welcome is only ever valid on a genuinely empty transcript, and this always follows
         // showFirstRunWelcomeIfNeeded() showing it (or a no-op if never shown/already dismissed),
-        // so clearWidget() here is safe even when nothing is currently showing. append() is never
-        // called while an approval widget occupies the same slot (see showFirstRunWelcomeIfNeeded's
-        // javadoc), so this never fights that widget for the slot.
-        transcript.clearWidget();
+        // so clearWidget() here is safe even when nothing is currently showing. Issue #4319 bug 1:
+        // append() is NOT guaranteed to skip the local-agent approval widget's slot the way the old
+        // comment here assumed -- AssistantLocalAgentRunner.narrateApproval's own "Waiting for your
+        // approval on X -- run timer paused." narration line streams back in through this exact path
+        // (appendLocalAgentOutput -> addCompactLocalAgentMilestone -> appendAgentMilestone -> append)
+        // while the ToolApprovalPromptPanel selector it is narrating about is still on screen, so an
+        // unconditional clearWidget() here destroyed the just-shown selector a moment after it
+        // rendered. Skip it while that widget is up; AssistantTranscriptView#canAppendIncrementally
+        // already falls back to a full refresh() whenever pendingWidget is non-null, which re-trails
+        // the widget after the new message instead of losing it.
+        if (!localAgentApprovalPromptShowing) {
+            transcript.clearWidget();
+        }
         transcript.append(role, text, rawResponse, kind);
         chatState.append(role, text, rawResponse, kind);
         updateContextTruncationBoundary();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -4120,6 +4120,66 @@ class ShaftPanelSetupTest {
                                 + markdown));
     }
 
+    /**
+     * Issue #4319 bug 2 (best evidence-consistent mechanism found -- not a confirmed live repro):
+     * Claude Code's {@code stream-json} protocol emits the model's own final "text" block as a plain
+     * assistant event the moment the turn ends ({@code ClaudeStreamEventMapper#describeAssistantEvent}
+     * -> {@code appendLocalAgentOutput} -> {@code addCompactLocalAgentMilestone}), rendering it as a
+     * dimmed {@code KIND_MILESTONE} bubble with nothing recognizing that this text IS about to become
+     * the run's terminal answer -- Claude's terminal {@code result} event's own {@code result} field
+     * carries the identical text on a normal completion. {@code finishLocalAgentResponse} then renders
+     * that same text again as a fresh, separate, clear bubble (non-Verbose runs never establish a
+     * streaming-placeholder index to replace in place -- see {@code replaceLocalAgentStreamPlaceholder}'s
+     * fresh-append branch), so the exact same wording appears twice: once dimmed, once clear. This
+     * reproduces with a plain completion (no approval pause, no stream-token mismatch), unlike the
+     * currentStream-mismatch hypothesis the issue itself first floated.
+     */
+    @Test
+    void assistantNonVerboseFinalizationDoesNotDuplicateAPlainTextFinalAnswerAlreadyStreamedAsAMilestone()
+            throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        String finalAnswer = "I need two things before I can generate this code: 1. No file is"
+                + " currently open. 2. Target URL confirmation.";
+
+        appendStreamingLocalAgentBubble(panel, 40);
+        appendLocalAgentOutput(panel, 40, finalAnswer);
+        showAgentResult(panel, 40, ShaftMcpToolResult.success(finalAnswer));
+
+        @SuppressWarnings("unchecked")
+        List<ShaftAssistantChatState.Message> messages =
+                ((ShaftAssistantChatState) getField(panel, "chatState")).activeMessages();
+        long occurrences = messages.stream().filter(message -> message.markdown.contains(finalAnswer)).count();
+
+        assertEquals(1, occurrences,
+                "the final answer must render exactly once, not once as a dimmed milestone and again"
+                        + " as the polished final bubble: " + transcriptMarkdown(panel));
+    }
+
+    /**
+     * Companion guardrail for the fix above: a milestone that streamed in DIFFERENT text from the
+     * eventual final answer (the common case -- a "Calling tool X..." milestone, not the model's own
+     * final text block) must never be retracted just because a terminal response follows it. Both
+     * must still render as separate bubbles.
+     */
+    @Test
+    void assistantNonVerboseFinalizationStillShowsADifferentMilestoneAndTheFinalAnswerSeparately()
+            throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        String milestone = "Calling tool Bash (grep locator)...";
+        String finalAnswer = "Found the search result element and generated the SHAFT test.";
+
+        appendStreamingLocalAgentBubble(panel, 41);
+        appendLocalAgentOutput(panel, 41, milestone);
+        showAgentResult(panel, 41, ShaftMcpToolResult.success(finalAnswer));
+
+        String markdown = transcriptMarkdown(panel);
+        assertAll(
+                () -> assertTrue(markdown.contains(milestone),
+                        "a milestone with genuinely different text must survive: " + markdown),
+                () -> assertTrue(markdown.contains(finalAnswer),
+                        "the final answer must still render: " + markdown));
+    }
+
     @Test
     void assistantNonVerboseRunShowsNoPlaceholderBubbleWhileRunning() throws Exception {
         // Issue #3919: the "_Running local assistant..._" placeholder bubble is gone -- progress
@@ -7254,6 +7314,85 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertTrue(second.isDone()),
                 () -> assertTrue(second.get().allowed()));
+    }
+
+    /**
+     * Issue #4319 bug 1: {@code LocalAgentApprovalBridge.awaitDecision} gives up locally on its own
+     * {@code TimeoutException} (the CLI moves on -- e.g. retries the same intent via a different
+     * tool) but never cancels/completes the bridge-facing future it handed out, so {@code
+     * localAgentApprovalPromptShowing} stays stuck {@code true} forever: a later approval request in
+     * the SAME run (the model's PowerShell retry after Bash's approval timed out) then finds the
+     * flag stuck and is silently queued behind a request that will never resolve -- never actually
+     * rendering its own selector, and never updating the status bar either (since {@code
+     * showLocalAgentApprovalPrompt}, the only place that sets the status text, never runs for it).
+     * This reproduces the abandonment with {@code future.cancel(true)}, mirroring the fix planned for
+     * the bridge side.
+     */
+    @Test
+    void abandonedLocalAgentApprovalUnsticksTheShowingFlagAndTheNextRequestStillShows() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        appendStreamingLocalAgentBubble(panel, 21);
+
+        LocalAgentApprovalBridge.ApprovalRequestHandler handler = localAgentApprovalHandler(panel, 21);
+        CompletableFuture<LocalAgentApprovalBridge.Decision> first = handler.requestApproval("Bash", new JsonObject());
+        SwingUtilities.invokeAndWait(() -> {
+        });
+        assertNotNull(transcriptWidget(panel), "the first request should render immediately");
+
+        // Simulates the bridge giving up on its own timeout, with no user decision ever arriving.
+        SwingUtilities.invokeAndWait(() -> first.cancel(true));
+
+        CompletableFuture<LocalAgentApprovalBridge.Decision> second =
+                handler.requestApproval("PowerShell", new JsonObject());
+        SwingUtilities.invokeAndWait(() -> {
+        });
+
+        JComponent secondWidget = transcriptWidget(panel);
+        assertAll(
+                () -> assertNotNull(secondWidget,
+                        "a second tool's approval request must still render its own selector after the"
+                                + " first one was abandoned (timed out), not resolved by the user"),
+                () -> assertTrue(secondWidget instanceof ToolApprovalPromptPanel,
+                        "the rendered widget must be the clickable approval selector"),
+                () -> assertEquals("Tool approval request for PowerShell",
+                        secondWidget.getAccessibleContext().getAccessibleName(),
+                        "the rendered widget must be the SECOND (PowerShell) request, not the stale"
+                                + " Bash widget left over from the abandoned first request"));
+    }
+
+    /**
+     * Issue #4319 bug 1: {@code AssistantLocalAgentRunner.narrateApproval} emits "Waiting for your
+     * approval on X -- run timer paused." through the SAME coalesced output pipeline that renders
+     * ordinary milestone bubbles (see {@code appendLocalAgentOutput} -> {@code
+     * addCompactLocalAgentMilestone} -> {@code appendAgentMilestone} -> {@code append}). {@code
+     * append} unconditionally calls {@code transcript.clearWidget()}, on the documented (but false,
+     * for this exact case) assumption that append is never called while an approval widget is
+     * showing -- so the narration line the user actually sees in the real transcript destroys the
+     * just-rendered {@link ToolApprovalPromptPanel} selector a moment after it appears, leaving only
+     * narration text with nothing left to click.
+     */
+    @Test
+    void localAgentApprovalWidgetSurvivesAMilestoneAppendedWhileItIsShowing() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        appendStreamingLocalAgentBubble(panel, 20);
+
+        LocalAgentApprovalBridge.ApprovalRequestHandler handler = localAgentApprovalHandler(panel, 20);
+        handler.requestApproval("Bash", new JsonObject());
+        SwingUtilities.invokeAndWait(() -> {
+        });
+        assertNotNull(transcriptWidget(panel), "the approval prompt should render immediately");
+
+        // Simulates narrateApproval's own narration line reaching the transcript through the real
+        // coalesced output path a live run uses.
+        appendLocalAgentOutput(panel, 20, "Waiting for your approval on Bash -- run timer paused.");
+
+        JComponent widgetAfterNarration = transcriptWidget(panel);
+        assertAll(
+                () -> assertNotNull(widgetAfterNarration,
+                        "a narration/milestone line streaming in while an approval prompt is showing"
+                                + " must not clobber it"),
+                () -> assertTrue(widgetAfterNarration instanceof ToolApprovalPromptPanel,
+                        "the surviving widget must still be the clickable approval selector"));
     }
 
     private static LocalAgentApprovalBridge.ApprovalRequestHandler localAgentApprovalHandler(


### PR DESCRIPTION
## Summary

Two real bugs the owner hit live in one Claude Code CLI Agent-mode session with the SHAFT Assistant panel, both in `ShaftAssistantPanel.java`.

### Bug 1 -- Bash/PowerShell tool-approval never shows a clickable selector

Two independent defects, both required to produce the reported symptom (neither alone fully explains it):

- `ShaftAssistantPanel.append()` unconditionally called `transcript.clearWidget()`, on the documented-but-false assumption that append is never called while an approval widget is showing. `AssistantLocalAgentRunner.narrateApproval`'s own "Waiting for your approval on X -- run timer paused." narration line streams back through this exact `append()` path (via the coalesced output pipeline) a moment after the `ToolApprovalPromptPanel` selector renders, destroying it. Fixed by gating `clearWidget()` on `localAgentApprovalPromptShowing`; `AssistantTranscriptView#canAppendIncrementally` already had a defensive fallback for exactly this case, so no other machinery needed to change.
- `LocalAgentApprovalBridge.awaitDecision` gave up locally on its own decision timeout but never told `ShaftAssistantPanel`, so `localAgentApprovalPromptShowing` stayed stuck `true` forever -- silently queuing every later approval request in the same run (the model's retry via a different tool, e.g. PowerShell after Bash) behind one that will never resolve, and leaving the status bar showing the first tool's stale name. Fixed by cancelling the bridge-facing future on timeout and having the panel react to that cancellation the same way it reacts to a real user decision.

### Bug 2 -- final answer renders twice (one greyed/stale, one clear)

**This root-cause mechanism is my best evidence-consistent finding, not a confirmed live repro** -- I could not reproduce the exact owner session, but I found and verified (via a real, unmocked production-code test) a deterministic mechanism that produces exactly the reported symptom on any plain-text-ending Agent turn:

Claude Code's `stream-json` protocol emits the model's own final "text" block as a plain assistant event (`ClaudeStreamEventMapper#describeAssistantEvent`) *before* the terminal `result` event. In non-Verbose mode that streams in as a dimmed `KIND_MILESTONE` bubble. The terminal `result` event's own text is, on a normal completion, the identical text -- and neither terminal branch in `showAgentResponse` had a streaming-placeholder index to replace in place (only Verbose mode ever establishes one), so both would append the same text again as a second, duplicate bubble: the dimmed milestone plus the clear final answer with its token-usage footer. This is not related to any `streamToken`/`activeLocalAgentStreamToken` mismatch, and does not require a second concurrent run.

Fixed in `showAgentResponse`: before either terminal branch renders, retract an exact-match trailing `KIND_MILESTONE` bubble. A milestone with genuinely different text (a tool call, a "Thinking:" line, ...) is left untouched -- verified by a companion guardrail test.

## Root cause: one or two?

**Three separate defects, not one shared root cause.** Bug 1's two defects are both about approval-widget/state lifecycle; Bug 2's defect is about milestone/terminal-event duplication in the streaming pipeline. I initially hypothesized Bug 2 might share a `streamToken` mismatch with Bug 1 (per the issue's own speculation) -- I could not find or reproduce that mechanism, and instead found and verified the milestone-duplication mechanism above, which needs no stream-token interaction with Bug 1 at all.

## Test plan

- [x] `ShaftPanelSetupTest`: 280/280 pass, including 4 new regression tests (2 for bug 1's two defects, 2 for bug 2's fix + guardrail)
- [x] `LocalAgentApprovalBridgeTest`: 11/11 pass
- [x] `AssistantLocalAgentRunnerApprovalTimeoutTest`: 4/4 pass
- [x] Full regression sweep: `AssistantLocalAgentRunner*`, `ShaftAssistantPanel*`, `com.shaft.intellij.approval.*` -- all green
- [x] Each new test watched RED (failing for the right reason against unfixed code) before the fix, then GREEN after
- [x] Rebased onto latest `origin/main` (past PR #4320, which touched the same file's `routeRow` region) -- clean rebase, no conflicts
- Run via `./gradlew.bat test --tests "..." -Dallure.automaticallyOpen=false`, `JAVA_HOME` pinned to `ms-21.0.11` per `shaft-mastery`'s intellij-plugin chapter

Fixes #4319

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01NGdgmezM75NX62aMypA5jn