### PR TITLE
Require adapted delegate retrieval and learning routes

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -216,8 +216,8 @@ file is added, moved or deleted, which is the only way a map stays true.
 
 | Host | Files |
 | --- | --- |
-| Codex | `AGENTS.md`; `.codex/config.toml`; `.codex/hooks.json`; roles `.codex/agents/chaos-engine.toml`, `.codex/agents/coder.toml`, `.codex/agents/reviewer.toml`, `.codex/agents/tester.toml` |
-| Claude | `CLAUDE.md`; `.claude/settings.json`; `.mcp.json`; redirects `.claude/skills/act-as-mohab/SKILL.md`, `.claude/skills/consult-first/SKILL.md`, `.claude/skills/retrieve-first/SKILL.md`; roles `.claude/agents/chaos-engine.md`, `.claude/agents/coder.md`, `.claude/agents/reviewer.md`, `.claude/agents/tester.md` |
+| Codex | `AGENTS.md`; `.codex/config.toml`; `.codex/hooks.json`; roles `.codex/agents/chaos-engine.toml`, `.codex/agents/coder.toml`, `.codex/agents/helper.toml`, `.codex/agents/reviewer.toml`, `.codex/agents/tester.toml` |
+| Claude | `CLAUDE.md`; `.claude/settings.json`; `.mcp.json`; redirects `.claude/skills/act-as-mohab/SKILL.md`, `.claude/skills/consult-first/SKILL.md`, `.claude/skills/retrieve-first/SKILL.md`; roles `.claude/agents/chaos-engine.md`, `.claude/agents/coder.md`, `.claude/agents/helper.md`, `.claude/agents/reviewer.md`, `.claude/agents/tester.md` |
 | Copilot | `.github/copilot-instructions.md`; scope files `.github/instructions/framework-source.instructions.md`, `.github/instructions/java-tests.instructions.md`; the redirect pack indexed by `.github/skills/README.md` |
 | Your own configuration | `.claude/user-harness/CLAUDE.md`, `.claude/user-harness/README.md`, `.claude/user-harness/settings.json` |
 

--- a/.agents/skills/act-as-mohab/SKILL.md
+++ b/.agents/skills/act-as-mohab/SKILL.md
@@ -49,6 +49,9 @@ the blast radius grows, or the user adds scope.
 Retrieval depth reads off the same answer. Load
 [retrieve-first](../retrieve-first/SKILL.md) before broad manual discovery on
 any row past the first, and at completion to keep the stores from drifting.
+When this entrypoint was loaded through a role adapter, load
+[retrieve-first](../retrieve-first/SKILL.md) before task-specific discovery,
+including one-file reversible work.
 
 ## Red flags
 

--- a/.agents/skills/act-as-mohab/references/delegation.md
+++ b/.agents/skills/act-as-mohab/references/delegation.md
@@ -24,9 +24,8 @@ before using it.
 ### Mechanical model
 
 Spec-exact repetitive edits, inventory, formatting, deterministic
-transformation, and log or result triage. It has no role adapter of its own, so
-the mechanical helper role in [roles](roles.md), which defines its limits,
-travels in the dispatch prompt.
+transformation, and log or result triage. The `helper` adapters carry the
+mechanical-helper role from [roles](roles.md) to both subagent hosts.
 
 ## Main-thread duties
 

--- a/.agents/skills/retrieve-first/SKILL.md
+++ b/.agents/skills/retrieve-first/SKILL.md
@@ -19,7 +19,7 @@ depth off that answer rather than judging it twice.
 
 | Triage result | Retrieve |
 | --- | --- |
-| One file, reversible | Nothing. The standing constraints arrived injected before your first tool call. |
+| One file, reversible | Main thread: nothing; SessionStart injected standing constraints. Delegates: use `memory search` before discovery, because SessionStart does not reach them. |
 | One module, reversible | `memory search "<subsystem>"`. Add MemPalace when the change touches history you were not present for. |
 | Public contract, many callers, or hard to reverse | All three, then verify every hit against the live file. |
 

--- a/.claude/agents/helper.md
+++ b/.claude/agents/helper.md
@@ -1,0 +1,7 @@
+---
+name: helper
+description: Use for deterministic, reversible, spec-exact work only.
+---
+
+Load [act-as-mohab](../../.agents/skills/act-as-mohab/SKILL.md), then follow
+the [mechanical helper role](../../.agents/skills/act-as-mohab/references/roles.md#mechanical-helper).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -70,6 +70,21 @@
           }
         ]
       }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3",
+            "args": [
+              "-c",
+              "import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')"
+            ],
+            "timeout": 30
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Task|Agent|Bash|PowerShell|shell_command|Write|Edit|NotebookEdit|mcp__shaft-memory__(remember_memory|save_memory_patch)",
+        "matcher": "Task|Agent|Bash|PowerShell|shell_command|Write|Edit|NotebookEdit|mcp__shaft-memory__(remember_memory|save_memory_patch)|mcp__mempalace__.*",
         "hooks": [
           {
             "type": "command",

--- a/.codex/agents/helper.toml
+++ b/.codex/agents/helper.toml
@@ -1,0 +1,7 @@
+# Managed by the SHAFT user harness.
+name = "helper"
+description = "Use for deterministic, reversible, spec-exact work only."
+developer_instructions = """
+Load [act-as-mohab](../../.agents/skills/act-as-mohab/SKILL.md), then follow
+the [mechanical helper role](../../.agents/skills/act-as-mohab/references/roles.md#mechanical-helper).
+"""

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -37,6 +37,18 @@
           }
         ]
       }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
+            "commandWindows": "py -3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Task|Agent|Bash|PowerShell|shell_command|Write|Edit|NotebookEdit|mcp__shaft-memory__(remember_memory|save_memory_patch)",
+        "matcher": "Task|Agent|Bash|PowerShell|shell_command|Write|Edit|NotebookEdit|mcp__shaft-memory__(remember_memory|save_memory_patch)|mcp__mempalace__.*",
         "hooks": [
           {
             "type": "command",

--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -1003,3 +1003,4 @@
 {"actor":"agent","event":"memory.created","id":"decision.when-a-matcher-strips-a-token-ask-what-that-token-asserted-before-widening-anything-else-on-the-same-premise","timestamp":"2026-08-05T15:02:18+03:00"}
 {"actor":"agent","event":"memory.deleted","id":"decision.when-a-matcher-strips-a-token-ask-what-that-token-asserted-before-widening-anything-else-on-the-same-premise","timestamp":"2026-08-05T15:04:08+03:00"}
 {"actor":"agent","event":"memory.created","id":"decision.a-flag-a-matcher-skips-is-an-assertion-not-noise-compare-its-value-before-widening-the-rule","timestamp":"2026-08-05T15:04:08+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.historical-dispatch-audits-must-count-the-structured-transcript-not-prose-summaries","timestamp":"2026-08-05T19:39:59+03:00"}

--- a/.memory/memory/gotchas/historical-dispatch-audits-must-count-the-structured-transcript-not-prose-summaries.json
+++ b/.memory/memory/gotchas/historical-dispatch-audits-must-count-the-structured-transcript-not-prose-summaries.json
@@ -1,0 +1,34 @@
+{
+  "body_path": "memory/gotchas/historical-dispatch-audits-must-count-the-structured-transcript-not-prose-summaries.md",
+  "content_hash": "sha256:087cecc1a5e046f44a1714d474c0a951c90d546fdbee87e887c97cee36ac23fc",
+  "created_at": "2026-08-05T19:39:59+03:00",
+  "evidence": [],
+  "facets": {
+    "applies_to": [
+      "scripts/agents/guard.py",
+      "tests/scripts/test_guard_lifecycle.py"
+    ],
+    "category": "gotcha"
+  },
+  "id": "gotcha.historical-dispatch-audits-must-count-the-structured-transcript-not-prose-summaries",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Implement #4570 delegate preflight"
+  },
+  "status": "active",
+  "tags": [
+    "harness",
+    "guard",
+    "issue-4570",
+    "audit"
+  ],
+  "title": "Historical dispatch audits must count the structured transcript, not prose summaries",
+  "type": "gotcha",
+  "updated_at": "2026-08-05T19:39:59+03:00"
+}

--- a/.memory/memory/gotchas/historical-dispatch-audits-must-count-the-structured-transcript-not-prose-summaries.md
+++ b/.memory/memory/gotchas/historical-dispatch-audits-must-count-the-structured-transcript-not-prose-summaries.md
@@ -1,0 +1,1 @@
+#4570's issue prose claimed eight unadapted general-purpose dispatches, but the source transcript contains 18 calls: nine adapted (six coder and three reviewer) and nine general-purpose. The portable A12 fixture must replay those exact events and treat the unadapted entries as negative controls; otherwise the regression validates the wrong premise.

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1354,6 +1354,7 @@ SUBPROCESS_TIMEOUT = 4
 # only unbounded loop is R13's, which queries once per branch name given.
 HOOK_BUDGET_SECONDS = 8.0
 _hook_deadline: float | None = None
+PREFLIGHT_MAX_BYTES = 8192
 
 
 def start_hook_budget(seconds: float = HOOK_BUDGET_SECONDS) -> None:
@@ -2460,6 +2461,67 @@ def ledger_events(hook_input: dict) -> list[str]:
     return events
 
 
+def _mempalace_wake_up(working_directory: object) -> str | None:
+    """Return bounded MemPalace context, or None when the optional tool cannot answer."""
+    if not working_directory:
+        return None
+    try:
+        completed = subprocess.run(  # nosec B603 - fixed read-only local command.
+            ["mempalace", "wake-up"],
+            cwd=str(working_directory),
+            capture_output=True,
+            text=True,
+            timeout=_subprocess_timeout(),
+            check=False,
+        )
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0 or not completed.stdout.strip():
+        return None
+    return completed.stdout.strip()
+
+
+def _bounded_preflight(context: list[str]) -> str:
+    """Keep injected retrieval below the cross-host byte ceiling."""
+    joined = "\n".join(context)
+    encoded = joined.encode("utf-8")
+    if len(encoded) <= PREFLIGHT_MAX_BYTES:
+        return joined
+    return encoded[:PREFLIGHT_MAX_BYTES].decode("utf-8", errors="ignore")
+
+
+def _memory_do_not_lines(working_directory: object) -> str | None:
+    """Return a few directly actionable native-Memory warnings, if present."""
+    if not working_directory:
+        return None
+    directory = os.path.join(str(working_directory), ".memory", "memory", "gotchas")
+    if not os.path.isdir(directory):
+        return None
+    try:
+        names = sorted(os.listdir(directory))
+    except OSError:
+        return None
+    reminders: list[str] = []
+    for name in names:
+        if not name.endswith(".md"):
+            continue
+        try:
+            with open(os.path.join(directory, name), encoding="utf-8") as handle:
+                lines = handle.read(2048).splitlines()
+        except (OSError, UnicodeError):
+            continue
+        for line in lines:
+            compact = " ".join(line.split())
+            if re.search(r"\bdo not\b", compact, re.IGNORECASE):
+                reminders.append(compact[:512])
+                break
+        if len(reminders) == 3:
+            break
+    if not reminders:
+        return None
+    return "Native Memory do-not reminders:\n" + "\n".join(f"- {line}" for line in reminders)
+
+
 def _standing_constraints(working_directory: object) -> str | None:
     """Return the titles of every stored constraint, as one injectable block.
 
@@ -2489,8 +2551,12 @@ def _standing_constraints(working_directory: object) -> str | None:
     directory = os.path.join(str(working_directory), ".memory", "memory", "constraints")
     if not os.path.isdir(directory):
         return None
+    try:
+        names = sorted(os.listdir(directory))
+    except OSError:
+        return None
     titles: list[str] = []
-    for name in sorted(os.listdir(directory)):
+    for name in names:
         if not name.endswith(".json"):
             continue
         try:
@@ -2522,6 +2588,12 @@ def run_session_start(hook_input: dict) -> int:
     constraints = _standing_constraints(_hook_working_directory(hook_input))
     if constraints:
         context.append(constraints)
+    reminders = _memory_do_not_lines(_hook_working_directory(hook_input))
+    if reminders:
+        context.append(reminders)
+    wake_up = _mempalace_wake_up(_hook_working_directory(hook_input))
+    if wake_up:
+        context.append(wake_up)
     report = _worktree_report(_hook_working_directory(hook_input))
     if report is None:
         context.append("Worktree hygiene could not be verified; inspect it before cleanup.")
@@ -2535,7 +2607,7 @@ def run_session_start(hook_input: dict) -> int:
             {
                 "hookSpecificOutput": {
                     "hookEventName": "SessionStart",
-                    "additionalContext": "\n".join(context),
+                    "additionalContext": _bounded_preflight(context),
                 }
             }
         )

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1781,6 +1781,33 @@ REVIEW_VERDICTS = frozenset({"APPROVED", "CHANGES_REQUESTED"})
 
 DISPATCH_TOOLS = frozenset({"Task", "Agent"})
 REVIEWER_SUBAGENT_TYPES = frozenset({"reviewer"})
+ADAPTED_SUBAGENT_TYPES = frozenset({"chaos-engine", "coder", "helper", "reviewer", "tester"})
+
+
+def check_r22_dispatch_adapter(hook_input: dict, tool_name: str) -> str | None:
+    """Refuse a dispatch whose type has no host-delivered role adapter.
+
+    R22 owns only the shape of a new delegate. It runs before R11, R12, R15,
+    R17, and R19 can apply to the delegate's own tool calls. Choosing any
+    listed type delivers the entrypoint; after a commit, the learning-loop
+    arming clause remains satisfiable by a learning write or its explicit
+    escape, then R15 review and R17 arming have their existing remedies. This
+    does not assert that an agent obeyed the delivered text.
+    """
+    if tool_name not in DISPATCH_TOOLS:
+        return None
+    tool_input = hook_input.get("tool_input")
+    if not isinstance(tool_input, dict):
+        subagent = ""
+    else:
+        subagent = tool_input.get("subagent_type") or tool_input.get("subagent") or ""
+    if isinstance(subagent, str) and subagent.strip().lower() in ADAPTED_SUBAGENT_TYPES:
+        return None
+    legal = " | ".join(sorted(ADAPTED_SUBAGENT_TYPES))
+    return (
+        "R22 blocked: this dispatch has no role adapter, so it cannot receive the "
+        "mandatory entrypoint. Re-dispatch with subagent_type: " + legal + "."
+    )
 
 
 _GH_GLOBAL_FLAGS_WITH_ARG = frozenset({"-R", "--repo"})
@@ -2105,6 +2132,11 @@ def check_r19_fresh_base(hook_input: dict, tool_name: str) -> str | None:
 
 def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
     tool_name = hook_input.get("tool_name", "")
+
+    reason = check_r22_dispatch_adapter(hook_input, tool_name)
+    if reason is not None:
+        _print_deny(reason, host)
+        return 0
 
     # Observed, not judged, and first: a reviewer dispatch is not a call this
     # hook has any reason to refuse, so recording it must not sit behind a
@@ -3154,6 +3186,7 @@ _SELF_TEST_COVERAGE: dict[str, str] = {
     "check_r19_fresh_base": "run_required_action_self_test",
     "check_r20_user_harness_drift": "run_required_action_self_test",
     "check_r21_run_state_not_recorded": "run_required_action_self_test",
+    "check_r22_dispatch_adapter": "run_required_action_self_test",
 }
 
 
@@ -3243,6 +3276,20 @@ def run_required_action_self_test() -> int:
             failures.append(description)
 
     write = {"tool_input": {"file_path": "shaft-engine/src/main/java/A.java"}}
+
+    # R22: only a host adapter can deliver the mandatory entrypoint to a delegate.
+    check(
+        "R22 blocks a dispatch with no host role adapter",
+        check_r22_dispatch_adapter(
+            {"tool_input": {"subagent_type": "general-purpose"}}, "Task"
+        )
+        is not None,
+    )
+    check(
+        "R22 allows a dispatch with a host role adapter",
+        check_r22_dispatch_adapter({"tool_input": {"subagent_type": "helper"}}, "Task")
+        is None,
+    )
 
     # R12: a production write needs an observed test run this session.
     check(

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -4012,7 +4012,7 @@ def main(argv: list[str]) -> int:
     event = hook_input.get("hook_event_name") or "PreToolUse"
     if event == "SessionStart":
         return run_session_start(hook_input)
-    if event == "Stop":
+    if event in {"Stop", "SubagentStop"}:
         return run_stop(hook_input)
     if event == "PreToolUse":
         return run_pretooluse(hook_input, hook_host(raw_hook_input))

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1297,6 +1297,29 @@ def _extract_command(hook_input: dict) -> str:
     return ""
 
 
+def _is_learning_write_command(command: str) -> bool:
+    """True for the CLI commands that persist a learning."""
+    for segment in _command_segments(_sanitize_for_command_head(command)):
+        memory = _tokens_after_head(segment, frozenset({"memory"}))
+        if memory and memory[:1] == ["remember"]:
+            return True
+        palace = _tokens_after_head(segment, frozenset({"mempalace"}))
+        if palace and palace[:1] in (["mine"], ["sweep"]):
+            return True
+    return False
+
+
+def _is_mempalace_write(tool_name: str, tool_input: object) -> bool:
+    """True for a mutating MemPalace MCP call, never its default dry run."""
+    if tool_name not in _MEMPALACE_WRITE_TOOLS:
+        return False
+    if tool_name == "mcp__mempalace__mempalace_delete_by_source":
+        return isinstance(tool_input, dict) and tool_input.get("dry_run") is False
+    if tool_name == "mcp__mempalace__mempalace_sync":
+        return isinstance(tool_input, dict) and tool_input.get("apply") is True
+    return True
+
+
 def _hook_working_directory(hook_input: dict) -> str | None:
     """Directory the guarded command will run in, or None when unknown."""
     # Hosts that report the session directory win over the hook process's own
@@ -1337,6 +1360,27 @@ _TEST_RUNNER = frozenset({"py", "python", "python3", "pytest", "mvn", "mvnw"})
 # run. `-Dtest=` is a prefix rather than a token, so it is checked separately.
 _TEST_TOKENS = frozenset({"unittest", "pytest", "surefire", "test", "verify"})
 _WRITE_TOOLS = frozenset({"Write", "Edit", "NotebookEdit"})
+_NATIVE_MEMORY_WRITE_TOOLS = frozenset(
+    {"mcp__shaft-memory__remember_memory", "mcp__shaft-memory__save_memory_patch"}
+)
+_MEMPALACE_WRITE_TOOLS = frozenset(
+    {
+        "mcp__mempalace__mempalace_add_drawer",
+        "mcp__mempalace__mempalace_checkpoint",
+        "mcp__mempalace__mempalace_create_tunnel",
+        "mcp__mempalace__mempalace_delete_by_source",
+        "mcp__mempalace__mempalace_delete_drawer",
+        "mcp__mempalace__mempalace_delete_hallway",
+        "mcp__mempalace__mempalace_delete_tunnel",
+        "mcp__mempalace__mempalace_diary_write",
+        "mcp__mempalace__mempalace_kg_add",
+        "mcp__mempalace__mempalace_kg_invalidate",
+        "mcp__mempalace__mempalace_kg_supersede",
+        "mcp__mempalace__mempalace_mine",
+        "mcp__mempalace__mempalace_sync",
+        "mcp__mempalace__mempalace_update_drawer",
+    }
+)
 # Ceiling for any single helper query, well inside the 10s PreToolUse timeout
 # in .claude/settings.json and .codex/hooks.json. It was 8s, which left no
 # margin: one slow `git` or `gh` on a contended machine and the hook is killed
@@ -2167,7 +2211,9 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
     # R16 reads these. Recorded here because a later hook invocation is a
     # fresh process: if the event is not written down as it happens, the
     # Stop hook has no way to know it ever did.
-    if tool_name.startswith("mcp__shaft-memory__"):
+    if tool_name in _NATIVE_MEMORY_WRITE_TOOLS or _is_mempalace_write(
+        tool_name, hook_input.get("tool_input")
+    ):
         ledger_record(hook_input, "memory-write")
     if reason is not None:
         _print_deny(reason, host)
@@ -2193,6 +2239,8 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
         if reason is not None:
             _print_deny(reason, host)
             return 0
+        if _is_learning_write_command(command):
+            ledger_record(hook_input, "memory-write")
         # Observed, not judged. R12 reads this ledger; recording here is the
         # only place a test run is visible, since a later hook invocation is a
         # fresh process with no memory of it.

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1309,6 +1309,29 @@ def _is_learning_write_command(command: str) -> bool:
     return False
 
 
+def _learning_none_event(command: str) -> str | None:
+    """Return a substantive `--learning-none` ledger event, if this is one."""
+    for segment in _command_segments(_sanitize_for_command_head(command)):
+        arguments = _tokens_after_head(segment, frozenset({"py", "python", "python3"}))
+        if not arguments:
+            continue
+        for index, argument in enumerate(arguments):
+            if not argument.replace("\\", "/").endswith("scripts/agents/guard.py"):
+                continue
+            remaining = arguments[index + 1 :]
+            if remaining[:1] != ["--learning-none"] or len(remaining) != 2:
+                continue
+            reason = remaining[1].strip()
+            if len(re.findall(r"[A-Za-z0-9]+", reason)) >= 3:
+                return f"learning-none:{reason}"
+    return None
+
+
+def _learning_route_recorded(hook_input: dict | None) -> bool:
+    events = ledger_events(hook_input or {})
+    return "memory-write" in events or any(event.startswith("learning-none:") for event in events)
+
+
 def _is_mempalace_write(tool_name: str, tool_input: object) -> bool:
     """True for a mutating MemPalace MCP call, never its default dry run."""
     if tool_name not in _MEMPALACE_WRITE_TOOLS:
@@ -1785,6 +1808,17 @@ def check_r15_review_before_arming(
         if not rest or rest[:2] != ["pr", "merge"]:
             continue
         arguments = rest[2:]
+        auto_merge = any(
+            argument == "--auto"
+            or (argument.lower().startswith("--auto=") and argument.lower()[7:] not in {"false", "0", "f"})
+            for argument in arguments
+        )
+        if auto_merge and "commit" in ledger_events(hook_input or {}) and not _learning_route_recorded(hook_input):
+            return (
+                "R15 blocked: this session committed work but recorded no learning route. "
+                "Write one learning to native Memory or MemPalace, or run `py -3 "
+                "scripts/agents/guard.py --learning-none \"<substantive reason>\"`."
+            )
         positional = [token for token in arguments if not token.startswith("-")]
         target = positional[0] if positional else None
         reviews = _independent_review_count(target)
@@ -2241,6 +2275,9 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
             return 0
         if _is_learning_write_command(command):
             ledger_record(hook_input, "memory-write")
+        learning_none = _learning_none_event(command)
+        if learning_none:
+            ledger_record(hook_input, learning_none)
         # Observed, not judged. R12 reads this ledger; recording here is the
         # only place a test run is visible, since a later hook invocation is a
         # fresh process with no memory of it.
@@ -2727,7 +2764,7 @@ def check_r16_learning_loop(hook_input: dict) -> str | None:
     events = ledger_events(hook_input)
     if "commit" not in events:
         return None  # a read-only session owes no learning
-    if "memory-write" in events:
+    if "memory-write" in events or any(event.startswith("learning-none:") for event in events):
         return None
     return (
         "Learning loop: this session committed work and routed no learning. Before "

--- a/tests/scripts/test_agent_harness_portability.py
+++ b/tests/scripts/test_agent_harness_portability.py
@@ -559,7 +559,7 @@ class AgentHarnessPortabilityTest(unittest.TestCase):
         codex_hooks = hook_groups(ROOT / ".codex/hooks.json")
         self.assertEqual(set(claude_hooks), set(codex_hooks))
         for hooks in (claude_hooks, codex_hooks):
-            self.assertEqual(set(hooks), {"PreToolUse", "SessionStart", "Stop"})
+            self.assertEqual(set(hooks), {"PreToolUse", "SessionStart", "Stop", "SubagentStop"})
             commands = {
                 handler["command"]
                 for groups in hooks.values()

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -119,7 +119,7 @@ BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 # from the boundary was invisible. Equality makes shrinking the boundary a
 # deliberate two-line edit that shows up in review, which is the only place the
 # question "why is the harness smaller today" gets asked.
-EXPECTED_ELEMENT_COUNT = 123
+EXPECTED_ELEMENT_COUNT = 125
 
 ATX_HEADING = re.compile(r"(?m)^#{1,6}\s+(.+?)\s*$")
 

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1007,6 +1007,12 @@ class HostParityTest(unittest.TestCase):
         codex = {path.stem for path in CODEX_AGENTS.glob("*.toml")}
         self.assertEqual(claude, codex, "role adapters differ between subagent hosts")
 
+    def test_mechanical_helper_has_a_host_adapter_on_both_subagent_hosts(self):
+        """A dispatch gate needs a legal mechanical role before it can refuse one."""
+        for path in (CLAUDE_AGENTS / "helper.md", CODEX_AGENTS / "helper.toml"):
+            with self.subTest(path=path):
+                self.assertTrue(path.is_file(), "mechanical-helper adapter is missing")
+
     def test_codex_role_adapters_use_the_documented_schema(self):
         tomllib = __import__("tomllib")
         headings = self.role_headings()

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1022,6 +1022,24 @@ class HostParityTest(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertTrue(path.is_file(), "mechanical-helper adapter is missing")
 
+    def test_role_adapters_make_first_row_retrieval_mandatory_for_delegates(self):
+        """#4570 A5: a delegate misses SessionStart, so its adapter path owns retrieval."""
+        clause = (
+            "When this entrypoint was loaded through a role adapter, load "
+            "[retrieve-first](../retrieve-first/SKILL.md) before task-specific discovery, "
+            "including one-file reversible work."
+        )
+        entrypoint = ENTRYPOINT.read_text(encoding="utf-8")
+        self.assertIn(re.sub(r"\s+", " ", clause), re.sub(r"\s+", " ", entrypoint))
+        for adapter in sorted(CLAUDE_AGENTS.glob("*.md")):
+            with self.subTest(adapter=adapter):
+                self.assertIn("act-as-mohab/SKILL.md", adapter.read_text(encoding="utf-8"))
+        tomllib = __import__("tomllib")
+        for adapter in sorted(CODEX_AGENTS.glob("*.toml")):
+            with self.subTest(adapter=adapter):
+                instructions = tomllib.loads(adapter.read_text(encoding="utf-8"))["developer_instructions"]
+                self.assertIn("act-as-mohab/SKILL.md", instructions)
+
     def test_codex_role_adapters_use_the_documented_schema(self):
         tomllib = __import__("tomllib")
         headings = self.role_headings()

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -251,9 +251,18 @@ REQUIRED_ACTION_REGISTRY: tuple[dict, ...] = (
     },
     {
         "law": None,
-        "rule": "query the stores before broad discovery",
+        "rule": "main thread receives native-Memory preflight before broad discovery",
         "status": "performed",
         "mechanism": "_standing_constraints",
+    },
+    {
+        "law": None,
+        "rule": "delegates query the stores before broad discovery",
+        "status": "prose-only",
+        "reason": (
+            "SessionStart belongs to the main thread. Role adapters deliver the entrypoint, "
+            "but a hook cannot observe whether a delegate used the retrieved context."
+        ),
     },
     {
         "law": None,

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1903,6 +1903,49 @@ class ObservedReviewDispatchTest(unittest.TestCase):
             inspect.getsource(guard._unarmed_reviewed_pull_request),
         )
 
+
+class DispatchAdapterGateTest(unittest.TestCase):
+    """R22 refuses dispatches that cannot receive a role adapter (#4570 A2)."""
+
+    @staticmethod
+    def payload(subagent: object) -> dict:
+        return {
+            "tool_name": "Task",
+            "tool_input": {"subagent_type": subagent},
+            "session_id": "r22",
+            "cwd": ".",
+        }
+
+    def test_run_pretooluse_denies_an_unadapted_dispatch(self):
+        """The hook path, not merely a helper, must refuse general-purpose."""
+        output = io.StringIO()
+        with patch("scripts.agents.guard.ledger_record"):
+            with redirect_stdout(output):
+                self.assertEqual(guard.run_pretooluse(self.payload("general-purpose")), 0)
+        self.assertIn("R22 blocked", output.getvalue())
+
+    def test_a_denied_dispatch_is_not_recorded_as_a_delegate(self):
+        events: list[str] = []
+        with patch(
+            "scripts.agents.guard.ledger_record", side_effect=lambda _payload, event: events.append(event)
+        ):
+            guard.run_pretooluse(self.payload("general-purpose"))
+        self.assertNotIn("delegate-dispatch", events)
+
+    def test_run_pretooluse_allows_every_adapted_dispatch(self):
+        for subagent in ("coder", "reviewer", "tester", "helper", "chaos-engine"):
+            with self.subTest(subagent=subagent):
+                output = io.StringIO()
+                with patch("scripts.agents.guard.ledger_record"):
+                    with redirect_stdout(output):
+                        self.assertEqual(guard.run_pretooluse(self.payload(subagent)), 0)
+                self.assertNotIn("R22 blocked", output.getvalue())
+
+    def test_r22_records_the_learning_loop_arming_escape(self):
+        source = inspect.getsource(guard.check_r22_dispatch_adapter).lower()
+        self.assertIn("learning-loop", source)
+        self.assertIn("escape", source)
+
     def test_the_recorder_is_wired_into_the_hook(self):
         """A recorder the hook never calls is the defect this batch keeps finding."""
         self.assertIn(

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -165,6 +165,7 @@ class GuardLifecycleTest(unittest.TestCase):
             "act-as-mohab", output["hookSpecificOutput"]["additionalContext"]
         )
 
+
     @patch("scripts.agents.guard._open_pull_request_count", return_value=1)
     @patch(
         "scripts.agents.guard._worktree_report",
@@ -321,6 +322,62 @@ class GuardLifecycleTest(unittest.TestCase):
         first, second = run.call_args_list
         self.assertLessEqual(first.kwargs["timeout"] + second.kwargs["timeout"], 20)
         self.assertNotIn("--check", second.args[0])
+
+
+class PreflightPackTest(unittest.TestCase):
+    """#4570 A4: bounded retrieval augments, but never blocks, SessionStart."""
+
+    def test_mempalace_wake_up_is_injected_and_the_full_pack_is_byte_capped(self):
+        self.assertTrue(hasattr(guard, "_mempalace_wake_up"), "A4 wake-up helper is missing")
+        with patch("scripts.agents.guard._worktree_report", return_value={"worktrees": [], "advisories": []}):
+            with patch("scripts.agents.guard._sync_advisory", return_value=None):
+                with patch(
+                    "scripts.agents.guard._mempalace_wake_up",
+                    return_value="MemPalace wake-up\n" + "x" * 9000,
+                ):
+                    stream = io.StringIO()
+                    with redirect_stdout(stream):
+                        self.assertEqual(guard.run_session_start({"cwd": "."}), 0)
+        context = json.loads(stream.getvalue())["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("MemPalace wake-up", context)
+        self.assertLessEqual(len(context.encode("utf-8")), 8192)
+
+    def test_mempalace_wake_up_fails_open_when_the_binary_cannot_run(self):
+        self.assertTrue(hasattr(guard, "_mempalace_wake_up"), "A4 wake-up helper is missing")
+        with patch("scripts.agents.guard.subprocess.run", side_effect=OSError):
+            self.assertIsNone(guard._mempalace_wake_up("."))
+
+    def test_mempalace_wake_up_fails_open_on_an_invalid_working_directory(self):
+        with patch("scripts.agents.guard.subprocess.run", side_effect=ValueError):
+            self.assertIsNone(guard._mempalace_wake_up("."))
+
+    def test_session_start_injects_native_memory_do_not_lines(self):
+        with tempfile.TemporaryDirectory() as directory:
+            constraints = os.path.join(directory, ".memory", "memory", "constraints")
+            gotchas = os.path.join(directory, ".memory", "memory", "gotchas")
+            os.makedirs(constraints)
+            os.makedirs(gotchas)
+            with open(os.path.join(constraints, "one.json"), "w", encoding="utf-8") as handle:
+                json.dump({"title": "A stored constraint"}, handle)
+            reminder = "Do not discard a squash-merged branch before diffing it."
+            with open(os.path.join(gotchas, "squash-merge.md"), "w", encoding="utf-8") as handle:
+                handle.write(reminder)
+            with patch("scripts.agents.guard._worktree_report", return_value={"worktrees": [], "advisories": []}):
+                with patch("scripts.agents.guard._sync_advisory", return_value=None):
+                    with patch("scripts.agents.guard._mempalace_wake_up", return_value=None):
+                        stream = io.StringIO()
+                        with redirect_stdout(stream):
+                            self.assertEqual(guard.run_session_start({"cwd": directory}), 0)
+        context = json.loads(stream.getvalue())["hookSpecificOutput"]["additionalContext"]
+        self.assertIn(reminder, context)
+
+    def test_native_memory_reminders_fail_open_when_the_store_cannot_be_read(self):
+        with patch("scripts.agents.guard.os.listdir", side_effect=OSError):
+            self.assertIsNone(guard._memory_do_not_lines("."))
+
+    def test_native_memory_constraints_fail_open_when_the_store_cannot_be_read(self):
+        with patch("scripts.agents.guard.os.listdir", side_effect=OSError):
+            self.assertIsNone(guard._standing_constraints("."))
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1052,6 +1052,29 @@ class LearningLoopStopGateTest(unittest.TestCase):
             self.assertEqual(output.getvalue().strip(), "")
 
 
+class DelegateStopHookTest(unittest.TestCase):
+    """A committed delegate must reach R16 through the host stop event (#4570 A8)."""
+
+    def setUp(self):
+        isolate_stop_rules(self, except_for=("check_r16_learning_loop",))
+
+    def test_subagent_stop_registration_reaches_r16(self):
+        root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        for name in (".claude/settings.json", ".codex/hooks.json"):
+            with self.subTest(host=name):
+                with open(os.path.join(root, name), encoding="utf-8") as handle:
+                    hooks = json.load(handle)["hooks"]
+                self.assertIn("SubagentStop", hooks)
+
+        output = io.StringIO()
+        payload = json.dumps({"hook_event_name": "SubagentStop", "session_id": "delegate"})
+        with patch("scripts.agents.guard.ledger_events", return_value=["commit"]):
+            with patch("sys.stdin", io.StringIO(payload)):
+                with redirect_stdout(output):
+                    self.assertEqual(guard.main([]), 0)
+        self.assertIn("Learning loop", output.getvalue())
+
+
 class UnarmedPullRequestStopGateTest(unittest.TestCase):
     """R17: opening a pull request does not end the duty; arming it is the duty.
 

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1075,6 +1075,63 @@ class DelegateStopHookTest(unittest.TestCase):
         self.assertIn("Learning loop", output.getvalue())
 
 
+class LearningWriteObservationTest(unittest.TestCase):
+    """R16 must observe every supported route that writes a learning (#4570 A9)."""
+
+    def events_after(
+        self, tool_name: str, command: str = "", tool_input: dict | None = None
+    ) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            with patch.dict(guard.os.environ, {"TMPDIR": directory, "TEMP": directory}):
+                payload = {
+                    "session_id": f"learning-{tool_name}-{command}",
+                    "cwd": directory,
+                    "tool_name": tool_name,
+                    "tool_input": {"command": command, **(tool_input or {})},
+                }
+                self.assertEqual(guard.run_pretooluse(payload), 0)
+                return guard.ledger_events(payload)
+
+    def test_mcp_and_cli_learning_writes_reach_the_ledger(self):
+        root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        for name in (".claude/settings.json", ".codex/hooks.json"):
+            with self.subTest(host=name):
+                with open(os.path.join(root, name), encoding="utf-8") as handle:
+                    matcher = json.load(handle)["hooks"]["PreToolUse"][0]["matcher"]
+                self.assertIn("mcp__mempalace__", matcher)
+
+        for tool_name, command in (
+            ("mcp__mempalace__mempalace_mine", ""),
+            ("Bash", "memory remember --stdin"),
+            ("PowerShell", "mempalace sweep"),
+        ):
+            with self.subTest(tool_name=tool_name, command=command):
+                self.assertIn("memory-write", self.events_after(tool_name, command))
+
+    def test_reading_or_mentioning_a_write_does_not_count(self):
+        self.assertNotIn("memory-write", self.events_after("mcp__shaft-memory__search_memory"))
+        self.assertNotIn(
+            "memory-write", self.events_after("mcp__mempalace__mempalace_get_aaak_spec")
+        )
+        self.assertNotIn(
+            "memory-write", self.events_after("mcp__mempalace__mempalace_delete_by_source")
+        )
+        self.assertNotIn("memory-write", self.events_after("mcp__mempalace__mempalace_sync"))
+        self.assertNotIn("memory-write", self.events_after("Bash", 'echo "memory remember"'))
+
+    def test_a_non_dry_memories_deletion_counts_as_a_write(self):
+        self.assertIn(
+            "memory-write",
+            self.events_after(
+                "mcp__mempalace__mempalace_delete_by_source", tool_input={"dry_run": False}
+            ),
+        )
+        self.assertIn(
+            "memory-write",
+            self.events_after("mcp__mempalace__mempalace_sync", tool_input={"apply": True}),
+        )
+
+
 class UnarmedPullRequestStopGateTest(unittest.TestCase):
     """R17: opening a pull request does not end the duty; arming it is the duty.
 

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -975,6 +975,37 @@ class ReviewBeforeArmingGateTest(unittest.TestCase):
                 guard.check_r15_review_before_arming("gh pr merge 4539 --auto --squash", "Bash")
             )
 
+    def test_arming_after_a_commit_requires_a_learning_route(self):
+        with patch("scripts.agents.guard._independent_review_count", return_value=1):
+            with patch("scripts.agents.guard.ledger_events", return_value=["commit"]):
+                reason = guard.check_r15_review_before_arming(
+                    "gh pr merge 4539 --auto --squash", "Bash", {"session_id": "s"}
+                )
+        self.assertIsNotNone(reason)
+        self.assertIn("learning", reason.lower())
+
+    def test_auto_equals_true_cannot_bypass_the_learning_route(self):
+        with patch("scripts.agents.guard._independent_review_count", return_value=1):
+            with patch("scripts.agents.guard.ledger_events", return_value=["commit"]):
+                for auto in ("true", "1", "t", "T"):
+                    with self.subTest(auto=auto):
+                        self.assertIsNotNone(
+                            guard.check_r15_review_before_arming(
+                                f"gh pr merge 4539 --auto={auto} --squash",
+                                "Bash",
+                                {"session_id": "s"},
+                            )
+                        )
+
+    def test_a_learning_write_keeps_reviewed_arming_available(self):
+        with patch("scripts.agents.guard._independent_review_count", return_value=1):
+            with patch("scripts.agents.guard.ledger_events", return_value=["commit", "memory-write"]):
+                self.assertIsNone(
+                    guard.check_r15_review_before_arming(
+                        "gh pr merge 4539 --auto --squash", "Bash", {"session_id": "s"}
+                    )
+                )
+
     def test_it_fails_open_when_the_review_state_cannot_be_answered(self):
         """No gh, no auth, no network: unknown is not zero (#4542)."""
         with patch("scripts.agents.guard._independent_review_count", return_value=None):
@@ -1130,6 +1161,36 @@ class LearningWriteObservationTest(unittest.TestCase):
             "memory-write",
             self.events_after("mcp__mempalace__mempalace_sync", tool_input={"apply": True}),
         )
+
+
+class LearningNoneEscapeTest(unittest.TestCase):
+    """R16 / #4570: the legitimate no-learning outcome reaches the closing gate."""
+
+    def events_after(self, command: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            with patch.dict(guard.os.environ, {"TMPDIR": directory, "TEMP": directory}):
+                payload = {
+                    "session_id": command,
+                    "cwd": directory,
+                    "tool_name": "Bash",
+                    "tool_input": {"command": command},
+                }
+                self.assertEqual(guard.run_pretooluse(payload), 0)
+                return guard.ledger_events(payload)
+
+    def test_substantive_learning_none_reason_is_recorded(self):
+        events = self.events_after(
+            'py -3 scripts/agents/guard.py --learning-none "No durable learning surfaced"'
+        )
+        self.assertIn("learning-none:No durable learning surfaced", events)
+
+    def test_empty_or_placeholder_reason_does_not_count(self):
+        for reason in ('""', '"n/a"'):
+            with self.subTest(reason=reason):
+                events = self.events_after(
+                    f"py -3 scripts/agents/guard.py --learning-none {reason}"
+                )
+                self.assertFalse(any(event.startswith("learning-none:") for event in events))
 
 
 class UnarmedPullRequestStopGateTest(unittest.TestCase):

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -2159,6 +2159,52 @@ class DispatchAdapterGateTest(unittest.TestCase):
                 text = open(os.path.join(root, name), encoding="utf-8").read()
                 self.assertIn("Task|Agent", text)
 
+
+class HistoricalDispatchReplayTest(unittest.TestCase):
+    """R22 / #4570 A12: replay the 18-dispatch audit without local transcript state."""
+
+    # Transcribed from session 834edc78-c25b-4c2c-8b65-9bf3bed8aa2b and its
+    # subagent logs. The original files are host runtime state, so the small,
+    # source-controlled fixture is what makes this regression portable to CI.
+    DISPATCHES = (
+        ("Adversarial review PR 4554", "reviewer", True),
+        ("Fix review findings 1 and 2 on PR 4554", "coder", True),
+        ("File review findings 3 and 4 as issues", "general-purpose", False),
+        ("Scoped review of PR 4554 new commits", "reviewer", True),
+        ("Analyze review-loop cost and propose caps", "general-purpose", False),
+        ("Correct R21 known-limits prose and log F1", "general-purpose", False),
+        ("Purge stale local worktrees safely", "coder", True),
+        ("Lane A: RED-before-GREEN validator", "coder", True),
+        ("Lane B: setUp pin, R19 scope, R12 honesty", "coder", True),
+        ("Lane C: credit scan, docstring sibling scan", "coder", True),
+        ("Lane D: stopping rule and design-ruling gate", "coder", True),
+        ("Audit and design dispatch-time enforcement", "reviewer", True),
+        ("List vacuous-risk tests", "general-purpose", False),
+        ("Extract prior-art issues", "general-purpose", False),
+        ("Read harness guidance files", "general-purpose", False),
+        ("Measure batch size vs review cycles", "general-purpose", False),
+        ("Inventory guard.py rules and tests", "general-purpose", False),
+        ("Audit ticket acceptance criteria vs diff", "general-purpose", False),
+    )
+
+    def test_correct_historical_dispatches_and_all_four_lanes_are_allowed(self):
+        self.assertEqual(len(self.DISPATCHES), 18)
+        lanes = [entry for entry in self.DISPATCHES if entry[0].startswith("Lane ")]
+        self.assertEqual(len(lanes), 4)
+        for description, subagent_type, allowed in self.DISPATCHES:
+            with self.subTest(description=description):
+                output = io.StringIO()
+                payload = {
+                    "tool_name": "Agent",
+                    "tool_input": {"subagent_type": subagent_type},
+                    "session_id": "historic-4570",
+                    "cwd": ".",
+                }
+                with patch("scripts.agents.guard.ledger_record"):
+                    with redirect_stdout(output):
+                        self.assertEqual(guard.run_pretooluse(payload), 0)
+                self.assertEqual("R22 blocked" not in output.getvalue(), allowed)
+
     def test_r15_accepts_an_observed_dispatch(self):
         arming = "gh pr merge 1 --auto --squash"
         with patch("scripts.agents.guard._independent_review_count", return_value=0):


### PR DESCRIPTION
Closes #4570

Implements all acceptance criteria:
- A1-A3: adds the helper adapters and the R22 adapted-role dispatch gate, including its pairwise legal-state walk.
- A4-A7: injects a bounded, fail-open Memory/MemPalace preflight; makes adapter-backed delegates load retrieve-first even on the first triage row; and records the honest main/delegate split.
- A8-A11: observes SubagentStop plus native-Memory/MemPalace learning writes, and requires an observed learning route or substantive `--learning-none` before auto-merge arming.
- A12: replays the measured 18-dispatch transcript, including all four lanes, as a portable regression fixture.

Commits:
- fbfe7b3303, 820e1a9be4, eda72e31b0, 94bab0c151, 890190198b, 45a89c5d2d, 7ca8780e7e, 0bdeb9f7f9, 9b6b354e4d, 3424711f0e

Validation:
- full agent-guidance CI equivalent: 625 tests
- guard self-test (93/93)
- agent setup validation with external checks skipped
- Memory canonical-store check