### PR TITLE
Fixes #4332: last-resort disambiguation for touch/tap's identifyUniqueElement path

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
@@ -39,7 +39,9 @@ import java.awt.*;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 /**
  * Helper utilities for low-level element discovery, interaction, and reporting.
@@ -253,15 +255,38 @@ public class ElementActionsHelper {
      * @return element information payload used by downstream action methods
      */
     public List<Object> waitForElementPresence(WebDriver driver, By elementLocator, boolean checkForVisibility) {
+        return waitForElementPresence(driver, elementLocator, checkForVisibility, false);
+    }
+
+    /**
+     * Waits for an element to be present (and optionally visible), then returns collected metadata,
+     * optionally enforcing that the locator resolves to a single element.
+     *
+     * @param driver the active WebDriver instance
+     * @param elementLocator locator of the target element
+     * @param checkForVisibility whether visibility must be validated
+     * @param enforceElementUniqueness when {@code true}, a locator matching more than one element is
+     *                                 retried for the full identification-timeout window (issue #4332,
+     *                                 mirroring {@code Actions.performAction}'s #4321 fix), then given
+     *                                 exactly one last-resort attempt narrowing to the single
+     *                                 displayed-and-enabled match if there is one; used only by
+     *                                 {@link #identifyUniqueElement(WebDriver, By, boolean)} -- other
+     *                                 callers (e.g. {@link #getElementsCount}) pass {@code false} and
+     *                                 keep the original permissive raw-count behavior
+     * @return element information payload used by downstream action methods
+     */
+    private List<Object> waitForElementPresence(WebDriver driver, By elementLocator, boolean checkForVisibility, boolean enforceElementUniqueness) {
         boolean isValidToCheckForVisibility = isValidToCheckForVisibility(elementLocator, checkForVisibility);
         var isMobileExecution = DriverFactoryHelper.isMobileNativeExecution() || DriverFactoryHelper.isMobileWebExecution();
         boolean collectLocatorHealth = LocatorHealthReporter.isEnabled();
         long locatorHealthStart = collectLocatorHealth ? System.nanoTime() : 0L;
         AtomicInteger locatorHealthPollingAttempts = collectLocatorHealth ? new AtomicInteger() : null;
         AtomicInteger locatorHealthStaleRetries = collectLocatorHealth ? new AtomicInteger() : null;
-        try {
-            List<Object> locatedElement = new SynchronizationManager(driver).fluentWait(isValidToCheckForVisibility)
-                    .until(f -> {
+        // issue #4332: false on every poll of the primary fluentWait below -- disambiguation must stay
+        // a strict LAST RESORT, applied only once the full identification-timeout retry window is
+        // exhausted, mirroring Actions.performAction's #4321 lastResortNarrowingAllowed flag.
+        AtomicBoolean lastResortNarrowingAllowed = new AtomicBoolean(false);
+        Function<WebDriver, List<Object>> attemptLocate = f -> {
                         if (locatorHealthPollingAttempts != null) {
                             locatorHealthPollingAttempts.incrementAndGet();
                         }
@@ -292,6 +317,34 @@ public class ElementActionsHelper {
                                     reportActionResult(driver, null, null, null, null, null, false);
                                     FailureReporter.fail(ElementActionsHelper.class, "Failed to identify unique element", invalidSelectorException);
                                     throw invalidSelectorException;
+                                }
+                            }
+                            // issue #4332: mirror Actions.performAction's #4321 last-resort
+                            // disambiguation for this separate identifyUniqueElement retry/timeout
+                            // path. Always throws during the normal retry loop (lastResortNarrowingAllowed
+                            // is false on every poll), preserving the full identification-timeout window
+                            // for a still-settling page; only the single last-resort attempt made after
+                            // that window is exhausted (see the TimeoutException handling below) allows
+                            // narrowing, and only when exactly one match is displayed and enabled. When
+                            // the last-resort attempt still can't narrow to a single actionable match,
+                            // this deliberately does NOT throw -- targetElements stays ambiguous so
+                            // identifyUniqueElement's own uniqueness check (one level up) reports the
+                            // failure exactly as it did before this fix.
+                            if (enforceElementUniqueness && targetElements.size() > 1
+                                    && SHAFT.Properties.flags.forceCheckElementLocatorIsUnique()
+                                    && !(elementLocator instanceof RelativeLocator.RelativeBy)) {
+                                if (!lastResortNarrowingAllowed.get()) {
+                                    throw new MultipleElementsFoundException();
+                                }
+                                int matchCountBeforeNarrowing = targetElements.size();
+                                Optional<WebElement> uniqueActionable =
+                                        com.shaft.gui.element.internal.Actions.uniqueDisplayedAndEnabledElement(targetElements);
+                                if (uniqueActionable.isPresent()) {
+                                    ReportManager.logDiscrete("Locator " + JavaHelper.formatLocatorToString(elementLocator)
+                                            + " matched " + matchCountBeforeNarrowing
+                                            + " elements; auto-resolved to the only displayed and enabled one"
+                                            + " after the identification timeout was exhausted.");
+                                    targetElements = List.of(uniqueActionable.get());
                                 }
                             }
                             WebElement targetElement = targetElements.getFirst();
@@ -388,7 +441,10 @@ public class ElementActionsHelper {
                             }
                             throw staleElementReferenceException;
                         }
-                    });
+        };
+        try {
+            List<Object> locatedElement = new SynchronizationManager(driver).fluentWait(isValidToCheckForVisibility)
+                    .until(attemptLocate::apply);
             recordLocatorHealthLookup(
                     elementLocator,
                     locatorHealthStart,
@@ -398,6 +454,27 @@ public class ElementActionsHelper {
                     locatorHealthStaleRetries);
             return locatedElement;
         } catch (org.openqa.selenium.TimeoutException timeoutException) {
+            if (enforceElementUniqueness && com.shaft.gui.element.internal.Actions.isCausedByAmbiguousLocator(timeoutException)) {
+                // issue #4332: the full identification-timeout retry window is exhausted and the
+                // locator is still ambiguous on every unmodified retry. Take exactly one more look,
+                // this time allowing narrowing to the single actionable match if there is one --
+                // mirrors Actions.performAction's #4321 last-resort attempt.
+                lastResortNarrowingAllowed.set(true);
+                try {
+                    List<Object> locatedElement = attemptLocate.apply(driver);
+                    recordLocatorHealthLookup(
+                            elementLocator,
+                            locatorHealthStart,
+                            locatorHealthPollingAttempts,
+                            resolvedElementCount(locatedElement),
+                            false,
+                            locatorHealthStaleRetries);
+                    return locatedElement;
+                } catch (RuntimeException stillUnresolvable) {
+                    // fall through to the ordinary timeout handling below, using the ORIGINAL
+                    // timeoutException so the reported failure is unchanged from before this fix.
+                }
+            }
             recordLocatorHealthLookup(
                     elementLocator,
                     locatorHealthStart,
@@ -786,7 +863,10 @@ public class ElementActionsHelper {
     }
 
     private List<Object> identifyUniqueElement(WebDriver driver, By elementLocator, boolean checkForVisibility) {
-        var matchingElementsInformation = getMatchingElementsInformation(driver, elementLocator, checkForVisibility);
+        // issue #4332: unlike getMatchingElementsInformation's other callers (e.g. getElementsCount,
+        // which needs the raw ambiguous count), identifyUniqueElement's whole purpose is uniqueness --
+        // it opts into the last-resort disambiguation retry inside waitForElementPresence.
+        var matchingElementsInformation = getMatchingElementsInformation(driver, elementLocator, checkForVisibility, true);
 
         if (elementLocator != null) {
             // in case of regular locator
@@ -826,6 +906,10 @@ public class ElementActionsHelper {
      * @return list containing count and resolved element details
      */
     public List<Object> getMatchingElementsInformation(WebDriver driver, By elementLocator, boolean checkForVisibility) {
+        return getMatchingElementsInformation(driver, elementLocator, checkForVisibility, false);
+    }
+
+    private List<Object> getMatchingElementsInformation(WebDriver driver, By elementLocator, boolean checkForVisibility, boolean enforceElementUniqueness) {
         if (elementLocator == null) {
             var elementInformation = new ArrayList<>();
             elementInformation.add(0);
@@ -833,7 +917,7 @@ public class ElementActionsHelper {
             return elementInformation;
         }
         if (!elementLocator.equals(By.tagName("html"))) {
-            return this.waitForElementPresence(driver, elementLocator, checkForVisibility);
+            return this.waitForElementPresence(driver, elementLocator, checkForVisibility, enforceElementUniqueness);
         } else {
             //if locator is just tag-name html
             var elementInformation = new ArrayList<>();

--- a/shaft-engine/src/test/java/testPackage/mockedTests/TouchMultipleElementsFailureTest.java
+++ b/shaft-engine/src/test/java/testPackage/mockedTests/TouchMultipleElementsFailureTest.java
@@ -1,0 +1,95 @@
+package testPackage.mockedTests;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.element.TouchActions;
+import com.shaft.gui.internal.exceptions.MultipleElementsFoundException;
+import com.shaft.properties.internal.Properties;
+import org.openqa.selenium.By;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import testPackage.TestPageServer;
+
+/**
+ * issue #4332: {@link com.shaft.gui.element.internal.ElementActionsHelper#identifyUniqueElement}
+ * is a separate ambiguous-locator resolution path from {@link com.shaft.gui.element.internal.Actions#performAction}
+ * (fixed for click/type/etc. by issue #4321 / PR #4326) -- exercised here via
+ * {@code touch().swipeElementIntoView(By, By, SwipeDirection)}'s non-Appium branch (TouchActions.java:739/741),
+ * which is one of the 8+ {@code identifyUniqueElement} call sites in TouchActions. This branch runs against a
+ * plain headless desktop browser (no Appium/mobile driver needed), same as {@code TouchActionsTests}.
+ */
+public class TouchMultipleElementsFailureTest {
+    private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
+    // issue #4321 second-pass review pattern, reused here: a short identification timeout keeps the
+    // last-resort-narrowing test (which must legitimately wait out the full window) fast, without
+    // changing the behavior under test.
+    private static final int SHORT_IDENTIFICATION_TIMEOUT_SECONDS = 6;
+    String mockedHTML = TestPageServer.url("multipleElementsFixture.html");
+    // 3 elements match, but only 1 is displayed+enabled (the other 2 are hidden/disabled) -- this
+    // MUST auto-resolve to the single actionable element instead of throwing, unlike mockedHTML
+    // above where all 3 matches are genuinely actionable.
+    String oneVisibleHTML = TestPageServer.url("multipleElementsOneVisibleFixture.html");
+    // #save is permanently disabled and #cancel is permanently enabled -- the narrowing must still
+    // only apply as a LAST RESORT, after the full identification timeout is exhausted, never during
+    // the retry loop itself.
+    String disabledEnabledButtonsHTML = TestPageServer.url("multipleButtonsDisabledEnabledFixture.html");
+
+    @Test
+    public void swipeElementIntoViewThrowsOnGenuinelyAmbiguousLocator() {
+        driver.get().browser().navigateToURL(mockedHTML);
+        assertThrowsMultipleElementsFoundException(() ->
+                driver.get().touch().swipeElementIntoView(null, By.xpath("//input"), TouchActions.SwipeDirection.DOWN));
+    }
+
+    @Test
+    public void swipeElementIntoViewResolvesToTheOnlyDisplayedAndEnabledElementAmongMultipleMatches() {
+        driver.get().browser().navigateToURL(oneVisibleHTML);
+        // the locator itself is genuinely ambiguous (3 matches); the action must still succeed
+        // because exactly one of them is displayed and enabled.
+        Assert.assertEquals(driver.get().element().getElementsCount(By.xpath("//input")), 3);
+        driver.get().touch().swipeElementIntoView(null, By.xpath("//input"), TouchActions.SwipeDirection.DOWN);
+    }
+
+    @Test
+    public void swipeElementIntoViewResolvesToTheOnlyEnabledButtonOnlyAfterTheIdentificationTimeoutIsExhausted() {
+        driver.get().browser().navigateToURL(disabledEnabledButtonsHTML);
+        Assert.assertEquals(driver.get().element().getElementsCount(By.xpath("//button")), 2);
+
+        long startMillis = System.currentTimeMillis();
+        driver.get().touch().swipeElementIntoView(null, By.xpath("//button"), TouchActions.SwipeDirection.DOWN);
+        long elapsedMillis = System.currentTimeMillis() - startMillis;
+
+        // proves the narrowing was NOT applied on the first poll (which would resolve near-instantly)
+        // -- it must only kick in as a last resort once the full identification timeout is spent.
+        Assert.assertTrue(elapsedMillis >= 4_000,
+                "Expected the disambiguation to wait out most of the " + SHORT_IDENTIFICATION_TIMEOUT_SECONDS
+                        + "s identification timeout as a last resort, but it resolved after only "
+                        + elapsedMillis + "ms.");
+    }
+
+    @BeforeMethod
+    void beforeMethod() {
+        SHAFT.Properties.timeouts.set().defaultElementIdentificationTimeout(SHORT_IDENTIFICATION_TIMEOUT_SECONDS);
+        driver.set(new SHAFT.GUI.WebDriver());
+    }
+
+    @AfterMethod(alwaysRun = true)
+    void afterMethod() {
+        if (driver.get() != null) driver.get().quit();
+        Properties.clearForCurrentThread();
+    }
+
+    private static void assertThrowsMultipleElementsFoundException(Runnable action) {
+        // TouchActions failures are reported via ElementActionsHelper#failAction, which throws
+        // org.junit.jupiter.api.Assertions.fail(...) (an AssertionError), unlike the RuntimeException
+        // thrown by Actions.performAction's report pipeline -- assert on Throwable, not RuntimeException.
+        Throwable thrown = Assert.expectThrows(Throwable.class, action::run);
+        Throwable cause = thrown;
+        while (cause != null && !(cause instanceof MultipleElementsFoundException)) {
+            cause = cause.getCause();
+        }
+        Assert.assertTrue(cause instanceof MultipleElementsFoundException,
+                "Expected a MultipleElementsFoundException in the cause chain, but got: " + thrown);
+    }
+}


### PR DESCRIPTION
## Summary
- Follow-up from #4321/PR #4326: `touch().tap()` and 8+ other `TouchActions` gestures resolve elements via `ElementActionsHelper.identifyUniqueElement`, a separate retry/timeout path from `Actions.performAction` -- confirmed by reading both in full (`ElementActionsHelper.java:255-482`, `865-895`, `905-925`; `Actions.java:470-963`, `1847-1883`). This path threw immediately on an ambiguous locator with **zero retry window**, unlike the already-fixed click/type path.
- `waitForElementPresence`'s existing `FluentWait` polling function now throws `MultipleElementsFoundException` on every poll when the locator is genuinely ambiguous (`MultipleElementsFoundException` was already in `SynchronizationManager`'s ignored-exception list, so this automatically preserves the full identification-timeout window). Gated behind a new private `enforceElementUniqueness` parameter, threaded only from `identifyUniqueElement` -- `getElementsCount` and other existing callers pass `false` and keep today's permissive raw-count behavior unchanged (verified: `ElementsHelperCoverageUnitTest` unaffected).
- Only after that `FluentWait` times out with `MultipleElementsFoundException` in the cause chain does it make **exactly one** last-resort attempt, narrowing to the single displayed+enabled candidate via `Actions.uniqueDisplayedAndEnabledElement` (reused directly -- same package `com.shaft.gui.element.internal`, no extraction needed). If still ambiguous, the raw multi-match data flows back to `identifyUniqueElement`'s existing `switch`, which fails with the exact same message/path as before this fix.
- Answers the issue's open question on test infra: no Appium/mobile driver is required. `touch().swipeElementIntoView(null, targetLocator, direction)`'s non-Appium branch (`TouchActions.java:736-742`) calls `identifyUniqueElement` directly and runs fine against a plain headless Chrome session, exactly like the existing `TouchActionsTests.java` precedent.

## Test plan
- [x] New `TouchMultipleElementsFailureTest` (headless Chrome + `TestPageServer` fixtures, mirroring `MultipleElementsFailureTest`'s pattern for the click/type path):
  - `swipeElementIntoViewThrowsOnGenuinelyAmbiguousLocator` -- 3 genuinely actionable matches still throws (pre-existing behavior, confirmed unchanged).
  - `swipeElementIntoViewResolvesToTheOnlyDisplayedAndEnabledElementAmongMultipleMatches` -- reproduces the bug on unpatched code (watched RED), passes after the fix (watched GREEN).
  - `swipeElementIntoViewResolvesToTheOnlyEnabledButtonOnlyAfterTheIdentificationTimeoutIsExhausted` -- proves the narrowing is a genuine last resort (elapsed time >= 4s of the 6s identification timeout), not applied on the first poll.
- [x] `mvn -pl shaft-engine test-compile` clean.
- [x] Regression suite green, no `mvn test` full run (repo guard against unscoped forked runs): `MultipleElementsFailureTest` (5), `ElementsHelperCoverageUnitTest` (23), `TouchActionsTests` (1), `ActionsCoverageUnitTest`/`ScreenshotManagerCoverageUnitTest`/`ElementActionsCoverageUnitTest` (53) -- all passed, confirming `getElementsCount`/other `waitForElementPresence` callers are unaffected.

Claude-Session: https://claude.ai/code/session_01NGdgmezM75NX62aMypA5jn