### PR TITLE
Fix #4481: make list-valued guidance globs fail loudly when empty

### DIFF
--- a/scripts/ci/validate_agent_guidance.py
+++ b/scripts/ci/validate_agent_guidance.py
@@ -46,7 +46,8 @@ def expand_globs(root: Path, patterns: list[str]) -> list[Path]:
 def expand_reported_globs(
     root: Path, patterns: list[str], config_key: str
 ) -> tuple[list[Path], list[dict[str, str]]]:
-    """Expand a list-valued guidance glob, reporting any pattern matching nothing.
+    """
+    Expand a list-valued guidance glob, reporting any pattern matching nothing.
 
     ``expand_globs`` merges every pattern's matches into one set, so a pattern
     that resolves to zero files -- the references directory moved or was
@@ -56,9 +57,15 @@ def expand_reported_globs(
     that pattern (#4481). ``validate_file_budgets`` already closes this for
     its own glob keys with a ``missing-file`` issue; every other list-valued
     glob key the budget defines -- ``active_guidance_globs``,
-    ``total_guidance_globs``, ``reference_scan_globs`` -- routes through here
-    instead of ``expand_globs`` directly so the same ``empty-glob`` issue
-    fires no matter which list it is missing from.
+    ``total_guidance_globs``, ``reference_scan_globs``, and each host's list
+    under ``host_skill_metadata_globs`` -- routes through here instead of
+    ``expand_globs`` directly so the same ``empty-glob`` issue fires no
+    matter which list it is missing from.
+
+    This guards patterns *within* an already-present list; it cannot detect
+    the list itself being absent or empty, because the loop below then runs
+    zero times. ``require_glob_list`` closes that one level up, for the three
+    budget keys that must always be present.
     """
     errors: list[dict[str, str]] = []
     paths: set[Path] = set()
@@ -69,6 +76,26 @@ def expand_reported_globs(
             continue
         paths.update(matched)
     return sorted(paths), errors
+
+
+def require_glob_list(budget: dict, config_key: str) -> tuple[list[str], list[dict[str, str]]]:
+    """
+    Return a required list-valued glob key, or report why it cannot be scanned.
+
+    ``expand_reported_globs`` only iterates the patterns it is given: if the
+    configured key is missing, renamed, or present but set to ``[]``, that
+    loop runs zero times, no ``empty-glob`` issue fires, and every check
+    downstream scans zero files while reporting nothing wrong -- the same
+    fail-open shape (#4481) one level up, at the list rather than the
+    pattern. The set of required keys is declared here, in the code that
+    consumes the budget, rather than inferred from whatever keys the JSON
+    happens to contain -- inference cannot notice a key that used to be
+    there and is not anymore.
+    """
+    value = budget.get(config_key)
+    if not isinstance(value, list) or not value:
+        return [], [issue("empty-glob-list", config_key, "required guidance glob list is missing or empty")]
+    return value, []
 
 
 def validate_file_budgets(root: Path, budget: dict) -> list[dict[str, str]]:
@@ -174,6 +201,10 @@ def validate_host_contexts(root: Path, budget: dict) -> list[dict[str, str]]:
     if listing_maximum is None:
         return errors
     for host, patterns in budget.get("host_skill_metadata_globs", {}).items():
+        _, pattern_errors = expand_reported_globs(
+            root, patterns, f"host_skill_metadata_globs.{host}"
+        )
+        errors.extend(pattern_errors)
         characters = skill_listing_chars(root, patterns)
         if characters > listing_maximum:
             errors.append(
@@ -248,9 +279,11 @@ def validate_total_reduction(root: Path, budget: dict) -> list[dict[str, str]]:
     minimum_reduction = budget.get("minimum_reduction_percent")
     if baseline is None or minimum_reduction is None:
         return []
-    paths, errors = expand_reported_globs(
-        root, budget.get("total_guidance_globs", []), "total_guidance_globs"
-    )
+    patterns, errors = require_glob_list(budget, "total_guidance_globs")
+    if errors:
+        return errors
+    paths, glob_errors = expand_reported_globs(root, patterns, "total_guidance_globs")
+    errors.extend(glob_errors)
     # Count LF-normalized bytes (read_text collapses CRLF) so the metric matches
     # the per-file byte check and the LF blobs CI checks out, not the CRLF a
     # Windows working tree carries.
@@ -616,11 +649,13 @@ def validate_repository(root: Path = ROOT, budget_path: Path | None = None) -> l
     """Run every guidance validation and return sorted issues."""
     selected_budget = budget_path or root / "scripts/ci/agent_guidance_budget.json"
     budget = load_budget(selected_budget)
+    active_patterns, active_key_errors = require_glob_list(budget, "active_guidance_globs")
+    reference_patterns, reference_key_errors = require_glob_list(budget, "reference_scan_globs")
     active_files, active_glob_errors = expand_reported_globs(
-        root, budget.get("active_guidance_globs", []), "active_guidance_globs"
+        root, active_patterns, "active_guidance_globs"
     )
     reference_files, reference_glob_errors = expand_reported_globs(
-        root, budget.get("reference_scan_globs", []), "reference_scan_globs"
+        root, reference_patterns, "reference_scan_globs"
     )
     errors = [
         *validate_file_budgets(root, budget),
@@ -633,6 +668,8 @@ def validate_repository(root: Path = ROOT, budget_path: Path | None = None) -> l
         *validate_forbidden_patterns(root, active_files, budget),
         *validate_stale_references(root, reference_files, budget),
         *validate_duplicate_paragraphs(root, active_files, budget),
+        *active_key_errors,
+        *reference_key_errors,
         *active_glob_errors,
         *reference_glob_errors,
     ]

--- a/scripts/ci/validate_agent_guidance.py
+++ b/scripts/ci/validate_agent_guidance.py
@@ -43,6 +43,34 @@ def expand_globs(root: Path, patterns: list[str]) -> list[Path]:
     return sorted(paths)
 
 
+def expand_reported_globs(
+    root: Path, patterns: list[str], config_key: str
+) -> tuple[list[Path], list[dict[str, str]]]:
+    """Expand a list-valued guidance glob, reporting any pattern matching nothing.
+
+    ``expand_globs`` merges every pattern's matches into one set, so a pattern
+    that resolves to zero files -- the references directory moved or was
+    renamed, a typo -- leaves no trace in the result: the merged set just
+    ends up a little smaller, and a check that iterates it for
+    ``all(...)``-shaped assertions keeps passing having verified nothing for
+    that pattern (#4481). ``validate_file_budgets`` already closes this for
+    its own glob keys with a ``missing-file`` issue; every other list-valued
+    glob key the budget defines -- ``active_guidance_globs``,
+    ``total_guidance_globs``, ``reference_scan_globs`` -- routes through here
+    instead of ``expand_globs`` directly so the same ``empty-glob`` issue
+    fires no matter which list it is missing from.
+    """
+    errors: list[dict[str, str]] = []
+    paths: set[Path] = set()
+    for pattern in patterns:
+        matched = expand_globs(root, [pattern])
+        if not matched:
+            errors.append(issue("empty-glob", pattern, f"{config_key} pattern matched no files"))
+            continue
+        paths.update(matched)
+    return sorted(paths), errors
+
+
 def validate_file_budgets(root: Path, budget: dict) -> list[dict[str, str]]:
     """Validate byte, character, and line budgets.
 
@@ -220,21 +248,23 @@ def validate_total_reduction(root: Path, budget: dict) -> list[dict[str, str]]:
     minimum_reduction = budget.get("minimum_reduction_percent")
     if baseline is None or minimum_reduction is None:
         return []
-    paths = expand_globs(root, budget.get("total_guidance_globs", []))
+    paths, errors = expand_reported_globs(
+        root, budget.get("total_guidance_globs", []), "total_guidance_globs"
+    )
     # Count LF-normalized bytes (read_text collapses CRLF) so the metric matches
     # the per-file byte check and the LF blobs CI checks out, not the CRLF a
     # Windows working tree carries.
     current = sum(len(path.read_text(encoding="utf-8").encode("utf-8")) for path in paths)
     maximum = math.floor(baseline * (1 - minimum_reduction / 100))
     if current > maximum:
-        return [
+        errors.append(
             issue(
                 "total-reduction",
                 "agent-guidance",
                 f"{current} bytes exceeds {maximum}; minimum reduction is {minimum_reduction}%",
             )
-        ]
-    return []
+        )
+    return errors
 
 
 _BLOCK_SCALAR_HEADER = re.compile(r"^[|>][+-]?\d*$")
@@ -586,8 +616,12 @@ def validate_repository(root: Path = ROOT, budget_path: Path | None = None) -> l
     """Run every guidance validation and return sorted issues."""
     selected_budget = budget_path or root / "scripts/ci/agent_guidance_budget.json"
     budget = load_budget(selected_budget)
-    active_files = expand_globs(root, budget.get("active_guidance_globs", []))
-    reference_files = expand_globs(root, budget.get("reference_scan_globs", []))
+    active_files, active_glob_errors = expand_reported_globs(
+        root, budget.get("active_guidance_globs", []), "active_guidance_globs"
+    )
+    reference_files, reference_glob_errors = expand_reported_globs(
+        root, budget.get("reference_scan_globs", []), "reference_scan_globs"
+    )
     errors = [
         *validate_file_budgets(root, budget),
         *validate_host_contexts(root, budget),
@@ -599,6 +633,8 @@ def validate_repository(root: Path = ROOT, budget_path: Path | None = None) -> l
         *validate_forbidden_patterns(root, active_files, budget),
         *validate_stale_references(root, reference_files, budget),
         *validate_duplicate_paragraphs(root, active_files, budget),
+        *active_glob_errors,
+        *reference_glob_errors,
     ]
     return sorted(errors, key=lambda item: (item["path"], item["code"], item["message"]))
 

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -208,7 +208,8 @@ def compact(path: Path) -> str:
 
 
 def glob_files(root: Path, patterns: tuple[str, ...]) -> list[Path]:
-    """Expand a fixed list of guidance globs, asserting every pattern hits.
+    """
+    Expand a fixed list of guidance globs, raising if any pattern misses.
 
     Callers use this to build the file set an ``all(...)``-shaped assertion
     (no duplicate line, no unscoped absolute) checks across every configured
@@ -216,12 +217,17 @@ def glob_files(root: Path, patterns: tuple[str, ...]) -> list[Path]:
     directory, a typo -- would otherwise shrink that set silently: "for every
     file in []" is trivially true, so the assertion keeps passing having
     checked nothing for that pattern (#4481). Raising here is what makes a
-    moved surface fail the test instead of dropping out of it unnoticed.
+    moved surface fail the test instead of dropping out of it unnoticed. A
+    bare ``assert`` would do the same today, but it compiles away under
+    ``python -O``/``PYTHONOPTIMIZE`` (bandit B101) -- this is the only
+    enforcement this helper has, so it must survive that flag even though
+    nothing in this repository currently sets it.
     """
     paths: set[Path] = set()
     for pattern in patterns:
         matched = [path for path in root.glob(pattern) if path.is_file()]
-        assert matched, f"guidance glob matched no files: {pattern}"
+        if not matched:
+            raise AssertionError(f"guidance glob matched no files: {pattern}")
         paths.update(matched)
     return sorted(paths)
 
@@ -720,8 +726,14 @@ class NoDuplicationTest(unittest.TestCase):
         return glob_files(ROOT, self.GUIDANCE_GLOBS)
 
     def test_no_substantive_line_is_repeated_across_guidance_files(self):
+        files = self.guidance_files()
+        # A gutted glob_files() (e.g. hardcoded to return []) would make this
+        # loop scan nothing and the duplicate check below pass trivially --
+        # the resolver's own tests catch that mutation, but this consumer
+        # must catch it too rather than rely on it (#4481).
+        self.assertTrue(files, "guidance_files() resolved to no files")
         seen: dict[str, list[str]] = {}
-        for path in self.guidance_files():
+        for path in files:
             for raw in path.read_text(encoding="utf-8").splitlines():
                 line = raw.strip()
                 if len(line) < self.MIN_DUPLICATE_LINE_CHARS:
@@ -948,8 +960,12 @@ class SoloOrOrchestrateTest(unittest.TestCase):
         delegate" -- so both are checked, across every tracked surface an agent
         can read rather than only the files that stated it first.
         """
+        files = glob_files(ROOT, self.GUIDANCE_GLOBS)
+        # Same guard as NoDuplicationTest: a gutted resolver must fail this
+        # test directly, not just the resolver's own unit tests (#4481).
+        self.assertTrue(files, "glob_files() resolved to no files")
         offenders = []
-        for path in glob_files(ROOT, self.GUIDANCE_GLOBS):
+        for path in files:
             if path.resolve() == ENTRYPOINT.resolve():
                 continue
             for sentence in self.unscoped_absolutes(path.read_text(encoding="utf-8")):

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import re
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -204,6 +205,25 @@ def markdown_body(path: Path) -> str:
 def compact(path: Path) -> str:
     """Return whitespace-collapsed lowercase content for phrase assertions."""
     return re.sub(r"\s+", " ", path.read_text(encoding="utf-8")).lower()
+
+
+def glob_files(root: Path, patterns: tuple[str, ...]) -> list[Path]:
+    """Expand a fixed list of guidance globs, asserting every pattern hits.
+
+    Callers use this to build the file set an ``all(...)``-shaped assertion
+    (no duplicate line, no unscoped absolute) checks across every configured
+    surface. A pattern that resolves to zero files -- a moved or renamed
+    directory, a typo -- would otherwise shrink that set silently: "for every
+    file in []" is trivially true, so the assertion keeps passing having
+    checked nothing for that pattern (#4481). Raising here is what makes a
+    moved surface fail the test instead of dropping out of it unnoticed.
+    """
+    paths: set[Path] = set()
+    for pattern in patterns:
+        matched = [path for path in root.glob(pattern) if path.is_file()]
+        assert matched, f"guidance glob matched no files: {pattern}"
+        paths.update(matched)
+    return sorted(paths)
 
 
 def local_links(path: Path) -> list[str]:
@@ -640,6 +660,36 @@ class CiGateIsBlockingTest(unittest.TestCase):
         self.assertIn("agent_guidance", outputs, "filter result is never exported")
 
 
+class GlobFilesHelperTest(unittest.TestCase):
+    """The resolver every GUIDANCE_GLOBS consumer in this file shares.
+
+    NoDuplicationTest and SoloOrOrchestrateTest each declare their own tuple
+    of guidance globs -- that duplication is the documented cost of host
+    discovery having no include mechanism -- but both feed their tuple
+    through this one resolver, so a pattern matching zero files reports the
+    same way regardless of which check's list it dropped out of (#4481).
+    """
+
+    def test_returns_every_matched_file_across_patterns(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "docs").mkdir()
+            (root / "docs/a.md").write_text("a", encoding="utf-8")
+            (root / "docs/b.md").write_text("b", encoding="utf-8")
+            (root / "AGENTS.md").write_text("agents", encoding="utf-8")
+            found = glob_files(root, ("AGENTS.md", "docs/*.md"))
+        self.assertEqual(
+            {path.name for path in found}, {"AGENTS.md", "a.md", "b.md"}
+        )
+
+    def test_raises_when_a_pattern_matches_nothing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "AGENTS.md").write_text("agents", encoding="utf-8")
+            with self.assertRaises(AssertionError):
+                glob_files(root, ("AGENTS.md", "moved-away/**/*.md"))
+
+
 class NoDuplicationTest(unittest.TestCase):
     """One rule, one home.
 
@@ -667,10 +717,7 @@ class NoDuplicationTest(unittest.TestCase):
     MIN_DUPLICATE_LINE_CHARS = 40
 
     def guidance_files(self) -> list[Path]:
-        paths: set[Path] = set()
-        for pattern in self.GUIDANCE_GLOBS:
-            paths.update(path for path in ROOT.glob(pattern) if path.is_file())
-        return sorted(paths)
+        return glob_files(ROOT, self.GUIDANCE_GLOBS)
 
     def test_no_substantive_line_is_repeated_across_guidance_files(self):
         seen: dict[str, list[str]] = {}
@@ -902,12 +949,11 @@ class SoloOrOrchestrateTest(unittest.TestCase):
         can read rather than only the files that stated it first.
         """
         offenders = []
-        for pattern in self.GUIDANCE_GLOBS:
-            for path in ROOT.glob(pattern):
-                if not path.is_file() or path.resolve() == ENTRYPOINT.resolve():
-                    continue
-                for sentence in self.unscoped_absolutes(path.read_text(encoding="utf-8")):
-                    offenders.append(f"{path.relative_to(ROOT).as_posix()}: {sentence}")
+        for path in glob_files(ROOT, self.GUIDANCE_GLOBS):
+            if path.resolve() == ENTRYPOINT.resolve():
+                continue
+            for sentence in self.unscoped_absolutes(path.read_text(encoding="utf-8")):
+                offenders.append(f"{path.relative_to(ROOT).as_posix()}: {sentence}")
         self.assertEqual(offenders, [], "unscoped implement/delegate absolute outside the entrypoint")
 
     def test_the_guard_catches_the_phrasings_that_previously_slipped_through(self):

--- a/tests/scripts/test_validate_agent_guidance.py
+++ b/tests/scripts/test_validate_agent_guidance.py
@@ -197,6 +197,50 @@ steps:
             {(error["path"], error["code"]) for error in errors},
         )
 
+    def test_an_active_guidance_glob_matching_nothing_is_reported_as_empty(self):
+        # active_guidance_globs feeds validate_forbidden_patterns and
+        # validate_duplicate_paragraphs, both "every matched file must hold"
+        # checks: a pattern that resolves to zero files -- a moved directory,
+        # a typo -- used to shrink the scanned set with no trace, so the check
+        # kept passing having verified nothing for it (#4481).
+        self.budget["active_guidance_globs"].append(".agents/skills/*/moved-away/**/*.md")
+        self.write_budget()
+        errors = validate_repository(self.root, self.budget_path)
+        self.assertIn(
+            (".agents/skills/*/moved-away/**/*.md", "empty-glob"),
+            {(error["path"], error["code"]) for error in errors},
+        )
+
+    def test_a_reference_scan_glob_matching_nothing_is_reported_as_empty(self):
+        # reference_scan_globs feeds validate_local_references and
+        # validate_stale_references -- same fail-open shape as
+        # active_guidance_globs, a different consuming pair of checks.
+        self.budget["reference_scan_globs"].append(".agents/skills/*/moved-away/**/*.md")
+        self.write_budget()
+        errors = validate_repository(self.root, self.budget_path)
+        self.assertIn(
+            (".agents/skills/*/moved-away/**/*.md", "empty-glob"),
+            {(error["path"], error["code"]) for error in errors},
+        )
+
+    def test_a_total_guidance_glob_matching_nothing_is_reported_as_empty(self):
+        # total_guidance_globs only runs once reduction_baseline_bytes and
+        # minimum_reduction_percent are configured (see
+        # test_total_reduction_is_noop_when_unconfigured); once it does, the
+        # same empty-glob reporting must apply to its own copy of the list.
+        self.budget["reduction_baseline_bytes"] = 1_000_000
+        self.budget["minimum_reduction_percent"] = 10
+        self.budget["total_guidance_globs"] = [
+            "AGENTS.md",
+            ".agents/skills/*/moved-away/**/*.md",
+        ]
+        self.write_budget()
+        errors = validate_repository(self.root, self.budget_path)
+        self.assertIn(
+            (".agents/skills/*/moved-away/**/*.md", "empty-glob"),
+            {(error["path"], error["code"]) for error in errors},
+        )
+
     def test_rejects_oversized_skill_md_file(self):
         self.budget["skill_budgets"] = {".github/skills": {"max_skill_md_bytes": 10}}
         self.write_budget()

--- a/tests/scripts/test_validate_agent_guidance.py
+++ b/tests/scripts/test_validate_agent_guidance.py
@@ -241,6 +241,76 @@ steps:
             {(error["path"], error["code"]) for error in errors},
         )
 
+    def test_an_active_guidance_glob_key_that_is_deleted_is_reported_as_empty(self):
+        # expand_reported_globs only guards patterns *within* an already
+        # present list -- deleting the key itself makes its loop run zero
+        # times, so no empty-glob issue fires and every downstream check
+        # scans nothing. That is #4481 one level up, at the list rather than
+        # the pattern; require_glob_list closes it by declaring the key
+        # required in code instead of inferring it from the JSON.
+        del self.budget["active_guidance_globs"]
+        self.write_budget()
+        self.assertIn(
+            ("active_guidance_globs", "empty-glob-list"),
+            {(error["path"], error["code"]) for error in validate_repository(self.root, self.budget_path)},
+        )
+
+    def test_an_active_guidance_glob_key_set_to_an_empty_list_is_reported_as_empty(self):
+        self.budget["active_guidance_globs"] = []
+        self.write_budget()
+        self.assertIn(
+            ("active_guidance_globs", "empty-glob-list"),
+            {(error["path"], error["code"]) for error in validate_repository(self.root, self.budget_path)},
+        )
+
+    def test_an_active_guidance_glob_key_that_is_renamed_is_reported_as_empty(self):
+        # A future budget restructure renaming the key, or a bad merge that
+        # drops it, must be caught the same way as deleting it outright.
+        self.budget["active_guidance_globs_renamed"] = self.budget.pop("active_guidance_globs")
+        self.write_budget()
+        self.assertIn(
+            ("active_guidance_globs", "empty-glob-list"),
+            {(error["path"], error["code"]) for error in validate_repository(self.root, self.budget_path)},
+        )
+
+    def test_a_reference_scan_glob_key_that_is_deleted_is_reported_as_empty(self):
+        del self.budget["reference_scan_globs"]
+        self.write_budget()
+        self.assertIn(
+            ("reference_scan_globs", "empty-glob-list"),
+            {(error["path"], error["code"]) for error in validate_repository(self.root, self.budget_path)},
+        )
+
+    def test_a_total_guidance_glob_key_that_is_deleted_is_reported_as_empty(self):
+        # total_guidance_globs only runs once reduction_baseline_bytes and
+        # minimum_reduction_percent are configured -- see
+        # test_total_reduction_is_noop_when_unconfigured -- but once it does,
+        # the same required-key guard must apply to its own copy of the list.
+        self.budget["reduction_baseline_bytes"] = 1_000_000
+        self.budget["minimum_reduction_percent"] = 10
+        self.budget.pop("total_guidance_globs", None)
+        self.write_budget()
+        self.assertIn(
+            ("total_guidance_globs", "empty-glob-list"),
+            {(error["path"], error["code"]) for error in validate_repository(self.root, self.budget_path)},
+        )
+
+    def test_a_host_skill_metadata_glob_matching_nothing_is_reported_as_empty(self):
+        # host_skill_metadata_globs is a {host: [patterns]} dict feeding
+        # skill_listing_chars via expand_globs directly -- a separate path
+        # from active_guidance_globs/reference_scan_globs/total_guidance_globs,
+        # so it needs its own wiring through the reporting resolver, per host.
+        self.budget["host_skill_metadata_globs"] = {
+            "codex": [".agents/skills/*/moved-away/**/*.md"]
+        }
+        self.budget["max_skill_listing_chars"] = 10_000
+        self.write_budget()
+        errors = validate_repository(self.root, self.budget_path)
+        self.assertIn(
+            (".agents/skills/*/moved-away/**/*.md", "empty-glob"),
+            {(error["path"], error["code"]) for error in errors},
+        )
+
     def test_rejects_oversized_skill_md_file(self):
         self.budget["skill_budgets"] = {".github/skills": {"max_skill_md_bytes": 10}}
         self.write_budget()


### PR DESCRIPTION
## Summary

Closes #4481.

Four of five copies of the `.agents/skills/act-as-mohab/references/**/*.md` glob failed open when the path moved: a pattern matching zero files silently shrinks the merged set, and an empty set trivially satisfies every `all(...)`-shaped check that scans it. `file_budgets` already reported `missing-file` for its own glob keys (#4458); the other three budget-side keys (`active_guidance_globs`, `total_guidance_globs`, `reference_scan_globs`) and the test-side `GUIDANCE_GLOBS` copies did not.

- `scripts/ci/validate_agent_guidance.py`: added `expand_reported_globs`, a shared resolver that reports an `empty-glob` issue per pattern in a configured list that matches nothing. Wired into `validate_repository` (for `active_guidance_globs` and `reference_scan_globs`) and `validate_total_reduction` (for `total_guidance_globs`).
- `tests/scripts/test_agent_router_contract.py`: added `glob_files`, the equivalent shared resolver for the test side, and pointed both `NoDuplicationTest.guidance_files()` and `SoloOrOrchestrateTest.test_no_other_file_states_an_unconditional_implement_or_delegate_rule` at it. Added `GlobFilesHelperTest` for direct coverage of the resolver.
- `tests/scripts/test_validate_agent_guidance.py`: added three tests, one per newly-guarded list key, following the existing `file_budgets` empty-glob test's pattern.

`scripts/ci/agent_guidance_budget.json` is out of scope for this PR (another agent owns edits there per the coordination plan for #4481) — the fix is entirely in the Python that consumes its glob lists, per the issue's suggested option 1 (report on empty match, no config restructuring).

## Why a shared resolver over five independent guards

The alternative considered was a named glob referenced by every consumer, or five independent per-site checks. A shared resolver was simpler and sufficient: every fail-open site already iterates a `list[str]` of patterns and merges matches, so one function each side (`expand_reported_globs` for the validator, `glob_files` for the test file) covers every current and future list-valued glob key without adding config indirection.

## Mutation proof (real, observed)

Renamed `.agents/skills/act-as-mohab/references/` to `references-moved/` and ran the affected checks:

- `python3 scripts/ci/validate_agent_guidance.py` — reported `empty-glob: .agents/skills/act-as-mohab/references/**/*.md: active_guidance_globs pattern matched no files` and the same for `reference_scan_globs`, alongside the pre-existing `missing-file` from `file_budgets`.
- `test_validate_agent_guidance.ValidateAgentGuidanceTest.test_current_repository_configuration_is_valid` — FAILED (as expected; the assertion now sees the new `empty-glob` issues among others).
- `test_agent_router_contract.NoDuplicationTest.test_no_substantive_line_is_repeated_across_guidance_files` — FAILED: `AssertionError: guidance glob matched no files: .agents/skills/act-as-mohab/references/**/*.md`.
- `test_agent_router_contract.SoloOrOrchestrateTest.test_no_other_file_states_an_unconditional_implement_or_delegate_rule` — same failure.

Restored the directory; all tests returned to green.

## Test plan

- [x] `python3 -m unittest tests.scripts.test_agent_harness_portability tests.scripts.test_agent_router_contract tests.scripts.test_sync_user_harness tests.scripts.test_validate_agent_guidance tests.scripts.test_validate_agent_setup -v` — `Ran 180 tests ... OK`
- [x] `py -3 scripts/ci/validate_agent_setup.py --skip-external` — `Agent setup is valid: 126857 guidance bytes, 338 memory objects.` (exit 0)
- [x] `git diff --check` — clean
- [x] Mutation proof above (rename references dir, observe RED, restore, observe GREEN)

Auto-merge intentionally not armed — an independent adversarial review is expected before merge.

https://claude.ai/code/session_017uBrtSmdU6Xvwmkyajqkuy