### PR TITLE
Fix #4417: recognize explicit Maven exec goals

### DIFF
--- a/tests/scripts/test_browserstack_module_boundary.py
+++ b/tests/scripts/test_browserstack_module_boundary.py
@@ -1,4 +1,5 @@
 import json
+import re
 import unittest
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -68,7 +69,9 @@ class BrowserStackModuleBoundaryTest(unittest.TestCase):
 
         self.assertTrue(commands)
         for command in commands:
-            if "exec:java" in command:
+            if "exec:java" in command or re.search(
+                r"exec-maven-plugin:[^ ]+:java(?:\s|$)", command
+            ):
                 self.assertIn("-f shaft-engine/pom.xml", command)
                 self.assertNotIn("shaft-browserstack", command)
                 continue


### PR DESCRIPTION
## Summary
- Update the BrowserStack module-boundary test to recognize fully qualified exec-maven-plugin Java goals used by Playwright installation steps.
- Preserve the existing module and BrowserStack dependency assertions for all other workflow Maven commands.

Closes #4417

## Test plan
- py -3 -m unittest tests.scripts.test_browserstack_module_boundary.BrowserStackModuleBoundaryTest.test_workflows_resolve_sdk_only_for_browserstack_jobs -v
- py -3 -m unittest tests.scripts.test_browserstack_module_boundary -v
- py -3 -m unittest discover -s tests/scripts -p 'test_*.py'
- git diff --check
