### PR TITLE
Fix(agent): require fresh task branches

### DIFF
--- a/.agents/skills/act-as-mohab/SKILL.md
+++ b/.agents/skills/act-as-mohab/SKILL.md
@@ -11,6 +11,14 @@ Single entrypoint for every host, main thread, and delegate. Load this file
 before task-specific discovery or work. Host adapters may point here; they
 must not restate its policy.
 
+## Task isolation
+
+Before task-specific discovery or edits, main thread must successfully fetch
+and prune. Create or verify a fresh `ChaosEngine/*` branch/worktree from fetched
+`origin/main`. Reuse it only for dependent work in the same user task. Never
+reuse that branch for a later user task. Stop and report if fetch or base
+verification fails.
+
 ## Operating contract
 
 1. Orient on requested outcome and concrete proof of done.

--- a/tests/scripts/test_agent_harness_portability.py
+++ b/tests/scripts/test_agent_harness_portability.py
@@ -85,6 +85,21 @@ class AgentHarnessPortabilityTest(unittest.TestCase):
         ):
             self.assertNotIn(retired_link, content)
 
+    def test_act_as_mohab_requires_fresh_task_branch_from_fetched_main(self):
+        content = (ROOT / ".agents/skills/act-as-mohab/SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        compact = re.sub(r"\s+", " ", content)
+        for required in (
+            "## Task isolation",
+            "Before task-specific discovery or edits",
+            "successfully fetch and prune",
+            "fresh `ChaosEngine/*` branch/worktree",
+            "fetched `origin/main`",
+            "Never reuse that branch for a later user task",
+        ):
+            self.assertIn(required, compact)
+
     def test_host_token_budgets_include_mandatory_entrypoint(self):
         budget = json.loads(
             (ROOT / "scripts/ci/agent_guidance_budget.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Require task isolation from a fetched `origin/main` branch/worktree.
- Permit reuse only for dependent work within the same user task.
- Add a structural regression check for the canonical rule.

## Validation
- `py -3 -m unittest tests.scripts.test_agent_harness_portability`
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- `py -3 scripts/ci/validate_skills.py`

Closes #4408