### PR TITLE
Fix #4444: move the release/publish workflows onto cache-maven-repo

### DIFF
--- a/.github/workflows/maven-central-reconcile.yml
+++ b/.github/workflows/maven-central-reconcile.yml
@@ -62,12 +62,15 @@ jobs:
           java-version: '25'
           distribution: 'zulu'
           check-latest: true
-          cache: 'maven'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      # cache-maven-repo, not setup-java's `cache: 'maven'` -- one key format
+      # with restore-keys across every call site (issues #4440, #4444).
+      - name: Cache Maven repository
+        uses: ./.github/actions/cache-maven-repo
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5.1
         with:

--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -106,12 +106,15 @@ jobs:
           java-version: '25'
           distribution: 'zulu'
           check-latest: true
-          cache: 'maven'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      # cache-maven-repo, not setup-java's `cache: 'maven'` -- one key format
+      # with restore-keys across every call site (issues #4440, #4444).
+      - name: Cache Maven repository
+        uses: ./.github/actions/cache-maven-repo
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5.1
         with:

--- a/.github/workflows/publishJavaDocs.yml
+++ b/.github/workflows/publishJavaDocs.yml
@@ -38,12 +38,15 @@ jobs:
           java-version: '25'
           distribution: 'zulu'
           check-latest: true
-          cache: 'maven'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      # cache-maven-repo, not setup-java's `cache: 'maven'` -- one key format
+      # with restore-keys across every call site (issues #4440, #4444).
+      - name: Cache Maven repository
+        uses: ./.github/actions/cache-maven-repo
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:

--- a/.github/workflows/shaft-pilot-release.yml
+++ b/.github/workflows/shaft-pilot-release.yml
@@ -90,7 +90,10 @@ jobs:
           java-version: "25"
           distribution: "zulu"
           check-latest: true
-          cache: "maven"
+      # cache-maven-repo, not setup-java's `cache: "maven"` -- one key format
+      # with restore-keys across every call site (issues #4440, #4444).
+      - name: Cache Maven repository
+        uses: ./.github/actions/cache-maven-repo
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5.1
         with:


### PR DESCRIPTION
## 📋 Description

Moves the last four `actions/setup-java` call sites off its built-in
`cache: maven` and onto `.github/actions/cache-maven-repo`, finishing what #4443
started for the high-frequency consumers.

## 🔗 Related Issue(s)

- Closes #4444
- Follows up #4443 / #4440

## 🗂️ Type of Change

- [x] 🔧 CI/CD or infrastructure change

## What changed

| File | Line before |
|---|---|
| `.github/workflows/maven-central-reconcile.yml` | 65 |
| `.github/workflows/mavenCentral_cd.yml` | 109 |
| `.github/workflows/publishJavaDocs.yml` | 41 |
| `.github/workflows/shaft-pilot-release.yml` | 93 |

Each drops `cache: 'maven'` from its `setup-java` step and gains a
`uses: ./.github/actions/cache-maven-repo` step immediately after it — the same
placement `setup-test-env` and `pr-gate.yml` already use.

Note `shaft-pilot-release.yml` spelled it `cache: "maven"` with double quotes, so
a single-quote grep finds only three of the four. All four are handled here.

### Why, given these are single-job and infrequent

The #4440 failure mode (22 jobs cold-resolving at once into an HTTP 429) does not
apply to them, which is why #4443 left them alone. The reason to move them anyway
is the cache budget, not the 429:

while they keep saving under `setup-java-<os>-<arch>-maven-<hash>`, the
repository carries **two ~500 MiB Maven cache families per pom hash**. Usage was
already 9.08 of 10 GiB during #4440, and it was LRU eviction inside that budget
that removed the fallback the nightly needed. `cache-maven-repo`'s own header
states the key format must stay identical across call sites; four stragglers kept
that only partly true.

## ✅ Pre-Submission Checklist

- [x] I have read the Contributing Guide and this PR follows its guidelines.
- [x] Documentation/agent-only changes pass their deterministic validators and `git diff --check`.
- [ ] Behavior changes have focused automated coverage — n/a, caching-only change to workflow YAML; the repository's workflow validators are the coverage that applies.
- [ ] Affected tests pass: `mvn ...` — n/a, no Java changed.
- [ ] Code/build changes compile once — n/a, no Java or build changed.
- [ ] New `public` methods and classes have JavaDoc — n/a.
- [x] I have not introduced any hardcoded credentials, secrets, or sensitive data — the `server-id`/GPG inputs on each `setup-java` step are untouched.
- [x] I have not broken backward compatibility.
- [ ] UI/reporting changes include screenshots — n/a.

## 🧪 How to Test

```
py -3 scripts/ci/validate_workflow_timeouts.py        -> All workflow jobs declare timeout-minutes.
py -3 scripts/ci/validate_maven_publication.py        -> Maven Central publication configuration is valid.
py -3 scripts/ci/validate_shaft_pilot_release.py      -> SHAFT Pilot release contract is valid.
py -3 scripts/ci/validate_shaft_mcp_configuration.py  -> ... configuration is valid.
py -3 -m unittest tests.scripts.test_validate_maven_publication tests.scripts.test_validate_shaft_pilot_release tests.scripts.test_validate_shaft_mcp_configuration
                                                      -> Ran 46 tests ... OK
```

A YAML parse of all four files confirms the new step is a sibling of
`setup-java` and lands immediately after it in every job, and a repository-wide
scan finds no remaining `cache: 'maven'` / `cache: "maven"`.

## Limitation worth stating plainly

These four workflows only run on release, publish, and reconcile events, so none
of them executes on this PR. The evidence above is structural — parse, ordering,
validators — plus the fact that the step being added is already proven in CI by
`setup-test-env` and `pr-gate.yml`. The first real proof is the next release run,
and a cache miss there degrades to one slow download, not a failure.

## Documentation Site

- Documentation PR: none
- Documentation not required because: internal CI caching, no public API or
  user-facing surface.
