### PR TITLE
Fix #4424: surface sandbox bootstrap failures on a successful CLI exit

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -687,7 +687,7 @@ final class AssistantLocalAgentRunner {
                 if (success) {
                     output = streamParser != null && streamParser.hasTerminalEvent()
                             ? streamParser.finalOutput(rawStderr)
-                            : agentOutput(true, rawStdout, rawStderr, "", verbose);
+                            : bufferedSuccessOutput(rawStdout, rawStderr, verbose);
                 } else if (streamParser != null) {
                     // A structured (stream-json / --json) CLI writes machine NDJSON to stdout, so on a
                     // failed run the raw stream must never reach the transcript verbatim -- rerun/codegen
@@ -883,6 +883,12 @@ final class AssistantLocalAgentRunner {
         // after it), then carried through composeOutput's trailing metadata line so
         // AssistantLocalAgentRunner.parseQuestion can recover it, mirroring planProposal above.
         private AssistantQuestion structuredQuestion;
+        // Whether any tool call was ever attempted, regardless of its outcome (issue #4424 round 2):
+        // distinct from filesTouched/permissionDenialsByTool, which only record a tool call's *result*.
+        // A run that attempted a (successful, non-mutating) tool call must not be treated as "silent"
+        // by finalOutput(String) just because it had nothing file/denial-worthy to report -- only a run
+        // that never got to attempt anything at all is that shape.
+        private boolean toolCallObserved;
 
         StructuredStreamParser(Format format) {
             this.format = format;
@@ -926,27 +932,39 @@ final class AssistantLocalAgentRunner {
         }
 
         /**
-         * Same as {@link #finalOutput()}, plus consulting {@code stderr} for an environment/sandbox
-         * bootstrap failure (issue #4424). {@code run()}'s success branch used to call the no-arg
-         * overload unconditionally, discarding {@code rawStderr} entirely once a terminal event had
-         * arrived -- so a CLI that exited 0 after its sandbox helper failed to launch (Codex's
-         * {@code sandbox-setup.exe ... Access is denied (os error 5)}) produced a confident-looking
-         * answer with no trace that no tool had actually run. That is not ordinary noise (contrast the
-         * Verbose-gated stderr fence in {@link #failureOutput}, issue #3965): it means the entire
-         * request was silently impossible, so {@link #sandboxBootstrapFailureNotice} surfaces one
-         * actionable line regardless of the Verbose toggle. A {@code null}/blank/non-matching {@code
-         * stderr} leaves {@code core} untouched, so this overload is byte-identical to {@link
-         * #finalOutput()} for the overwhelmingly common case. This overload is deliberately separate
-         * from (rather than replacing) {@link #finalOutput()}, which stays in use where {@code
-         * terminalAnswerConsumer} recovers a cancelled/killed run's answer with no stderr in scope.
+         * Same as {@link #finalOutput()}, plus consulting {@code stderr} (issue #4424). {@code run()}'s
+         * success branch used to call the no-arg overload unconditionally, discarding {@code rawStderr}
+         * entirely once a terminal event had arrived. The general rule (round 2 of this issue, after an
+         * adversarial review showed a single-string {@code sandbox-setup} match was both incomplete --
+         * an unrelated MCP-startup failure hit the identical silent shape -- and fragile -- a bare
+         * naming-convention drift such as {@code SandboxSetup.exe} defeated it): <b>a zero-exit run that
+         * attempted zero tool calls, touched zero files and hit zero denials, but did emit stderr, must
+         * surface that stderr -- or a notice pointing at it -- regardless of the Verbose toggle.</b> That
+         * is not ordinary noise (contrast the Verbose-gated stderr fence in {@link #failureOutput}, issue
+         * #3965): if literally nothing else happened, the stderr is the only account of what went wrong,
+         * so withholding it makes the whole request silently impossible without a trace. {@code
+         * toolCallObserved} is what keeps this from becoming "always surface any stderr": a run that DID
+         * attempt a tool call but simply had nothing file/denial-worthy to report keeps withholding
+         * incidental stderr noise exactly as issue #3965 established. {@link
+         * #sandboxBootstrapFailureHeadline} still recognizes the sandbox-bootstrap shape for a more
+         * specific, actionable headline, but only as an enrichment on top of the general rule -- never
+         * as its gate -- so an unrecognized shape still surfaces via the generic headline. A {@code
+         * null}/blank stderr, or any tool-call/file/denial activity, leaves {@code core} untouched, so
+         * this overload is byte-identical to {@link #finalOutput()} for the overwhelmingly common case.
+         * This overload is deliberately separate from (rather than replacing) {@link #finalOutput()},
+         * which stays in use where {@code terminalAnswerConsumer} recovers a cancelled/killed run's
+         * answer with no stderr in scope.
          */
         synchronized String finalOutput(String stderr) {
             String core = answer.strip();
-            String notice = sandboxBootstrapFailureNotice(stderr);
-            if (notice != null) {
+            boolean silentRun = filesTouched.isEmpty() && permissionDenialsByTool.isEmpty() && !toolCallObserved;
+            String stderrText = stderr == null ? "" : stderr.strip();
+            boolean surfaceStderr = silentRun && !stderrText.isBlank();
+            if (surfaceStderr) {
+                String notice = stderrNotice(stderrText);
                 core = core.isBlank() ? notice : core + "\n\n" + notice;
             }
-            return composeOutput(core, notice != null);
+            return composeOutput(core, surfaceStderr);
         }
 
         /**
@@ -974,27 +992,43 @@ final class AssistantLocalAgentRunner {
         }
 
         /**
-         * {@code sandbox-setup} together with an access-denied/permission-denied bootstrap failure
-         * (Windows' "Access is denied (os error 5)" and its equivalent shapes) means the sandbox
-         * helper never launched, so no tool could run for this request at all -- see {@link
-         * #finalOutput(String)}. Returns {@code null} (no notice) for {@code null}/blank stderr or any
-         * shape that doesn't match, so ordinary stderr never gets this treatment.
+         * Builds the notice {@link #finalOutput(String)} appends for a silent run that emitted stderr:
+         * a specific, actionable headline for the recognized sandbox-bootstrap-failure shape when
+         * {@link #sandboxBootstrapFailureHeadline} recognizes it, or a generic headline otherwise --
+         * either way the full raw {@code stderrText} always follows as a fenced block, so an
+         * unrecognized shape is never dropped just because it doesn't match a known pattern (issue
+         * #4424 review round 2, finding 2). {@code stderrText} is assumed already non-blank.
          */
-        private static String sandboxBootstrapFailureNotice(String stderr) {
-            if (stderr == null || stderr.isBlank()) {
-                return null;
+        private static String stderrNotice(String stderrText) {
+            String headline = sandboxBootstrapFailureHeadline(stderrText);
+            if (headline == null) {
+                headline = "**Note:** no tool ran for this request, but the CLI reported this on stderr:";
             }
-            String lower = stderr.toLowerCase(Locale.ROOT);
-            if (!lower.contains("sandbox-setup")) {
+            return headline + "\n\n```\n" + stderrText + "\n```";
+        }
+
+        /**
+         * Recognizes the sandbox-bootstrap-failure shape (Codex's sandbox helper failing to launch,
+         * e.g. {@code sandbox-setup.exe ... Access is denied (os error 5)}) for a more specific,
+         * actionable headline than {@link #stderrNotice}'s generic fallback. This is deliberately an
+         * enrichment only, never a gate: {@link #finalOutput(String)} surfaces stderr on a silent run
+         * regardless of whether this recognizes it, so a naming-convention drift (e.g. {@code
+         * SandboxSetup.exe}, no hyphen) degrades to the generic headline instead of silently dropping
+         * the stderr the way a single fitted string match would (issue #4424 review round 2, finding
+         * 2). Matches on "sandbox" and "setup" as separate substrings (order- and separator-agnostic)
+         * rather than the literal token, plus an access/permission-denied signal.
+         */
+        private static String sandboxBootstrapFailureHeadline(String stderrText) {
+            String lower = stderrText.toLowerCase(Locale.ROOT);
+            if (!lower.contains("sandbox") || !lower.contains("setup")) {
                 return null;
             }
             if (!(lower.contains("access is denied") || lower.contains("permission denied")
                     || lower.contains("os error 5"))) {
                 return null;
             }
-            return "**Environment setup failed:** the sandbox helper (`sandbox-setup`) could not launch, "
-                    + "so no tool could run for this request. Ask an administrator to grant it access, "
-                    + "then try again.\n\n```\n" + stderr.strip() + "\n```";
+            return "**Environment setup failed:** the sandbox helper could not launch, so no tool could "
+                    + "run for this request. Ask an administrator to grant it access, then try again.";
         }
 
         private String composeOutput(String core) {
@@ -1061,14 +1095,16 @@ final class AssistantLocalAgentRunner {
          * an unexplained bare confirmation with no visible trace of what happened.
          *
          * <p>{@code explicitNoActivityNotice} (issue #4424) widens that guarantee to the shape the
-         * original "no silent bare confirmation" guard missed: a sandbox/environment bootstrap
-         * failure happens before any tool executes, so both {@code filesTouched} and {@code
-         * permissionDenialsByTool} stay empty and this footer used to render nothing at all between
-         * the answer and the usage line. {@link #finalOutput(String)} passes {@code true} only when
-         * it has already detected that exact shape via {@link #sandboxBootstrapFailureNotice}, so a
-         * plain empty/empty run with no detected bootstrap failure (an ordinary Q&A that never
-         * needed a tool) still renders {@code ""} exactly as before -- this stays additive, not a
-         * blanket "always explain an empty run" change.
+         * original "no silent bare confirmation" guard missed: a run whose CLI process died before any
+         * tool executed (a sandbox/environment bootstrap failure, an MCP server that failed to start,
+         * or any other pre-tool-call collapse) leaves {@code filesTouched}, {@code
+         * permissionDenialsByTool}, <em>and</em> {@code toolCallObserved} all empty/false, so this
+         * footer used to render nothing at all between the answer and the usage line. {@link
+         * #finalOutput(String)} passes {@code true} only when it has already decided to surface stderr
+         * for exactly that silent-run shape, so a plain empty/empty run that genuinely has nothing to
+         * report (an ordinary Q&A that never needed a tool, or a tool call that ran but touched no
+         * files and was never denied) still renders {@code ""} exactly as before -- this stays
+         * additive, not a blanket "always explain an empty run" change.
          */
         private String activitySummary(boolean explicitNoActivityNotice) {
             if (filesTouched.isEmpty() && permissionDenialsByTool.isEmpty()) {
@@ -1131,6 +1167,15 @@ final class AssistantLocalAgentRunner {
         /** Looks up a previously remembered tool name by its {@code tool_use_id}, or {@code null}. */
         String toolNameFor(String toolUseId) {
             return toolNamesByUseId.get(toolUseId);
+        }
+
+        /**
+         * Marks that a tool call was attempted, whatever its outcome (issue #4424 round 2) -- see
+         * {@link #toolCallObserved}. Called once per tool-call event from either mapper, regardless of
+         * whether the call also turns out to touch a file or fail/get denied.
+         */
+        void recordToolCallObserved() {
+            toolCallObserved = true;
         }
 
         /** Records that {@code path} was created or edited, for the final activity-summary footer. */
@@ -1859,7 +1904,10 @@ final class AssistantLocalAgentRunner {
      * stderr} is folded into the compact terminal answer only when {@code verbose} is {@code true} --
      * a non-verbose run withholds it here, but never loses it entirely, since the same raw stderr
      * already reached the live {@code outputConsumer} stream (Verbose-gated there, at the panel) while
-     * the process was running.
+     * the process was running. On success with non-blank {@code stdout}, {@code stderr} is never
+     * folded in at all, verbose or not -- see {@link #bufferedSuccessOutput} for why a successful
+     * {@link #run} answer needs different treatment than this general-purpose composer's other
+     * callers (issue #4424 review round 2, finding 3).
      */
     static String agentOutput(boolean success, String stdout, String stderr, String fallback, boolean verbose) {
         if (success && stdout != null && !stdout.isBlank()) {
@@ -1874,6 +1922,36 @@ final class AssistantLocalAgentRunner {
         }
         if (sections.isEmpty() && fallback != null && !fallback.isBlank()) {
             sections.add(fallback);
+        }
+        return String.join("\n\n", sections).trim();
+    }
+
+    /**
+     * Composes {@link #run}'s buffered/custom-command <em>success</em> answer for the interactive
+     * transcript. Issue #4424 review round 2, finding 3: {@link #agentOutput}'s short-circuit above
+     * (returning bare {@code stdout} on success, unconditionally) is a deliberate, tested design
+     * choice for its other caller ({@link #runCompactPreamble}'s low-stakes auxiliary status line,
+     * pinned by {@code AssistantCommandTest#directLocalAgentOutputPrefersStdoutOnSuccessAndIncludes
+     * StderrOnFailure}), but it is the wrong choice for a custom command's or Copilot's actual answer:
+     * a CLI that printed a confident-looking answer to stdout while its real failure reason went to
+     * stderr (the reviewer's reproduction: {@code sandbox-setup.exe ... Access is denied (os error
+     * 5)}) stayed silent about it even with Verbose on, since the short-circuit runs before {@code
+     * verbose}-gated stderr is ever considered. This dedicated composer folds {@code stdout} and
+     * {@code verbose}-gated {@code stderr} together the same way regardless of whether {@code stdout}
+     * is present, closing that gap for the one caller where it actually matters, without touching
+     * {@code agentOutput}'s existing contract elsewhere. Scoped to the {@code verbose}-is-ignored
+     * inconsistency only, not to ungating Verbose generally: unlike the structured-stream path's
+     * {@code toolCallObserved} signal (see {@link StructuredStreamParser#finalOutput(String)}), this
+     * buffered path has no reliable way to tell a silent failure apart from ordinary successful-run
+     * stderr chatter, so {@code verbose} off still withholds {@code stderr} here exactly as before.
+     */
+    static String bufferedSuccessOutput(String stdout, String stderr, boolean verbose) {
+        List<String> sections = new ArrayList<>();
+        if (stdout != null && !stdout.isBlank()) {
+            sections.add(stdout.strip());
+        }
+        if (verbose && stderr != null && !stderr.isBlank()) {
+            sections.add(stderr.strip());
         }
         return String.join("\n\n", sections).trim();
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -686,7 +686,7 @@ final class AssistantLocalAgentRunner {
                 String output;
                 if (success) {
                     output = streamParser != null && streamParser.hasTerminalEvent()
-                            ? streamParser.finalOutput()
+                            ? streamParser.finalOutput(rawStderr)
                             : agentOutput(true, rawStdout, rawStderr, "", verbose);
                 } else if (streamParser != null) {
                     // A structured (stream-json / --json) CLI writes machine NDJSON to stdout, so on a
@@ -922,7 +922,31 @@ final class AssistantLocalAgentRunner {
         }
 
         synchronized String finalOutput() {
-            return composeOutput(answer.strip());
+            return finalOutput(null);
+        }
+
+        /**
+         * Same as {@link #finalOutput()}, plus consulting {@code stderr} for an environment/sandbox
+         * bootstrap failure (issue #4424). {@code run()}'s success branch used to call the no-arg
+         * overload unconditionally, discarding {@code rawStderr} entirely once a terminal event had
+         * arrived -- so a CLI that exited 0 after its sandbox helper failed to launch (Codex's
+         * {@code sandbox-setup.exe ... Access is denied (os error 5)}) produced a confident-looking
+         * answer with no trace that no tool had actually run. That is not ordinary noise (contrast the
+         * Verbose-gated stderr fence in {@link #failureOutput}, issue #3965): it means the entire
+         * request was silently impossible, so {@link #sandboxBootstrapFailureNotice} surfaces one
+         * actionable line regardless of the Verbose toggle. A {@code null}/blank/non-matching {@code
+         * stderr} leaves {@code core} untouched, so this overload is byte-identical to {@link
+         * #finalOutput()} for the overwhelmingly common case. This overload is deliberately separate
+         * from (rather than replacing) {@link #finalOutput()}, which stays in use where {@code
+         * terminalAnswerConsumer} recovers a cancelled/killed run's answer with no stderr in scope.
+         */
+        synchronized String finalOutput(String stderr) {
+            String core = answer.strip();
+            String notice = sandboxBootstrapFailureNotice(stderr);
+            if (notice != null) {
+                core = core.isBlank() ? notice : core + "\n\n" + notice;
+            }
+            return composeOutput(core, notice != null);
         }
 
         /**
@@ -949,9 +973,37 @@ final class AssistantLocalAgentRunner {
             return composeOutput(core);
         }
 
+        /**
+         * {@code sandbox-setup} together with an access-denied/permission-denied bootstrap failure
+         * (Windows' "Access is denied (os error 5)" and its equivalent shapes) means the sandbox
+         * helper never launched, so no tool could run for this request at all -- see {@link
+         * #finalOutput(String)}. Returns {@code null} (no notice) for {@code null}/blank stderr or any
+         * shape that doesn't match, so ordinary stderr never gets this treatment.
+         */
+        private static String sandboxBootstrapFailureNotice(String stderr) {
+            if (stderr == null || stderr.isBlank()) {
+                return null;
+            }
+            String lower = stderr.toLowerCase(Locale.ROOT);
+            if (!lower.contains("sandbox-setup")) {
+                return null;
+            }
+            if (!(lower.contains("access is denied") || lower.contains("permission denied")
+                    || lower.contains("os error 5"))) {
+                return null;
+            }
+            return "**Environment setup failed:** the sandbox helper (`sandbox-setup`) could not launch, "
+                    + "so no tool could run for this request. Ask an administrator to grant it access, "
+                    + "then try again.\n\n```\n" + stderr.strip() + "\n```";
+        }
+
         private String composeOutput(String core) {
+            return composeOutput(core, false);
+        }
+
+        private String composeOutput(String core, boolean explicitNoActivityNotice) {
             StringBuilder output = new StringBuilder(core);
-            String activity = activitySummary();
+            String activity = activitySummary(explicitNoActivityNotice);
             if (!activity.isBlank()) {
                 output.append("\n\n").append(activity);
             }
@@ -1007,10 +1059,24 @@ final class AssistantLocalAgentRunner {
          * created or edited, and which tool calls were denied. This renders even with Verbose off,
          * so a run that silently lost most of its tool calls to permission denials can never end as
          * an unexplained bare confirmation with no visible trace of what happened.
+         *
+         * <p>{@code explicitNoActivityNotice} (issue #4424) widens that guarantee to the shape the
+         * original "no silent bare confirmation" guard missed: a sandbox/environment bootstrap
+         * failure happens before any tool executes, so both {@code filesTouched} and {@code
+         * permissionDenialsByTool} stay empty and this footer used to render nothing at all between
+         * the answer and the usage line. {@link #finalOutput(String)} passes {@code true} only when
+         * it has already detected that exact shape via {@link #sandboxBootstrapFailureNotice}, so a
+         * plain empty/empty run with no detected bootstrap failure (an ordinary Q&A that never
+         * needed a tool) still renders {@code ""} exactly as before -- this stays additive, not a
+         * blanket "always explain an empty run" change.
          */
-        private String activitySummary() {
+        private String activitySummary(boolean explicitNoActivityNotice) {
             if (filesTouched.isEmpty() && permissionDenialsByTool.isEmpty()) {
-                return "";
+                if (!explicitNoActivityNotice) {
+                    return "";
+                }
+                return String.join("\n", "---", "**Local agent activity**",
+                        "- No files were created or edited, and no tool calls ran.");
             }
             List<String> lines = new ArrayList<>();
             lines.add("---");

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -685,9 +685,18 @@ final class AssistantLocalAgentRunner {
                 String rawStderr = stderrNow(stderr);
                 String output;
                 if (success) {
-                    output = streamParser != null && streamParser.hasTerminalEvent()
-                            ? streamParser.finalOutput(rawStderr)
-                            : bufferedSuccessOutput(rawStdout, rawStderr, verbose);
+                    if (streamParser != null && streamParser.hasTerminalEvent()) {
+                        output = streamParser.finalOutput(rawStderr);
+                    } else {
+                        // Issue #4424 review round 3, finding 4: when streamParser != null, this CLI
+                        // is structured (Claude stream-json / Codex --json), so rawStdout here is raw
+                        // NDJSON even though the run exited 0 -- never safe to hand to
+                        // bufferedSuccessOutput as literal stdout content, mirroring the failure
+                        // branch's guard three lines below (its own comment names thinking_tokens as
+                        // exactly the leak this prevents). A genuinely buffered/custom command
+                        // (streamParser == null) has ordinary text in rawStdout instead, unaffected.
+                        output = bufferedSuccessOutput(streamParser == null ? rawStdout : "", rawStderr, verbose);
+                    }
                 } else if (streamParser != null) {
                     // A structured (stream-json / --json) CLI writes machine NDJSON to stdout, so on a
                     // failed run the raw stream must never reach the transcript verbatim -- rerun/codegen
@@ -945,21 +954,30 @@ final class AssistantLocalAgentRunner {
          * so withholding it makes the whole request silently impossible without a trace. {@code
          * toolCallObserved} is what keeps this from becoming "always surface any stderr": a run that DID
          * attempt a tool call but simply had nothing file/denial-worthy to report keeps withholding
-         * incidental stderr noise exactly as issue #3965 established. {@link
-         * #sandboxBootstrapFailureHeadline} still recognizes the sandbox-bootstrap shape for a more
-         * specific, actionable headline, but only as an enrichment on top of the general rule -- never
-         * as its gate -- so an unrecognized shape still surfaces via the generic headline. A {@code
-         * null}/blank stderr, or any tool-call/file/denial activity, leaves {@code core} untouched, so
-         * this overload is byte-identical to {@link #finalOutput()} for the overwhelmingly common case.
-         * This overload is deliberately separate from (rather than replacing) {@link #finalOutput()},
-         * which stays in use where {@code terminalAnswerConsumer} recovers a cancelled/killed run's
-         * answer with no stderr in scope.
+         * incidental stderr noise exactly as issue #3965 established.
+         *
+         * <p>{@code recognizedBootstrapFailure} (round 3): {@link #sandboxBootstrapFailureHeadline}
+         * recognizing the sandbox-bootstrap shape fires <em>on its own</em>, independent of {@code
+         * silentRun} -- round 2 had folded it in only as an enrichment gated behind {@code silentRun},
+         * which silently dropped a <em>recognized</em> bootstrap failure whenever the run also had real
+         * tool activity to report (e.g. a patch-application call that succeeded via one path while a
+         * different operation's sandbox helper failed to launch, leaving its only trace on stderr).
+         * That partially-degraded shape is precisely the case a user cannot diagnose alone, so a
+         * recognized failure surfaces regardless of tool activity, alongside (not instead of) the
+         * general {@code silentRun} rule for the unrecognized case. An unrecognized, non-{@code
+         * silentRun} shape (ordinary chatter from a run that also did real work) still stays withheld.
+         * A {@code null}/blank stderr, or a plain empty/empty/no-activity run with unrecognized
+         * stderr, leaves {@code core} untouched, so this overload is byte-identical to {@link
+         * #finalOutput()} for the overwhelmingly common case. This overload is deliberately separate
+         * from (rather than replacing) {@link #finalOutput()}, which stays in use where {@code
+         * terminalAnswerConsumer} recovers a cancelled/killed run's answer with no stderr in scope.
          */
         synchronized String finalOutput(String stderr) {
             String core = answer.strip();
             boolean silentRun = filesTouched.isEmpty() && permissionDenialsByTool.isEmpty() && !toolCallObserved;
             String stderrText = stderr == null ? "" : stderr.strip();
-            boolean surfaceStderr = silentRun && !stderrText.isBlank();
+            boolean recognizedBootstrapFailure = sandboxBootstrapFailureHeadline(stderrText) != null;
+            boolean surfaceStderr = !stderrText.isBlank() && (silentRun || recognizedBootstrapFailure);
             if (surfaceStderr) {
                 String notice = stderrNotice(stderrText);
                 core = core.isBlank() ? notice : core + "\n\n" + notice;
@@ -1100,11 +1118,14 @@ final class AssistantLocalAgentRunner {
          * or any other pre-tool-call collapse) leaves {@code filesTouched}, {@code
          * permissionDenialsByTool}, <em>and</em> {@code toolCallObserved} all empty/false, so this
          * footer used to render nothing at all between the answer and the usage line. {@link
-         * #finalOutput(String)} passes {@code true} only when it has already decided to surface stderr
-         * for exactly that silent-run shape, so a plain empty/empty run that genuinely has nothing to
-         * report (an ordinary Q&A that never needed a tool, or a tool call that ran but touched no
-         * files and was never denied) still renders {@code ""} exactly as before -- this stays
-         * additive, not a blanket "always explain an empty run" change.
+         * #finalOutput(String)} passes {@code true} whenever it has decided to surface stderr; when
+         * that happens for a recognized bootstrap failure alongside real activity (round 3), {@code
+         * filesTouched}/{@code permissionDenialsByTool} are non-empty anyway, so this method's
+         * empty/empty branch below never engages and the parameter is simply unused for that call --
+         * only a genuinely empty/empty run's rendering depends on it. A plain empty/empty run that
+         * genuinely has nothing to report (an ordinary Q&A that never needed a tool, or a tool call
+         * that ran but touched no files and was never denied) still renders {@code ""} exactly as
+         * before -- this stays additive, not a blanket "always explain an empty run" change.
          */
         private String activitySummary(boolean explicitNoActivityNotice) {
             if (filesTouched.isEmpty() && permissionDenialsByTool.isEmpty()) {
@@ -1939,19 +1960,29 @@ final class AssistantLocalAgentRunner {
      * verbose}-gated stderr is ever considered. This dedicated composer folds {@code stdout} and
      * {@code verbose}-gated {@code stderr} together the same way regardless of whether {@code stdout}
      * is present, closing that gap for the one caller where it actually matters, without touching
-     * {@code agentOutput}'s existing contract elsewhere. Scoped to the {@code verbose}-is-ignored
-     * inconsistency only, not to ungating Verbose generally: unlike the structured-stream path's
-     * {@code toolCallObserved} signal (see {@link StructuredStreamParser#finalOutput(String)}), this
-     * buffered path has no reliable way to tell a silent failure apart from ordinary successful-run
-     * stderr chatter, so {@code verbose} off still withholds {@code stderr} here exactly as before.
+     * {@code agentOutput}'s existing contract elsewhere.
+     *
+     * <p>Issue #4424 review round 3, finding 2: round 2's javadoc claimed this path "has no reliable
+     * way to tell a silent failure apart from ordinary successful-run stderr chatter" -- that claim
+     * was too broad. Blank {@code stdout} <em>is</em> a reliable discriminator here, the buffered
+     * analogue of the structured-stream path's {@code toolCallObserved == false} (see {@link
+     * StructuredStreamParser#finalOutput(String)}): if the CLI produced no stdout at all, nothing
+     * else happened worth staying silent about, so {@code stderr} surfaces regardless of {@code
+     * verbose} in that case. A run that DID produce {@code stdout} keeps withholding {@code stderr}
+     * on {@code verbose} off exactly as before -- that part of the round-2 claim holds, since there
+     * genuinely is no signal to distinguish a real failure from ordinary chatter once the CLI has
+     * already produced real output.
      */
     static String bufferedSuccessOutput(String stdout, String stderr, boolean verbose) {
-        List<String> sections = new ArrayList<>();
-        if (stdout != null && !stdout.isBlank()) {
-            sections.add(stdout.strip());
+        String stdoutText = stdout == null ? "" : stdout.strip();
+        String stderrText = stderr == null ? "" : stderr.strip();
+        if (stdoutText.isBlank()) {
+            return stderrText;
         }
-        if (verbose && stderr != null && !stderr.isBlank()) {
-            sections.add(stderr.strip());
+        List<String> sections = new ArrayList<>();
+        sections.add(stdoutText);
+        if (verbose && !stderrText.isBlank()) {
+            sections.add(stderrText);
         }
         return String.join("\n\n", sections).trim();
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ClaudeStreamEventMapper.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ClaudeStreamEventMapper.java
@@ -70,7 +70,12 @@ final class ClaudeStreamEventMapper implements StreamEventMapper {
                 }
             } else if ("redacted_thinking".equals(blockType)) {
                 lines.add("Thinking: (redacted by Claude for safety)");
-            } else if ("tool_use".equals(blockType)) {
+            } else if ("tool_use".equals(blockType) || "server_tool_use".equals(blockType)) {
+                // Issue #4424 review round 3, finding 1: server_tool_use (Claude's server-executed
+                // tools, e.g. its built-in web search) is a real tool-call block this mapper never
+                // recognized at all, so it never reached recordToolCallObserved() either -- treated
+                // identically to tool_use since both mean the same thing for our purposes: a tool was
+                // called.
                 lines.add(describeToolUseBlock(block));
             } else if ("text".equals(blockType)) {
                 String text = StreamJson.stringField(block, "text");
@@ -230,6 +235,11 @@ final class ClaudeStreamEventMapper implements StreamEventMapper {
             if (!"tool_result".equals(StreamJson.stringField(block, "type"))) {
                 continue;
             }
+            // Issue #4424 review round 3, finding 1: a tool_result block proves a tool call
+            // happened even if its requesting tool_use event was somehow missed (toolNameFor
+            // returning null just below is exactly that case) -- recordToolCallObserved() must not
+            // depend solely on having seen the request.
+            state.recordToolCallObserved();
             String toolName = state.toolNameFor(StreamJson.stringField(block, "tool_use_id"));
             String label = toolName == null ? "tool" : toolName;
             String text = toolResultText(block.get("content"));

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ClaudeStreamEventMapper.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ClaudeStreamEventMapper.java
@@ -83,6 +83,10 @@ final class ClaudeStreamEventMapper implements StreamEventMapper {
     }
 
     private String describeToolUseBlock(JsonObject block) {
+        // Issue #4424 round 2: a tool_use block means a tool call was attempted, regardless of what it
+        // turns out to be (including ExitPlanMode's plan-proposal branch below) -- see
+        // StructuredStreamParser#toolCallObserved.
+        state.recordToolCallObserved();
         String toolName = StreamJson.stringField(block, "name");
         String toolUseId = StreamJson.stringField(block, "id");
         if (toolUseId != null && toolName != null) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/CodexStreamEventMapper.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/CodexStreamEventMapper.java
@@ -131,6 +131,9 @@ final class CodexStreamEventMapper implements StreamEventMapper {
     }
 
     private MapResult describeToolCallItem(String type, JsonObject item) {
+        // Issue #4424 round 2: a command_execution/mcp_tool_call/collab_tool_call item means a tool
+        // call was attempted, regardless of outcome -- see StructuredStreamParser#toolCallObserved.
+        state.recordToolCallObserved();
         String toolName = StreamJson.firstNonBlank(StreamJson.stringField(item, "name"),
                 StreamJson.stringField(item, "tool"), StreamJson.stringField(item, "command"));
         String label = toolName == null ? "(unknown)" : toolName;

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/CodexStreamEventMapper.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/CodexStreamEventMapper.java
@@ -104,6 +104,12 @@ final class CodexStreamEventMapper implements StreamEventMapper {
             return describeToolCallItem(type, item);
         }
         if ("file_change".equals(itemType)) {
+            // Issue #4424 review round 3, finding 1: a file_change item is a real tool call
+            // (Codex's patch-application counterpart to Claude's Write/Edit) regardless of whether
+            // it has a usable changes array -- recordCodexFileMutation below returns early for a
+            // missing/malformed array without marking toolCallObserved, which used to leave a run
+            // that genuinely edited a file misclassified as "silently did nothing".
+            state.recordToolCallObserved();
             if ("item.completed".equals(type)) {
                 recordCodexFileMutation(item);
             }
@@ -114,6 +120,10 @@ final class CodexStreamEventMapper implements StreamEventMapper {
             return text != null && !text.isBlank() ? MapResult.rendered(text) : MapResult.UNKNOWN;
         }
         if ("web_search".equals(itemType)) {
+            // Issue #4424 review round 3, finding 1: web_search is a real tool call per this
+            // mapper's own javadoc, not merely informational -- must count the same as
+            // command_execution/mcp_tool_call/collab_tool_call.
+            state.recordToolCallObserved();
             String query = StreamJson.stringField(item, "query");
             return query != null && !query.isBlank() ? MapResult.rendered("Web search: " + query) : MapResult.UNKNOWN;
         }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
@@ -697,6 +697,174 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
     }
 
     /**
+     * Issue #4424 review round 3, finding 2: the round-2 PR body claimed the buffered path "has no
+     * reliable way to tell a silent failure apart from ordinary successful-run stderr chatter" --
+     * false for the sub-case that matters. {@code sections.isEmpty()} (blank stdout) IS the buffered
+     * analogue of the structured-stream path's {@code toolCallObserved == false}: nothing else
+     * happened, so stderr must surface regardless of Verbose. A run that DID produce stdout keeps
+     * withholding stderr on Verbose off exactly as before (pinned by the sibling test above and
+     * {@code bufferedSuccessOutputStillWithholdsStderrAlongsideNonBlankStdoutWhenVerboseIsOff}).
+     */
+    @Test
+    void bufferedSuccessOutputSurfacesStderrWhenStdoutIsBlankRegardlessOfVerbose() {
+        assertEquals("sandbox-setup.exe failed to launch: Access is denied (os error 5)",
+                AssistantLocalAgentRunner.bufferedSuccessOutput(
+                        "", "sandbox-setup.exe failed to launch: Access is denied (os error 5)", false));
+    }
+
+    /**
+     * End-to-end sibling of the probe above via a real custom-command invocation: concretely, this
+     * is the shape Copilot's default command (a first-party client with no structured stream at all)
+     * or any custom command hits when its CLI produced no stdout at all but reported a real reason on
+     * stderr.
+     */
+    @Test
+    void customCommandWithBlankStdoutSurfacesStderrEvenWithVerboseOff() throws Exception {
+        String stderr = "sandbox-setup.exe failed to launch: Access is denied (os error 5)";
+
+        ShaftMcpToolResult result = successfulRun(customCommandInvocation(), "", stderr, false);
+
+        assertTrue(result.success(), result.output());
+        assertTrue(result.output().contains("Access is denied (os error 5)"),
+                "Blank stdout with real stderr must surface it regardless of Verbose: " + result.output());
+    }
+
+    /**
+     * Issue #4424 review round 3, finding 4: a structured CLI (Claude/Codex) that exits 0 without
+     * ever emitting a terminal event has only raw NDJSON in its stdout -- {@code rawStdout} must
+     * never reach {@code bufferedSuccessOutput} as literal stdout content, mirroring the guard the
+     * failure branch a few lines below already has (its own comment names {@code thinking_tokens} as
+     * exactly the leak this prevents). A genuinely buffered/custom command ({@code streamParser ==
+     * null}) is unaffected -- its raw stdout is legitimate text, not NDJSON.
+     */
+    @Test
+    void successfulCodexRunWithoutATerminalEventNeverLeaksRawNdjson() throws Exception {
+        String rawLines = "{\"type\":\"thread.started\",\"thread_id\":\"t-1\"}\n{\"type\":\"turn.started\"}\n";
+
+        ShaftMcpToolResult result = successfulRun(codexInvocation(), rawLines, "", true);
+
+        assertTrue(result.success(), result.output());
+        assertFalse(result.output().contains("thread.started"),
+                "Raw native NDJSON must never leak into a successful-but-terminal-eventless answer: "
+                        + result.output());
+    }
+
+    /**
+     * Same shape, combined with finding 2's blank-stdout discriminator: once the raw NDJSON is
+     * correctly discarded (not shown as "stdout"), the run's stdout is effectively blank, so a real
+     * sandbox-bootstrap stderr must surface instead of the composed answer staying silent.
+     */
+    @Test
+    void successfulCodexRunWithoutATerminalEventStillSurfacesStderrInsteadOfRawNdjson() throws Exception {
+        String rawLines = "{\"type\":\"thread.started\",\"thread_id\":\"t-1\"}\n{\"type\":\"turn.started\"}\n";
+        String stderr = "sandbox-setup.exe failed to launch: Access is denied (os error 5)";
+
+        ShaftMcpToolResult result = successfulRun(codexInvocation(), rawLines, stderr, false);
+
+        assertTrue(result.success(), result.output());
+        assertFalse(result.output().contains("thread.started"), result.output());
+        assertTrue(result.output().contains("Access is denied (os error 5)"), result.output());
+    }
+
+    /**
+     * Issue #4424 review round 3, finding 3: round 2 silently gated the recognized sandbox-bootstrap
+     * notice behind {@code silentRun}, so a partially-degraded run (a patch-application tool call
+     * that succeeded via one path, while a DIFFERENT operation's sandbox helper failed to launch and
+     * left its only trace on stderr) dropped the bootstrap failure entirely -- exactly the case a
+     * user cannot diagnose alone. A recognized bootstrap shape must surface regardless of tool
+     * activity, alongside (not instead of) the general {@code silentRun} rule.
+     */
+    @Test
+    void recognizedSandboxBootstrapFailureSurfacesEvenAlongsideSuccessfulFileActivity() throws Exception {
+        String fileChangeEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"file_change\","
+                + "\"status\":\"completed\",\"changes\":[{\"path\":\"a.txt\",\"kind\":\"update\"}]}}";
+        String stderr = "sandbox-setup.exe failed to launch: Access is denied (os error 5)";
+
+        ShaftMcpToolResult result = successfulRun(codexInvocation(),
+                fileChangeEvent + "\n" + codexTurnCompletedEvent() + "\n", stderr, false);
+
+        assertTrue(result.success(), result.output());
+        assertTrue(result.output().contains("Access is denied (os error 5)"),
+                "A recognized bootstrap failure must surface even alongside real file activity: "
+                        + result.output());
+        assertTrue(result.output().contains("Files created or edited: `a.txt`"), result.output());
+    }
+
+    /**
+     * Issue #4424 review round 3, finding 1: {@code recordToolCallObserved()} was only wired into
+     * {@code describeToolCallItem} (command_execution/mcp_tool_call/collab_tool_call), so a Codex
+     * {@code web_search} item -- a real tool call per this mapper's own javadoc -- left {@code
+     * toolCallObserved} false, falsely classifying the run as "silently did nothing" and both
+     * re-injecting suppressed ordinary stderr noise into a successful Verbose-off run AND asserting
+     * a false "no tool calls ran" footer alongside a run that plainly used one.
+     */
+    @Test
+    void codexWebSearchItemCountsAsAToolCallObservedSoIncidentalStderrStaysWithheld() throws Exception {
+        String webSearchEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"web_search\","
+                + "\"id\":\"ws-1\",\"query\":\"latest Selenium 4 release notes\"}}";
+
+        ShaftMcpToolResult result = successfulRun(codexInvocation(),
+                webSearchEvent + "\n" + codexTurnCompletedEvent() + "\n", "some incidental progress chatter", false);
+
+        assertTrue(result.success(), result.output());
+        assertFalse(result.output().contains("incidental progress chatter"), result.output());
+        assertFalse(result.output().contains("no tool calls ran"), result.output());
+    }
+
+    /**
+     * Same gap, Codex {@code file_change} item -- including the edge case the reviewer specifically
+     * probed, a completed item with no {@code changes} array at all, which also makes {@code
+     * recordCodexFileMutation} return early without touching {@code filesTouched}.
+     */
+    @Test
+    void codexFileChangeItemWithNoChangesArrayStillCountsAsAToolCallObserved() throws Exception {
+        String fileChangeEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"file_change\",\"status\":\"completed\"}}";
+
+        ShaftMcpToolResult result = successfulRun(codexInvocation(),
+                fileChangeEvent + "\n" + codexTurnCompletedEvent() + "\n", "some incidental progress chatter", false);
+
+        assertTrue(result.success(), result.output());
+        assertFalse(result.output().contains("incidental progress chatter"), result.output());
+        assertFalse(result.output().contains("no tool calls ran"), result.output());
+    }
+
+    /**
+     * Claude-side sibling: {@code server_tool_use} is a real content-block type (Claude's
+     * server-executed tools, e.g. web search) that {@code describeAssistantEvent} never recognized
+     * at all, so it never reached {@code recordToolCallObserved()} either.
+     */
+    @Test
+    void claudeServerToolUseBlockCountsAsAToolCallObserved() throws Exception {
+        String serverToolUseEvent = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"server_tool_use\","
+                + "\"id\":\"stu-1\",\"name\":\"web_search\",\"input\":{\"query\":\"selenium 4\"}}]}}";
+
+        ShaftMcpToolResult result = successfulRun(claudeInvocation(),
+                serverToolUseEvent + "\n" + claudeResultEvent("done") + "\n", "incidental chatter", false);
+
+        assertTrue(result.success(), result.output());
+        assertFalse(result.output().contains("incidental chatter"), result.output());
+        assertFalse(result.output().contains("no tool calls ran"), result.output());
+    }
+
+    /**
+     * A {@code tool_result} block proves a tool call happened even if the requesting {@code
+     * tool_use} event was somehow missed -- correlated here to an id SHAFT never saw a {@code
+     * tool_use} block for.
+     */
+    @Test
+    void claudeToolResultWithNoPriorToolUseEventStillCountsAsAToolCallObserved() throws Exception {
+        String toolResultEvent = "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\","
+                + "\"tool_use_id\":\"unseen-id\",\"content\":\"ok\",\"is_error\":false}]}}";
+
+        ShaftMcpToolResult result = successfulRun(claudeInvocation(),
+                toolResultEvent + "\n" + claudeResultEvent("done") + "\n", "incidental chatter", false);
+
+        assertTrue(result.success(), result.output());
+        assertFalse(result.output().contains("incidental chatter"), result.output());
+        assertFalse(result.output().contains("no tool calls ran"), result.output());
+    }
+
+    /**
      * Regression coverage for issue #4424: on a <em>successful</em> exit (unlike the failure paths
      * exercised above), {@code rawStderr} used to be computed and then discarded entirely once a
      * structured stream had a terminal event, so a sandbox/environment bootstrap failure that

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
@@ -456,13 +456,25 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
         assertTrue(output.contains("Denied tool calls: Bash ×2, mcp__shaft-mcp__shaft_coding_partner_plan"), output);
     }
 
+    /**
+     * Issue #4424 review round 2: distinguishes the two sides of the widened "no silent bare
+     * confirmation" guarantee. A plain Q&A run that never attempted a tool call AND never received
+     * any stderr has genuinely nothing to report, so it must stay exactly as terse as before this
+     * issue -- contrast {@code successfulRunWithNonBootstrapStderrAndZeroToolCallsStillSurfacesIt
+     * RegardlessOfVerbose} below, which pins the opposite case (identical zero-tool-call shape, but
+     * WITH stderr) to prove the new rule fires on the stderr signal, not on "no tool calls" alone.
+     * Uses {@code successfulRun} (explicit blank stderr, Verbose ON) instead of the shorter {@code
+     * finalOutput} helper specifically to make that precondition textual, not merely implicit in a
+     * stub default.
+     */
     @Test
     void finalOutputStaysCleanWhenNothingWasWrittenAndNothingWasDenied() throws Exception {
-        String output = finalOutput(claudeInvocation(),
-                claudeAssistantTextEvent("plain answer") + "\n" + claudeResultEvent("plain answer") + "\n");
+        ShaftMcpToolResult result = successfulRun(claudeInvocation(),
+                claudeAssistantTextEvent("plain answer") + "\n" + claudeResultEvent("plain answer") + "\n", "", true);
 
-        assertTrue(!output.contains("Local agent activity"),
-                "A plain Q&A run must not grow an activity footer: " + output);
+        assertTrue(result.success(), result.output());
+        assertTrue(!result.output().contains("Local agent activity"),
+                "A plain Q&A run with no stderr must not grow an activity footer: " + result.output());
     }
 
     /**
@@ -506,12 +518,17 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
         assertTrue(output.contains("Failed or denied tool calls: file_change"), output);
     }
 
+    /**
+     * Codex-side sibling of {@code finalOutputStaysCleanWhenNothingWasWrittenAndNothingWasDenied}
+     * above (issue #4424 review round 2): explicit blank stderr, Verbose ON.
+     */
     @Test
     void finalOutputStaysCleanForCodexWhenNothingWasWrittenAndNothingFailed() throws Exception {
-        String output = finalOutput(codexInvocation(), codexTurnCompletedEvent() + "\n");
+        ShaftMcpToolResult result = successfulRun(codexInvocation(), codexTurnCompletedEvent() + "\n", "", true);
 
-        assertTrue(!output.contains("Local agent activity"),
-                "A plain Codex Q&A run must not grow an activity footer: " + output);
+        assertTrue(result.success(), result.output());
+        assertTrue(!result.output().contains("Local agent activity"),
+                "A plain Codex Q&A run with no stderr must not grow an activity footer: " + result.output());
     }
 
     /**
@@ -635,6 +652,51 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
     }
 
     /**
+     * Issue #4424 review round 2, finding 3: {@code run()}'s buffered/custom-command success path
+     * had its own, unreachable-by-the-structured-stream-fix instance of the same bug. {@link
+     * AssistantLocalAgentRunner#agentOutput} itself keeps its original short-circuit (a custom
+     * command's success answer no longer routes through it -- see {@code bufferedSuccessOutput}'s
+     * javadoc for why that short-circuit is a deliberate, separately-pinned contract for its other
+     * caller, {@code runCompactPreamble}). {@code bufferedSuccessOutput} folds {@code stdout} and
+     * {@code verbose}-gated {@code stderr} together the same way whether or not {@code stdout} also
+     * has content, closing the "Verbose is ignored on success" gap the reviewer's probe found.
+     */
+    @Test
+    void bufferedSuccessOutputSurfacesStderrAlongsideNonBlankStdoutWhenVerboseIsOn() {
+        assertEquals("ok\n\nsandbox-setup.exe failed to launch: Access is denied (os error 5)",
+                AssistantLocalAgentRunner.bufferedSuccessOutput(
+                        "ok", "sandbox-setup.exe failed to launch: Access is denied (os error 5)", true));
+    }
+
+    /**
+     * Companion pin: Verbose off keeps withholding stderr here too (matching the already-established
+     * #3965 contract), since (unlike the structured-stream path) there is no reliable "nothing else
+     * happened" signal here to distinguish a silent failure from ordinary successful-run stderr
+     * chatter.
+     */
+    @Test
+    void bufferedSuccessOutputStillWithholdsStderrAlongsideNonBlankStdoutWhenVerboseIsOff() {
+        assertEquals("ok", AssistantLocalAgentRunner.bufferedSuccessOutput("ok", "some stderr chatter", false));
+    }
+
+    /**
+     * End-to-end reproduction of the reviewer's exact probe: a custom command whose stdout looks like
+     * a complete, confident answer while its stderr carries the sandbox-bootstrap failure, Verbose
+     * ON. Before this fix, {@code result.output()} was bare {@code "ok"} with zero trace.
+     */
+    @Test
+    void customCommandSurfacesStderrAlongsideNonBlankStdoutWhenVerboseIsOn() throws Exception {
+        String stderr = "sandbox-setup.exe failed to launch: Access is denied (os error 5)";
+
+        ShaftMcpToolResult result = successfulRun(customCommandInvocation(), "ok", stderr, true);
+
+        assertTrue(result.success(), result.output());
+        assertTrue(result.output().contains("Access is denied (os error 5)"),
+                "A custom command's stderr must surface alongside its stdout when Verbose is on: "
+                        + result.output());
+    }
+
+    /**
      * Regression coverage for issue #4424: on a <em>successful</em> exit (unlike the failure paths
      * exercised above), {@code rawStderr} used to be computed and then discarded entirely once a
      * structured stream had a terminal event, so a sandbox/environment bootstrap failure that
@@ -672,6 +734,115 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
                 claudeAssistantTextEvent("plain answer") + "\n" + claudeResultEvent("plain answer") + "\n");
 
         assertEquals("plain answer\n\n{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}", output);
+    }
+
+    /**
+     * Issue #4424 review round 2, finding 1: the fix above must not be fitted to the one observed
+     * "sandbox-setup" string. The actual rule is broader -- a zero-exit run with zero tool calls,
+     * zero files touched and zero denials, but non-blank stderr, must never be silent, whatever the
+     * stderr says. An MCP-server startup failure is a different, unrelated cause from the sandbox
+     * bootstrap failure and must surface all the same, with Verbose ON (matching the reviewer's
+     * probe exactly: the bug reproduced even with Verbose on, since {@code finalOutput()} never took
+     * stderr into account at all before this issue).
+     */
+    @Test
+    void successfulRunWithNonBootstrapStderrAndZeroToolCallsStillSurfacesItRegardlessOfVerbose()
+            throws Exception {
+        String stderr = "Error: MCP server 'shaft-tools' failed to start (ECONNREFUSED 127.0.0.1:5173)";
+
+        ShaftMcpToolResult result = successfulRun(codexInvocation(), codexTurnCompletedEvent() + "\n", stderr, true);
+
+        assertTrue(result.success(), result.output());
+        assertTrue(result.output().contains("ECONNREFUSED"),
+                "Any stderr on an otherwise-silent successful run must surface, not only the "
+                        + "sandbox-setup shape: " + result.output());
+    }
+
+    /**
+     * Same as above, Verbose OFF -- proves the rule is genuinely ungated by Verbose, not merely
+     * coincidentally true for Verbose-on inputs.
+     */
+    @Test
+    void successfulRunWithNonBootstrapStderrSurfacesItEvenWithVerboseOff() throws Exception {
+        String stderr = "Error: MCP server 'shaft-tools' failed to start (ECONNREFUSED 127.0.0.1:5173)";
+
+        ShaftMcpToolResult result = successfulRun(codexInvocation(), codexTurnCompletedEvent() + "\n", stderr, false);
+
+        assertTrue(result.success(), result.output());
+        assertTrue(result.output().contains("ECONNREFUSED"), result.output());
+    }
+
+    /**
+     * Issue #4424 review round 2, finding 2: detection fitted to one exact string is exactly the
+     * failure mode issue #4469 recorded against a directive list fitted to its known offenders. Only
+     * the hyphen changed here (a plausible naming-convention drift); "Access is denied (os error 5)"
+     * is verbatim present. The general stderr-surfacing rule must not depend on recognizing
+     * "sandbox-setup" literally -- it must surface this too.
+     */
+    @Test
+    void successfulRunWithASandboxSetupNamingVariantStillSurfacesTheStderr() throws Exception {
+        String stderr = "SandboxSetup.exe failed to launch: Access is denied (os error 5)";
+
+        ShaftMcpToolResult result = successfulRun(codexInvocation(), codexTurnCompletedEvent() + "\n", stderr, false);
+
+        assertTrue(result.success(), result.output());
+        assertTrue(result.output().contains("Access is denied (os error 5)"), result.output());
+    }
+
+    /**
+     * Boundary regression proving the fix is not "always surface any stderr on a successful run":
+     * a run that DID attempt a tool call (so it is not the "silently did nothing" shape #4424
+     * reported), touched no files, and had no denials must keep withholding incidental stderr noise
+     * when Verbose is off -- exactly the ordinary-noise contract issue #3965 established. This is
+     * what proves {@code toolCallObserved} genuinely narrows the new rule instead of widening
+     * {@code activitySummary}'s guard unconditionally.
+     */
+    @Test
+    void successfulCodexRunWithAToolCallButNothingToReportWithholdsIncidentalStderrWhenVerboseIsOff()
+            throws Exception {
+        String toolEvent = "{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\","
+                + "\"name\":\"shell\",\"command\":\"ls\",\"aggregated_output\":\"\",\"exit_code\":0}}";
+
+        ShaftMcpToolResult result = successfulRun(codexInvocation(),
+                toolEvent + "\n" + codexTurnCompletedEvent() + "\n", "some incidental progress chatter", false);
+
+        assertTrue(result.success(), result.output());
+        assertFalse(result.output().contains("incidental progress chatter"), result.output());
+    }
+
+    /**
+     * Same boundary proof on the Claude side, confirming {@code ClaudeStreamEventMapper} also wires
+     * a {@code tool_use} block into {@code toolCallObserved}.
+     */
+    @Test
+    void successfulClaudeRunWithAToolCallButNothingToReportWithholdsIncidentalStderrWhenVerboseIsOff()
+            throws Exception {
+        String toolUseEvent = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\","
+                + "\"id\":\"tool-1\",\"name\":\"Read\",\"input\":{\"file_path\":\"a.txt\"}}]}}";
+
+        ShaftMcpToolResult result = successfulRun(claudeInvocation(),
+                toolUseEvent + "\n" + claudeResultEvent("done") + "\n", "incidental chatter", false);
+
+        assertTrue(result.success(), result.output());
+        assertFalse(result.output().contains("incidental chatter"), result.output());
+    }
+
+    /**
+     * Edge case: when the terminal answer text is itself blank, the stderr notice becomes the whole
+     * core -- must not leave a leading blank line from the (skipped) "core + notice" concatenation.
+     */
+    @Test
+    void successfulRunWithNoAnswerTextAtAllStillSurfacesTheStderrNoticeCleanly() throws Exception {
+        String emptyResultEvent =
+                "{\"type\":\"result\",\"result\":\"\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}";
+        String stderr = "Error: MCP server 'shaft-tools' failed to start (ECONNREFUSED 127.0.0.1:5173)";
+
+        ShaftMcpToolResult result = successfulRun(claudeInvocation(), emptyResultEvent + "\n", stderr, true);
+
+        assertTrue(result.success(), result.output());
+        assertTrue(result.output().contains("ECONNREFUSED"), result.output());
+        assertFalse(result.output().startsWith("\n\n"),
+                "A blank core must not leave a leading blank line: " + result.output());
     }
 
     private static ShaftMcpToolResult successfulRun(

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerVerboseStreamTest.java
@@ -634,6 +634,54 @@ class AssistantLocalAgentRunnerVerboseStreamTest {
                         AssistantLocalAgentRunner.agentOutput(true, "", "warning", "", true)));
     }
 
+    /**
+     * Regression coverage for issue #4424: on a <em>successful</em> exit (unlike the failure paths
+     * exercised above), {@code rawStderr} used to be computed and then discarded entirely once a
+     * structured stream had a terminal event, so a sandbox/environment bootstrap failure that
+     * happened before any tool could run (Codex's {@code sandbox-setup.exe ... Access is denied
+     * (os error 5)}) silently vanished from the composed answer -- the CLI exited 0, the model
+     * narrated a plausible-sounding confirmation, and nothing in the transcript hinted that no tool
+     * had actually run. This must be surfaced <em>even with Verbose off</em>, unlike the ordinary
+     * stderr noise gated by issue #3965 below: a sandbox bootstrap failure means the entire request
+     * was silently impossible, not just noisy.
+     */
+    @Test
+    void successfulRunWithSandboxBootstrapFailureStderrSurfacesAnActionableNoticeEvenWithVerboseOff()
+            throws Exception {
+        String stderr = "codex-windows-sandbox-setup.exe failed to launch: Access is denied (os error 5)";
+
+        ShaftMcpToolResult result =
+                successfulRun(codexInvocation(), codexTurnCompletedEvent() + "\n", stderr, false);
+
+        assertTrue(result.success(), result.output());
+        String lowerOutput = result.output().toLowerCase(java.util.Locale.ROOT);
+        assertTrue(lowerOutput.contains("sandbox-setup") && result.output().contains("Access is denied"),
+                "A sandbox bootstrap failure must surface an actionable notice even with Verbose off: "
+                        + result.output());
+    }
+
+    /**
+     * Regression guard for the fix above: a normal successful structured run, whose stderr never
+     * matches the sandbox-bootstrap-failure shape, must render byte-identical output to today's --
+     * no notice, no extra blank lines -- so consulting stderr on the success path never turns into
+     * noise for the overwhelmingly common case.
+     */
+    @Test
+    void successfulRunWithoutSandboxBootstrapStderrStaysByteIdenticalToTodaysOutput() throws Exception {
+        String output = finalOutput(claudeInvocation(),
+                claudeAssistantTextEvent("plain answer") + "\n" + claudeResultEvent("plain answer") + "\n");
+
+        assertEquals("plain answer\n\n{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}", output);
+    }
+
+    private static ShaftMcpToolResult successfulRun(
+            AssistantCommand.Invocation invocation, String stdout, String stderr, boolean verbose) throws Exception {
+        StubProcess process = new StubProcess(stdout, stderr, 0);
+        ShaftMcpInvocation running = AssistantLocalAgentRunner.start(
+                invocation, line -> { }, (command, workingDirectory, environment) -> process, false, verbose);
+        return running.future().get(5, TimeUnit.SECONDS);
+    }
+
     private static ShaftMcpToolResult failingRun(
             AssistantCommand.Invocation invocation, String stdout, String stderr, int exitCode) throws Exception {
         StubProcess process = new StubProcess(stdout, stderr, exitCode);


### PR DESCRIPTION
## Summary

`Closes #4424`. A structured-stream local-agent run (Claude/Codex) that exits 0 with a terminal event, or a buffered/custom-command run, could silently discard its stderr even when that stderr was the only account of what actually happened -- most concretely, Codex's sandbox helper failing to launch (`sandbox-setup.exe ... Access is denied (os error 5)`) before any tool could run. The transcript ended as a confident bare confirmation with no trace of the failure. This went through three review rounds; this body describes the final shipped state, not the intermediate ones (see the PR comments for that history).

## The rule being shipped

**A zero-exit run that attempted zero tool calls, touched zero files, and hit zero denials, but did emit stderr, surfaces that stderr (or a notice pointing at it) regardless of the Verbose toggle.** A recognized sandbox-bootstrap-failure shape surfaces on its own too, even alongside real tool activity (a partially-degraded run a user cannot otherwise diagnose). This is not ordinary noise (contrast the Verbose-gated stderr fence for failure paths, issue #3965): if nothing else happened, stderr is the only account of what went wrong, so withholding it makes the whole request silently impossible without a trace.

### Structured-stream path (`StructuredStreamParser`, `AssistantLocalAgentRunner.java`)

- `finalOutput(String stderr)` overload (the no-arg `finalOutput()` stays for the `terminalAnswerConsumer` side channel, where stderr is out of scope): surfaces stderr when the run attempted **zero tool calls** (new `toolCallObserved` flag) **and** touched zero files **and** hit zero denials, or independently when the stderr matches a recognized sandbox-bootstrap shape (`sandboxBootstrapFailureHeadline`) -- the recognized shape is enrichment (a nicer, specific headline) layered on the general rule, never its gate, so an unrecognized shape still surfaces via a generic headline.
- `toolCallObserved` is fed by every tool-bearing event on both mappers: Claude's `tool_use`, `server_tool_use`, and `tool_result` blocks; Codex's `command_execution`/`mcp_tool_call`/`collab_tool_call`, `web_search`, and `file_change` items. This is what keeps the rule from becoming "always surface any stderr": a run that attempted a tool call but had nothing file/denial-worthy to report still withholds incidental stderr noise exactly as issue #3965 established.
- `activitySummary()`'s "no silent bare confirmation" guard renders an explicit "no files, no tool calls" line for the same silent-run shape instead of staying blank.
- `run()`'s success branch never hands raw NDJSON stdout to the buffered composer below: a structured CLI that exits 0 without ever emitting a terminal event has only machine NDJSON in `rawStdout`, mirroring the guard the failure branch a few lines below already has.

### Buffered/custom-command path (`bufferedSuccessOutput`, new)

- `run()`'s buffered success answer (Copilot's default command, or any hand-typed custom command) now goes through a dedicated `bufferedSuccessOutput(stdout, stderr, verbose)` instead of `agentOutput`. `agentOutput` itself is untouched -- its success-path short-circuit is a separate, deliberately-tested contract for its other caller, `runCompactPreamble`'s low-stakes auxiliary status line.
- `bufferedSuccessOutput` surfaces stderr regardless of Verbose when stdout is blank (the buffered analogue of `toolCallObserved == false`: nothing else happened). When stdout has real content, stderr stays Verbose-gated exactly as before -- there is no reliable signal in this path to distinguish a real failure from ordinary chatter once the CLI has already produced real output, so Verbose off keeps withholding it there.

## Test plan

Every fix went through a RED-first cycle; the exact assertion failures for each round are recorded in the PR comments below (round 2's four general-case tests plus round 3's nine tests covering F1-F4). Summary:

- `AssistantLocalAgentRunnerVerboseStreamTest`: 68 tests, 0 failed.
- Full `AssistantLocalAgentRunner*` wildcard suite plus `AssistantCommandTest` (the test an earlier attempt at the buffered-path fix broke, then fixed by splitting `bufferedSuccessOutput` out of `agentOutput` instead of changing `agentOutput`): green.
- Byte-identical regression for an ordinary successful run (`successfulRunWithoutSandboxBootstrapStderrStaysByteIdenticalToTodaysOutput`): still passes, exact literal `"plain answer\n\n{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}"`.
- Full module `./gradlew test`: 1309 tests, 21 skipped. Re-run multiple times across every round; each run fails a different 2-3 tests, always in `ShaftPanelSetupTest`/`ToolApprovalPromptPanelTest`, always the same `threadUtil.kt:32` (`SwingTimerWatcherExtension`) / `ThreadLeakTracker.java:206` Swing-timer / thread-leak signature, never touching the changed files -- confirmed pre-existing, non-deterministic test-infrastructure flakiness (tracked separately by the reviewer, not part of this PR).

Environment note for reviewers: `shaft-intellij` is a Gradle module outside the Maven reactor (`mvn` will not run these tests); the module also requires JDK 21 for its Gradle daemon (JDK 25 crashes it on Windows, per its own `settings.gradle.kts` check).

Not arming auto-merge -- waiting for the next independent review pass.
