### PR TITLE
Delete the guidance that restates other guidance

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -129,42 +129,40 @@ Reached from the entrypoint or the routing table, never loaded by default.
 
 ### Repository playbooks
 
-One per kind of work in this repository. The routing table links all thirteen
-directly.
+One per kind of work in this repository. Which deliverable sends you to which
+playbook is stated once, in [routing](act-as-mohab/references/routing.md) — this
+list is the inventory, not a second copy of the triggers.
 
-| Playbook | Covers |
-| --- | --- |
-| [agent guidance](act-as-mohab/references/playbooks/agent-guidance-boundary-guard.md) | Changing the harness itself: skills, host adapters, hooks, budgets, retrieval setup. |
-| [PDCA](act-as-mohab/references/playbooks/agentic-pdca-loop.md) | The explicit plan-do-check-act loop, run as main-thread phases rather than persona agents. |
-| [framework source](act-as-mohab/references/playbooks/framework-source.md) | Production Java: public API compatibility, the properties layer, logging, reporting, and thread-local state. |
-| [Java tests](act-as-mohab/references/playbooks/java-tests.md) | Test Java: driver lifecycle, parallelism hazards, headless execution, and evidence reuse. |
-| [CI failures](act-as-mohab/references/playbooks/ci-failure-investigator.md) | Diagnosing a red run, job, or scheduled suite from real logs and reports. |
-| [flaky tests](act-as-mohab/references/playbooks/flaky-test-stabilizer.md) | Turning an inconsistent pass or fail into a deterministic reproduction and a real fix. |
-| [release and dependencies](act-as-mohab/references/playbooks/release-dependency-guard.md) | Versioning, BOM wiring, dependency updates, and Maven Central safeguards. |
-| [MCP transport](act-as-mohab/references/playbooks/mcp-transport-contract-auditor.md) | The MCP tool contract, its transport, and the clients that consume it. |
-| [module boundaries](act-as-mohab/references/playbooks/modular-boundary-auditor.md) | Keeping the Maven reactor's module edges honest, including consumer fixtures. |
-| [reports](act-as-mohab/references/playbooks/allure-extent-report-operator.md) | Generating and trusting Allure and Extent output, including the verdict rules. |
-| [public docs](act-as-mohab/references/playbooks/public-behavior-docs-synchronizer.md) | Keeping externally documented behaviour in step with what the code actually does. |
-| [UI design](act-as-mohab/references/playbooks/shaft-ui-design.md) | Any visible surface: design standards, visual QA, UX copy, accessibility, responsive behaviour. |
-| [marketing](act-as-mohab/references/playbooks/shaft-marketing-ad-producer.md) | Promotional material that has to stay true to what the product does. |
+- [agent guidance](act-as-mohab/references/playbooks/agent-guidance-boundary-guard.md)
+- [PDCA](act-as-mohab/references/playbooks/agentic-pdca-loop.md)
+- [framework source](act-as-mohab/references/playbooks/framework-source.md)
+- [Java tests](act-as-mohab/references/playbooks/java-tests.md)
+- [CI failures](act-as-mohab/references/playbooks/ci-failure-investigator.md)
+- [flaky tests](act-as-mohab/references/playbooks/flaky-test-stabilizer.md)
+- [release and dependencies](act-as-mohab/references/playbooks/release-dependency-guard.md)
+- [MCP transport](act-as-mohab/references/playbooks/mcp-transport-contract-auditor.md)
+- [module boundaries](act-as-mohab/references/playbooks/modular-boundary-auditor.md)
+- [reports](act-as-mohab/references/playbooks/allure-extent-report-operator.md)
+- [public docs](act-as-mohab/references/playbooks/public-behavior-docs-synchronizer.md)
+- [UI design](act-as-mohab/references/playbooks/shaft-ui-design.md)
+- [marketing](act-as-mohab/references/playbooks/shaft-marketing-ad-producer.md)
 
 ### SHAFT mastery chapters
 
 Ten expert domains. Each encodes incident history that is expensive to
-re-derive, so read the one the task touches and skip the rest.
+re-derive, so read the one the task touches and skip the rest — which one that
+is, [routing](act-as-mohab/references/routing.md) says.
 
-| Chapter | Read it when the task touches |
-| --- | --- |
-| [Selenium BiDi](act-as-mohab/references/shaft-mastery/selenium-bidi.md) | The recorder, preload scripts, network capture, browser lifecycle. |
-| [Allure internals](act-as-mohab/references/shaft-mastery/allure-internals.md) | Report generation and patching, results JSON, verdict analysis. |
-| [Appium mobile](act-as-mohab/references/shaft-mastery/appium-mobile.md) | Mobile recording and replay, emulators, mobile CI. |
-| [Maven release](act-as-mohab/references/shaft-mastery/maven-release.md) | Versioning, Central publishing, BOM, dependency convergence. |
-| [TestNG lifecycle](act-as-mohab/references/shaft-mastery/testng-lifecycle.md) | Listeners, forked JVMs, properties precedence, scoped runs. |
-| [IntelliJ plugin](act-as-mohab/references/shaft-mastery/intellij-plugin.md) | The plugin's desktop UI, tool windows, Gradle and JDK setup. |
-| [MCP protocol](act-as-mohab/references/shaft-mastery/mcp-protocol.md) | MCP tools, stdio transport, workspace roots, clients. |
-| [CI forensics](act-as-mohab/references/shaft-mastery/ci-forensics.md) | Red runs, scheduled suites, workflow YAML, sharding. |
-| [Wait strategies](act-as-mohab/references/shaft-mastery/wait-strategies.md) | Races, synchronization, deterministic reproduction. |
-| [Locator healing](act-as-mohab/references/shaft-mastery/locator-healing.md) | Locator choice, semantic selectors, the healer and doctor. |
+- [Selenium BiDi](act-as-mohab/references/shaft-mastery/selenium-bidi.md)
+- [Allure internals](act-as-mohab/references/shaft-mastery/allure-internals.md)
+- [Appium mobile](act-as-mohab/references/shaft-mastery/appium-mobile.md)
+- [Maven release](act-as-mohab/references/shaft-mastery/maven-release.md)
+- [TestNG lifecycle](act-as-mohab/references/shaft-mastery/testng-lifecycle.md)
+- [IntelliJ plugin](act-as-mohab/references/shaft-mastery/intellij-plugin.md)
+- [MCP protocol](act-as-mohab/references/shaft-mastery/mcp-protocol.md)
+- [CI forensics](act-as-mohab/references/shaft-mastery/ci-forensics.md)
+- [Wait strategies](act-as-mohab/references/shaft-mastery/wait-strategies.md)
+- [Locator healing](act-as-mohab/references/shaft-mastery/locator-healing.md)
 
 ### The product pack
 

--- a/.agents/skills/act-as-mohab/references/work-github-playbook.md
+++ b/.agents/skills/act-as-mohab/references/work-github-playbook.md
@@ -101,7 +101,11 @@ of it.
 
 One issue is one work stream, so the entrypoint's solo-or-orchestrate rule
 normally puts this session in solo mode and the shapes below apply only while
-orchestrating. For each item, decide dispatch shape:
+orchestrating. The mechanics of a dispatch — the covenant every prompt opens
+with, which file scopes may run concurrently and in what isolation, and what the
+mechanical capability level may be handed — belong to
+[delegation](delegation.md) and are not restated here. What is specific to
+working an issue is which items to dispatch at all:
 
 - **Scout it yourself first** when it requires an architectural or
   data-model decision (e.g. "where does this state actually live, and can a
@@ -114,14 +118,6 @@ orchestrating. For each item, decide dispatch shape:
   what's explicitly out of scope, what tests to add and where, and the exact
   validation command to run. A vague spec produces a vague implementation —
   the spec is where your scouting work pays off.
-- Every subagent prompt must open with: load `act-as-mohab`, then follow it.
-- **Sequential, not parallel, when file scopes overlap.** Two subagents
-  editing the same file concurrently in a shared working tree will race or
-  corrupt each other's edits — check each spec's file list against the
-  others before deciding parallel vs. sequential dispatch. Only run
-  independent-file items in parallel.
-- The mechanical capability level is for low-risk mechanical edits, log/report summarization, and bulk
-  repetitive triage — not for a spec that requires judgment calls mid-flight.
 
 ## 3b. Tracking issue + one-issue-per-subtask (mandatory default for new work)
 
@@ -255,21 +251,11 @@ a bundle into this repo's PR — open it separately and say so.
 
 ## 6. Learning Loop before wrapping up
 
-Before the final push: route anything durable that surfaced mid-session —
-
-- A durable fact, gotcha, or precedent worth remembering → commit it via
-  this repo's memory mechanism (`.memory/`), not left implicit in the PR
-  description.
-- Something outside this issue's scope that you noticed but didn't chase →
-  a new GitHub issue (search first, consolidate with an existing one if it
-  overlaps) — never silently drop it, never silently expand scope to fix it
-  now either.
-- A skill or guidance file that misled you, or a genuinely new reusable
-  procedure this session established → update the skill, not just a one-off
-  mention in the report.
-
-"Nothing durable surfaced" is a valid, honest outcome — say so rather than
-manufacturing a memory entry to fill the step.
+Route everything durable that surfaced mid-session through the entrypoint's
+Learning-loop table, which owns the destinations and the rule that nothing
+durable is a valid result. This section adds only the timing: do it *before* the
+final push, while the session still remembers what it learned. A learning routed
+after the push is a learning nobody wrote down.
 
 ## 7. Push, PR, green, merge, compact
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,8 +107,10 @@ them before it touches anything:
 
 Most agents discover that entrypoint on their own. The
 [agent skills map](.agents/skills/README.md) explains how the skills fit
-together, what each one covers, and how each host imports them. Read it once
-before your first agent-assisted change.
+together and how each host imports them; which task sends you to which surface
+is stated once, in the
+[routing table](.agents/skills/act-as-mohab/references/routing.md). Read the map
+once before your first agent-assisted change.
 
 - Keep the scope tight and follow existing package and module boundaries.
 - Preserve public API compatibility. Deprecate before removing or renaming a


### PR DESCRIPTION
## Summary

Two subtasks of #4452. Both delete a paraphrase of a rule that already has a
home and replace it with a pointer to that home. **Guidance bytes 129090 →
126723, a measured −2367.** Zero characters added to the always-loaded surface;
neither file is in any host's `host_contexts`.

**#4454 — the skills map stopped restating the routing table.**
`.agents/skills/README.md`'s playbook `Covers` column and mastery
`Read it when the task touches` column were `routing.md`'s trigger column with
the columns swapped:

| | |
| --- | --- |
| README | `\| [Selenium BiDi](…) \| The recorder, preload scripts, network capture, browser lifecycle. \|` |
| routing.md | `\| Recorder, preload scripts, network capture, browser lifecycle \| [Selenium BiDi](…) \|` |

Same trigger, different words, two files. This is precisely the paraphrase
`NoDuplicationTest`'s own docstring concedes the validator cannot see — the
verbatim-paragraph check needs 180 characters and the identical-line check needs
an exact match, and a swapped-column restatement clears both.

It had already begun to drift, which is the argument for removing it rather than
re-syncing it: `routing.md` says "A red CI run, job, or scheduled suite" where
the README said "Diagnosing a red run, job, or scheduled suite from real logs
and reports."

Both tables become link inventories that point at `routing.md` for the trigger.
Every path string `SkillsMapTest::test_the_map_covers_every_skill_playbook_and_chapter`
requires survives, and `test_the_map_links_resolve` still passes. **−1648 bytes.**

**#4455 — the GitHub playbook stopped restating delegation and the Learning loop.**
Sec. 6 was a three-bullet paraphrase of the entrypoint's six-row Learning-loop
table, so an agent reading only the playbook learned half the destinations and
had no way to know it. It now points at the table and keeps the one thing it
genuinely adds: the *timing* — route before the final push, not after.

Sec. 3's dispatch bullets restated `delegation.md` three times over: the covenant
every prompt opens with, the concurrent-file-scope rule, and the mechanical
level's definition. Those go. The spec-quality bar ("exact files, exact
method/field names verified against the real code, the precedent pattern to
follow with a real `file:line` reference…") exists nowhere else and is kept
verbatim. **−719 bytes.**

Closes #4454
Closes #4455

## On the estimate in #4452

The tracker projected −3000 to −4000 for the README and −1200 to −1600 for the
playbook, roughly −4200 to −5600 together. Measured: **−1648 and −719, −2367
together.** The direction was right; the magnitude was about double the reality.
Anyone sizing follow-on cleanup against that figure should use the measured one.

## For the reviewer

The tracker flags this pair as the one place it trades contributor readability
for an anti-drift guarantee, and says explicitly that if a reviewer disagrees on
the README, that item should be dropped and the ratchet funded from the playbook
alone. That call is yours: the README's playbook and mastery sections are now
bare link lists, and a contributor skimming the map has to open `routing.md` to
learn what each surface covers. My view is that a description that exists in two
files will diverge, and this one already had — but "the map got less useful" is a
legitimate reading and no test can settle it.

Note that #4452's Subtask 5 (arming a total-guidance ratchet) is **not** in this
PR and is not being implemented: it reverses the closed owner directive in #3745.
The conflict is written up in #4458 for a decision. These deletions stand on
their own — they remove duplication, not merely bytes to fund a ceiling.

## Review round 2 — what changed

The independent adversarial review examined all 26 deleted passages individually
and found 20 redundant against a stronger survivor, 6 the worse of two drifted
copies, and nothing to restore. It also settled the reachability question for
agents: `.agents/skills/README.md` is in no host's `host_contexts`, so the agent
load path is `AGENTS.md` → `SKILL.md` → `## Route` → `routing.md`, and the README
is never on it. The readability trade is a contributor-facing one only.

**One CONFIRMED finding, fixed in `52c1778`.** `CONTRIBUTING.md` promised the map
"explains how the skills fit together, **what each one covers**, and how each
host imports them". After this PR that is false for 23 of 33 surfaces — the 13
playbooks and 10 chapters are bare links, and only the 2 skills and 8 method
references keep prose. A contributor arriving from CONTRIBUTING would have had to
open `routing.md` and read its table backwards, since it is keyed trigger → file.
The sentence now claims only what the map still does and links onward to the
routing table. The `.agents/skills/README.md` link is untouched because
`test_the_map_exists_and_is_linked_from_the_contribution_guide` asserts it, and
the new path is relative and resolves, so `validate_local_references` covers it.
Guidance bytes are unchanged by that commit: `CONTRIBUTING.md` is in
`reference_scan_globs` but not `total_guidance_globs`.

**Considered, not missed — the `.memory/` binding.** Sec. 6 previously contained
the only occurrence of the token `.memory/` in this playbook; it is now 0 (was 1,
verified with `grep -c`). The binding of "native Memory" → the `.memory/` store
therefore survives in this PR only via `AGENTS.md:71` ("Query native
`.memory/`, MemPalace, and Graphify"). That file is always-loaded on every host,
so the binding holds for any agent that reaches the playbook at all — the
playbook is on-demand and `AGENTS.md` is not. It is nonetheless the thinnest link
in this diff, and if `AGENTS.md` ever drops that token the connection goes with
it, silently.

**Filed rather than folded in:** the review noted this PR applies its own
principle inconsistently — the Method references table at `README.md:119-128`
survives untouched, and 4 of its 8 rows duplicate a routing trigger exactly as
the deleted columns did. That is #4463, with the analysis of why the other 4 rows
are a different case.

## Test plan

- [x] `py -3 scripts/ci/validate_agent_setup.py --skip-external` — `Agent setup is valid: 126723 guidance bytes, 0% reduction, 336 memory objects.` (was 129090)
- [x] `py -3 scripts/agents/guard.py --self-test` — `R10 NUL-corruption self-test summary: 0 failed.`
- [x] the ten agent-harness modules from `pr-gate.yml` — `Ran 208 tests … OK`
- [x] `git diff --check` — clean
- [x] after the CONTRIBUTING fix: validator re-run (`126723 guidance bytes`, unchanged) and the ten harness modules (`Ran 208 tests … OK`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uBrtSmdU6Xvwmkyajqkuy

