### PR TITLE
Group current-agent label + configure gear into one chip in ShaftSettingsConfigurable

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -32,6 +32,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
+import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -81,7 +82,17 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
     private JButton testRecoveryAction;
     private JLabel currentAgentConfigurationTitle;
     private JLabel currentAgentConfiguration;
-    private JPanel currentAgentConfigurationRow;
+    /**
+     * Bordered chip wrapping {@link #currentAgentConfiguration} + {@link #configureAgent} together
+     * so the "which agent is this / configure it" pair reads as one grouped unit in the "Current
+     * agent" form row, instead of a plain unbordered value label sitting directly against a boxed
+     * icon button (issue #4322, an adjacent finding from #4316/PR #4320). Mirrors the {@code
+     * currentAgentChip} idiom {@code ShaftAssistantPanel} uses for the same label/gear pair in its
+     * {@code routeRow}, with the same neutral informational tint ({@link
+     * ShaftStatusPresentation#progress()}). Visibility mirrors both wrapped controls' shared
+     * {@code showSummary} gate in {@link #updateAgentConfigurationControls()}.
+     */
+    private JPanel currentAgentChip;
     private JButton configureAgent;
     private JLabel assistantProviderTypeLabel;
     private JLabel assistantFamilyLabel;
@@ -345,7 +356,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         testGithubKey.addActionListener(event -> testProviderKey(
                 GITHUB_PROVIDER_KEY, githubKey, githubKeyStatus, testGithubKey, "GitHub", ProviderKeyProbe::testGithub));
         currentAgentConfigurationTitle = label("Current agent", 'C', currentAgentConfiguration);
-        currentAgentConfigurationRow = agentConfigurationRow(currentAgentConfiguration, configureAgent);
+        currentAgentChip = agentConfigurationRow(currentAgentConfiguration, configureAgent);
         assistantProviderTypeLabel = label("Provider type", 'Y', assistantProviderType);
         assistantFamilyLabel = label("Family", 'F', assistantFamily);
         assistantRuntimeLabel = label("Runtime", 'R', assistantRuntime);
@@ -377,7 +388,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
                 .addComponent(headlessExecution)
                 .addComponent(testExecutionHelp)
                 .addComponent(section("Execution"))
-                .addLabeledComponent(currentAgentConfigurationTitle, currentAgentConfigurationRow)
+                .addLabeledComponent(currentAgentConfigurationTitle, currentAgentChip)
                 .addLabeledComponent(assistantProviderTypeLabel, assistantProviderType)
                 .addLabeledComponent(assistantFamilyLabel, assistantFamily)
                 .addLabeledComponent(assistantRuntimeLabel, assistantRuntime)
@@ -528,7 +539,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         testRecoveryAction = null;
         currentAgentConfigurationTitle = null;
         currentAgentConfiguration = null;
-        currentAgentConfigurationRow = null;
+        currentAgentChip = null;
         configureAgent = null;
         assistantProviderTypeLabel = null;
         assistantFamilyLabel = null;
@@ -718,10 +729,26 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         return row;
     }
 
+    /**
+     * Builds the bordered "chip" wrapping {@code currentConfiguration} + {@code configureButton}
+     * (issue #4322). Neutral informational tint ({@code progress()}) -- the same idiom {@code
+     * ShaftAssistantPanel#currentAgentChip} uses for the identical label/gear pair in its
+     * {@code routeRow} (PR #4320) -- distinct from a high-stakes-toggle warning tint, since this
+     * pair is just "which agent is this / configure it".
+     */
     private static JPanel agentConfigurationRow(JLabel currentConfiguration, JButton configureButton) {
-        JPanel row = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
-        row.add(currentConfiguration);
-        row.add(configureButton);
+        JPanel row = new JPanel(new BorderLayout(4, 0));
+        row.setOpaque(true);
+        row.setBackground(ShaftStatusPresentation.tint(
+                javax.swing.UIManager.getColor("Panel.background") == null
+                        ? java.awt.Color.WHITE
+                        : javax.swing.UIManager.getColor("Panel.background"),
+                ShaftStatusPresentation.progress(), 0.08D));
+        row.setBorder(JBUI.Borders.compound(
+                JBUI.Borders.customLine(ShaftStatusPresentation.progress(), 1),
+                JBUI.Borders.empty(2, 6)));
+        row.add(currentConfiguration, BorderLayout.CENTER);
+        row.add(configureButton, BorderLayout.EAST);
         return row;
     }
 
@@ -1138,7 +1165,10 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         boolean showSummary = mcpReady(state) && !editingAgentConfiguration;
         boolean cloud = advanced && "CLOUD".equals(assistantProviderType.getSelectedItem());
         currentAgentConfigurationTitle.setVisible(showSummary);
-        currentAgentConfigurationRow.setVisible(showSummary);
+        // Chip has no state of its own; it only needs to stay in lockstep with the label's and
+        // configureAgent button's own shared showSummary gate so it never renders as an empty
+        // colored box (mirrors ShaftAssistantPanel's currentAgentChip comment, issue #4316/PR #4320).
+        currentAgentChip.setVisible(showSummary);
         currentAgentConfiguration.setVisible(showSummary);
         configureAgent.setVisible(showSummary);
         assistantProviderTypeLabel.setVisible(advanced && !showSummary);

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -291,6 +292,48 @@ class ShaftSettingsConfigurableTest {
                 () -> assertTrue(secondDescription.contains("Codex"), secondDescription),
                 () -> assertNotEquals(firstDescription, secondDescription,
                         "the description must track the live agent configuration after it changes"));
+    }
+
+    /**
+     * Issue #4322 (adjacent finding from #4316/PR #4320): {@code currentAgentConfiguration} (the
+     * "Agent: Local / Codex / CLI"-style label) and {@code configureAgent} (the settings gear) used
+     * to sit as two bare controls in the "Current agent" form row -- a plain, unbordered value label
+     * directly touching a boxed icon button, with no shared visual grouping -- the same clutter
+     * #4316 fixed in {@code ShaftAssistantPanel}'s {@code routeRow}. They now share one bordered
+     * {@code currentAgentChip} {@link JPanel}, mirroring the {@code currentAgentChip}/{@code
+     * allowSourceMutationChip} idiom PR #4320 introduced there.
+     */
+    @Test
+    void currentAgentChipGroupsLabelAndConfigureButtonWhenSummaryIsShown() throws Exception {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        settings.mcpCommand = "\"java\" \"@target/shaft-mcp.args\"";
+        settings.mcpSetupComplete = true;
+        ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(settings, new InMemoryCredentials());
+        JComponent panel = (JComponent) configurable.createComponent();
+
+        JPanel chip = (JPanel) getField(configurable, "currentAgentChip");
+        JLabel currentAgent = findByAccessibleName(panel, "Current agent configuration", JLabel.class);
+        JButton configure = findByAccessibleName(panel, "Configure assistant agent", JButton.class);
+
+        assertNotNull(chip, "currentAgentChip field must exist and be wired into the form");
+        assertTrue(chip.isVisible(), "MCP is ready and not mid-edit, so the summary row -- and its "
+                + "grouping chip -- must be visible");
+        assertTrue(containsComponent(chip, currentAgent), "chip must contain the current-agent-configuration label");
+        assertTrue(containsComponent(chip, configure), "chip must contain the configure/settings gear button");
+    }
+
+    /** Same summary-shown gate {@code currentAgentConfiguration}/{@code configureAgent} already used individually. */
+    @Test
+    void currentAgentChipHiddenWhenSummaryIsNotShown() throws Exception {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(settings, new InMemoryCredentials());
+        configurable.createComponent();
+
+        JPanel chip = (JPanel) getField(configurable, "currentAgentChip");
+
+        assertNotNull(chip, "currentAgentChip field must exist and be wired into the form");
+        assertFalse(chip.isVisible(), "MCP is not ready, so the summary row is not shown -- the "
+                + "grouping chip must stay hidden exactly like the two controls it wraps used to");
     }
 
     @Test
@@ -908,6 +951,10 @@ class ShaftSettingsConfigurableTest {
         Field field = target.getClass().getDeclaredField(name);
         field.setAccessible(true); // NOPMD - test-only field inspection, matching the established getField/setField helpers in ShaftPanelSetupTest
         return field.get(target);
+    }
+
+    private static boolean containsComponent(Container container, Component target) {
+        return Arrays.stream(container.getComponents()).anyMatch(child -> child == target);
     }
 
     private static List<JButton> collectButtons(Component root) {


### PR DESCRIPTION
## Summary
- Adjacent finding from #4316/PR #4320: the "Current agent" form row in `ShaftSettingsConfigurable` (the plugin's Settings panel) had the same unstyled-pair problem `ShaftAssistantPanel`'s `routeRow` had -- `currentAgentConfiguration` (the "Agent: Local / Codex / CLI"-style label) and `configureAgent` (the settings gear) sat directly against each other with no shared visual grouping: a plain unbordered text label touching a boxed icon button.
- **Confirmed, not assumed**: rendered a real BEFORE screenshot via the existing `ShaftPluginScreenshotRendererTest.rendersFeatureCatalogScreenshotsWhenOutputDirectoryIsProvided` (already covers this panel -- no test-harness extension needed), cropped/zoomed to the "Current agent" row, and visually verified the clutter.
- The existing `agentConfigurationRow()` wrapper panel already grouped both controls structurally (a `JPanel` holding both), but had no border/tint of its own -- just a bare `FlowLayout`. Renamed it to `currentAgentChip` (matching the `ShaftAssistantPanel` precedent's field name) and gave it the same bordered/tinted chip treatment PR #4320 used for the identical label/gear pair there: `BorderLayout` (label CENTER, button EAST), background tinted 8% with `ShaftStatusPresentation.progress()` over the panel background, 1px `customLine(progress())` border + 2/6px padding.
- Conditional visibility (`showSummary`) is preserved exactly on both wrapped controls; the chip's own visibility is set alongside them so it never renders as an empty box.
- Accessible names/descriptions/tooltips on both controls, and `configureAgent`'s action listener/icon, are unchanged -- only relocated into the (now-styled) wrapper.

## Test plan
- [x] `ShaftSettingsConfigurableTest` (2 new tests, TDD: watched `NoSuchFieldException` red before the `currentAgentChip` field existed): `currentAgentChipGroupsLabelAndConfigureButtonWhenSummaryIsShown` / `currentAgentChipHiddenWhenSummaryIsNotShown`.
- [x] `ShaftSettingsConfigurableTest` full class -- green.
- [x] `ShaftPluginScreenshotRendererTest` -- full scoped run green, both before (unmodified code) and after this change.
- [x] Real BEFORE/AFTER PNG evidence rendered via `-Dshaft.intellij.screenshotDir=...` (light + dark) -- not attached inline (no non-interactive image-upload path from this session); files handed to the requesting orchestrator with local paths for review.

Scoped Gradle run only (`shaft-intellij` is a Gradle module, not Maven):
```
JAVA_HOME=<ms-21.0.11 JDK> ./gradlew test --tests "com.shaft.intellij.settings.ShaftSettingsConfigurableTest" --tests "com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest"
```
No full suite, no headed IntelliJ launch.

Fixes #4322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGdgmezM75NX62aMypA5jn