### PR TITLE
Fix #4496: enforce the ChaosEngine/* branch prefix in check_r9_worktree_add

### DIFF
--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -22,14 +22,19 @@
 #      `stash pop` can pop and DROP an unrelated entry from another
 #      session/worktree (issue #4130). Read-only `git stash list` / `git
 #      stash show` stay allowed.
-#   R9 `git worktree add` guardrails (issue #4126): (B1) deny when the Bash
-#      tool's worktree path argument contains backslashes -- Git Bash/MSYS
+#   R9 `git worktree add` guardrails (issue #4126, #4496): (B1) deny when the
+#      Bash tool's worktree path argument contains backslashes -- Git Bash/MSYS
 #      consumes each backslash as an escape and the path silently collapses
 #      into one garbage segment at the repo root, exit 0. PowerShell is
 #      unaffected, so this check is Bash-only. (B2) deny any
 #      `git worktree add` missing `-c core.longpaths=true`, which otherwise
 #      aborts with `Filename too long` checking out existing over-long
-#      .memory/** paths. Both fail open on anything not confidently parsed.
+#      .memory/** paths. (B3) deny `-b`/`-B` with a branch name that does not
+#      start with `ChaosEngine/` -- the entrypoint's Task isolation section
+#      requires it, and tools that key off the prefix (PR watchers, worktree
+#      cleanup) go blind to a non-conforming branch. `--detach` and checking
+#      out an existing branch (no `-b`/`-B`) create no new branch, so neither
+#      is checked. All three fail open on anything not confidently parsed.
 #   R10 Deny `git add`/`git stage`/`git commit` when a changed file is almost
 #      entirely NUL bytes (issue #4437). After an unclean shutdown the
 #      filesystem can record an allocation without ever flushing the data
@@ -610,6 +615,28 @@ def _worktree_add_path(rest_after_add: list[str]) -> str | None:
     return None
 
 
+_CHAOS_ENGINE_BRANCH_PREFIX = "ChaosEngine/"
+
+
+def _worktree_add_branch(rest_after_add: list[str]) -> str | None:
+    """Return the `-b`/`-B` branch name in `rest_after_add`, or None if absent.
+
+    None also covers `--detach` and checking out an existing branch (no
+    `-b`/`-B` at all) -- neither creates a new branch, so neither is subject
+    to the ChaosEngine/* naming requirement.
+    """
+    index = 0
+    while index < len(rest_after_add):
+        token = rest_after_add[index]
+        if token in ("-b", "-B"):
+            return rest_after_add[index + 1] if index + 1 < len(rest_after_add) else None
+        if token in _GIT_WORKTREE_ADD_FLAGS_WITH_ARG:
+            index += 2
+            continue
+        index += 1
+    return None
+
+
 def check_r9_worktree_add(command: str, tool_name: str) -> str | None:
     """Return a block reason for an unsafe `git worktree add` invocation, or None."""
     for segment in _git_segments(command):
@@ -633,6 +660,18 @@ def check_r9_worktree_add(command: str, tool_name: str) -> str | None:
                     "#4126). Use forward slashes instead, e.g. "
                     f"'{path.replace(chr(92), '/')}'."
                 )
+
+        branch = _worktree_add_branch(rest_after_add)
+        if branch is not None and not branch.startswith(_CHAOS_ENGINE_BRANCH_PREFIX):
+            return (
+                "R9 (git worktree add non-conforming branch prefix): the "
+                "entrypoint's Task isolation section requires every session "
+                f"branch to be `{_CHAOS_ENGINE_BRANCH_PREFIX}*` off a fresh "
+                f"`origin/main` -- '{branch}' does not start with that prefix. "
+                "Tools that key off the prefix (PR watchers, worktree "
+                "cleanup) go blind to work on a non-conforming branch (issue "
+                f"#4496). Use `{_CHAOS_ENGINE_BRANCH_PREFIX}<slug>` instead."
+            )
 
         if not _LONGPATHS_RE.search(segment):
             match = re.search(r"\bworktree\b", segment, re.IGNORECASE)
@@ -1672,6 +1711,53 @@ def run_r9_worktree_self_test() -> int:
         'git commit -m "ran git worktree add worktrees\\w4067 earlier"', "Bash"
     )
     check("git worktree add mentioned in commit message prose is not a real command", reason is None)
+
+    # --- B3: non-ChaosEngine/* branch via -b is denied (issue #4496) ---
+    reason = check_r9_worktree_add(
+        "git -c core.longpaths=true worktree add worktrees/x "
+        "-b not-chaos-engine/whatever origin/main",
+        "Bash",
+    )
+    check("non-ChaosEngine/* branch via -b is denied", reason is not None)
+    check(
+        "branch-prefix denial names ChaosEngine/",
+        reason is not None and "ChaosEngine/" in reason,
+    )
+
+    # --- B3 also applies to -B (force-create/reset) and to PowerShell ---
+    reason = check_r9_worktree_add(
+        "git -c core.longpaths=true worktree add worktrees/x "
+        "-B not-chaos-engine/whatever origin/main",
+        "PowerShell",
+    )
+    check("non-ChaosEngine/* branch via -B is denied on PowerShell too", reason is not None)
+
+    # --- --detach (no branch created at all) stays allowed ---
+    reason = check_r9_worktree_add(
+        "git -c core.longpaths=true worktree add worktrees/probe --detach origin/main",
+        "Bash",
+    )
+    check("git worktree add --detach (no branch created) stays allowed", reason is None)
+
+    # --- Checking out an existing branch (no -b/-B) stays allowed ---
+    reason = check_r9_worktree_add(
+        "git -c core.longpaths=true worktree add worktrees/x not-chaos-engine/existing",
+        "Bash",
+    )
+    check(
+        "worktree add checking out an existing branch (no -b/-B) stays allowed",
+        reason is None,
+    )
+
+    # --- A non-conforming branch mentioned in commit-message prose is not a real command ---
+    reason = check_r9_worktree_add(
+        'git commit -m "use git worktree add x -b not-chaos-engine/y next time"',
+        "Bash",
+    )
+    check(
+        "git worktree add -b mentioned in commit message prose is not a real command",
+        reason is None,
+    )
 
     total_checks = len(failures)
     print(f"\nR9 worktree-add self-test summary: {total_checks} failed.")


### PR DESCRIPTION
Closes #4496

## Owner's constraint decision

The owner decided on the issue (2026-08-04): the `ChaosEngine/*` branch
prefix required by the entrypoint's Task isolation section is a **real
constraint**, not a preference. Per that decision, this PR implements the
issue's own constraint answer verbatim: extend `check_r9_worktree_add` with
one predicate, rather than add a new mechanism or a CI check that fails a
PR after the branch (and its work) already exist -- renaming it would need
a force-push, which is blocked in this repository.

## Change

`scripts/agents/guard.py`: `check_r9_worktree_add` gains predicate B3 --
a `git worktree add ... -b <name>` (or `-B`) is rejected when `<name>` does
not start with `ChaosEngine/`. `--detach` and checking out an existing
branch (no `-b`/`-B` at all) create no new branch, so neither is checked.

## Mutation result (issue's proof requirement)

Ran the issue's cited attempt directly against the guard:

```
$ py -3 -c "... check_r9_worktree_add('git -c core.longpaths=true worktree add worktrees/whatever -b not-chaos-engine/whatever origin/main', 'Bash') ..."
BLOCKED
R9 (git worktree add non-conforming branch prefix): the entrypoint's Task
isolation section requires every session branch to be `ChaosEngine/*` off a
fresh `origin/main` -- 'not-chaos-engine/whatever' does not start with that
prefix. Tools that key off the prefix (PR watchers, worktree cleanup) go
blind to work on a non-conforming branch. Use `ChaosEngine/<slug>` instead.
```

Then deleted the predicate call site with a small Python mutation script
(avoids the CRLF/PowerShell-regex trap that can silently no-op a mutation on
this file) and reran `--self-test`:

```
R9 worktree-add self-test summary: 3 failed.
Failed cases: non-ChaosEngine/* branch via -b is denied, branch-prefix
denial names ChaosEngine/, non-ChaosEngine/* branch via -B is denied on
PowerShell too
```

`git diff --stat` and a `grep` for the removed call site confirmed the
mutation actually landed before recording that result. Reverted with
`git checkout -- scripts/agents/guard.py` and reran `--self-test` to
confirm green again (93/93, R9/R10/R11 all 0 failed).

## Checks run

- `py -3 scripts/agents/guard.py --self-test` -- command self-test 93/93
  passed; R9 worktree-add 0 failed; R10 NUL-corruption 0 failed; R11
  memory-write 0 failed.
- `py -3 -m unittest tests.scripts.test_guard_memory_worktree
  tests.scripts.test_guard_nul_corruption tests.scripts.test_guard_lifecycle`
  -- 72 tests, OK.
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` -- "Agent setup
  is valid: 140922 guidance bytes, 339 memory objects.", exit 0.

## Scope

`scripts/agents/guard.py` only. No new test-harness module, no CI workflow
change, no wording change to the entrypoint.
