### PR TITLE
Fix #4314: installer wizard polish pass (dead copy, agent check, merged buttons, recheck icon, blank Next badge)

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -140,6 +140,7 @@ final class ShaftMcpSetupPanel extends JPanel {
     private JLabel readyChecklist;
     private final JButton copyUpgradeCommand;
     private final JButton checkUpgrade;
+    private final JButton checkChosenAgent;
     private final JLabel upgradeDetail;
     private final JButton installNow;
     private final JButton checkMcpVersion;
@@ -350,6 +351,16 @@ final class ShaftMcpSetupPanel extends JPanel {
         checkMcpVersion.setToolTipText("Compare the installed SHAFT MCP version against the latest release");
         applyLabeledAction(checkMcpVersion, ShaftIcons.CHECK);
         checkMcpVersion.addActionListener(event -> runMcpVersionCheck(true));
+        // Issue #4314 fix 2: every other step already has its own "Check" button that turns its
+        // badge green on its own -- "2 Pick agent" only turned green as a side effect of the full
+        // step-4 MCP probe. This lets a user verify "is my picked agent already installed/connected"
+        // without running the whole setup flow.
+        checkChosenAgent = new JButton("Check");
+        checkChosenAgent.getAccessibleContext().setAccessibleName("Check agent connection");
+        checkChosenAgent.setToolTipText("Verify the selected agent is already installed and connected, "
+                + "without running the full SHAFT MCP setup check");
+        applyLabeledAction(checkChosenAgent, ShaftIcons.CHECK);
+        checkChosenAgent.addActionListener(event -> checkChosenAgentClicked());
         // Primary one-click install action (issue #3743; reworked for JetBrains Marketplace
         // compliance -- see ShaftPluginSecurityTest, which forbids this plugin from spawning
         // processes): opens a terminal with the full MCP + skills + CLI command pre-typed through
@@ -539,6 +550,10 @@ final class ShaftMcpSetupPanel extends JPanel {
         apiKeyRow.setVisible(false);
         agentControls.add(apiKeyRow);
         agentControls.add(recommendedAgent);
+        JPanel chooseActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+        chooseActions.setOpaque(false);
+        chooseActions.add(checkChosenAgent);
+        agentControls.add(chooseActions);
         // Issue #3771: each labeledControl row above packs its own label at that label's natural
         // width ("Assistant family" is longer than "Runtime"), so without this the dropdowns beside
         // them land at different x-offsets -- a ragged left edge next to a real aligned form.
@@ -1174,6 +1189,46 @@ final class ShaftMcpSetupPanel extends JPanel {
         updateActionState(false);
     }
 
+    /**
+     * "2 Pick agent"'s own standalone "Check" (issue #4314 fix 2): verifies the currently selected
+     * family/runtime is already installed/connected without running the whole step-4 MCP probe.
+     * Mirrors {@link #connectAgentClicked()}'s off-EDT dispatch for the non-cloud deep readiness
+     * probe (spawns the client CLI, ~10s -- must never block the EDT); the Gemini cloud route stays
+     * inline since it only does a fast local Password Safe lookup.
+     *
+     * <p>Deliberately does <b>not</b> call {@link #applyAgentLaneState}: that method also flips the
+     * Ready step's startChatting/startWithoutAgent/connectAgent visibility, which this step-2-only
+     * check must never touch (those widgets are earned solely by the real step-4 MCP probe). Only
+     * {@code settings.agentLaneReady} and this row's own badge (via {@link #updateActionState}) are
+     * updated here.</p>
+     */
+    private void checkChosenAgentClicked() {
+        if (progress.isVisible()) {
+            return;
+        }
+        applySelectionToSettings();
+        setRunning(true, "Checking agent (~10s)...");
+        if (cloudFamilySelected()) {
+            applyChosenAgentCheckResult(verifySelectedAgentReadiness(null));
+            return;
+        }
+        String selectedClient = settings.defaultAutobotClient;
+        String selectedRuntime = settings.assistantRuntime;
+        CompletableFuture.supplyAsync(() -> deepReadinessProbe.test(selectedClient, selectedRuntime),
+                        ShaftPluginExecutor.getInstance().executor())
+                .whenComplete((readiness, error) -> ApplicationManager.getApplication().invokeLater(() ->
+                        applyChosenAgentCheckResult(error != null
+                                ? ShaftMcpToolResult.failure("Could not run the agent readiness check: "
+                                        + error.getMessage())
+                                : readiness)));
+    }
+
+    private void applyChosenAgentCheckResult(ShaftMcpToolResult readiness) {
+        setRunning(false, readiness.success() ? "Agent connected." : "Agent not ready yet. See details below.");
+        settings.agentLaneReady = readiness.success();
+        updateActionState(false);
+    }
+
     private void setRunning(boolean running, String text) {
         updateActionState(running);
         progress.setVisible(running);
@@ -1195,6 +1250,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         // row's own blue/green/red styling is what conveys pass/fail now.
         test.setEnabled(!running);
         installShaftCli.setEnabled(!running);
+        checkChosenAgent.setEnabled(!running);
         checkUpgrade.setEnabled(!running);
         copyUpgradeCommand.setEnabled(!running);
         checkMcpVersion.setEnabled(!running);

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -168,7 +168,6 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JLabel readyState;
     private final JLabel status;
     private final JLabel recommendedAgent;
-    private final JLabel setupSummary;
     private final JLabel recoveryStatus;
     private final JLabel toast;
     private final JButton copyCommand;
@@ -440,17 +439,6 @@ final class ShaftMcpSetupPanel extends JPanel {
         recommendedAgent.setText(recommendedAgentText);
         recommendedAgent.getAccessibleContext().setAccessibleDescription(recommendedAgentText);
         recommendedAgent.setVisible(true);
-        setupSummary = new JLabel();
-        setupSummary.getAccessibleContext().setAccessibleName("SHAFT MCP setup summary");
-        setupSummary.setText("Installs SHAFT MCP locally and configures the selected client.");
-        // Accessible description mirrors the live summary text (issue #3603): see
-        // updateLiveSummary(), the choke point every later update runs through.
-        setupSummary.getAccessibleContext().setAccessibleDescription(setupSummary.getText());
-        // Muted caption weight (issue #3601 B1.2), matching the ShaftAssistantPanel status-line
-        // idiom: this line restates the live target/runtime selection already visible in the form
-        // above it, so it should read as secondary detail, not a peer of the intro copy.
-        setupSummary.setFont(setupSummary.getFont().deriveFont(Math.max(10.0F, setupSummary.getFont().getSize2D() - 1.0F)));
-        setupSummary.setForeground(ShaftStatusPresentation.pending());
         recoveryStatus = new JLabel();
         recoveryStatus.getAccessibleContext().setAccessibleName("SHAFT MCP recovery summary");
         recoveryStatus.setVisible(false);
@@ -700,14 +688,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         JLabel title = new JLabel("Connect SHAFT Assistant");
         title.setFont(title.getFont().deriveFont(Font.BOLD, title.getFont().getSize2D() + 3f));
         // Agent-agnostic positioning (issue #3425 C3): the same workflows run on every agent.
-        // First user-visible mention of "MCP" in this file (issue #3601 B1.2): expanded once here,
-        // in plain prose, so the acronym never appears unexplained before this screen defines it.
-        JLabel summary = new JLabel("<html><body style='width: 240px'>Pick an agent — recording, code "
-                + "generation, and failure diagnosis work the same on Codex, Claude Code, Copilot, and Gemini. "
-                + "SHAFT handles the wiring through MCP (Model Context Protocol).</body></html>");
-        summary.setForeground(ShaftStatusPresentation.pending());
         intro.add(title, BorderLayout.NORTH);
-        intro.add(summary, BorderLayout.CENTER);
         installerDetailsPanel = FormBuilder.createFormBuilder()
                 .addComponent(targetRow)
                 .addComponent(installShaftCli)
@@ -727,7 +708,6 @@ final class ShaftMcpSetupPanel extends JPanel {
         });
         JPanel form = FormBuilder.createFormBuilder()
                 .addComponent(intro)
-                .addComponent(setupSummary)
                 .addComponent(runtimeStatus)
                 .addComponent(workflow)
                 .addComponent(advancedInstallerToggle)
@@ -2354,10 +2334,6 @@ final class ShaftMcpSetupPanel extends JPanel {
     }
 
     private void updateLiveSummary() {
-        String target = String.valueOf(installerTarget.getSelectedItem()).replace('_', ' ');
-        String setupSummaryText = "Target: " + target + ". Runtime: " + assistantRuntimeLabel() + ".";
-        setupSummary.setText(setupSummaryText);
-        setupSummary.getAccessibleContext().setAccessibleDescription(setupSummaryText);
         String recommendedAgentText = recommendedAgentText();
         recommendedAgent.setText(recommendedAgentText);
         recommendedAgent.getAccessibleContext().setAccessibleDescription(recommendedAgentText);

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -2173,16 +2173,24 @@ final class ShaftMcpSetupPanel extends JPanel {
                 default -> UIManagerColors.foreground();
             });
         }
+        // Issue #4314 fix 5: the "next" badge is blanked out entirely -- no text, no opaque pill
+        // background, no border -- since it looked like a clickable button but wasn't and added no
+        // signal beyond the "done" (green) transition + auto-expanding next row already convey.
+        // Every other state keeps its exact existing text/opacity/border, untouched.
         stateLabel.setText(switch (state) {
             case "done" -> "Done";
             case "failed" -> "Failed";
-            case "next" -> "Next";
+            case "next" -> "";
             case "checking" -> "Checking";
             case "optional" -> "Offline";
             default -> "Waiting";
         });
         stateLabel.setToolTipText(name + " is " + displayState(state));
         stateLabel.getAccessibleContext().setAccessibleDescription(name + " setup state: " + state);
+        stateLabel.setOpaque(!"next".equals(state));
+        stateLabel.setBorder("next".equals(state)
+                ? JBUI.Borders.empty(2, 6)
+                : JBUI.Borders.compound(JBUI.Borders.customLine(UIManagerColors.border(), 1), JBUI.Borders.empty(2, 6)));
         stateLabel.setBackground(switch (state) {
             case "done" -> UIManagerColors.doneBackground();
             case "next", "checking", "optional" -> UIManagerColors.activeBackground();

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -144,7 +144,6 @@ final class ShaftMcpSetupPanel extends JPanel {
     private final JLabel upgradeDetail;
     private final JButton installNow;
     private final JButton checkMcpVersion;
-    private final JButton copyMcpInstallCommand;
     private final JLabel mcpVersionDetail;
     private final JButton test;
     private final JButton startChatting;
@@ -363,23 +362,20 @@ final class ShaftMcpSetupPanel extends JPanel {
         checkChosenAgent.addActionListener(event -> checkChosenAgentClicked());
         // Primary one-click install action (issue #3743; reworked for JetBrains Marketplace
         // compliance -- see ShaftPluginSecurityTest, which forbids this plugin from spawning
-        // processes): opens a terminal with the full MCP + skills + CLI command pre-typed through
-        // the same TerminalOpener seam as "Copy SHAFT MCP install command" below; the plugin never
-        // executes the command itself, the user presses Enter.
+        // processes): copies the full MCP + skills + CLI command to the clipboard AND opens a
+        // terminal with it pre-typed through the same TerminalOpener seam, via the shared
+        // copyCommandIntoTerminal() helper every other copy-then-terminal action on this screen
+        // already uses; the plugin never executes the command itself, the user presses Enter.
+        // Issue #4314 fix 3: this used to be two functionally near-identical buttons ("Install" and
+        // a separate "Copy" that additionally copied to clipboard first) -- merged into this one.
         installNow = new JButton("Install");
         installNow.getAccessibleContext().setAccessibleName("Install SHAFT MCP");
-        installNow.setToolTipText("Opens a terminal with the SHAFT MCP + skills + shaft-cli install command "
-                + "pre-typed for the selected client -- press Enter there to run it, then press Check.");
+        installNow.setToolTipText("Copies the SHAFT MCP + skills + shaft-cli install command to the clipboard and "
+                + "opens a terminal with it pre-typed for the selected client -- press Enter there to run it, "
+                + "then press Check.");
         installNow.setMnemonic(KeyEvent.VK_I);
         applyLabeledAction(installNow, ShaftIcons.DOWNLOAD);
         installNow.addActionListener(event -> runInstall());
-        copyMcpInstallCommand = new JButton("Copy");
-        copyMcpInstallCommand.getAccessibleContext().setAccessibleName("Copy SHAFT MCP install command");
-        copyMcpInstallCommand.setToolTipText("Copy the SHAFT MCP install/update command and open a terminal with "
-                + "it pre-typed — just press Enter there to run it");
-        copyMcpInstallCommand.setMnemonic(KeyEvent.VK_C);
-        applyLabeledAction(copyMcpInstallCommand, ShaftIcons.COPY);
-        copyMcpInstallCommand.addActionListener(event -> copyMcpInstallCommand());
         mcpVersionDetail = setupStatusLabel("SHAFT MCP version status");
         test = new JButton("Check");
         test.getAccessibleContext().setAccessibleName("Test SHAFT MCP connection");
@@ -569,12 +565,13 @@ final class ShaftMcpSetupPanel extends JPanel {
         upgradeActions.add(copyUpgradeCommand);
         upgradeActions.add(upgradeDetail);
         // Merged row #3 (issue #3560): the old separate "SHAFT MCP version" row is folded into
-        // "3 Install SHAFT MCP" — one row, one Check, one Copy, badge driven by mcpVersionStepState().
+        // "3 Install SHAFT MCP" — one row, one Check, one Install, badge driven by
+        // mcpVersionStepState(). Issue #4314 fix 3: Install and the old separate Copy button are
+        // themselves merged into this one Install action.
         JPanel installActions = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
         installActions.setOpaque(false);
         installActions.add(installNow);
         installActions.add(checkMcpVersion);
-        installActions.add(copyMcpInstallCommand);
         installActions.add(mcpVersionDetail);
         upgradeRow = stepRow(upgradeStep, upgradeState, upgradeActions);
         chooseRow = stepRow(chooseStep, chooseState, agentControls);
@@ -1254,7 +1251,6 @@ final class ShaftMcpSetupPanel extends JPanel {
         checkUpgrade.setEnabled(!running);
         copyUpgradeCommand.setEnabled(!running);
         checkMcpVersion.setEnabled(!running);
-        copyMcpInstallCommand.setEnabled(!running);
         installNow.setEnabled(!running);
         startChatting.setVisible((complete && !startWithoutAgent.isVisible()) || startChatting.isVisible());
         startChatting.setEnabled(!running && startChatting.isVisible());
@@ -1586,46 +1582,22 @@ final class ShaftMcpSetupPanel extends JPanel {
     }
 
     /**
-     * Copies the SHAFT MCP install/update command for the selected client. Install and upgrade are
-     * the same command — re-running the installer script always fetches the latest release — so
-     * there is no separate "install" vs "upgrade" flavor of this command (issue #3538). This is now
-     * the single copy action for the merged "3 Install SHAFT MCP" row (issue #3560), so it goes
-     * through {@link #installerCommand()} — the same helper the Advanced installer options panel
-     * uses — to honor the "Also install shaft-cli" checkbox.
-     */
-    private void copyMcpInstallCommand() {
-        String command = installerCommand();
-        copy(command, "Copied SHAFT MCP install command");
-        boolean opened = terminalOpener.open("SHAFT MCP install", command, typed -> { });
-        if (opened) {
-            openIntellijTerminal();
-        }
-        setStatusText(opened
-                ? "Terminal opened with the SHAFT MCP install command pre-typed. Press Enter there to run it; "
-                + "when it finishes, press Check."
-                : "SHAFT MCP install command copied. Paste it into a terminal, run it; when it finishes, press Check.");
-        updateActionState(false);
-    }
-
-    /**
      * Primary "Install SHAFT MCP" action (issue #3743; reworked for JetBrains Marketplace
      * compliance -- {@code ShaftPluginSecurityTest} forbids this plugin from spawning OS
-     * processes). Routes the full MCP + skills + CLI command through the exact same {@link
-     * #terminalOpener} seam {@link #copyMcpInstallCommand()} uses: a terminal opens with the
-     * command pre-typed and the user presses Enter to actually run it -- the plugin itself never
-     * executes anything.
+     * processes). Copies the full MCP + skills + CLI command for the selected client to the
+     * clipboard AND opens a terminal with it pre-typed, through {@link #copyCommandIntoTerminal} --
+     * the same copy-then-terminal helper every other action on this screen shares -- so the plugin
+     * itself never executes anything; the user presses Enter. Install and upgrade are the same
+     * command — re-running the installer script always fetches the latest release — so there is no
+     * separate "install" vs "upgrade" flavor of this command (issue #3538); it goes through {@link
+     * #installerCommand()} — the same helper the Advanced installer options panel uses — to honor
+     * the "Also install shaft-cli" checkbox.
+     *
+     * <p>Issue #4314 fix 3: this used to be two functionally near-identical actions -- this one and
+     * a separate "Copy" button that additionally copied to the clipboard first -- merged here.</p>
      */
     private void runInstall() {
-        String command = installerCommand();
-        boolean opened = terminalOpener.open("SHAFT MCP install", command, typed -> setStatusText(typed
-                ? "Command ready in the terminal -- run it, then press Check."
-                : "Couldn't auto-type the command there. Use Copy and paste it manually, then press Check."));
-        if (opened) {
-            openIntellijTerminal();
-            setStatusText("Terminal opened — typing the command...");
-        } else {
-            setStatusText("Could not open a terminal. Use Copy to get the install command instead.");
-        }
+        copyCommandIntoTerminal(installerCommand(), "SHAFT MCP install", "Copied SHAFT MCP install command");
         updateActionState(false);
     }
 
@@ -1645,7 +1617,7 @@ final class ShaftMcpSetupPanel extends JPanel {
         copyCommandIntoTerminal(installerCommand(), "SHAFT MCP install",
                 "Installer command copied. Run it in terminal, then check.");
         updateActionState(false);
-        copyMcpInstallCommand.requestFocusInWindow();
+        installNow.requestFocusInWindow();
     }
 
     /**

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -88,6 +88,10 @@ final class ShaftMcpSetupPanel extends JPanel {
     /** Client-property key {@link #stepRow} stashes its action component under, so the row-collapse
      * logic (issue #3601 S2) can find and hide it without a dedicated field per row. */
     private static final String STEP_ACTION_KEY = "shaft.stepRow.action";
+    /** Client-property key {@link #stepRow} stashes its discoverable recheck icon under (issue
+     * #4314 fix 4), so {@link #styleStepRow} can show it only in the "done" state without a
+     * dedicated field per row. */
+    private static final String STEP_RECHECK_KEY = "shaft.stepRow.recheck";
 
     @FunctionalInterface
     interface AgentReadinessProbe {
@@ -2205,7 +2209,7 @@ final class ShaftMcpSetupPanel extends JPanel {
      * content onto its own line sidesteps that degenerate case entirely: it always gets the row's
      * full width to itself.
      */
-    private static JPanel stepRow(JLabel label, JLabel stateLabel, JComponent action) {
+    private JPanel stepRow(JLabel label, JLabel stateLabel, JComponent action) {
         JPanel row = new JPanel(new GridBagLayout());
         row.setOpaque(true);
         GridBagConstraints labelConstraints = new GridBagConstraints();
@@ -2220,10 +2224,27 @@ final class ShaftMcpSetupPanel extends JPanel {
         stateConstraints.anchor = GridBagConstraints.WEST;
         stateConstraints.insets = JBUI.insets(0, 0, 0, 10);
         row.add(stateLabel, stateConstraints);
+        // Discoverable recheck affordance (issue #4314 fix 4): a collapsed "done" row was already
+        // reconfigurable non-destructively by clicking it (toggleStepRowInspection below), but
+        // nothing on screen hinted it was clickable. This icon -- only shown once the row is
+        // actually "done" (see styleStepRow) -- fires that exact same toggle, never new logic; a
+        // plain JButton is keyboard-reachable on its own via the normal Tab/Enter/Space contract, so
+        // it needs no extra key bindings of its own, and (being an opaque child component) consumes
+        // its own clicks without also triggering the whole-row MouseAdapter installed below.
+        JButton recheck = ShaftIconButtons.create("Recheck this step",
+                label.getAccessibleContext().getAccessibleName() + " recheck", ShaftIcons.RERUN,
+                event -> toggleStepRowInspection(row));
+        recheck.setVisible(false);
+        GridBagConstraints recheckConstraints = new GridBagConstraints();
+        recheckConstraints.gridx = 2;
+        recheckConstraints.gridy = 0;
+        recheckConstraints.anchor = GridBagConstraints.NORTHEAST;
+        recheckConstraints.weightx = 1.0;
+        row.add(recheck, recheckConstraints);
         GridBagConstraints actionConstraints = new GridBagConstraints();
         actionConstraints.gridx = 0;
         actionConstraints.gridy = 1;
-        actionConstraints.gridwidth = 2;
+        actionConstraints.gridwidth = 3;
         actionConstraints.anchor = GridBagConstraints.WEST;
         actionConstraints.fill = GridBagConstraints.HORIZONTAL;
         actionConstraints.weightx = 1.0;
@@ -2233,6 +2254,7 @@ final class ShaftMcpSetupPanel extends JPanel {
                 JBUI.Borders.customLine(UIManagerColors.border(), 1),
                 JBUI.Borders.empty(8, 10)));
         row.putClientProperty(STEP_ACTION_KEY, action);
+        row.putClientProperty(STEP_RECHECK_KEY, recheck);
         return row;
     }
 
@@ -2416,6 +2438,13 @@ final class ShaftMcpSetupPanel extends JPanel {
                     default -> UIManagerColors.border();
                 }, 1),
                 JBUI.Borders.empty(8, 10)));
+        // Issue #4314 fix 4: the recheck icon only signals something once there is something to
+        // recheck -- i.e. once the row has actually finished, matching the "done rows are the ones
+        // worth re-inspecting" behavior toggleStepRowInspection already assumes.
+        Object recheck = row.getClientProperty(STEP_RECHECK_KEY);
+        if (recheck instanceof JComponent recheckIcon) {
+            recheckIcon.setVisible("done".equals(state));
+        }
     }
 
     private static String escapeHtml(String text) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -749,7 +749,9 @@ class ShaftPanelSetupTest {
             assertTrue(containsText(toolWindow, "3 Install SHAFT MCP"));
             assertTrue(containsText(toolWindow, "4 Check setup"));
             assertTrue(containsText(toolWindow, "Connect SHAFT Assistant"));
-            assertTrue(containsText(toolWindow, "Target: "));
+            // Issue #4314 fix 1: the redundant "Target: X. Runtime: Y." setupSummary caption is
+            // removed -- the family/runtime combo boxes above it already show the live selection.
+            assertNull(findByAccessibleName(toolWindow, "SHAFT MCP setup summary", JLabel.class));
             assertNotNull(findByAccessibleName(toolWindow, "Install SHAFT MCP setup state", JLabel.class));
             assertNull(findByAccessibleName(toolWindow, "SHAFT MCP command status", JLabel.class));
             assertFalse(findByAccessibleName(toolWindow, "Assistant runtime setup status", JLabel.class).isVisible());
@@ -2115,11 +2117,31 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void setupIntroDropsDeadGreyedCopyAndRedundantTargetRuntimeSummary() {
+        // Issue #4314 fix 1: the intro's greyed "Pick an agent -- recording, code generation..."
+        // paragraph and the redundant "Target: X. Runtime: Y." setupSummary caption (already
+        // restated by the family/runtime combo boxes above it) add no value and cramp the layout --
+        // both are removed, while the bold "Connect SHAFT Assistant" title stays.
+        ShaftSettingsState.Settings settings = unverifiedMcpSettings();
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
+        }, readyProbe());
+
+        assertAll(
+                () -> assertTrue(containsText(panel, "Connect SHAFT Assistant")),
+                () -> assertFalse(containsText(panel, "Pick an agent")),
+                () -> assertFalse(containsText(panel, "Model Context Protocol")),
+                () -> assertFalse(containsText(panel, "Installs SHAFT MCP locally")),
+                () -> assertFalse(containsText(panel, "Target: ")),
+                () -> assertNull(findByAccessibleName(panel, "SHAFT MCP setup summary", JLabel.class)));
+    }
+
+    @Test
     void setupPanelAccessibleDescriptionsTrackLiveStatusRecoveryChecklistAndToastAcrossUpdates() throws Exception {
-        // Issue #3603: setupSummary/status/recoveryStatus/readyChecklist/toast keep a short,
-        // stable accessible NAME (test-id-safe, e.g. "SHAFT MCP setup next step"), but a screen
-        // reader also needs the live, real content those labels display -- carried by the
-        // accessible DESCRIPTION, which must keep tracking every later update, not just the first.
+        // Issue #3603: status/recoveryStatus/readyChecklist/toast keep a short, stable accessible
+        // NAME (test-id-safe, e.g. "SHAFT MCP setup next step"), but a screen reader also needs the
+        // live, real content those labels display -- carried by the accessible DESCRIPTION, which
+        // must keep tracking every later update, not just the first. (setupSummary itself was
+        // removed by issue #4314 fix 1 as redundant with the family/runtime combo boxes.)
         ShaftSettingsState.Settings settings = unverifiedMcpSettings();
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
         }, readyProbe());
@@ -2133,22 +2155,11 @@ class ShaftPanelSetupTest {
         JLabel readyChecklist = findByAccessibleName(panel, "Setup ready checklist", JLabel.class);
         JLabel recoveryStatus = findByAccessibleName(panel, "SHAFT MCP recovery summary", JLabel.class);
         JLabel toastLabel = findByAccessibleName(panel, "SHAFT setup clipboard toast", JLabel.class);
-        JLabel setupSummary = findByAccessibleName(panel, "SHAFT MCP setup summary", JLabel.class);
-        JComboBox<?> family = findByAccessibleName(panel, "Assistant family", JComboBox.class);
-        JComboBox<?> runtime = findByAccessibleName(panel, "Assistant runtime", JComboBox.class);
         assertAll(
                 () -> assertNotNull(status),
                 () -> assertNotNull(readyChecklist),
                 () -> assertNotNull(recoveryStatus),
-                () -> assertNotNull(toastLabel),
-                () -> assertNotNull(setupSummary));
-        // setupSummary already reflects the live target/runtime selection as soon as the panel is
-        // built (updateLiveSummary() runs during construction), so the description must already
-        // mirror that live text rather than the static placeholder setText() was first given.
-        String initialSetupSummaryDescription = setupSummary.getAccessibleContext().getAccessibleDescription();
-        assertAll(
-                () -> assertEquals(setupSummary.getText(), initialSetupSummaryDescription),
-                () -> assertTrue(initialSetupSummaryDescription.contains("CODEX"), initialSetupSummaryDescription));
+                () -> assertNotNull(toastLabel));
 
         showTestResult(panel, ShaftMcpToolResult.success("Probe OK\nMCP workspace: C:/work/shaft"));
         String firstStatusDescription = status.getAccessibleContext().getAccessibleDescription();
@@ -2158,17 +2169,6 @@ class ShaftPanelSetupTest {
                 () -> assertFalse(firstStatusDescription.isBlank()),
                 () -> assertEquals(readyChecklist.getText(), firstChecklistDescription),
                 () -> assertTrue(firstChecklistDescription.contains("Ready to record"), firstChecklistDescription));
-
-        // Live-update proof for setupSummary: switching the assistant family/runtime must update
-        // the description to the NEW target/runtime text, not just retain the initial selection.
-        family.setSelectedItem("CLAUDE");
-        runtime.setSelectedItem("DESKTOP_APP");
-        String secondSetupSummaryDescription = setupSummary.getAccessibleContext().getAccessibleDescription();
-        assertAll(
-                () -> assertEquals(setupSummary.getText(), secondSetupSummaryDescription),
-                () -> assertTrue(secondSetupSummaryDescription.contains("CLAUDE"), secondSetupSummaryDescription),
-                () -> assertNotEquals(initialSetupSummaryDescription, secondSetupSummaryDescription,
-                        "the description must track the live target/runtime summary after it changes"));
 
         // Live-update proof: a second, different result (a failure) must update the descriptions to
         // their NEW text, not just retain what the first successful check produced.

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1297,16 +1297,16 @@ class ShaftPanelSetupTest {
     void setupPanelShowsNoGreenStepsOnFreshLanding() {
         // Issue #3560: none of the numbered verification steps may be green until the user has
         // explicitly clicked that row's Check and it passed -- a fresh landing always starts
-        // neutral/blue ("Next"), never green ("Done"), regardless of what passive on-disk/PATH
-        // detection would otherwise reveal.
+        // neutral ("next" -- a blank badge as of issue #4314 fix 5), never green ("Done"),
+        // regardless of what passive on-disk/PATH detection would otherwise reveal.
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
         });
         assertAll(
-                () -> assertEquals("Next",
+                () -> assertEquals("",
                         findByAccessibleName(panel, "Upgrade project setup state", JLabel.class).getText()),
-                () -> assertEquals("Next",
+                () -> assertEquals("",
                         findByAccessibleName(panel, "Choose agent setup state", JLabel.class).getText()),
-                () -> assertEquals("Next",
+                () -> assertEquals("",
                         findByAccessibleName(panel, "Install SHAFT MCP setup state", JLabel.class).getText()),
                 () -> assertNotEquals("Done",
                         findByAccessibleName(panel, "Check now setup state", JLabel.class).getText()));
@@ -1333,8 +1333,9 @@ class ShaftPanelSetupTest {
         JLabel upgradeState = findByAccessibleName(panel, "Upgrade project setup state", JLabel.class);
         JLabel upgradeDetail = findByAccessibleName(panel, "SHAFT project version status", JLabel.class);
 
-        // Nothing is green until the user presses Check (issue #3560/#3426 A4/A5).
-        assertEquals("Next", upgradeState.getText());
+        // Nothing is green until the user presses Check (issue #3560/#3426 A4/A5); the "next" badge
+        // itself renders blank (issue #4314 fix 5).
+        assertEquals("", upgradeState.getText());
 
         // A project already on the latest release (or newer) is green once checked.
         setField(panel, "upgradeChecker", (java.util.function.Supplier<ShaftProjectVersionCheck.Result>) () ->
@@ -1354,9 +1355,45 @@ class ShaftPanelSetupTest {
                         ShaftProjectVersionCheck.State.UPGRADE_AVAILABLE, "10.2.20260101", "10.3.20260710"));
         clickAccessible(panel, "Check SHAFT project version");
         assertAll(
-                () -> assertEquals("Next", upgradeState.getText()),
+                () -> assertEquals("", upgradeState.getText()),
                 () -> assertTrue(upgradeDetail.getText().contains("10.3.20260710 is available")),
                 () -> assertTrue(findByAccessibleName(panel, "Copy SHAFT upgrade command", JButton.class).isVisible()));
+    }
+
+    @Test
+    void nextStateBadgeRendersBlankInsteadOfALookalikeButton() throws Exception {
+        // Issue #4314 fix 5: the "next" badge used to render an opaque, bordered, "Next"-labeled
+        // pill that looked like a clickable button but wasn't -- the owner found it added no signal
+        // beyond the "done" (green) transition + auto-expanding next row already convey. Blank it
+        // out specifically for "next"; every other state (done/failed/checking/optional) keeps its
+        // exact existing text/colors/opacity, and the step name label itself keeps its existing
+        // bold/blue "active step" styling -- only the redundant badge pill is removed.
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
+        });
+        JLabel upgradeState = findByAccessibleName(panel, "Upgrade project setup state", JLabel.class);
+        // upgradeStep's own accessible NAME is dynamic (rewritten by setStep() to include the live
+        // state), unlike upgradeState's stable name (issue #3603), so it must be read by field.
+        JLabel upgradeStep = (JLabel) getField(panel, "upgradeStep");
+
+        assertAll(
+                () -> assertEquals("", upgradeState.getText()),
+                () -> assertFalse(upgradeState.isOpaque(),
+                        "a blank badge must not paint an opaque pill background"),
+                () -> assertFalse(upgradeState.getBorder() instanceof javax.swing.border.CompoundBorder,
+                        "a blank badge must not paint a visible border either"),
+                () -> assertEquals(java.awt.Font.BOLD, upgradeStep.getFont().getStyle() & java.awt.Font.BOLD,
+                        "the step name label's own bold 'active step' styling is untouched"));
+
+        setField(panel, "upgradeChecker", (java.util.function.Supplier<ShaftProjectVersionCheck.Result>) () ->
+                new ShaftProjectVersionCheck.Result(
+                        ShaftProjectVersionCheck.State.UP_TO_DATE, "10.3.20260710", "10.3.20260710"));
+        clickAccessible(panel, "Check SHAFT project version");
+
+        assertAll(
+                () -> assertEquals("Done", upgradeState.getText(), "the done badge is untouched"),
+                () -> assertTrue(upgradeState.isOpaque(), "the done badge keeps its opaque pill"),
+                () -> assertTrue(upgradeState.getBorder() instanceof javax.swing.border.CompoundBorder,
+                        "the done badge keeps its visible border"));
     }
 
     @Test
@@ -1368,8 +1405,9 @@ class ShaftPanelSetupTest {
         JLabel installState = findByAccessibleName(panel, "Install SHAFT MCP setup state", JLabel.class);
         JLabel mcpVersionDetail = findByAccessibleName(panel, "SHAFT MCP version status", JLabel.class);
 
-        // Nothing is green until the user presses Check (issue #3560/#3426 A4/A5).
-        assertEquals("Next", installState.getText());
+        // Nothing is green until the user presses Check (issue #3560/#3426 A4/A5); the "next" badge
+        // itself renders blank (issue #4314 fix 5).
+        assertEquals("", installState.getText());
 
         // Installed at or above the latest release is green once checked, matching the
         // "Upgrade project" row's real-check pattern (issue #3538).
@@ -1392,7 +1430,7 @@ class ShaftPanelSetupTest {
                         ShaftMcpVersionCheck.State.UPGRADE_AVAILABLE, "10.2.20260101", "10.3.20260710"));
         clickAccessible(panel, "Check SHAFT MCP version");
         assertAll(
-                () -> assertEquals("Next", installState.getText()),
+                () -> assertEquals("", installState.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("latest 10.3.20260710")),
                 () -> assertTrue(
                         findByAccessibleName(panel, "Install SHAFT MCP", JButton.class).isVisible()));
@@ -1402,7 +1440,7 @@ class ShaftPanelSetupTest {
                 new ShaftMcpVersionCheck.Result(ShaftMcpVersionCheck.State.NOT_INSTALLED, "", ""));
         clickAccessible(panel, "Check SHAFT MCP version");
         assertAll(
-                () -> assertEquals("Next", installState.getText()),
+                () -> assertEquals("", installState.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("not installed yet")),
                 () -> assertTrue(
                         findByAccessibleName(panel, "Install SHAFT MCP", JButton.class).isVisible()));
@@ -1961,7 +1999,8 @@ class ShaftPanelSetupTest {
 
         assertAll(
                 () -> assertFalse(settings.agentLaneReady),
-                () -> assertEquals("Next", chooseState.getText()),
+                // The "next" badge itself renders blank (issue #4314 fix 5).
+                () -> assertEquals("", chooseState.getText()),
                 () -> assertFalse(settings.mcpSetupComplete),
                 () -> assertFalse(findByAccessibleName(panel, "Connect SHAFT agent", JButton.class).isVisible()));
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1876,6 +1876,81 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void chooseRowOffersAStandaloneCheckButtonMirroringOtherStepsCheckPattern() throws Exception {
+        // Issue #4314 fix 2: every other step (Upgrade, Install) already has its own "Check" button
+        // that turns its badge green on its own -- "2 Pick agent" only ever turned green as a side
+        // effect of the full step-4 MCP probe. This button lets a user verify "is my picked agent
+        // already installed/connected" without running the whole setup flow.
+        ShaftSettingsState.Settings settings = unverifiedMcpSettings();
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
+        }, readyProbe());
+        JPanel chooseRow = (JPanel) getField(panel, "chooseRow");
+
+        JButton checkChosenAgent = findByAccessibleName(chooseRow, "Check agent connection", JButton.class);
+
+        assertAll(
+                () -> assertNotNull(checkChosenAgent, "chooseRow should carry its own Check button"),
+                () -> assertTrue(checkChosenAgent.isVisible()));
+    }
+
+    @Test
+    void checkingTheSelectedAgentReflectsCloudReadinessIntoTheChooseBadgeWithoutTouchingReadyStepWidgets()
+            throws Exception {
+        // The Check click must only settle settings.agentLaneReady and the "2 Pick agent" badge --
+        // NOT run the full applyAgentLaneState() side effects the Ready step (startChatting/
+        // startWithoutAgent/connectAgent) only earns from an actual step-4 MCP probe.
+        java.util.Map<String, String> storedKeys = new java.util.HashMap<>();
+        storedKeys.put("GEMINI_API_KEY", "already-stored-key");
+        ShaftMcpSetupPanel.CloudKeyStore keyStore = fakeKeyStore(storedKeys);
+        ShaftSettingsState.Settings settings = unverifiedMcpSettings();
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
+        }, readyProbe(), keyStore);
+        JComboBox<?> family = findByAccessibleName(panel, "Assistant family", JComboBox.class);
+        family.setSelectedItem("GEMINI");
+        JPanel chooseRow = (JPanel) getField(panel, "chooseRow");
+        JLabel chooseState = (JLabel) getField(panel, "chooseState");
+
+        clickAccessible(chooseRow, "Check agent connection");
+
+        assertAll(
+                () -> assertTrue(settings.agentLaneReady),
+                () -> assertEquals("Done", chooseState.getText()),
+                () -> assertFalse(settings.mcpSetupComplete,
+                        "the full step-4 MCP probe must never run as a side effect of this check"),
+                () -> assertFalse(findByAccessibleName(panel, "Start chatting with SHAFT Assistant", JButton.class)
+                        .isVisible()),
+                () -> assertFalse(findByAccessibleName(panel, "Start SHAFT without an agent", JButton.class)
+                        .isVisible()),
+                () -> assertFalse(findByAccessibleName(panel, "Connect SHAFT agent", JButton.class).isVisible()));
+    }
+
+    @Test
+    void checkingTheSelectedAgentRunsTheDeepProbeOffTheEdtAndReflectsFailureIntoTheChooseBadgeOnly()
+            throws Exception {
+        // Non-cloud families' readiness check spawns the client CLI (~10s) -- exactly like
+        // connectAgentClicked()'s existing off-EDT dispatch -- so the click must synchronously enter
+        // a busy state and the real result must only land once the (simulated) async hand-off
+        // completes.
+        ShaftSettingsState.Settings settings = unverifiedMcpSettings();
+        ShaftMcpToolResult notReady = ShaftMcpToolResult.failure("Codex CLI executable is not available on PATH.");
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
+        }, readyProbe(), (client, runtime) -> notReady);
+        JPanel chooseRow = (JPanel) getField(panel, "chooseRow");
+        JLabel chooseState = (JLabel) getField(panel, "chooseState");
+
+        clickAccessible(chooseRow, "Check agent connection");
+        assertTrue(containsText(panel, "Checking agent"), "click must synchronously enter the busy state");
+
+        invokeApplyChosenAgentCheckResult(panel, notReady);
+
+        assertAll(
+                () -> assertFalse(settings.agentLaneReady),
+                () -> assertEquals("Next", chooseState.getText()),
+                () -> assertFalse(settings.mcpSetupComplete),
+                () -> assertFalse(findByAccessibleName(panel, "Connect SHAFT agent", JButton.class).isVisible()));
+    }
+
+    @Test
     void connectAgentButtonKeepsTheNotReadyStateWithoutCrashingWhenTheRetryStillFails() throws Exception {
         ShaftSettingsState.Settings settings = connectedMcpSettings();
         ShaftMcpToolResult stillFailing = ShaftMcpToolResult.failure("Codex CLI executable is not available on PATH.");
@@ -5466,6 +5541,9 @@ class ShaftPanelSetupTest {
                 // The shaft-mcp version step's check button is labeled like its upgrade-step peer
                 // above: it names the exact check being run on a first-run setup screen (issue #3538).
                 .filter(button -> !"Check SHAFT MCP version".equals(accessibleName(button)))
+                // "2 Pick agent"'s own standalone Check button (issue #4314 fix 2) is the same
+                // first-run-setup-screen Check pattern as the two rows above it.
+                .filter(button -> !"Check agent connection".equals(accessibleName(button)))
                 // Lane/teaching controls keep visible labels by design: the no-agent start names
                 // its lane (issue #3425 A2/B7/A6).
                 .filter(button -> !"Start SHAFT without an agent".equals(accessibleName(button)))
@@ -7577,6 +7655,21 @@ class ShaftPanelSetupTest {
             throws Exception {
         Method applyResult = ShaftMcpSetupPanel.class.getDeclaredMethod(
                 "applyConnectAgentResult", ShaftMcpToolResult.class);
+        applyResult.setAccessible(true);
+        applyResult.invoke(panel, readiness);
+    }
+
+    /**
+     * Invokes checkChosenAgentClicked()'s real completion path directly, mirroring
+     * {@link #invokeApplyConnectAgentResult} above: the non-cloud branch's background probe/EDT
+     * hand-off cannot complete in this headless harness (no live IntelliJ Application), so tests
+     * simulate "the check's result arrived" by calling the same private method that hand-off would
+     * otherwise invoke.
+     */
+    private static void invokeApplyChosenAgentCheckResult(ShaftMcpSetupPanel panel, ShaftMcpToolResult readiness)
+            throws Exception {
+        Method applyResult = ShaftMcpSetupPanel.class.getDeclaredMethod(
+                "applyChosenAgentCheckResult", ShaftMcpToolResult.class);
         applyResult.setAccessible(true);
         applyResult.invoke(panel, readiness);
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -769,7 +769,7 @@ class ShaftPanelSetupTest {
             assertFalse(nextStep.isVisible());
             assertFalse(installerDetailsPanel.isVisible());
             assertFalse(detailsPanel.isVisible());
-            assertTrue(findByAccessibleName(toolWindow, "Copy SHAFT MCP install command", JButton.class).isVisible());
+            assertTrue(findByAccessibleName(toolWindow, "Install SHAFT MCP", JButton.class).isVisible());
             // No shaft-mcp is installed in this isolated data root, so the real check is offered
             // immediately: verification, not clicking, is what completes setup (issue #3426 A5).
             assertTrue(findByAccessibleName(toolWindow, "Test SHAFT MCP connection", JButton.class).isVisible());
@@ -970,7 +970,7 @@ class ShaftPanelSetupTest {
             // command still points at the installed artifacts.
             String inferred = ShaftMcpSetupPanel.inferInstalledStdioCommand(appData, bootstrap);
             assertAll(
-                    () -> assertTrue(findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()),
+                    () -> assertTrue(findByAccessibleName(panel, "Install SHAFT MCP", JButton.class).isVisible()),
                     () -> assertNull(findByAccessibleName(panel, "Open terminal for MCP installer", JButton.class)),
                     () -> assertTrue(findByAccessibleName(panel, "Test SHAFT MCP connection", JButton.class).isVisible()),
                     () -> assertFalse(installerDetailsPanel.isVisible()),
@@ -1082,8 +1082,11 @@ class ShaftPanelSetupTest {
     void installButtonRoutesTheFullInstallerCommandThroughTheTerminalOpenerSeam() throws Exception {
         // Issue #3743, reworked for JetBrains Marketplace compliance (ShaftPluginSecurityTest
         // forbids this plugin from spawning OS processes): the primary "Install SHAFT MCP" action
-        // now goes through the exact same TerminalOpener seam the Copy fallback uses, carrying the
-        // same MCP + skills + CLI command for the selected client -- no process is ever launched.
+        // goes through the TerminalOpener seam, carrying the same MCP + skills + CLI command for
+        // the selected client -- no process is ever launched. Issue #4314 fix 3: the duplicate
+        // "Copy SHAFT MCP install command" button is gone -- Install alone now also copies the
+        // command to the clipboard, via the same copyCommandIntoTerminal() helper every other
+        // copy-then-terminal action on this screen already shares.
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
         });
         JButton installButton = findByAccessibleName(panel, "Install SHAFT MCP", JButton.class);
@@ -1091,6 +1094,8 @@ class ShaftPanelSetupTest {
                 () -> assertNotNull(installButton),
                 () -> assertTrue(installButton.isVisible()),
                 () -> assertTrue(installButton.isEnabled()),
+                () -> assertNull(findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class),
+                        "the duplicate Copy button is gone -- Install now does both"),
                 // Advanced installer options (including the raw command text area) stay hidden by
                 // default alongside the primary Install action (issue #3743 (b)).
                 () -> assertFalse(((JComponent) getField(panel, "installerDetailsPanel")).isVisible()),
@@ -1098,6 +1103,8 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(findByAccessibleName(panel, "Also install shaft-cli command line", JCheckBox.class)
                         .isSelected()));
 
+        AtomicReference<String> copied = new AtomicReference<>("");
+        setField(panel, "copySink", (Consumer<String>) copied::set);
         AtomicReference<String> terminalTab = new AtomicReference<>();
         AtomicReference<String> terminalCommand = new AtomicReference<>();
         setField(panel, "terminalOpener", (ShaftMcpSetupPanel.TerminalOpener) (tab, command, onOutcome) -> {
@@ -1113,13 +1120,20 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(terminalCommand.get().contains("--install-shaft-skills --install-shaft-cli"),
                         terminalCommand.get()),
                 () -> assertTrue(terminalCommand.get().contains("codex"), terminalCommand.get()),
-                () -> assertTrue(containsText(panel, "Terminal opened — typing the command...")));
+                () -> assertEquals(terminalCommand.get(), copied.get(),
+                        "clipboard and pre-typed terminal command must be the exact same installer command"),
+                () -> assertTrue(containsText(panel, "Copied SHAFT MCP install command. Terminal opened — "
+                        + "typing the command...")));
     }
 
     @Test
     void installButtonNeverSpawnsAProcessAndReflectsTheTerminalOutcome() throws Exception {
         ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), blankMcpSettings(), () -> {
         });
+        // Issue #4314 fix 3: Install now also copies to the clipboard, so this headless test must
+        // stub copySink like every other clipboard-touching test here -- the real copyToClipboard()
+        // has no system clipboard to reach in this harness.
+        setField(panel, "copySink", (Consumer<String>) copied -> { });
         JButton installButton = findByAccessibleName(panel, "Install SHAFT MCP", JButton.class);
         AtomicReference<Consumer<Boolean>> capturedOutcome = new AtomicReference<>();
         setField(panel, "terminalOpener", (ShaftMcpSetupPanel.TerminalOpener) (tab, command, onOutcome) -> {
@@ -1131,7 +1145,8 @@ class ShaftPanelSetupTest {
         assertNotNull(capturedOutcome.get(), "the outcome callback must be captured");
 
         capturedOutcome.get().accept(Boolean.TRUE);
-        assertTrue(containsText(panel, "Command ready in the terminal -- run it, then press Check."));
+        assertTrue(containsText(panel, "Copied SHAFT MCP install command. Terminal opened with it pre-typed — "
+                + "press Enter there to run it."));
 
         // The process-execution seam is gone entirely (compliance rework, issue #3743): no
         // installerProcessLauncher field and no InstallerProcessLauncher nested type remain.
@@ -1365,10 +1380,11 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertEquals("Done", installState.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("is up to date")),
-                // Check and Copy stay visible in every state now (issue #3560): the row's
-                // blue/green/red styling conveys pass/fail, not button visibility.
+                // Check and Install stay visible in every state now (issue #3560; merged with the
+                // old Copy button by issue #4314 fix 3): the row's blue/green/red styling conveys
+                // pass/fail, not button visibility.
                 () -> assertTrue(
-                        findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()));
+                        findByAccessibleName(panel, "Install SHAFT MCP", JButton.class).isVisible()));
 
         // Installed but behind the latest release keeps the row actionable.
         setField(panel, "mcpVersionChecker", (java.util.function.Supplier<ShaftMcpVersionCheck.Result>) () ->
@@ -1379,7 +1395,7 @@ class ShaftPanelSetupTest {
                 () -> assertEquals("Next", installState.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("latest 10.3.20260710")),
                 () -> assertTrue(
-                        findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()));
+                        findByAccessibleName(panel, "Install SHAFT MCP", JButton.class).isVisible()));
 
         // Nothing installed offers the install command.
         setField(panel, "mcpVersionChecker", (java.util.function.Supplier<ShaftMcpVersionCheck.Result>) () ->
@@ -1389,7 +1405,7 @@ class ShaftPanelSetupTest {
                 () -> assertEquals("Next", installState.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("not installed yet")),
                 () -> assertTrue(
-                        findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()));
+                        findByAccessibleName(panel, "Install SHAFT MCP", JButton.class).isVisible()));
 
         // Offline (latest unknown) is a neutral, non-blocking badge — never "Failed" and never
         // disables the rest of setup (issue #3538); it reads as "Offline" with a retry callout,
@@ -1404,7 +1420,7 @@ class ShaftPanelSetupTest {
                         mcpVersionDetail.getText()),
                 () -> assertTrue(mcpVersionDetail.getText().contains("10.3.20260703")),
                 () -> assertTrue(
-                        findByAccessibleName(panel, "Copy SHAFT MCP install command", JButton.class).isVisible()),
+                        findByAccessibleName(panel, "Install SHAFT MCP", JButton.class).isVisible()),
                 () -> assertTrue(findByAccessibleName(panel, "Test SHAFT MCP connection", JButton.class).isVisible(),
                         "the MCP version row must never gate the rest of setup"));
     }
@@ -1626,7 +1642,7 @@ class ShaftPanelSetupTest {
             setField(panel, "copySink", (Consumer<String>) copied::set);
             JComponent detailsPanel = (JComponent) getField(panel, "detailsPanel");
 
-            clickAccessible(panel, "Copy SHAFT MCP install command");
+            clickAccessible(panel, "Install SHAFT MCP");
             clickAccessible(panel, "Test SHAFT MCP connection");
 
             assertAll(
@@ -5702,7 +5718,7 @@ class ShaftPanelSetupTest {
                 () -> assertIcon(findButton(panel, "Rerun")),
                 () -> assertIcon(findButton(panel, "Cancel")),
                 () -> assertIcon(findByAccessibleName(panel, "Send assistant prompt", JButton.class)),
-                () -> assertIcon(findButton(setupPanel, "Copy SHAFT MCP install command")),
+                () -> assertIcon(findButton(setupPanel, "Install SHAFT MCP")),
                 () -> assertIcon(findButton(setupPanel, "Copy SHAFT upgrade command")),
                 () -> assertIcon(findButton(setupPanel, "Check SHAFT project version")),
                 () -> assertIcon(findButton(setupPanel, "Test SHAFT MCP connection")),
@@ -6105,12 +6121,13 @@ class ShaftPanelSetupTest {
             });
             AtomicReference<String> copied = new AtomicReference<>("");
             setField(panel, "copySink", (Consumer<String>) copied::set);
-            // Both the installer copy and the real verification are available from the start,
-            // and stay visible in every state (issue #3560): the check is what completes setup,
-            // so it is never hidden behind click sequencing or button visibility.
-            assertVisiblePrimarySetupActions(panel, "Install SHAFT MCP", "Copy SHAFT MCP install command", "Test SHAFT MCP connection");
+            // The installer action and the real verification are available from the start, and
+            // stay visible in every state (issue #3560): the check is what completes setup, so it
+            // is never hidden behind click sequencing or button visibility. Issue #4314 fix 3: the
+            // old separate Copy button is gone -- Install alone now also copies the command.
+            assertVisiblePrimarySetupActions(panel, "Install SHAFT MCP", "Test SHAFT MCP connection");
 
-            clickAccessible(panel, "Copy SHAFT MCP install command");
+            clickAccessible(panel, "Install SHAFT MCP");
             assertAll(
                     () -> assertTrue(copied.get().contains("install-shaft-mcp")),
                     () -> assertTrue(copied.get().contains("codex")),
@@ -6124,10 +6141,10 @@ class ShaftPanelSetupTest {
             } else {
                 assertTrue(copied.get().contains("sh \"$tmp\" --codex"));
             }
-            assertVisiblePrimarySetupActions(panel, "Install SHAFT MCP", "Copy SHAFT MCP install command", "Test SHAFT MCP connection");
+            assertVisiblePrimarySetupActions(panel, "Install SHAFT MCP", "Test SHAFT MCP connection");
 
             clickAccessible(panel, "Test SHAFT MCP connection");
-            assertVisiblePrimarySetupActions(panel, "Install SHAFT MCP", "Copy SHAFT MCP install command", "Test SHAFT MCP connection");
+            assertVisiblePrimarySetupActions(panel, "Install SHAFT MCP", "Test SHAFT MCP connection");
         } finally {
             restoreProperty("shaft.intellij.mcp.applicationDataRoot", oldAppData);
             restoreProperty("shaft.intellij.mcp.bootstrapRoot", oldBootstrap);
@@ -6136,12 +6153,12 @@ class ShaftPanelSetupTest {
         ShaftSettingsState.Settings settings = unverifiedMcpSettings();
         ShaftMcpSetupPanel connectedPanel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
         }, readyProbe());
-        assertVisiblePrimarySetupActions(connectedPanel, "Install SHAFT MCP", "Copy SHAFT MCP install command", "Test SHAFT MCP connection");
+        assertVisiblePrimarySetupActions(connectedPanel, "Install SHAFT MCP", "Test SHAFT MCP connection");
 
         showTestResult(connectedPanel, ShaftMcpToolResult.success("Probe OK"));
-        // Check and Copy remain visible/enabled alongside "Start chatting" (issue #3560): the row
-        // color, not button visibility, now conveys that setup already passed.
-        assertVisiblePrimarySetupActions(connectedPanel, "Install SHAFT MCP", "Copy SHAFT MCP install command",
+        // Check and Install remain visible/enabled alongside "Start chatting" (issue #3560): the
+        // row color, not button visibility, now conveys that setup already passed.
+        assertVisiblePrimarySetupActions(connectedPanel, "Install SHAFT MCP",
                 "Test SHAFT MCP connection", "Start chatting with SHAFT Assistant");
     }
 
@@ -6173,7 +6190,7 @@ class ShaftPanelSetupTest {
                     () -> assertTrue(copied.get().contains("install-shaft-mcp")),
                     () -> assertTrue(copied.get().contains("--install-shaft-skills")),
                     () -> assertVisiblePrimarySetupActions(panel,
-                            "Install SHAFT MCP", "Copy SHAFT MCP install command", "Test SHAFT MCP connection"),
+                            "Install SHAFT MCP", "Test SHAFT MCP connection"),
                     () -> assertTrue(containsText(panel, "Installer command copied. Run it in terminal, then check.")));
         } finally {
             restoreProperty("shaft.intellij.mcp.applicationDataRoot", oldAppData);
@@ -8244,7 +8261,6 @@ class ShaftPanelSetupTest {
     private static boolean isSetupPrimaryAction(JButton button) {
         return List.of(
                 "Install SHAFT MCP",
-                "Copy SHAFT MCP install command",
                 "Test SHAFT MCP connection",
                 "Start chatting with SHAFT Assistant").contains(accessibleName(button));
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2611,6 +2611,37 @@ class ShaftPanelSetupTest {
         assertFalse(chooseAction.isVisible(), "Space toggles the row again, collapsing it back");
     }
 
+    @Test
+    void doneStepRowShowsADiscoverableRecheckIconThatReusesTheExistingToggle() throws Exception {
+        // Issue #4314 fix 4: a collapsed "done" row was already reconfigurable non-destructively by
+        // clicking it (toggleStepRowInspection/installRowInspectionToggle) -- but nothing on screen
+        // hinted it was clickable. A small recheck icon, visible only once the row is "done", makes
+        // that existing behavior discoverable; it must reuse the same toggle, never new logic.
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.agentLaneReady = true;
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
+        });
+
+        JPanel chooseRow = (JPanel) getField(panel, "chooseRow");
+        JPanel upgradeRow = (JPanel) getField(panel, "upgradeRow");
+        JButton chooseRecheck = findByAccessibleName(chooseRow, "Choose agent setup step recheck", JButton.class);
+        JButton upgradeRecheck = findByAccessibleName(upgradeRow, "Upgrade project setup step recheck", JButton.class);
+        JComponent chooseAction = stepRowAction(panel, chooseRow);
+
+        assertAll(
+                () -> assertNotNull(chooseRecheck, "a done row should carry a recheck icon"),
+                () -> assertTrue(chooseRecheck.isVisible(), "the icon is relevant once the row is done"),
+                () -> assertNotNull(upgradeRecheck, "every step row carries the icon"),
+                () -> assertFalse(upgradeRecheck.isVisible(), "...but it stays hidden outside the done state"),
+                () -> assertFalse(chooseAction.isVisible(), "row starts collapsed since a later step is active"));
+
+        chooseRecheck.doClick();
+        assertTrue(chooseAction.isVisible(), "clicking the recheck icon must reuse the existing row toggle");
+
+        chooseRecheck.doClick();
+        assertFalse(chooseAction.isVisible(), "clicking again collapses it back, same as clicking the row");
+    }
+
     private static JComponent stepRowAction(ShaftMcpSetupPanel panel, JPanel row) throws Exception {
         Method method = ShaftMcpSetupPanel.class.getDeclaredMethod("stepRowAction", JPanel.class);
         method.setAccessible(true);


### PR DESCRIPTION
## Summary

Fixes #4314 -- 5 owner-reviewed UX issues in the SHAFT MCP setup wizard panel (`shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java`), landed as 5 independently-verified commits on one branch/PR since all target the same file.

1. **Remove dead greyed copy** -- deleted the intro's greyed "Pick an agent -- recording, code generation..." paragraph and the redundant "Target: X. Runtime: Y." `setupSummary` caption (already restated by the family/runtime combo boxes above it). Bold "Connect SHAFT Assistant" title stays.
2. **Add a "Check" button to "2 Pick agent"** -- every other step (Upgrade, Install) already had its own Check button; this step only turned green as a side effect of the full step-4 MCP probe. New `checkChosenAgent` button calls the existing `verifySelectedAgentReadiness(...)` for the current family/runtime (off-EDT for the non-cloud deep probe, inline for the fast Gemini cloud path) and reflects the result into `settings.agentLaneReady` + the row's own badge -- **does not** call `applyAgentLaneState()`, since that would also flip the Ready step's `startChatting`/`startWithoutAgent`/`connectAgent` visibility, which a step-2-only check must never touch.
3. **Merge duplicate Install/Copy buttons** -- `installNow` and `copyMcpInstallCommand` were functionally near-identical (both built the installer command and opened a terminal pre-typed through the same seam); the only real difference was Copy's explicit clipboard copy. Kept "Install" and routed it through the existing `copyCommandIntoTerminal()` helper (already used elsewhere on this screen) so it now does both. Deleted `copyMcpInstallCommand` entirely.
4. **Discoverable recheck affordance** -- a collapsed "Done" row was already reconfigurable by clicking it (`toggleStepRowInspection`), but nothing hinted it was clickable. Added a small icon (`ShaftIcons.RERUN`, an existing refresh glyph -- no new asset) in the top-right corner of each step row, visible only in the "done" state, wired to the exact same toggle.
5. **Remove the "Next" badge specifically** -- the `"next"` state badge rendered an opaque, bordered pill that looked like a button but wasn't. Blanked out for `"next"` only (no text/opacity/border); `"done"`/`"failed"`/`"checking"`/`"optional"` badges are completely untouched.

## Judgment calls made (both documented inline in the diff)

- **Fix 2**: the check reflects into `settings.agentLaneReady` + calls `updateActionState(false)` (which safely refreshes the row's badge) rather than the broader `applyAgentLaneState()`, to avoid touching Ready-step widgets from a step-2-only check.
- **Fix 5**: left the step-name label's own bold/blue "active step" font styling untouched for `"next"`/`"checking"`/`"optional"` -- it's a separate, already-useful signal the owner didn't flag, and removing it too would make the active row read at the same visual weight as an inactive one.

## Test plan

- [x] TDD throughout: each of the 5 fixes got a failing test first (watched RED for the right reason), then the minimal production change (watched GREEN), as 5 separate commits.
- [x] `ShaftPanelSetupTest.java` updated to assert the **new** correct behavior everywhere a removed/changed element was previously asserted (removed-label assertions, badge text/opacity/border, button-presence/merge, icon-only-button allowlists) -- not relaxed.
- [x] Scoped run only, headless: `./gradlew.bat test --tests "com.shaft.intellij.ui.ShaftPanelSetupTest" -Dallure.automaticallyOpen=false` (JAVA_HOME pinned to the ms-21.0.11 JDK per the known Gradle-daemon-JDK25 gotcha) -- green after every commit and again after rebasing onto latest origin/main.
- [x] No full suite, no allure serve/open, no headed IntelliJ launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGdgmezM75NX62aMypA5jn