### PR TITLE
Read each index in a multi-index YAML list key

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/YAMLFileManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/YAMLFileManager.java
@@ -318,7 +318,7 @@ public class YAMLFileManager {
 
         for (int i = 0; i < indexes.size(); i++) {
             value = parseObjectToList(value, Object.class)
-                    .get(indexes.stream().findFirst().orElseThrow());
+                    .get(indexes.get(i));
         }
 
         return value;

--- a/shaft-engine/src/test/java/testPackage/unitTests/YAMLFileManagerUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/YAMLFileManagerUnitTest.java
@@ -205,6 +205,12 @@ public class YAMLFileManagerUnitTest {
                 .isEqualTo("You caught me").perform();
     }
 
+    @Test(description = "get: nested list with different indexes reads each level separately")
+    public void getNestedListWithDifferentIndexes() {
+        Validations.assertThat().object(yaml.getString("matrix[1][0]"))
+                .isEqualTo("r1c0").perform();
+    }
+
     @Test(description = "get: mixed map and list path")
     public void getMixedMapAndListPath() {
         Validations.assertThat().object(yaml.getString("mix-map-list.m1[1].l1.m2[1].l3"))

--- a/shaft-engine/src/test/resources/testDataFiles/yaml/yaml_test_data.yaml
+++ b/shaft-engine/src/test/resources/testDataFiles/yaml/yaml_test_data.yaml
@@ -48,6 +48,14 @@ nested-list:
           -
             - You caught me
 
+matrix:
+  -
+    - r0c0
+    - r0c1
+  -
+    - r1c0
+    - r1c1
+
 nested-map:
   a:
     b:


### PR DESCRIPTION
## Summary
- A key like `matrix[1][0]` reused the first index for every level, so nested list lookups returned the wrong element
- Walk the parsed indexes in order
- Existing tests only used all-zero or single indexes, so this was invisible

## Tests
YAMLFileManagerUnitTest + YAMLFileManagerTests --> [2026-07-31_16-49-39-554_AllureReport.html](https://github.com/user-attachments/files/30591827/2026-07-31_16-49-39-554_AllureReport.html)
