### PR TITLE
Fixes #4328: reset Flags to pristine snapshot at test-class boundaries

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Properties.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Properties.java
@@ -39,6 +39,16 @@ public class Properties {
     static Paths basePaths;
     static Pattern basePattern;
     static volatile Flags baseFlags;
+    /**
+     * Pristine snapshot of {@link #baseFlags}, captured by {@code PropertiesHelper.loadProperties()}
+     * immediately after {@code baseFlags} is first assigned, before any {@code Flags.set()} override is
+     * possible. {@link Flags} is intentionally shared across all threads (unlike the per-thread override
+     * configs below) so that a value set from one thread is visible from another -- see the {@link Flags}
+     * class javadoc. {@link #clearForCurrentThread()} uses this snapshot to restore {@code baseFlags} to
+     * its initialized state at test-class lifecycle boundaries, so a flag flipped by one test class does
+     * not leak into the next test class sharing the same Surefire fork.
+     */
+    static volatile Flags pristineBaseFlags;
     static Reporting baseReporting;
     static Allure baseAllure;
     static Timeouts baseTimeouts;
@@ -237,5 +247,10 @@ public class Properties {
         naturalActionsOverride.remove();
         playwrightOverride.remove();
         captureOverride.remove();
+        synchronized (Properties.class) {
+            if (pristineBaseFlags != null) {
+                baseFlags = pristineBaseFlags;
+            }
+        }
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -93,6 +93,9 @@ public class PropertiesHelper {
         Properties.baseBrowserStack = ConfigFactory.create(BrowserStack.class);
         Properties.internal = ConfigFactory.create(Internal.class);
         Properties.baseFlags = ConfigFactory.create(Flags.class);
+        // Snapshot the just-loaded, override-free instance so clearForCurrentThread() can restore
+        // Flags to this pristine state at test-class lifecycle boundaries (see Properties.pristineBaseFlags).
+        Properties.pristineBaseFlags = Properties.baseFlags;
         Properties.cucumber = ConfigFactory.create(Cucumber.class);
         Properties.baseHealenium = ConfigFactory.create(Healenium.class);
         Properties.baseHealing = ConfigFactory.create(Healing.class);

--- a/shaft-engine/src/test/java/testPackage/unitTests/FlagsSetPropertyCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/FlagsSetPropertyCoverageUnitTest.java
@@ -2,6 +2,7 @@ package testPackage.unitTests;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.properties.internal.Flags;
+import com.shaft.properties.internal.Properties;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -146,5 +147,23 @@ public class FlagsSetPropertyCoverageUnitTest {
         Assert.assertEquals(SHAFT.Properties.flags.validateSwipeToElement(), !originalValidateSwipeToElement);
         Assert.assertEquals(SHAFT.Properties.flags.disableSslCertificateCheck(), !originalDisableSslCertificateCheck);
         Assert.assertEquals(SHAFT.Properties.flags.telemetryEnabled(), !originalTelemetryEnabled);
+    }
+
+    @Test(description = "Regression #4328: clearForCurrentThread() must reset a Flags override back to its "
+            + "pristine initialized value, closing the test-class-boundary leak (TestNGListener fires this "
+            + "same call whenever a new test class's @BeforeClass starts on a pooled Surefire thread)")
+    public void testClearForCurrentThreadResetsFlagsOverrideToPristineValue() {
+        boolean pristineValue = SHAFT.Properties.flags.forceCheckElementLocatorIsUnique();
+
+        SHAFT.Properties.flags.set().forceCheckElementLocatorIsUnique(!pristineValue);
+        Assert.assertEquals(SHAFT.Properties.flags.forceCheckElementLocatorIsUnique(), !pristineValue,
+                "sanity check: the override should take effect before the lifecycle boundary fires");
+
+        Properties.clearForCurrentThread();
+
+        Assert.assertEquals(SHAFT.Properties.flags.forceCheckElementLocatorIsUnique(), pristineValue,
+                "clearForCurrentThread() should restore Flags to their pristine initialized value, otherwise a "
+                        + "flag flipped by one test class silently leaks into the next test class sharing the "
+                        + "same Surefire fork (#4328)");
     }
 }


### PR DESCRIPTION
## Summary

`SHAFT.Properties.flags.set()` mutates the JVM-global `Properties.baseFlags` field, but `Properties.clearForCurrentThread()` never reset it -- unlike every sibling properties category, which gets a `.remove()` call on its own `*Override` `ThreadLocal`. Under Surefire's default `reuseForks=true`, a flag flipped by one test class (e.g. `ActionsCoverageUnitTest` setting `forceCheckElementLocatorIsUnique(false)`) silently leaked into whatever test class ran next in the same fork (e.g. `MultipleElementsFailureTest`), disabling a real safety check for unrelated tests.

**Design note (escalated and resolved with the orchestrator before implementing):** literally mirroring the sibling `ThreadLocal` pattern would have broken an existing, currently-passing, intentional test -- `ThreadLocalPropertiesTest.testFlagsConfigurationIsSharedAcrossThreads` -- which proves `Flags` is deliberately visible across real OS threads within a single test's execution (documented in `Properties.java`'s class javadoc). So this fix does **not** touch `Flags.setProperty`, `ThreadLocalPropertiesManager`, or the global-sharing mechanism. Instead:

- `PropertiesHelper.loadProperties()` now snapshots `Properties.baseFlags` into a new `Properties.pristineBaseFlags` field immediately after it's created, before any `.set()` override is possible.
- `Properties.clearForCurrentThread()` restores `baseFlags` from that snapshot (same `synchronized(Properties.class)` discipline the setter uses).

This closes the test-class-boundary leak because `TestNGListener` already calls `clearForCurrentThread()` whenever a new test class's `@BeforeClass` starts on a pooled Surefire thread (`TestNGListener.java:296-301`) -- while leaving the documented cross-thread-during-a-test guarantee untouched.

## Before / after evidence

**RED** -- new regression test `FlagsSetPropertyCoverageUnitTest.testClearForCurrentThreadResetsFlagsOverrideToPristineValue`, run before the fix:
```
Tests run: 2, Failures: 1, Errors: 0
java.lang.AssertionError: clearForCurrentThread() should restore Flags to their pristine initialized
value, otherwise a flag flipped by one test class silently leaks into the next test class sharing the
same Surefire fork (#4328) expected [true] but found [false]
```

**GREEN** -- same test after the fix:
```
Total: 2  ·  Passed: 2  ·  Failed: 0  ·  Skipped: 0
```

**Original repro before fix** (per issue #4328, on unmodified `main`): `MultipleElementsFailureTest.click`/`.clickUsingJS`/`.type` fail with "should have thrown an exception of type class java.lang.RuntimeException" when run after `ActionsCoverageUnitTest` in the same fork.

**Original repro after fix:**
```
mvn -pl shaft-engine test -Dtest=ActionsCoverageUnitTest,MultipleElementsFailureTest -DheadlessExecution=true -Dallure.automaticallyOpen=false
Total: 44  ·  Passed: 44  ·  Failed: 0  ·  Skipped: 0
```
`MultipleElementsFailureTest.type` correctly throws `MultipleElementsFoundException` again.

**Cross-thread guarantee unmodified and still green** (proves this fix didn't regress the documented sharing behavior):
```
mvn -pl shaft-engine test -Dtest=ThreadLocalPropertiesTest -DheadlessExecution=true -Dallure.automaticallyOpen=false
Total: 22  ·  Passed: 22  ·  Failed: 0  ·  Skipped: 0
```
`git diff` on `ThreadLocalPropertiesTest.java` is empty -- the file was not touched.

**Broader Properties/Flags suite** (`APIPropertiesUnitTest`, `BrowserStackPropertiesUnitTest`, `PropertiesHelperCoverageUnitTest`, `PropertiesHelperEvidenceLevelUnitTest`, `PropertiesHelperInitializationUnitTest`, `PropertiesHelperMaximumPerformanceModeUnitTest`, `PropertiesUnitTest`, `ThreadLocalPropertiesTest`, `FlagsSetPropertyCoverageUnitTest`): 0 failures, all green (verified via `testng-results.xml`, not just Maven's exit code, per the "local mvn test never fails the build" gotcha).

**Compile check:** `mvn -pl shaft-engine test-compile` -- clean, exit 0.

## Test plan
- [x] RED: `FlagsSetPropertyCoverageUnitTest#testClearForCurrentThreadResetsFlagsOverrideToPristineValue` watched failing for the right reason
- [x] GREEN: same test watched passing after the minimal fix
- [x] `ThreadLocalPropertiesTest` (incl. the cross-thread-sharing test) re-run and confirmed still green, unmodified
- [x] Original combined-run repro (`ActionsCoverageUnitTest` + `MultipleElementsFailureTest`) re-run and confirmed fixed
- [x] Broader Properties/Flags-touching test classes re-run scoped, 0 failures
- [x] `mvn -pl shaft-engine test-compile` clean

https://claude.ai/code/session_01NGdgmezM75NX62aMypA5jn