### PR TITLE
Fix(harness): detect abandoned worktrees and refuse NUL-corrupted commits

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -88,11 +88,14 @@ jobs:
               - 'scripts/ci/validate_agent_setup.py'
               - 'scripts/ci/validate_agent_guidance.py'
               - 'scripts/ci/validate_skills.py'
+              - 'scripts/ci/worktree_hygiene.py'
               - 'scripts/ci/agent_guidance_budget.json'
               - 'tests/scripts/test_agent_router_contract.py'
               - 'tests/scripts/test_agent_harness_portability.py'
+              - 'tests/scripts/test_guard_nul_corruption.py'
               - 'tests/scripts/test_validate_agent_guidance.py'
               - 'tests/scripts/test_validate_agent_setup.py'
+              - 'tests/scripts/test_worktree_hygiene.py'
               - 'tests/scripts/test_validate_skills.py'
               - 'tests/scripts/test_sync_user_harness.py'
               - 'tests/scripts/test_shaft_skills_content.py'
@@ -188,14 +191,18 @@ jobs:
           python3 -m unittest
           tests.scripts.test_agent_router_contract
           tests.scripts.test_agent_harness_portability
+          tests.scripts.test_guard_nul_corruption
           tests.scripts.test_validate_agent_guidance
           tests.scripts.test_validate_agent_setup
           tests.scripts.test_validate_skills
           tests.scripts.test_sync_user_harness
           tests.scripts.test_shaft_skills_content
+          tests.scripts.test_worktree_hygiene
           -v
       - name: Validate agent guidance budgets and routing
         run: python3 scripts/ci/validate_agent_setup.py --skip-external
+      - name: Run the portable PreToolUse guard self-test
+        run: python3 scripts/agents/guard.py --self-test
 
   # intellij-plugin.yml runs two independent PR jobs today (installer
   # verification across three OSes, and the Gradle plugin build); both are

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -30,6 +30,19 @@
 #      `git worktree add` missing `-c core.longpaths=true`, which otherwise
 #      aborts with `Filename too long` checking out existing over-long
 #      .memory/** paths. Both fail open on anything not confidently parsed.
+#   R10 Deny `git add`/`git stage`/`git commit` when a changed file is almost
+#      entirely NUL bytes (issue #4437). After an unclean shutdown the
+#      filesystem can record an allocation without ever flushing the data
+#      blocks, leaving files of a plausible size filled with zeros -- 652 of
+#      653 files in one worktree, presented by `git status` as ordinary ` M`
+#      entries. Unlike R1-R9 this rule reads repository state, so it needs a
+#      working directory and is dispatched alongside R9 rather than from the
+#      pure `evaluate_command` path. Every uncertain step fails open.
+#      Deliberate limits: it targets WHOLLY zeroed files (>= 95% NUL across
+#      head, middle, and tail), not partial corruption of a large binary; it
+#      cannot resolve a user's `git` aliases, which are invisible in the
+#      command string; and it does not descend into submodules, whose gitlink
+#      is all `git diff` reports.
 #
 # Claude-compatible and Codex use snake_case input and hookSpecificOutput.
 # Grok may supply camelCase fields and uses top-level deny/reason. The
@@ -40,6 +53,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess  # nosec B404 - R10 runs one fixed, read-only git query.
 import sys
 
 # ---------------------------------------------------------------------------
@@ -598,6 +612,295 @@ def check_r9_worktree_add(command: str, tool_name: str) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# R10: refuse to stage or commit NUL-corrupted files
+# ---------------------------------------------------------------------------
+
+_STAGING_SUBCOMMANDS = frozenset({"add", "stage", "commit"})
+
+# A file whose sampled bytes are almost entirely NUL is not content anyone
+# authored. 0.95 (rather than 1.0) keeps a partially-flushed tail in range
+# while staying far above any real format: an archive, image, or class file
+# is never near-uniformly zero across head, middle, and tail.
+_NUL_RATIO_THRESHOLD = 0.95
+# Sample three windows instead of a prefix: a legitimately zero-padded file
+# can open with a long run of NUL and still carry real content later. 8 KiB
+# per window matches git's own binary sniff (the first 8000 bytes) and keeps
+# the worst case -- _NUL_MAX_SCANNED_PATHS files -- to tens of megabytes read.
+_NUL_SAMPLE_WINDOW_BYTES = 8 * 1024
+_NUL_MAX_SCANNED_PATHS = 2000
+_NUL_MAX_REPORTED_PATHS = 5
+# Must leave room, inside the PreToolUse hook timeout the host configs declare
+# (10s in .claude/settings.json and .codex/hooks.json), for two git queries
+# plus the sampling loop -- measured at 0.84s for 700 zeroed files. Exceeding
+# the hook budget would have the host kill the guard mid-query instead of
+# letting this rule fail open.
+_GIT_QUERY_TIMEOUT_SECONDS = 4
+
+
+def nul_byte_ratio(path) -> float | None:
+    """Fraction of NUL bytes in `path`, or None when empty/unreadable.
+
+    Reads at most three windows (head, middle, tail) so a large file costs a
+    bounded number of reads and a zero-padded head cannot masquerade as
+    whole-file corruption.
+    """
+    try:
+        size = os.path.getsize(path)
+        if size <= 0:
+            return None
+        with open(path, "rb") as handle:
+            if size <= 3 * _NUL_SAMPLE_WINDOW_BYTES:
+                sample = handle.read()
+            else:
+                chunks = []
+                for offset in (
+                    0,
+                    (size // 2) - (_NUL_SAMPLE_WINDOW_BYTES // 2),
+                    size - _NUL_SAMPLE_WINDOW_BYTES,
+                ):
+                    handle.seek(offset)
+                    chunks.append(handle.read(_NUL_SAMPLE_WINDOW_BYTES))
+                sample = b"".join(chunks)
+    except OSError:
+        return None
+    if not sample:
+        return None
+    return sample.count(0) / len(sample)
+
+
+class _StagingInvocation:
+    """What a staging command stages, and where."""
+
+    def __init__(self, subcommand: str, directories: list[str], pathspecs: list[str]):
+        self.subcommand = subcommand
+        self.directories = directories  # -C / --work-tree, applied in order
+        self.pathspecs = pathspecs  # empty means "everything"
+
+
+def _normalize_pathspec(value: str) -> str | None:
+    """Reduce a pathspec to a repository-relative posix prefix, or None."""
+    cleaned = value.strip("\"'").replace("\\", "/").strip()
+    while cleaned.startswith("./"):
+        cleaned = cleaned[2:]
+    cleaned = cleaned.rstrip("/")
+    if not cleaned or cleaned in (".", "*") or cleaned.startswith(":"):
+        return None  # "everything", or magic pathspec syntax: do not narrow
+    if "*" in cleaned or "?" in cleaned or "[" in cleaned:
+        return None  # a glob: matching it here would risk a false negative
+    return cleaned
+
+
+_NESTED_COMMAND_RE = re.compile(
+    r"(?:--?[Cc]ommand|-[Cc]|/[Cc])\s+(\"(?:[^\"\\]|\\.)*\"|'(?:[^'\\]|\\.)*')"
+)
+
+
+def _staging_invocation(command: str) -> _StagingInvocation | None:
+    """Describe the first command that really stages content, or None.
+
+    A nested interpreter payload (`bash -c "git add -A"`) is retried as a
+    command of its own only when the outer command stages nothing, so the
+    common case keeps its quoted arguments intact -- unwrapping every quoted
+    string up front would blank a legitimate `--work-tree="<path>"` value.
+    """
+    direct = _staging_invocation_in(command)
+    if direct is not None:
+        return direct
+    for payload in _NESTED_COMMAND_RE.findall(command):
+        nested = _staging_invocation_in(payload[1:-1])
+        if nested is not None:
+            return nested
+    return None
+
+
+def _staging_invocation_in(command: str) -> _StagingInvocation | None:
+    """Describe the first git segment of `command` that stages content.
+
+    Every git segment is examined, not just the first: `git status && git add
+    -A` is an ordinary agent shape, and stopping at the leading read-only
+    segment would wave the commit through.
+    """
+    for segment in _git_segments(command):
+        rest = _tokens_after_head(segment, _GIT_NAMES)
+        if rest is None:
+            continue
+        directories: list[str] = []
+        index = 0
+        subcommand = None
+        while index < len(rest):
+            token = rest[index]
+            if token == "-C" and index + 1 < len(rest):
+                directories.append(rest[index + 1].strip("\"'"))
+                index += 2
+                continue
+            if token == "--work-tree" and index + 1 < len(rest):
+                directories.append(rest[index + 1].strip("\"'"))
+                index += 2
+                continue
+            if token.startswith("--work-tree="):
+                directories.append(token.split("=", 1)[1].strip("\"'"))
+                index += 1
+                continue
+            if token in _GIT_GLOBAL_OPTS_WITH_ARG:
+                index += 2
+                continue
+            if token.startswith("-"):
+                index += 1
+                continue
+            subcommand = token.lower()
+            index += 1
+            break
+        if subcommand not in _STAGING_SUBCOMMANDS:
+            continue
+
+        # `git add <path>` names what it stages, and honouring that lets an
+        # agent rescue healthy files while one corrupt file sits in the tree.
+        # `git commit -m <message>` does NOT: its arguments are message text,
+        # so a commit pathspec is only read after an explicit `--`.
+        pathspecs: list[str] = []
+        narrowable = subcommand in ("add", "stage")
+        after_separator = False
+        while index < len(rest):
+            token = rest[index]
+            index += 1
+            if token == "--":
+                after_separator = True
+                continue
+            if token.startswith("--pathspec-from-file"):
+                pathspecs = []  # the list lives in a file: do not narrow
+                break
+            if token.startswith("-") and not after_separator:
+                continue
+            if not (narrowable or after_separator):
+                continue
+            normalized = _normalize_pathspec(token)
+            if normalized is None:
+                pathspecs = []
+                break
+            pathspecs.append(normalized)
+        return _StagingInvocation(subcommand, directories, pathspecs)
+    return None
+
+
+def _git_paths(cwd: str, *arguments: str) -> list[str] | None:
+    """Run a NUL-delimited, read-only git path query, or None when untrusted.
+
+    Output is decoded with `os.fsdecode` rather than the process locale:
+    `text=True` on a non-UTF-8 host mangles a non-ASCII filename into one that
+    no longer resolves on disk, which silently exempts it from scanning.
+    `core.quotePath=false` stops git octal-escaping the same names.
+    """
+    try:
+        completed = subprocess.run(  # nosec B603 B607 - fixed read-only git query.
+            ["git", "-c", "core.quotePath=false", *arguments],
+            cwd=cwd,
+            capture_output=True,
+            timeout=_GIT_QUERY_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None  # no HEAD, not a repository, or git refused: allow
+    return [os.fsdecode(entry) for entry in completed.stdout.split(b"\0") if entry]
+
+
+def _candidate_paths(cwd: str) -> list[str] | None:
+    """Every path a stage/commit could capture: changed, staged, or untracked.
+
+    `git diff HEAD` spans the index and the working tree in one call, covering
+    `git add`, `git commit`, and `git commit -a`. It cannot see an untracked
+    file, so `git ls-files --others` supplies those -- without them a single
+    `git add -A && git commit` would carry a newly zeroed file straight
+    through. Ignored paths are excluded, so build output is never scanned.
+    """
+    changed = _git_paths(cwd, "diff", "--name-only", "-z", "HEAD")
+    if changed is None:
+        return None
+    untracked = _git_paths(cwd, "ls-files", "--others", "--exclude-standard", "-z") or []
+    seen: dict[str, None] = {}
+    for path in (*changed, *untracked):
+        seen.setdefault(path, None)
+    return list(seen)
+
+
+def scan_for_nul_corruption(
+    cwd: str, pathspecs: list[str] | None = None
+) -> tuple[list[str], int]:
+    """Return (corrupted paths, paths examined) for a working directory.
+
+    Shared with the repository's worktree hygiene report so one definition of
+    "this file is zeroed" serves both the deny guard and the reporting path.
+    Fails open as an empty result whenever git cannot be trusted.
+
+    Every candidate is sampled directly rather than pre-filtered on the diff's
+    line counts: a `diff` attribute in .gitattributes can give a NUL-filled
+    file non-zero insertion/deletion counts, and a pre-filter keyed on those
+    counts would exempt exactly the file it needs to catch.
+    """
+    candidates = _candidate_paths(cwd)
+    if not candidates:
+        return [], 0
+    if pathspecs:
+        candidates = [
+            path
+            for path in candidates
+            if any(path == spec or path.startswith(spec + "/") for spec in pathspecs)
+        ]
+    examined = candidates[:_NUL_MAX_SCANNED_PATHS]
+    corrupt = [
+        path
+        for path in examined
+        # An unreadable file yields None and is treated as healthy: this rule
+        # denies a tool call, so it must never block on what it cannot read.
+        if (nul_byte_ratio(os.path.join(cwd, path)) or 0.0) >= _NUL_RATIO_THRESHOLD
+    ]
+    return corrupt, len(examined)
+
+
+def check_r10_nul_corruption(command: str, cwd: str | None = None) -> str | None:
+    """Return a block reason when staging/committing NUL-corrupted files."""
+    if not cwd:
+        return None
+    invocation = _staging_invocation(command)
+    if invocation is None:
+        return None
+
+    directory = cwd
+    for part in invocation.directories:
+        directory = os.path.join(directory, part)
+
+    corrupt, examined = scan_for_nul_corruption(directory, invocation.pathspecs)
+    if not corrupt:
+        return None
+
+    shown = ", ".join(corrupt[:_NUL_MAX_REPORTED_PATHS])
+    if len(corrupt) > _NUL_MAX_REPORTED_PATHS:
+        shown += f", ... (+{len(corrupt) - _NUL_MAX_REPORTED_PATHS} more)"
+    restore_target = (
+        corrupt[0] if len(corrupt) == 1 else "<each corrupt path listed above>"
+    )
+    return (
+        f"R10 (NUL-byte corruption): {len(corrupt)} of {examined} candidate "
+        "file(s) are almost entirely NUL bytes and would be committed as "
+        f"zeroed content: {shown}. Files of a plausible size filled with NUL "
+        "are the signature of an unclean shutdown -- the filesystem recorded "
+        "the allocation but never flushed the data blocks. This reads as "
+        "ordinary ' M' entries in `git status`, and `git diff --shortstat` "
+        "reports the changed files with 0 insertions(+) and 0 deletions(-), so "
+        "committing it looks like a large but unremarkable diff (issue #4437: "
+        "652 of 653 files in one worktree were zeroed this way). Do not stage "
+        "or commit the zeroed content. Confirm with `git diff --stat HEAD -- "
+        "<path>`, then restore only the corrupt paths: `git restore "
+        f"--source=HEAD --staged --worktree -- {restore_target}`. Do not "
+        "restore the whole worktree -- that would discard the healthy "
+        "uncommitted work alongside it. Healthy files can still be committed "
+        "by naming them, e.g. `git add <healthy path>`. Re-create any work "
+        "that existed only in the corrupt files."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -676,6 +979,21 @@ def _extract_command(hook_input: dict) -> str:
     return ""
 
 
+def _hook_working_directory(hook_input: dict) -> str | None:
+    """Directory the guarded command will run in, or None when unknown.
+
+    Hosts that report the session directory win over the hook process's own
+    directory, which is not guaranteed to be the checkout the command targets.
+    """
+    supplied = hook_input.get("cwd")
+    if isinstance(supplied, str) and supplied.strip():
+        return supplied
+    try:
+        return os.getcwd()
+    except OSError:
+        return None
+
+
 def _print_deny(reason: str, host: str) -> None:
     if host == "grok":
         output = {"decision": "deny", "reason": reason}
@@ -700,6 +1018,8 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
         reason = evaluate_command(command)
         if reason is None:
             reason = check_r9_worktree_add(command, tool_name)
+        if reason is None:
+            reason = check_r10_nul_corruption(command, _hook_working_directory(hook_input))
         if reason is not None:
             _print_deny(reason, host)
         return 0
@@ -844,6 +1164,19 @@ _SELF_TEST_CASES: list[tuple[str, str, bool]] = [
     ("non-stash git command allowed", "git status", False),
     ("git stash mentioned in commit message prose is not a real command",
      'git commit -m "ran git stash pop earlier"', False),
+
+    # --- R10: staging/committing is never blocked by command SHAPE alone
+    # (issue #4437). R10 reads repository state and is dispatched with a
+    # working directory, exactly like R9's tool-name-dependent checks. These
+    # rows fail the moment someone moves R10 into `_CHECKS`, which would make
+    # every `git add`/`git commit` deniable from the command string with no
+    # repository to justify it. The corruption behaviour itself is proven
+    # against a real fixture in run_r10_nul_corruption_self_test. ---
+    ("git add -A allowed without repository context", "git add -A", False),
+    ("git add . allowed without repository context", "git add .", False),
+    ("git commit allowed without repository context", 'git commit -m "message"', False),
+    ("git commit -am allowed without repository context", 'git commit -am "message"', False),
+    ("git stage allowed without repository context", "git stage src/Example.java", False),
 ]
 
 
@@ -940,11 +1273,132 @@ def run_r9_worktree_self_test() -> int:
     return 0
 
 
+def run_r10_nul_corruption_self_test() -> int:
+    """Exercises R10 against a real NUL-corrupted file in a throwaway repository.
+
+    The 2026-08-04 corruption was invisible to inspection -- `git status`
+    showed ordinary ' M' entries -- so this builds the failure on disk and
+    runs the real git rather than asserting against a hand-written diff.
+
+    Deliberately overlaps tests/scripts/test_guard_nul_corruption.py: the guard
+    ships to hosts that have neither this repository's test runner nor its test
+    tree, and `--self-test` is the only way to check it there.
+    """
+    import shutil
+    import tempfile
+
+    failures: list[str] = []
+
+    def check(description: str, condition: bool) -> None:
+        status = "PASS" if condition else "FAIL"
+        print(f"[{status}] {description}")
+        if not condition:
+            failures.append(description)
+
+    if shutil.which("git") is None:
+        print("[SKIP] R10 self-test: git is unavailable on PATH")
+        return 0
+
+    with tempfile.TemporaryDirectory() as directory:
+        def git(*arguments: str) -> int:
+            return subprocess.run(  # nosec B603 B607 - fixed git commands on a temp fixture.
+                ["git", *arguments],
+                cwd=directory,
+                capture_output=True,
+                text=True,
+                check=False,
+            ).returncode
+
+        git("init", "-q", "-b", "main", ".")
+        git("config", "user.email", "harness@example.invalid")
+        git("config", "user.name", "Harness")
+        source = os.path.join(directory, "Example.java")
+        with open(source, "wb") as handle:
+            handle.write(b"class Example {\n}\n")
+        healthy = os.path.join(directory, "notes.md")
+        with open(healthy, "wb") as handle:
+            handle.write(b"# Notes\n")
+        git("add", "-A")
+        git("commit", "-qm", "initial")
+
+        reason = check_r10_nul_corruption("git add -A", directory)
+        check("clean worktree is allowed", reason is None)
+
+        with open(healthy, "wb") as handle:
+            handle.write(b"# Notes\n\nAn ordinary edit.\n")
+        reason = check_r10_nul_corruption("git add -A", directory)
+        check("ordinary text edit is allowed", reason is None)
+
+        # The incident shape: a plausible size, every byte zero.
+        with open(source, "wb") as handle:
+            handle.write(b"\x00" * 68)
+
+        reason = check_r10_nul_corruption("git add -A", directory)
+        check("NUL-filled tracked file blocks `git add`", reason is not None)
+        check(
+            "denial names the corrupt path",
+            reason is not None and "Example.java" in reason,
+        )
+        check(
+            "denial names the restore command",
+            reason is not None and "git restore" in reason,
+        )
+
+        reason = check_r10_nul_corruption("git status && git add -A", directory)
+        check("staging chained after a read-only git command is inspected", reason is not None)
+
+        reason = check_r10_nul_corruption("git add notes.md", directory)
+        check("an explicit healthy pathspec is allowed", reason is None)
+
+        reason = check_r10_nul_corruption("git add Example.java", directory)
+        check("an explicit corrupt pathspec is denied", reason is not None)
+
+        with tempfile.TemporaryDirectory() as elsewhere:
+            reason = check_r10_nul_corruption(f'git -C "{directory}" add -A', elsewhere)
+            check("`git -C <repo>` inspects the repository it names", reason is not None)
+
+        git("add", "-A")
+        reason = check_r10_nul_corruption('git commit -m "wip"', directory)
+        check("NUL-filled staged file blocks `git commit`", reason is not None)
+
+        untracked = os.path.join(directory, "fresh.md")
+        with open(untracked, "wb") as handle:
+            handle.write(b"\x00" * 300)
+        reason = check_r10_nul_corruption('git add -A && git commit -m "wip"', directory)
+        check("an untracked NUL file is caught before `add && commit`", reason is not None)
+        os.remove(untracked)
+
+        reason = check_r10_nul_corruption("git status", directory)
+        check("read-only `git status` is not inspected", reason is None)
+
+        reason = check_r10_nul_corruption("git push origin main", directory)
+        check("`git push` is not inspected", reason is None)
+
+        reason = check_r10_nul_corruption(
+            'gh pr create --body "run git add -A first"', directory
+        )
+        check("prose mentioning `git add` is not a real command", reason is None)
+
+        reason = check_r10_nul_corruption("git add -A", None)
+        check("missing working directory fails open", reason is None)
+
+    with tempfile.TemporaryDirectory() as outside:
+        reason = check_r10_nul_corruption("git add -A", outside)
+        check("directory outside any repository fails open", reason is None)
+
+    print(f"\nR10 NUL-corruption self-test summary: {len(failures)} failed.")
+    if failures:
+        print("Failed cases: " + ", ".join(failures))
+        return 1
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if "--self-test" in argv:
         command_result = run_self_test()
         r9_result = run_r9_worktree_self_test()
-        return command_result or r9_result
+        r10_result = run_r10_nul_corruption_self_test()
+        return command_result or r9_result or r10_result
 
     raw = sys.stdin.read()
     if not raw.strip():

--- a/scripts/ci/local_gate.py
+++ b/scripts/ci/local_gate.py
@@ -53,7 +53,7 @@
 #         mvn -pl <modules> -am -DskipTests -Dgpg.skip=true verify
 #
 #     ``-DskipTests`` skips Surefire/Failsafe entirely (no JVM fork storm,
-#     compatible with the ``.claude/hooks/guard.py`` PreToolUse guard, which
+#     compatible with the ``scripts/agents/guard.py`` PreToolUse guard, which
 #     explicitly allows this exact shape) while still running full compile
 #     plus the Enforcer executions above, since Enforcer's default phase is
 #     ``validate``/``verify`` regardless of ``-DskipTests``.

--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -26,6 +26,10 @@ from scripts.ci.validate_documentation_boundaries import (  # noqa: E402
     validate_repository as validate_documentation,
 )
 from scripts.ci.validate_skills import validate_repository as validate_skill_hygiene  # noqa: E402
+from scripts.ci.worktree_hygiene import (  # noqa: E402
+    collect_worktree_report,
+    format_advisories,
+)
 
 MEMORY_PACKAGE = "@aictx/memory@0.1.55"
 MEMORY_TOOLS = {
@@ -334,6 +338,26 @@ def collect_metrics(root: Path = ROOT) -> dict:
     }
 
 
+def collect_worktree_metrics(root: Path = ROOT, *, run_external: bool = True) -> dict:
+    """Describe worktrees holding pending, superseded, or corrupt work.
+
+    Reported, never fatal (issue #4437). Concurrent sessions each own a
+    worktree, so a dirty one is normal and must not fail the gate agents run
+    constantly -- but a worktree that is corrupt, already upstream, or holding
+    uncommitted work nobody will return to has to be visible somewhere an agent
+    already looks.
+
+    Local git only, in both modes. Asking GitHub about each branch would add
+    one network round trip per worktree to a command contributors run by hand;
+    `scripts/ci/worktree_hygiene.py --check-pull-requests` owns that lookup.
+    `run_external` is accepted so this reads like its sibling collectors and
+    can gain an external check without a signature change.
+    """
+    del run_external
+    report = collect_worktree_report(root)
+    return {"worktrees": report, "worktree_advisories": format_advisories(report)}
+
+
 def validate_repository(
     root: Path = ROOT, *, run_external: bool = True
 ) -> tuple[list[dict[str, str]], dict]:
@@ -350,9 +374,11 @@ def validate_repository(
     if run_external:
         errors.extend(run_memory_check(root))
         errors.extend(run_command(root, ["git", "diff", "--check"], "diff-check"))
+    metrics = collect_metrics(root)
+    metrics.update(collect_worktree_metrics(root, run_external=run_external))
     return (
         sorted(errors, key=lambda item: (item["path"], item["code"], item["message"])),
-        collect_metrics(root),
+        metrics,
     )
 
 
@@ -377,7 +403,9 @@ def main() -> int:
     )
     if args.format == "json":
         print(json.dumps({"valid": not errors, "errors": errors, "metrics": metrics}, indent=2))
-    elif errors:
+        return 1 if errors else 0
+
+    if errors:
         for error in errors:
             print(f"{error['code']}: {error['path']}: {error['message']}", file=sys.stderr)
     else:
@@ -387,6 +415,11 @@ def main() -> int:
             f"{metrics['guidance_reduction_percent']}% reduction, "
             f"{metrics['memory_objects']} memory objects."
         )
+    # Advisories print whether or not the gate passed: they describe work that
+    # is at risk, not a broken setup, and a passing run is exactly when an
+    # agent would otherwise stop reading.
+    for advisory in metrics.get("worktree_advisories", []):
+        print(advisory)
     return 1 if errors else 0
 
 

--- a/scripts/ci/worktree_hygiene.py
+++ b/scripts/ci/worktree_hygiene.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Report worktrees whose work is pending, already upstream, or corrupt.
+
+Uncommitted changes in a worktree are indistinguishable from finished work
+until something says otherwise. Issue #4437: seven worktrees accumulated in one
+checkout, three holding uncommitted changes. Two of those held documentation
+that had already landed on `origin/main` through another path, and one held 652
+entirely NUL-filled files that `git status` reported as ordinary ' M' entries.
+Establishing that cost a full byte-level investigation and landed zero commits.
+
+This module turns the three conditions into reportable states:
+
+* ``corrupt``     -- changed files are almost entirely NUL bytes.
+* ``abandoned``   -- another worktree holds uncommitted changes, carries no
+                     patch that is not already upstream, and has no open pull
+                     request. Nobody is coming back for it.
+* ``superseded``  -- a linked worktree is clean and carries no patch that is not
+                     already upstream. Its content landed through another path;
+                     remove it.
+* ``uncommitted`` -- changes exist that no commit holds yet, in a worktree that
+                     is otherwise live (including the one you are working in).
+
+Advisories are reported, never fatal: concurrent sessions legitimately hold
+their own worktrees, so this must inform an agent rather than block it.
+Relationship to upstream uses ``git cherry``, not ahead/behind: the 2026-08-04
+worktrees carried commits whose patches were already on ``origin/main``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess  # nosec B404 - fixed, read-only git and gh queries.
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.agents.guard import scan_for_nul_corruption  # noqa: E402
+
+UPSTREAM_BRANCH = "main"
+UPSTREAM_REF = f"origin/{UPSTREAM_BRANCH}"
+GIT_TIMEOUT_SECONDS = 30
+PULL_REQUEST_TIMEOUT_SECONDS = 30
+# A checkout with more linked worktrees than this is already the problem this
+# report exists to surface; scanning every one of them is not worth the wait.
+MAX_REPORTED_WORKTREES = 50
+
+ADVISORY_STATES = ("corrupt", "abandoned", "superseded", "uncommitted", "unknown")
+
+
+def _git(cwd: Path, *arguments: str) -> str | None:
+    """Run one read-only git query, or return None when it cannot be trusted.
+
+    `core.longpaths=true` matches the guard's R9 requirement: without it git
+    aborts with `Filename too long` on this repository's over-long `.memory/**`
+    paths, and a failed status query would otherwise read as "clean".
+    """
+    try:
+        completed = subprocess.run(  # nosec B603 B607 - fixed read-only git query.
+            ["git", "-c", "core.longpaths=true", *arguments],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return completed.stdout if completed.returncode == 0 else None
+
+
+def _parse_worktree_list(output: str) -> list[dict]:
+    """Parse `git worktree list --porcelain` into worktree records.
+
+    `locked` and `prunable` are kept, not discarded: they are the only signals
+    distinguishing a worktree a live session holds, or one whose directory is
+    already gone, from one that is genuinely idle.
+    """
+    entries: list[dict] = []
+    current: dict = {}
+
+    def blank() -> dict:
+        return {"path": None, "branch": None, "locked": False, "prunable": False}
+
+    for line in output.splitlines():
+        if not line.strip():
+            if current:
+                entries.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        if key == "worktree":
+            if current:
+                entries.append(current)
+            current = blank()
+            current["path"] = value
+        elif key == "branch":
+            current["branch"] = value.removeprefix("refs/heads/")
+        elif key == "detached":
+            current["branch"] = None
+        elif key == "locked":
+            current["locked"] = True
+        elif key == "prunable":
+            current["prunable"] = True
+    if current:
+        entries.append(current)
+    return [entry for entry in entries if entry.get("path")]
+
+
+def _uncommitted_files(worktree: Path) -> int | None:
+    """Count changed paths, or None when git could not answer.
+
+    None is not zero. Reading a failed query as "clean" would feed the
+    superseded verdict, which tells the reader to delete the branch.
+    """
+    output = _git(worktree, "status", "--porcelain")
+    if output is None:
+        return None
+    return len([line for line in output.splitlines() if line.strip()])
+
+
+def _unique_commits(root: Path, committish: str | None) -> int | None:
+    """Commits on `committish` whose patch is not already upstream, or None.
+
+    `git cherry` marks a patch-identical commit with '-' even when its hash
+    differs, which is exactly the case ahead/behind gets wrong: a branch can be
+    one commit "ahead" of upstream and carry nothing new.
+    """
+    if committish is None:
+        return None
+    if _git(root, "rev-parse", "--verify", "--quiet", UPSTREAM_REF) is None:
+        return None
+    output = _git(root, "cherry", UPSTREAM_REF, committish)
+    if output is None:
+        return None
+    return len([line for line in output.splitlines() if line.startswith("+")])
+
+
+def _ahead_behind(root: Path, committish: str | None) -> tuple[int | None, int | None]:
+    """Commit counts relative to upstream, or (None, None) when unknown."""
+    if committish is None:
+        return None, None
+    output = _git(
+        root, "rev-list", "--left-right", "--count", f"{UPSTREAM_REF}...{committish}"
+    )
+    if output is None:
+        return None, None
+    parts = output.split()
+    if len(parts) != 2 or not all(part.isdigit() for part in parts):
+        return None, None
+    return int(parts[1]), int(parts[0])  # ahead, behind
+
+
+def open_pull_requests_via_gh(branch: str) -> int:
+    """Open pull requests for `branch`, via the GitHub CLI when it is available."""
+    if shutil.which("gh") is None:
+        raise RuntimeError("gh is unavailable")
+    completed = subprocess.run(  # nosec B603 B607 - fixed read-only gh query.
+        ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number"],
+        capture_output=True,
+        text=True,
+        timeout=PULL_REQUEST_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or "gh pr list failed")
+    return len(json.loads(completed.stdout or "[]"))
+
+
+def _classify(entry: dict) -> str:
+    """Name the one condition that decides what to do with this worktree.
+
+    Every verdict beyond "there are uncommitted files here" needs positive
+    evidence, because the advice attached to it is destructive. A worktree that
+    is merely clean and carries no unique patch is indistinguishable from one
+    another session created seconds ago from origin/main, so absence of work is
+    never treated as proof that work has landed.
+    """
+    if entry["corrupt_files"]:
+        return "corrupt"
+
+    uncommitted = entry["uncommitted_files"]
+    # A live session holds a locked worktree; the entrypoint says report it and
+    # leave it alone, never propose removing it.
+    protected = entry["is_current"] or entry["is_main"] or entry["locked"]
+    already_upstream = entry["unique_commits"] == 0
+    has_open_pull_request = bool(entry["open_pull_requests"])
+    carries_commits = bool(entry["ahead"])
+
+    if uncommitted:
+        if not protected and already_upstream and not has_open_pull_request:
+            return "abandoned"
+        return "uncommitted"
+    if uncommitted is None:
+        return "unknown"  # git could not answer; claim nothing about it
+
+    # Work reachable from no branch at all: a detached worktree whose commits
+    # are not upstream is the only copy of them.
+    if (
+        entry["branch"] is None
+        and not protected
+        and entry["unique_commits"]
+        and not has_open_pull_request
+    ):
+        return "abandoned"
+    # Superseded needs commits that exist and are already upstream -- not the
+    # mere absence of any.
+    if (
+        not protected
+        and entry["branch"] != UPSTREAM_BRANCH
+        and carries_commits
+        and already_upstream
+    ):
+        return "superseded"
+    if entry["unique_commits"]:
+        return "pending"
+    return "clean"
+
+
+def collect_worktree_report(
+    root: Path,
+    *,
+    open_pull_requests: Callable[[str], int] | None = None,
+) -> list[dict]:
+    """Describe every worktree of `root`'s repository, `root`'s own included.
+
+    Returns an empty list -- never an error -- when the directory is not a
+    repository or git cannot answer, so a caller can always report the result.
+    """
+    listing = _git(root, "worktree", "list", "--porcelain")
+    if listing is None:
+        return []
+
+    # Ask git which worktree `root` belongs to rather than assuming `root` is
+    # a worktree root: run from a subdirectory, comparing paths directly would
+    # mark the live worktree "not current" and then, once it is dirty, report
+    # the session's own in-progress work as abandoned.
+    toplevel = _git(root, "rev-parse", "--show-toplevel")
+    try:
+        current = Path(toplevel.strip()).resolve() if toplevel else root.resolve()
+    except OSError:
+        return []
+
+    report: list[dict] = []
+    for index, record in enumerate(_parse_worktree_list(listing)[:MAX_REPORTED_WORKTREES]):
+        if record["prunable"]:
+            continue  # the directory is already gone; `git worktree prune` owns it
+        worktree = Path(record["path"])
+        try:
+            resolved = worktree.resolve()
+        except OSError:
+            continue
+        branch = record["branch"]
+        # A detached worktree still has commits worth accounting for, so fall
+        # back to its HEAD rather than reporting nothing about it.
+        head = (_git(worktree, "rev-parse", "HEAD") or "").strip() or None
+        committish = branch or head
+        corrupt, _ = scan_for_nul_corruption(str(worktree))
+        ahead, behind = _ahead_behind(root, committish)
+
+        pull_requests: int | None = None
+        if open_pull_requests is not None and branch is not None:
+            try:
+                pull_requests = int(open_pull_requests(branch))
+            except Exception:  # noqa: BLE001 - a lookup failure must not hide the report
+                pull_requests = None
+
+        entry = {
+            "path": resolved.as_posix(),
+            "branch": branch,
+            "is_main": index == 0,
+            "is_current": resolved == current,
+            "locked": record["locked"],
+            "uncommitted_files": _uncommitted_files(worktree),
+            "corrupt_files": len(corrupt),
+            "corrupt_paths": corrupt[:5],
+            "ahead": ahead,
+            "behind": behind,
+            "unique_commits": _unique_commits(root, committish),
+            "open_pull_requests": pull_requests,
+        }
+        entry["state"] = _classify(entry)
+        report.append(entry)
+    return report
+
+
+def _describe(entry: dict) -> str:
+    branch = entry["branch"] or "detached HEAD"
+    location = entry["path"]
+    uncommitted = entry["uncommitted_files"]
+
+    if entry["state"] == "corrupt":
+        shown = ", ".join(entry["corrupt_paths"]) or "changed files"
+        return (
+            f"worktree-corrupt: {location} ({branch}): {entry['corrupt_files']} "
+            f"changed file(s) are almost entirely NUL bytes ({shown}). Files of "
+            "a plausible size filled with NUL are the signature of an unclean "
+            "shutdown, and git reports them as ordinary modifications. Do not "
+            "commit them: restore with `git restore --source=HEAD --staged "
+            "--worktree -- .` in that worktree, then re-create anything that "
+            "existed only there."
+        )
+    if entry["state"] == "abandoned":
+        if entry["branch"] is None:
+            held = (
+                f"{entry['unique_commits']} commit(s) on a detached HEAD that "
+                "no branch references"
+            )
+        else:
+            held = (
+                f"{uncommitted} uncommitted file(s) and no commit that is not "
+                f"already on {UPSTREAM_REF}"
+            )
+        caveat = (
+            "" if entry["open_pull_requests"] is not None
+            else " (open pull requests were not checked -- rerun with "
+            "--check-pull-requests to confirm)"
+        )
+        return (
+            f"worktree-abandoned: {location} ({branch}): {held}{caveat}. "
+            "Nothing but this working tree holds that work. Commit, push, and "
+            "open a pull request from that worktree, or confirm it is "
+            "redundant -- do not leave it to a cleanup pass to decide."
+        )
+    if entry["state"] == "superseded":
+        return (
+            f"worktree-superseded: {location} ({branch}): clean, and all "
+            f"{entry['ahead']} of its commit(s) are already on {UPSTREAM_REF} "
+            "by content. Its work landed through another path. If no session "
+            "is using it, remove the worktree and delete the branch."
+        )
+    if entry["state"] == "unknown":
+        return (
+            f"worktree-unknown: {location} ({branch}): git could not report "
+            "this worktree's status, so nothing can be concluded about the "
+            "work in it. Inspect it before any cleanup pass touches it."
+        )
+    return (
+        f"worktree-uncommitted: {location} ({branch}): {uncommitted} "
+        "uncommitted file(s). Uncommitted work is not done -- commit and push "
+        "it before ending the turn, or discard it deliberately."
+    )
+
+
+def format_advisories(report: list[dict]) -> list[str]:
+    """One actionable line per worktree that needs attention."""
+    return [_describe(entry) for entry in report if entry["state"] in ADVISORY_STATES]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument(
+        "--check-pull-requests",
+        action="store_true",
+        help="Ask the GitHub CLI whether each branch has an open pull request.",
+    )
+    return parser
+
+
+def main() -> int:
+    """Run the CLI. Always exits 0: this reports, it does not gate."""
+    args = build_parser().parse_args()
+    report = collect_worktree_report(
+        args.root.resolve(),
+        open_pull_requests=open_pull_requests_via_gh if args.check_pull_requests else None,
+    )
+    if args.format == "json":
+        print(json.dumps({"worktrees": report, "advisories": format_advisories(report)}, indent=2))
+        return 0
+    advisories = format_advisories(report)
+    if not advisories:
+        print(f"Worktree hygiene is clean: {len(report)} worktree(s), nothing to report.")
+        return 0
+    for advisory in advisories:
+        print(advisory)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mcp/install_shaft_mcp.py
+++ b/scripts/mcp/install_shaft_mcp.py
@@ -60,10 +60,17 @@ RETIRED_SHAFT_SKILL_DIRECTORIES = frozenset((
     "verifying-and-applying-shaft-changes",
     "writing-shaft-tests",
 ))
+# Every module validate_agent_setup.py imports at module scope must be listed
+# here, or the installed validator dies on ImportError in the user's project.
+# tests/scripts/test_install_shaft_mcp.py reads the real import statements and
+# fails when this list falls behind them.
 AGENT_VALIDATION_SCRIPT_FILES = (
+    "scripts/agents/guard.py",
     "scripts/ci/validate_agent_setup.py",
     "scripts/ci/validate_agent_guidance.py",
     "scripts/ci/validate_documentation_boundaries.py",
+    "scripts/ci/validate_skills.py",
+    "scripts/ci/worktree_hygiene.py",
     "scripts/ci/agent_guidance_budget.json",
 )
 AGENT_GUIDANCE_SCAFFOLD_MARKER = "AGENTS.md"

--- a/tests/scripts/test_guard_nul_corruption.py
+++ b/tests/scripts/test_guard_nul_corruption.py
@@ -1,0 +1,364 @@
+"""R10: refuse to stage or commit NUL-corrupted files.
+
+Reproduces the 2026-08-04 incident (issue #4437): after an unclean shutdown,
+652 of 653 files in an abandoned worktree were entirely NUL-filled with
+plausible sizes -- a 676-byte `.gitignore` had become 726 bytes of zeros.
+`git status` showed ordinary ` M` entries and only `git diff --shortstat`
+hinted at it ("653 files changed, 0 insertions(+), 0 deletions(-)").
+
+Every case below builds the corruption as a real fixture on disk and runs the
+real `git`, rather than asserting against a hand-written diff string.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # nosec B404 - tests drive the local git binary on fixtures.
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.agents.guard import (
+    check_r10_nul_corruption,
+    evaluate_command,
+    nul_byte_ratio,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARD = ROOT / "scripts/agents/guard.py"
+
+# A minimal, genuinely binary PNG: real binary content that is NOT NUL-filled.
+PNG_BYTES = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000a49444154789c6360000002000100ffff03000006000557bfabd400"
+    "00000049454e44ae426082"
+)
+
+
+def git(cwd: Path, *arguments: str) -> subprocess.CompletedProcess:
+    return subprocess.run(  # nosec B603 B607 - fixed git commands on a temp fixture.
+        ["git", *arguments],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class NulCorruptionGuardTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        git(self.root, "init", "-q", "-b", "main", ".")
+        git(self.root, "config", "user.email", "harness@example.invalid")
+        git(self.root, "config", "user.name", "Harness")
+        self.write_bytes(".gitignore", b"target/\nallure-results/\n")
+        self.write_bytes("src/Example.java", b"class Example {\n}\n")
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "-qm", "initial")
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write_bytes(self, relative_path: str, content: bytes) -> Path:
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        return path
+
+    def corrupt(self, relative_path: str) -> None:
+        """Overwrite a tracked file with NUL bytes at a plausible size."""
+        path = self.root / relative_path
+        self.write_bytes(relative_path, b"\x00" * (path.stat().st_size + 50))
+
+    # --- the incident itself -------------------------------------------------
+
+    def test_staging_a_nul_filled_tracked_file_is_denied(self):
+        self.corrupt(".gitignore")
+        reason = check_r10_nul_corruption("git add -A", str(self.root))
+        self.assertIsNotNone(reason)
+        self.assertIn("R10", reason)
+        self.assertIn(".gitignore", reason)
+
+    def test_committing_a_nul_filled_tracked_file_is_denied(self):
+        self.corrupt("src/Example.java")
+        git(self.root, "add", "-A")
+        reason = check_r10_nul_corruption('git commit -m "wip"', str(self.root))
+        self.assertIsNotNone(reason)
+        self.assertIn("src/Example.java", reason)
+
+    def test_commit_dash_a_is_denied_without_an_explicit_add(self):
+        self.corrupt("src/Example.java")
+        reason = check_r10_nul_corruption('git commit -am "wip"', str(self.root))
+        self.assertIsNotNone(reason)
+
+    def test_denial_names_the_restore_command_and_the_corruption_cause(self):
+        self.corrupt(".gitignore")
+        reason = check_r10_nul_corruption("git add -A", str(self.root))
+        self.assertIn("git restore", reason)
+        self.assertIn("NUL", reason)
+
+    def test_git_dash_c_inspects_the_repository_it_names(self):
+        # `git -C <worktree> ...` is this repository's documented way to touch
+        # another worktree, so taking the directory from the calling process
+        # instead of the command leaves that whole shape unguarded.
+        self.corrupt(".gitignore")
+        with tempfile.TemporaryDirectory() as elsewhere:
+            reason = check_r10_nul_corruption(
+                f'git -C "{self.root}" add -A', elsewhere
+            )
+        self.assertIsNotNone(reason)
+        self.assertIn(".gitignore", reason)
+
+    def test_git_work_tree_flag_inspects_the_repository_it_names(self):
+        self.corrupt(".gitignore")
+        with tempfile.TemporaryDirectory() as elsewhere:
+            reason = check_r10_nul_corruption(
+                f'git --git-dir="{self.root}/.git" --work-tree="{self.root}" add -A',
+                elsewhere,
+            )
+        self.assertIsNotNone(reason)
+
+    def test_git_dash_c_naming_a_clean_repository_is_allowed(self):
+        # The mirror image: corruption in the calling directory must not deny a
+        # command that operates somewhere else entirely.
+        with tempfile.TemporaryDirectory() as clean:
+            path = Path(clean)
+            git(path, "init", "-q", "-b", "main", ".")
+            git(path, "config", "user.email", "harness@example.invalid")
+            git(path, "config", "user.name", "Harness")
+            (path / "a.txt").write_bytes(b"content\n")
+            git(path, "add", "-A")
+            git(path, "commit", "-qm", "initial")
+            (path / "a.txt").write_bytes(b"edited content\n")
+
+            self.corrupt(".gitignore")
+            reason = check_r10_nul_corruption(f'git -C "{clean}" add -A', str(self.root))
+        self.assertIsNone(reason)
+
+    def test_untracked_nul_file_is_caught_when_add_and_commit_are_chained(self):
+        # `git diff HEAD` cannot see an untracked path, so a single-line
+        # `add && commit` would otherwise commit a newly zeroed file.
+        self.write_bytes("fresh.md", b"\x00" * 300)
+        reason = check_r10_nul_corruption(
+            'git add -A && git commit -m "wip"', str(self.root)
+        )
+        self.assertIsNotNone(reason)
+        self.assertIn("fresh.md", reason)
+
+    def test_untracked_healthy_file_is_allowed(self):
+        self.write_bytes("fresh.md", b"# Fresh notes\n")
+        self.assertIsNone(check_r10_nul_corruption("git add -A", str(self.root)))
+
+    def test_ignored_files_are_not_scanned(self):
+        self.write_bytes(".gitignore", b"target/\n")
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "-qm", "ignore target")
+        self.write_bytes("target/classes.bin", b"\x00" * 4096)
+        self.assertIsNone(check_r10_nul_corruption("git add -A", str(self.root)))
+
+    def test_non_ascii_paths_are_scanned(self):
+        self.write_bytes("café-日本.md", "# Café\n".encode("utf-8"))
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "-qm", "add non-ascii")
+        self.corrupt("café-日本.md")
+        reason = check_r10_nul_corruption("git add -A", str(self.root))
+        self.assertIsNotNone(reason)
+
+    def test_an_explicit_pathspec_limits_the_scan(self):
+        # One corrupt file must not make it impossible to rescue healthy work:
+        # `git add <healthy>` names what it stages, so honour it.
+        self.corrupt(".gitignore")
+        self.write_bytes("src/Example.java", b"class Example {\n  // real work\n}\n")
+
+        self.assertIsNone(
+            check_r10_nul_corruption("git add src/Example.java", str(self.root))
+        )
+        self.assertIsNotNone(
+            check_r10_nul_corruption("git add .gitignore", str(self.root))
+        )
+        self.assertIsNotNone(check_r10_nul_corruption("git add -A", str(self.root)))
+        self.assertIsNotNone(check_r10_nul_corruption("git add .", str(self.root)))
+
+    def test_a_pathspec_directory_covers_the_files_beneath_it(self):
+        self.corrupt("src/Example.java")
+        self.assertIsNotNone(check_r10_nul_corruption("git add src", str(self.root)))
+        self.assertIsNone(check_r10_nul_corruption("git add .gitignore", str(self.root)))
+
+    def test_commit_message_arguments_are_never_read_as_pathspecs(self):
+        # `git commit -m src/Example.java` must not be read as "only scan that
+        # path". Only an explicit `--` separator delimits a commit pathspec.
+        self.corrupt(".gitignore")
+        git(self.root, "add", "-A")
+        self.assertIsNotNone(
+            check_r10_nul_corruption(
+                'git commit -m "touched src/Example.java"', str(self.root)
+            )
+        )
+
+    def test_staging_nested_in_an_interpreter_argument_is_inspected(self):
+        self.corrupt(".gitignore")
+        self.assertIsNotNone(
+            check_r10_nul_corruption('bash -c "git add -A"', str(self.root))
+        )
+
+    def test_many_corrupt_files_report_a_count_rather_than_every_path(self):
+        for index in range(12):
+            self.write_bytes(f"module{index}/File.java", b"class File {\n}\n")
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "-qm", "more files")
+        for index in range(12):
+            self.corrupt(f"module{index}/File.java")
+        reason = check_r10_nul_corruption("git add -A", str(self.root))
+        self.assertIsNotNone(reason)
+        self.assertIn("12 of", reason)
+        self.assertIn("+7 more", reason)
+        self.assertLess(reason.count("module"), 12)
+
+    def test_denial_does_not_recommend_discarding_the_whole_worktree(self):
+        # The remedy must not destroy the healthy uncommitted work an agent is
+        # trying to save -- that is the data loss this rule exists to prevent.
+        self.corrupt(".gitignore")
+        self.write_bytes("src/Example.java", b"class Example {\n  // real work\n}\n")
+        reason = check_r10_nul_corruption("git add -A", str(self.root))
+        self.assertIn("git restore --source=HEAD --staged --worktree -- .gitignore", reason)
+        self.assertIn("Do not restore the whole worktree", reason)
+        self.assertNotIn("--worktree -- .\n", reason)
+        self.assertNotIn("for all of them", reason)
+
+    # --- must not fire on healthy work --------------------------------------
+
+    def test_ordinary_text_edit_is_allowed(self):
+        self.write_bytes("src/Example.java", b"class Example {\n  // edited\n}\n")
+        self.assertIsNone(check_r10_nul_corruption("git add -A", str(self.root)))
+
+    def test_genuinely_binary_content_is_allowed(self):
+        self.write_bytes("assets/logo.png", PNG_BYTES)
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "-qm", "add logo")
+        self.write_bytes("assets/logo.png", PNG_BYTES + PNG_BYTES)
+        self.assertIsNone(check_r10_nul_corruption("git add -A", str(self.root)))
+
+    def test_empty_file_is_allowed(self):
+        self.write_bytes("src/Example.java", b"")
+        self.assertIsNone(check_r10_nul_corruption("git add -A", str(self.root)))
+
+    def test_staging_chained_after_another_git_command_is_still_inspected(self):
+        # Agents routinely chain `git status && git add -A`. Stopping at the
+        # first git segment would let the corrupt commit straight through.
+        self.corrupt(".gitignore")
+        for command in (
+            "git status && git add -A",
+            'git fetch origin; git commit -am "wip"',
+            'git status | cat && git add . && git commit -m "wip"',
+        ):
+            self.assertIsNotNone(
+                check_r10_nul_corruption(command, str(self.root)), command
+            )
+
+    def test_read_only_git_commands_are_not_inspected(self):
+        self.corrupt(".gitignore")
+        for command in ("git status", "git diff", "git log --oneline", "git push"):
+            self.assertIsNone(
+                check_r10_nul_corruption(command, str(self.root)), command
+            )
+
+    def test_prose_mentioning_git_add_is_not_a_real_command(self):
+        self.corrupt(".gitignore")
+        self.assertIsNone(
+            check_r10_nul_corruption(
+                'gh pr create --body "run git add -A first"', str(self.root)
+            )
+        )
+
+    # --- fail open rather than block real work ------------------------------
+
+    def test_missing_working_directory_fails_open(self):
+        self.assertIsNone(check_r10_nul_corruption("git add -A", None))
+
+    def test_directory_outside_any_repository_fails_open(self):
+        with tempfile.TemporaryDirectory() as outside:
+            self.assertIsNone(check_r10_nul_corruption("git add -A", outside))
+
+    def test_repository_without_a_commit_fails_open(self):
+        with tempfile.TemporaryDirectory() as fresh:
+            path = Path(fresh)
+            git(path, "init", "-q", "-b", "main", ".")
+            (path / "a.txt").write_bytes(b"\x00" * 64)
+            self.assertIsNone(check_r10_nul_corruption("git add -A", str(path)))
+
+    def test_pure_command_evaluation_never_blocks_on_shape_alone(self):
+        # evaluate_command stays repository-independent: R10 needs a working
+        # directory, so a bare `git add`/`git commit` must never be blocked by
+        # the command string on its own.
+        for command in ("git add -A", 'git commit -m "message"', "git add ."):
+            self.assertIsNone(evaluate_command(command), command)
+
+    # --- the sampling primitive ---------------------------------------------
+
+    def test_nul_byte_ratio_samples_beyond_the_first_block(self):
+        # A file that merely starts with a long zero run is not corruption;
+        # sampling only the head would misread it.
+        padded = self.write_bytes("padded.bin", b"\x00" * 200_000 + b"payload" * 20_000)
+        self.assertLess(nul_byte_ratio(padded), 0.95)
+
+        wholly_nul = self.write_bytes("zeroed.bin", b"\x00" * 400_000)
+        self.assertEqual(nul_byte_ratio(wholly_nul), 1.0)
+
+    def test_nul_byte_ratio_returns_none_for_unreadable_or_empty_paths(self):
+        self.assertIsNone(nul_byte_ratio(self.write_bytes("empty.txt", b"")))
+        self.assertIsNone(nul_byte_ratio(self.root / "missing.txt"))
+
+    # --- end to end through the hook ----------------------------------------
+
+    def test_hook_denies_a_corrupt_commit_from_the_repository_working_directory(self):
+        self.corrupt(".gitignore")
+        completed = subprocess.run(  # nosec B603 - trusted interpreter and repo script.
+            [sys.executable, str(GUARD)],
+            input=json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "git add -A"},
+                }
+            ),
+            cwd=self.root,
+            env=dict(os.environ, SHAFT_GUARD_HOST="claude"),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        payload = json.loads(completed.stdout)
+        specific = payload["hookSpecificOutput"]
+        self.assertEqual(specific["permissionDecision"], "deny")
+        self.assertIn("R10", specific["permissionDecisionReason"])
+
+    def test_hook_prefers_the_supplied_working_directory_over_the_process_one(self):
+        self.corrupt(".gitignore")
+        completed = subprocess.run(  # nosec B603 - trusted interpreter and repo script.
+            [sys.executable, str(GUARD)],
+            input=json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "git add -A"},
+                    "cwd": str(self.root),
+                }
+            ),
+            cwd=ROOT,
+            env=dict(os.environ, SHAFT_GUARD_HOST="claude"),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("R10", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -4,6 +4,7 @@ import hashlib
 import io
 import json
 import os
+import re
 import subprocess  # nosec B404 -- Windows junction test uses resolved System32 cmd.exe only.
 import tempfile
 import unittest
@@ -161,6 +162,25 @@ class InstallShaftMcpTest(unittest.TestCase):
         # making the onboarding-referenced `validate_agent_setup.py` crash with
         # FileNotFoundError on any project that installed them.
         self.assertIn("scripts/ci/agent_guidance_budget.json", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
+
+    def test_agent_validation_manifest_ships_every_module_the_validator_imports(self):
+        # Same class of defect as issue #3363 bug 9, one level up: the manifest
+        # copies validate_agent_setup.py into a user's project, so any sibling
+        # module it imports at module scope must travel with it or the
+        # installed validator dies on ImportError. Checked by reading the real
+        # import statements rather than by listing them again here.
+        repository_root = Path(__file__).resolve().parents[2]
+        shipped = set(MODULE.AGENT_VALIDATION_SCRIPT_FILES)
+        missing = set()
+        for relative in sorted(shipped):
+            if not relative.endswith(".py"):
+                continue
+            source = (repository_root / relative).read_text(encoding="utf-8")
+            for module in re.findall(r"(?m)^from (scripts[\w.]*) import", source):
+                required = module.replace(".", "/") + ".py"
+                if required not in shipped:
+                    missing.add(f"{relative} imports {module}")
+        self.assertEqual(sorted(missing), [])
 
     def test_render_client_menu_groups_ai_agents_and_advanced_sections(self):
         lines = MODULE.render_client_menu()

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -1,4 +1,5 @@
 import json
+import subprocess  # nosec B404 - tests drive the local git binary on fixtures.
 import tempfile
 import unittest
 from pathlib import Path
@@ -7,6 +8,7 @@ from unittest.mock import patch
 from scripts.ci.validate_agent_setup import (
     GENERATED_MEMORY_PATHS,
     KNOWN_SECRET_SCANNER_LANDMINE_FILES,
+    collect_worktree_metrics,
     run_memory_check,
     validate_memory_setup,
     validate_repository,
@@ -153,6 +155,48 @@ approval_mode = "prompt"
         allowlisted_path = sorted(KNOWN_SECRET_SCANNER_LANDMINE_FILES)[0]
         self.write(allowlisted_path, "desk-abcdefghijklmnopqrstuvwxyz\n")
         self.assertNotIn("memory-secret-landmine", self.codes())
+
+    def git(self, *arguments):
+        return subprocess.run(  # nosec B603 B607 - fixed git commands on a temp fixture.
+            ["git", "-c", "core.longpaths=true", *arguments],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_worktree_metrics_report_uncommitted_work(self):
+        # Issue #4437: uncommitted work rotted in worktrees because nothing an
+        # agent runs ever mentioned it.
+        self.git("init", "-q", "-b", "main", ".")
+        self.git("config", "user.email", "harness@example.invalid")
+        self.git("config", "user.name", "Harness")
+        self.write("notes.md", "committed\n")
+        self.git("add", "notes.md")
+        self.git("commit", "-qm", "initial")
+        self.write("notes.md", "uncommitted edit\n")
+
+        metrics = collect_worktree_metrics(self.root, run_external=False)
+
+        advisories = metrics["worktree_advisories"]
+        self.assertEqual(len(advisories), 1)
+        self.assertIn("uncommitted", advisories[0])
+        self.assertEqual(metrics["worktrees"][0]["state"], "uncommitted")
+
+    def test_worktree_metrics_are_empty_outside_a_repository(self):
+        metrics = collect_worktree_metrics(self.root, run_external=False)
+        self.assertEqual(metrics["worktrees"], [])
+        self.assertEqual(metrics["worktree_advisories"], [])
+
+    def test_validator_carries_the_worktree_report_without_gating_on_it(self):
+        # The report must ride along with --skip-external, the invocation
+        # AGENTS.md prescribes -- and must never fail it, because concurrent
+        # sessions legitimately hold dirty worktrees of their own.
+        repository_root = Path(__file__).resolve().parents[2]
+        errors, metrics = validate_repository(repository_root, run_external=False)
+        self.assertIn("worktrees", metrics)
+        self.assertIn("worktree_advisories", metrics)
+        self.assertNotIn("worktree", {error["code"] for error in errors})
 
     def test_overlong_non_relation_filename_still_caught_without_relation_hint(self):
         # Negative test: relaxing the relation-file message must not open a

--- a/tests/scripts/test_worktree_hygiene.py
+++ b/tests/scripts/test_worktree_hygiene.py
@@ -1,0 +1,383 @@
+"""Abandoned, superseded, and corrupt worktrees must be reportable conditions.
+
+Issue #4437: seven stale worktrees accumulated in one checkout. Three held
+uncommitted changes, and nothing distinguished them from live work -- two
+carried documentation that had already landed on `origin/main` through another
+path, and one held 652 entirely NUL-filled files. A routine cleanup would have
+destroyed all of it, and re-doing the "recoverable" work would have regressed
+`main`.
+
+Every fixture below is a real repository with real `git worktree add` links.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - tests drive the local git binary on fixtures.
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.ci.worktree_hygiene import (
+    collect_worktree_report,
+    format_advisories,
+    open_pull_requests_via_gh,
+)
+
+
+def git(cwd: Path, *arguments: str) -> subprocess.CompletedProcess:
+    return subprocess.run(  # nosec B603 B607 - fixed git commands on a temp fixture.
+        ["git", "-c", "core.longpaths=true", *arguments],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class WorktreeHygieneTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.base = Path(self.temporary_directory.name)
+        self.main = self.base / "checkout"
+        self.main.mkdir()
+        git(self.main, "init", "-q", "-b", "main", ".")
+        git(self.main, "config", "user.email", "harness@example.invalid")
+        git(self.main, "config", "user.name", "Harness")
+        self.write(self.main, "README.md", "# Project\n")
+        git(self.main, "add", "-A")
+        git(self.main, "commit", "-qm", "initial")
+        self.publish_main()
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def publish_main(self) -> None:
+        """Point refs/remotes/origin/main at the current main, without a remote."""
+        head = git(self.main, "rev-parse", "main").stdout.strip()
+        git(self.main, "update-ref", "refs/remotes/origin/main", head)
+
+    def write(self, root: Path, relative_path: str, content: str) -> Path:
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def add_worktree(self, name: str, branch: str) -> Path:
+        path = self.base / name
+        git(self.main, "worktree", "add", "-q", "-b", branch, str(path), "main")
+        git(path, "config", "user.email", "harness@example.invalid")
+        git(path, "config", "user.name", "Harness")
+        return path
+
+    def entry(self, report: list[dict], name: str) -> dict:
+        matches = [item for item in report if Path(item["path"]).name == name]
+        self.assertEqual(len(matches), 1, f"{name} not found in {report}")
+        return matches[0]
+
+    # --- nothing to report --------------------------------------------------
+
+    def test_lone_clean_checkout_reports_nothing(self):
+        report = collect_worktree_report(self.main)
+        self.assertEqual(len(report), 1)
+        self.assertTrue(report[0]["is_main"])
+        self.assertTrue(report[0]["is_current"])
+        self.assertEqual(report[0]["state"], "clean")
+        self.assertEqual(format_advisories(report), [])
+
+    def test_directory_outside_any_repository_reports_nothing(self):
+        with tempfile.TemporaryDirectory() as outside:
+            self.assertEqual(collect_worktree_report(Path(outside)), [])
+
+    # --- abandoned: uncommitted work nobody is looking at --------------------
+
+    def test_other_worktree_holding_uncommitted_work_is_abandoned(self):
+        worktree = self.add_worktree("stale", "ChaosEngine/stale")
+        self.write(worktree, "docs/guide.md", "Thirteen files of real work.\n")
+        self.write(worktree, "README.md", "# Project\n\nEdited.\n")
+
+        entry = self.entry(collect_worktree_report(self.main), "stale")
+        self.assertEqual(entry["state"], "abandoned")
+        self.assertEqual(entry["uncommitted_files"], 2)
+        self.assertEqual(entry["unique_commits"], 0)
+        self.assertEqual(entry["branch"], "ChaosEngine/stale")
+        self.assertFalse(entry["is_current"])
+
+    def test_abandoned_advisory_names_the_path_and_the_pending_work(self):
+        worktree = self.add_worktree("stale", "ChaosEngine/stale")
+        self.write(worktree, "docs/guide.md", "work\n")
+
+        advisories = format_advisories(collect_worktree_report(self.main))
+        self.assertEqual(len(advisories), 1)
+        advisory = advisories[0]
+        self.assertIn("abandoned", advisory)
+        self.assertIn("stale", advisory)
+        self.assertIn("1 uncommitted", advisory)
+
+    def test_worktree_with_its_own_commits_is_not_abandoned(self):
+        worktree = self.add_worktree("live", "ChaosEngine/live")
+        self.write(worktree, "feature.txt", "new\n")
+        git(worktree, "add", "-A")
+        git(worktree, "commit", "-qm", "feature")
+        self.write(worktree, "feature.txt", "new and edited\n")
+
+        entry = self.entry(collect_worktree_report(self.main), "live")
+        self.assertEqual(entry["unique_commits"], 1)
+        self.assertEqual(entry["ahead"], 1)
+        self.assertEqual(entry["state"], "uncommitted")
+
+    # --- superseded: already upstream through another path -------------------
+
+    def test_a_freshly_created_clean_worktree_is_not_superseded(self):
+        # A worktree another session created seconds ago from origin/main is
+        # clean and carries no unique patch -- identical on paper to one whose
+        # work has landed. Calling it superseded tells the reader to delete a
+        # live session's checkout, which the mandatory entrypoint forbids.
+        self.add_worktree("fresh", "ChaosEngine/fresh")
+
+        entry = self.entry(collect_worktree_report(self.main), "fresh")
+        self.assertEqual(entry["ahead"], 0, "it has never committed anything")
+        self.assertEqual(entry["state"], "clean")
+        self.assertEqual(format_advisories(collect_worktree_report(self.main)), [])
+
+    def test_a_worktree_holding_the_upstream_branch_is_never_superseded(self):
+        # Advising "delete the branch" for a worktree parked on main would
+        # propose deleting main itself.
+        git(self.main, "checkout", "-q", "-b", "ChaosEngine/elsewhere")
+        self.write(self.main, "feature.txt", "work\n")
+        git(self.main, "add", "-A")
+        git(self.main, "commit", "-qm", "feature")
+
+        path = self.base / "mainline"
+        git(self.main, "worktree", "add", "-q", str(path), "main")
+
+        entry = self.entry(collect_worktree_report(self.main), "mainline")
+        self.assertEqual(entry["branch"], "main")
+        self.assertNotEqual(entry["state"], "superseded")
+
+    def test_a_locked_worktree_is_left_alone(self):
+        # `git worktree list --porcelain` marks a worktree a live session holds.
+        worktree = self.add_worktree("held", "ChaosEngine/held")
+        self.write(worktree, "docs/guide.md", "in progress\n")
+        git(self.main, "worktree", "lock", str(worktree), "--reason", "agent session")
+
+        entry = self.entry(collect_worktree_report(self.main), "held")
+        self.assertTrue(entry["locked"])
+        self.assertEqual(entry["state"], "uncommitted")
+        advisory = next(item for item in format_advisories(collect_worktree_report(self.main))
+                        if "held" in item)
+        self.assertNotIn("abandoned", advisory)
+
+    def test_a_prunable_worktree_entry_is_skipped(self):
+        import shutil
+
+        worktree = self.add_worktree("gone", "ChaosEngine/gone")
+        shutil.rmtree(worktree)
+
+        report = collect_worktree_report(self.main)
+        self.assertEqual([Path(item["path"]).name for item in report], ["checkout"])
+
+    def test_patch_identical_commits_count_as_already_upstream(self):
+        # The 2026-08-04 case: the content had already landed on origin/main
+        # through a different commit. Ahead/behind alone calls this live work;
+        # only patch identity (`git cherry`) sees that it is already upstream.
+        worktree = self.add_worktree("duplicate", "ChaosEngine/duplicate")
+        self.write(worktree, "catalog.md", "The properties catalog.\n")
+        git(worktree, "add", "-A")
+        git(worktree, "commit", "-qm", "add catalog")
+        carried = git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+        # Main moved on independently, so replaying the patch there produces a
+        # different commit hash carrying identical content -- the shape that
+        # made the abandoned catalog draft look like unlanded work.
+        self.write(self.main, "CHANGELOG.md", "Unrelated progress.\n")
+        git(self.main, "add", "-A")
+        git(self.main, "commit", "-qm", "unrelated")
+        picked = git(self.main, "cherry-pick", carried)
+        self.assertEqual(picked.returncode, 0, picked.stderr)
+        self.assertNotEqual(
+            git(self.main, "rev-parse", "main").stdout.strip(),
+            carried,
+            "the replayed commit must be a different commit, not a fast-forward",
+        )
+        self.publish_main()
+
+        entry = self.entry(collect_worktree_report(self.main), "duplicate")
+        self.assertEqual(entry["ahead"], 1, "the branch really does carry a commit")
+        self.assertEqual(entry["unique_commits"], 0, "but its patch is already upstream")
+        self.assertEqual(entry["state"], "superseded")
+
+        advisory = next(item for item in format_advisories(collect_worktree_report(self.main))
+                        if "duplicate" in item)
+        self.assertIn("superseded", advisory)
+        self.assertIn("already", advisory)
+
+    # --- corrupt: NUL-filled content masquerading as ordinary edits ----------
+
+    def test_nul_filled_files_make_a_worktree_corrupt(self):
+        worktree = self.add_worktree("zeroed", "ChaosEngine/zeroed")
+        (worktree / "README.md").write_bytes(b"\x00" * 200)
+
+        entry = self.entry(collect_worktree_report(self.main), "zeroed")
+        self.assertEqual(entry["corrupt_files"], 1)
+        self.assertEqual(entry["state"], "corrupt")
+
+        advisory = next(item for item in format_advisories(collect_worktree_report(self.main))
+                        if "zeroed" in item)
+        self.assertIn("corrupt", advisory)
+        self.assertIn("NUL", advisory)
+        self.assertIn("git restore", advisory)
+
+    def test_corruption_outranks_abandonment(self):
+        worktree = self.add_worktree("zeroed", "ChaosEngine/zeroed")
+        (worktree / "README.md").write_bytes(b"\x00" * 200)
+        self.write(worktree, "notes.md", "real work\n")
+
+        entry = self.entry(collect_worktree_report(self.main), "zeroed")
+        self.assertEqual(entry["state"], "corrupt")
+
+    # --- ending a turn with uncommitted changes -----------------------------
+
+    def test_current_worktree_with_uncommitted_changes_is_reported(self):
+        self.write(self.main, "README.md", "# Project\n\nUnsaved.\n")
+
+        report = collect_worktree_report(self.main)
+        entry = self.entry(report, "checkout")
+        self.assertTrue(entry["is_current"])
+        self.assertEqual(entry["state"], "uncommitted")
+
+        advisories = format_advisories(report)
+        self.assertEqual(len(advisories), 1)
+        self.assertIn("uncommitted", advisories[0])
+        self.assertIn("commit", advisories[0])
+
+    def test_report_is_taken_from_the_worktree_it_runs_in(self):
+        worktree = self.add_worktree("other", "ChaosEngine/other")
+        report = collect_worktree_report(worktree)
+        self.assertTrue(self.entry(report, "other")["is_current"])
+        self.assertFalse(self.entry(report, "checkout")["is_current"])
+
+    def test_running_from_a_subdirectory_still_identifies_the_current_worktree(self):
+        # Comparing the given directory against worktree roots would call the
+        # live worktree "not current" and then, if it were dirty, abandoned.
+        worktree = self.add_worktree("other", "ChaosEngine/other")
+        self.write(worktree, "docs/guide.md", "work in progress\n")
+
+        report = collect_worktree_report(worktree / "docs")
+        entry = self.entry(report, "other")
+        self.assertTrue(entry["is_current"])
+        self.assertEqual(entry["state"], "uncommitted")
+
+    # --- open pull requests refine, but never gate, the classification ------
+
+    def test_open_pull_request_keeps_a_dirty_worktree_out_of_abandoned(self):
+        worktree = self.add_worktree("reviewed", "ChaosEngine/reviewed")
+        self.write(worktree, "docs/guide.md", "work\n")
+
+        def pull_requests(branch: str) -> int:
+            return 1 if branch == "ChaosEngine/reviewed" else 0
+
+        entry = self.entry(
+            collect_worktree_report(self.main, open_pull_requests=pull_requests),
+            "reviewed",
+        )
+        self.assertEqual(entry["open_pull_requests"], 1)
+        self.assertEqual(entry["state"], "uncommitted")
+
+    def test_pull_request_lookup_is_optional_and_unknown_by_default(self):
+        worktree = self.add_worktree("stale", "ChaosEngine/stale")
+        self.write(worktree, "docs/guide.md", "work\n")
+
+        entry = self.entry(collect_worktree_report(self.main), "stale")
+        self.assertIsNone(entry["open_pull_requests"])
+        self.assertEqual(entry["state"], "abandoned")
+
+    def test_a_failing_pull_request_lookup_does_not_break_the_report(self):
+        worktree = self.add_worktree("stale", "ChaosEngine/stale")
+        self.write(worktree, "docs/guide.md", "work\n")
+
+        def pull_requests(branch: str) -> int:
+            raise RuntimeError("gh is unavailable")
+
+        entry = self.entry(
+            collect_worktree_report(self.main, open_pull_requests=pull_requests),
+            "stale",
+        )
+        self.assertIsNone(entry["open_pull_requests"])
+        self.assertEqual(entry["state"], "abandoned")
+
+    def test_advisory_says_when_no_pull_request_lookup_happened(self):
+        worktree = self.add_worktree("stale", "ChaosEngine/stale")
+        self.write(worktree, "docs/guide.md", "work\n")
+
+        advisory = next(item for item in format_advisories(collect_worktree_report(self.main))
+                        if "stale" in item)
+        self.assertIn("not checked", advisory)
+
+    # --- detached HEAD holding work no branch references --------------------
+
+    def test_detached_head_carrying_unreferenced_commits_is_abandoned(self):
+        worktree = self.add_worktree("orphan", "ChaosEngine/orphan")
+        self.write(worktree, "rescue.md", "the only copy of this work\n")
+        git(worktree, "add", "-A")
+        git(worktree, "commit", "-qm", "work")
+        carried = git(worktree, "rev-parse", "HEAD").stdout.strip()
+        git(worktree, "checkout", "-q", "--detach", carried)
+        git(self.main, "branch", "-D", "ChaosEngine/orphan")
+
+        entry = self.entry(collect_worktree_report(self.main), "orphan")
+        self.assertIsNone(entry["branch"])
+        self.assertEqual(entry["unique_commits"], 1)
+        self.assertEqual(entry["state"], "abandoned")
+        advisory = next(item for item in format_advisories(collect_worktree_report(self.main))
+                        if "orphan" in item)
+        self.assertIn("detached HEAD", advisory)
+
+    def test_detached_head_already_upstream_is_not_abandoned(self):
+        worktree = self.add_worktree("detached", "ChaosEngine/detached")
+        head = git(worktree, "rev-parse", "HEAD").stdout.strip()
+        git(worktree, "checkout", "-q", "--detach", head)
+
+        entry = self.entry(collect_worktree_report(self.main), "detached")
+        self.assertEqual(entry["unique_commits"], 0)
+        self.assertNotEqual(entry["state"], "abandoned")
+
+    # --- missing upstream must not invent a verdict -------------------------
+
+    def test_without_an_upstream_ref_nothing_is_called_superseded(self):
+        git(self.main, "update-ref", "-d", "refs/remotes/origin/main")
+        self.add_worktree("landed", "ChaosEngine/landed")
+
+        entry = self.entry(collect_worktree_report(self.main), "landed")
+        self.assertIsNone(entry["unique_commits"])
+        self.assertNotEqual(entry["state"], "superseded")
+
+
+class OpenPullRequestLookupTest(unittest.TestCase):
+    """The one function that leaves the machine."""
+
+    def test_missing_github_cli_raises_rather_than_reporting_zero(self):
+        # Reporting 0 would be indistinguishable from "no open pull request",
+        # which is one of the inputs that decides the abandoned verdict.
+        with patch("scripts.ci.worktree_hygiene.shutil.which", return_value=None):
+            with self.assertRaises(RuntimeError):
+                open_pull_requests_via_gh("ChaosEngine/example")
+
+    def test_a_failed_lookup_raises_rather_than_reporting_zero(self):
+        completed = subprocess.CompletedProcess([], 1, "", "not authenticated")
+        with patch("scripts.ci.worktree_hygiene.shutil.which", return_value="gh"), patch(
+            "scripts.ci.worktree_hygiene.subprocess.run", return_value=completed
+        ):
+            with self.assertRaises(RuntimeError):
+                open_pull_requests_via_gh("ChaosEngine/example")
+
+    def test_open_pull_requests_are_counted(self):
+        completed = subprocess.CompletedProcess([], 0, '[{"number": 1}, {"number": 2}]', "")
+        with patch("scripts.ci.worktree_hygiene.shutil.which", return_value="gh"), patch(
+            "scripts.ci.worktree_hygiene.subprocess.run", return_value=completed
+        ):
+            self.assertEqual(open_pull_requests_via_gh("ChaosEngine/example"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📋 Description

Makes two silent worktree failure modes detectable. A worktree holding uncommitted changes is now classified and reported (corrupt / abandoned / superseded / uncommitted / unknown / clean) through the validator agents already run, and a new PreToolUse guard rule refuses to stage or commit files that are almost entirely NUL bytes.

## 🔗 Related Issue(s)

- Closes #4437
- Part of #4434

## 🗂️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🚀 New feature (non-breaking change that adds functionality)
- [x] ✅ Test coverage improvement
- [x] 🔧 CI/CD or infrastructure change

## What this fixes

Found live in the main checkout on 2026-08-04. Seven worktrees had accumulated; three held uncommitted changes. Two carried documentation **already landed on `origin/main` through another path**, and one held **652 entirely NUL-filled files** that `git status` reported as ordinary ` M` entries. Establishing that cost a full byte-level investigation and landed zero commits. A routine cleanup would have destroyed all of it, and re-doing the "recoverable" work would have regressed `main`.

### 1. Worktree hygiene — `scripts/ci/worktree_hygiene.py` (new)

Classifies every worktree and emits one actionable line per finding, wired into `scripts/ci/validate_agent_setup.py` so it rides along with `--skip-external`, the invocation `AGENTS.md` prescribes. Advisories are **reported, never fatal** — concurrent sessions legitimately hold their own worktrees, so this must inform an agent rather than block it.

Relationship to upstream uses `git cherry`, not ahead/behind: the abandoned branches carried commits whose *patches* were already on `origin/main`, which ahead/behind reads as live work.

Every verdict past "there are uncommitted files here" requires **positive evidence**, because the advice attached to it is destructive. Left alone: a `locked` worktree (a live session holds it), the primary checkout, the current worktree, one parked on the upstream branch, and one that has never committed — a freshly created worktree is clean and carries no unique patch, which on paper is identical to one whose work has landed. `prunable` entries are skipped, and a git query that cannot answer reports `unknown` rather than `clean`.

The standalone CLI adds the open-pull-request lookup:

```
py -3 scripts/ci/worktree_hygiene.py --check-pull-requests
```

That lookup is deliberately **not** wired into the validator: it would add one network round trip per worktree to a command contributors run by hand.

### 2. Guard rule R10 — NUL-byte corruption

`scripts/agents/guard.py` gains R10, alongside R8 (`git stash`) and R9 (`git worktree add`), which exist for comparable data-loss reasons. It refuses `git add` / `git stage` / `git commit` when a candidate file is ≥95% NUL across head, middle, and tail samples.

- Samples three windows, not a prefix, so a legitimately zero-padded file is not mistaken for a zeroed one.
- Resolves the directory the command actually targets (`git -C <path>`, `--work-tree=`), not the calling process's.
- Covers untracked files, so a single-line `git add -A && git commit -m x` cannot slip a newly zeroed file through.
- Honours an explicit `git add <path>` pathspec, so healthy work can still be rescued while one corrupt file sits in the tree. `git commit -m <message>` arguments are never read as pathspecs — only an explicit `--` delimits a commit pathspec.
- Names only the corrupt paths to restore, and explicitly warns against restoring the whole worktree, which would discard the healthy uncommitted work alongside it.
- Samples every candidate directly rather than pre-filtering on diff line counts: a `diff` attribute in `.gitattributes` can give a NUL-filled file non-zero insertion counts, and such a pre-filter would exempt exactly the file it needs to catch.

Unlike R1–R9 it reads repository state, so it is dispatched with a working directory rather than from the pure `evaluate_command` path (which stays repository-independent, pinned by self-test rows). Every uncertain step **fails open**: missing git, no HEAD, not a repository, unreadable file, timeout.

### 3. Installer manifest

`AGENT_VALIDATION_SCRIPT_FILES` ships `validate_agent_setup.py` into a user's project but did not carry every module it imports — `validate_skills.py` was **already** missing, so an installed validator died on `ImportError`. Now complete, with a test that reads the real `from scripts... import` statements rather than restating the list.

## ✅ Pre-Submission Checklist

- [x] I have read the Contributing Guide and this PR follows its guidelines.
- [x] Documentation/agent-only changes pass their deterministic validators and `git diff --check`.
- [x] Behavior changes have focused automated coverage.
- [ ] Affected tests pass: `mvn ...` — n/a, no Java changed.
- [ ] Code/build changes compile once — n/a, no Java or build changed.
- [ ] New `public` methods and classes have JavaDoc — n/a, Python only.
- [x] I have not introduced any hardcoded credentials, secrets, or sensitive data.
- [x] I have not broken backward compatibility. `evaluate_command` and `collect_metrics` are unchanged; `validate_repository` still returns `(errors, metrics)` with purely additive metrics keys.
- [ ] UI/reporting changes include screenshots — n/a.

## 🧪 How to Test

1. `py -3 scripts/agents/guard.py --self-test`
2. `py -3 scripts/ci/validate_agent_setup.py --skip-external`
3. `py -3 -m unittest tests.scripts.test_guard_nul_corruption tests.scripts.test_worktree_hygiene tests.scripts.test_validate_agent_setup tests.scripts.test_install_shaft_mcp`
4. Reproduce the corruption directly: in a scratch repo, commit a text file, overwrite it with NUL bytes at a plausible size, then confirm `git add -A` is denied and `git status` still shows it as a plain ` M`.

## Evidence

`py -3 scripts/agents/guard.py --self-test` → exit 0

```
Self-test summary: 93/93 passed, 0 failed.
R9 worktree-add self-test summary: 0 failed.
R10 NUL-corruption self-test summary: 0 failed.
```

`py -3 scripts/ci/validate_agent_setup.py --skip-external` → exit 0, and the new advisory line is real output from this machine:

```
Agent setup is valid: 129090 guidance bytes, 0% reduction, 331 memory objects.
worktree-uncommitted: .../.claude/worktrees/agent-aad1174a12f8f48aa
  (ChaosEngine/harness-abandoned-worktree-guard-4437): 10 uncommitted file(s).
  Uncommitted work is not done -- commit and push it before ending the turn, or discard it deliberately.
```

Full agent-guidance suite plus the installer suite, exactly as CI runs them:

```
Ran 231 tests in 37.558s
OK
```

Adversarial review caught two blockers before commit, both now fixed and covered by regression tests:

- A live sibling worktree another session had just created was classified `superseded` with the advice *"Remove the worktree and delete the branch"* — reproduced against this repository's real `codex-harness-parity-4434` worktree, and contradicting the entrypoint's "skip and report, never delete". Fixed by requiring `ahead >= 1` and honouring the `locked` marker; verified silent on the same worktree afterwards.
- `git -C <corrupt-repo> add -A` bypassed R10 entirely because the directory came from the calling process rather than the command — the exact shape `.memory` prescribes for touching another worktree.

Also fixed from that review: chained `git status && git add -A`, untracked NUL files, non-ASCII paths (decoded with `os.fsdecode` + `core.quotePath=false` rather than the process locale), detached-HEAD work no branch references, `git status` failure being read as "clean", prunable entries, and a `git diff --check`-style `core.longpaths=true` on every query.

`py -3 scripts/ci/validate_workflow_timeouts.py` and `py -3 scripts/ci/validate_orphaned_suite_files.py` both pass.

## Documentation Site

- Documentation PR: none
- Documentation not required because: this is internal agent-harness tooling with no public API, user-facing behavior, or documented surface. Nothing under `shafthq.github.io` describes `scripts/agents/guard.py` or `scripts/ci/validate_agent_setup.py`.

## 📝 Additional Notes

Known, deliberate limits of R10, documented in the rule header:

- It targets **wholly** zeroed files. The issue's "45 MB `.ipa` was 84% NUL" example is by construction below the 0.95 threshold; lowering it would risk denying legitimate padded binaries, and blocking a real commit is the worse failure for a PreToolUse guard.
- It cannot resolve a user's `git` aliases, which are invisible in the command string.
- It does not descend into submodules, whose gitlink is all `git diff` reports.

Adjacent finding, not fixed here: this repository's main checkout carries a branch whose remote was deleted, with unique commits and uncommitted files — filed separately rather than touched from this worktree.
