### PR TITLE
Distil the working method into checked mechanism: the unbound check

### DIFF
--- a/.agents/skills/act-as-mohab/SKILL.md
+++ b/.agents/skills/act-as-mohab/SKILL.md
@@ -49,7 +49,7 @@ the blast radius grows, or the user adds scope.
 These phrases mean you are about to break a law above. When you catch yourself
 writing or thinking one, stop and satisfy the law instead: "should work",
 "probably fine", "just this once", "I will add the test after", "the delegate
-said it passed", "close enough", "no need to run it".
+said it passed", "close enough", "no need to run it", "the check covers it".
 
 ## Task isolation
 
@@ -81,8 +81,7 @@ repository and never rewrites remote history.
 6. Report outcome, exact checks, failures, and Learning Loop result.
 
 Consult [field heuristics](references/heuristics.md) only for deeper
-investigation, risk analysis, or review. Use the full sequential PDCA playbook
-only when the user asks for PDCA, personas, or refinement loops.
+investigation, risk analysis, or review.
 
 ## Always-composed behavior
 

--- a/.agents/skills/act-as-mohab/references/heuristics.md
+++ b/.agents/skills/act-as-mohab/references/heuristics.md
@@ -26,8 +26,6 @@ files and observations outrank this guidance.
 
 - Test the unknown most likely to invalidate the approach first. Estimate work
   by unknowns and blast radius, not line count.
-- Fix small blockers in the direct path. Keep larger adjacent findings out of
-  the diff and route them through the repository's issue process.
 - Use a throwaway probe for high uncertainty, then discard it before TDD
   implementation.
 - Match surrounding naming and idioms. Comments record constraints; they do
@@ -45,8 +43,8 @@ or write a pre-mortem. More techniques are ceremony unless risk warrants them.
 - Verify the changed behavior, nearest plausible regression, and negative path.
   Ensure the run used fresh sources and inspect real test reports rather than a
   success banner or stale artifact.
-- Review delegated work in two passes: specification, then quality. Follow
-  [delegation](delegation.md) and the [verification-gap lens](verification-gap-lens.md).
+- Review delegated work per [delegation](delegation.md) and the
+  [verification-gap lens](verification-gap-lens.md).
 - State outcome first. Distinguish observed, inferred, assumed, skipped, and
   failed work. Cite repository-relative `path:line` evidence and exact commands.
 - Report a decisive failure line, not an unrequested log dump. If safe in-scope
@@ -58,7 +56,6 @@ or write a pre-mortem. More techniques are ceremony unless risk warrants them.
   for the specific state-changing action, and do not transfer authorization
   between similar actions.
 - Restore any system this work breaks before continuing or handing off.
-- Own the requested outcome through its authorized lifecycle, not merely the
-  diff. New user input reorders explicit commitments; it does not erase them.
+- New user input reorders explicit commitments; it does not erase them.
 - Exhaustive mode adds evidence, affected coverage, and independent attempts to
   refute the result. It does not add verbose reports or repeated ceremony.

--- a/.agents/skills/act-as-mohab/references/heuristics.md
+++ b/.agents/skills/act-as-mohab/references/heuristics.md
@@ -26,6 +26,7 @@ files and observations outrank this guidance.
 
 - Test the unknown most likely to invalidate the approach first. Estimate work
   by unknowns and blast radius, not line count.
+- Fix small blockers in the direct path.
 - Use a throwaway probe for high uncertainty, then discard it before TDD
   implementation.
 - Match surrounding naming and idioms. Comments record constraints; they do

--- a/.agents/skills/act-as-mohab/references/routing.md
+++ b/.agents/skills/act-as-mohab/references/routing.md
@@ -28,7 +28,10 @@ before broad manual discovery, not all of them by reflex.
 | What does the code do right now? | targeted `rg` and exact reads | Always. This is the only source that settles a disagreement. |
 
 A retrieved claim is a lead, never a verdict: confirm it against the live file
-before acting on it, and a stale index never outranks what is on disk.
+before acting on it, and a stale index never outranks what is on disk. Your own
+plan is a source too, and the oldest one you hold: it was written before the
+reads. When a plan step loses to a file, amend the plan then, rather than
+working around it.
 
 If a store is unavailable, name the degraded mode in your report and continue
 with the rest. Skipping a store whose trigger fired, without saying so, is the

--- a/.agents/skills/act-as-mohab/references/routing.md
+++ b/.agents/skills/act-as-mohab/references/routing.md
@@ -29,9 +29,8 @@ before broad manual discovery, not all of them by reflex.
 
 A retrieved claim is a lead, never a verdict: confirm it against the live file
 before acting on it, and a stale index never outranks what is on disk. Your own
-plan is a source too, and the oldest one you hold: it was written before the
-reads. When a plan step loses to a file, amend the plan then, rather than
-working around it.
+plan ranks here too, below every one of them: it is the oldest source you hold,
+written before the reads.
 
 If a store is unavailable, name the degraded mode in your report and continue
 with the rest. Skipping a store whose trigger fired, without saying so, is the

--- a/.agents/skills/act-as-mohab/references/verification-gap-lens.md
+++ b/.agents/skills/act-as-mohab/references/verification-gap-lens.md
@@ -12,7 +12,7 @@ produce broke where it's actually used, would a test fail? Don't hunt for
 correctness bugs generally — that's the rest of the review; this lens is
 verification-coverage only.
 
-## The three gap shapes
+## The four gap shapes
 
 1. **Regression gap.** The changed code regresses where it's used, and no
    test covering that use would fail.
@@ -26,6 +26,12 @@ verification-coverage only.
    behavior but wouldn't actually catch a regression — skipped, flaky, not
    run in the normal path, or too weak to observe the change (mock-only,
    snapshot-only, success/no-throw checks).
+4. **Unbound-check gap.** The change adds or edits a check, guard, pin or
+   metric that would still pass with the thing it protects removed. Three
+   ways it happens: the test declares its own copy of a pattern, threshold
+   or clause the shipped artifact owns, so it verifies the copy; a metric
+   whose input is absent reports that absence as a value; or the fix's own
+   mechanism is unguarded, so reverting it leaves the suite green.
 
 ## The Demonstration technique
 
@@ -36,21 +42,34 @@ drop the path; untested downstream code that nothing would actually break
 is not a finding. Then find the relevant test and ask: would the
 Demonstration make an assertion fail? If yes, it's verified — no finding.
 
+## Proving a check binds
+
+Imagining the Demonstration is right for code you are reviewing. For a check
+in your own diff it is not, because the mutation is free and revertible:
+apply it, run it, read the failure, revert. Mutate the shipped artifact,
+never a fixture.
+
+Weakening counts as a mutation. A rule survives deletion and dies by
+addition — appending "unless time is short" leaves every pinned word in
+place — so mutate by qualifying as well as by removing. Make a metric move;
+one that cannot report failure is reporting its own absence. And check your
+own diff against the rule's text rather than against what you meant by it:
+you are the weakest available witness to a rule you wrote.
+
 ## Evidence rules (non-negotiable)
 
-- Read a test before claiming what it covers, runs, asserts, or misses.
+- Read a test before claiming what it covers, runs, asserts, or misses, and
+  re-open it before writing the finding rather than reporting from memory of
+  having glanced at it earlier in the review.
 - Before claiming no test exists, search the repo by symbol and import
   reference — expected file locations alone aren't enough (`gotcha.local-mvn-test-never-fails-the-build-read-surefire-xml-counts-for-verdicts`
   is the SHAFT-specific version of this: `BUILD SUCCESS` from `mvn test`
   proves nothing — read `surefire-reports/TEST-*.xml` counts before calling
   anything green).
-- Never assert what you didn't verify; an ungrounded finding gets dropped,
-  not softened.
 - Say what you actually checked ("none of the tests I read cover this") and
-  how far you looked. Only claim a test doesn't exist anywhere when the
-  symbol/import search actually shows that.
-- Don't assign severity, confidence, or priority — that's triage's job (see
-  the four-bucket taxonomy in SKILL.md's Delegation section).
+  how far you looked.
+- Don't assign severity, confidence, or priority — that's the returned-work
+  triage in delegation.md.
 
 ## Trimmed review sequence
 
@@ -62,14 +81,12 @@ Demonstration make an assertion fail? If yes, it's verified — no finding.
    consumers. Stop at the nearest boundary where a test would fail or the
    next hop is guesswork.
 4. **Qualify each consumer with the Demonstration, then read its test.**
-5. **Re-open the specific test or search result before writing the finding.**
-   Don't report from memory of having glanced at it earlier in the review.
 
 ## Findings shape
 
 Each finding: `location` (`file:line`), `trigger_condition` (the gap, one
 line), `potential_consequence` (what ships wrong and why the checked tests
-wouldn't catch it), `gap_shape` (one of the three above, or `other` for a
+wouldn't catch it), `gap_shape` (one of the four above, or `other` for a
 genuine problem noticed in passing), `evidence` (what you actually read,
 with `file:line`). An empty list is a valid, complete result — say so
 plainly rather than padding with low-confidence noise.

--- a/.agents/skills/act-as-mohab/references/verification-gap-lens.md
+++ b/.agents/skills/act-as-mohab/references/verification-gap-lens.md
@@ -52,9 +52,7 @@ never a fixture.
 Weakening counts as a mutation. A rule survives deletion and dies by
 addition — appending "unless time is short" leaves every pinned word in
 place — so mutate by qualifying as well as by removing. Make a metric move;
-one that cannot report failure is reporting its own absence. And check your
-own diff against the rule's text rather than against what you meant by it:
-you are the weakest available witness to a rule you wrote.
+one that cannot report failure is reporting its own absence.
 
 ## Evidence rules (non-negotiable)
 
@@ -67,7 +65,9 @@ you are the weakest available witness to a rule you wrote.
   proves nothing — read `surefire-reports/TEST-*.xml` counts before calling
   anything green).
 - Say what you actually checked ("none of the tests I read cover this") and
-  how far you looked.
+  how far you looked. An ungrounded finding gets dropped, not softened — that
+  is a wider rule than the refuted bucket, which is about a finding you did
+  ground and disproved.
 - Don't assign severity, confidence, or priority — that's the returned-work
   triage in delegation.md.
 

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -26,6 +26,7 @@ REFERENCES = CANONICAL_SKILLS / "act-as-mohab/references"
 ROUTING = REFERENCES / "routing.md"
 ROLES = REFERENCES / "roles.md"
 DELEGATION = REFERENCES / "delegation.md"
+LENS = REFERENCES / "verification-gap-lens.md"
 CONSULT = CANONICAL_SKILLS / "consult-first/SKILL.md"
 BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 
@@ -38,30 +39,35 @@ MAX_READ_CHAIN_HOPS = 2
 # A file whose entire body is a pointer costs a read and teaches nothing.
 REDIRECT_STUB_MAX_CHARS = 250
 
-# Entrypoint sections that own a pinned clause, by heading prefix.
+# Sections that own a pinned clause, by heading prefix.
 IRON_LAWS = "iron laws"
 RED_FLAGS = "red flags"
 TDD = "test-driven development"
+GAP_SHAPES = "the four gap shapes"
+BINDING = "proving a check binds"
 
-# Every clause the entrypoint is not allowed to lose, as (section, literal).
+# Every clause this repository's guidance is not allowed to lose, as
+# (file, section, literal).
 #
 # This tuple lists *locations*, never a second copy of the rule: the mutations
 # in DisciplineTest are spliced into whatever the shipped file says at run
 # time, so a pin cannot end up verifying a private copy of the text it is
 # supposed to protect. Each clause's justification is in the named test that
 # asserts it.
-PINNED_CLAUSES: tuple[tuple[str, str], ...] = (
-    (IRON_LAWS, "evidence over inference"),
-    (IRON_LAWS, "inspect or run before claiming"),
-    (IRON_LAWS, "no production code before an observed failing test"),
-    (IRON_LAWS, "never weaken, delete, or rewrite a test to reach green"),
-    (IRON_LAWS, "never claim a check you did not run"),
-    (TDD, "only an expected assertion failure"),
-    (TDD, "a pass or setup, syntax, or environment error is not red"),
-    (TDD, "revert that new code and restart"),
-    (TDD, "asserts nothing, prints instead of asserting, or mocks the behavior under test"),
-    (TDD, "never backfill tests after implementation"),
-    (RED_FLAGS, "the check covers it"),
+PINNED_CLAUSES: tuple[tuple[Path, str, str], ...] = (
+    (ENTRYPOINT, IRON_LAWS, "evidence over inference"),
+    (ENTRYPOINT, IRON_LAWS, "inspect or run before claiming"),
+    (ENTRYPOINT, IRON_LAWS, "no production code before an observed failing test"),
+    (ENTRYPOINT, IRON_LAWS, "never weaken, delete, or rewrite a test to reach green"),
+    (ENTRYPOINT, IRON_LAWS, "never claim a check you did not run"),
+    (ENTRYPOINT, TDD, "only an expected assertion failure"),
+    (ENTRYPOINT, TDD, "a pass or setup, syntax, or environment error is not red"),
+    (ENTRYPOINT, TDD, "revert that new code and restart"),
+    (ENTRYPOINT, TDD, "asserts nothing, prints instead of asserting, or mocks the behavior under test"),
+    (ENTRYPOINT, TDD, "never backfill tests after implementation"),
+    (ENTRYPOINT, RED_FLAGS, "the check covers it"),
+    (LENS, GAP_SHAPES, "unbound-check gap"),
+    (LENS, BINDING, "apply it, run it, read the failure, revert"),
 )
 
 # Words that leave every pinned word in place and turn the rule into a
@@ -110,28 +116,35 @@ def rule_blocks(section: str) -> list[str]:
     return [re.sub(r"\s+", " ", part).strip().lower() for part in parts if part and part.strip()]
 
 
-def clause_defects(source: str) -> list[str]:
+def clause_defects(overrides: dict[Path, str] | None = None) -> list[str]:
     """Report every pinned clause that is missing, duplicated, or qualified.
+
+    Reads each pinned file from disk unless `overrides` supplies a mutated
+    body, which is what lets the mutation tests below prove the pins bind
+    without ever holding a copy of the text they protect.
 
     Presence alone was the whole check until #4467: a pin says a phrase is
     there and says nothing about what surrounds it, so an edit that *adds* an
     escape hatch next to the clause passed every pin while gutting the law.
     """
+    overrides = overrides or {}
     defects = []
-    for heading, clause in PINNED_CLAUSES:
+    for path, heading, clause in PINNED_CLAUSES:
+        where = f"{path.name}:{heading!r}"
+        source = overrides.get(path, path.read_text(encoding="utf-8"))
         sections = headed_sections(source, heading)
         if len(sections) != 1:
-            defects.append(f"{heading!r}: expected one section, found {len(sections)}")
+            defects.append(f"{where}: expected one section, found {len(sections)}")
             continue
         pattern = clause_pattern(clause)
         matched = [block for block in rule_blocks(sections[0]) if re.search(pattern, block)]
         if not matched:
-            defects.append(f"{heading!r}: clause missing: {clause!r}")
+            defects.append(f"{where}: clause missing: {clause!r}")
             continue
         for block in matched:
             hits = [marker for marker in EXEMPTION_MARKERS if marker in block]
             if hits:
-                defects.append(f"{heading!r}: {clause!r} qualified by {hits[0]!r}")
+                defects.append(f"{where}: {clause!r} qualified by {hits[0]!r}")
     return defects
 
 
@@ -934,10 +947,10 @@ class DisciplineTest(unittest.TestCase):
         """
         self.assertIn(
             clause,
-            [pinned for _, pinned in PINNED_CLAUSES],
+            [pinned for _, _, pinned in PINNED_CLAUSES],
             f"clause is asserted but not registered for mutation: {clause!r}",
         )
-        offending = [defect for defect in clause_defects(self.source()) if clause in defect]
+        offending = [defect for defect in clause_defects() if clause in defect]
         self.assertEqual(offending, [])
 
     def iron_laws(self) -> str:
@@ -1044,25 +1057,27 @@ class DisciplineTest(unittest.TestCase):
         for phrase in ("should", "probably", "just this once", "close enough"):
             self.assertIn(phrase, content, f"red-flag phrase missing: {phrase}")
 
-    def mutate(self, clause: str, insertion: str) -> str:
-        """Splice `insertion` in after `clause` in the shipped entrypoint text.
+    def mutate(self, path: Path, clause: str, insertion: str) -> dict[Path, str]:
+        """Splice `insertion` in after `clause` in the shipped file's own text.
 
         The mutation is built from the file, never from a literal in this
         module. A test that carries its own copy of the text it protects
         verifies the copy, which is how a gutted check stays green.
         """
-        source = self.source()
+        source = path.read_text(encoding="utf-8")
         match = re.search(clause_pattern(clause), source, re.I)
-        self.assertIsNotNone(match, f"clause is not in the entrypoint at all: {clause!r}")
-        return source[: match.end()] + insertion + source[match.end() :]
+        self.assertIsNotNone(match, f"clause is not in {path.name} at all: {clause!r}")
+        return {path: source[: match.end()] + insertion + source[match.end() :]}
 
     def test_deleting_any_pinned_clause_is_reported(self):
-        for heading, clause in PINNED_CLAUSES:
+        for path, _, clause in PINNED_CLAUSES:
             with self.subTest(clause=clause):
-                source = self.source()
+                source = path.read_text(encoding="utf-8")
                 mutated = re.sub(clause_pattern(clause), "", source, count=1, flags=re.I)
                 self.assertTrue(mutated != source, "the mutation did not apply")
-                self.assertTrue(clause_defects(mutated), "deleting the clause is not reported")
+                self.assertTrue(
+                    clause_defects({path: mutated}), "deleting the clause is not reported"
+                )
 
     def test_qualifying_any_pinned_clause_is_reported(self):
         """#4467: a pin that only checks presence passes on a gutted rule.
@@ -1071,9 +1086,9 @@ class DisciplineTest(unittest.TestCase):
         pinned word in place, and every pin in this class passed on it until
         this test existed.
         """
-        for heading, clause in PINNED_CLAUSES:
+        for path, _, clause in PINNED_CLAUSES:
             with self.subTest(clause=clause):
-                mutated = self.mutate(clause, ", unless time is short")
+                mutated = self.mutate(path, clause, ", unless time is short")
                 self.assertTrue(clause_defects(mutated), "qualifying the clause is not reported")
 
     def test_the_two_weakenings_named_in_the_review_are_reported(self):
@@ -1089,7 +1104,7 @@ class DisciplineTest(unittest.TestCase):
         )
         for clause, insertion in cases:
             with self.subTest(clause=clause):
-                defects = clause_defects(self.mutate(clause, insertion))
+                defects = clause_defects(self.mutate(ENTRYPOINT, clause, insertion))
                 self.assertTrue(defects, f"the review's own counter-example passes: {insertion!r}")
 
     def test_red_flags_name_the_sentence_that_ships_a_check_protecting_nothing(self):
@@ -1110,6 +1125,21 @@ class DisciplineTest(unittest.TestCase):
         before any reviewer loads a reference.
         """
         self.assert_clause_holds("the check covers it")
+
+    def test_the_review_lens_keeps_the_unbound_check_shape_and_its_proof(self):
+        """The on-demand half of #4471, and the one rule here with no home
+        anywhere else in the harness.
+
+        The lens's other three gap shapes are about production behaviour. This
+        one is about the check itself, and its proof step is the only place the
+        harness says an obligation is discharged by *running* the mutation
+        rather than imagining it -- which is the distinction the four defects
+        in #4471 all fell through. Left as prose it would be the kind of rule
+        this repository has already watched erode, so it is pinned like an iron
+        law and mutated like one.
+        """
+        self.assert_clause_holds("unbound-check gap")
+        self.assert_clause_holds("apply it, run it, read the failure, revert")
 
     def test_delegation_states_the_parallel_agent_cap(self):
         self.assertRegex(compact(DELEGATION), r"(?:four|4) (?:active |concurrent |parallel |writing )*agents")

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -38,6 +38,99 @@ MAX_READ_CHAIN_HOPS = 2
 # A file whose entire body is a pointer costs a read and teaches nothing.
 REDIRECT_STUB_MAX_CHARS = 250
 
+# Entrypoint sections that own a pinned clause, by heading prefix.
+IRON_LAWS = "iron laws"
+RED_FLAGS = "red flags"
+TDD = "test-driven development"
+
+# Every clause the entrypoint is not allowed to lose, as (section, literal).
+#
+# This tuple lists *locations*, never a second copy of the rule: the mutations
+# in DisciplineTest are spliced into whatever the shipped file says at run
+# time, so a pin cannot end up verifying a private copy of the text it is
+# supposed to protect. Each clause's justification is in the named test that
+# asserts it.
+PINNED_CLAUSES: tuple[tuple[str, str], ...] = (
+    (IRON_LAWS, "evidence over inference"),
+    (IRON_LAWS, "inspect or run before claiming"),
+    (IRON_LAWS, "no production code before an observed failing test"),
+    (IRON_LAWS, "never weaken, delete, or rewrite a test to reach green"),
+    (IRON_LAWS, "never claim a check you did not run"),
+    (TDD, "only an expected assertion failure"),
+    (TDD, "a pass or setup, syntax, or environment error is not red"),
+    (TDD, "revert that new code and restart"),
+)
+
+# Words that leave every pinned word in place and turn the rule into a
+# suggestion. Deliberately short. The TDD section legitimately carves out
+# documentation with "may skip test-first", and a marker list wide enough to
+# catch that phrasing would push an author to obscure a correct exemption in
+# order to pass -- which is the failure this check exists to prevent, inverted.
+EXEMPTION_MARKERS = (
+    "unless",
+    "except",
+    "exempt",
+    "optional",
+    "where practical",
+    "when time allows",
+    "if time",
+    "at your discretion",
+    "best effort",
+)
+
+
+def clause_pattern(clause: str) -> str:
+    """Whitespace-tolerant literal matcher; the entrypoint wraps clauses."""
+    return r"\s+".join(re.escape(word) for word in clause.split())
+
+
+def headed_sections(source: str, heading: str) -> list[str]:
+    """Return every level-2 or level-3 section whose heading starts with `heading`."""
+    return [
+        body
+        for body in re.split(r"(?m)^#{2,3} ", source)
+        if body.lower().startswith(heading)
+    ]
+
+
+def rule_blocks(section: str) -> list[str]:
+    """Split a section into its rule units: list items and paragraphs.
+
+    This is the scope an exemption is judged against, and neither obvious
+    alternative works. Sentence scope misses `"...did not run. Routine checks
+    are exempt."`, because the escape hatch is a *new* sentence. Section scope
+    reports the TDD section's legitimate documentation carve-out. The rule item
+    is the unit an author actually edits, and both weakenings named in #4467
+    land inside the very law they weaken.
+    """
+    parts = re.split(r"(?m)^(?=\s*(?:\d+\.|[-*])\s)|\n\s*\n", section)
+    return [re.sub(r"\s+", " ", part).strip().lower() for part in parts if part and part.strip()]
+
+
+def clause_defects(source: str) -> list[str]:
+    """Report every pinned clause that is missing, duplicated, or qualified.
+
+    Presence alone was the whole check until #4467: a pin says a phrase is
+    there and says nothing about what surrounds it, so an edit that *adds* an
+    escape hatch next to the clause passed every pin while gutting the law.
+    """
+    defects = []
+    for heading, clause in PINNED_CLAUSES:
+        sections = headed_sections(source, heading)
+        if len(sections) != 1:
+            defects.append(f"{heading!r}: expected one section, found {len(sections)}")
+            continue
+        pattern = clause_pattern(clause)
+        matched = [block for block in rule_blocks(sections[0]) if re.search(pattern, block)]
+        if not matched:
+            defects.append(f"{heading!r}: clause missing: {clause!r}")
+            continue
+        for block in matched:
+            hits = [marker for marker in EXEMPTION_MARKERS if marker in block]
+            if hits:
+                defects.append(f"{heading!r}: {clause!r} qualified by {hits[0]!r}")
+    return defects
+
 
 def frontmatter(path: Path) -> dict[str, str]:
     """Parse the flat YAML frontmatter every skill in this repository uses."""
@@ -808,15 +901,41 @@ class DisciplineTest(unittest.TestCase):
     and Graphify nudges. Rules with a failing check behind them survived.
 
     Each pin below asserts the clause that carries the rule, inside the section
-    that owns it, and each was verified to fail when that clause is removed --
-    a pin that passes on any prose is decoration.
+    that owns it -- a pin that passes on any prose is decoration.
 
-    Scope, stated plainly so the next reader does not overrate these: a presence
-    pin catches deletion and renaming. It does not catch weakening by addition.
-    "Never claim a check you did not run. Routine checks are exempt." keeps the
-    pinned phrase and guts the law, and every pin here passes on it. Closing
-    that is #4467.
+    The proof that a pin binds used to be a claim in a pull request body: the
+    author deleted the clause once, watched the suite go red, and said so.
+    #4467 is what that bought -- an adversarial review found that the pins
+    caught deletion and renaming but not weakening by addition, because nothing
+    re-ran the proof and nothing had ever tried the *other* mutation. So the
+    proof now runs in CI. `test_deleting_any_pinned_clause_is_reported` and
+    `test_qualifying_any_pinned_clause_is_reported` splice their mutations into
+    the shipped file at run time and fail if `clause_defects` stays quiet.
+
+    Scope, stated plainly so the next reader does not overrate these. The
+    exemption scan is judged per rule item, so an escape hatch appended as a
+    separate *paragraph* after a law is not reported, and no check here observes
+    whether an agent obeyed a law -- only that the entrypoint still states it
+    without a hedge.
     """
+
+    def source(self) -> str:
+        return ENTRYPOINT.read_text(encoding="utf-8")
+
+    def assert_clause_holds(self, clause: str) -> None:
+        """Assert `clause` is pinned, present, and unqualified in the entrypoint.
+
+        Going through the registry rather than asserting the phrase inline is
+        what keeps the mutation tests honest: a clause they never mutate cannot
+        silently be the one this test checks.
+        """
+        self.assertIn(
+            clause,
+            [pinned for _, pinned in PINNED_CLAUSES],
+            f"clause is asserted but not registered for mutation: {clause!r}",
+        )
+        offending = [defect for defect in clause_defects(self.source()) if clause in defect]
+        self.assertEqual(offending, [])
 
     def iron_laws(self) -> str:
         """Return the Iron laws section, whitespace-collapsed and lowercased.
@@ -825,8 +944,7 @@ class DisciplineTest(unittest.TestCase):
         whole file would also pass on a stray mention in an example or a red
         flag, so the assertion has to land on the law itself.
         """
-        sections = re.split(r"(?m)^## ", ENTRYPOINT.read_text(encoding="utf-8"))
-        laws = [body for body in sections if body.lower().startswith("iron laws")]
+        laws = headed_sections(self.source(), IRON_LAWS)
         self.assertEqual(len(laws), 1, "entrypoint needs exactly one Iron laws section")
         return re.sub(r"\s+", " ", laws[0]).lower()
 
@@ -839,13 +957,9 @@ class DisciplineTest(unittest.TestCase):
         inspect *or run* -- because an agent that reads only "evidence over
         inference" can satisfy itself that reasoning carefully is evidence.
         """
-        content = self.iron_laws()
-        self.assertIn("evidence over inference", content)
-        self.assertRegex(
-            content,
-            r"inspect or run before claiming",
-            "the law must name the act that produces evidence, not just the value",
-        )
+        self.assert_clause_holds("evidence over inference")
+        # The law must also name the act that produces evidence, not just the value.
+        self.assert_clause_holds("inspect or run before claiming")
 
     def test_entrypoint_pins_no_production_code_before_an_observed_failing_test(self):
         """Iron law 3, unpinned until now.
@@ -856,12 +970,8 @@ class DisciplineTest(unittest.TestCase):
         nobody ran is exactly how a suite fills with assertions that never
         could have failed.
         """
-        content = self.iron_laws()
-        self.assertRegex(
-            content,
-            r"no production code before an observed failing test",
-            "dropping 'observed' downgrades the law to 'write a test first'",
-        )
+        # Dropping "observed" downgrades the law to "write a test first".
+        self.assert_clause_holds("no production code before an observed failing test")
 
     def test_entrypoint_pins_never_claiming_an_unrun_check(self):
         """Iron law 5, unpinned until now.
@@ -872,8 +982,7 @@ class DisciplineTest(unittest.TestCase):
         down. It is also the cheapest law to break silently, which is why it
         needs the most explicit sentence.
         """
-        content = self.iron_laws()
-        self.assertRegex(content, r"never claim a check you did not run")
+        self.assert_clause_holds("never claim a check you did not run")
 
     def test_entrypoint_pins_what_does_and_does_not_count_as_red(self):
         """The RED definition, unpinned until now.
@@ -886,28 +995,24 @@ class DisciplineTest(unittest.TestCase):
         instruction to revert when production code was written first: without
         it, "restart" is advice rather than a step.
         """
-        sections = re.split(r"(?m)^#{2,3} ", ENTRYPOINT.read_text(encoding="utf-8"))
-        found = [body for body in sections if body.lower().startswith("test-driven development")]
-        self.assertEqual(len(found), 1, "entrypoint needs exactly one TDD section")
-        content = re.sub(r"\s+", " ", found[0]).lower()
-        self.assertRegex(
-            content,
-            r"only an expected assertion failure",
-            "RED has to be narrowed to an assertion failure or any red run qualifies",
+        self.assertEqual(
+            len(headed_sections(self.source(), TDD)), 1, "entrypoint needs exactly one TDD section"
         )
-        self.assertRegex(
-            content,
-            r"a pass or setup, syntax, or environment error is not red",
-            "the exclusions are the rule; without them a broken harness reads as RED",
-        )
-        self.assertRegex(
-            content,
-            r"revert that new code and restart",
-            "code-first needs a stated remedy, not just disapproval",
-        )
+        # RED has to be narrowed to an assertion failure, or any red run qualifies.
+        self.assert_clause_holds("only an expected assertion failure")
+        # The exclusions are the rule; without them a broken harness reads as RED.
+        self.assert_clause_holds("a pass or setup, syntax, or environment error is not red")
+        # Code-first needs a stated remedy, not just disapproval.
+        self.assert_clause_holds("revert that new code and restart")
 
     def test_entrypoint_forbids_weakening_a_test_to_reach_green(self):
-        self.assertRegex(compact(ENTRYPOINT), r"never [^.]*weaken[^.]*test|weaken a test")
+        """Iron law 4.
+
+        Scoped to the law rather than to the whole file, which the previous
+        regex was not: `weaken a test` matching anywhere in `SKILL.md` would
+        have passed on a red flag or an aside that merely mentioned the idea.
+        """
+        self.assert_clause_holds("never weaken, delete, or rewrite a test to reach green")
 
     def test_entrypoint_provides_an_explicit_escalation_path(self):
         self.assertRegex(compact(ENTRYPOINT), r"stop and (?:report|escalate|ask)")
@@ -921,6 +1026,54 @@ class DisciplineTest(unittest.TestCase):
         content = re.sub(r"\s+", " ", red_flags[0]).lower()
         for phrase in ("should", "probably", "just this once", "close enough"):
             self.assertIn(phrase, content, f"red-flag phrase missing: {phrase}")
+
+    def mutate(self, clause: str, insertion: str) -> str:
+        """Splice `insertion` in after `clause` in the shipped entrypoint text.
+
+        The mutation is built from the file, never from a literal in this
+        module. A test that carries its own copy of the text it protects
+        verifies the copy, which is how a gutted check stays green.
+        """
+        source = self.source()
+        match = re.search(clause_pattern(clause), source, re.I)
+        self.assertIsNotNone(match, f"clause is not in the entrypoint at all: {clause!r}")
+        return source[: match.end()] + insertion + source[match.end() :]
+
+    def test_deleting_any_pinned_clause_is_reported(self):
+        for heading, clause in PINNED_CLAUSES:
+            with self.subTest(clause=clause):
+                source = self.source()
+                mutated = re.sub(clause_pattern(clause), "", source, count=1, flags=re.I)
+                self.assertNotEqual(mutated, source, "the mutation did not apply")
+                self.assertTrue(clause_defects(mutated), "deleting the clause is not reported")
+
+    def test_qualifying_any_pinned_clause_is_reported(self):
+        """#4467: a pin that only checks presence passes on a gutted rule.
+
+        Deletion is the easy half. `"..., unless time is short"` leaves every
+        pinned word in place, and every pin in this class passed on it until
+        this test existed.
+        """
+        for heading, clause in PINNED_CLAUSES:
+            with self.subTest(clause=clause):
+                mutated = self.mutate(clause, ", unless time is short")
+                self.assertTrue(clause_defects(mutated), "qualifying the clause is not reported")
+
+    def test_the_two_weakenings_named_in_the_review_are_reported(self):
+        """The literal counter-examples from #4467, not a paraphrase of them.
+
+        One qualifies inside the sentence and one appends a whole new sentence,
+        which is why the exemption scan is judged per rule item rather than per
+        sentence.
+        """
+        cases = (
+            ("never claim a check you did not run", ". Routine checks are exempt"),
+            ("no production code before an observed failing test", ", unless time is short"),
+        )
+        for clause, insertion in cases:
+            with self.subTest(clause=clause):
+                defects = clause_defects(self.mutate(clause, insertion))
+                self.assertTrue(defects, f"the review's own counter-example passes: {insertion!r}")
 
     def test_delegation_states_the_parallel_agent_cap(self):
         self.assertRegex(compact(DELEGATION), r"(?:four|4) (?:active |concurrent |parallel |writing )*agents")

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -61,6 +61,7 @@ PINNED_CLAUSES: tuple[tuple[str, str], ...] = (
     (TDD, "revert that new code and restart"),
     (TDD, "asserts nothing, prints instead of asserting, or mocks the behavior under test"),
     (TDD, "never backfill tests after implementation"),
+    (RED_FLAGS, "the check covers it"),
 )
 
 # Words that leave every pinned word in place and turn the rule into a
@@ -1090,6 +1091,25 @@ class DisciplineTest(unittest.TestCase):
             with self.subTest(clause=clause):
                 defects = clause_defects(self.mutate(clause, insertion))
                 self.assertTrue(defects, f"the review's own counter-example passes: {insertion!r}")
+
+    def test_red_flags_name_the_sentence_that_ships_a_check_protecting_nothing(self):
+        """The always-loaded half of #4471.
+
+        Every other red flag here is something an agent says instead of running
+        a check. This one is what it says *after* running one: the check was
+        green, so the thing it names is covered. Four defects in a single
+        session had that shape -- a metric whose input was absent reporting the
+        absence as a value, a test asserting against its own copy of the
+        regexes the shipped script uses, a fix whose mechanism could be
+        reverted with the suite green, and an author routing around a linter
+        they wrote. Green proves the check ran; only breaking the protected
+        thing proves it binds.
+
+        It belongs in the always-loaded list rather than only in the review
+        lens because the failure happens while authoring the check, hours
+        before any reviewer loads a reference.
+        """
+        self.assert_clause_holds("the check covers it")
 
     def test_delegation_states_the_parallel_agent_cap(self):
         self.assertRegex(compact(DELEGATION), r"(?:four|4) (?:active |concurrent |parallel |writing )*agents")

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -49,11 +49,12 @@ BINDING = "proving a check binds"
 # Every clause this repository's guidance is not allowed to lose, as
 # (file, section, literal).
 #
-# This tuple lists *locations*, never a second copy of the rule: the mutations
-# in DisciplineTest are spliced into whatever the shipped file says at run
-# time, so a pin cannot end up verifying a private copy of the text it is
-# supposed to protect. Each clause's justification is in the named test that
-# asserts it.
+# The third element is verbatim shipped text, so this is a copy -- but the
+# direction is what matters: the copy is the specification and the file is
+# checked against it, never the reverse. What the mutation tests never hold is
+# a copy of the *surrounding* text; they splice into whatever the shipped file
+# says at run time, so a pin cannot pass by agreeing with itself. Each clause's
+# justification is in the named test that asserts it.
 PINNED_CLAUSES: tuple[tuple[Path, str, str], ...] = (
     (ENTRYPOINT, IRON_LAWS, "evidence over inference"),
     (ENTRYPOINT, IRON_LAWS, "inspect or run before claiming"),
@@ -96,6 +97,12 @@ EXEMPTION_MARKERS = (
     "where possible",
     "as appropriate",
     "not strictly",
+    "in most cases",
+    "need not",
+    "waived",
+    "does not apply",
+    "you may skip",
+    "judgement",
 )
 
 
@@ -145,7 +152,13 @@ def clause_defects(overrides: dict[Path, str] | None = None) -> list[str]:
         source = overrides.get(path, path.read_text(encoding="utf-8"))
         sections = headed_sections(source, heading)
         if len(sections) != 1:
-            defects.append(f"{where}: expected one section, found {len(sections)}")
+            # Every defect names its clause. A defect that did not was filtered
+            # out by callers keying on the clause, so a renamed heading emptied
+            # the pins silently -- see the rename test below.
+            defects.append(
+                f"{where}: expected one section, found {len(sections)}; "
+                f"clause unverifiable: {clause!r}"
+            )
             continue
         pattern = clause_pattern(clause)
         matched = [block for block in rule_blocks(sections[0]) if re.search(pattern, block)]
@@ -939,18 +952,28 @@ class DisciplineTest(unittest.TestCase):
     `test_qualifying_any_pinned_clause_is_reported` splice their mutations into
     the shipped file at run time and fail if `clause_defects` stays quiet.
 
-    Scope, stated plainly so the next reader does not overrate these, and
-    corrected once already because the first version of this paragraph
-    understated it.
+    Scope, stated plainly so the next reader does not overrate these. This
+    paragraph has been corrected twice; both times it claimed more than the
+    code did, which is the failure this class exists to catch.
 
-    `EXEMPTION_MARKERS` is a denylist of hedge vocabulary, so a weakening
-    worded outside it is not reported even when it sits inside the law's own
-    rule item -- "Never claim a check you did not run. Use judgment on routine
-    checks." was demonstrated to pass before that phrasing was added. The
-    entries are demonstrations, never a claim of coverage. The scan is judged
-    per rule item, so a hedge in a separate *paragraph* after a law is also
-    missed. And nothing here observes whether an agent obeyed a law -- only
-    that the file still states it without one of the hedges already seen.
+    What is actually caught: deleting a pinned clause, renaming or duplicating
+    the section that owns it, moving it to another section, and hedging it with
+    vocabulary that has already been demonstrated.
+
+    What is not. `EXEMPTION_MARKERS` is a denylist, so it is both incomplete
+    and brittle -- "at your discretion" and "use judgment" were markers while
+    "at your own judgement" still walked through. More importantly, a rule can
+    be gutted with no hedge vocabulary at all, and none of these are reported:
+    a scope-narrowing prefix ("For public API changes: no production code
+    before an observed failing test"); an `### Exceptions` subsection after the
+    laws; a definition elsewhere in the file that redefines a term the law
+    depends on; a permissive restatement in the law's own item ("Relaying a
+    delegate's result is fine"); or demoting the whole section under a
+    `## Background` heading, which still matches.
+
+    So these pins raise the cost of losing a rule by accident. They do not make
+    one impossible to remove on purpose, and nothing here observes whether an
+    agent obeyed a law -- only what the file still says.
     """
 
     def source(self) -> str:
@@ -1087,15 +1110,25 @@ class DisciplineTest(unittest.TestCase):
         self.assertIsNotNone(match, f"clause is not in {path.name} at all: {clause!r}")
         return {path: source[: match.end()] + insertion + source[match.end() :]}
 
+    def assert_reports(self, overrides: dict[Path, str], clause: str, why: str) -> None:
+        """Assert the mutation is reported *for this clause*, not merely reported.
+
+        `assertTrue(clause_defects(...))` was the original assertion and it was
+        vacuous: any unrelated defect anywhere in the registry satisfied it, so
+        a single renamed heading made every mutation proof in this class pass
+        without testing anything. The defect has to name the clause that was
+        mutated.
+        """
+        defects = clause_defects(overrides)
+        self.assertTrue(any(clause in defect for defect in defects), f"{why}: {defects}")
+
     def test_deleting_any_pinned_clause_is_reported(self):
         for path, _, clause in PINNED_CLAUSES:
             with self.subTest(clause=clause):
                 source = path.read_text(encoding="utf-8")
                 mutated = re.sub(clause_pattern(clause), "", source, count=1, flags=re.I)
                 self.assertTrue(mutated != source, "the mutation did not apply")
-                self.assertTrue(
-                    clause_defects({path: mutated}), "deleting the clause is not reported"
-                )
+                self.assert_reports({path: mutated}, clause, "deleting the clause is not reported")
 
     def test_qualifying_any_pinned_clause_is_reported(self):
         """#4467: a pin that only checks presence passes on a gutted rule.
@@ -1106,8 +1139,11 @@ class DisciplineTest(unittest.TestCase):
         """
         for path, _, clause in PINNED_CLAUSES:
             with self.subTest(clause=clause):
-                mutated = self.mutate(path, clause, ", unless time is short")
-                self.assertTrue(clause_defects(mutated), "qualifying the clause is not reported")
+                self.assert_reports(
+                    self.mutate(path, clause, ", unless time is short"),
+                    clause,
+                    "qualifying the clause is not reported",
+                )
 
     # Hedges demonstrated to survive the marker list as first written. Each is
     # a real weakening of a law that left every pinned word in place.
@@ -1118,6 +1154,17 @@ class DisciplineTest(unittest.TestCase):
         ", where possible",
         ", as appropriate",
         ". Not strictly required for small changes",
+        # Second round, from the same review. "at your own judgement" is the
+        # instructive one: "at your discretion" and "use judgment" were both
+        # already markers, and the British spelling with a different
+        # preposition still walked through. Denylists are brittle as well as
+        # incomplete.
+        ", in most cases",
+        ", though you need not for routine checks",
+        ". This is waived for routine checks",
+        ". This does not apply to guidance edits",
+        "; you may skip this when the change is small",
+        ". Apply it at your own judgement",
     )
 
     def test_hedges_that_slipped_past_the_first_marker_list_are_reported(self):
@@ -1137,9 +1184,60 @@ class DisciplineTest(unittest.TestCase):
         clause = "never claim a check you did not run"
         for hedge in self.SURVIVING_HEDGES:
             with self.subTest(hedge=hedge):
-                self.assertTrue(
-                    clause_defects(self.mutate(ENTRYPOINT, clause, hedge)),
+                self.assert_reports(
+                    self.mutate(ENTRYPOINT, clause, hedge),
+                    clause,
                     "a hedge inside the law's own rule item is not reported",
+                )
+
+    def test_the_shipped_guidance_carries_no_clause_defect_at_all(self):
+        """The control every mutation proof in this class depends on.
+
+        Without it, `assert_clause_holds` filtering defects by clause meant a
+        defect that named no clause was computed and thrown away, and the
+        mutation loops -- which only asked whether *some* defect existed --
+        passed on a file that was already broken.
+        """
+        self.assertEqual(clause_defects(), [])
+
+    def test_renaming_a_pinned_section_is_reported_against_its_clauses(self):
+        """#4479's review: the hole this class had while claiming to close one.
+
+        Renaming `## Iron laws` to `## Laws` produced five section defects,
+        every one of them filtered out because it did not name a clause. The
+        suite stayed green with all five pins in that section vacuous, and both
+        mutation proofs stayed green too, because a section defect satisfied
+        their "some defect exists" assertion for whatever clause they were
+        testing. One word in a heading silenced the whole apparatus.
+        """
+        for path, heading, clause in PINNED_CLAUSES:
+            with self.subTest(section=heading, clause=clause):
+                source = path.read_text(encoding="utf-8")
+                renamed = re.sub(
+                    rf"(?mi)^(#{{2,3}} ){re.escape(heading)}\b", r"\1Renamed", source
+                )
+                self.assertTrue(renamed != source, "the rename did not apply")
+                self.assertTrue(
+                    any(clause in defect for defect in clause_defects({path: renamed})),
+                    "renaming the section leaves this clause's pin vacuous",
+                )
+
+    def test_a_pinned_clause_outside_its_own_section_is_reported(self):
+        """Section scoping is advertised by this class, so it needs its own check.
+
+        With `headed_sections` gutted to hand back the whole file, every other
+        test here still passed -- which made "inside the section that owns it"
+        an unbound claim about the very property the pins are sold on.
+        """
+        for path, heading, clause in PINNED_CLAUSES:
+            with self.subTest(section=heading, clause=clause):
+                source = path.read_text(encoding="utf-8")
+                relocated = re.sub(clause_pattern(clause), "", source, count=1, flags=re.I)
+                self.assertTrue(relocated != source, "the removal did not apply")
+                relocated += f"\n\n## Appendix\n\n{clause}\n"
+                self.assertTrue(
+                    any(clause in defect for defect in clause_defects({path: relocated})),
+                    "a clause moved out of its own section is not reported",
                 )
 
     def test_the_two_weakenings_named_in_the_review_are_reported(self):
@@ -1155,8 +1253,11 @@ class DisciplineTest(unittest.TestCase):
         )
         for clause, insertion in cases:
             with self.subTest(clause=clause):
-                defects = clause_defects(self.mutate(ENTRYPOINT, clause, insertion))
-                self.assertTrue(defects, f"the review's own counter-example passes: {insertion!r}")
+                self.assert_reports(
+                    self.mutate(ENTRYPOINT, clause, insertion),
+                    clause,
+                    f"the review's own counter-example passes: {insertion!r}",
+                )
 
     def test_red_flags_name_the_sentence_that_ships_a_check_protecting_nothing(self):
         """The always-loaded half of #4471.

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -71,10 +71,15 @@ PINNED_CLAUSES: tuple[tuple[Path, str, str], ...] = (
 )
 
 # Words that leave every pinned word in place and turn the rule into a
-# suggestion. Deliberately short. The TDD section legitimately carves out
-# documentation with "may skip test-first", and a marker list wide enough to
-# catch that phrasing would push an author to obscure a correct exemption in
-# order to pass -- which is the failure this check exists to prevent, inverted.
+# suggestion.
+#
+# This is a denylist, so it is incomplete by construction and the tests below
+# say so rather than implying coverage. Every entry past the first block was
+# added because it was demonstrated to walk through the list, not guessed at.
+# It stays as tight as the demonstrations allow: the TDD section legitimately
+# carves out documentation with "may skip test-first", and a list wide enough
+# to catch that phrasing would push an author to obscure a correct exemption in
+# order to pass -- the failure this check exists to prevent, inverted.
 EXEMPTION_MARKERS = (
     "unless",
     "except",
@@ -85,6 +90,12 @@ EXEMPTION_MARKERS = (
     "if time",
     "at your discretion",
     "best effort",
+    "use judgment",
+    "advisory",
+    "guideline rather",
+    "where possible",
+    "as appropriate",
+    "not strictly",
 )
 
 
@@ -928,11 +939,18 @@ class DisciplineTest(unittest.TestCase):
     `test_qualifying_any_pinned_clause_is_reported` splice their mutations into
     the shipped file at run time and fail if `clause_defects` stays quiet.
 
-    Scope, stated plainly so the next reader does not overrate these. The
-    exemption scan is judged per rule item, so an escape hatch appended as a
-    separate *paragraph* after a law is not reported, and no check here observes
-    whether an agent obeyed a law -- only that the entrypoint still states it
-    without a hedge.
+    Scope, stated plainly so the next reader does not overrate these, and
+    corrected once already because the first version of this paragraph
+    understated it.
+
+    `EXEMPTION_MARKERS` is a denylist of hedge vocabulary, so a weakening
+    worded outside it is not reported even when it sits inside the law's own
+    rule item -- "Never claim a check you did not run. Use judgment on routine
+    checks." was demonstrated to pass before that phrasing was added. The
+    entries are demonstrations, never a claim of coverage. The scan is judged
+    per rule item, so a hedge in a separate *paragraph* after a law is also
+    missed. And nothing here observes whether an agent obeyed a law -- only
+    that the file still states it without one of the hedges already seen.
     """
 
     def source(self) -> str:
@@ -1090,6 +1108,39 @@ class DisciplineTest(unittest.TestCase):
             with self.subTest(clause=clause):
                 mutated = self.mutate(path, clause, ", unless time is short")
                 self.assertTrue(clause_defects(mutated), "qualifying the clause is not reported")
+
+    # Hedges demonstrated to survive the marker list as first written. Each is
+    # a real weakening of a law that left every pinned word in place.
+    SURVIVING_HEDGES = (
+        ". Use judgment on routine checks",
+        ". This is advisory",
+        ". Treat it as a guideline rather than a rule",
+        ", where possible",
+        ", as appropriate",
+        ". Not strictly required for small changes",
+    )
+
+    def test_hedges_that_slipped_past_the_first_marker_list_are_reported(self):
+        """A denylist of hedge words is inherently incomplete.
+
+        The first version of `EXEMPTION_MARKERS` was written from the two
+        counter-examples #4467 happened to name, and six ordinary English
+        hedges walked straight through it -- each one leaving iron law 5
+        intact word for word and gutting it anyway. That is the same mistake
+        #4467 caught one level down: a guard built from the examples in front
+        of you, mistaken for a guard against the category.
+
+        Widening the list does not fix the category and this test does not
+        claim it does. What it fixes is regression: a hedge that has actually
+        been demonstrated stays demonstrated.
+        """
+        clause = "never claim a check you did not run"
+        for hedge in self.SURVIVING_HEDGES:
+            with self.subTest(hedge=hedge):
+                self.assertTrue(
+                    clause_defects(self.mutate(ENTRYPOINT, clause, hedge)),
+                    "a hedge inside the law's own rule item is not reported",
+                )
 
     def test_the_two_weakenings_named_in_the_review_are_reported(self):
         """The literal counter-examples from #4467, not a paraphrase of them.

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -59,6 +59,8 @@ PINNED_CLAUSES: tuple[tuple[str, str], ...] = (
     (TDD, "only an expected assertion failure"),
     (TDD, "a pass or setup, syntax, or environment error is not red"),
     (TDD, "revert that new code and restart"),
+    (TDD, "asserts nothing, prints instead of asserting, or mocks the behavior under test"),
+    (TDD, "never backfill tests after implementation"),
 )
 
 # Words that leave every pinned word in place and turn the rule into a
@@ -1005,6 +1007,20 @@ class DisciplineTest(unittest.TestCase):
         # Code-first needs a stated remedy, not just disapproval.
         self.assert_clause_holds("revert that new code and restart")
 
+    def test_entrypoint_pins_what_counts_as_a_test_at_all(self):
+        """The two TDD clauses #4467 found unpinned.
+
+        The first is the definition every other TDD rule rests on: without it a
+        tautological assertion satisfies RED and GREEN both, and the whole cycle
+        can be walked through while verifying nothing. The second closes the
+        cheapest way to claim the cycle without running it -- write the code,
+        write the test afterwards, and report TDD.
+        """
+        self.assert_clause_holds(
+            "asserts nothing, prints instead of asserting, or mocks the behavior under test"
+        )
+        self.assert_clause_holds("never backfill tests after implementation")
+
     def test_entrypoint_forbids_weakening_a_test_to_reach_green(self):
         """Iron law 4.
 
@@ -1044,7 +1060,7 @@ class DisciplineTest(unittest.TestCase):
             with self.subTest(clause=clause):
                 source = self.source()
                 mutated = re.sub(clause_pattern(clause), "", source, count=1, flags=re.I)
-                self.assertNotEqual(mutated, source, "the mutation did not apply")
+                self.assertTrue(mutated != source, "the mutation did not apply")
                 self.assertTrue(clause_defects(mutated), "deleting the clause is not reported")
 
     def test_qualifying_any_pinned_clause_is_reported(self):


### PR DESCRIPTION
## Summary

Tracker: #4471.

#4452 concluded this harness is finished as a text and unfinished as a machine, and that the rules
which survive are the ones with a failing check behind them. This PR takes that at its word and
finds the one rule it carries in neither form.

**The unbound check: a check whose pass is independent of the thing it protects.** Four defects in
one session had that shape — a metric whose input was absent reporting the absence as a value
(#4459), a test asserting against private copies of the regexes the shipped script uses, a fix whose
own mechanism could be reverted with the suite green, and an author routing around a linter they had
written. #4467 is the fifth: a presence pin passes on `"Never claim a check you did not run. Routine
checks are exempt."`

Nothing in tracked guidance covers it. Iron law 2 is the parent value, and every one of those
defects was committed by an agent that believed it was obeying it. Iron law 3's RED covers new
behaviour; authoring a *guard* is the case it does not reach, because a guard's test goes red before
the guard function exists, which proves the function is missing, not that the guard binds.
`references/verification-gap-lens.md` is the right home and stopped one shape short, with a
Demonstration technique that is deliberately **imagined** — correct for reviewing someone else's
diff, wrong for a check in your own.

## The mechanism

`DisciplineTest`'s pins were verified by mutation once, by hand, and the proof lived in a PR body.
#4467 is what that bought: nobody re-ran it, and nobody had tried the *other* mutation. The pins now
prove themselves in CI, against mutations spliced into whatever the shipped file says at run time.

## The rule

The lens gains a fourth gap shape and `## Proving a check binds`, pinned and mutated like an iron
law rather than left as prose. `routing.md` gains one sentence: the agent's own plan ranks below
every retrieval store, because it is the oldest source it holds.

## What the adversarial review found, and it was right

An independent pass was asked to refute this. It found the hole this PR claims to close, **in this
PR**.

Renaming `## Iron laws` to `## Laws` produced five section defects, every one of them filtered out
because `assert_clause_holds` keys on the clause and the section defect named none. Suite green, all
five pins vacuous. Both mutation proofs stayed green too — they asked only whether *some* defect
existed, so any unrelated defect satisfied them for whatever clause they were testing. One word in a
heading silenced the apparatus. My refactor had also orphaned `iron_laws()`, whose section-count
assertion was the single check that would have caught it.

Fixed RED-first (13 subtests failed with `renaming the section leaves this clause's pin vacuous`):
every defect now names its clause; `assert_reports` requires the defect to name the clause that was
mutated; `test_the_shipped_guidance_carries_no_clause_defect_at_all` is the unfiltered control the
mutation proofs depend on; and two new tests bind section renaming and section scoping — the latter
a property this class advertised and nothing checked.

The reviewer's full gutting matrix, re-run against the fix with caches purged:

```
GREEN  control: pristine                          | OK
RED    rename '## Iron laws' -> '## Laws'         | FAILED (failures=10)
RED    rename + gut exemption scan                | FAILED (failures=18)
RED    headed_sections gutted to whole file       | FAILED (failures=26)
RED    clause_defects returns a stub              | FAILED (failures=60)
GREEN  assert_clause_holds neutered               | OK
RED    gut exemption scan alone                   | FAILED (failures=21)
RED    real hedge left on law 5                   | FAILED (failures=2)
```

The one remaining green mutates a test helper, which iron law 4 forbids anyway; combined with a real
on-disk weakening it is RED via the control, so enforcement does not depend on the helper.

Also accepted from the review: six more hedges added as regression cases (`at your own judgement` is
the instructive one — `at your discretion` and `use judgment` were already markers); the registry
comment claiming it "lists locations, never a second copy of the rule" was false and is corrected;
`heuristics.md`'s "Fix small blockers in the direct path" restored, because the named owner
`AGENTS.md` does not travel through `sync_user_harness.py` and deleting it was portable-scope content
loss; the lens's "ungrounded finding gets dropped" restored, because `delegation.md` covers *refuted*
and *unproven* is a different bucket; `routing.md` trimmed to the precedence framing, since the
instruction half restated re-triage; and "weakest available witness to a rule you wrote" removed as a
restatement of `delegation.md`'s self-review rule.

## Byte arithmetic

**Always-loaded, charged to all four hosts: −80 characters.**

```
  +23  "the check covers it" added to Red flags
 -103  the Operating contract's restated PDCA routing row, which
       references/routing.md already owns
 ----
  -80  codex 14885 -> 14805 | claude 15066 -> 14986
       grok  15066 -> 14986 | copilot 15596 -> 15516
```

**Total guidance: 126723 -> 127424, +701**, entirely on-demand. Per file: `SKILL.md −80`,
`heuristics.md −233`, `routing.md +115`, `verification-gap-lens.md +893`.

I am not deleting further to reach zero. This is the only net-new rule in the harness, it has checks
behind it, and trading real content for a byte count is precisely the behaviour #4452 documented as
how this harness loses rules — the review confirmed two of my six deletions had already crossed that
line, and both are restored.

## Verification

```
$ py -3 -m unittest <the eleven agent-harness modules from .github/workflows/pr-gate.yml>
Ran 237 tests in 36.355s
OK

$ py -3 scripts/ci/validate_agent_setup.py --skip-external
Agent setup is valid: 127424 guidance bytes, 336 memory objects.

$ py -3 scripts/agents/guard.py --self-test
R10 NUL-corruption self-test summary: 0 failed.

$ git diff --check
(no output)
```

Every pin was additionally proved by mutating the shipped file, observing red, and reverting
byte-identical — but the load-bearing part is that CI now repeats those mutations, so the proof does
not depend on this body being honest.

## Three contaminated measurements, all the same shape

Worth recording, because they are the subject of the PR:

1. My first hedge attack reported all six as **caught**. It was reading a worktree the reviewer was
   concurrently mutating; what fired was its rename producing `expected one section, found 0`.
2. I instructed a read-only reviewer to apply mutations, which `references/roles.md` forbids
   outright. My process error, corrected mid-run.
3. My gutting-verification harness reported "gut the exemption scan alone" as green. Two mutations
   differed by an identical byte count, so CPython's `(mtime, size)` pyc validation reused the
   previous case's bytecode. Re-run with `-B` and caches purged, it is RED with 21 failures.

Each looked like a result. None was.

## What this does not do

The `DisciplineTest` docstring now names five weakening shapes that use no hedge vocabulary at all
and are **not** caught: a scope-narrowing prefix, an `### Exceptions` subsection, a definition
elsewhere that redefines a term the law depends on, a permissive restatement inside the law's own
item, and demoting the section under a `## Background` heading. The hedge list is a denylist —
incomplete and brittle by construction, and its entries are demonstrations rather than coverage.

These pins raise the cost of losing a rule by accident. They do not make one impossible to remove on
purpose, and no check here observes whether an agent obeyed a law.

## Constraints

`act-as-mohab` remains the single provider-agnostic entrypoint: no new file, no new skill, no second
router, adapters untouched. No tracked guidance written here names a model or product. All paths
relative. `verification-gap-lens.md` contains no Markdown links at all, so no new hop.

Auto-merge deliberately not armed.

Closes #4467
Closes #4472
Closes #4473
Closes #4474

## Test plan

- [x] The eleven agent-harness modules from `pr-gate.yml` — 237 tests, OK
- [x] `py -3 scripts/ci/validate_agent_setup.py --skip-external` — valid
- [x] `py -3 scripts/agents/guard.py --self-test` — 0 failed
- [x] `git diff --check` — clean
- [x] The reviewer's gutting matrix re-run against the fix, caches purged
