### PR TITLE
Fix Codex Assistant runs in non-git workspaces

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -1142,6 +1142,7 @@ final class AssistantLocalAgentRunner {
      */
     private static List<String> codexCommand(String mode, boolean allowSourceMutation, String model, String effort) {
         List<String> command = new ArrayList<>(List.of("codex", "exec"));
+        command.add("--skip-git-repo-check");
         if (!model.isBlank()) {
             command.add("--model");
             command.add(model);

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantModelCatalog.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantModelCatalog.java
@@ -24,7 +24,8 @@ final class AssistantModelCatalog {
      * Returns the suggested models for a cloud provider selected in the Assistant chat view.
      *
      * @param provider cloud provider identifier: gemini, openai, anthropic, or github
-     * @return non-empty model list, most capable defaults first
+     * @return fallback model list; Codex deliberately falls back to its CLI default because
+     * account entitlements are not discoverable when the CLI cannot list models
      */
     static List<String> cloudModels(String provider) {
         return switch (normalizeLower(provider)) {
@@ -46,7 +47,7 @@ final class AssistantModelCatalog {
         return switch (normalizeUpper(family)) {
             case "CLAUDE" -> CLAUDE_MODELS;
             case "COPILOT" -> List.of("gpt-5.2", "claude-sonnet-5", "gemini-3.5-pro");
-            default -> List.of("gpt-5.2-codex", "gpt-5.2", "gpt-5.1-codex-mini");
+            default -> List.of();
         };
     }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -3431,6 +3431,9 @@ final class ShaftAssistantPanel extends JPanel {
         String previousSelection = localModel.getEditor() == null
                 ? null
                 : String.valueOf(localModel.getEditor().getItem());
+        String selectedModel = previousSelection != null && !previousSelection.isBlank()
+                ? previousSelection
+                : settings.localModel == null ? "" : settings.localModel.trim();
         // The CLI-reported list wins; the curated catalog keeps the selector useful when the CLI
         // cannot list its models (issue #3369).
         localModelListIsFallback = models.isEmpty();
@@ -3442,10 +3445,11 @@ final class ShaftAssistantPanel extends JPanel {
         if (localModel.getEditor().getEditorComponent() instanceof JTextComponent localModelEditor) {
             localModelEditor.setToolTipText(tooltip);
         }
-        if (previousSelection != null && !previousSelection.isBlank()) {
-            localModel.setSelectedItem(previousSelection);
-        } else if (settings.localModel != null && !settings.localModel.isBlank()) {
-            localModel.setSelectedItem(settings.localModel.trim());
+        if (effectiveModels.isEmpty() && "CODEX".equals(family)
+                && "gpt-5.2-codex".equalsIgnoreCase(selectedModel)) {
+            localModel.setSelectedItem("");
+        } else if (!selectedModel.isBlank()) {
+            localModel.setSelectedItem(selectedModel);
         } else if (!effectiveModels.isEmpty()) {
             localModel.setSelectedItem(effectiveModels.get(0));
         }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -512,10 +512,11 @@ class AssistantCommandTest {
         // Deliberate flag change (R3-T1): codex exec now always adds the experimental --json flag,
         // and claude always adds --output-format stream-json --verbose, so the runner receives
         // incremental NDJSON events instead of a single buffered blob. Custom commands are untouched.
-        assertEquals(List.of("codex", "exec", "--sandbox", "read-only", "--json", "-"),
+        assertEquals(List.of("codex", "exec", "--skip-git-repo-check", "--sandbox", "read-only", "--json", "-"),
                 AssistantLocalAgentRunner.commandFor(codexAsk.arguments()));
         assertEquals(List.of(
                 "codex", "exec",
+                "--skip-git-repo-check",
                 "--sandbox", "workspace-write",
                 "-c", "mcp_servers.shaft-mcp.default_tools_approval_mode=\"approve\"",
                 "-c", "mcp_servers.shaft-mcp.tool_timeout_sec=600",
@@ -527,6 +528,7 @@ class AssistantCommandTest {
         // hard-coded unconditionally as it was before.
         assertEquals(List.of(
                 "codex", "exec",
+                "--skip-git-repo-check",
                 "--sandbox", "read-only",
                 "-c", "mcp_servers.shaft-mcp.tool_timeout_sec=600",
                 "--json",
@@ -556,6 +558,7 @@ class AssistantCommandTest {
         assertAll(
                 () -> assertEquals(List.of(
                                 "codex", "exec",
+                                "--skip-git-repo-check",
                                 "--model", "gpt-5.2-codex",
                                 "-c", "model_reasoning_effort=\"high\"",
                                 "--sandbox", "read-only", "--json", "-"),

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerCommandTest.java
@@ -49,6 +49,14 @@ class AssistantLocalAgentRunnerCommandTest {
     }
 
     @Test
+    void codexCommandSupportsNonGitWorkspaces() {
+        List<String> command = AssistantLocalAgentRunner.commandFor(arguments("CODEX", "ASK", false));
+
+        assertTrue(command.contains("--skip-git-repo-check"),
+                "The documented demo workspace is not a git repository: " + command);
+    }
+
+    @Test
     void claudeAgentCommandOnlyUsesAcceptEditsPermissionModeWhenApprovalStoreGrantsIt() {
         List<String> granted = AssistantLocalAgentRunner.commandFor(arguments("CLAUDE_CODE", "AGENT", true));
         List<String> ungranted = AssistantLocalAgentRunner.commandFor(arguments("CLAUDE_CODE", "AGENT", false));

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantModelCatalogTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantModelCatalogTest.java
@@ -26,10 +26,9 @@ class AssistantModelCatalogTest {
     void localCatalogCoversEveryAssistantFamily() {
         assertAll(
                 () -> assertTrue(AssistantModelCatalog.localModels("CLAUDE").contains("claude-sonnet-5")),
-                () -> assertFalse(AssistantModelCatalog.localModels("CODEX").isEmpty()),
+                () -> assertEquals(List.of(), AssistantModelCatalog.localModels("CODEX")),
                 () -> assertFalse(AssistantModelCatalog.localModels("COPILOT").isEmpty()),
-                () -> assertEquals(AssistantModelCatalog.localModels("CODEX"),
-                        AssistantModelCatalog.localModels("unknown-family")));
+                () -> assertEquals(List.of(), AssistantModelCatalog.localModels("unknown-family")));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2124,6 +2124,37 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void assistantClearsPersistedCodexFallbackWhenModelDiscoveryIsEmpty() throws Exception {
+        ShaftSettingsState.Settings settings = blankMcpSettings();
+        settings.localModel = "gpt-5.2-codex";
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, settings);
+
+        applyLocalModels(panel, "CODEX", List.of());
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Explain this failure", selectedRoute(panel), "ASK", ".", "", false);
+
+        assertAll(
+                () -> assertEquals("", settings.localModel),
+                () -> assertFalse(AssistantLocalAgentRunner.commandFor(invocation.arguments()).contains("--model")));
+    }
+
+    @Test
+    void assistantKeepsExplicitCodexModelWhenModelDiscoveryIsEmpty() throws Exception {
+        ShaftSettingsState.Settings settings = blankMcpSettings();
+        settings.localModel = "account-compatible-model";
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, settings);
+
+        applyLocalModels(panel, "CODEX", List.of());
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "Explain this failure", selectedRoute(panel), "ASK", ".", "", false);
+
+        assertAll(
+                () -> assertEquals("account-compatible-model", settings.localModel),
+                () -> assertTrue(AssistantLocalAgentRunner.commandFor(invocation.arguments())
+                        .contains("account-compatible-model")));
+    }
+
+    @Test
     void assistantRefreshLocalModelsButtonIsVisibleForLocalCliAndResetsModelListFamily() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         JButton refresh = findByAccessibleName(panel, "Refresh local agent models", JButton.class);
@@ -8058,6 +8089,12 @@ class ShaftPanelSetupTest {
         Method method = ShaftAssistantPanel.class.getDeclaredMethod("applyLocalModels", String.class, List.class);
         method.setAccessible(true);
         method.invoke(panel, family, models);
+    }
+
+    private static AssistantCommand.Selection selectedRoute(ShaftAssistantPanel panel) throws Exception {
+        Method method = ShaftAssistantPanel.class.getDeclaredMethod("selectedRoute");
+        method.setAccessible(true);
+        return (AssistantCommand.Selection) method.invoke(panel);
     }
 
     private static void setField(Object target, String name, Object value) throws Exception {


### PR DESCRIPTION
Allows the default Codex Assistant command to run in the documented non-git recording workspace and defers model selection to the authenticated Codex CLI when discovery is unavailable. Existing persisted gpt-5.2-codex fallbacks now clear to the CLI default, while explicit account-compatible model entries remain preserved. Focused regressions cover command construction and both persisted-model paths. Closes #4422. Closes #4423. Related to #4299; the remaining live-flow blocker is tracked in #4424. Validation: AssistantCommandTest, AssistantLocalAgentRunnerCommandTest, and persisted-model ShaftPanelSetupTest regressions passed with JDK 21.