### PR TITLE
Fix #4321: self-heal MultipleElementsFoundException when exactly one match is actionable

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -59,6 +59,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -506,8 +507,19 @@ public class Actions extends ElementActions {
                     throw new NoSuchElementException("Cannot locate an element using " + JavaHelper.formatLocatorToString(locator));
 
                 // ensure element locator is unique if applicable
-                if (foundElements.get().size() > 1 && SHAFT.Properties.flags.forceCheckElementLocatorIsUnique() && !(locator instanceof RelativeLocator.RelativeBy) && !(locator instanceof ByAll))
-                    throw new MultipleElementsFoundException();
+                if (foundElements.get().size() > 1 && SHAFT.Properties.flags.forceCheckElementLocatorIsUnique() && !(locator instanceof RelativeLocator.RelativeBy) && !(locator instanceof ByAll)) {
+                    // issue #4321: a locator matching several elements is only genuinely ambiguous when
+                    // more than one of them is actually actionable. When exactly one is displayed and
+                    // enabled (the rest are hidden/disabled decoys -- e.g. duplicated markup for
+                    // different breakpoints), narrow to that single element instead of failing; any
+                    // other split (0, or 2+, displayed-and-enabled matches) still throws exactly as before.
+                    Optional<WebElement> uniqueActionable = uniqueDisplayedAndEnabledElement(foundElements.get());
+                    if (uniqueActionable.isPresent()) {
+                        foundElements.set(List.of(uniqueActionable.get()));
+                    } else {
+                        throw new MultipleElementsFoundException();
+                    }
+                }
 
                 if (healingResolution.get() == null) {
                     HealingManager.observe(
@@ -618,7 +630,14 @@ public class Actions extends ElementActions {
                             && SHAFT.Properties.flags.forceCheckElementLocatorIsUnique()
                             && !(locator instanceof RelativeLocator.RelativeBy)
                             && !(locator instanceof ByAll)) {
-                        throw new MultipleElementsFoundException();
+                        // issue #4321: same narrowing as the initial lookup above -- only auto-resolve
+                        // when exactly one refreshed match is actually actionable.
+                        Optional<WebElement> uniqueActionable = uniqueDisplayedAndEnabledElement(foundElements.get());
+                        if (uniqueActionable.isPresent()) {
+                            foundElements.set(List.of(uniqueActionable.get()));
+                        } else {
+                            throw new MultipleElementsFoundException();
+                        }
                     }
                 }
                 if (lazyLoadingActivityObserved && !isMobileNativeExecution && shouldCheckNativeActionability(action, locator)) {
@@ -1766,6 +1785,37 @@ public class Actions extends ElementActions {
             }
         }
         return false;
+    }
+
+    /**
+     * Finds the single actionable (displayed and enabled) element among {@code elements}, reusing
+     * the same per-element {@code isDisplayed()}/{@code isEnabled()} filtering already applied by
+     * {@link #chooseBestEffortDisplayedElement(List)}. Unlike that best-effort picker, this method
+     * never guesses: it returns a match only when EXACTLY ONE element qualifies, so a locator that
+     * matches several genuinely actionable elements stays ambiguous (issue #4321) -- disambiguation
+     * is intentionally narrow, not a general-purpose "pick one" fallback.
+     *
+     * @param elements candidate elements matched by the target locator
+     * @return the single displayed-and-enabled element, or empty when zero or several qualify
+     */
+    static Optional<WebElement> uniqueDisplayedAndEnabledElement(List<WebElement> elements) {
+        if (elements == null || elements.isEmpty()) {
+            return Optional.empty();
+        }
+        WebElement match = null;
+        for (WebElement element : elements) {
+            try {
+                if (element.isDisplayed() && element.isEnabled()) {
+                    if (match != null) {
+                        return Optional.empty();
+                    }
+                    match = element;
+                }
+            } catch (WebDriverException ignored) {
+                // try next match
+            }
+        }
+        return Optional.ofNullable(match);
     }
 
     private static NoSuchElementException createDragAndDropElementNotFoundException(By locator, String role, NoSuchElementException rootCauseException) {

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -522,10 +522,18 @@ public class Actions extends ElementActions {
                     // only when exactly one match is displayed and enabled (the rest are hidden/disabled
                     // decoys -- e.g. duplicated markup for different breakpoints); any other split (0, or
                     // 2+, displayed-and-enabled matches) still throws.
+                    int matchCountBeforeNarrowing = foundElements.get().size();
                     Optional<WebElement> uniqueActionable = lastResortNarrowingAllowed.get()
                             ? uniqueDisplayedAndEnabledElement(foundElements.get())
                             : Optional.empty();
                     if (uniqueActionable.isPresent()) {
+                        // issue #4321: a real ambiguity was just auto-resolved -- trace it so a user
+                        // whose locator matches more than one element notices it, instead of the action
+                        // silently looking like an ordinary pass.
+                        ReportManager.logDiscrete("Locator " + JavaHelper.formatLocatorToString(locator)
+                                + " matched " + matchCountBeforeNarrowing
+                                + " elements; auto-resolved to the only displayed and enabled one after the"
+                                + " identification timeout was exhausted.");
                         foundElements.set(List.of(uniqueActionable.get()));
                     } else {
                         throw new MultipleElementsFoundException();
@@ -647,10 +655,16 @@ public class Actions extends ElementActions {
                         // issue #4321: same last-resort-only narrowing as the initial lookup above --
                         // only auto-resolve when exactly one refreshed match is actually actionable, and
                         // only on the single post-timeout attempt (see comment on the initial lookup).
+                        int refreshedMatchCountBeforeNarrowing = foundElements.get().size();
                         Optional<WebElement> uniqueActionable = lastResortNarrowingAllowed.get()
                                 ? uniqueDisplayedAndEnabledElement(foundElements.get())
                                 : Optional.empty();
                         if (uniqueActionable.isPresent()) {
+                            ReportManager.logDiscrete("Locator " + JavaHelper.formatLocatorToString(locator)
+                                    + " matched " + refreshedMatchCountBeforeNarrowing
+                                    + " elements after lazy-loading settled; auto-resolved to the only"
+                                    + " displayed and enabled one after the identification timeout was"
+                                    + " exhausted.");
                             foundElements.set(List.of(uniqueActionable.get()));
                         } else {
                             throw new MultipleElementsFoundException();

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -485,9 +485,14 @@ public class Actions extends ElementActions {
         AtomicReference<HealingResolution> healingResolution = new AtomicReference<>();
         AtomicReference<HealingResolution> secondaryHealingResolution = new AtomicReference<>();
         AtomicReference<By> secondaryLocator = new AtomicReference<>();
+        // issue #4321 (second-pass review): disambiguation must be a strict LAST RESORT, applied only
+        // once the full identification-timeout retry window below is exhausted -- never during the
+        // loop itself, so a still-settling page always gets its full window before any narrowing is
+        // even considered. False for every poll of the primary fluentWait call; flipped true only for
+        // the single extra attempt made after that call times out with an ambiguous locator.
+        AtomicBoolean lastResortNarrowingAllowed = new AtomicBoolean(false);
 
-        try {
-            new SynchronizationManager(driverFactoryHelper.getDriver()).fluentWait(true).until(d -> {
+        Function<WebDriver, Boolean> attemptElementActionOnce = d -> {
                 flakeProfile.waitLoops.incrementAndGet();
                 flakeProfile.locatorLookups.incrementAndGet();
                 // find all elements matching the target locator
@@ -509,11 +514,17 @@ public class Actions extends ElementActions {
                 // ensure element locator is unique if applicable
                 if (foundElements.get().size() > 1 && SHAFT.Properties.flags.forceCheckElementLocatorIsUnique() && !(locator instanceof RelativeLocator.RelativeBy) && !(locator instanceof ByAll)) {
                     // issue #4321: a locator matching several elements is only genuinely ambiguous when
-                    // more than one of them is actually actionable. When exactly one is displayed and
-                    // enabled (the rest are hidden/disabled decoys -- e.g. duplicated markup for
-                    // different breakpoints), narrow to that single element instead of failing; any
-                    // other split (0, or 2+, displayed-and-enabled matches) still throws exactly as before.
-                    Optional<WebElement> uniqueActionable = uniqueDisplayedAndEnabledElement(foundElements.get());
+                    // more than one of them is actually actionable. This ALWAYS throws during the normal
+                    // retry loop (lastResortNarrowingAllowed is false here on every poll), identical to
+                    // pre-#4321 behavior -- a still-settling page keeps its full identification-timeout
+                    // window. Only the single last-resort attempt made after that window is exhausted
+                    // (see the outer try/catch around the fluentWait call below) allows narrowing, and
+                    // only when exactly one match is displayed and enabled (the rest are hidden/disabled
+                    // decoys -- e.g. duplicated markup for different breakpoints); any other split (0, or
+                    // 2+, displayed-and-enabled matches) still throws.
+                    Optional<WebElement> uniqueActionable = lastResortNarrowingAllowed.get()
+                            ? uniqueDisplayedAndEnabledElement(foundElements.get())
+                            : Optional.empty();
                     if (uniqueActionable.isPresent()) {
                         foundElements.set(List.of(uniqueActionable.get()));
                     } else {
@@ -522,6 +533,9 @@ public class Actions extends ElementActions {
                 }
 
                 if (healingResolution.get() == null) {
+                    // issue #4327 (follow-up, not yet implemented): a last-resort-narrowed single
+                    // element is fed into observe() exactly like a naturally-unique match, so it can seed
+                    // a heal-history fingerprint an ambiguous locator could not have earned before #4321.
                     HealingManager.observe(
                             d,
                             locator,
@@ -630,9 +644,12 @@ public class Actions extends ElementActions {
                             && SHAFT.Properties.flags.forceCheckElementLocatorIsUnique()
                             && !(locator instanceof RelativeLocator.RelativeBy)
                             && !(locator instanceof ByAll)) {
-                        // issue #4321: same narrowing as the initial lookup above -- only auto-resolve
-                        // when exactly one refreshed match is actually actionable.
-                        Optional<WebElement> uniqueActionable = uniqueDisplayedAndEnabledElement(foundElements.get());
+                        // issue #4321: same last-resort-only narrowing as the initial lookup above --
+                        // only auto-resolve when exactly one refreshed match is actually actionable, and
+                        // only on the single post-timeout attempt (see comment on the initial lookup).
+                        Optional<WebElement> uniqueActionable = lastResortNarrowingAllowed.get()
+                                ? uniqueDisplayedAndEnabledElement(foundElements.get())
+                                : Optional.empty();
                         if (uniqueActionable.isPresent()) {
                             foundElements.set(List.of(uniqueActionable.get()));
                         } else {
@@ -914,7 +931,22 @@ public class Actions extends ElementActions {
                         true,
                         "");
                 return true;
-            });
+        };
+
+        try {
+            try {
+                new SynchronizationManager(driverFactoryHelper.getDriver()).fluentWait(true).until(attemptElementActionOnce::apply);
+            } catch (RuntimeException timeoutFailure) {
+                if (isCausedByAmbiguousLocator(timeoutFailure)) {
+                    // issue #4321: the full identification-timeout retry window is exhausted and the
+                    // locator is still ambiguous on every unmodified retry. Take exactly one more look,
+                    // this time allowing narrowing to the single actionable match if there is one.
+                    lastResortNarrowingAllowed.set(true);
+                    attemptElementActionOnce.apply(driverFactoryHelper.getDriver());
+                } else {
+                    throw timeoutFailure;
+                }
+            }
         } catch (RuntimeException exception) {
             HealingManager.recordOutcome(
                     driverFactoryHelper.getDriver(),
@@ -1816,6 +1848,24 @@ public class Actions extends ElementActions {
             }
         }
         return Optional.ofNullable(match);
+    }
+
+    /**
+     * Checks whether {@code exception} -- typically the {@link org.openqa.selenium.TimeoutException}
+     * thrown when {@link SynchronizationManager}'s fluentWait exhausts the identification timeout --
+     * was ultimately caused by an ambiguous locator, by walking the full cause chain rather than
+     * assuming a fixed wrapping depth (issue #4321).
+     *
+     * @param exception the caught failure to inspect
+     * @return {@code true} when {@link MultipleElementsFoundException} appears anywhere in the chain
+     */
+    static boolean isCausedByAmbiguousLocator(Throwable exception) {
+        for (Throwable cause = exception; cause != null; cause = cause.getCause()) {
+            if (cause instanceof MultipleElementsFoundException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static NoSuchElementException createDragAndDropElementNotFoundException(By locator, String role, NoSuchElementException rootCauseException) {

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -1044,6 +1044,23 @@ public class ActionsCoverageUnitTest {
     }
 
     @Test
+    public void isCausedByAmbiguousLocatorShouldWalkTheFullCauseChain() {
+        // issue #4321 second-pass review: the last-resort retry must trigger only when a
+        // MultipleElementsFoundException appears anywhere in the failure's cause chain -- typically
+        // wrapped by FluentWait's TimeoutException, but never assuming a fixed wrapping depth.
+        Assert.assertTrue(Actions.isCausedByAmbiguousLocator(new com.shaft.gui.internal.exceptions.MultipleElementsFoundException()));
+        Assert.assertTrue(Actions.isCausedByAmbiguousLocator(
+                new org.openqa.selenium.TimeoutException("timed out",
+                        new com.shaft.gui.internal.exceptions.MultipleElementsFoundException())));
+        Assert.assertTrue(Actions.isCausedByAmbiguousLocator(
+                new RuntimeException("wrapper", new RuntimeException("nested",
+                        new com.shaft.gui.internal.exceptions.MultipleElementsFoundException()))));
+        Assert.assertFalse(Actions.isCausedByAmbiguousLocator(new NoSuchElementException("not found")));
+        Assert.assertFalse(Actions.isCausedByAmbiguousLocator(
+                new org.openqa.selenium.TimeoutException("timed out", new StaleElementReferenceException("stale"))));
+    }
+
+    @Test
     public void getTextShouldReturnEmptyStringWhenAllTextFallbacksAreNull() {
         WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.withSettings().extraInterfaces(JavascriptExecutor.class, TakesScreenshot.class));
         WebElement element = standardElement();

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ActionsCoverageUnitTest.java
@@ -57,6 +57,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -1004,7 +1005,43 @@ public class ActionsCoverageUnitTest {
                 .contains("Caused by: java.lang.IllegalArgumentException: cause"));
     }
 
+    @Test
+    public void uniqueDisplayedAndEnabledElementShouldNarrowOnlyWhenExactlyOneQualifies() {
+        // issue #4321: disambiguation must only fire when the found-elements list has exactly one
+        // displayed-and-enabled candidate; any other split (zero, or two-or-more) must stay ambiguous.
+        WebElement hidden = mock(WebElement.class);
+        when(hidden.isDisplayed()).thenReturn(false);
+        WebElement visibleButDisabled = mock(WebElement.class);
+        when(visibleButDisabled.isDisplayed()).thenReturn(true);
+        when(visibleButDisabled.isEnabled()).thenReturn(false);
+        WebElement visibleEnabled = mock(WebElement.class);
+        when(visibleEnabled.isDisplayed()).thenReturn(true);
+        when(visibleEnabled.isEnabled()).thenReturn(true);
 
+        Assert.assertEquals(
+                Actions.uniqueDisplayedAndEnabledElement(List.of(hidden, visibleButDisabled, visibleEnabled)),
+                Optional.of(visibleEnabled));
+
+        WebElement anotherVisibleEnabled = mock(WebElement.class);
+        when(anotherVisibleEnabled.isDisplayed()).thenReturn(true);
+        when(anotherVisibleEnabled.isEnabled()).thenReturn(true);
+        Assert.assertEquals(
+                Actions.uniqueDisplayedAndEnabledElement(List.of(visibleEnabled, anotherVisibleEnabled)),
+                Optional.empty());
+
+        Assert.assertEquals(
+                Actions.uniqueDisplayedAndEnabledElement(List.of(hidden, visibleButDisabled)),
+                Optional.empty());
+
+        WebElement throwing = mock(WebElement.class);
+        when(throwing.isDisplayed()).thenThrow(new WebDriverException("stale-ish"));
+        Assert.assertEquals(
+                Actions.uniqueDisplayedAndEnabledElement(List.of(throwing, visibleEnabled)),
+                Optional.of(visibleEnabled));
+
+        Assert.assertEquals(Actions.uniqueDisplayedAndEnabledElement(List.of()), Optional.empty());
+        Assert.assertEquals(Actions.uniqueDisplayedAndEnabledElement(null), Optional.empty());
+    }
 
     @Test
     public void getTextShouldReturnEmptyStringWhenAllTextFallbacksAreNull() {

--- a/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
@@ -82,6 +82,11 @@ public class MultipleElementsFailureTest {
                 "Expected the disambiguation to wait out most of the " + SHORT_IDENTIFICATION_TIMEOUT_SECONDS
                         + "s identification timeout as a last resort, but it resolved after only "
                         + elapsedMillis + "ms.");
+        // proves WHICH button was actually clicked -- #save's `onclick` marker never fires because a
+        // native `disabled` button ignores click events entirely, so a silent no-op on #save would
+        // leave the title unchanged and fail this assertion, instead of passing as it would if this
+        // test only checked that "some click succeeded".
+        Assert.assertEquals(driver.get().browser().getCurrentWindowTitle(), "cancel-clicked");
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
@@ -3,6 +3,7 @@ package testPackage.mockedTests;
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.internal.exceptions.MultipleElementsFoundException;
 import org.openqa.selenium.By;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -11,6 +12,10 @@ import testPackage.TestPageServer;
 public class MultipleElementsFailureTest {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
     String mockedHTML = TestPageServer.url("multipleElementsFixture.html");
+    // issue #4321: 3 elements match, but only 1 is displayed+enabled (the other 2 are hidden /
+    // disabled respectively) -- this MUST auto-resolve to the single actionable element instead of
+    // throwing, unlike mockedHTML above where all 3 matches are genuinely actionable.
+    String oneVisibleHTML = TestPageServer.url("multipleElementsOneVisibleFixture.html");
 
 
     @Test(expectedExceptions = {RuntimeException.class})
@@ -29,6 +34,22 @@ public class MultipleElementsFailureTest {
     public void clickUsingJS() {
         driver.get().browser().navigateToURL(mockedHTML);
         driver.get().element().clickUsingJavascript(By.xpath("//input"));
+    }
+
+    @Test
+    public void typeResolvesToTheOnlyVisibleAndEnabledElementAmongMultipleMatches() {
+        driver.get().browser().navigateToURL(oneVisibleHTML);
+        // the locator itself is genuinely ambiguous (3 matches); the action must still succeed
+        // because exactly one of them is displayed and enabled.
+        Assert.assertEquals(driver.get().element().getElementsCount(By.xpath("//input")), 3);
+        driver.get().element().type(By.xpath("//input"), "standard_user");
+    }
+
+    @Test
+    public void clickResolvesToTheOnlyVisibleAndEnabledElementAmongMultipleMatches() {
+        driver.get().browser().navigateToURL(oneVisibleHTML);
+        Assert.assertEquals(driver.get().element().getElementsCount(By.xpath("//input")), 3);
+        driver.get().element().click(By.xpath("//input"));
     }
 
     @BeforeMethod

--- a/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
@@ -2,6 +2,7 @@ package testPackage.mockedTests;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.internal.exceptions.MultipleElementsFoundException;
+import com.shaft.properties.internal.Properties;
 import org.openqa.selenium.By;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -11,29 +12,43 @@ import testPackage.TestPageServer;
 
 public class MultipleElementsFailureTest {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
+    // issue #4321 second-pass review: a short identification timeout keeps this class's
+    // last-resort-narrowing tests (which must legitimately wait out the full window) fast, without
+    // changing the behavior under test.
+    private static final int SHORT_IDENTIFICATION_TIMEOUT_SECONDS = 6;
     String mockedHTML = TestPageServer.url("multipleElementsFixture.html");
     // issue #4321: 3 elements match, but only 1 is displayed+enabled (the other 2 are hidden /
     // disabled respectively) -- this MUST auto-resolve to the single actionable element instead of
     // throwing, unlike mockedHTML above where all 3 matches are genuinely actionable.
     String oneVisibleHTML = TestPageServer.url("multipleElementsOneVisibleFixture.html");
+    // issue #4321 second-pass review (PR #4326 independent review): 2 buttons match, #save is
+    // permanently disabled and #cancel is permanently enabled -- the narrowing must still only
+    // apply as a LAST RESORT, after the full identification timeout is exhausted, never during the
+    // retry loop itself.
+    String disabledEnabledButtonsHTML = TestPageServer.url("multipleButtonsDisabledEnabledFixture.html");
+    // issue #4321 second-pass review: #save starts disabled and becomes enabled shortly after
+    // navigation (well before the identification timeout elapses), so by the time a last-resort
+    // check would run, BOTH buttons are displayed+enabled -- this locator must stay genuinely
+    // ambiguous and throw, never narrow early to #cancel while #save is still disabled.
+    String delayedEnableButtonsHTML = TestPageServer.url("multipleButtonsDelayedEnableFixture.html");
 
 
-    @Test(expectedExceptions = {RuntimeException.class})
+    @Test
     public void type() {
         driver.get().browser().navigateToURL(mockedHTML);
-        driver.get().element().type(By.xpath("//input"), "standard_user");
+        assertThrowsMultipleElementsFoundException(() -> driver.get().element().type(By.xpath("//input"), "standard_user"));
     }
 
-    @Test(expectedExceptions = {RuntimeException.class})
+    @Test
     public void click() {
         driver.get().browser().navigateToURL(mockedHTML);
-        driver.get().element().click(By.xpath("//input"));
+        assertThrowsMultipleElementsFoundException(() -> driver.get().element().click(By.xpath("//input")));
     }
 
-    @Test(expectedExceptions = {RuntimeException.class})
+    @Test
     public void clickUsingJS() {
         driver.get().browser().navigateToURL(mockedHTML);
-        driver.get().element().clickUsingJavascript(By.xpath("//input"));
+        assertThrowsMultipleElementsFoundException(() -> driver.get().element().clickUsingJavascript(By.xpath("//input")));
     }
 
     @Test
@@ -52,9 +67,35 @@ public class MultipleElementsFailureTest {
         driver.get().element().click(By.xpath("//input"));
     }
 
-    @BeforeMethod
+    @Test
+    public void clickResolvesToTheOnlyEnabledButtonOnlyAfterTheIdentificationTimeoutIsExhausted() {
+        driver.get().browser().navigateToURL(disabledEnabledButtonsHTML);
+        Assert.assertEquals(driver.get().element().getElementsCount(By.xpath("//button")), 2);
 
+        long startMillis = System.currentTimeMillis();
+        driver.get().element().click(By.xpath("//button"));
+        long elapsedMillis = System.currentTimeMillis() - startMillis;
+
+        // proves the narrowing was NOT applied on the first poll (which would resolve near-instantly)
+        // -- it must only kick in as a last resort once the full identification timeout is spent.
+        Assert.assertTrue(elapsedMillis >= 4_000,
+                "Expected the disambiguation to wait out most of the " + SHORT_IDENTIFICATION_TIMEOUT_SECONDS
+                        + "s identification timeout as a last resort, but it resolved after only "
+                        + elapsedMillis + "ms.");
+    }
+
+    @Test
+    public void staysAmbiguousWhenTheSecondMatchBecomesActionableBeforeTheIdentificationTimeoutElapses() {
+        driver.get().browser().navigateToURL(delayedEnableButtonsHTML);
+        Assert.assertEquals(driver.get().element().getElementsCount(By.xpath("//button")), 2);
+        // by the time the full identification timeout elapses, #save has also become enabled, so
+        // BOTH buttons are actionable -- this must throw, never silently click #cancel.
+        assertThrowsMultipleElementsFoundException(() -> driver.get().element().click(By.xpath("//button")));
+    }
+
+    @BeforeMethod
     void beforeMethod() {
+        SHAFT.Properties.timeouts.set().defaultElementIdentificationTimeout(SHORT_IDENTIFICATION_TIMEOUT_SECONDS);
         driver.set(new SHAFT.GUI.WebDriver());
     }
 
@@ -62,5 +103,16 @@ public class MultipleElementsFailureTest {
     @AfterMethod(alwaysRun = true)
     void afterMethod() {
         if (driver.get() != null) driver.get().quit();
+        Properties.clearForCurrentThread();
+    }
+
+    private static void assertThrowsMultipleElementsFoundException(Runnable action) {
+        RuntimeException thrown = Assert.expectThrows(RuntimeException.class, action::run);
+        Throwable cause = thrown;
+        while (cause != null && !(cause instanceof MultipleElementsFoundException)) {
+            cause = cause.getCause();
+        }
+        Assert.assertTrue(cause instanceof MultipleElementsFoundException,
+                "Expected a MultipleElementsFoundException in the cause chain, but got: " + thrown);
     }
 }

--- a/shaft-engine/src/test/resources/testDataFiles/multipleButtonsDelayedEnableFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/multipleButtonsDelayedEnableFixture.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT Multiple Buttons Delayed Enable Fixture</title>
+</head>
+<body>
+<button id="save" disabled>Save</button>
+<button id="cancel">Cancel</button>
+<script>
+    // enables #save well before the (short, test-configured) element-identification timeout
+    // elapses, so BOTH buttons end up displayed+enabled by the time a last-resort disambiguation
+    // check would ever run -- the locator must stay genuinely ambiguous, never narrow early to
+    // #cancel while #save is still disabled.
+    setTimeout(function () {
+        document.getElementById("save").disabled = false;
+    }, 3000);
+</script>
+</body>
+</html>

--- a/shaft-engine/src/test/resources/testDataFiles/multipleButtonsDisabledEnabledFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/multipleButtonsDisabledEnabledFixture.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT Multiple Buttons Disabled/Enabled Fixture</title>
+</head>
+<body>
+<button id="save" disabled>Save</button>
+<button id="cancel">Cancel</button>
+</body>
+</html>

--- a/shaft-engine/src/test/resources/testDataFiles/multipleButtonsDisabledEnabledFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/multipleButtonsDisabledEnabledFixture.html
@@ -5,7 +5,11 @@
     <title>SHAFT Multiple Buttons Disabled/Enabled Fixture</title>
 </head>
 <body>
-<button id="save" disabled>Save</button>
-<button id="cancel">Cancel</button>
+<!-- onclick markers let the test prove WHICH button actually got clicked, instead of only
+     asserting that some click succeeded (a native `disabled` button ignores click events
+     entirely, so if #save were ever clicked in error, neither marker would fire and the
+     assertion below would correctly fail rather than pass on a silent no-op). -->
+<button id="save" disabled onclick="document.title='save-clicked'">Save</button>
+<button id="cancel" onclick="document.title='cancel-clicked'">Cancel</button>
 </body>
 </html>

--- a/shaft-engine/src/test/resources/testDataFiles/multipleElementsOneVisibleFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/multipleElementsOneVisibleFixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SHAFT Multiple Elements One Visible Fixture</title>
+</head>
+<body>
+<input style="display:none"/>
+<input disabled/>
+<input/>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Fixes #4321. When a locator matches more than one element, `Actions.performAction()`
already retries for the full identification timeout (`SHAFT.Properties.timeouts.defaultElementIdentificationTimeout()`,
default 10s) before failing -- `MultipleElementsFoundException` was already in
`SynchronizationManager`'s `FluentWait` ignore-list. But every retry re-ran the
*same unchanged locator*, so a genuinely-resolvable ambiguity (e.g. one hidden/disabled
decoy element alongside the real target) always ended up throwing anyway.

This PR adds **last-resort-only** disambiguation: after the full identification
timeout is exhausted and the locator is *still* ambiguous on every unmodified retry,
SHAFT makes exactly one additional attempt, narrowing to the single element that is
both displayed and enabled -- but only if exactly one qualifies. Any other split
(zero, or two-or-more, displayed-and-enabled matches) still throws
`MultipleElementsFoundException` exactly as before.

**This design went through two rounds of independent architectural review** (this
touches `Actions.java`, the highest-blast-radius file in the framework). The first
round caught a real bug in an earlier version of this PR that narrowed *during* the
retry loop instead of only as a last resort -- that version could silently resolve
on the very first poll and click the wrong element (e.g. a genuinely enabled
"Cancel" button beside a still-initializing, currently-disabled "Save") while
reporting PASS. See the PR comment history for the full back-and-forth; the design
below is what survived both passes.

## What's implemented

- `Actions.uniqueDisplayedAndEnabledElement(List<WebElement>)` (`Actions.java:1847`)
  -- returns the single element when exactly one of the candidates is displayed AND
  enabled, reusing the same filtering idiom as the existing
  `chooseBestEffortDisplayedElement` (generalized from its previous mobile-only
  scope, not new scoring logic).
- The primary `FluentWait` retry loop is **behaviorally unchanged**: both of its
  `throw new MultipleElementsFoundException()` sites (`Actions.java:515-543` initial
  lookup, `Actions.java:651-671` post-lazy-load refreshed lookup) always throw during
  every poll, gated by a `lastResortNarrowingAllowed` flag that stays `false` for the
  whole loop -- identical to pre-#4321 behavior, so a still-settling page always gets
  its full identification-timeout window.
- `Actions.isCausedByAmbiguousLocator(Throwable)` (`Actions.java:1876`) -- walks the
  full cause chain (not a fixed wrapping depth) to detect when the primary loop's
  `TimeoutException` was ultimately caused by `MultipleElementsFoundException`.
- When that's true, `performAction()` (`Actions.java:950-963`) makes exactly one
  additional attempt with narrowing enabled, implemented by naming the existing
  `FluentWait` lambda (`attemptElementActionOnce`, declared at `Actions.java:495`) so
  it's callable a second time -- zero duplication of the ~400-line action-dispatch
  switch statement.
- A `ReportManager.logDiscrete(...)` trace line fires at the point narrowing
  actually resolves an ambiguity, naming the original match count and that
  auto-resolution happened after the identification timeout -- so a real ambiguity
  is visible in the report instead of silently looking like an ordinary pass.

## Tests (all in `shaft-engine`, real headless Chrome via `TestPageServer` unless noted)

- `MultipleElementsFailureTest` (7 tests):
  - `type` / `click` / `clickUsingJS` -- pre-existing regression guard (3 plain,
    all-actionable `<input>`s): still throw `MultipleElementsFoundException`
    unchanged. Assertions strengthened to check the cause chain specifically
    (`assertThrowsMultipleElementsFoundException` helper) instead of the too-broad
    `expectedExceptions = {RuntimeException.class}`.
  - `typeResolvesToTheOnlyVisibleAndEnabledElementAmongMultipleMatches` /
    `clickResolvesToTheOnlyVisibleAndEnabledElementAmongMultipleMatches` -- 3
    `<input>`s (1 hidden, 1 disabled, 1 actionable): action succeeds.
  - `clickResolvesToTheOnlyEnabledButtonOnlyAfterTheIdentificationTimeoutIsExhausted`
    -- 2 `<button>`s (one permanently disabled, one permanently enabled): asserts
    elapsed time proves the narrowing did *not* fire on the first poll, and asserts
    an `onclick`-marker (`document.title`) proves *which* button was actually
    clicked (a disabled button ignores click events entirely, so a silent no-op on
    the wrong element would leave the marker unset and fail this assertion).
  - `staysAmbiguousWhenTheSecondMatchBecomesActionableBeforeTheIdentificationTimeoutElapses`
    -- 2 `<button>`s, one starts disabled and is JS-enabled mid-window: proves the
    locator stays genuinely ambiguous and throws, never silently resolving to the
    wrong button while the real target was still initializing.
- `ActionsCoverageUnitTest` (43 tests, mocked `WebElement`/`WebDriver`, no browser):
  unit coverage for `uniqueDisplayedAndEnabledElement` and the new
  `isCausedByAmbiguousLocator` cause-chain walker.
- `ElementsHelperCoverageUnitTest` (21 tests): adjacent element-lookup coverage,
  unaffected.

All classes run isolated (own Surefire fork) and headless
(`-DheadlessExecution=true -Dallure.automaticallyOpen=false`); every new/changed
test was watched RED (against the pre-fix code, for the exact expected reason) then
GREEN.

## Scope decisions

- **Why not shaft-heal / `HealingManager`?** Investigated first. It's fingerprint/
  history-based: it only fires on the zero-match branch and requires a previously-
  observed unique fingerprint, so it cannot help a locator that has never uniquely
  resolved before (#4321's literal reported scenario). Extending it to the
  multi-match branch for the *different* case of DOM-drift-into-ambiguity-with-
  prior-history is tracked separately: #4327.
- **Why not shaft-capture's `LocatorPolicy`?** Confirmed capture-time-only
  (`ElementSnapshot`/`LocatorCandidate` evidence), not callable at runtime with just
  a live driver + locator.
- **Why not `touch().tap()` / `ElementActionsHelper.identifyUniqueElement`?**
  Genuinely separate element-resolution mechanism (`waitForElementPresence`, its own
  retry/timeout implementation, no shared code with the `FluentWait`-based fix here).
  Tracked separately, confirmed with the orchestrator: #4332.
- **Deferred, tracked separately, not fixed in this PR:**
  - #4327 -- `HealingManager.resolve()` on the multi-match branch (see above).
  - #4332 -- `touch().tap()` disambiguation (see above).
  - #4334 -- the last-resort path drops the original `TimeoutException`'s "tried for
    N second(s)" diagnostic context when it also fails.
  - #4335 -- docs (`webConfig.md`) need a note that `forceCheckElementLocatorIsUnique`
    is now "last resort after timeout", not absolute.
  - #4336 -- `MultipleElementsFailureTest` isn't wired into `pr-gate.yml` (only the
    broader, less-frequent `e2eTests.yml`); `ActionsCoverageUnitTest` /
    `ElementsHelperCoverageUnitTest` already are.

## Known cosmetic issue (disclosed, not fixed)

The `FluentWait` lambda body in `performAction()` is indented one level shallower
than ideal after being extracted into a named `Function` variable (it used to sit
two nesting levels deep inside `try { ... .until(d -> {`; the declaration is now one
level up). Left as-is rather than risk a blind bulk reindent on this specific file
under time pressure -- it contains multi-line Java text blocks (`"""..."""` for
inline JS) where a naive whitespace-stripping pass could shift string content. Happy
to do a careful manual pass if requested.

## Review status

This PR has been through **two rounds of independent Opus architectural review**
given the blast radius of `Actions.java`. The first round blocked the initial
in-loop-narrowing design (real bug: could resolve prematurely and act on the wrong
element). The second round approved the reworked last-resort design with the three
nits addressed in the latest commits (last-resort logging, this PR body, the
strengthened button-click assertion). **Do not auto-merge without confirming the
current review round's outcome** -- check the PR comment thread for the latest
status before arming.
