### PR TITLE
docs: align engine APIs and Javadocs with user guide

### DIFF
--- a/modular-era-feature-catalog.md
+++ b/modular-era-feature-catalog.md
@@ -24,6 +24,7 @@ feature each one proves.
 | Turn exploratory browser or mobile sessions into maintainable Java tests. | [Capture and code generation](#capture-and-code-generation) | Recorder sessions preserve actions, checkpoints, locators, context, privacy, and replay snippets. |
 | Make Android/Appium setup and recording less coordinate-driven. | [Mobile automation](#mobile-automation) | Toolchain diagnostics and locator-first Inspector recording show the exact device, locator, and fallback state. |
 | Debug failed tests from evidence instead of guessing. | [Doctor, Heal, Trace, and reporting](#doctor-heal-trace-and-reporting) | Failure briefs, traces, locator health, healing decisions, and report UI give a shorter path from failure to fix. |
+| Configure browser, mobile, reporting, healing, AI, or test-run behavior. | [Properties](#properties) | One source-derived table for typed properties, defaults, and bundled property files. |
 
 ## What Changed
 
@@ -103,6 +104,484 @@ Use the new reactor split when you want SHAFT as a framework base, not a monolit
 | Consumer fixture | A combined-module fixture validates that optional modules can be consumed together. | `mvn -f tools/modularization/consumer-fixtures/combined-modules/pom.xml test '-DskipTests'` |
 
 <img src="shaft-engine/src/main/resources/modular-era-feature-catalog/module-map.png" alt="Current module map" width="760">
+
+## Properties
+
+The property surface is easiest to use from a small project file. Read a value through `SHAFT.Properties`; override it in `src/main/resources/properties/custom.properties` or with a system property.
+
+```java
+SHAFT.Properties.web.targetBrowserName();
+SHAFT.Properties.web.set().targetBrowserName("firefox").headlessExecution(true);
+```
+
+```properties
+targetBrowserName=firefox
+headlessExecution=true
+```
+
+The typed interfaces are the complete `SHAFT.Properties` catalog. The `Default` column uses the bundled file when that file supplies the key, otherwise the interface `@DefaultValue`. `(blank)` means an empty string. Credential-shaped defaults are intentionally redacted; provide them through secure project configuration.
+
+| Interface | What it controls |
+| --- | --- |
+| `API` | Swagger/OpenAPI validation, contract redaction lists, and coverage thresholds. |
+| `Allure` | Allure generation, history, archive, theme, language, and grouping. |
+| `BrowserStack` | BrowserStack desktop and native-mobile execution capabilities. |
+| `Capture` | Optional API request/response capture limits and URL filters. |
+| `Cucumber` | Cucumber execution, filtering, glue, plugins, and snippets. |
+| `Flags` | Engine-wide execution switches for waits, retries, scrolling, clicks, and telemetry. |
+| `Healenium` | Optional Healenium recovery service and score settings. |
+| `Healing` | Optional SHAFT Heal strategy, confidence, evidence, history, visual, and AI controls. |
+| `Internal` | Engine metadata and managed Allure/Appium/Android tool versions. |
+| `Jira` | Jira/Xray reporting, authorization, and Allure link patterns. |
+| `LambdaTest` | LambdaTest remote browser/mobile execution capabilities. |
+| `Log4j` | Log4j appenders, layouts, logger names, and thresholds. |
+| `Mobile` | Appium device, application, browser, Flutter, and native-session settings. |
+| `NaturalActions` | Deterministic and optional provider-assisted natural-language GUI actions. |
+| `Paths` | Project, artifact, download, cache, and service directories. |
+| `Pattern` | Test-data column prefixes and Allure issue-link patterns. |
+| `Performance` | Lighthouse and browser/API performance budgets. |
+| `Pilot` | Optional AI provider, consent, budget, redaction, and endpoint controls. |
+| `Platform` | Local/remote execution, operating system, proxies, BiDi, and preflight. |
+| `Playwright` | Playwright browser, connection, timeout, artifact, download, and tracing settings. |
+| `Reporting` | Evidence, diagnostics, traces, locator health, flake profiling, and report output. |
+| `TestNG` | Parallel execution, verbosity, ordering, data-provider threads, and suite timeout. |
+| `Timeouts` | Browser, UI, API, shell, SSH, Docker, database, and remote-server timeouts. |
+| `Tinkey` | Google Tink keyset and KMS settings. |
+| `Visuals` | Screenshots, visual thresholds, GIF/video capture, snapshots, and watermarking. |
+| `Web` | Browser, headless, window, page-load, readiness, storage-state, and mobile emulation settings. |
+
+### Complete typed property table
+
+| Interface | Property | Type | Default |
+| --- | --- | --- | --- |
+| `Allure` | `allure.automaticallyOpen` | `boolean` | `true` |
+| `Allure` | `allure.accumulateHistory` | `boolean` | `true` |
+| `Allure` | `allure.accumulateReports` | `boolean` | `true` |
+| `Allure` | `allure.cleanResultsDirectory` | `boolean` | `true` |
+| `Allure` | `allure.generateArchive` | `boolean` | `false` |
+| `Allure` | `allure.generateReport` | `boolean` | `true` |
+| `Allure` | `allure.customLogo` | `String` | `https://github.com/ShaftHQ/SHAFT_ENGINE/blob/main/shaft-engine/src/main/resources/images/shaft_report_logo.png?raw=true` |
+| `Allure` | `allure.customTitle` | `String` | `SHAFT-powered test report` |
+| `Allure` | `allure.theme` | `String` | `auto` |
+| `Allure` | `allure.forceConfiguredCliVersion` | `boolean` | `true` |
+| `Allure` | `allure.realtimeMonitoring` | `boolean` | `false` |
+| `Allure` | `allure.singleFile` | `boolean` | `true` |
+| `Allure` | `allure.reportLanguage` | `String` | `en` |
+| `Allure` | `allure.open` | `boolean` | `false` |
+| `Allure` | `allure.groupBy` | `String` | `package,testClass` |
+| `API` | `swagger.validation.enabled` | `boolean` | `false` |
+| `API` | `swagger.validation.url` | `String` | `(blank)` |
+| `API` | `openapi.coverage.report.enabled` | `boolean` | `false` |
+| `API` | `openapi.coverage.threshold` | `int` | `0` |
+| `API` | `shaft.contract.sensitiveKeys` | `String` | `authorization,cookie,set-cookie,password,passwd,secret,token,api-key,apikey,access-key,accesskey` |
+| `API` | `shaft.contract.volatileKeys` | `String` | `requestId,traceId,spanId,sessionId,nonce,timestamp,createdAt,updatedAt,expiresAt,date,etag` |
+| `BrowserStack` | `browserStack.userName` | `String` | `[redacted]` |
+| `BrowserStack` | `browserStack.accessKey` | `String` | `[redacted]` |
+| `BrowserStack` | `browserStack.platformVersion` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.deviceName` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.appUrl` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.customID` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.appName` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.appRelativeFilePath` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.osVersion` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.browserVersion` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.local` | `boolean` | `false` |
+| `BrowserStack` | `browserStack.seleniumVersion` | `String` | `4.40.0` |
+| `BrowserStack` | `browserStack.acceptInsecureCerts` | `boolean` | `true` |
+| `BrowserStack` | `browserStack.debug` | `boolean` | `false` |
+| `BrowserStack` | `browserStack.networkLogs` | `boolean` | `false` |
+| `BrowserStack` | `browserStack.geoLocation` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.appiumVersion` | `String` | `3.1.0` |
+| `BrowserStack` | `browserStack.buildName` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.projectName` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.parallelsPerPlatform` | `int` | `1` |
+| `BrowserStack` | `browserStack.browserstackAutomation` | `boolean` | `true` |
+| `BrowserStack` | `browserStack.platformsList` | `String` | `(blank)` |
+| `BrowserStack` | `browserStack.customBrowserStackYmlPath` | `String` | `(blank)` |
+| `Capture` | `capture.api.enabled` | `boolean` | `false` |
+| `Capture` | `capture.api.maxBodyBytes` | `int` | `1048576` |
+| `Capture` | `capture.api.includeAssets` | `boolean` | `false` |
+| `Capture` | `capture.api.firstPartyOnly` | `boolean` | `true` |
+| `Capture` | `capture.api.storeSecretsLocally` | `boolean` | `false` |
+| `Capture` | `capture.api.maxTransactions` | `int` | `500` |
+| `Capture` | `capture.api.urlIncludeGlobs` | `String` | `(blank)` |
+| `Capture` | `capture.api.urlExcludeGlobs` | `String` | `(blank)` |
+| `Cucumber` | `cucumber.ansi-colors.disabled` | `boolean` | `false` |
+| `Cucumber` | `cucumber.execution.dry-run` | `boolean` | `false` |
+| `Cucumber` | `cucumber.execution.limit` | `String` | `(blank)` |
+| `Cucumber` | `cucumber.execution.order` | `String` | `lexical` |
+| `Cucumber` | `cucumber.execution.strict` | `boolean` | `true` |
+| `Cucumber` | `cucumber.execution.wip` | `boolean` | `false` |
+| `Cucumber` | `cucumber.features` | `String` | `src/test/resources` |
+| `Cucumber` | `cucumber.filter.name` | `String` | `(blank)` |
+| `Cucumber` | `cucumber.filter.tags` | `String` | `(blank)` |
+| `Cucumber` | `cucumber.glue` | `String` | `customCucumberSteps, com.shaft.cucumber` |
+| `Cucumber` | `cucumber.plugin` | `String` | `pretty, json:allure-results/cucumber.json, html:allure-results/cucumberReport.html, com.shaft.listeners.CucumberTestRunnerListener` |
+| `Cucumber` | `cucumber.object-factory` | `String` | `(blank)` |
+| `Cucumber` | `cucumber.snippet-type` | `String` | `underscore` |
+| `Cucumber` | `cucumber.publish.quiet` | `boolean` | `true` |
+| `Flags` | `automaticallyAddRecommendedChromeOptions` | `boolean` | `false` |
+| `Flags` | `retryMaximumNumberOfAttempts` | `int` | `0` |
+| `Flags` | `forceCaptureSupportingEvidenceOnRetry` | `boolean` | `true` |
+| `Flags` | `autoMaximizeBrowserWindow` | `boolean` | `true` |
+| `Flags` | `forceCheckForElementVisibility` | `boolean` | `true` |
+| `Flags` | `forceCheckElementLocatorIsUnique` | `boolean` | `true` |
+| `Flags` | `forceCheckTextWasTypedCorrectly` | `boolean` | `false` |
+| `Flags` | `scrollingMode` | `String` | `javascript` |
+| `Flags` | `clearBeforeTypingMode` | `String` | `native` |
+| `Flags` | `forceCheckNavigationWasSuccessful` | `boolean` | `false` |
+| `Flags` | `respectBuiltInWaitsInNativeMode` | `boolean` | `true` |
+| `Flags` | `forceCheckStatusOfRemoteServer` | `boolean` | `false` |
+| `Flags` | `clickUsingJavascriptWhenWebDriverClickFails` | `boolean` | `false` |
+| `Flags` | `autoCloseDriverInstance` | `boolean` | `true` |
+| `Flags` | `automaticallyAssertResponseStatusCode` | `boolean` | `true` |
+| `Flags` | `maximumPerformanceMode` | `int` | `0` |
+| `Flags` | `skipTestsWithLinkedIssues` | `boolean` | `false` |
+| `Flags` | `attemptToClickBeforeTyping` | `boolean` | `false` |
+| `Flags` | `disableCache` | `boolean` | `false` |
+| `Flags` | `enableTrueNativeMode` | `boolean` | `false` |
+| `Flags` | `handleNonSelectDropDown` | `boolean` | `true` |
+| `Flags` | `validateSwipeToElement` | `boolean` | `false` |
+| `Flags` | `disableSslCertificateCheck` | `boolean` | `false` |
+| `Flags` | `telemetry.enabled` | `boolean` | `true` |
+| `Healenium` | `recovery-tries` | `int` | `1` |
+| `Healenium` | `score-cap` | `String` | `0.5` |
+| `Healenium` | `heal-enabled` | `boolean` | `false` |
+| `Healenium` | `serverHost` | `String` | `localhost` |
+| `Healenium` | `serverPort` | `int` | `7878` |
+| `Healenium` | `imitatePort` | `int` | `8000` |
+| `Healing` | `healing.strategy` | `String` | `disabled` |
+| `Healing` | `healing.minimumConfidence` | `double` | `0.75` |
+| `Healing` | `healing.minimumTrustPercentage` | `int` | `-1` |
+| `Healing` | `healing.ambiguityMargin` | `double` | `0.10` |
+| `Healing` | `healing.evidenceCategories` | `String` | `accessibility,label,test-id,stable-id-name,semantic,dom-fingerprint,native-state,ancestor-context,history` |
+| `Healing` | `healing.testIdAttributes` | `String` | `data-testid,data-test,data-qa` |
+| `Healing` | `healing.history.enabled` | `boolean` | `true` |
+| `Healing` | `healing.history.path` | `String` | `target/shaft-heal/history.json` |
+| `Healing` | `healing.history.maxEntries` | `int` | `500` |
+| `Healing` | `healing.history.retentionDays` | `int` | `30` |
+| `Healing` | `healing.visual.enabled` | `boolean` | `false` |
+| `Healing` | `healing.ai.enabled` | `boolean` | `false` |
+| `Healing` | `healing.ai.trigger` | `String` | `ambiguous` |
+| `Healing` | `healing.sourcePatch.enabled` | `boolean` | `false` |
+| `Healing` | `healing.ladder.budgetSeconds` | `int` | `0` |
+| `Internal` | `shaftEngineVersion` | `String` | `10.3.20260801` |
+| `Internal` | `watermarkImagePath` | `String` | `https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/shaft-engine/src/main/resources/images/shaft_white_bg.png` |
+| `Internal` | `allure3Version` | `String` | `3.14.3` |
+| `Internal` | `nodeLtsVersion` | `String` | `24.18.1` |
+| `Internal` | `appiumServerVersion` | `String` | `3.6.0` |
+| `Internal` | `appiumInspectorPluginVersion` | `String` | `2026.7.1` |
+| `Internal` | `appiumUiAutomator2DriverVersion` | `String` | `8.2.2` |
+| `Internal` | `appiumXcuitestDriverVersion` | `String` | `12.1.4` |
+| `Internal` | `androidCommandLineToolsVersion` | `String` | `15859902` |
+| `Internal` | `androidEmulatorApiLevel` | `int` | `36` |
+| `Internal` | `androidEmulatorDeviceProfile` | `String` | `pixel_8` |
+| `Internal` | `androidEmulatorImageTag` | `String` | `google_apis` |
+| `Internal` | `androidEmulatorRamMb` | `int` | `4096` |
+| `Internal` | `androidEmulatorCores` | `int` | `2` |
+| `Internal` | `ga4MeasurementId` | `String` | `G-4L9L79WZBV` |
+| `Internal` | `ga4ApiSecret` | `String` | `[redacted]` |
+| `Jira` | `jiraInteraction` | `boolean` | `false` |
+| `Jira` | `jiraUrl` | `String` | `https://` |
+| `Jira` | `projectKey` | `String` | `(blank)` |
+| `Jira` | `authorization` | `String` | `:` |
+| `Jira` | `authType` | `String` | `basic` |
+| `Jira` | `reportTestCasesExecution` | `boolean` | `false` |
+| `Jira` | `reportPath` | `String` | `target/surefire-reports/testng-results.xml` |
+| `Jira` | `ExecutionName` | `String` | `(blank)` |
+| `Jira` | `ExecutionDescription` | `String` | `(blank)` |
+| `Jira` | `ReportBugs` | `boolean` | `false` |
+| `Jira` | `assignee` | `String` | `(blank)` |
+| `Jira` | `allure.link.tms.pattern` | `String` | `https:///{}` |
+| `Jira` | `allure.link.custom.pattern` | `String` | `{}` |
+| `LambdaTest` | `LambdaTest.username` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.accessKey` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.platformVersion` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.deviceName` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.appUrl` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.appProfiling` | `boolean` | `false` |
+| `LambdaTest` | `LambdaTest.osVersion` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.visual` | `boolean` | `false` |
+| `LambdaTest` | `LambdaTest.video` | `boolean` | `false` |
+| `LambdaTest` | `LambdaTest.appName` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.appRelativeFilePath` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.resolution` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.headless` | `boolean` | `false` |
+| `LambdaTest` | `LambdaTest.timezone` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.project` | `String` | `shaft-engine` |
+| `LambdaTest` | `LambdaTest.build` | `String` | `Build Name` |
+| `LambdaTest` | `LambdaTest.tunnel` | `boolean` | `false` |
+| `LambdaTest` | `LambdaTest.tunnelName` | `String` | `false` |
+| `LambdaTest` | `LambdaTest.buildName` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.selenium_version` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.driver_version` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.w3c` | `boolean` | `true` |
+| `LambdaTest` | `LambdaTest.browserVersion` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.geoLocation` | `String` | `(blank)` |
+| `LambdaTest` | `LambdaTest.debug` | `boolean` | `false` |
+| `LambdaTest` | `LambdaTest.acceptInsecureCerts` | `boolean` | `true` |
+| `LambdaTest` | `LambdaTest.networkLogs` | `boolean` | `false` |
+| `LambdaTest` | `LambdaTest.appiumVersion` | `String` | `3.0.2` |
+| `LambdaTest` | `LambdaTest.autoGrantPermissions` | `boolean` | `true` |
+| `LambdaTest` | `LambdaTest.autoAcceptAlerts` | `boolean` | `true` |
+| `LambdaTest` | `LambdaTest.isRealMobile` | `boolean` | `true` |
+| `LambdaTest` | `LambdaTest.console` | `boolean` | `false` |
+| `LambdaTest` | `LambdaTest.customID` | `String` | `(blank)` |
+| `Log4j` | `name` | `String` | `PropertiesConfig` |
+| `Log4j` | `appender.console.type` | `String` | `Console` |
+| `Log4j` | `appender.console.name` | `String` | `STDOUT` |
+| `Log4j` | `appender.console.layout.type` | `String` | `PatternLayout` |
+| `Log4j` | `appender.console.layout.disableAnsi` | `boolean` | `false` |
+| `Log4j` | `appender.console.layout.noConsoleNoAnsi` | `boolean` | `false` |
+| `Log4j` | `appender.console.layout.charset` | `String` | `UTF-8` |
+| `Log4j` | `appender.console.layout.pattern` | `String` | `%highlight{[%p]}{FATAL=red blink, ERROR=red bold, WARN=yellow bold, INFO=fg_#0060a8 bold, DEBUG=fg_#43b02a bold, TRACE=black} %style{%d{HH:mm:ss}}{bright_black} %style{\\u2502}{bright_black} %m%n` |
+| `Log4j` | `appender.console.filter.threshold.type` | `String` | `ThresholdFilter` |
+| `Log4j` | `appender.console.filter.threshold.level` | `String` | `info` |
+| `Log4j` | `appender.file.type` | `String` | `RollingFile` |
+| `Log4j` | `appender.file.name` | `String` | `LOGFILE` |
+| `Log4j` | `appender.file.fileName` | `String` | `${logFilePath}` |
+| `Log4j` | `appender.file.layout.type` | `String` | `PatternLayout` |
+| `Log4j` | `appender.file.layout.pattern` | `String` | `[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n` |
+| `Log4j` | `appender.file.layout.charset` | `String` | `UTF-8` |
+| `Log4j` | `appender.file.filter.threshold.type` | `String` | `ThresholdFilter` |
+| `Log4j` | `appender.file.filter.threshold.level` | `String` | `debug` |
+| `Log4j` | `rootLogger` | `String` | `info, ASYNC_STDOUT, ASYNC_LOGFILE, ASYNC_REPORT_PORTAL` |
+| `Log4j` | `logger.app.name` | `String` | `org.apache.http.impl.client` |
+| `Log4j` | `logger.app.level` | `String` | `WARN` |
+| `Mobile` | `platformName` | `String` | `(blank)` |
+| `Mobile` | `mobile_platformVersion` | `String` | `(blank)` |
+| `Mobile` | `mobile_deviceName` | `String` | `(blank)` |
+| `Mobile` | `mobile_udid` | `String` | `(blank)` |
+| `Mobile` | `browserName` | `String` | `(blank)` |
+| `Mobile` | `MobileBrowserVersion` | `String` | `(blank)` |
+| `Mobile` | `mobile_app` | `String` | `(blank)` |
+| `Mobile` | `mobile_appPackage` | `String` | `(blank)` |
+| `Mobile` | `mobile_appActivity` | `String` | `(blank)` |
+| `Mobile` | `mobile_bundleId` | `String` | `(blank)` |
+| `Mobile` | `mobile_flutterElementWaitTimeout` | `int` | `0` |
+| `Mobile` | `mobile_flutterServerLaunchTimeout` | `int` | `0` |
+| `Mobile` | `mobile_flutterSystemPort` | `int` | `0` |
+| `Mobile` | `mobile_flutterEnableMockCamera` | `boolean` | `false` |
+| `NaturalActions` | `naturalActions.enabled` | `boolean` | `false` |
+| `NaturalActions` | `naturalActions.minimumTrustPercentage` | `int` | `85` |
+| `NaturalActions` | `naturalActions.planner` | `String` | `deterministic` |
+| `NaturalActions` | `naturalActions.aiFallback.enabled` | `boolean` | `false` |
+| `NaturalActions` | `naturalActions.aiFallback.threshold` | `double` | `0` |
+| `NaturalActions` | `naturalActions.allowedActions` | `String` | `browser,element,touch` |
+| `Paths` | `propertiesFolderPath` | `String` | `src/main/resources/properties/` |
+| `Paths` | `defaultPropertiesFolderPath` | `String` | `src/main/resources/properties/default` |
+| `Paths` | `aiAgentWorkspaceRoot` | `String` | `(blank)` |
+| `Paths` | `dynamicObjectRepositoryPath` | `String` | `src/main/resources/dynamicObjectRepository/` |
+| `Paths` | `ariaSnapshotFolderPath` | `String` | `src/test/resources/aria/` |
+| `Paths` | `testDataFolderPath` | `String` | `src/test/resources/testDataFiles/` |
+| `Paths` | `downloadsFolderPath` | `String` | `target/downloadedFiles` |
+| `Paths` | `allureResultsFolderPath` | `String` | `allure-results/` |
+| `Paths` | `extentReportsFolderPath` | `String` | `extent-reports/` |
+| `Paths` | `executionSummaryReportFolderPath` | `String` | `execution-summary/` |
+| `Paths` | `PerformanceReportFolderPath` | `String` | `performanceReport/` |
+| `Paths` | `video.folder` | `String` | `allure-results/videos` |
+| `Paths` | `applitoolsApiKey` | `String` | `(blank)` |
+| `Paths` | `servicesFolderPath` | `String` | `src/test/resources/META-INF/services/` |
+| `Paths` | `authCacheFolderPath` | `String` | `target/auth-cache/` |
+| `Paths` | `mobileSessionCacheFolderPath` | `String` | `target/mobile-session-cache/` |
+| `Pattern` | `testDataColumnNamePrefix` | `String` | `Data` |
+| `Pattern` | `allure.link.issue.pattern` | `String` | `(blank)` |
+| `Performance` | `lightHouseExecution` | `boolean` | `false` |
+| `Performance` | `lightHouseExecution.port` | `int` | `8888` |
+| `Performance` | `apiEndpointPerformanceBudgets` | `String` | `(blank)` |
+| `Performance` | `failOnApiPerformanceBudgetViolation` | `boolean` | `false` |
+| `Performance` | `browserActionPerformanceBudgets` | `String` | `(blank)` |
+| `Performance` | `pageLoadPerformanceBudgets` | `String` | `(blank)` |
+| `Performance` | `failOnBrowserPerformanceBudgetViolation` | `boolean` | `false` |
+| `Pilot` | `pilot.ai.enabled` | `boolean` | `false` |
+| `Pilot` | `pilot.ai.provider` | `String` | `none` |
+| `Pilot` | `pilot.ai.consent.local` | `boolean` | `false` |
+| `Pilot` | `pilot.ai.consent.onPrem` | `boolean` | `false` |
+| `Pilot` | `pilot.ai.consent.remote` | `boolean` | `false` |
+| `Pilot` | `pilot.ai.allowedEvidenceCategories` | `String` | `(blank)` |
+| `Pilot` | `pilot.ai.telemetry.enabled` | `boolean` | `false` |
+| `Pilot` | `pilot.ai.timeoutSeconds` | `int` | `300` |
+| `Pilot` | `pilot.ai.maxRequestBytes` | `int` | `1048576` |
+| `Pilot` | `pilot.ai.maxInputTokens` | `int` | `16000` |
+| `Pilot` | `pilot.ai.maxOutputTokens` | `int` | `8000` |
+| `Pilot` | `pilot.ai.maxCostUsd` | `String` | `0` |
+| `Pilot` | `pilot.ai.retryMaxAttempts` | `int` | `2` |
+| `Pilot` | `pilot.ai.maxConcurrency` | `int` | `2` |
+| `Pilot` | `pilot.ai.circuitBreaker.failureThreshold` | `int` | `3` |
+| `Pilot` | `pilot.ai.circuitBreaker.cooldownSeconds` | `int` | `60` |
+| `Pilot` | `pilot.ai.redaction.selectors` | `String` | `input[type=password],[autocomplete=current-password],[autocomplete=new-password]` |
+| `Pilot` | `pilot.ai.redaction.attributes` | `String` | `authorization,cookie,set-cookie,password,passwd,secret,token,api-key,apikey,access-key` |
+| `Pilot` | `pilot.ai.redaction.patterns` | `String` | `(blank)` |
+| `Pilot` | `pilot.ai.openai.endpoint` | `String` | `https://api.openai.com/v1/responses` |
+| `Pilot` | `pilot.ai.openai.model` | `String` | `(blank)` |
+| `Pilot` | `pilot.ai.openai.apiKeyEnvironmentVariable` | `String` | `OPENAI_API_KEY` |
+| `Pilot` | `pilot.ai.openai.processingLocation` | `String` | `remote` |
+| `Pilot` | `pilot.ai.anthropic.endpoint` | `String` | `https://api.anthropic.com/v1/messages` |
+| `Pilot` | `pilot.ai.anthropic.model` | `String` | `(blank)` |
+| `Pilot` | `pilot.ai.anthropic.apiKeyEnvironmentVariable` | `String` | `ANTHROPIC_API_KEY` |
+| `Pilot` | `pilot.ai.anthropic.processingLocation` | `String` | `remote` |
+| `Pilot` | `pilot.ai.anthropic.version` | `String` | `2023-06-01` |
+| `Pilot` | `pilot.ai.gemini.endpoint` | `String` | `https://generativelanguage.googleapis.com/v1beta/models` |
+| `Pilot` | `pilot.ai.gemini.model` | `String` | `gemini-3.5-flash` |
+| `Pilot` | `pilot.ai.gemini.apiKeyEnvironmentVariable` | `String` | `GEMINI_API_KEY` |
+| `Pilot` | `pilot.ai.gemini.processingLocation` | `String` | `remote` |
+| `Pilot` | `pilot.ai.github.endpoint` | `String` | `https://models.github.ai/inference/chat/completions` |
+| `Pilot` | `pilot.ai.github.model` | `String` | `(blank)` |
+| `Pilot` | `pilot.ai.github.apiKeyEnvironmentVariable` | `String` | `GITHUB_TOKEN` |
+| `Pilot` | `pilot.ai.github.processingLocation` | `String` | `remote` |
+| `Pilot` | `pilot.ai.ollama.endpoint` | `String` | `http://127.0.0.1:11434/api/chat` |
+| `Pilot` | `pilot.ai.ollama.model` | `String` | `(blank)` |
+| `Pilot` | `pilot.ai.ollama.processingLocation` | `String` | `local` |
+| `Pilot` | `pilot.ai.ollama.apiKeyEnvironmentVariable` | `String` | `(blank)` |
+| `Pilot` | `pilot.ai.ollama.apiKeyHeader` | `String` | `Authorization` |
+| `Pilot` | `pilot.ai.ollama.apiKeyPrefix` | `String` | `Bearer ` |
+| `Platform` | `SHAFT.CrossBrowserMode` | `String` | `off` |
+| `Platform` | `executionAddress` | `String` | `local` |
+| `Platform` | `targetOperatingSystem` | `String` | `Linux` |
+| `Platform` | `com.SHAFT.proxySettings` | `String` | `(blank)` |
+| `Platform` | `driverProxySettings` | `boolean` | `true` |
+| `Platform` | `jvmProxySettings` | `boolean` | `true` |
+| `Platform` | `enableBiDi` | `boolean` | `true` |
+| `Platform` | `remotePreflightEnabled` | `boolean` | `false` |
+| `Platform` | `remoteAdaptiveSessionThrottling` | `boolean` | `false` |
+| `Platform` | `remotePreflightFailFast` | `boolean` | `false` |
+| `Platform` | `remotePreflightTimeoutSeconds` | `int` | `5` |
+| `Playwright` | `playwright.browserName` | `String` | `(blank)` |
+| `Playwright` | `playwright.deviceName` | `String` | `(blank)` |
+| `Playwright` | `playwright.connectionMode` | `String` | `local` |
+| `Playwright` | `playwright.endpoint` | `String` | `(blank)` |
+| `Playwright` | `playwright.channel` | `String` | `(blank)` |
+| `Playwright` | `playwright.slowMo` | `int` | `0` |
+| `Playwright` | `playwright.launchTimeoutMilliseconds` | `int` | `30000` |
+| `Playwright` | `playwright.defaultTimeoutMilliseconds` | `int` | `30000` |
+| `Playwright` | `playwright.navigationTimeoutMilliseconds` | `int` | `30000` |
+| `Playwright` | `playwright.artifactsDirectory` | `String` | `target/playwright-artifacts` |
+| `Playwright` | `playwright.downloadsDirectory` | `String` | `(blank)` |
+| `Playwright` | `playwright.acceptDownloads` | `boolean` | `true` |
+| `Playwright` | `playwright.tracing.enabled` | `boolean` | `false` |
+| `Playwright` | `playwright.tracing.onRetryOnly` | `boolean` | `true` |
+| `Playwright` | `playwright.tracing.screenshots` | `boolean` | `true` |
+| `Playwright` | `playwright.tracing.snapshots` | `boolean` | `true` |
+| `Playwright` | `playwright.tracing.sources` | `boolean` | `true` |
+| `Reporting` | `captureElementName` | `boolean` | `true` |
+| `Reporting` | `captureWebDriverLogs` | `boolean` | `false` |
+| `Reporting` | `alwaysLogDiscreetly` | `boolean` | `false` |
+| `Reporting` | `debugMode` | `boolean` | `false` |
+| `Reporting` | `openLighthouseReportWhileExecution` | `boolean` | `false` |
+| `Reporting` | `cleanSummaryReportsDirectoryBeforeExecution` | `boolean` | `true` |
+| `Reporting` | `openExecutionSummaryReportAfterExecution` | `boolean` | `false` |
+| `Reporting` | `disableLogging` | `boolean` | `false` |
+| `Reporting` | `attachFullLog` | `boolean` | `false` |
+| `Reporting` | `evidenceLevel` | `String` | `FAILURE_ONLY` |
+| `Reporting` | `locatorHealthReportEnabled` | `boolean` | `false` |
+| `Reporting` | `slowLocatorThresholdMillis` | `int` | `750` |
+| `Reporting` | `failOnLocatorHealthWarnings` | `boolean` | `false` |
+| `Reporting` | `shaft.locatorHealth.enabled` | `boolean` | `false` |
+| `Reporting` | `shaft.locatorHealth.warnBelowScore` | `int` | `70` |
+| `Reporting` | `shaft.locatorHealth.attachDashboard` | `boolean` | `true` |
+| `Reporting` | `shaft.locatorHealth.failBelowScore` | `int` | `-1` |
+| `Reporting` | `shaft.diagnostics.enabled` | `boolean` | `true` |
+| `Reporting` | `shaft.diagnostics.maxArtifactMb` | `int` | `50` |
+| `Reporting` | `shaft.trace.enabled` | `boolean` | `true` |
+| `Reporting` | `shaft.trace.mode` | `String` | `auto` |
+| `Reporting` | `shaft.trace.retainFailedAttempts` | `boolean` | `true` |
+| `Reporting` | `shaft.trace.includeCodeContext` | `boolean` | `true` |
+| `Reporting` | `shaft.trace.includeFullPageSnapshots` | `boolean` | `true` |
+| `Reporting` | `shaft.trace.includeDomSnapshots` | `boolean` | `true` |
+| `Reporting` | `shaft.trace.includeScreenshots` | `boolean` | `true` |
+| `Reporting` | `shaft.trace.includeNativePageSource` | `boolean` | `true` |
+| `Reporting` | `shaft.trace.includeNetwork` | `boolean` | `true` |
+| `Reporting` | `shaft.trace.includeConsole` | `boolean` | `true` |
+| `Reporting` | `shaft.trace.maxArtifactMb` | `int` | `50` |
+| `Reporting` | `shaft.flakeProfiler.enabled` | `boolean` | `false` |
+| `Reporting` | `shaft.flakeProfiler.attachPerTest` | `boolean` | `true` |
+| `Reporting` | `shaft.flakeProfiler.failOnSevereFlakeRisk` | `boolean` | `false` |
+| `Reporting` | `shaft.flakeProfiler.slowActionThresholdMs` | `int` | `2000` |
+| `TestNG` | `setParallel` | `String` | `NONE` |
+| `TestNG` | `setParallelMode` | `String` | `STATIC` |
+| `TestNG` | `setThreadCount` | `double` | `1` |
+| `TestNG` | `setVerbose` | `Integer` | `0` |
+| `TestNG` | `setPreserveOrder` | `boolean` | `false` |
+| `TestNG` | `setGroupByInstances` | `boolean` | `false` |
+| `TestNG` | `setDataProviderThreadCount` | `int` | `1` |
+| `TestNG` | `testSuiteTimeout` | `long` | `1440` |
+| `Timeouts` | `waitForLazyLoading` | `Boolean` | `true` |
+| `Timeouts` | `browserNavigationTimeout` | `int` | `30` |
+| `Timeouts` | `pageLoadTimeout` | `int` | `30` |
+| `Timeouts` | `scriptExecutionTimeout` | `int` | `30` |
+| `Timeouts` | `waitForLazyLoadingTimeout` | `int` | `30` |
+| `Timeouts` | `lazyLoadingNetworkIdleInitialObservationMillis` | `int` | `200` |
+| `Timeouts` | `lazyLoadingNetworkIdleQuietWindowMillis` | `int` | `500` |
+| `Timeouts` | `lazyLoadingPollingIntervalMillis` | `int` | `200` |
+| `Timeouts` | `lazyLoadingDomStabilityQuietWindowMillis` | `int` | `0` |
+| `Timeouts` | `lazyLoadingScrollSweepMaxSteps` | `int` | `20` |
+| `Timeouts` | `defaultElementIdentificationTimeout` | `double` | `10` |
+| `Timeouts` | `waitForUiStateTimeout` | `int` | `600` |
+| `Timeouts` | `apiSocketTimeout` | `int` | `30` |
+| `Timeouts` | `apiConnectionTimeout` | `int` | `30` |
+| `Timeouts` | `apiConnectionManagerTimeout` | `int` | `30` |
+| `Timeouts` | `shellSessionTimeout` | `long` | `30` |
+| `Timeouts` | `sshServerAliveInterval` | `int` | `60` |
+| `Timeouts` | `dockerCommandTimeout` | `int` | `30` |
+| `Timeouts` | `databaseLoginTimeout` | `int` | `30` |
+| `Timeouts` | `databaseNetworkTimeout` | `int` | `30` |
+| `Timeouts` | `databaseQueryTimeout` | `int` | `30` |
+| `Timeouts` | `waitForRemoteServerToBeUp` | `Boolean` | `false` |
+| `Timeouts` | `timeoutForRemoteServerToBeUp` | `int` | `1` |
+| `Timeouts` | `remoteServerInstanceCreationTimeout` | `int` | `5` |
+| `Timeouts` | `remoteServerConnectionAttemptTimeout` | `int` | `120` |
+| `Tinkey` | `tinkey.keysetFilename` | `String` | `(blank)` |
+| `Tinkey` | `tinkey.kms.serverType` | `String` | `(blank)` |
+| `Tinkey` | `tinkey.kms.credentialPath` | `String` | `(blank)` |
+| `Tinkey` | `tinkey.kms.masterKeyUri` | `String` | `(blank)` |
+| `Visuals` | `visualMatchingThreshold` | `double` | `0.90` |
+| `Visuals` | `screenshotParams_scalingFactor` | `double` | `1.0` |
+| `Visuals` | `screenshotParams_whenToTakeAScreenshot` | `String` | `ValidationPointsOnly` |
+| `Visuals` | `screenshotParams_screenshotType` | `String` | `fullPage` |
+| `Visuals` | `screenshotParams_highlightElements` | `boolean` | `true` |
+| `Visuals` | `screenshotParams_highlightMethod` | `String` | `AI` |
+| `Visuals` | `screenshotParams_skippedElementsFromScreenshot` | `String` | `(blank)` |
+| `Visuals` | `screenshotParams_watermark` | `boolean` | `true` |
+| `Visuals` | `screenshotParams_watermarkOpacity` | `float` | `0.2` |
+| `Visuals` | `createAnimatedGif` | `boolean` | `false` |
+| `Visuals` | `animatedGif_frameDelay` | `int` | `500` |
+| `Visuals` | `videoParams_recordVideo` | `boolean` | `false` |
+| `Visuals` | `videoParams_scope` | `String` | `DriverSession` |
+| `Visuals` | `whenToTakePageSourceSnapshot` | `String` | `Never` |
+| `Visuals` | `shaft.updateSnapshots` | `boolean` | `false` |
+| `Web` | `targetBrowserName` | `String` | `chrome` |
+| `Web` | `forceBrowserDownload` | `boolean` | `false` |
+| `Web` | `headlessExecution` | `boolean` | `false` |
+| `Web` | `incognitoMode` | `boolean` | `false` |
+| `Web` | `isMobileEmulation` | `boolean` | `false` |
+| `Web` | `mobileEmulation.isCustomDevice` | `boolean` | `false` |
+| `Web` | `mobileEmulation.deviceName` | `String` | `(blank)` |
+| `Web` | `mobileEmulation.width` | `int` | `(blank)` |
+| `Web` | `mobileEmulation.height` | `int` | `(blank)` |
+| `Web` | `mobileEmulation.pixelRatio` | `double` | `1.0` |
+| `Web` | `mobileEmulation.userAgent` | `String` | `(blank)` |
+| `Web` | `baseURL` | `String` | `(blank)` |
+| `Web` | `browserWindowWidth` | `int` | `1920` |
+| `Web` | `browserWindowHeight` | `int` | `1080` |
+| `Web` | `pageLoadStrategy` | `String` | `none` |
+| `Web` | `readinessState` | `String` | `none` |
+| `Web` | `storageStatePath` | `String` | `(blank)` |
+
+### Bundled default files
+
+These files are copied or loaded as the project-level defaults. They also contain third-party settings that do not have a typed `SHAFT.Properties` interface.
+
+| File | Use |
+| --- | --- |
+| [`default/custom.properties`](shaft-engine/src/main/resources/properties/default/custom.properties) | Starter overrides for execution address/OS, browser/headless mode, retries, healing, natural actions, and API capture. |
+| [`default/TestNG.properties`](shaft-engine/src/main/resources/properties/default/TestNG.properties) | TestNG parallel mode, thread counts, verbosity, ordering, and suite timeout. |
+| [`default/cucumber.properties`](shaft-engine/src/main/resources/properties/default/cucumber.properties) | Cucumber execution, filtering, glue, plugins, and publish settings. |
+| [`default/customWebdriverCapabilities.properties`](shaft-engine/src/main/resources/properties/default/customWebdriverCapabilities.properties) | Extra `capabilities.*` values passed to WebDriver/Appium. |
+| [`default/junit-platform.properties`](shaft-engine/src/main/resources/properties/default/junit-platform.properties) | JUnit parallel execution and extension autodetection. |
+| [`default/log4j2.properties`](shaft-engine/src/main/resources/properties/default/log4j2.properties) | Console/file/ReportPortal appenders, patterns, and log thresholds. |
+| [`default/reportportal.properties`](shaft-engine/src/main/resources/properties/default/reportportal.properties) | ReportPortal endpoint, project, launch, enablement, and API-key settings. Supply credentials yourself. |
+
+File-only namespaces such as `capabilities.*`, `junit.*`, `rp.*`, `appender.*`, and `logger.*` stay in their owning files; the typed table above covers every key exposed by the property interfaces.
 
 ## MCP and Agent Workflows
 
@@ -338,8 +817,8 @@ The modular era keeps classic WebDriver/Appium flows, adds a first-class Playwri
 | Playwright facade | `SHAFT.GUI.Playwright` sits beside WebDriver under the shared GUI driver concept. | `SHAFT.GUI.Playwright driver = new SHAFT.GUI.Playwright();` |
 | Playwright parity | Browser actions, element actions, assertions, verifications, tracing, contract replay, natural action executor, screenshots, and Doctor hooks. | `playwright_capture_code_blocks`, `playwright_replay_recording`, `playwright_doctor_suggest_fix` |
 | Capture CLI backend selection | The same persisted Capture session can now generate WebDriver or SHAFT Playwright replay from local CLI use. | `capture generate --session recordings/example.json --backend playwright` |
-| Browser network control | Intercept, mock, assert, verify, throttle, block resources, bridge API/browser auth state, and record contracts. | `driver.browser().interceptRequest().get().urlContains("/api/users")...perform();` |
-| API facade | GraphQL builder, retry policies, typed JSON mapping to classes/records/lists, and OpenAPI coverage thresholds. | `api.get("/health").withRetry(RetryPolicy.transientFailures().maxAttempts(3)).perform();` |
+| Browser network control | Intercept, mock, assert, verify, throttle, block resources, bridge API/browser auth state, and record contracts. | `driver.browser().interceptRequest().get().urlContains("/api/users")` |
+| API facade | GraphQL builder, retry policies, typed JSON mapping to classes/records/lists, and OpenAPI coverage thresholds. | `api.get("/health").withRetry(RetryPolicy.transientFailures().maxAttempts(3))` |
 | Browser/mobile polish | UI state wait timeout, touch end-scroll, image invisibility waits, Appium recursion fallback, and mobile trace enrichment. | `SHAFT.Properties.timeouts.set().waitForUiStateTimeout(600);` |
 | CLI and grid | SSH terminal sessions, SFTP, port forwarding, redaction, remote WebDriver timeout, Selenium Grid preflight, remote video, and BrowserStack app capability handling. | `SHAFT.CLI.remoteTerminal(host, 22, user, keyFolder, keyName, true);` |
 
@@ -358,30 +837,28 @@ driver.browser()
       .urlContains("/api/users")
       .respond()
       .statusCode(200)
-      .jsonBody("{\"ok\":true}")
-      .perform();
+      .jsonBody("{\"ok\":true}");
 driver.browser().throttleNetwork(250, 64, 32);
 driver.browser().blockNetworkResources("*.png", "*.jpg");
 ```
 
 ```java
 SHAFT.Contracts.startRecording("src/test/resources/contracts/checkout.json", "/api/checkout");
-api.post("/api/checkout").setRequestBody(order).perform();
+api.post("/api/checkout").setRequestBody(order);
 SHAFT.Contracts.stopRecording();
 
 SHAFT.Contracts.startAssertMode("src/test/resources/contracts/checkout.json");
-api.post("/api/checkout").setRequestBody(order).perform();
+api.post("/api/checkout").setRequestBody(order);
 SHAFT.Contracts.stopValidation();
 ```
 
 ```java
-api.sendGraphQlRequest("/graphql", "query { viewer { id } }").perform();
+api.sendGraphQlRequest("/graphql", "query { viewer { id } }");
 
 api.get("/health")
-   .withRetry(RetryPolicy.transientFailures().maxAttempts(3))
-   .perform();
+   .withRetry(RetryPolicy.transientFailures().maxAttempts(3));
 
-User user = api.get("/users/1").perform().getResponseAs(User.class);
+var userRequest = api.get("/users/1");
 ```
 
 <table>

--- a/pom.xml
+++ b/pom.xml
@@ -667,7 +667,8 @@
                     <doclint>all,-missing</doclint>
                     <docfilessubdirs>false</docfilessubdirs>
                     <encoding>UTF-8</encoding>
-                    <failOnError>false</failOnError>
+                    <failOnError>true</failOnError>
+                    <failOnWarnings>true</failOnWarnings>
                     <show>public</show>
                     <nohelp>true</nohelp>
                     <noindex>true</noindex>

--- a/scripts/ci/assemble_javadocs.py
+++ b/scripts/ci/assemble_javadocs.py
@@ -14,6 +14,7 @@ MODULES = {
     "shaft-engine": "Core engine",
     "shaft-pilot-core": "SHAFT Pilot contracts and security",
     "shaft-capture": "Deterministic browser capture model",
+    "shaft-capture-proxy": "API capture proxy integration",
     "shaft-doctor": "Offline deterministic failure diagnosis",
     "shaft-ai": "Optional direct AI providers",
     "shaft-heal": "Deterministic explainable element recovery",
@@ -22,7 +23,19 @@ MODULES = {
     "shaft-visual": "Visual processing integration",
     "shaft-sikulix": "SikuliX desktop automation",
     "shaft-mcp": "Model Context Protocol server",
+    "shaft-cli": "SHAFT command-line tools",
+    "report-aggregate": "Aggregated SHAFT test reports",
 }
+
+
+def reactor_java_modules(root: Path = ROOT) -> list[str]:
+    """Return reactor modules that contain production Java sources."""
+    modules = ET.parse(root / "pom.xml").getroot().findall("m:modules/m:module", namespaces=NS)
+    return [
+        module.text.strip()
+        for module in modules
+        if module.text and list((root / module.text.strip() / "src" / "main" / "java").rglob("*.java"))
+    ]
 
 
 def project_version(root: Path = ROOT) -> str:

--- a/scripts/ci/assemble_javadocs.py
+++ b/scripts/ci/assemble_javadocs.py
@@ -30,7 +30,7 @@ MODULES = {
 
 def reactor_java_modules(root: Path = ROOT) -> list[str]:
     """Return reactor modules that contain production Java sources."""
-    modules = ET.parse(root / "pom.xml").getroot().findall("m:modules/m:module", namespaces=NS)
+    modules = ET.parse(root / "pom.xml").getroot().findall("m:modules/m:module", namespaces=NS)  # nosec B314 - repository-local Maven metadata
     return [
         module.text.strip()
         for module in modules

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/api/ApiTestRenderer.java
@@ -347,7 +347,7 @@ public final class ApiTestRenderer {
         line(source, "        driver.browser().interceptRequest()");
         line(source, "                .urlContains(\"" + escape(relativePath(transaction)) + "\")");
         line(source, "                .assertResponse(v -> {");
-        line(source, "                    v.time().isLessThan(30000L).perform();");
+        line(source, "                    v.time().isLessThan(30000L);");
         renderHybridBodyAssertion(source, artifacts, className, transaction, depth);
         line(source, "                });");
     }
@@ -367,11 +367,11 @@ public final class ApiTestRenderer {
         if (depth == ApiValidationDepth.SCHEMA) {
             String relativePath = "api-capture/" + className + "-" + sanitizeIdentifier(transaction.transactionId()) + "-schema.json";
             artifacts.put(relativePath, JsonSchemaInferencer.infer(transaction.responseBody()));
-            line(source, "                    v.matchesSchema(\"" + escape(relativePath) + "\").perform();");
+            line(source, "                    v.matchesSchema(\"" + escape(relativePath) + "\");");
         } else {
             String relativePath = "api-capture/" + className + "-" + sanitizeIdentifier(transaction.transactionId()) + "-body.json";
             artifacts.put(relativePath, normalizeForGoldenFile(transaction.responseBody(), transaction.responseLeaves()));
-            line(source, "                    v.isEqualToFileContentIgnoringOrder(\"" + escape(relativePath) + "\").perform();");
+            line(source, "                    v.isEqualToFileContentIgnoringOrder(\"" + escape(relativePath) + "\");");
         }
     }
 
@@ -777,8 +777,7 @@ public final class ApiTestRenderer {
         line(source, "        SHAFT.Validations.assertThat()");
         line(source, "                .object(" + apiField + ".getResponseJSONValue(\""
                 + escape(leaf.jsonPath()) + "\"))");
-        line(source, "                .isEqualTo(\"" + escape(leaf.value()) + "\")");
-        line(source, "                .perform();");
+        line(source, "                .isEqualTo(\"" + escape(leaf.value()) + "\");");
     }
 
     private static void renderHeaderAssertions(StringBuilder source, String apiField, ApiTransaction transaction) {
@@ -791,8 +790,7 @@ public final class ApiTestRenderer {
             line(source, "        SHAFT.Validations.assertThat()");
             line(source, "                .object(" + apiField + ".getResponse().getHeader(\""
                     + escape(header.getKey()) + "\"))");
-            line(source, "                .isEqualTo(\"" + escape(header.getValue()) + "\")");
-            line(source, "                .perform();");
+            line(source, "                .isEqualTo(\"" + escape(header.getValue()) + "\");");
         }
     }
 
@@ -804,7 +802,7 @@ public final class ApiTestRenderer {
         }
         String relativePath = "api-capture/" + className + "-" + sanitizeIdentifier(transaction.transactionId()) + "-schema.json";
         artifacts.put(relativePath, JsonSchemaInferencer.infer(transaction.responseBody()));
-        line(source, "        " + apiField + ".assertThatResponse().matchesSchema(\"" + escape(relativePath) + "\").perform();");
+        line(source, "        " + apiField + ".assertThatResponse().matchesSchema(\"" + escape(relativePath) + "\");");
     }
 
     private static void renderFullBodyAssertion(
@@ -816,7 +814,7 @@ public final class ApiTestRenderer {
         String relativePath = "api-capture/" + className + "-" + sanitizeIdentifier(transaction.transactionId()) + "-body.json";
         artifacts.put(relativePath, normalizeForGoldenFile(transaction.responseBody(), leaves));
         line(source, "        " + apiField + ".assertThatResponse().isEqualToFileContentIgnoringOrder(\""
-                + escape(relativePath) + "\").perform();");
+                + escape(relativePath) + "\");");
     }
 
     private static void renderHelperMethods(StringBuilder source) {

--- a/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
@@ -775,8 +775,8 @@ public class SHAFT {
      * <p><b>Usage example:</b>
      * <pre>{@code
      * SHAFT.API api = new SHAFT.API("https://jsonplaceholder.typicode.com");
-     * api.get("/posts/1").setTargetStatusCode(200).perform();
-     * api.assertThatResponse().extractedJsonValue("$.title").isNotNull().perform();
+     * api.get("/posts/1").setTargetStatusCode(200);
+     * api.assertThatResponse().extractedJsonValue("$.title").isNotNull();
      * }</pre>
      *
      * @see RequestBuilder
@@ -1335,11 +1335,11 @@ public class SHAFT {
      * <p><b>Usage example:</b>
      * <pre>{@code
      * SHAFT.Contracts.startRecording("src/test/resources/contracts/checkout.json", "/api/checkout");
-     * api.post("/api/checkout").setRequestBody(order).perform();
+     * api.post("/api/checkout").setRequestBody(order);
      * SHAFT.Contracts.stopRecording();
      *
      * SHAFT.Contracts.startAssertMode("src/test/resources/contracts/checkout.json");
-     * api.post("/api/checkout").setRequestBody(order).perform();
+     * api.post("/api/checkout").setRequestBody(order);
      * SHAFT.Contracts.stopValidation();
      * }</pre>
      */
@@ -1583,8 +1583,8 @@ public class SHAFT {
      *
      * <p><b>Usage example:</b>
      * <pre>{@code
-     * SHAFT.Validations.assertThat().object(actualValue).isEqualTo(expectedValue).perform();
-     * SHAFT.Validations.verifyThat().number(count).isGreaterThan(0).perform();
+     * SHAFT.Validations.assertThat().object(actualValue).isEqualTo(expectedValue);
+     * SHAFT.Validations.verifyThat().number(count).isGreaterThan(0);
      * }</pre>
      */
     public static class Validations {

--- a/shaft-engine/src/main/java/com/shaft/gui/driver/BrowserAssertions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/BrowserAssertions.java
@@ -27,7 +27,7 @@ public interface BrowserAssertions {
 
     /**
      * Asserts that the current page matches its baseline full-page screenshot. Executes immediately,
-     * like every other assertion &mdash; no {@code perform()} is required.
+     * like every other assertion.
      *
      * @return a ValidationsExecutor object to optionally set a custom validation message
      */

--- a/shaft-engine/src/main/java/com/shaft/gui/driver/ElementAssertions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/ElementAssertions.java
@@ -53,7 +53,7 @@ public interface ElementAssertions {
 
     /**
      * Asserts that the element matches its baseline screenshot. Executes immediately, like every other
-     * assertion &mdash; no {@code perform()} is required.
+     * assertion.
      *
      * @return a ValidationsExecutor object to optionally set a custom validation message
      */
@@ -76,7 +76,7 @@ public interface ElementAssertions {
      * Starts an accessible-name-tree regression assertion against the element's baseline aria snapshot.
      *
      * @param snapshotFileName the baseline file name (under the configured aria snapshot folder) to compare against or create
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     default ValidationsExecutor matchesAriaSnapshot(String snapshotFileName) {
         throw new UnsupportedOperationException("matchesAriaSnapshot is not supported by this element assertions implementation.");

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Mobile.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Mobile.java
@@ -71,18 +71,22 @@ public interface Mobile extends EngineProperties<Mobile> {
     @DefaultValue("")
     String bundleId();
 
+    /** Maximum time in seconds to wait for a Flutter element. Zero keeps the default wait behavior. */
     @Key("mobile_flutterElementWaitTimeout")
     @DefaultValue("0")
     int flutterElementWaitTimeout();
 
+    /** Maximum time in seconds to wait for the Flutter driver server to start. */
     @Key("mobile_flutterServerLaunchTimeout")
     @DefaultValue("0")
     int flutterServerLaunchTimeout();
 
+    /** Local system port used by the Flutter driver; zero lets the driver choose. */
     @Key("mobile_flutterSystemPort")
     @DefaultValue("0")
     int flutterSystemPort();
 
+    /** Whether Flutter tests use a mocked camera instead of the device camera. */
     @Key("mobile_flutterEnableMockCamera")
     @DefaultValue("false")
     boolean flutterEnableMockCamera();

--- a/shaft-engine/src/main/java/com/shaft/validation/Validations.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/Validations.java
@@ -11,8 +11,8 @@ import com.shaft.validation.internal.ValidationsBuilder;
  *
  * <p><b>Usage example:</b>
  * <pre>{@code
- * Validations.assertThat().object(actual).isEqualTo(expected).perform();
- * Validations.verifyThat().number(count).isGreaterThan(0).perform();
+ * Validations.assertThat().object(actual).isEqualTo(expected);
+ * Validations.verifyThat().number(count).isGreaterThan(0);
  * }</pre>
  *
  * @see com.shaft.driver.SHAFT.Validations

--- a/shaft-engine/src/main/java/com/shaft/validation/VisualComparisonOptions.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/VisualComparisonOptions.java
@@ -12,9 +12,8 @@ import java.util.List;
  * {@code toHaveScreenshot()} options.
  *
  * <p>Build with {@link #create()} and the fluent setters, then pass the result to
- * {@code assertThat(...).matchesScreenshot(options)}. Like every other SHAFT assertion,
- * {@code matchesScreenshot(...)} executes immediately &mdash; no trailing {@code perform()} is
- * required.</p>
+ * {@code assertThat(...).matchesScreenshot(options)}. The comparison runs when the terminal
+ * assertion is called.</p>
  *
  * <pre>{@code
  * driver.element().assertThat(By.id("logo"))

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/FileValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/FileValidationsBuilder.java
@@ -21,7 +21,7 @@ public class FileValidationsBuilder {
     /**
      * Use this to check if a certain file exists
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor exists() {
         this.validationMethod = "fileExists";
@@ -35,7 +35,7 @@ public class FileValidationsBuilder {
     /**
      * Use this to check if a certain file does not exist
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotExist() {
         this.validationMethod = "fileExists";

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/JSONValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/JSONValidationsBuilder.java
@@ -12,7 +12,7 @@ public class JSONValidationsBuilder extends NativeValidationsBuilder {
      * Use this to check that the actual json response is equal to the expected json value (ignoring ordering)
      *
      * @param expectedValue the test data / expected value for the object under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor equalsIgnoringOrder(Object expectedValue) {
         this.expectedValue = expectedValue;
@@ -29,7 +29,7 @@ public class JSONValidationsBuilder extends NativeValidationsBuilder {
      * Use this to check that the actual json response is not equal to the expected json value (ignoring ordering)
      *
      * @param expectedValue the test data / expected value for the object under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotEqualIgnoringOrder(Object expectedValue) {
         this.expectedValue = expectedValue;

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/NativeValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/NativeValidationsBuilder.java
@@ -84,7 +84,7 @@ public class NativeValidationsBuilder {
      * Use this to check that the actual object is equal to the expected value
      *
      * @param expectedValue the test data / expected value for the object under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isEqualTo(Object expectedValue) {
         this.expectedValue = expectedValue;
@@ -97,7 +97,7 @@ public class NativeValidationsBuilder {
     }
 
     /**
-     * Overrides the default object method equals and is the same as calling isEqualTo(expectedValue).perform();
+     * Overrides the default object method equals and runs the equivalent object comparison.
      *
      * @param expectedValue the test data / expected value for the object under test
      * @return boolean value true if passed and throws AssertionError if failed (return value can be safely ignored)
@@ -113,7 +113,7 @@ public class NativeValidationsBuilder {
      * Use this to check that the actual object is not equal to the expected value
      *
      * @param expectedValue the test data / expected value for the object under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotEqual(Object expectedValue) {
         this.expectedValue = expectedValue;
@@ -129,7 +129,7 @@ public class NativeValidationsBuilder {
      * Use this to check that the actual object contains the expected value
      *
      * @param expectedValue the test data / expected value for the object under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor contains(Object expectedValue) {
         this.expectedValue = expectedValue;
@@ -145,7 +145,7 @@ public class NativeValidationsBuilder {
      * Use this to check that the actual object does not contain the expected value
      *
      * @param expectedValue the test data / expected value for the object under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotContain(Object expectedValue) {
         this.expectedValue = expectedValue;
@@ -161,7 +161,7 @@ public class NativeValidationsBuilder {
      * Use this to check that the actual object matches the expected regular expression
      *
      * @param expectedValue the test data / expected regular expression for the object under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor matchesRegex(Object expectedValue) {
         this.expectedValue = expectedValue;
@@ -177,7 +177,7 @@ public class NativeValidationsBuilder {
      * Use this to check that the actual object does not match the expected regular expression
      *
      * @param expectedValue the test data / expected regular expression for the object under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotMatchRegex(Object expectedValue) {
         this.expectedValue = expectedValue;
@@ -193,7 +193,7 @@ public class NativeValidationsBuilder {
      * Use this to check that the actual object is equal to the expected value (ignoring case sensitivity)
      *
      * @param expectedValue the test data / expected value for the object under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor equalsIgnoringCaseSensitivity(Object expectedValue) {
         this.expectedValue = expectedValue;
@@ -209,7 +209,7 @@ public class NativeValidationsBuilder {
      * Use this to check that the actual object is not equal to the expected value (ignoring case sensitivity)
      *
      * @param expectedValue the test data / expected value for the object under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotEqualIgnoringCaseSensitivity(Object expectedValue) {
         this.expectedValue = expectedValue;
@@ -224,7 +224,7 @@ public class NativeValidationsBuilder {
     /**
      * Use this to check that the actual object is null
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isNull() {
         this.expectedValue = null;
@@ -239,7 +239,7 @@ public class NativeValidationsBuilder {
     /**
      * Use this to check that the actual object is not null
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isNotNull() {
         this.expectedValue = null;
@@ -254,7 +254,7 @@ public class NativeValidationsBuilder {
     /**
      * Use this to check that the actual object is true
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isTrue() {
         this.expectedValue = true;
@@ -269,7 +269,7 @@ public class NativeValidationsBuilder {
     /**
      * Use this to check that the actual object is false
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isFalse() {
         this.expectedValue = false;
@@ -336,7 +336,7 @@ public class NativeValidationsBuilder {
     /**
      * Convenience method that validates Arabic text characters and RTL direction.
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      * @throws IllegalStateException if called outside text-based assertions
      */
     public ValidationsExecutor isArabic() {

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/NumberValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/NumberValidationsBuilder.java
@@ -34,7 +34,7 @@ public class NumberValidationsBuilder {
      * Use this to check that the actual number is equal to the expected value
      *
      * @param expectedValue the test data / expected value for the number under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isEqualTo(Number expectedValue) {
         this.expectedValue = expectedValue;
@@ -47,7 +47,7 @@ public class NumberValidationsBuilder {
     }
 
     /**
-     * Overrides the default object method equals and is the same as calling isEqualTo((Number) expectedValue).perform();
+     * Overrides the default object method equals and runs the equivalent numeric comparison.
      *
      * @param expectedValue the test data / expected value for the number under test
      * @return boolean value true if passed and throws AssertionError if failed (return value can be safely ignored)
@@ -63,7 +63,7 @@ public class NumberValidationsBuilder {
      * Use this to check that the actual number does not equal the expected value
      *
      * @param expectedValue the test data / expected value for the number under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotEqual(Number expectedValue) {
         this.expectedValue = expectedValue;
@@ -79,7 +79,7 @@ public class NumberValidationsBuilder {
      * Use this to check that the actual number is greater than or equal to the expected value
      *
      * @param expectedValue the test data / expected value for the number under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isGreaterThanOrEquals(Number expectedValue) {
         this.expectedValue = expectedValue;
@@ -95,7 +95,7 @@ public class NumberValidationsBuilder {
      * Use this to check that the actual number is greater than the expected value
      *
      * @param expectedValue the test data / expected value for the number under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isGreaterThan(Number expectedValue) {
         this.expectedValue = expectedValue;
@@ -111,7 +111,7 @@ public class NumberValidationsBuilder {
      * Use this to check that the actual number is less than or equal to the expected value
      *
      * @param expectedValue the test data / expected value for the number under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isLessThanOrEquals(Number expectedValue) {
         this.expectedValue = expectedValue;
@@ -127,7 +127,7 @@ public class NumberValidationsBuilder {
      * Use this to check that the actual number is less than the expected value
      *
      * @param expectedValue the test data / expected value for the number under test
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isLessThan(Number expectedValue) {
         this.expectedValue = expectedValue;

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/RestValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/RestValidationsBuilder.java
@@ -28,7 +28,7 @@ public class RestValidationsBuilder {
      * Use this to check if the content of the provided actual response object is equal to the expected file content
      *
      * @param fileRelativePath relative path to the target expected response file
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isEqualToFileContent(String fileRelativePath) {
         fileRelativePath = JavaHelper.appendTestDataToRelativePath(fileRelativePath);
@@ -46,7 +46,7 @@ public class RestValidationsBuilder {
      * Use this to check if the content of the provided actual response object is equal to the expected file content (Ignoring Order)
      *
      * @param fileRelativePath relative path to the target expected response file
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor isEqualToFileContentIgnoringOrder(String fileRelativePath) {
         fileRelativePath = JavaHelper.appendTestDataToRelativePath(fileRelativePath);
@@ -64,7 +64,7 @@ public class RestValidationsBuilder {
      * Use this to check if the content of the provided actual response object is not equal to the expected file content
      *
      * @param fileRelativePath relative path to the target expected response file
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotEqualFileContent(String fileRelativePath) {
         fileRelativePath = JavaHelper.appendTestDataToRelativePath(fileRelativePath);
@@ -82,7 +82,7 @@ public class RestValidationsBuilder {
      * Use this to check if the content of the provided actual response object is not equal to the expected file content (Ignoring Order)
      *
      * @param fileRelativePath relative path to the target expected response file
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotEqualFileContentIgnoringOrder(String fileRelativePath) {
         fileRelativePath = JavaHelper.appendTestDataToRelativePath(fileRelativePath);
@@ -100,7 +100,7 @@ public class RestValidationsBuilder {
      * Use this to check if the content of the provided actual response object contains the expected file content
      *
      * @param fileRelativePath relative path to the target expected response file
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor containsFileContent(String fileRelativePath) {
         fileRelativePath = JavaHelper.appendTestDataToRelativePath(fileRelativePath);
@@ -118,7 +118,7 @@ public class RestValidationsBuilder {
      * Use this to check if the content of the provided actual response object does not contain the expected file content
      *
      * @param fileRelativePath relative path to the target expected response file
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotContainFileContent(String fileRelativePath) {
         fileRelativePath = JavaHelper.appendTestDataToRelativePath(fileRelativePath);
@@ -180,7 +180,7 @@ public class RestValidationsBuilder {
      * Use this to check if the content of the provided actual response object matches the schema for the expected file content
      *
      * @param fileRelativePath relative path to the target expected response file
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor matchesSchema(String fileRelativePath) {
         fileRelativePath = JavaHelper.appendTestDataToRelativePath(fileRelativePath);
@@ -198,7 +198,7 @@ public class RestValidationsBuilder {
      * Use this to check if the content of the provided actual response object matches the schema for the expected file content
      *
      * @param fileRelativePath relative path to the target expected response file
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor doesNotMatchSchema(String fileRelativePath) {
         fileRelativePath = JavaHelper.appendTestDataToRelativePath(fileRelativePath);

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/TextDirectionValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/TextDirectionValidationsBuilder.java
@@ -21,7 +21,7 @@ public class TextDirectionValidationsBuilder {
      * Validates that text direction metadata equals the target direction.
      *
      * @param direction expected direction (LTR/RTL)
-     * @return validations executor for optional custom message and perform
+     * @return validations executor retained for source compatibility
      */
     public ValidationsExecutor is(ValidationEnums.TextDirection direction) {
         return nativeValidationsBuilder.isEqualTo(direction.getValue());
@@ -31,7 +31,7 @@ public class TextDirectionValidationsBuilder {
      * Validates that text direction metadata is not equal to the target direction.
      *
      * @param direction unexpected direction (LTR/RTL)
-     * @return validations executor for optional custom message and perform
+     * @return validations executor retained for source compatibility
      */
     public ValidationsExecutor isNot(ValidationEnums.TextDirection direction) {
         return nativeValidationsBuilder.doesNotEqual(direction.getValue());
@@ -40,7 +40,7 @@ public class TextDirectionValidationsBuilder {
     /**
      * Convenience alias for asserting left-to-right direction.
      *
-     * @return validations executor for optional custom message and perform
+     * @return validations executor retained for source compatibility
      */
     public ValidationsExecutor isLeftToRight() {
         return is(ValidationEnums.TextDirection.LTR);
@@ -49,7 +49,7 @@ public class TextDirectionValidationsBuilder {
     /**
      * Convenience alias for asserting right-to-left direction.
      *
-     * @return validations executor for optional custom message and perform
+     * @return validations executor retained for source compatibility
      */
     public ValidationsExecutor isRightToLeft() {
         return is(ValidationEnums.TextDirection.RTL);

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/TextLanguageValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/TextLanguageValidationsBuilder.java
@@ -23,7 +23,7 @@ public class TextLanguageValidationsBuilder {
      * Validates that the target text contains characters from the selected language preset.
      *
      * @param language expected language preset
-     * @return validations executor for optional custom message and perform
+     * @return validations executor retained for source compatibility
      */
     public ValidationsExecutor is(ValidationEnums.TextLanguage language) {
         return nativeValidationsBuilder.matchesRegex(language.getDetectionRegex());
@@ -33,7 +33,7 @@ public class TextLanguageValidationsBuilder {
      * Validates that the target text does not contain characters from the selected language preset.
      *
      * @param language unexpected language preset
-     * @return validations executor for optional custom message and perform
+     * @return validations executor retained for source compatibility
      */
     public ValidationsExecutor isNot(ValidationEnums.TextLanguage language) {
         return nativeValidationsBuilder.doesNotMatchRegex(language.getDetectionRegex());
@@ -43,7 +43,7 @@ public class TextLanguageValidationsBuilder {
      * Validates that the target text matches a supported language code.
      *
      * @param languageCode two-letter language code (e.g., ar, en, es, fr, de)
-     * @return validations executor for optional custom message and perform
+     * @return validations executor retained for source compatibility
      * @throws IllegalArgumentException when the language code is unsupported
      */
     public ValidationsExecutor is(String languageCode) {
@@ -54,7 +54,7 @@ public class TextLanguageValidationsBuilder {
      * Validates that the target text does not match a supported language code.
      *
      * @param languageCode two-letter language code (e.g., ar, en, es, fr, de)
-     * @return validations executor for optional custom message and perform
+     * @return validations executor retained for source compatibility
      * @throws IllegalArgumentException when the language code is unsupported
      */
     public ValidationsExecutor isNot(String languageCode) {

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsBuilder.java
@@ -84,7 +84,7 @@ public class ValidationsBuilder {
     /**
      * Force fails the current validation
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor forceFail() {
         return forceFail("Force fail.");

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/ValidationsExecutor.java
@@ -148,7 +148,7 @@ public class ValidationsExecutor {
      * Set a customized business-readable message that will appear in the execution report instead of the technical log message which will be nested under it
      *
      * @param customReportMessage the message that you would like to describe this validation in the execution report
-     * @return the current ValidationsExecutor object so that you can call the "perform()" method and execute this validation
+     * @return the current executor for source compatibility with legacy validation chains
      */
     public ValidationsExecutor withCustomReportMessage(String customReportMessage) {
         this.customReportMessage = customReportMessage;

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/VisualValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/VisualValidationsBuilder.java
@@ -12,9 +12,8 @@ import java.util.List;
 /**
  * Fluent options builder for the {@code matchesScreenshot()} visual-regression assertion.
  *
- * <p>Unlike most SHAFT validation builders (which execute immediately on their terminal call),
- * this builder gathers optional diff-budget/mask options before {@link #perform()} triggers the
- * comparison, mirroring Playwright's {@code toHaveScreenshot()} options.</p>
+ * <p>This builder gathers optional diff-budget and mask options before the visual comparison
+ * runs, mirroring Playwright's {@code toHaveScreenshot()} options.</p>
  */
 @SuppressWarnings("unused")
 public class VisualValidationsBuilder {
@@ -95,7 +94,7 @@ public class VisualValidationsBuilder {
      * Executes the visual-regression comparison (or saves a new baseline on first run / when
      * {@code -Dshaft.updateSnapshots=true} is set).
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     public ValidationsExecutor perform() {
         var executor = new ValidationsExecutor(this);

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverBrowserValidationsBuilder.java
@@ -88,8 +88,8 @@ public class WebDriverBrowserValidationsBuilder implements com.shaft.gui.driver.
     /**
      * Use this to check that the current page matches its visual-regression baseline screenshot
      * (full-page pixel diff via OpenCV). On the first test run this method takes a full-page screenshot
-     * and the test passes, saving it as the baseline for subsequent runs. The comparison executes
-     * immediately &mdash; no {@code perform()} is required.
+     * and the test passes, saving it as the baseline for subsequent runs. The comparison runs
+     * when this terminal assertion is called.
      *
      * @return a ValidationsExecutor object to optionally set a custom validation message
      */

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java
@@ -30,7 +30,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
     /**
      * Use this to check that the target element exists
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     @Override
     public ValidationsExecutor exists() {
@@ -45,7 +45,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
     /**
      * Use this to check that the target element does not exist
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     @Override
     public ValidationsExecutor doesNotExist() {
@@ -62,7 +62,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
      * On the first test run this method will take a screenshot of the target element and the test will pass, and on following runs the element will be compared against that reference image.
      * The reference images are stored under src/test/resources/DynamicObjectRepository for later maintenance
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     @Override
     public ValidationsExecutor matchesReferenceImage() {
@@ -79,7 +79,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
      * Use this to check that the target element matches a reference image.
      *
      * @param visualValidationEngine the selected visualValidationEngine that will be used to perform the image comparison
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     @Override
     public ValidationsExecutor matchesReferenceImage(ValidationEnums.VisualValidationEngine visualValidationEngine) {
@@ -97,7 +97,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
      * On the first test run this method will take a screenshot of the target element and the test will pass, and on following runs the element will be compared against that reference image.
      * The reference images are stored under src/test/resources/DynamicObjectRepository for later maintenance
      *
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     @Override
     public ValidationsExecutor doesNotMatchReferenceImage() {
@@ -114,7 +114,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
      * Use this to check that the target element does not match a reference image.
      *
      * @param visualValidationEngine the selected visualValidationEngine that will be used to perform the image comparison
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     @Override
     public ValidationsExecutor doesNotMatchReferenceImage(ValidationEnums.VisualValidationEngine visualValidationEngine) {
@@ -132,7 +132,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
      * (pixel diff via OpenCV). On the first test run this method takes a screenshot of the target
      * element and the test passes, saving it as the baseline for subsequent runs. Baselines are stored
      * alongside the other visual baselines under the configured {@code dynamicObjectRepositoryPath}.
-     * The comparison executes immediately &mdash; no {@code perform()} is required.
+     * The comparison runs when this terminal assertion is called.
      *
      * @return a ValidationsExecutor object to optionally set a custom validation message
      */
@@ -164,7 +164,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
      * under the configured {@code ariaSnapshotFolderPath}.
      *
      * @param snapshotFileName the baseline file name (without extension) to compare against or create
-     * @return a ValidationsExecutor object to set your custom validation message (if needed) and then perform() your validation
+     * @return a ValidationsExecutor object retained for source compatibility
      */
     @Override
     public ValidationsExecutor matchesAriaSnapshot(String snapshotFileName) {

--- a/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/src/test/java/testPackage/TestClass.java
+++ b/shaft-engine/src/main/resources/examples/JUnit/shaft-junit-api/src/test/java/testPackage/TestClass.java
@@ -19,8 +19,7 @@ public class TestClass {
     @Test
     void getCountryInfoUsingCapitalName() {
         driver.get("capital/{capital}".replace("{capital}", "Cairo"))
-                .perform()
-                .assertThatResponse().extractedJsonValue("[0].name.common").isEqualTo(testData.get("expectedCountryName")).perform();
+                .assertThatResponse().extractedJsonValue("[0].name.common").isEqualTo(testData.get("expectedCountryName"));
     }
 
     @BeforeEach

--- a/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/src/test/java/testPackage/TestClass.java
+++ b/shaft-engine/src/main/resources/examples/TestNG/shaft-testng-api/src/test/java/testPackage/TestClass.java
@@ -14,8 +14,7 @@ public class TestClass {
     @Test
     public void getCountryInfoUsingCapitalName() {
         driver.get("capital/{capital}".replace("{capital}", "Cairo"))
-                .perform()
-                .assertThatResponse().extractedJsonValue("[0].name.common").isEqualTo(testData.get("expectedCountryName")).perform();
+                .assertThatResponse().extractedJsonValue("[0].name.common").isEqualTo(testData.get("expectedCountryName"));
     }
 
     @BeforeClass

--- a/shaft-skills/shaft-api-testing/references/playbook.md
+++ b/shaft-skills/shaft-api-testing/references/playbook.md
@@ -15,7 +15,8 @@
 
 ## Valid examples
 
-- Execute `api.get("/posts/1").setTargetStatusCode(200).perform()` and assert stable response fields with `api.assertThatResponse()`.
+- Execute the request, then assert the response: `api.get("/posts/1").setTargetStatusCode(200);` followed by `api.assertThatResponse().extractedJsonValue("$.id").isNotNull();`.
+- After the request completes, assert stable response fields with `api.assertThatResponse().extractedJsonValue("$.id").isNotNull()`.
 - Test a create/read/delete workflow with unique data and guaranteed deletion in cleanup.
 - Verify an unauthorized request returns the specified status and safe error shape without logging the credential.
 - Validate an eventually consistent job with bounded polling for the documented terminal state.

--- a/shaft-skills/shaft-assertions/references/playbook.md
+++ b/shaft-skills/shaft-assertions/references/playbook.md
@@ -6,7 +6,7 @@
 2. Assert the smallest stable observable state that proves the behavior, close to the action that produced it. [`ISTQB-CTFL`, `SELENIUM-PRACTICES`]
 3. Use `assertThat()` for a blocking invariant and `verifyThat()` only when continued execution intentionally collects useful independent evidence. [`SHAFT-GUIDE`]
 4. Select the typed SHAFT surface that owns the actual value: browser, element, API response, object, number, file, or image. [`SHAFT-GUIDE`]
-5. Complete the selected validation builder with `.perform()` when required; builder construction alone provides no verdict. [`SHAFT-GUIDE`]
+5. Terminal validation methods execute immediately and return an executor only for optional report-message customization; creating a builder alone provides no verdict. [`SHAFT-GUIDE`]
 6. Compare exact values only when exactness is contractual; otherwise use contains, regex, range, presence, state, or schema assertions that express the real tolerance. [`ISTQB-CTFL`]
 7. Keep expected and actual orientation clear, normalize only contractually irrelevant variation, and never weaken an assertion to make a flaky result green. [`ISTQB-CTFL`, `ALLURE-STABILITY`]
 8. Add a concise custom report message when domain intent would otherwise be unclear, naming expected behavior and relevant identity without secrets. [`SHAFT-REPORTING`]
@@ -15,10 +15,10 @@
 
 ## Valid examples
 
-- Assert `driver.assertThat().browser().url().contains("/dashboard").perform()` after successful sign-in.
-- Assert `driver.element().assertThat(status).text().isEqualTo("Paid").perform()` after payment capture.
-- Assert `api.assertThatResponse().extractedJsonValue("id").isEqualTo(expectedId).perform()` for a service contract.
-- Use `SHAFT.Validations.verifyThat().object(warning).contains("deprecated").perform()` only when later independent checks remain valuable.
+- Assert `driver.assertThat().browser().url().contains("/dashboard")` after successful sign-in.
+- Assert `driver.element().assertThat(status).text().isEqualTo("Paid")` after payment capture.
+- Assert `api.assertThatResponse().extractedJsonValue("$.id").isEqualTo(expectedId)` for a service contract.
+- Use `SHAFT.Validations.verifyThat().object(warning).contains("deprecated")` only when later independent checks remain valuable.
 
 ## Boundary
 

--- a/shaft-skills/shaft-fluent-api/SKILL.md
+++ b/shaft-skills/shaft-fluent-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shaft-fluent-api
-description: Use when composing, reviewing, or repairing SHAFT fluent browser, element, touch, assertion, verification, report-message, and perform chains.
+description: Use when composing, reviewing, or repairing SHAFT fluent browser, element, touch, assertion, verification, and report-message chains.
 ---
 
 # SHAFT Fluent API

--- a/shaft-skills/shaft-fluent-api/references/playbook.md
+++ b/shaft-skills/shaft-fluent-api/references/playbook.md
@@ -7,7 +7,7 @@
 3. Use `.and()` only to move through supported SHAFT fluent contexts; do not invent transitions because they read naturally. [`SHAFT-GUIDE`]
 4. Keep a chain in one coherent user action or oracle; split it when intermediate values, branches, recovery, or diagnostics matter. [`ISTQB-CTFL`]
 5. Preserve ordered side effects and stop after the first state-changing failure rather than masking it with later steps. [`ISTQB-CTFL`, `SHAFT-REPORTING`]
-6. End validation builders with `.perform()` when the selected API requires execution; an unfinished builder is not an assertion. [`SHAFT-GUIDE`]
+6. End validation chains with a terminal assertion method; SHAFT evaluates that method immediately, while an unfinished builder is not an assertion. [`SHAFT-GUIDE`]
 7. Choose `assertThat()` for a blocking invariant and `verifyThat()` only when collecting further evidence after a noncritical mismatch is intentional. [`SHAFT-GUIDE`, `ISTQB-CTFL`]
 8. Attach `withCustomReportMessage(...)` to the smallest meaningful action or validation, using domain intent rather than restating syntax. [`SHAFT-REPORTING`]
 9. Do not mix raw Selenium/Appium/REST-assured calls or third-party assertions into a SHAFT chain. [`SHAFT-GUIDE`, `SELENIUM-PRACTICES`]
@@ -15,9 +15,9 @@
 
 ## Valid examples
 
-- Chain navigation to an element visibility assertion with `driver.browser().navigateToURL(url).and().element().assertThat(title).isVisible().perform()`.
+- Navigate with `driver.browser().navigateToURL(url)`, then assert visibility with `driver.element().assertThat(title).isVisible()`.
 - Chain form actions through `driver.element().type(email, user).and().type(password, pass).and().click(submit)`.
-- Replace an unfinished browser assertion builder with `driver.assertThat().browser().url().contains("/dashboard").perform()`.
+- Replace an unfinished browser assertion builder with `driver.assertThat().browser().url().contains("/dashboard")`.
 
 ## Boundary
 

--- a/tests/scripts/test_assemble_javadocs.py
+++ b/tests/scripts/test_assemble_javadocs.py
@@ -2,10 +2,15 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.ci.assemble_javadocs import MODULES, assemble_javadocs
+from scripts.ci.assemble_javadocs import MODULES, assemble_javadocs, reactor_java_modules
 
 
 class AssembleJavadocsTest(unittest.TestCase):
+    def test_module_inventory_covers_every_java_bearing_reactor_module(self):
+        root = Path(__file__).resolve().parents[2]
+
+        self.assertEqual(set(MODULES), set(reactor_java_modules(root)))
+
     def test_assembles_all_module_sites_with_navigation(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tools/modularization/consumer-fixtures/junit-web/src/test/java/fixture/JUnitWebConsumer.java
+++ b/tools/modularization/consumer-fixtures/junit-web/src/test/java/fixture/JUnitWebConsumer.java
@@ -18,18 +18,18 @@ class JUnitWebConsumer {
     @Test
     void shaftAssertionPassesInJunitConsumerProject() {
         Assertions.assertDoesNotThrow(
-                () -> SHAFT.Validations.assertThat().object("SHAFT").isEqualTo("SHAFT").perform());
+                () -> SHAFT.Validations.assertThat().object("SHAFT").isEqualTo("SHAFT"));
     }
 
     @Test
     void expectedShaftAssertionFailureIsAssertionErrorInJunitConsumerProject() {
         Assertions.assertThrows(AssertionError.class,
-                () -> SHAFT.Validations.assertThat().object("actual").isEqualTo("expected").perform());
+                () -> SHAFT.Validations.assertThat().object("actual").isEqualTo("expected"));
     }
 
     @Test
     void softVerificationFailureIsAvailableToJunitExtensionPath() {
-        SHAFT.Validations.verifyThat().object("actual").isEqualTo("expected").perform();
+        SHAFT.Validations.verifyThat().object("actual").isEqualTo("expected");
 
         Assertions.assertNotNull(ValidationsHelper.getVerificationErrorToForceFail());
         ValidationsHelper.resetVerificationStateAfterFailing();

--- a/tools/modularization/consumer-fixtures/testng-web/src/test/java/fixture/TestNgWebConsumer.java
+++ b/tools/modularization/consumer-fixtures/testng-web/src/test/java/fixture/TestNgWebConsumer.java
@@ -15,18 +15,18 @@ import java.util.ServiceLoader;
 public class TestNgWebConsumer {
     @Test
     public void shaftAssertionPassesInTestNgConsumerProject() {
-        SHAFT.Validations.assertThat().object("SHAFT").isEqualTo("SHAFT").perform();
+        SHAFT.Validations.assertThat().object("SHAFT").isEqualTo("SHAFT");
     }
 
     @Test
     public void expectedShaftAssertionFailureIsAssertionErrorInTestNgConsumerProject() {
         Assert.expectThrows(AssertionError.class,
-                () -> SHAFT.Validations.assertThat().object("actual").isEqualTo("expected").perform());
+                () -> SHAFT.Validations.assertThat().object("actual").isEqualTo("expected"));
     }
 
     @Test
     public void softVerificationFailureIsAvailableToTestNgListenerPath() {
-        SHAFT.Validations.verifyThat().object("actual").isEqualTo("expected").perform();
+        SHAFT.Validations.verifyThat().object("actual").isEqualTo("expected");
 
         Assert.assertNotNull(ValidationsHelper.getVerificationErrorToForceFail());
         ValidationsHelper.resetVerificationStateAfterFailing();


### PR DESCRIPTION
## Summary

- Align public API Javadocs, examples, validation builders, and the generated feature catalog with current engine behavior.
- Make the Javadocs build fail on warnings and errors, and cover every Java-bearing reactor module in the assembled Javadocs site.
- Add missing mobile property documentation and update SHAFT skills and source examples to match the user guide.
- Preserve the runtime request execution method for backwards compatibility while removing its legacy suffix from visible documentation and examples.

## Validation

- `mvn --batch-mode -Dmaven.javadoc.failOnError=true -Dmaven.javadoc.failOnWarnings=true -Ddoclint=all -Dallure.automaticallyOpen=false javadoc:jar`
- `py -3 scripts/ci/assemble_javadocs.py`
- `py -3 -m unittest tests.scripts.test_assemble_javadocs -v`
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`

This is the source companion to the SHAFT user-guide PR.