### PR TITLE
Fixes #4334

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/Actions.java
@@ -956,7 +956,16 @@ public class Actions extends ElementActions {
                     // locator is still ambiguous on every unmodified retry. Take exactly one more look,
                     // this time allowing narrowing to the single actionable match if there is one.
                     lastResortNarrowingAllowed.set(true);
-                    attemptElementActionOnce.apply(driverFactoryHelper.getDriver());
+                    try {
+                        attemptElementActionOnce.apply(driverFactoryHelper.getDriver());
+                    } catch (RuntimeException lastResortFailure) {
+                        // issue #4334: the last-resort attempt bypasses fluentWait, so its own failure has
+                        // no "tried for N second(s)" wrapper -- suppress the original TimeoutException onto
+                        // it so that diagnostic context (the identification timeout was fully exhausted
+                        // before this was reported ambiguous) is not silently dropped.
+                        lastResortFailure.addSuppressed(timeoutFailure);
+                        throw lastResortFailure;
+                    }
                 } else {
                     throw timeoutFailure;
                 }

--- a/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/MultipleElementsFailureTest.java
@@ -52,6 +52,35 @@ public class MultipleElementsFailureTest {
     }
 
     @Test
+    public void clickPreservesOriginalTimeoutDiagnosticsWhenStillAmbiguousAfterLastResort() {
+        // issue #4334: when the single last-resort narrowing attempt (issue #4321/PR #4326) ALSO
+        // fails because the locator is still genuinely ambiguous, the final MultipleElementsFoundException
+        // must not silently drop the original primary-loop TimeoutException -- it carried the "tried for
+        // N second(s)" identification-timeout diagnostics that a bare last-resort failure has no way to
+        // reproduce on its own.
+        driver.get().browser().navigateToURL(mockedHTML);
+        RuntimeException thrown = Assert.expectThrows(RuntimeException.class,
+                () -> driver.get().element().click(By.xpath("//input")));
+        // the exception SHAFT reports to the user wraps the real failure as its cause (see
+        // Actions.reportBroken/reportedException handling) -- the suppressed diagnostics can live on
+        // either the outer wrapper or the wrapped cause, so walk the whole chain.
+        boolean originalTimeoutDiagnosticsPreserved = false;
+        for (Throwable current = thrown; current != null; current = current.getCause()) {
+            if (java.util.Arrays.stream(current.getSuppressed())
+                    .anyMatch(suppressed -> suppressed instanceof org.openqa.selenium.TimeoutException
+                            && suppressed.getMessage() != null
+                            && suppressed.getMessage().contains("tried for"))) {
+                originalTimeoutDiagnosticsPreserved = true;
+                break;
+            }
+        }
+        Assert.assertTrue(originalTimeoutDiagnosticsPreserved,
+                "Expected the original TimeoutException (carrying the 'tried for ... second(s)' "
+                        + "identification-timeout diagnostics) to be preserved as a suppressed exception "
+                        + "somewhere in the final failure's cause chain, but none was found; thrown was: " + thrown);
+    }
+
+    @Test
     public void typeResolvesToTheOnlyVisibleAndEnabledElementAmongMultipleMatches() {
         driver.get().browser().navigateToURL(oneVisibleHTML);
         // the locator itself is genuinely ambiguous (3 matches); the action must still succeed


### PR DESCRIPTION
## Summary
- The last-resort ambiguous-locator disambiguation added by #4321/PR #4326 (`Actions.java`) bypasses `FluentWait`, so when that single last-resort attempt ALSO fails (still genuinely ambiguous), the resulting `MultipleElementsFoundException` had no reference to the original primary-loop `TimeoutException` and its "tried for N second(s)" diagnostic message -- strictly less context than users got before #4321.
- Fix: catch the last-resort attempt's failure and `addSuppressed(timeoutFailure)` onto it before rethrowing, preserving the original timeout diagnostics without changing the exception type users see (`MultipleElementsFoundException`).

## Test plan
- [x] RED: added `MultipleElementsFailureTest#clickPreservesOriginalTimeoutDiagnosticsWhenStillAmbiguousAfterLastResort`, watched it fail (suppressed exceptions were empty).
- [x] GREEN: implemented the `addSuppressed` fix, watched the new test pass.
- [x] `MultipleElementsFailureTest` full class: 8/8 passed (7 pre-existing + 1 new).
- [x] `ActionsCoverageUnitTest` full class: 43/43 passed, no regressions.
- [x] `mvn -pl shaft-engine test-compile`: BUILD SUCCESS.

Fixes #4334

https://claude.ai/code/session_01NGdgmezM75NX62aMypA5jn