### PR TITLE
Fix #4495 #4505: count memory objects from git, refuse an untargeted memory write from a linked worktree

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -307,6 +307,7 @@ change it:
 | `tests/scripts/test_validate_agent_setup.py` | The aggregate gate and the host-parity matrix. |
 | `tests/scripts/test_validate_skills.py` | Skill frontmatter, names, and body limits. |
 | `tests/scripts/test_guard_lifecycle.py`, `tests/scripts/test_guard_nul_corruption.py` | The lifecycle guard's decisions and its behaviour on a corrupt state file. |
+| `tests/scripts/test_guard_memory_worktree.py` | That a memory write from a linked worktree is refused, and that each host actually invokes the guard for it. |
 | `tests/scripts/test_sync_user_harness.py` | The user-level deployment. |
 | `tests/scripts/test_worktree_hygiene.py` | The worktree survey. |
 | `tests/scripts/test_shaft_skills_content.py`, `tests/scripts/test_shaft_skill_cli_examples.py` | The published product pack's content and its CLI examples. |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|PowerShell|shell_command",
+        "matcher": "Bash|PowerShell|shell_command|mcp__shaft-memory__(remember_memory|save_memory_patch)",
         "hooks": [
           {
             "type": "command",

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|PowerShell|shell_command",
+        "matcher": "Bash|PowerShell|shell_command|mcp__shaft-memory__(remember_memory|save_memory_patch)",
         "hooks": [
           {
             "type": "command",

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -101,6 +101,7 @@ jobs:
               - 'tests/scripts/test_agent_harness_portability.py'
               - 'tests/scripts/test_agent_harness_reachability.py'
               - 'tests/scripts/test_guard_nul_corruption.py'
+              - 'tests/scripts/test_guard_memory_worktree.py'
               - 'tests/scripts/test_guard_lifecycle.py'
               - 'tests/scripts/test_validate_agent_guidance.py'
               - 'tests/scripts/test_validate_agent_setup.py'
@@ -216,6 +217,7 @@ jobs:
           tests.scripts.test_agent_harness_portability
           tests.scripts.test_agent_harness_reachability
           tests.scripts.test_guard_nul_corruption
+          tests.scripts.test_guard_memory_worktree
           tests.scripts.test_guard_lifecycle
           tests.scripts.test_validate_agent_guidance
           tests.scripts.test_validate_agent_setup

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1039,6 +1039,71 @@ def check_r10_nul_corruption(command: str, cwd: str | None = None) -> str | None
 _CHECKS = (check_r1_maven, check_r2_allure, check_r3_gui_open, check_r8_git_stash)
 
 
+# ---------------------------------------------------------------------------
+# R11: refuse an MCP memory write issued from a linked worktree
+# ---------------------------------------------------------------------------
+
+# Only the write path. Reads are the session-entry point AGENTS.md mandates,
+# and a read cannot strand work in the wrong tree, so blocking them would make
+# worktree isolation cost an agent its memory for no safety gain.
+_MEMORY_WRITE_TOOLS = frozenset(
+    {
+        "mcp__shaft-memory__remember_memory",
+        "mcp__shaft-memory__save_memory_patch",
+    }
+)
+
+
+def is_linked_worktree(cwd: str | None) -> bool:
+    """True when `cwd` sits inside a linked worktree rather than the primary checkout.
+
+    Git's own layout is the tell: a linked worktree's `.git` is a *file* holding
+    a `gitdir:` pointer, while the primary checkout's is a directory. Read off
+    the filesystem rather than by shelling out, because this runs inside a
+    PreToolUse hook whose budget the host caps at 10 seconds and R10 already
+    spends two git queries of that.
+
+    Fails open -- outside a repository there is no linked worktree to be in, and
+    a guard that denies where it cannot tell would block memory writes in every
+    checkout it does not understand.
+    """
+    if not cwd:
+        return False
+    try:
+        current = os.path.abspath(cwd)
+    except (OSError, ValueError):
+        return False
+    while True:
+        marker = os.path.join(current, ".git")
+        if os.path.isfile(marker):
+            return True
+        if os.path.isdir(marker):
+            return False
+        parent = os.path.dirname(current)
+        if parent == current:
+            return False
+        current = parent
+
+
+def check_r11_memory_write_worktree(tool_name: str, cwd: str | None) -> str | None:
+    """Return a block reason for an MCP memory write from a linked worktree, or None."""
+    if tool_name not in _MEMORY_WRITE_TOOLS or not is_linked_worktree(cwd):
+        return None
+    return (
+        "R11 (MCP memory write from a linked worktree): `.mcp.json` declares "
+        "shaft-memory with `\"cwd\": \".\"` and one server process serves the "
+        "whole session, so this write would land in the PRIMARY checkout -- "
+        "uncommitted, on whatever branch that tree holds, which belongs to a "
+        "different session. Observed twice in one session by two different "
+        "agents (issue #4505). `memory check` still passes, because the object "
+        "is valid; it is just in the wrong tree, so nothing in your own "
+        "verification can detect it. Run the CLI from this worktree instead -- "
+        "`memory remember --stdin` resolves its root with `git rev-parse "
+        "--show-toplevel` from its own cwd, so it writes here, where your "
+        "branch can commit it."
+    )
+
+
 def evaluate_command(command: str) -> str | None:
     """Return the first blocking reason found, or None if the command is allowed."""
     for check in _CHECKS:
@@ -1141,6 +1206,13 @@ def _print_deny(reason: str, host: str) -> None:
 
 def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
     tool_name = hook_input.get("tool_name", "")
+
+    reason = check_r11_memory_write_worktree(
+        tool_name, _hook_working_directory(hook_input)
+    )
+    if reason is not None:
+        _print_deny(reason, host)
+        return 0
 
     if tool_name in ("Bash", "PowerShell"):
         command = _extract_command(hook_input)

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1075,11 +1075,15 @@ def is_linked_worktree(cwd: str | None) -> bool:
     """True when `cwd` sits inside a linked worktree rather than the primary checkout.
 
     A `.git` *file* is not the tell on its own, which an earlier revision of
-    this rule assumed. `git init --separate-git-dir` gives an ordinary primary
-    checkout the same shape, and so does a submodule -- both would have been
-    refused, and told the refusal was about worktree isolation. The tell is
-    where the `gitdir:` pointer lands: git puts a linked worktree's admin
-    directory under `<common>/worktrees/<name>`, and nothing else lives there.
+    this rule assumed: `git init --separate-git-dir` gives an ordinary primary
+    checkout the same shape, and so does a submodule. Nor is the pointer's
+    *path* the tell, which the revision after that assumed -- a separate-git-dir
+    checkout whose admin directory happens to sit under any folder named
+    `worktrees` matched it too. Two path heuristics, two misclassifications.
+
+    The tell is structural instead: git writes `gitdir` and `commondir` files
+    INSIDE a linked worktree's admin directory, and nowhere else. Their presence
+    is what a linked worktree is, rather than something its path looks like.
 
     Read off the filesystem rather than by shelling out, because this runs
     inside a PreToolUse hook whose budget the host caps at 10 seconds and R10
@@ -1096,31 +1100,52 @@ def is_linked_worktree(cwd: str | None) -> bool:
     if not os.path.isfile(marker):
         return False
     try:
-        with open(marker, encoding="utf-8", errors="replace") as handle:
+        # utf-8-sig, because `str.strip()` does not strip a U+FEFF BOM and the
+        # `gitdir:` match would then miss. Git never writes one; a Windows
+        # editor that rewrote the file might.
+        with open(marker, encoding="utf-8-sig", errors="replace") as handle:
             pointer = handle.read(4096).strip()
     except OSError:
         return False
     if not pointer.lower().startswith("gitdir:"):
         return False
-    target = pointer.split(":", 1)[1].strip().replace("\\", "/")
-    return "/worktrees/" in f"/{target.strip('/')}/"
+    admin = pointer.split(":", 1)[1].strip()
+    if not os.path.isabs(admin):
+        # `git worktree add --relative-paths` writes a pointer relative to the
+        # checkout holding the `.git` file.
+        admin = os.path.join(root, admin)
+    return os.path.isfile(os.path.join(admin, "gitdir")) and os.path.isfile(
+        os.path.join(admin, "commondir")
+    )
 
 
 def _targets_this_worktree(tool_input: dict | None, root: str) -> bool:
     """True when `project_root` provably selects `root` for this one tool call."""
-    # Only an ABSOLUTE path is provable from here. The server resolves
-    # `resolve(server_cwd, project_root ?? ".")` (server.js:11538), and the
-    # server's cwd is not something this hook can observe -- so a relative
-    # value, including the default ".", lands somewhere this rule cannot
-    # compute. The server's own argument description recommends absolute paths
-    # for exactly this reason.
+    # Two conditions, and neither is redundant.
+    #
+    # ABSOLUTE, because the server resolves `resolve(server_cwd, project_root ??
+    # ".")` (server.js:11538) and the server's cwd is not something this hook
+    # can observe -- so a relative value, including the default ".", lands
+    # somewhere this rule cannot compute. The server's own argument description
+    # recommends absolute paths for exactly this reason.
+    #
+    # And the target's WORKTREE ROOT rather than the target itself, because the
+    # server does not use the path it is given: `resolveProjectPaths` runs it
+    # through `findGitRoot` (`git rev-parse --show-toplevel`) and adopts that
+    # (server.js:1226-1240). Demanding exact equality was stricter than the
+    # server's own semantics and refused a write that would have landed
+    # correctly -- an agent one directory deep, say `<worktree>/shaft-engine`,
+    # passing its own cwd.
     if not isinstance(tool_input, dict):
         return False
     target = tool_input.get("project_root")
     if not isinstance(target, str) or not target.strip() or not os.path.isabs(target):
         return False
     try:
-        return os.path.normcase(os.path.realpath(target)) == os.path.normcase(
+        resolved = worktree_root(os.path.realpath(target))
+        if resolved is None:
+            return False
+        return os.path.normcase(resolved) == os.path.normcase(
             os.path.realpath(root)
         )
     except (OSError, ValueError):

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1158,8 +1158,11 @@ def check_r11_memory_write_worktree(
     """Return a block reason for an untargeted MCP memory write from a linked worktree."""
     if tool_name not in _MEMORY_WRITE_TOOLS:
         return None
+    # `is_linked_worktree` already returns False whenever `worktree_root` is
+    # None, so a `root is None` disjunct here could never be the reason and was
+    # dead code.
     root = worktree_root(cwd)
-    if root is None or not is_linked_worktree(cwd):
+    if not is_linked_worktree(cwd):
         return None
     if _targets_this_worktree(tool_input, root):
         return None

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1054,53 +1054,104 @@ _MEMORY_WRITE_TOOLS = frozenset(
 )
 
 
+def worktree_root(cwd: str | None) -> str | None:
+    """Return the checkout root containing `cwd`, or None when there is none."""
+    if not cwd:
+        return None
+    try:
+        current = os.path.abspath(cwd)
+    except (OSError, ValueError):
+        return None
+    while True:
+        if os.path.exists(os.path.join(current, ".git")):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None
+        current = parent
+
+
 def is_linked_worktree(cwd: str | None) -> bool:
     """True when `cwd` sits inside a linked worktree rather than the primary checkout.
 
-    Git's own layout is the tell: a linked worktree's `.git` is a *file* holding
-    a `gitdir:` pointer, while the primary checkout's is a directory. Read off
-    the filesystem rather than by shelling out, because this runs inside a
-    PreToolUse hook whose budget the host caps at 10 seconds and R10 already
-    spends two git queries of that.
+    A `.git` *file* is not the tell on its own, which an earlier revision of
+    this rule assumed. `git init --separate-git-dir` gives an ordinary primary
+    checkout the same shape, and so does a submodule -- both would have been
+    refused, and told the refusal was about worktree isolation. The tell is
+    where the `gitdir:` pointer lands: git puts a linked worktree's admin
+    directory under `<common>/worktrees/<name>`, and nothing else lives there.
+
+    Read off the filesystem rather than by shelling out, because this runs
+    inside a PreToolUse hook whose budget the host caps at 10 seconds and R10
+    already spends two git queries of that.
 
     Fails open -- outside a repository there is no linked worktree to be in, and
     a guard that denies where it cannot tell would block memory writes in every
     checkout it does not understand.
     """
-    if not cwd:
+    root = worktree_root(cwd)
+    if root is None:
+        return False
+    marker = os.path.join(root, ".git")
+    if not os.path.isfile(marker):
         return False
     try:
-        current = os.path.abspath(cwd)
+        with open(marker, encoding="utf-8", errors="replace") as handle:
+            pointer = handle.read(4096).strip()
+    except OSError:
+        return False
+    if not pointer.lower().startswith("gitdir:"):
+        return False
+    target = pointer.split(":", 1)[1].strip().replace("\\", "/")
+    return "/worktrees/" in f"/{target.strip('/')}/"
+
+
+def _targets_this_worktree(tool_input: dict | None, root: str) -> bool:
+    """True when `project_root` provably selects `root` for this one tool call."""
+    # Only an ABSOLUTE path is provable from here. The server resolves
+    # `resolve(server_cwd, project_root ?? ".")` (server.js:11538), and the
+    # server's cwd is not something this hook can observe -- so a relative
+    # value, including the default ".", lands somewhere this rule cannot
+    # compute. The server's own argument description recommends absolute paths
+    # for exactly this reason.
+    if not isinstance(tool_input, dict):
+        return False
+    target = tool_input.get("project_root")
+    if not isinstance(target, str) or not target.strip() or not os.path.isabs(target):
+        return False
+    try:
+        return os.path.normcase(os.path.realpath(target)) == os.path.normcase(
+            os.path.realpath(root)
+        )
     except (OSError, ValueError):
         return False
-    while True:
-        marker = os.path.join(current, ".git")
-        if os.path.isfile(marker):
-            return True
-        if os.path.isdir(marker):
-            return False
-        parent = os.path.dirname(current)
-        if parent == current:
-            return False
-        current = parent
 
 
-def check_r11_memory_write_worktree(tool_name: str, cwd: str | None) -> str | None:
-    """Return a block reason for an MCP memory write from a linked worktree, or None."""
-    if tool_name not in _MEMORY_WRITE_TOOLS or not is_linked_worktree(cwd):
+def check_r11_memory_write_worktree(
+    tool_name: str, cwd: str | None, tool_input: dict | None = None
+) -> str | None:
+    """Return a block reason for an untargeted MCP memory write from a linked worktree."""
+    if tool_name not in _MEMORY_WRITE_TOOLS:
+        return None
+    root = worktree_root(cwd)
+    if root is None or not is_linked_worktree(cwd):
+        return None
+    if _targets_this_worktree(tool_input, root):
         return None
     return (
-        "R11 (MCP memory write from a linked worktree): `.mcp.json` declares "
-        "shaft-memory with `\"cwd\": \".\"` and one server process serves the "
-        "whole session, so this write would land in the PRIMARY checkout -- "
-        "uncommitted, on whatever branch that tree holds, which belongs to a "
-        "different session. Observed twice in one session by two different "
-        "agents (issue #4505). `memory check` still passes, because the object "
-        "is valid; it is just in the wrong tree, so nothing in your own "
-        "verification can detect it. Run the CLI from this worktree instead -- "
-        "`memory remember --stdin` resolves its root with `git rev-parse "
-        "--show-toplevel` from its own cwd, so it writes here, where your "
-        "branch can commit it."
+        "R11 (untargeted MCP memory write from a linked worktree): one "
+        "shaft-memory server serves the whole session and `.mcp.json` roots it "
+        "with `\"cwd\": \".\"`, so an untargeted write resolves against the "
+        "server's launch directory rather than this worktree. When those "
+        "differ the object lands in another session's tree -- uncommitted, on "
+        "a branch that is not yours. Observed twice in one session by two "
+        "different agents (issue #4505), and `memory check` passes either way, "
+        "because the object is valid; it is only in the wrong tree, so nothing "
+        "in your own verification can detect it. Name the destination instead "
+        f"of inheriting it: pass an absolute `project_root` of '{root}', which "
+        "the server resolves per call, or run `memory remember --stdin` from "
+        "this worktree, where the CLI resolves its own root with `git "
+        "rev-parse --show-toplevel`."
     )
 
 
@@ -1208,7 +1259,9 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
     tool_name = hook_input.get("tool_name", "")
 
     reason = check_r11_memory_write_worktree(
-        tool_name, _hook_working_directory(hook_input)
+        tool_name,
+        _hook_working_directory(hook_input),
+        hook_input.get("tool_input"),
     )
     if reason is not None:
         _print_deny(reason, host)
@@ -1718,12 +1771,114 @@ def run_r10_nul_corruption_self_test() -> int:
     return 0
 
 
+def run_r11_memory_write_self_test() -> int:
+    """Exercise R11 against a real linked worktree in a throwaway repository."""
+    # R9 and R10 each ship one of these and `--self-test` runs all of them, so
+    # a rule without one is invisible to the number agents quote as evidence:
+    # `--self-test 93/93` could not move if R11 broke entirely.
+    #
+    # Imported locally for the same reason R10's suite does: the guard ships to
+    # hosts that have neither this repository's test runner nor its test tree,
+    # and `--self-test` is the only way to check it there.
+    import tempfile
+
+    failures: list[str] = []
+
+    def check(description: str, condition: bool) -> None:
+        status = "PASS" if condition else "FAIL"
+        print(f"[{status}] {description}")
+        if not condition:
+            failures.append(description)
+
+    def git(cwd: str, *arguments: str) -> None:
+        subprocess.run(  # nosec B603 B607 - fixed git commands on a temp fixture.
+            ["git", "-c", "core.longpaths=true", *arguments],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    with tempfile.TemporaryDirectory() as container:
+        primary = os.path.join(container, "primary")
+        linked = os.path.join(container, "linked")
+        os.makedirs(primary)
+        git(primary, "init", "-q", "-b", "main", ".")
+        git(primary, "config", "user.email", "harness@example.invalid")
+        git(primary, "config", "user.name", "Harness")
+        with open(os.path.join(primary, "notes.md"), "w", encoding="utf-8") as handle:
+            handle.write("committed\n")
+        git(primary, "add", "notes.md")
+        git(primary, "commit", "-qm", "initial")
+        git(primary, "worktree", "add", linked, "-b", "ChaosEngine/selftest")
+
+        check("fixture linked worktree is detected", is_linked_worktree(linked))
+        check("fixture primary checkout is not linked", not is_linked_worktree(primary))
+
+        reason = check_r11_memory_write_worktree(
+            "mcp__shaft-memory__remember_memory", linked, None
+        )
+        check("untargeted memory write from a linked worktree is denied", reason is not None)
+        check(
+            "denial names project_root as the remedy",
+            reason is not None and "project_root" in reason,
+        )
+        check(
+            "denial names the CLI as the other remedy",
+            reason is not None and "memory remember" in reason,
+        )
+        check(
+            "denial does not claim where the write would land",
+            reason is not None and "would land in the PRIMARY" not in reason,
+        )
+
+        reason = check_r11_memory_write_worktree(
+            "mcp__shaft-memory__remember_memory", linked, {"project_root": linked}
+        )
+        check("write targeted at this worktree is allowed", reason is None)
+
+        reason = check_r11_memory_write_worktree(
+            "mcp__shaft-memory__remember_memory", linked, {"project_root": primary}
+        )
+        check("write targeted at another tree is denied", reason is not None)
+
+        reason = check_r11_memory_write_worktree(
+            "mcp__shaft-memory__remember_memory", linked, {"project_root": "."}
+        )
+        check("relative project_root is denied", reason is not None)
+
+        reason = check_r11_memory_write_worktree(
+            "mcp__shaft-memory__remember_memory", primary, None
+        )
+        check("memory write from the primary checkout is allowed", reason is None)
+
+        reason = check_r11_memory_write_worktree(
+            "mcp__shaft-memory__load_memory", linked, None
+        )
+        check("memory read from a linked worktree is allowed", reason is None)
+
+        reason = check_r11_memory_write_worktree("Bash", linked, None)
+        check("an unrelated tool is not touched by R11", reason is None)
+
+        reason = check_r11_memory_write_worktree(
+            "mcp__shaft-memory__remember_memory", container, None
+        )
+        check("directory outside any repository fails open", reason is None)
+
+    print(f"\nR11 memory-write self-test summary: {len(failures)} failed.")
+    if failures:
+        print("Failed cases: " + ", ".join(failures))
+        return 1
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if "--self-test" in argv:
         command_result = run_self_test()
         r9_result = run_r9_worktree_self_test()
         r10_result = run_r10_nul_corruption_self_test()
-        return command_result or r9_result or r10_result
+        r11_result = run_r11_memory_write_self_test()
+        return command_result or r9_result or r10_result or r11_result
 
     raw = sys.stdin.read()
     if not raw.strip():

--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -532,12 +532,77 @@ def reduction_percent(guidance_bytes: int, baseline: int | None) -> float | None
     return round((1 - guidance_bytes / baseline) * 100, 2)
 
 
+def _git_paths(root: Path, *arguments: str) -> set[str] | None:
+    """Return repository-relative paths from a read-only git query, or None.
+
+    None means git could not answer -- no binary, or not a repository -- and is
+    deliberately distinct from the empty set, which means git answered "none".
+    """
+    executable = shutil.which("git")
+    if executable is None:
+        return None
+    try:
+        completed = subprocess.run(  # nosec B603 - fixed, read-only git queries.
+            [executable, *arguments],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    return {line.strip() for line in completed.stdout.splitlines() if line.strip()}
+
+
+def memory_object_counts(root: Path, memory_root: Path) -> tuple[int, int | None]:
+    """Return (landed objects, objects present but not landed) under `memory_root`.
+
+    #4495: this was `memory_root.rglob("*.json")`, a filesystem walk that never
+    consulted git, so an object that was never `git add`ed was counted exactly
+    like a committed one -- and this banner is what agents in this repository
+    are told to quote as proof of their change.
+
+    Two git views, because #4497 found the mirror defect by reading only one.
+    "Has this landed" is a question about HEAD and nothing else, so a staged
+    file is not landed. "Does this exist and is nobody hiding it" is a question
+    about the worktree minus ignored files, which is
+    `--cached --others --exclude-standard`. The index alone answers neither: it
+    is neither what is there nor what has landed.
+
+    The second element is None when git could not answer at all -- outside a
+    repository there is no "landed" to speak of, and reporting 0 there would
+    publish a non-measurement in the units of a measurement (see
+    `reduction_percent`).
+    """
+    if not memory_root.is_dir():
+        return 0, None
+    relative = memory_root.relative_to(root).as_posix()
+    landed = _git_paths(root, "ls-tree", "-r", "--name-only", "HEAD", "--", relative)
+    visible = _git_paths(
+        root, "ls-files", "--cached", "--others", "--exclude-standard", "--", relative
+    )
+    if landed is None or visible is None:
+        return len(list(memory_root.rglob("*.json"))), None
+    objects = {path for path in landed if path.endswith(".json")}
+    present = {path for path in visible if path.endswith(".json")}
+    return len(objects), len(present - objects)
+
+
 def format_banner(metrics: dict) -> str:
     """Render the one-line summary a passing run prints, omitting what was not measured."""
     parts = [f"{metrics['guidance_bytes']} guidance bytes"]
     if metrics.get("guidance_reduction_percent") is not None:
         parts.append(f"{metrics['guidance_reduction_percent']}% reduction")
-    parts.append(f"{metrics['memory_objects']} memory objects")
+    objects = f"{metrics['memory_objects']} memory objects"
+    # Labelled only when there is something to label. `338 memory objects` is
+    # quotable as a claim about main; `338 memory objects (1 untracked)` is not.
+    untracked = metrics.get("memory_objects_untracked")
+    if untracked:
+        objects += f" ({untracked} untracked)"
+    parts.append(objects)
     return f"Agent setup is valid: {', '.join(parts)}."
 
 
@@ -569,14 +634,14 @@ def collect_metrics(root: Path = ROOT) -> dict:
         except (OSError, json.JSONDecodeError):
             pass
     memory_root = root / ".memory/memory"
+    landed_objects, unlanded_objects = memory_object_counts(root, memory_root)
     return {
         "guidance_bytes": guidance_bytes,
         "guidance_reduction_percent": reduction,
         "always_loaded_body_chars": host_body_chars,
         "skill_listing_chars": host_listing_chars,
-        "memory_objects": len(list(memory_root.rglob("*.json")))
-        if memory_root.is_dir()
-        else 0,
+        "memory_objects": landed_objects,
+        "memory_objects_untracked": unlanded_objects,
         "memory_default_token_budget": memory_budget,
         "codex_memory_tools": sorted(MEMORY_TOOLS),
     }

--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -585,13 +585,21 @@ def memory_object_counts(root: Path, memory_root: Path) -> tuple[int, int | None
     publish a non-measurement in the units of a measurement (see
     `reduction_percent`).
     """
-    if not memory_root.is_dir():
-        # Zero, and verified: there is no store, which the filesystem settles on
-        # its own. Returning None here rendered as "unverified: git could not
-        # answer" -- git answered fine, there was simply nothing to count. That
-        # is the same class of false statement as the refusal message this PR
-        # already retracted once.
-        return 0, 0
+    # No special case for a missing directory, deliberately. Two earlier
+    # attempts both put a false statement in the banner: `(0, None)` said
+    # "unverified: git could not answer" when git was never asked, and `(0, 0)`
+    # said "zero, verified" for a tree where git could still see committed
+    # objects. Both fired BEFORE either query, which is what made them wrong.
+    #
+    # Reachable here rather than hypothetical: R9 exists because plain `git
+    # worktree add` aborts part-way through checking out over-long `.memory/**`
+    # paths (#4126), leaving exactly that state -- no store on disk, a HEAD full
+    # of objects. A sparse checkout does the same.
+    #
+    # Letting the queries answer needs no guard. `relative_to` is a pure path
+    # operation, and git accepts a pathspec matching nothing with exit 0 and
+    # empty output, so `landed` is what HEAD holds and `present` is empty. The
+    # fallback below still covers the genuinely unanswerable case.
     relative = memory_root.relative_to(root).as_posix()
     # `-z` must precede the `--`, or git reads it as a pathspec and matches
     # nothing -- silently, with exit code 0 and an empty result.
@@ -609,7 +617,8 @@ def memory_object_counts(root: Path, memory_root: Path) -> tuple[int, int | None
         relative,
     )
     if landed is None or visible is None:
-        return len(list(memory_root.rglob("*.json"))), None
+        walked = len(list(memory_root.rglob("*.json"))) if memory_root.is_dir() else 0
+        return walked, None
     objects = {path for path in landed if path.endswith(".json")}
     present = {path for path in visible if path.endswith(".json")}
     return len(objects), len(present - objects)

--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -586,7 +586,12 @@ def memory_object_counts(root: Path, memory_root: Path) -> tuple[int, int | None
     `reduction_percent`).
     """
     if not memory_root.is_dir():
-        return 0, None
+        # Zero, and verified: there is no store, which the filesystem settles on
+        # its own. Returning None here rendered as "unverified: git could not
+        # answer" -- git answered fine, there was simply nothing to count. That
+        # is the same class of false statement as the refusal message this PR
+        # already retracted once.
+        return 0, 0
     relative = memory_root.relative_to(root).as_posix()
     # `-z` must precede the `--`, or git reads it as a pathspec and matches
     # nothing -- silently, with exit code 0 and an empty result.
@@ -622,12 +627,15 @@ def format_banner(metrics: dict) -> str:
     # verify says so: the fallback is the pre-fix filesystem walk, and letting
     # it print the quotable wording restores #4495's hole in the one path where
     # the fix does not apply.
-    if "memory_objects_untracked" in metrics:
-        untracked = metrics["memory_objects_untracked"]
-        if untracked is None:
-            objects += " (unverified: git could not answer)"
-        elif untracked:
-            objects += f" ({untracked} untracked)"
+    # Indexed, not `.get`: a caller that omits the key would otherwise receive
+    # the bare, quotable wording by default, which is the one thing this
+    # labelling exists to prevent. `collect_metrics` always sets it, so a
+    # KeyError here means a new caller has to make the choice deliberately.
+    untracked = metrics["memory_objects_untracked"]
+    if untracked is None:
+        objects += " (unverified: git could not answer)"
+    elif untracked:
+        objects += f" ({untracked} untracked)"
     parts.append(objects)
     return f"Agent setup is valid: {', '.join(parts)}."
 

--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -535,6 +535,14 @@ def reduction_percent(guidance_bytes: int, baseline: int | None) -> float | None
 def _git_paths(root: Path, *arguments: str) -> set[str] | None:
     """Return repository-relative paths from a read-only git query, or None.
 
+    Every query is NUL-delimited (`-z`). Without it git applies `core.quotepath`
+    and renders a non-ASCII path as a quoted C-style string --
+    `".memory/.../caf\\303\\251.json"`, trailing quote included -- which then
+    fails a `.endswith(".json")` match and drops the object from the count
+    entirely. A newline in a filename splits one path into two lines for the
+    same reason. `-z` emits raw bytes with an unambiguous separator, so neither
+    shape can misparse.
+
     None means git could not answer -- no binary, or not a repository -- and is
     deliberately distinct from the empty set, which means git answered "none".
     """
@@ -554,7 +562,7 @@ def _git_paths(root: Path, *arguments: str) -> set[str] | None:
         return None
     if completed.returncode != 0:
         return None
-    return {line.strip() for line in completed.stdout.splitlines() if line.strip()}
+    return {entry for entry in completed.stdout.split("\0") if entry}
 
 
 def memory_object_counts(root: Path, memory_root: Path) -> tuple[int, int | None]:
@@ -580,9 +588,20 @@ def memory_object_counts(root: Path, memory_root: Path) -> tuple[int, int | None
     if not memory_root.is_dir():
         return 0, None
     relative = memory_root.relative_to(root).as_posix()
-    landed = _git_paths(root, "ls-tree", "-r", "--name-only", "HEAD", "--", relative)
+    # `-z` must precede the `--`, or git reads it as a pathspec and matches
+    # nothing -- silently, with exit code 0 and an empty result.
+    landed = _git_paths(
+        root, "ls-tree", "-r", "-z", "--name-only", "HEAD", "--", relative
+    )
     visible = _git_paths(
-        root, "ls-files", "--cached", "--others", "--exclude-standard", "--", relative
+        root,
+        "ls-files",
+        "-z",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "--",
+        relative,
     )
     if landed is None or visible is None:
         return len(list(memory_root.rglob("*.json"))), None
@@ -597,11 +616,18 @@ def format_banner(metrics: dict) -> str:
     if metrics.get("guidance_reduction_percent") is not None:
         parts.append(f"{metrics['guidance_reduction_percent']}% reduction")
     objects = f"{metrics['memory_objects']} memory objects"
-    # Labelled only when there is something to label. `338 memory objects` is
-    # quotable as a claim about main; `338 memory objects (1 untracked)` is not.
-    untracked = metrics.get("memory_objects_untracked")
-    if untracked:
-        objects += f" ({untracked} untracked)"
+    # Three states, and the bare wording belongs to exactly one of them.
+    # `338 memory objects` is quotable as a claim about main, so it is reserved
+    # for a git-verified count with nothing outstanding. A count git could not
+    # verify says so: the fallback is the pre-fix filesystem walk, and letting
+    # it print the quotable wording restores #4495's hole in the one path where
+    # the fix does not apply.
+    if "memory_objects_untracked" in metrics:
+        untracked = metrics["memory_objects_untracked"]
+        if untracked is None:
+            objects += " (unverified: git could not answer)"
+        elif untracked:
+            objects += f" ({untracked} untracked)"
     parts.append(objects)
     return f"Agent setup is valid: {', '.join(parts)}."
 

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -111,7 +111,7 @@ BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 # from the boundary was invisible. Equality makes shrinking the boundary a
 # deliberate two-line edit that shows up in review, which is the only place the
 # question "why is the harness smaller today" gets asked.
-EXPECTED_ELEMENT_COUNT = 99
+EXPECTED_ELEMENT_COUNT = 100
 
 # Inline `spans` and fenced blocks both carry instrument paths in this
 # repository's house style -- README.md writes the validate command in a bash

--- a/tests/scripts/test_guard_memory_worktree.py
+++ b/tests/scripts/test_guard_memory_worktree.py
@@ -26,12 +26,14 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import subprocess  # nosec B404 - tests drive the local git binary on fixtures.
 import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 from scripts.agents.guard import is_linked_worktree, run_pretooluse
 
@@ -160,17 +162,94 @@ class MemoryWriteFromLinkedWorktreeTest(unittest.TestCase):
         # The server's own argument description says relative paths resolve
         # from the MCP server launch directory, not from the agent's cwd, and
         # recommends absolute paths. "." is the default that produced the bug.
+        #
+        # The process cwd is forced to the fixture worktree, and that is the
+        # whole point of this test. Without it `realpath(".")` resolved against
+        # the test runner's directory -- never the fixture -- so all three
+        # values were rejected INCIDENTALLY and the `isabs` clause the
+        # docstring rests its safety argument on could be deleted with the
+        # suite green. With cwd pinned here, `realpath(".")` equals the root and
+        # only `isabs` can still refuse it.
         for value in (".", "..", "some/relative/path"):
             with self.subTest(project_root=value):
-                self.assertIsNotNone(
-                    self.denial_reason(
-                        self.decision(
-                            "mcp__shaft-memory__remember_memory",
-                            self.linked,
-                            {"project_root": value},
+                with patch("os.getcwd", return_value=str(self.linked)):
+                    self.assertIsNotNone(
+                        self.denial_reason(
+                            self.decision(
+                                "mcp__shaft-memory__remember_memory",
+                                self.linked,
+                                {"project_root": value},
+                            )
                         )
                     )
+
+    def test_the_isabs_clause_is_what_refuses_the_default_project_root(self):
+        # The sharpest form of the case above, as its own case so the reason it
+        # exists cannot be lost: run the guard in a subprocess whose cwd IS the
+        # worktree, so `os.path.realpath(".")` genuinely equals the root. The
+        # only thing left standing between `project_root: "."` and an allow is
+        # `os.path.isabs`.
+        payload = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "mcp__shaft-memory__remember_memory",
+                "tool_input": {"task": "t", "project_root": "."},
+                "cwd": str(self.linked),
+            }
+        )
+        completed = subprocess.run(  # nosec B603 B607 - the repository's own guard.
+            [sys.executable, str(ROOT / "scripts/agents/guard.py")],
+            input=payload,
+            cwd=str(self.linked),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("R11", completed.stdout, completed.stdout)
+
+    def test_a_write_targeted_at_a_subdirectory_of_this_worktree_is_allowed(self):
+        # The server does not use the path it is given: `resolveProjectPaths`
+        # runs it through `findGitRoot` (`git rev-parse --show-toplevel`) and
+        # adopts that (server.js:1226-1240). Confirmed against the real server,
+        # which reported the repository root for a `project_root` naming a
+        # subdirectory. Demanding exact equality was therefore stricter than the
+        # server's own semantics, and refused a write that would have landed
+        # correctly -- an agent working one directory deep, which in this
+        # repository is the normal shape for any Maven module.
+        module = self.linked / "shaft-engine"
+        module.mkdir()
+        self.assertIsNone(
+            self.denial_reason(
+                self.decision(
+                    "mcp__shaft-memory__remember_memory",
+                    self.linked,
+                    {"project_root": str(module)},
                 )
+            )
+        )
+
+    def test_the_rule_still_fires_from_a_subdirectory_of_the_worktree(self):
+        # `worktree_root`'s upward walk carries the common case and nothing
+        # pinned it: every other case passes the root itself, so deleting the
+        # walk left the suite green while R11 silently stopped firing for every
+        # agent one directory deep.
+        module = self.linked / "shaft-engine"
+        module.mkdir()
+        reason = self.denial_reason(
+            self.decision("mcp__shaft-memory__remember_memory", module)
+        )
+        self.assertIsNotNone(reason)
+        self.assertIn("R11", reason)
+
+    def test_the_refusal_names_this_worktree_as_the_value_to_pass(self):
+        # The interpolated path is what an agent copies verbatim out of the
+        # refusal. Asserting only the literal substring "project_root" let the
+        # value itself be wrong with the suite green.
+        reason = self.denial_reason(
+            self.decision("mcp__shaft-memory__remember_memory", self.linked)
+        )
+        self.assertIn(str(self.linked), reason)
 
     def test_memory_patch_write_from_a_linked_worktree_is_denied_too(self):
         reason = self.denial_reason(
@@ -225,6 +304,44 @@ class MemoryWriteFromLinkedWorktreeTest(unittest.TestCase):
         self.assertTrue((separate / ".git").is_file())
         self.assertFalse(is_linked_worktree(str(separate)))
 
+    def test_a_separate_git_dir_under_a_folder_named_worktrees_is_not_linked(self):
+        # The first fix for this replaced one path heuristic with another: a
+        # `gitdir:` pointer containing a `/worktrees/` segment. A
+        # separate-git-dir checkout whose admin directory happens to sit under
+        # any folder with that name still matched, and was still refused with a
+        # message about worktree isolation. The structural tell -- git writes
+        # `gitdir` and `commondir` INSIDE a linked worktree's admin directory
+        # and nowhere else -- has no such surface.
+        decoy = self.container / "decoy"
+        admin = self.container / "worktrees" / "x.git"
+        decoy.mkdir()
+        admin.parent.mkdir(parents=True, exist_ok=True)
+        git(decoy, "init", "-q", "-b", "main", "--separate-git-dir", str(admin), ".")
+        pointer = (decoy / ".git").read_text(encoding="utf-8")
+        self.assertIn("worktrees", pointer)
+        self.assertFalse(is_linked_worktree(str(decoy)))
+
+    def test_a_relative_gitdir_pointer_is_still_detected(self):
+        # `git worktree add --relative-paths` writes `gitdir: ../p/.git/
+        # worktrees/name`, which must resolve against the checkout holding the
+        # `.git` file rather than against the process cwd.
+        #
+        # Built on a fresh directory pointing at the REAL admin directory
+        # rather than by rewriting the real worktree's `.git`: that file is
+        # read-only on Windows and the attribute survives `chmod`, so
+        # overwriting it raises PermissionError. Pointing a new checkout at the
+        # same admin dir exercises the relative branch without mutating a
+        # worktree git owns.
+        admin = (
+            (self.linked / ".git").read_text(encoding="utf-8").split(":", 1)[1].strip()
+        )
+        synthetic = self.container / "relative-pointer"
+        synthetic.mkdir()
+        (synthetic / ".git").write_text(
+            f"gitdir: {os.path.relpath(admin, synthetic)}\n", encoding="utf-8"
+        )
+        self.assertTrue(is_linked_worktree(str(synthetic)))
+
     def test_the_real_guard_process_denies_a_real_mcp_payload(self):
         # The unit cases call `run_pretooluse` in-process. This drives the
         # tracked script the hosts actually launch, over stdin, with the JSON
@@ -274,23 +391,43 @@ class MemoryWriteFromLinkedWorktreeTest(unittest.TestCase):
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertEqual(completed.stdout.strip(), "", completed.stdout)
 
-    def test_a_payload_without_cwd_fails_open_rather_than_denying_blindly(self):
+    def test_a_payload_without_cwd_falls_back_to_the_process_directory(self):
         # Not every host sends `cwd`. `_hook_working_directory` then falls back
-        # to the hook process's own directory, which is the client launch dir,
-        # not the agent's worktree -- so R11 sees the primary checkout and does
-        # not fire. That is a miss, not a false denial, and a miss is the right
-        # side to fail on: denying every memory write on a host whose payload
-        # shape is unknown would be worse than the defect. Pinned so the
-        # direction of the failure is a decision rather than an accident.
-        buffer = io.StringIO()
-        with redirect_stdout(buffer):
-            run_pretooluse(
-                {
-                    "tool_name": "mcp__shaft-memory__remember_memory",
-                    "tool_input": {"task": "t"},
-                }
-            )
-        self.assertEqual(buffer.getvalue().strip(), "")
+        # to the hook process's own directory.
+        #
+        # The first version of this test asserted "no output" while letting the
+        # fallback pick up the TEST RUNNER's real cwd -- so it passed from a
+        # primary checkout and FAILED ON CLEAN CODE from a linked worktree,
+        # where R11 correctly fires on the runner's own tree. CI runs
+        # `actions/checkout`, a primary checkout, so it would have stayed green
+        # forever while every agent working in the `ChaosEngine/*` worktree the
+        # entrypoint mandates saw a red test they did not cause. It also masked
+        # ten surviving mutations, which all reddened the suite through this one
+        # failure rather than through the behaviour they attacked.
+        #
+        # Control the directory instead of inheriting it, and assert both
+        # branches, so what the fallback does is pinned rather than ambient.
+        with patch("os.getcwd", return_value=str(self.primary)):
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                run_pretooluse(
+                    {
+                        "tool_name": "mcp__shaft-memory__remember_memory",
+                        "tool_input": {"task": "t"},
+                    }
+                )
+            self.assertEqual(buffer.getvalue().strip(), "")
+
+        with patch("os.getcwd", return_value=str(self.linked)):
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                run_pretooluse(
+                    {
+                        "tool_name": "mcp__shaft-memory__remember_memory",
+                        "tool_input": {"task": "t"},
+                    }
+                )
+            self.assertIn("R11", buffer.getvalue())
 
     def test_outside_a_repository_the_rule_fails_open(self):
         # A guard that denies where it cannot tell would block memory writes in

--- a/tests/scripts/test_guard_memory_worktree.py
+++ b/tests/scripts/test_guard_memory_worktree.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import shutil
 import subprocess  # nosec B404 - tests drive the local git binary on fixtures.
 import sys
 import tempfile
@@ -320,6 +321,94 @@ class MemoryWriteFromLinkedWorktreeTest(unittest.TestCase):
         pointer = (decoy / ".git").read_text(encoding="utf-8")
         self.assertIn("worktrees", pointer)
         self.assertFalse(is_linked_worktree(str(decoy)))
+
+    def synthetic_admin(self, name: str, *files: str) -> Path:
+        """A checkout whose `.git` points at an admin dir holding only `files`."""
+        checkout = self.container / name
+        admin = self.container / f"{name}-admin"
+        checkout.mkdir()
+        admin.mkdir()
+        for filename in files:
+            (admin / filename).write_text("x\n", encoding="utf-8")
+        (checkout / ".git").write_text(f"gitdir: {admin}\n", encoding="utf-8")
+        return checkout
+
+    def test_both_admin_files_are_required_not_either(self):
+        # The predicate rests on git writing BOTH `gitdir` and `commondir`
+        # inside a linked worktree's admin directory. Nothing verified the
+        # conjunction: the only negative fixture -- the separate-git-dir decoy
+        # -- has NEITHER, so each half alone still classified it correctly and
+        # either could be deleted with the suite green.
+        self.assertFalse(is_linked_worktree(str(self.synthetic_admin("only-gitdir", "gitdir"))))
+        self.assertFalse(
+            is_linked_worktree(str(self.synthetic_admin("only-commondir", "commondir")))
+        )
+        self.assertTrue(
+            is_linked_worktree(str(self.synthetic_admin("both", "gitdir", "commondir")))
+        )
+
+    def test_a_submodule_is_not_a_linked_worktree(self):
+        # The docstring names submodules as a case the path-based predicates got
+        # wrong, so it needs a fixture rather than an assertion.
+        #
+        # Built to git's real submodule layout instead of by running `git
+        # submodule add`: that needs `protocol.file.allow=always` for a local
+        # source and is refused outright in some environments, which turned this
+        # into a permanent skip -- and a test that always skips is not a test.
+        # What the predicate reads is the admin directory's contents, and a
+        # submodule's `.git/modules/<name>` carries neither marker file.
+        parent = self.container / "super"
+        admin = parent / ".git" / "modules" / "sub"
+        submodule = parent / "sub"
+        admin.mkdir(parents=True)
+        submodule.mkdir(parents=True)
+        # Real submodule admin dirs hold these; neither is `gitdir`/`commondir`.
+        (admin / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+        (admin / "config").write_text("[core]\n", encoding="utf-8")
+        (submodule / ".git").write_text(f"gitdir: {admin}\n", encoding="utf-8")
+        self.assertFalse(is_linked_worktree(str(submodule)))
+
+    def test_a_gitdir_pointer_with_a_bom_is_still_read(self):
+        # `str.strip()` does not remove U+FEFF, so a BOM made the `gitdir:`
+        # match miss and the rule fail open silently. Git never writes one; an
+        # editor that rewrote the file might. The `utf-8-sig` that handles it
+        # was unbound.
+        checkout = self.container / "bom"
+        admin = self.container / "bom-admin"
+        checkout.mkdir()
+        admin.mkdir()
+        for filename in ("gitdir", "commondir"):
+            (admin / filename).write_text("x\n", encoding="utf-8")
+        (checkout / ".git").write_bytes(
+            "﻿".encode("utf-8") + f"gitdir: {admin}\n".encode("utf-8")
+        )
+        self.assertTrue(is_linked_worktree(str(checkout)))
+
+    def test_a_pruned_admin_directory_fails_open(self):
+        # `git worktree prune`, a moved repository before `git worktree repair`,
+        # or a half-deleted worktree leaves a `.git` file pointing at an admin
+        # dir that is gone. R11 then stops firing. That is the documented
+        # fail-open direction rather than a false denial, and it is new relative
+        # to the path-based predicate, so pin the direction deliberately.
+        checkout = self.synthetic_admin("pruned", "gitdir", "commondir")
+        self.assertTrue(is_linked_worktree(str(checkout)))
+        shutil.rmtree(self.container / "pruned-admin")
+        self.assertFalse(is_linked_worktree(str(checkout)))
+
+    def test_an_absolute_target_outside_any_repository_is_denied(self):
+        # The "cannot prove it" branch of the project_root check: if the target
+        # resolves to no checkout at all, nothing has been proven and the write
+        # must still be refused. Inverting that branch left the suite green.
+        outside = self.container / "not-a-repo"
+        outside.mkdir()
+        reason = self.denial_reason(
+            self.decision(
+                "mcp__shaft-memory__remember_memory",
+                self.linked,
+                {"project_root": str(outside)},
+            )
+        )
+        self.assertIsNotNone(reason)
 
     def test_a_relative_gitdir_pointer_is_still_detected(self):
         # `git worktree add --relative-paths` writes `gitdir: ../p/.git/

--- a/tests/scripts/test_guard_memory_worktree.py
+++ b/tests/scripts/test_guard_memory_worktree.py
@@ -1,0 +1,216 @@
+"""R11: refuse an MCP memory write issued from a linked worktree."""
+# Issue #4505, observed twice in one session by two different agents on two
+# unrelated tasks: an agent working in a linked worktree wrote a memory object,
+# and the `.json`, the `.md` and the appended `.memory/events.jsonl` line landed
+# in the *primary* checkout instead -- uncommitted, on whatever branch that tree
+# happened to have checked out, which belonged to a different session.
+#
+# The issue guessed the cause was the CLI resolving the shared `.git` to the
+# primary tree. It is not: `@aictx/memory@0.1.55` resolves its root with
+# `git rev-parse --show-toplevel` from its own cwd (dist/cli/main.js,
+# findGitRoot), which is correct. The real mechanism is that `.mcp.json`
+# declares the server with `"cwd": "."` and one server process serves the whole
+# session, so *every* agent's MCP memory write lands in the tree the client
+# started in, no matter which worktree the agent itself occupies.
+#
+# That is not something this repository can fix inside the server. What it can
+# do is what the issue asks for as the fallback: "a refusal an agent can see
+# beats a success it cannot verify". The write is refused at the moment it is
+# attempted, and the agent is pointed at the CLI, which honours its own cwd.
+#
+# Every case below builds a real linked worktree with the real `git` rather than
+# faking the layout, because the tell being detected -- `.git` as a file rather
+# than a directory -- is a property git creates, not one worth hand-writing.
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess  # nosec B404 - tests drive the local git binary on fixtures.
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from scripts.agents.guard import is_linked_worktree, run_pretooluse
+
+
+def git(cwd: Path, *arguments: str) -> subprocess.CompletedProcess:
+    return subprocess.run(  # nosec B603 B607 - fixed git commands on a temp fixture.
+        ["git", "-c", "core.longpaths=true", *arguments],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class MemoryWriteFromLinkedWorktreeTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.container = Path(self.temporary_directory.name)
+        self.primary = self.container / "primary"
+        self.primary.mkdir()
+        git(self.primary, "init", "-q", "-b", "main", ".")
+        git(self.primary, "config", "user.email", "harness@example.invalid")
+        git(self.primary, "config", "user.name", "Harness")
+        (self.primary / "notes.md").write_text("committed\n", encoding="utf-8")
+        git(self.primary, "add", "notes.md")
+        git(self.primary, "commit", "-qm", "initial")
+
+        self.linked = self.container / "linked"
+        git(
+            self.primary,
+            "worktree",
+            "add",
+            str(self.linked),
+            "-b",
+            "ChaosEngine/fixture",
+        )
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def decision(self, tool_name: str, cwd: Path) -> dict | None:
+        """Return the guard's hook output for one PreToolUse call, or None."""
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            run_pretooluse({"tool_name": tool_name, "cwd": str(cwd)})
+        printed = buffer.getvalue().strip()
+        return json.loads(printed) if printed else None
+
+    def denial_reason(self, output: dict | None) -> str | None:
+        if output is None:
+            return None
+        specific = output.get("hookSpecificOutput", {})
+        if specific.get("permissionDecision") != "deny":
+            return None
+        return specific.get("permissionDecisionReason")
+
+    def test_the_fixture_really_is_a_linked_worktree(self):
+        # The whole rule keys off this distinction, so pin it rather than
+        # assume git's layout: a linked worktree's `.git` is a *file* holding a
+        # `gitdir:` pointer; the primary checkout's is a directory.
+        self.assertTrue((self.linked / ".git").is_file())
+        self.assertTrue((self.primary / ".git").is_dir())
+        self.assertTrue(is_linked_worktree(str(self.linked)))
+        self.assertFalse(is_linked_worktree(str(self.primary)))
+
+    def test_memory_write_from_a_linked_worktree_is_denied(self):
+        reason = self.denial_reason(
+            self.decision("mcp__shaft-memory__remember_memory", self.linked)
+        )
+        self.assertIsNotNone(reason)
+        self.assertIn("R11", reason)
+        # The refusal has to be actionable: the CLI resolves its own cwd
+        # correctly, so it is the way out, not a dead end.
+        self.assertIn("memory remember", reason)
+
+    def test_memory_patch_write_from_a_linked_worktree_is_denied_too(self):
+        reason = self.denial_reason(
+            self.decision("mcp__shaft-memory__save_memory_patch", self.linked)
+        )
+        self.assertIsNotNone(reason)
+
+    def test_memory_write_from_the_primary_checkout_is_allowed(self):
+        # The rule must not fire where the write is already correct, or every
+        # solo session pays for a defect only concurrent sessions have.
+        self.assertIsNone(
+            self.denial_reason(
+                self.decision("mcp__shaft-memory__remember_memory", self.primary)
+            )
+        )
+
+    def test_memory_reads_from_a_linked_worktree_are_allowed(self):
+        # Reads are the session-entry point AGENTS.md mandates. Blocking them
+        # would make worktree isolation cost an agent its memory entirely, and
+        # a read cannot strand work in the wrong tree.
+        for tool in (
+            "mcp__shaft-memory__load_memory",
+            "mcp__shaft-memory__search_memory",
+            "mcp__shaft-memory__inspect_memory",
+            "mcp__shaft-memory__diff_memory",
+        ):
+            with self.subTest(tool=tool):
+                self.assertIsNone(
+                    self.denial_reason(self.decision(tool, self.linked))
+                )
+
+    def test_an_unrelated_mcp_tool_from_a_linked_worktree_is_allowed(self):
+        # R11 is about one server's write path, not about linked worktrees
+        # being second-class.
+        self.assertIsNone(
+            self.denial_reason(
+                self.decision("mcp__mempalace__mempalace_add_drawer", self.linked)
+            )
+        )
+
+    def test_outside_a_repository_the_rule_fails_open(self):
+        # A guard that denies where it cannot tell would block memory writes in
+        # any checkout it does not understand.
+        self.assertFalse(is_linked_worktree(str(self.container)))
+        self.assertIsNone(
+            self.denial_reason(
+                self.decision("mcp__shaft-memory__remember_memory", self.container)
+            )
+        )
+
+
+class MemoryWriteGuardIsReachableTest(unittest.TestCase):
+    """A rule the host never invokes is a rule that does not exist.
+
+    R11 lives behind a PreToolUse matcher. The matcher shipped as
+    `Bash|PowerShell|shell_command`, which no MCP tool name matches -- so the
+    rule could pass every test above and still never run once in production.
+    That is the same shape as the defect it guards: a check whose pass is
+    independent of the thing it verifies.
+    """
+
+    ROOT = Path(__file__).resolve().parents[2]
+
+    def pretooluse_matchers(self, relative_path: str, *keys: str) -> list[str]:
+        configuration = json.loads(
+            (self.ROOT / relative_path).read_text(encoding="utf-8")
+        )
+        for key in keys:
+            configuration = configuration[key]
+        return [entry.get("matcher", "") for entry in configuration]
+
+    def assert_matches_the_write_tools(self, matchers: list[str], host: str):
+        import re
+
+        for tool in (
+            "mcp__shaft-memory__remember_memory",
+            "mcp__shaft-memory__save_memory_patch",
+        ):
+            with self.subTest(host=host, tool=tool):
+                self.assertTrue(
+                    any(re.search(matcher, tool) for matcher in matchers if matcher),
+                    f"{host} PreToolUse never invokes the guard for {tool}",
+                )
+        # The tools R11 deliberately leaves alone must not be dragged in.
+        with self.subTest(host=host, tool="load_memory"):
+            self.assertFalse(
+                any(
+                    re.search(matcher, "mcp__shaft-memory__load_memory")
+                    for matcher in matchers
+                    if matcher
+                ),
+                f"{host} PreToolUse fires on a memory read, which R11 allows",
+            )
+
+    def test_claude_invokes_the_guard_for_memory_writes(self):
+        self.assert_matches_the_write_tools(
+            self.pretooluse_matchers(".claude/settings.json", "hooks", "PreToolUse"),
+            "claude",
+        )
+
+    def test_codex_invokes_the_guard_for_memory_writes(self):
+        self.assert_matches_the_write_tools(
+            self.pretooluse_matchers(".codex/hooks.json", "hooks", "PreToolUse"),
+            "codex",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_guard_memory_worktree.py
+++ b/tests/scripts/test_guard_memory_worktree.py
@@ -27,12 +27,15 @@ from __future__ import annotations
 import io
 import json
 import subprocess  # nosec B404 - tests drive the local git binary on fixtures.
+import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
 
 from scripts.agents.guard import is_linked_worktree, run_pretooluse
+
+ROOT = Path(__file__).resolve().parents[2]
 
 
 def git(cwd: Path, *arguments: str) -> subprocess.CompletedProcess:
@@ -71,11 +74,16 @@ class MemoryWriteFromLinkedWorktreeTest(unittest.TestCase):
     def tearDown(self):
         self.temporary_directory.cleanup()
 
-    def decision(self, tool_name: str, cwd: Path) -> dict | None:
+    def decision(
+        self, tool_name: str, cwd: Path, tool_input: dict | None = None
+    ) -> dict | None:
         """Return the guard's hook output for one PreToolUse call, or None."""
+        hook_input = {"tool_name": tool_name, "cwd": str(cwd)}
+        if tool_input is not None:
+            hook_input["tool_input"] = tool_input
         buffer = io.StringIO()
         with redirect_stdout(buffer):
-            run_pretooluse({"tool_name": tool_name, "cwd": str(cwd)})
+            run_pretooluse(hook_input)
         printed = buffer.getvalue().strip()
         return json.loads(printed) if printed else None
 
@@ -96,15 +104,73 @@ class MemoryWriteFromLinkedWorktreeTest(unittest.TestCase):
         self.assertTrue(is_linked_worktree(str(self.linked)))
         self.assertFalse(is_linked_worktree(str(self.primary)))
 
-    def test_memory_write_from_a_linked_worktree_is_denied(self):
+    def test_memory_write_from_a_linked_worktree_without_a_target_is_denied(self):
         reason = self.denial_reason(
             self.decision("mcp__shaft-memory__remember_memory", self.linked)
         )
         self.assertIsNotNone(reason)
         self.assertIn("R11", reason)
-        # The refusal has to be actionable: the CLI resolves its own cwd
-        # correctly, so it is the way out, not a dead end.
+        # The refusal has to be actionable, and BOTH remedies have to appear.
+        # An earlier revision named only the CLI, on the false premise that the
+        # server could not be targeted at all; the adversarial review of #4507
+        # refuted that from the shipped bundle.
+        self.assertIn("project_root", reason)
         self.assertIn("memory remember", reason)
+
+    def test_the_refusal_does_not_claim_where_the_write_would_land(self):
+        # The first revision asserted "this write would land in the PRIMARY
+        # checkout". With `project_root` supplied that is false, and the rule
+        # cannot see the argument unless it reads tool_input -- so the message
+        # stated a falsehood it had no way to check. A guard that lies about
+        # its reason teaches agents to distrust the guard.
+        reason = self.denial_reason(
+            self.decision("mcp__shaft-memory__remember_memory", self.linked)
+        )
+        self.assertNotIn("would land in the PRIMARY", reason)
+
+    def test_a_write_explicitly_targeted_at_this_worktree_is_allowed(self):
+        # `@aictx/memory@0.1.55` resolves every tool call's root as
+        # resolve(server_cwd, args.project_root ?? ".") -- server.js:11538,
+        # used by remember_memory at :11821 and save_memory_patch at :11965.
+        # An absolute project_root naming this worktree therefore writes HERE,
+        # and denying it would refuse the correct call.
+        self.assertIsNone(
+            self.denial_reason(
+                self.decision(
+                    "mcp__shaft-memory__remember_memory",
+                    self.linked,
+                    {"project_root": str(self.linked)},
+                )
+            )
+        )
+
+    def test_a_write_targeted_at_another_tree_is_still_denied(self):
+        # Supplying the argument is not the point; supplying it correctly is.
+        reason = self.denial_reason(
+            self.decision(
+                "mcp__shaft-memory__remember_memory",
+                self.linked,
+                {"project_root": str(self.primary)},
+            )
+        )
+        self.assertIsNotNone(reason)
+        self.assertIn("project_root", reason)
+
+    def test_a_relative_project_root_is_denied_because_it_resolves_elsewhere(self):
+        # The server's own argument description says relative paths resolve
+        # from the MCP server launch directory, not from the agent's cwd, and
+        # recommends absolute paths. "." is the default that produced the bug.
+        for value in (".", "..", "some/relative/path"):
+            with self.subTest(project_root=value):
+                self.assertIsNotNone(
+                    self.denial_reason(
+                        self.decision(
+                            "mcp__shaft-memory__remember_memory",
+                            self.linked,
+                            {"project_root": value},
+                        )
+                    )
+                )
 
     def test_memory_patch_write_from_a_linked_worktree_is_denied_too(self):
         reason = self.denial_reason(
@@ -144,6 +210,87 @@ class MemoryWriteFromLinkedWorktreeTest(unittest.TestCase):
                 self.decision("mcp__mempalace__mempalace_add_drawer", self.linked)
             )
         )
+
+    def test_a_separate_git_dir_checkout_is_not_a_linked_worktree(self):
+        # `git init --separate-git-dir` gives a PRIMARY checkout a `.git` file
+        # holding a gitdir: pointer -- the same shape a linked worktree has.
+        # Classifying it as linked would refuse memory writes in an ordinary
+        # checkout and explain it with worktree isolation, which has nothing to
+        # do with it. The real tell is where the pointer lands: a linked
+        # worktree's gitdir sits under `<common>/worktrees/<name>`.
+        separate = self.container / "separate"
+        elsewhere = self.container / "elsewhere.git"
+        separate.mkdir()
+        git(separate, "init", "-q", "-b", "main", "--separate-git-dir", str(elsewhere), ".")
+        self.assertTrue((separate / ".git").is_file())
+        self.assertFalse(is_linked_worktree(str(separate)))
+
+    def test_the_real_guard_process_denies_a_real_mcp_payload(self):
+        # The unit cases call `run_pretooluse` in-process. This drives the
+        # tracked script the hosts actually launch, over stdin, with the JSON
+        # shape a host sends -- so the payload contract (tool_name, cwd,
+        # tool_input) is exercised end to end rather than modelled.
+        #
+        # It still cannot prove that Claude or Codex *route* an MCP tool name
+        # through PreToolUse at all; that is asserted by the matcher test below
+        # and remains the one link in this chain nothing here executes.
+        payload = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "mcp__shaft-memory__remember_memory",
+                "tool_input": {"task": "t"},
+                "cwd": str(self.linked),
+            }
+        )
+        completed = subprocess.run(  # nosec B603 B607 - the repository's own guard.
+            [sys.executable, str(ROOT / "scripts/agents/guard.py")],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        output = json.loads(completed.stdout)
+        self.assertEqual(
+            output["hookSpecificOutput"]["permissionDecision"], "deny", completed.stdout
+        )
+
+    def test_the_real_guard_process_allows_a_targeted_mcp_payload(self):
+        payload = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "mcp__shaft-memory__remember_memory",
+                "tool_input": {"task": "t", "project_root": str(self.linked)},
+                "cwd": str(self.linked),
+            }
+        )
+        completed = subprocess.run(  # nosec B603 B607 - the repository's own guard.
+            [sys.executable, str(ROOT / "scripts/agents/guard.py")],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout.strip(), "", completed.stdout)
+
+    def test_a_payload_without_cwd_fails_open_rather_than_denying_blindly(self):
+        # Not every host sends `cwd`. `_hook_working_directory` then falls back
+        # to the hook process's own directory, which is the client launch dir,
+        # not the agent's worktree -- so R11 sees the primary checkout and does
+        # not fire. That is a miss, not a false denial, and a miss is the right
+        # side to fail on: denying every memory write on a host whose payload
+        # shape is unknown would be worse than the defect. Pinned so the
+        # direction of the failure is a decision rather than an accident.
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            run_pretooluse(
+                {
+                    "tool_name": "mcp__shaft-memory__remember_memory",
+                    "tool_input": {"task": "t"},
+                }
+            )
+        self.assertEqual(buffer.getvalue().strip(), "")
 
     def test_outside_a_repository_the_rule_fails_open(self):
         # A guard that denies where it cannot tell would block memory writes in

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -381,6 +381,62 @@ approval_mode = "prompt"
         self.assertEqual(metrics["memory_objects"], tracked + 1)
         self.assertEqual(metrics["memory_objects_untracked"], 0)
 
+    def test_a_non_ascii_object_is_still_counted(self):
+        # `core.quotepath` is on by default, so git renders a non-ASCII path as
+        # a quoted C-style string: ".memory/.../caf\303\251.json" -- trailing
+        # quote and all. Matching on `.endswith(".json")` therefore dropped it
+        # from BOTH the landed and the present sets, so a committed object
+        # vanished from the count and an uncommitted one was reported as
+        # neither landed nor untracked. That is strictly worse than the
+        # filesystem walk this replaced, which counted it correctly.
+        self.init_repository()
+        self.git("add", ".")
+        self.git("commit", "-qm", "initial")
+        tracked = self.metrics_for_budget()["memory_objects"]
+
+        self.write(".memory/memory/gotchas/café-naïve.json", "{}")
+        self.git("add", "--", ".memory/memory/gotchas/café-naïve.json")
+        self.git("commit", "-qm", "non-ascii object")
+
+        metrics = self.metrics_for_budget()
+        self.assertEqual(metrics["memory_objects"], tracked + 1)
+        self.assertEqual(metrics["memory_objects_untracked"], 0)
+
+    def test_a_non_ascii_object_left_uncommitted_is_reported_as_untracked(self):
+        self.init_repository()
+        self.git("add", ".")
+        self.git("commit", "-qm", "initial")
+        tracked = self.metrics_for_budget()["memory_objects"]
+
+        self.write(".memory/memory/gotchas/café-naïve.json", "{}")
+
+        metrics = self.metrics_for_budget()
+        self.assertEqual(metrics["memory_objects"], tracked)
+        self.assertEqual(metrics["memory_objects_untracked"], 1)
+
+    def test_when_git_cannot_answer_the_count_is_labelled_not_quoted_silently(self):
+        # The fallback returned the pre-fix `rglob` walk, and because the
+        # untracked figure was None the banner printed no label at all -- a
+        # count indistinguishable from a git-verified one, which is exactly the
+        # hole #4495 reports. It fires on an unborn HEAD (a repository with no
+        # commits yet), with no git on PATH, and on an exported archive with no
+        # `.git` at all.
+        self.init_repository()  # no commit: HEAD is unborn, `ls-tree HEAD` fails
+        self.write(".memory/memory/gotchas/never-committed.json", "{}")
+
+        metrics = self.metrics_for_budget()
+        self.assertIsNone(metrics["memory_objects_untracked"])
+        banner = format_banner(metrics)
+        self.assertIn("unverified", banner)
+        self.assertNotRegex(banner, r"\d+ memory objects\.")
+        # The count itself must still be the honest worktree figure. Asserting
+        # only the label would leave the fallback's arithmetic unbound -- the
+        # review of #4507 killed an earlier version of this test by replacing
+        # the whole fallback with `return 0, None` and watching it stay green.
+        on_disk = len(list((self.root / ".memory/memory").rglob("*.json")))
+        self.assertEqual(metrics["memory_objects"], on_disk)
+        self.assertGreater(on_disk, 0)
+
     def test_banner_labels_untracked_objects_so_the_figure_cannot_be_misquoted(self):
         # `339 memory objects` is quotable as a claim about main. `338 memory
         # objects (1 untracked)` is not, which is the whole point of #4495.

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -470,15 +470,49 @@ approval_mode = "prompt"
         self.assertEqual(metrics["memory_objects"], on_disk)
         self.assertGreater(on_disk, 0)
 
-    def test_an_absent_store_reports_zero_verified_not_unverified(self):
-        # `(0, None)` rendered as "unverified: git could not answer", which is
-        # false: git answered fine, there was simply no store to count. Zero is
-        # settled by the filesystem alone here, so it is a verified zero. The
-        # same class of false statement as the refusal message this change
-        # already retracted once.
+    def test_a_store_missing_from_the_worktree_still_reports_what_git_holds(self):
+        # Two earlier attempts at this case each put a false statement in the
+        # banner. `(0, None)` said "unverified: git could not answer" when git
+        # was never asked. `(0, 0)` said "zero, verified" for a tree where git
+        # could still see committed objects -- the bare, quotable wording, for
+        # the exact discrepancy #4495 exists to expose. Both returned BEFORE
+        # either query, which is what made them wrong.
+        #
+        # The earlier test could not catch it: its fixture never called
+        # `init_repository`, so nothing was in HEAD there either. It pinned the
+        # empty-repository case and passed while the real one was broken. The
+        # committed objects here are the whole point.
+        #
+        # Not hypothetical: R9 in the guard exists because plain `git worktree
+        # add` aborts part-way through checking out over-long `.memory/**`
+        # paths (#4126), leaving precisely this state.
         import shutil as _shutil
 
+        self.init_repository()
+        self.write(".memory/memory/gotchas/committed.json", "{}")
+        self.git("add", ".")
+        self.git("commit", "-qm", "initial")
+        landed = self.metrics_for_budget()["memory_objects"]
+        self.assertGreater(landed, 0)
+
         _shutil.rmtree(self.root / ".memory/memory")
+
+        metrics = self.metrics_for_budget()
+        self.assertEqual(metrics["memory_objects"], landed)
+        self.assertEqual(metrics["memory_objects_untracked"], 0)
+
+    def test_an_empty_repository_with_no_store_reports_a_plain_zero(self):
+        # The case the previous test used to cover, kept because it is the one
+        # where zero really is the whole truth.
+        import shutil as _shutil
+
+        self.init_repository()
+        self.git("add", ".")
+        self.git("commit", "-qm", "initial")
+        _shutil.rmtree(self.root / ".memory/memory")
+        self.git("add", "-A")
+        self.git("commit", "-qm", "drop the store")
+
         metrics = self.metrics_for_budget()
         self.assertEqual(metrics["memory_objects"], 0)
         self.assertEqual(metrics["memory_objects_untracked"], 0)

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -338,6 +338,75 @@ approval_mode = "prompt"
         )
         self.assertIn("50.0% reduction", measured)
 
+    def init_repository(self):
+        """Make the fixture a real repository so the count can consult git."""
+        self.git("init", "-q", "-b", "main", ".")
+        self.git("config", "user.email", "harness@example.invalid")
+        self.git("config", "user.name", "Harness")
+
+    def test_an_untracked_memory_object_does_not_move_the_reported_count(self):
+        # #4495: the count was `memory_root.rglob("*.json")` -- a filesystem
+        # walk that never consults git, so an object present but never `git
+        # add`ed was counted exactly like a committed one. This banner is what
+        # agents are told to quote as proof of their change, so the one
+        # artefact the harness treats as proof-of-work was satisfiable by work
+        # that was never committed. It landed for real the day it was filed,
+        # when a delegate's `memory remember` wrote into the wrong tree
+        # (#4505) and the higher number was then reasoned about as `main`.
+        self.init_repository()
+        self.git("add", ".")
+        self.git("commit", "-qm", "initial")
+        tracked = self.metrics_for_budget()["memory_objects"]
+
+        self.write(".memory/memory/gotchas/never-added.json", "{}")
+        self.write(".memory/memory/gotchas/never-added.md", "body\n")
+
+        metrics = self.metrics_for_budget()
+        self.assertEqual(metrics["memory_objects"], tracked)
+        self.assertEqual(metrics["memory_objects_untracked"], 1)
+
+    def test_a_committed_memory_object_does_move_the_reported_count(self):
+        # The negative half: fixing the untracked case must not be bought by
+        # making the count blind to real work.
+        self.init_repository()
+        self.git("add", ".")
+        self.git("commit", "-qm", "initial")
+        tracked = self.metrics_for_budget()["memory_objects"]
+
+        self.write(".memory/memory/gotchas/really-added.json", "{}")
+        self.git("add", ".memory/memory/gotchas/really-added.json")
+        self.git("commit", "-qm", "add object")
+
+        metrics = self.metrics_for_budget()
+        self.assertEqual(metrics["memory_objects"], tracked + 1)
+        self.assertEqual(metrics["memory_objects_untracked"], 0)
+
+    def test_banner_labels_untracked_objects_so_the_figure_cannot_be_misquoted(self):
+        # `339 memory objects` is quotable as a claim about main. `338 memory
+        # objects (1 untracked)` is not, which is the whole point of #4495.
+        self.assertEqual(
+            format_banner(
+                {
+                    "guidance_bytes": 129_090,
+                    "guidance_reduction_percent": None,
+                    "memory_objects": 338,
+                    "memory_objects_untracked": 1,
+                }
+            ),
+            "Agent setup is valid: 129090 guidance bytes, 338 memory objects (1 untracked).",
+        )
+        self.assertEqual(
+            format_banner(
+                {
+                    "guidance_bytes": 129_090,
+                    "guidance_reduction_percent": None,
+                    "memory_objects": 338,
+                    "memory_objects_untracked": 0,
+                }
+            ),
+            "Agent setup is valid: 129090 guidance bytes, 338 memory objects.",
+        )
+
     def test_overlong_non_relation_filename_still_caught_without_relation_hint(self):
         # Negative test: relaxing the relation-file message must not open a
         # hole for genuinely over-long non-relation memory objects, which

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -330,11 +330,21 @@ approval_mode = "prompt"
 
     def test_banner_omits_the_reduction_clause_when_nothing_measured_it(self):
         banner = format_banner(
-            {"guidance_bytes": 129_090, "guidance_reduction_percent": None, "memory_objects": 336}
+            {
+                "guidance_bytes": 129_090,
+                "guidance_reduction_percent": None,
+                "memory_objects": 336,
+                "memory_objects_untracked": 0,
+            }
         )
         self.assertEqual(banner, "Agent setup is valid: 129090 guidance bytes, 336 memory objects.")
         measured = format_banner(
-            {"guidance_bytes": 75_000, "guidance_reduction_percent": 50.0, "memory_objects": 336}
+            {
+                "guidance_bytes": 75_000,
+                "guidance_reduction_percent": 50.0,
+                "memory_objects": 336,
+                "memory_objects_untracked": 0,
+            }
         )
         self.assertIn("50.0% reduction", measured)
 
@@ -380,6 +390,29 @@ approval_mode = "prompt"
         metrics = self.metrics_for_budget()
         self.assertEqual(metrics["memory_objects"], tracked + 1)
         self.assertEqual(metrics["memory_objects_untracked"], 0)
+
+    def test_the_count_is_json_objects_and_not_every_file_in_the_store(self):
+        # Every other assertion here is RELATIVE -- `tracked`, `tracked + 1` --
+        # computed by the same code on both sides, so a change to what a
+        # "memory object" IS cancels out. Dropping the `.json` filter made the
+        # live banner read `678 memory objects` instead of 339, because the
+        # store holds one `.md` beside every `.json`, and the whole suite
+        # stayed green. The one number #4495 exists to make trustworthy could
+        # double silently. This pins the units absolutely.
+        self.init_repository()
+        self.write(".memory/memory/gotchas/one.json", "{}")
+        self.write(".memory/memory/gotchas/one.md", "body\n")
+        self.write(".memory/memory/gotchas/two.json", "{}")
+        self.write(".memory/memory/gotchas/two.md", "body\n")
+        self.git("add", ".")
+        self.git("commit", "-qm", "initial")
+
+        memory_root = self.root / ".memory/memory"
+        json_files = len(list(memory_root.rglob("*.json")))
+        every_file = len([path for path in memory_root.rglob("*") if path.is_file()])
+        self.assertGreater(every_file, json_files)  # the fixture can tell them apart
+
+        self.assertEqual(self.metrics_for_budget()["memory_objects"], json_files)
 
     def test_a_non_ascii_object_is_still_counted(self):
         # `core.quotepath` is on by default, so git renders a non-ASCII path as
@@ -436,6 +469,34 @@ approval_mode = "prompt"
         on_disk = len(list((self.root / ".memory/memory").rglob("*.json")))
         self.assertEqual(metrics["memory_objects"], on_disk)
         self.assertGreater(on_disk, 0)
+
+    def test_an_absent_store_reports_zero_verified_not_unverified(self):
+        # `(0, None)` rendered as "unverified: git could not answer", which is
+        # false: git answered fine, there was simply no store to count. Zero is
+        # settled by the filesystem alone here, so it is a verified zero. The
+        # same class of false statement as the refusal message this change
+        # already retracted once.
+        import shutil as _shutil
+
+        _shutil.rmtree(self.root / ".memory/memory")
+        metrics = self.metrics_for_budget()
+        self.assertEqual(metrics["memory_objects"], 0)
+        self.assertEqual(metrics["memory_objects_untracked"], 0)
+        self.assertNotIn("unverified", format_banner(metrics))
+
+    def test_the_banner_refuses_to_render_without_the_untracked_figure(self):
+        # Keyed on presence, a caller that simply omitted the field got the
+        # bare, quotable wording by default -- the one outcome the labelling
+        # exists to prevent. Omission must be loud rather than silently
+        # optimistic.
+        with self.assertRaises(KeyError):
+            format_banner(
+                {
+                    "guidance_bytes": 129_090,
+                    "guidance_reduction_percent": None,
+                    "memory_objects": 338,
+                }
+            )
 
     def test_banner_labels_untracked_objects_so_the_figure_cannot_be_misquoted(self):
         # `339 memory objects` is quotable as a claim about main. `338 memory


### PR DESCRIPTION
## Summary

Two defects that are the same mistake pointed in opposite directions: a check and its metric disagreeing about which view of a file they mean.

> **Reworked after adversarial review.** The review refuted the mechanism claim the #4505 half was originally built on, and found a regression plus an unenforced branch in the #4495 half. Both are fixed here; the corrected reasoning is below and the superseded claim is called out explicitly so the history stays legible.

**#4495 — the proof-of-work banner counted files git had never seen.**
`collect_metrics` counted memory objects with `memory_root.rglob("*.json")`, a filesystem walk that never consulted git. An object present but never `git add`ed was counted exactly like a committed one. `AGENTS.md` names this banner as the smallest non-redundant check for memory work and the iron laws require quoting its output, so the one artefact the harness treats as proof-of-work was satisfiable by work that was never committed.

The count now derives from two git views, because #4497 found the mirror defect by reading only one:

| Question | View | Command |
| --- | --- | --- |
| has this landed | HEAD, and nothing else | `ls-tree -r -z --name-only HEAD` |
| does this exist and is nobody hiding it | worktree minus ignored | `ls-files -z --cached --others --exclude-standard` |

The index alone answers neither — it is neither what is there nor what has landed.

The banner has **three** states, not two, and the bare wording belongs to exactly one of them:

```
339 memory objects                                     <- verified, nothing outstanding
339 memory objects (1 untracked)                       <- verified, present but not landed
339 memory objects (unverified: git could not answer)  <- fell back to the filesystem walk
```

Only the first is quotable as a claim about `main`. The third matters more than it looks: the fallback *is* the pre-fix metric, so letting it print the quotable wording restores the whole defect in the one path the fix does not cover.

**#4505 — an MCP memory write from a linked worktree lands in the wrong tree.**

The issue hypothesised the CLI resolved the shared `.git` to the primary tree. It does not: `@aictx/memory@0.1.55` resolves its root with `git rev-parse --show-toplevel` from its own cwd (`dist/cli/main.js`, `findGitRoot`), correctly. One server process serves the whole session and `.mcp.json` roots it with `"cwd": "."`, so an untargeted MCP write resolves against the client's launch directory rather than the agent's worktree.

**An earlier revision of this PR claimed that was "not fixable inside the server". That was wrong**, and the review disproved it from the shipped bundle. Every tool call takes an optional `project_root`:

```js
// server.js:11538
function resolveMcpProjectCwd(context, args) {
  return resolve13(context.cwd, args.project_root ?? ".");
}
```

used by `remember_memory` at `:11821` and `save_memory_patch` at `:11965`, and documented in its own argument description as being for "when one globally started MCP server serves multiple projects". So the write *can* be aimed at a linked worktree — which means **#4505's primary acceptance is reachable, not just its fallback**, and this is a real fix rather than a substituted one.

R11 therefore reads the argument instead of guessing:

- an **absolute** `project_root` equal to this worktree → **allowed**, because it provably writes here;
- anything else, including the default `"."` → **denied**, naming *both* remedies: the argument, and the CLI run from this worktree.

Relative values stay denied because the server resolves them against its own launch directory, which this hook cannot observe. The refusal no longer asserts where the write would land — the previous message said "this write would land in the PRIMARY checkout", a claim it had no way to check, because it never read `tool_input`.

`is_linked_worktree` no longer treats any `.git` *file* as the tell. `git init --separate-git-dir` and any submodule have that same shape and would have been refused, with an explanation about worktree isolation that had nothing to do with them. The tell is where the `gitdir:` pointer lands: git puts a linked worktree's admin directory under `<common>/worktrees/<name>`.

**Both host matchers gain the two write tools.** Without that, R11 would pass every test and never run once in production — a check whose pass is independent of the thing it verifies, which is precisely the defect class it guards.

Closes #4495
Closes #4505

## Test plan

- [x] `tests.scripts.test_guard_memory_worktree` — 17/17, on a real linked worktree built with the real `git`.
- [x] `tests.scripts.test_validate_agent_setup` — 39/39. RED first reproduced #4495 exactly: `AssertionError: 3 != 2`.
- [x] 227/227 across the seven affected modules together.
- [x] `guard.py --self-test` — 93/93, with the R9, R10 **and new R11** suites each at 0 failed. R11 previously had no self-test at all, so the 93/93 this PR originally quoted could not have moved if R11 broke entirely.
- [x] `validate_agent_setup.py --skip-external` — valid.
- [x] Mutation on the live tree: an untracked object holds the landed count at `339 memory objects (1 untracked)` instead of reading 340.

Every mutation the review used to kill the first revision now dies:

| Mutation | Before | After |
| --- | --- | --- |
| fallback → `return 0, None` | 36/36 green | 1 failure |
| drop `-z` from `ls-tree` | n/a (was the bug) | 4 failures |
| ignore `project_root` | n/a (was the bug) | 2 failures + R11 self-test |
| `_MEMORY_WRITE_TOOLS = frozenset()` | 2 failures | 2 failures |
| `is_linked_worktree` → `False` | 3 failures | 3 failures |
| revert both host matchers | 4 failures | 4 failures |
| `memory_object_counts` → `rglob` | 2 failures | 2 failures |

### Fixed from review, in detail

- **F1** R11 denied a correct call and its message stated an unverifiable falsehood — redesigned around `project_root`.
- **F2** the git-unavailable fallback silently restored #4495's hole and was entirely unenforced — three banner states, and the fallback's arithmetic pinned, not just its label.
- **F4** `core.quotepath` dropped non-ASCII objects from *both* counts, a strict regression against `rglob` — `-z` with a NUL split on both queries. The `-z` must precede the `--`, or git reads it as a pathspec and returns exit 0 with an empty result.
- **F5** `is_linked_worktree` misclassified `--separate-git-dir` checkouts and submodules — now keys on the `worktrees/` pointer.
- **F6** reachability was pinned by the test's own `re.search` model — added end-to-end cases driving the tracked guard script over stdin with a real MCP payload, denied and allowed. A payload with no `cwd` is pinned to fail open, so the direction of that failure is a decision rather than an accident.
- **F7** `--self-test` was blind to R11 — R11 now ships a suite alongside R9 and R10.
- **F8** the deny message body and the `None`-vs-`0` untracked return were unpinned — both now observable and asserted.

### Still open, honestly

Whether Claude Code and Codex actually route `mcp__shaft-memory__*` names through this PreToolUse matcher in production, and whether their payloads carry `cwd` for a worktree-isolated subagent. Both are load-bearing for R11 ever firing and both are asserted rather than executed; the test says so where it asserts them.

## Adjacent findings, filed not folded

- **#4506** — `test_pilot_module_boundary` red on clean `origin/main` with a stale `LmStudioProvider` expectation, and run by no workflow. Verified in a detached probe worktree at `origin/main`.
- **#4508** — `backForwardJourneyRecordsUserTraversals` flaky on edge; the test uses `waitFor` condition polls for DOM state but fixed `Thread.sleep` calls for the recorder appends it actually asserts.
- **#4509** — `guidance_bytes` has the identical filesystem-walk defect, prints first in this same banner line, and was explicitly raised as a question by #4495.
