### PR TITLE
Fix #4445: retry a Maven Central refusal in a fresh process

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 scripts/mcp/*.sh text eol=lf
+scripts/ci/*.sh text eol=lf
 .claude/workflows/*.js text eol=lf
 shaft-skills/references/*.md text eol=lf
 scripts/mcp/*.py text eol=lf

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -78,8 +78,14 @@ jobs:
         uses: ./.github/actions/setup-test-env
         with:
           node-version: '20'
+      # See the note in e2eTests.yml: a Central refusal in this step, which has
+      # no continue-on-error, cascades into a missing Allure summary (#4445).
+      # `shell: bash` is explicit because these jobs run on Windows and macOS.
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
+        shell: bash
+        run: >-
+          bash scripts/ci/maven_retry.sh 2 60
+          mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Print Edge version
         continue-on-error: true
         run: (Get-Item (Get-Command msedge).Source).VersionInfo.ProductVersion
@@ -113,8 +119,14 @@ jobs:
         uses: ./.github/actions/setup-test-env
         with:
           node-version: '20'
+      # See the note in e2eTests.yml: a Central refusal in this step, which has
+      # no continue-on-error, cascades into a missing Allure summary (#4445).
+      # `shell: bash` is explicit because these jobs run on Windows and macOS.
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
+        shell: bash
+        run: >-
+          bash scripts/ci/maven_retry.sh 2 60
+          mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || format('{0}, !%regex[.*MobileEmulation.*]', env.GLOBAL_TESTING_SCOPE) }}"
@@ -149,8 +161,14 @@ jobs:
         uses: ./.github/actions/setup-test-env
         with:
           node-version: '20'
+      # See the note in e2eTests.yml: a Central refusal in this step, which has
+      # no continue-on-error, cascades into a missing Allure summary (#4445).
+      # `shell: bash` is explicit because these jobs run on Windows and macOS.
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
+        shell: bash
+        run: >-
+          bash scripts/ci/maven_retry.sh 2 60
+          mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=WINDOWS" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
@@ -328,8 +346,14 @@ jobs:
         uses: ./.github/actions/setup-test-env
         with:
           node-version: '20'
+      # See the note in e2eTests.yml: a Central refusal in this step, which has
+      # no continue-on-error, cascades into a missing Allure summary (#4445).
+      # `shell: bash` is explicit because these jobs run on Windows and macOS.
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
+        shell: bash
+        run: >-
+          bash scripts/ci/maven_retry.sh 2 60
+          mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -281,8 +281,16 @@ jobs:
           node-version: '20'
       - name: Check running containers
         run: docker ps
+      # Wrapped because this step, not `Run tests`, is where a cold cache pays:
+      # it has no continue-on-error, so a Central refusal here skips `Run tests`
+      # and `Post-Test Report and Check` then fails on a missing Allure summary
+      # (issue #4445, run 30876948089). The retry is a fresh process; Maven's
+      # own in-JVM retries had already spent 6m05s losing to the same 429.
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
+        shell: bash
+        run: >-
+          bash scripts/ci/maven_retry.sh 2 60
+          mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
@@ -319,8 +327,16 @@ jobs:
           node-version: '20'
       - name: Check running containers
         run: docker ps
+      # Wrapped because this step, not `Run tests`, is where a cold cache pays:
+      # it has no continue-on-error, so a Central refusal here skips `Run tests`
+      # and `Post-Test Report and Check` then fails on a missing Allure summary
+      # (issue #4445, run 30876948089). The retry is a fresh process; Maven's
+      # own in-JVM retries had already spent 6m05s losing to the same 429.
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
+        shell: bash
+        run: >-
+          bash scripts/ci/maven_retry.sh 2 60
+          mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
@@ -357,8 +373,16 @@ jobs:
           node-version: '20'
       - name: Check running containers
         run: docker ps
+      # Wrapped because this step, not `Run tests`, is where a cold cache pays:
+      # it has no continue-on-error, so a Central refusal here skips `Run tests`
+      # and `Post-Test Report and Check` then fails on a missing Allure summary
+      # (issue #4445, run 30876948089). The retry is a fresh process; Maven's
+      # own in-JVM retries had already spent 6m05s losing to the same 429.
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
+        shell: bash
+        run: >-
+          bash scripts/ci/maven_retry.sh 2 60
+          mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
         run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
@@ -674,8 +698,16 @@ jobs:
         uses: ./.github/actions/setup-test-env
         with:
           node-version: '20'
+      # Wrapped because this step, not `Run tests`, is where a cold cache pays:
+      # it has no continue-on-error, so a Central refusal here skips `Run tests`
+      # and `Post-Test Report and Check` then fails on a missing Allure summary
+      # (issue #4445, run 30876948089). The retry is a fresh process; Maven's
+      # own in-JVM retries had already spent 6m05s losing to the same 429.
       - name: Install optional visual test runtime
-        run: mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
+        shell: bash
+        run: >-
+          bash scripts/ci/maven_retry.sh 2 60
+          mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
         timeout-minutes: 40

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -103,6 +103,11 @@ jobs:
               - 'tests/scripts/test_validate_skills.py'
               - 'tests/scripts/test_sync_user_harness.py'
               - 'tests/scripts/test_shaft_skills_content.py'
+              # Not agent guidance, but this is the only gate that runs the
+              # script suites on both a Linux and a Windows runner, which is
+              # what maven_retry.sh needs (issue #4445).
+              - 'scripts/ci/maven_retry.sh'
+              - 'tests/scripts/test_maven_retry.py'
             intellij:
               - 'shaft-intellij/**'
               - '.github/workflows/publish-intellij-plugin.yml'
@@ -211,6 +216,7 @@ jobs:
           tests.scripts.test_sync_user_harness
           tests.scripts.test_shaft_skills_content
           tests.scripts.test_worktree_hygiene
+          tests.scripts.test_maven_retry
           -v
       - name: Validate agent guidance budgets and routing
         run: python scripts/ci/validate_agent_setup.py --skip-external

--- a/scripts/ci/maven_retry.sh
+++ b/scripts/ci/maven_retry.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Re-run a Maven invocation in a FRESH process when Maven Central refuses the
+# transfer, and only then.
+#
+# Maven's own resolver already retries in-JVM (aether.connector.http.retryHandler.count,
+# default 3). In run 30876948089 that spent 6m05s -- 04:13:04 to 04:19:09 -- and
+# still lost, because every in-JVM retry sits inside the same rate-limit window
+# Central is refusing. Raising that count buys more of the same. A new process
+# after a pause is the only lever left that changes the input.
+#
+# Usage: maven_retry.sh <attempts> <pause-seconds> <command> [args...]
+set -uo pipefail
+
+attempts=${1:?usage: maven_retry.sh <attempts> <pause-seconds> <command> [args...]}
+shift
+pause=${1:?usage: maven_retry.sh <attempts> <pause-seconds> <command> [args...]}
+shift
+
+# "The network refused us", not "the build is broken". A compilation error, a
+# failing test, or a genuinely missing artifact must fail on the first attempt:
+# retrying those burns the job's timeout to arrive at the same answer, and
+# buries the real error under two more rounds of output.
+RETRYABLE='status code: 429|Too Many Requests|Could not transfer artifact|Connection reset|Connection timed out|Read timed out|Premature end of Content-Length'
+
+output=$(mktemp)
+trap 'rm -f "$output"' EXIT
+
+attempt=1
+while :; do
+  "$@" 2>&1 | tee "$output"
+  status=${PIPESTATUS[0]}
+
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+
+  if ! grep -Eq "$RETRYABLE" "$output"; then
+    echo "maven-retry: attempt ${attempt} failed for a reason that is not a transfer error; not retrying." >&2
+    exit "$status"
+  fi
+
+  if [ "$attempt" -ge "$attempts" ]; then
+    echo "maven-retry: still refused after ${attempt} attempt(s); giving up." >&2
+    exit "$status"
+  fi
+
+  echo "maven-retry: transfer refused on attempt ${attempt}/${attempts}; sleeping ${pause}s, then retrying in a fresh process." >&2
+  sleep "$pause"
+  attempt=$((attempt + 1))
+done

--- a/tests/scripts/test_maven_retry.py
+++ b/tests/scripts/test_maven_retry.py
@@ -1,0 +1,119 @@
+"""Behaviour of scripts/ci/maven_retry.sh."""
+# The loop lives in a standalone script rather than inline in each workflow step
+# so it can be exercised here against a fake command, on both runners the agent
+# guidance gate uses. A cold-cache Maven Central 429 cannot be reproduced on
+# demand (issue #4445), so the contract proven here is the control flow: what
+# retries, what does not, and how many attempts each costs.
+
+import os
+import shutil
+import subprocess  # nosec B404 - runs the checked-in retry script under bash.
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RETRY_SCRIPT = REPO_ROOT / "scripts" / "ci" / "maven_retry.sh"
+
+# The real thing, trimmed from run 30876948089's failing job.
+CENTRAL_429 = (
+    "[ERROR] Non-resolvable import POM: The following artifacts could not be "
+    "resolved: org.junit:junit-bom:pom:6.1.2 (absent): Could not transfer "
+    "artifact org.junit:junit-bom:pom:6.1.2 from/to central "
+    "(https://repo.maven.apache.org/maven2): status code: 429, reason phrase: "
+    "Too Many Requests (429)"
+)
+GENUINE_FAILURE = (
+    "[ERROR] Failed to execute goal on project shaft-visual: Compilation failure"
+)
+
+
+def _bash() -> str | None:
+    return shutil.which("bash")
+
+
+class MavenRetryScriptTest(unittest.TestCase):
+    def setUp(self):
+        if _bash() is None:
+            self.skipTest("bash is unavailable on this host")
+        if not RETRY_SCRIPT.is_file():
+            self.fail(f"retry script is missing: {RETRY_SCRIPT}")
+        # ignore_cleanup_errors: on Windows the bash process can still hold the
+        # directory briefly after it exits, and a cleanup race must not be
+        # reported as a failure of the behaviour under test.
+        self._directory = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.workspace = Path(self._directory.name)
+        self.addCleanup(self._directory.cleanup)
+        # Everything the run touches is copied into one directory and invoked
+        # relative to it. `bash` on a Windows host may be Git Bash (which reads
+        # `C:/...`) or WSL (which reads `/mnt/c/...`), and only a relative path
+        # from a translated working directory means the same thing to both.
+        self.script = self.workspace / "retry.sh"
+        self.script.write_text(
+            RETRY_SCRIPT.read_text(encoding="utf-8"), encoding="utf-8", newline="\n"
+        )
+
+    def _fake_command(self, *, output: str, fail_times: int) -> str:
+        # Records one line per invocation, then fails `fail_times` times before
+        # succeeding, so the test can count attempts rather than infer them.
+        script = self.workspace / "fake-mvn.sh"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            'echo "attempt" >> attempts.log\n'
+            "count=$(wc -l < attempts.log)\n"
+            f'if [ "$count" -le {fail_times} ]; then\n'
+            f'  echo "{output}"\n'
+            "  exit 1\n"
+            "fi\n"
+            'echo "BUILD SUCCESS"\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        os.chmod(script, 0o755)  # nosec B103 - test fixture the test itself runs.
+        return "./fake-mvn.sh"
+
+    def _run(self, command: str, *, attempts: int = 3, pause: int = 0):
+        completed = subprocess.run(  # nosec B603 - fixed bash invocation in a temp dir.
+            [_bash(), "./retry.sh", str(attempts), str(pause), "bash", command],
+            cwd=self.workspace,
+            capture_output=True,
+            text=True,
+        )
+        log = self.workspace / "attempts.log"
+        made = len(log.read_text(encoding="utf-8").splitlines()) if log.is_file() else 0
+        return completed, made
+
+    def test_a_command_that_succeeds_runs_once(self):
+        command = self._fake_command(output="", fail_times=0)
+        completed, attempts = self._run(command)
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+        self.assertEqual(1, attempts)
+
+    def test_a_central_429_is_retried_in_a_fresh_process_until_it_succeeds(self):
+        command = self._fake_command(output=CENTRAL_429, fail_times=2)
+        completed, attempts = self._run(command, attempts=3)
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+        self.assertEqual(3, attempts)
+
+    def test_a_genuine_build_failure_is_not_retried(self):
+        # Retrying a compilation error would burn the job's timeout to reach the
+        # same failure, and would hide it behind two more minutes of noise.
+        command = self._fake_command(output=GENUINE_FAILURE, fail_times=99)
+        completed, attempts = self._run(command, attempts=3)
+        self.assertNotEqual(0, completed.returncode)
+        self.assertEqual(1, attempts)
+
+    def test_a_persistent_429_exhausts_the_attempts_and_fails(self):
+        command = self._fake_command(output=CENTRAL_429, fail_times=99)
+        completed, attempts = self._run(command, attempts=2)
+        self.assertNotEqual(0, completed.returncode)
+        self.assertEqual(2, attempts)
+
+    def test_the_failing_output_is_still_visible_to_the_job_log(self):
+        command = self._fake_command(output=CENTRAL_429, fail_times=99)
+        completed, _ = self._run(command, attempts=2)
+        self.assertIn("429", completed.stdout + completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📋 Description

Stops a cold-cache Maven Central refusal from sinking an e2e job, by retrying the
install in a **fresh process** rather than asking Maven to retry harder inside the
one that is already being refused.

## 🔗 Related Issue(s)

- Closes #4445
- Follows up #4443 / #4440

## 🗂️ Type of Change

- [x] 🔧 CI/CD or infrastructure change
- [x] 🐛 Bug fix (a transient network fault fails the job and hides the real result)

## Evidence, before design

Run [30876948089](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/30876948089),
job `Ubuntu_Firefox_Grid`, from the GitHub API:

```
failure  Install optional visual test runtime  04:13:04Z -> 04:19:09Z   (6m05s)
skipped  Run tests                             04:19:09Z -> 04:19:09Z
failure  Post-Test Report and Check            04:19:09Z -> 04:19:11Z
```

and from its log:

```
[ERROR] Unresolveable build extension: Plugin org.sonatype.central:central-publishing-maven-plugin:0.11.0 ...
[ERROR] Non-resolvable import POM: org.junit:junit-bom:pom:6.1.2 (absent): Could not transfer ...
        status code: 429, reason phrase: Too Many Requests (429)
[ERROR] Non-resolvable import POM: io.qameta.allure:allure-bom:pom:2.35.4 (absent): ... 429
```

Two things this establishes that the issue could only suspect:

1. The 429s land on **import POMs and a build extension** — model building, before
   the reactor starts. This is not a slow jar transfer; it is tiny POM fetches
   being rate-limited at the very front of the build.
2. Maven had already been retrying for **6m05s** inside one JVM
   (`aether.connector.http.retryHandler.count`, default 3) and still lost.

## What changed, and the reasoning

`scripts/ci/maven_retry.sh` re-runs a Maven command as a **new process** after a
pause, and only when the failure output carries a transfer-refusal marker
(`status code: 429`, `Too Many Requests`, `Could not transfer artifact`,
connection/read timeouts). Defaults: 2 attempts, 60s pause.

Wired into **all eight** install call sites — four in `e2eTests.yml`, four in
`e2eLocalTests.yml`. The issue said seven; the live tree has eight.

### Why not simply raise the resolver's retry count

Because the evidence says it would not have helped. Every in-JVM retry sits
inside the same rate-limit window Central is refusing; the log shows 6m05s of
exactly that. The issue itself predicted raising the count would "burn twelve
minutes and still lose", and the timings support it. A new process after a pause
is the only lever that changes the input rather than repeating it.

### Why a genuine failure must not retry

A compilation failure, a failing test, or a genuinely missing artifact fails on
the **first** attempt. Retrying those would spend the job's timeout arriving at
the same answer and bury the real error under two more rounds of output. This is
asserted by `test_a_genuine_build_failure_is_not_retried`.

### Why this step and not `Run tests`

`Run tests` already carries `continue-on-error: true`; the install step does not.
That asymmetry is the whole bug: a refusal in install skips the tests, and
`Post-Test Report and Check` then fails on a missing Allure summary. `Run visual
module tests` is deliberately left alone — it is a test run, and retrying tests
would mask flakiness.

### Timeout headroom

Worst case adds one pause plus one attempt, and only on the failure path. The
tightest job is `Ubuntu_MicrosoftEdge_Grid` at 35 min; today that path is a
guaranteed failure at ~6 min, so the trade is a possible success at ~13 min
against a certain failure. Attempts and pause are positional arguments, so a job
that needs a different budget can pass one.

## ✅ Pre-Submission Checklist

- [x] I have read the Contributing Guide and this PR follows its guidelines.
- [x] Documentation/agent-only changes pass their deterministic validators and `git diff --check`.
- [x] Behavior changes have focused automated coverage — `tests/scripts/test_maven_retry.py`, 5 tests, written before the script and observed failing first.
- [ ] Affected tests pass: `mvn ...` — n/a, no Java changed.
- [ ] Code/build changes compile once — n/a, no Java changed.
- [ ] New `public` methods and classes have JavaDoc — n/a.
- [x] I have not introduced any hardcoded credentials, secrets, or sensitive data.
- [x] I have not broken backward compatibility.
- [ ] UI/reporting changes include screenshots — n/a.

## 🧪 How to Test

```
py -3 -m unittest tests.scripts.test_maven_retry -v      -> Ran 5 tests ... OK
py -3 scripts/ci/validate_workflow_timeouts.py           -> All workflow jobs declare timeout-minutes.
py -3 -m unittest <the 10 agent-harness modules + test_maven_retry>
                                                         -> Ran 213 tests ... OK
```

The new module is registered in `pr-gate.yml`'s harness job, which runs on
`ubuntu-22.04` **and** `windows-2025` — the cross-OS coverage a bash script needs.

## Two traps found while building this

- **`bash` is not one thing on Windows.** On the dev host `bash` on PATH is WSL
  (`/mnt/c/...`); on the CI windows runner it is Git Bash (`C:/...`). A test that
  passes an absolute path works on one and fails on the other. The test therefore
  copies everything into one directory and invokes relatively, which means the
  same thing to both.
- **`scripts/ci/*.sh` was not pinned to LF.** `scripts/mcp/*.sh` already was. A
  CRLF checkout of this script would fail on the Linux runners with a bad
  interpreter line, so `.gitattributes` now covers `scripts/ci/*.sh` too.

## Limitation worth stating plainly

A real cold-cache 429 cannot be reproduced on demand — doing so would mean
deliberately hammering Maven Central, which is not something to do to a shared
public service. So what is proven here is the **control flow**: what retries,
what does not, how many attempts each costs, and that the failing output still
reaches the job log. Whether a 60s pause is enough to clear Central's window is
the one thing only a real recurrence can answer, and if it is not, the pause is a
positional argument.

## Documentation Site

- Documentation PR: none
- Documentation not required because: internal CI hardening, no public API or
  user-facing surface.
