### PR TITLE
Clarify auto-notify does not cover a delegate's own backgrounded work

### DIFF
--- a/.claude/skills/act-as-mohab/SKILL.md
+++ b/.claude/skills/act-as-mohab/SKILL.md
@@ -195,7 +195,9 @@ up front. Recursive: every delegating agent owes its sub-delegates the same
 watch. The check-in is consultancy, not monitoring — concrete support (a
 solved sub-problem, a decision, a re-spec), never a bare "status?" ping.
 Two-sided: delegates owe the same proactive report (covenant below),
-volunteered, not extracted.
+volunteered, not extracted. Auto-notify covers only work you launched; a
+delegate pausing on its own backgrounded work wakes no one — message it,
+don't wait.
 
 **Delegates run act-as-mohab implicitly.** Every delegated agent runs this
 skill's full method whether or not it can load the file — the Subagent


### PR DESCRIPTION
## Summary
- Dangling uncommitted edit found on an unrelated branch during a worktree cleanup pass, split out into its own PR since it isn't related to that branch's topic.
- Adds one clarifying line to the act-as-mohab covenant: auto-notify only covers work the orchestrator itself launched via the task harness -- a delegate that backgrounds its own subprocess and ends its turn is paused, not done, and nothing wakes the orchestrator automatically.

## Test plan
- [x] Docs-only change, no code/tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfxetzdJtF13MCJDRNQwgG