### PR TITLE
Address #4350: ship shaft-skills distribution via plugin marketplace + skills CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,42 @@
+{
+  "name": "shafthq",
+  "owner": {
+    "name": "ShaftHQ",
+    "url": "https://github.com/ShaftHQ"
+  },
+  "description": "Official ShaftHQ marketplace. Agent skills that teach AI coding agents to write, record, and debug SHAFT_ENGINE tests correctly.",
+  "plugins": [
+    {
+      "name": "shaft-skills",
+      "source": "./shaft-skills",
+      "description": "Official SHAFT agent skills: methodology router, locator strategy, test planning and authoring, MCP-driven recording, failure analysis, and change verification.",
+      "author": {
+        "name": "ShaftHQ"
+      },
+      "homepage": "https://shafthq.github.io/docs/start/overview",
+      "repository": "https://github.com/ShaftHQ/SHAFT_ENGINE",
+      "license": "MIT",
+      "keywords": [
+        "shaft",
+        "test-automation",
+        "selenium",
+        "appium",
+        "rest-assured",
+        "java",
+        "testng",
+        "junit"
+      ],
+      "category": "testing",
+      "strict": false,
+      "skills": [
+        "./act-as-shaft-dev",
+        "./analyzing-shaft-failures",
+        "./choosing-shaft-locators",
+        "./planning-shaft-tests",
+        "./recording-shaft-tests-with-mcp",
+        "./verifying-and-applying-shaft-changes",
+        "./writing-shaft-tests"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,33 @@ SHAFT tool window, reuse existing code, review generated blocks, verify locally.
 - [Modular-era feature catalog](modular-era-feature-catalog.md) — which optional
   module or command to adopt, with screenshots.
 
+## Agent Skills
+
+SHAFT ships a first-party skill pack in [`shaft-skills/`](shaft-skills) that
+teaches AI coding agents SHAFT conventions: locator strategy, test planning
+and authoring, MCP-driven recording, failure analysis, and change
+verification.
+
+Install as a Claude Code plugin (ships the full pack, including the shared
+`references/` lookups):
+
+```text
+/plugin marketplace add ShaftHQ/SHAFT_ENGINE
+/plugin install shaft-skills@shafthq
+```
+
+Or install individual skills to Claude Code, Cursor, Codex, and other agents
+with the [skills CLI](https://github.com/vercel-labs/skills):
+
+```shell
+npx skills add ShaftHQ/SHAFT_ENGINE --skill act-as-shaft-dev --skill writing-shaft-tests
+```
+
+The CLI picker also lists this repository's internal maintainer skills; the
+user-facing pack is the seven skills under `shaft-skills/`. Per-skill CLI
+installs copy each skill directory on its own, so the optional
+`shaft-skills/references/` lookups ship only with the plugin install.
+
 ## Contributing
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — local setup, validation, and pull requests.


### PR DESCRIPTION
## Summary

Addresses #4350 — the distribution/discoverability half. The skill content the issue asks to design already exists (`shaft-skills/`, 7 skills + `references/`, prior art through #4271/#4031/#3881); what was missing was any way for an external SHAFT user to install it. This PR adds exactly that wiring:

- **`.claude-plugin/marketplace.json`** (new): official `shafthq` marketplace with one `shaft-skills` plugin entry, `source: ./shaft-skills`, `strict: false` (marketplace entry is the whole manifest — no per-plugin `plugin.json` needed, per [plugin-marketplaces docs](https://code.claude.com/docs/en/plugin-marketplaces)). The `skills` field lists the seven skill directories individually — verified against the bundled source of `skills` CLI v1.5.20, which resolves each entry's parent as its scan container, while Claude Code loads each listed directory as one skill; the explicit list is the only shape both tools resolve.
- **`README.md`**: new "Agent Skills" section with both install paths and an honest note on their difference.

## Verification (all run locally, this session)

- `claude plugin validate <repo>` — passed (Claude Code v2.1.220).
- Real end-to-end plugin install: `claude plugin marketplace add <path>` + `claude plugin install shaft-skills@shafthq` → component inventory shows exactly the 7 skills, ~605 always-on tokens, `references/` present in the plugin cache copy. Uninstalled and cache cleaned after.
- `npx skills add <path> --list`: **before** the manifest, 0 of the 7 `shaft-skills/` skills were discovered (only 20 internal `.claude/skills` + `.agents/skills` entries); **after**, all 7 appear. A real `--skill act-as-shaft-dev --skill writing-shaft-tests -a claude-code` install landed both in a test project's `.claude/skills/`.
- `py -3 scripts/ci/validate_agent_setup.py` — passes, but note it has no coverage of `shaft-skills/`, `.claude-plugin/`, or the README; the pass proves no regression, not correctness of the new files.
- `marketplace.json` is valid JSON (`py -3 -m json.tool`).

## What this does NOT ship (left of #4350)

- The issue's "common pitfalls" content idea (e.g. `Actions.report()` throws `RuntimeException`, not `AssertionError`) is documented **nowhere in the user-facing pack** — only in the internal TDD skill adaptation. Content gap, deliberately not authored here.
- `npx skills add ShaftHQ/SHAFT_ENGINE` also surfaces 20 internal maintainer skills (`.claude/skills/`, `.agents/skills/`) alongside the pack — the CLI scans those dirs by convention and has no exclusion mechanism yet (upstream feature request: vercel-labs/skills#572). The plugin route is unaffected (exactly 7 skills). README notes this honestly.
- Per-skill CLI installs copy each skill dir alone, so `../references/*.md` lookups only ship via the plugin install (skills phrase these as optional, so degradation is soft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkZJgRNK97QeuGHK3aVULT