### PR TITLE
Fix #4450 item 3: guard against PR-less remote branches

### DIFF
--- a/scripts/ci/worktree_hygiene.py
+++ b/scripts/ci/worktree_hygiene.py
@@ -33,6 +33,7 @@ import json
 import shutil
 import subprocess  # nosec B404 - fixed, read-only git and gh queries.
 import sys
+import time
 from collections.abc import Callable
 from pathlib import Path
 
@@ -49,8 +50,16 @@ PULL_REQUEST_TIMEOUT_SECONDS = 30
 # A checkout with more linked worktrees than this is already the problem this
 # report exists to surface; scanning every one of them is not worth the wait.
 MAX_REPORTED_WORKTREES = 50
+# Issue #4450: `ChaosEngine/user-evaluation-20260802` was pushed to origin, its
+# worktree was cleaned up, and no pull request was ever opened -- invisible to
+# this report (local worktrees only) and to `--check-pull-requests` (open pull
+# requests for worktrees that still exist, only). A short grace period keeps a
+# branch pushed minutes ago, mid-session, from being flagged before its author
+# has had a chance to open a pull request.
+DEFAULT_STALE_DAYS = 3
+SECONDS_PER_DAY = 86400
 
-ADVISORY_STATES = ("corrupt", "abandoned", "superseded", "uncommitted", "unknown")
+ADVISORY_STATES = ("corrupt", "abandoned", "superseded", "uncommitted", "unknown", "orphaned")
 
 
 def _git(cwd: Path, *arguments: str) -> str | None:
@@ -149,6 +158,82 @@ def _ahead_behind(root: Path, committish: str | None) -> tuple[int | None, int |
     return int(parts[1]), int(parts[0])  # ahead, behind
 
 
+def _remote_only_branch_names(root: Path, worktree_branches: set[str]) -> list[str]:
+    """Origin branches no linked worktree references, upstream excluded."""
+    # `git worktree list` already accounts for every branch that has a
+    # worktree; this only has to name the ones nothing local still holds.
+    output = _git(root, "for-each-ref", "--format=%(refname:strip=3)", "refs/remotes/origin")
+    if output is None:
+        return []
+    names = [line.strip() for line in output.splitlines() if line.strip()]
+    return [
+        name
+        for name in names
+        if name and name not in (UPSTREAM_BRANCH, "HEAD") and name not in worktree_branches
+    ]
+
+
+def _last_commit_epoch(root: Path, ref: str) -> int | None:
+    """Committer-date epoch of `ref`'s tip, or None when git could not answer."""
+    output = _git(root, "log", "-1", "--format=%ct", ref)
+    if output is None:
+        return None
+    value = output.strip()
+    return int(value) if value.isdigit() else None
+
+
+def _classify_remote_only(entry: dict) -> str:
+    """An open pull request means it is already visible; anything else is not."""
+    pull_request_status_known = entry["open_pull_requests"] is not None
+    has_open_pull_request = bool(entry["open_pull_requests"])
+    if pull_request_status_known and has_open_pull_request:
+        return "clean"
+    return "orphaned"
+
+
+def _collect_remote_only_entries(
+    root: Path,
+    worktree_branches: set[str],
+    *,
+    open_pull_requests: Callable[[str], int] | None,
+    stale_days: float,
+    now: float | None,
+) -> list[dict]:
+    """Stale origin branches with no worktree, as reportable entries."""
+    reference_time = time.time() if now is None else now
+    threshold = reference_time - (stale_days * SECONDS_PER_DAY)
+
+    entries: list[dict] = []
+    names = _remote_only_branch_names(root, worktree_branches)
+    for name in names[:MAX_REPORTED_WORKTREES]:
+        last_commit_epoch = _last_commit_epoch(root, f"refs/remotes/origin/{name}")
+        if last_commit_epoch is None or last_commit_epoch >= threshold:
+            continue  # too young to call idle, or git could not answer
+
+        pull_requests: int | None = None
+        if open_pull_requests is not None:
+            try:
+                pull_requests = int(open_pull_requests(name))
+            except Exception:  # noqa: BLE001 - a lookup failure must not hide the report
+                pull_requests = None
+
+        entry = {
+            "path": f"origin/{name}",
+            "branch": name,
+            "is_main": False,
+            "is_current": False,
+            "locked": False,
+            "is_remote_only": True,
+            "last_commit_epoch": last_commit_epoch,
+            "age_days": (reference_time - last_commit_epoch) / SECONDS_PER_DAY,
+            "open_pull_requests": pull_requests,
+        }
+        entry["state"] = _classify_remote_only(entry)
+        if entry["state"] != "clean":
+            entries.append(entry)
+    return entries
+
+
 def open_pull_requests_via_gh(branch: str) -> int:
     """Open pull requests for `branch`, via the GitHub CLI when it is available."""
     if shutil.which("gh") is None:
@@ -223,8 +308,16 @@ def collect_worktree_report(
     root: Path,
     *,
     open_pull_requests: Callable[[str], int] | None = None,
+    stale_days: float = DEFAULT_STALE_DAYS,
+    now: float | None = None,
 ) -> list[dict]:
-    """Describe every worktree of `root`'s repository, `root`'s own included."""
+    """Describe every worktree of `root`'s repository, `root`'s own included,
+
+    plus any origin branch old enough to call idle that no worktree here
+    references (issue #4450) -- local `git` only, same as the rest of this
+    report; `open_pull_requests` is the one call that can leave the machine,
+    and it is reused here exactly as it is for worktrees above.
+    """
     # Returns an empty list -- never an error -- when the directory is not a
     # repository or git cannot answer, so a caller can always report the
     # result.
@@ -283,14 +376,42 @@ def collect_worktree_report(
         }
         entry["state"] = _classify(entry)
         report.append(entry)
+
+    worktree_branches = {entry["branch"] for entry in report if entry["branch"]}
+    report.extend(
+        _collect_remote_only_entries(
+            root,
+            worktree_branches,
+            open_pull_requests=open_pull_requests,
+            stale_days=stale_days,
+            now=now,
+        )
+    )
     return report
 
 
 def _describe(entry: dict) -> str:
     branch = entry["branch"] or "detached HEAD"
     location = entry["path"]
-    uncommitted = entry["uncommitted_files"]
+    uncommitted = entry.get("uncommitted_files")
 
+    if entry["state"] == "orphaned":
+        age = int(entry["age_days"])
+        caveat = (
+            "no open pull request" if entry["open_pull_requests"] is not None
+            else "open pull requests were not checked -- rerun with "
+            "--check-pull-requests to confirm"
+        )
+        return (
+            f"branch-orphaned: {location} ({branch}): {age} day(s) since its last "
+            f"commit, no local worktree holds it, and {caveat}. This branch is "
+            "invisible to every other hygiene check. Its commit count relative to "
+            f"{UPSTREAM_REF} is not evidence either way -- this repo squash-merges, "
+            "so landed work can still show commits ahead of main. Diff its tip "
+            "against main over exactly the files it touched, then check whether "
+            "anything still differing ever existed on main, before opening a pull "
+            "request for it or deleting it."
+        )
     if entry["state"] == "corrupt":
         shown = ", ".join(entry["corrupt_paths"]) or "changed files"
         return (

--- a/tests/scripts/test_worktree_hygiene.py
+++ b/tests/scripts/test_worktree_hygiene.py
@@ -10,8 +10,10 @@
 
 from __future__ import annotations
 
+import os
 import subprocess  # nosec B404 - tests drive the local git binary on fixtures.
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -67,6 +69,36 @@ class WorktreeHygieneTest(unittest.TestCase):
         git(path, "config", "user.email", "harness@example.invalid")
         git(path, "config", "user.name", "Harness")
         return path
+
+    def push_and_remove_worktree(
+        self, name: str, branch: str, *, commit_epoch: int | None = None
+    ) -> str:
+        """Simulate a session that pushed `branch` to origin, then cleaned up
+
+        locally -- exactly the shape issue #4450 describes: a real commit only
+        `refs/remotes/origin/<branch>` still references, no worktree, no local
+        branch, and (by default) no pull request.
+        """
+        worktree = self.add_worktree(name, branch)
+        self.write(worktree, "notes.md", "session work\n")
+        git(worktree, "add", "-A")
+        env = None
+        if commit_epoch is not None:
+            stamp = f"{commit_epoch} +0000"
+            env = {**os.environ, "GIT_AUTHOR_DATE": stamp, "GIT_COMMITTER_DATE": stamp}
+        subprocess.run(  # nosec B603 B607 - fixed git command on a temp fixture.
+            ["git", "-c", "core.longpaths=true", "commit", "-qm", "session work"],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        head = git(worktree, "rev-parse", branch).stdout.strip()
+        git(self.main, "update-ref", f"refs/remotes/origin/{branch}", head)
+        git(self.main, "worktree", "remove", "--force", str(worktree))
+        git(self.main, "branch", "-D", branch)
+        return head
 
     def entry(self, report: list[dict], name: str) -> dict:
         matches = [item for item in report if Path(item["path"]).name == name]
@@ -390,6 +422,140 @@ class WorktreeHygieneTest(unittest.TestCase):
         entry = self.entry(collect_worktree_report(self.main), "landed")
         self.assertIsNone(entry["unique_commits"])
         self.assertNotEqual(entry["state"], "superseded")
+
+    # --- orphaned: pushed to origin, no worktree, no PR, no activity --------
+    # Issue #4450: `ChaosEngine/user-evaluation-20260802` was pushed, its
+    # worktree cleaned up, and no PR was ever opened. Its one commit -- a
+    # durable memory object -- was invisible to this report (local worktrees
+    # only) and to `--check-pull-requests` (open pull requests only).
+
+    def test_orphaned_remote_branch_with_no_worktree_is_reported(self):
+        old_epoch = int(time.time()) - (10 * 86400)
+        self.push_and_remove_worktree(
+            "gone", "ChaosEngine/gone-4450", commit_epoch=old_epoch
+        )
+
+        report = collect_worktree_report(self.main, open_pull_requests=lambda _b: 0)
+        advisories = format_advisories(report)
+
+        self.assertTrue(
+            any("ChaosEngine/gone-4450" in advisory for advisory in advisories),
+            f"expected an advisory naming the orphaned branch, got: {advisories}",
+        )
+        entry = next(item for item in report if item["path"] == "origin/ChaosEngine/gone-4450")
+        self.assertEqual(entry["state"], "orphaned")
+        self.assertTrue(entry["is_remote_only"])
+
+    def test_a_branch_pushed_minutes_ago_is_not_yet_orphaned(self):
+        # A session mid-task, or one about to open its pull request in the
+        # same turn, must not be flagged before it has had a chance to.
+        recent_epoch = int(time.time()) - 3600
+        self.push_and_remove_worktree(
+            "brand-new", "ChaosEngine/brand-new", commit_epoch=recent_epoch
+        )
+
+        report = collect_worktree_report(self.main, open_pull_requests=lambda _b: 0)
+        self.assertEqual(
+            [item for item in report if item.get("is_remote_only")],
+            [],
+        )
+        self.assertEqual(format_advisories(report), [])
+
+    def test_orphaned_branch_with_an_open_pull_request_is_not_flagged(self):
+        # It is already visible through the normal review flow -- the actual
+        # gap this guard closes is a branch with no worktree AND no PR.
+        old_epoch = int(time.time()) - (10 * 86400)
+        self.push_and_remove_worktree(
+            "reviewed", "ChaosEngine/reviewed-elsewhere", commit_epoch=old_epoch
+        )
+
+        report = collect_worktree_report(
+            self.main, open_pull_requests=lambda branch: 1
+        )
+        self.assertEqual(
+            [item for item in report if item.get("is_remote_only")],
+            [],
+        )
+        self.assertEqual(format_advisories(report), [])
+
+    def test_orphaned_branch_advisory_caveats_an_unchecked_pull_request(self):
+        # `--check-pull-requests` is opt-in and hits the network; the default
+        # local-only run must still surface the branch, honestly qualified.
+        old_epoch = int(time.time()) - (10 * 86400)
+        self.push_and_remove_worktree(
+            "unchecked", "ChaosEngine/unchecked-pr", commit_epoch=old_epoch
+        )
+
+        report = collect_worktree_report(self.main)  # no open_pull_requests callback
+        entry = next(
+            item for item in report if item["path"] == "origin/ChaosEngine/unchecked-pr"
+        )
+        self.assertEqual(entry["state"], "orphaned")
+        self.assertIsNone(entry["open_pull_requests"])
+
+        advisory = next(
+            item for item in format_advisories(report) if "unchecked-pr" in item
+        )
+        self.assertIn("not checked", advisory)
+        self.assertIn("--check-pull-requests", advisory)
+
+    def test_orphaned_branch_advisory_does_not_claim_ahead_count_as_proof(self):
+        # The issue's own correctness point, in bold: this repo squash-merges,
+        # so a landed branch still shows commits ahead of main. The advisory
+        # must send the reader to a content diff, never assert "unmerged".
+        old_epoch = int(time.time()) - (10 * 86400)
+        self.push_and_remove_worktree(
+            "maybe-landed", "ChaosEngine/maybe-landed", commit_epoch=old_epoch
+        )
+
+        advisory = next(
+            item
+            for item in format_advisories(
+                collect_worktree_report(self.main, open_pull_requests=lambda _b: 0)
+            )
+            if "maybe-landed" in item
+        )
+        self.assertIn("squash-merges", advisory)
+        self.assertIn("not evidence", advisory)
+        self.assertIn("Diff its tip against main", advisory)
+
+    def test_a_branch_that_still_has_a_local_worktree_is_not_reported_as_orphaned(self):
+        # The remote-only scan must not double-report a branch the ordinary
+        # worktree walk already covers.
+        old_epoch = int(time.time()) - (10 * 86400)
+        worktree = self.add_worktree("still-here", "ChaosEngine/still-here")
+        self.write(worktree, "notes.md", "session work\n")
+        git(worktree, "add", "-A")
+        env = {**os.environ, "GIT_AUTHOR_DATE": f"{old_epoch} +0000",
+               "GIT_COMMITTER_DATE": f"{old_epoch} +0000"}
+        subprocess.run(  # nosec B603 B607 - fixed git command on a temp fixture.
+            ["git", "-c", "core.longpaths=true", "commit", "-qm", "session work"],
+            cwd=worktree, capture_output=True, text=True, env=env, check=False,
+        )
+        head = git(worktree, "rev-parse", "ChaosEngine/still-here").stdout.strip()
+        git(self.main, "update-ref", "refs/remotes/origin/ChaosEngine/still-here", head)
+
+        report = collect_worktree_report(self.main, open_pull_requests=lambda _b: 0)
+        self.assertEqual(
+            [item for item in report if item.get("is_remote_only")],
+            [],
+        )
+
+    def test_origin_main_is_never_reported_as_orphaned(self):
+        old_epoch = int(time.time()) - (10 * 86400)
+        env = {**os.environ, "GIT_AUTHOR_DATE": f"{old_epoch} +0000",
+               "GIT_COMMITTER_DATE": f"{old_epoch} +0000"}
+        subprocess.run(  # nosec B603 B607 - fixed git command on a temp fixture.
+            ["git", "-c", "core.longpaths=true", "commit", "--allow-empty", "-qm", "old"],
+            cwd=self.main, capture_output=True, text=True, env=env, check=False,
+        )
+        self.publish_main()
+
+        report = collect_worktree_report(self.main, open_pull_requests=lambda _b: 0)
+        self.assertEqual(
+            [item for item in report if item.get("is_remote_only")],
+            [],
+        )
 
 
 class OpenPullRequestLookupTest(unittest.TestCase):

--- a/tests/scripts/test_worktree_hygiene.py
+++ b/tests/scripts/test_worktree_hygiene.py
@@ -499,6 +499,29 @@ class WorktreeHygieneTest(unittest.TestCase):
         self.assertIn("not checked", advisory)
         self.assertIn("--check-pull-requests", advisory)
 
+    def test_a_failing_pull_request_lookup_still_reports_the_orphaned_branch(self):
+        # gh missing or unauthenticated must not hide the branch, and must not
+        # be mistaken for a confirmed "no open pull request" either.
+        old_epoch = int(time.time()) - (10 * 86400)
+        self.push_and_remove_worktree(
+            "flaky-gh", "ChaosEngine/flaky-gh-lookup", commit_epoch=old_epoch
+        )
+
+        def pull_requests(branch: str) -> int:
+            raise RuntimeError("gh is unavailable")
+
+        report = collect_worktree_report(self.main, open_pull_requests=pull_requests)
+        entry = next(
+            item for item in report if item["path"] == "origin/ChaosEngine/flaky-gh-lookup"
+        )
+        self.assertEqual(entry["state"], "orphaned")
+        self.assertIsNone(entry["open_pull_requests"])
+
+        advisory = next(
+            item for item in format_advisories(report) if "flaky-gh-lookup" in item
+        )
+        self.assertIn("not checked", advisory)
+
     def test_orphaned_branch_advisory_does_not_claim_ahead_count_as_proof(self):
         # The issue's own correctness point, in bold: this repo squash-merges,
         # so a landed branch still shows commits ahead of main. The advisory


### PR DESCRIPTION
## Summary

Items 1 and 2 of #4450 already landed (#4470 re-landed the orphaned memory
object; five of six stale remote branches were deleted). This PR does item
3, the remaining ask: a guard for the gap the issue names -- a branch
pushed to `origin` with no PR and no activity for N days is invisible to
`scripts/ci/worktree_hygiene.py` (local worktrees only) and to its
`--check-pull-requests` mode (open PRs for branches that still have a
worktree, only).

`collect_worktree_report()` now also lists origin branches no linked
worktree references, once their last commit is at least 3 days old (a
grace period so a branch pushed minutes into a session is not flagged
before its author has had a chance to open a PR). A branch with a
confirmed open pull request is excluded -- it is already visible through
the normal review flow. When `gh` is absent or unauthenticated, the check
degrades to an honestly-caveated advisory instead of erroring or hanging,
reusing the exact `open_pull_requests` callback and try/except pattern
already proven safe for the existing worktree entries.

Per the issue's own bolded correctness point: the advisory text never
treats ahead-count as evidence of unlanded work (this repo squash-merges,
so landed work can still show commits ahead of `main`). It instead points
the reader at the content-diff method the issue's investigation actually
used -- diff the branch tip against `main` over the files it touched, then
ask whether anything still differing ever existed on `main`.

Both public functions (`collect_worktree_report`, used by
`validate_agent_setup.py`) keep their existing call signature backward
compatible -- new args are keyword-only with defaults.

## Findings from this pass

- **`shaft-skills-distribution-4350` is now safe to delete.** #4501 exists
  and fully documents (quotes verbatim) the one workflow step that branch
  uniquely covered. The branch's remaining value was that documentation;
  now that it lives in a tracked issue, the branch itself carries nothing
  irreplaceable. Not deleted here per instructions -- reporting only.
- **The `pr-gate.yml` run-list gap did not reproduce.** `tests/scripts/test_worktree_hygiene.py` is present in both the path filter (line 107) and the `Run agent harness unit tests` run list (line 226) on current `main` -- it was added by #4497. No action needed; not filed as an issue since the premise no longer holds.

## Test plan

- [x] RED first: `test_orphaned_remote_branch_with_no_worktree_is_reported` written and run before any production code changed -- confirmed a genuine assertion failure (`[]` had nothing naming the branch), not an ImportError/setup error.
- [x] `py -3 -m unittest tests.scripts.test_worktree_hygiene tests.scripts.test_validate_agent_setup tests.scripts.test_guard_lifecycle` -- 75 tests, all green.
- [x] `py -3 scripts/ci/validate_agent_setup.py --skip-external` -- exit 0, advisory-only.
- [x] `py -3 scripts/ci/worktree_hygiene.py` and `--check-pull-requests` -- both run against this real repo; both surface `origin/ChaosEngine/shaft-skills-distribution-4350`, exactly the branch #4450's own investigation flagged as needing a human decision.
- [x] Manually confirmed graceful degradation with `gh` unavailable (`shutil.which` patched to `None`): no exception, no hang, reports the branch with a "not checked" caveat instead of asserting anything false.

Closes #4450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uBrtSmdU6Xvwmkyajqkuy