### PR TITLE
Wire MultipleElementsFailureTest into pr-gate.yml's shaft-engine unit-tests step

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -295,6 +295,20 @@ jobs:
   # TestNG suite XML found by #4071 (that file is deleted in the same change
   # that added this line) -- pure file-read plus JSONCompare, no driver, no
   # network, verified green with a scoped local run before being added.
+  # testPackage.mockedTests.MultipleElementsFailureTest (issue #4336, follow-up
+  # to #4321/#4326) is the one exception to "no live-browser suites here": it
+  # DOES construct a real SHAFT.GUI.WebDriver() session, but -- unlike the
+  # nightly-only CoverageTests suites -- needs no remote Selenium Grid. Its
+  # driver defaults (properties/default/custom.properties: executionAddress=
+  # local, targetBrowserName=chrome) launch a local headless Chrome session,
+  # the same shape the capture-e2e job above already runs successfully on
+  # this same ubuntu-22.04 runner with zero extra browser-setup steps. It
+  # only talks to TestPageServer, an in-JVM HttpServer serving local HTML
+  # fixtures -- no Docker, no network. Verified with a scoped local run
+  # (`-Dtest=MultipleElementsFailureTest -DheadlessExecution=true`) before
+  # being added; previously only ran via e2eTests.yml's nightly/broad
+  # GLOBAL_TESTING_SCOPE selector, so a regression here could merge before
+  # the broader E2E suite caught it.
   unit-tests:
     name: Unit Tests (${{ matrix.module }})
     needs: changes
@@ -327,7 +341,7 @@ jobs:
         run: >-
           mvn --batch-mode
           -pl shaft-engine test
-          '-Dtest=testPackage/unitTests/*, DriverFactoryHelperAugmentationUnitTest, DriverFactoryHelperCoverageUnitTest, DriverFactoryHelperStorageStateUnitTest, OptionsManagerCoverageUnitTest, RemoteGridPreflightUnitTest, ActionsCoverageUnitTest, ActionsExceptionDetailsUnitTest, ElementInformationCoverageUnitTest, ElementsHelperCoverageUnitTest, AriaSnapshotHelperUnitTest, MobileAccessibilityTreeConverterUnitTest, AnimatedGifManagerCoverageUnitTest, ImageProcessingActionsReportingUnitTest, ImageProcessingActionsScreenshotBaselineUnitTest, ScreenshotHelperCoverageUnitTest, ScreenshotManagerCoverageUnitTest, LocatorHealthReporterUnitTest, RecordManagerCoverageUnitTest, PlaywrightSessionFactoryStorageStateUnitTest, ShardPartitionerUnitTest, UpdateCheckerUnitTest, LightHouseGenerateReportCoverageUnitTest, PropertiesHelperDownloadRetryUnitTest, PropertyFileManagerInternalUnitTest, AllureManagerCoverageUnitTest, BrowserPerformanceExecutionReportUnitTest, FlakeProfilerUnitTest, ProgressBarLoggerCoverageUnitTest, ValidationsHelperCoverageUnitTest, ValidationsHelperNewPatternCoverageUnitTest, VisualValidationsBuilderUnitTest, WebDriverElementValidationsBuilderAriaSnapshotUnitTest, WebDriverElementValidationsBuilderCoverageUnitTest, AssertionEvidenceReporterTest, FailureTraceReporterTest, JsonActionsTests, !RestValidationsBuilderUnitTest'
+          '-Dtest=testPackage/unitTests/*, DriverFactoryHelperAugmentationUnitTest, DriverFactoryHelperCoverageUnitTest, DriverFactoryHelperStorageStateUnitTest, OptionsManagerCoverageUnitTest, RemoteGridPreflightUnitTest, ActionsCoverageUnitTest, ActionsExceptionDetailsUnitTest, ElementInformationCoverageUnitTest, ElementsHelperCoverageUnitTest, AriaSnapshotHelperUnitTest, MobileAccessibilityTreeConverterUnitTest, AnimatedGifManagerCoverageUnitTest, ImageProcessingActionsReportingUnitTest, ImageProcessingActionsScreenshotBaselineUnitTest, ScreenshotHelperCoverageUnitTest, ScreenshotManagerCoverageUnitTest, LocatorHealthReporterUnitTest, RecordManagerCoverageUnitTest, PlaywrightSessionFactoryStorageStateUnitTest, ShardPartitionerUnitTest, UpdateCheckerUnitTest, LightHouseGenerateReportCoverageUnitTest, PropertiesHelperDownloadRetryUnitTest, PropertyFileManagerInternalUnitTest, AllureManagerCoverageUnitTest, BrowserPerformanceExecutionReportUnitTest, FlakeProfilerUnitTest, ProgressBarLoggerCoverageUnitTest, ValidationsHelperCoverageUnitTest, ValidationsHelperNewPatternCoverageUnitTest, VisualValidationsBuilderUnitTest, WebDriverElementValidationsBuilderAriaSnapshotUnitTest, WebDriverElementValidationsBuilderCoverageUnitTest, AssertionEvidenceReporterTest, FailureTraceReporterTest, JsonActionsTests, MultipleElementsFailureTest, !RestValidationsBuilderUnitTest'
           -Dsurefire.failIfNoSpecifiedTests=false
           '-DheadlessExecution=true' '-Dallure.automaticallyOpen=false' -Dgpg.skip
       - name: Verify shaft-engine unit test results


### PR DESCRIPTION
## Summary
Fixes #4336

`testPackage.mockedTests.MultipleElementsFailureTest` (the real-headless-browser regression suite proving #4321's self-heal fix and its own ambiguous-locator throw behavior, both the original 3 tests and the 4 added in PR #4326) previously only ran via `e2eTests.yml`'s broad nightly `GLOBAL_TESTING_SCOPE` selector -- not on every PR, unlike the adjacent `ActionsCoverageUnitTest`/`ElementsHelperCoverageUnitTest` which are already correctly wired into `pr-gate.yml`.

- Confirmed the class constructs a real `SHAFT.GUI.WebDriver()` session (`MultipleElementsFailureTest.java:104`), so it needs a real driver, unlike the pure-Mockito unit tests already in that step.
- Confirmed it does NOT need a remote Selenium Grid: its driver defaults (`shaft-engine/src/main/resources/properties/default/custom.properties:6,10` -- `executionAddress=local`, `targetBrowserName=chrome`) launch a local headless Chrome session, and its only external dependency (`TestPageServer`) is an in-JVM `HttpServer` serving local HTML fixtures -- no Docker, no network.
- Confirmed the existing `capture-e2e` job in the same file already runs a real headless-Chrome browser test (`ManagedCaptureRecorderBrowserTest`) on the identical `ubuntu-22.04` runner with zero extra browser-setup steps -- proving Chrome + Selenium Manager already work there without new infra.
- Given that, the `javacore`-gated `unit-tests` step (the same one `ActionsCoverageUnitTest`/`ElementsHelperCoverageUnitTest` already use) is the right home -- no new job/step needed.

## Changes
- `.github/workflows/pr-gate.yml`: added `MultipleElementsFailureTest` to the `shaft-engine` leg's `-Dtest=` inclusion list, and documented why in the block comment above the job.

## Test plan
- [x] Gap proven before the fix: `grep -c MultipleElementsFailureTest .github/workflows/pr-gate.yml` -> `0`
- [x] Fix proven after: same grep now matches the updated `-Dtest=` line
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-gate.yml'))"` -> OK
- [x] `py -3 scripts/ci/validate_workflow_timeouts.py` -> all jobs declare `timeout-minutes`
- [x] Ran the exact CI command locally: `mvn --batch-mode -pl shaft-engine test -Dtest=MultipleElementsFailureTest -Dsurefire.failIfNoSpecifiedTests=false -DheadlessExecution=true -Dallure.automaticallyOpen=false -Dgpg.skip` -> `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0` in ~78s (well inside the job's 15-minute timeout), local headless Chrome session confirmed in the log ("Started local WebDriver session: ... Chrome, headless")

🤖 Generated with [Claude Code](https://claude.com/claude-code)