### PR TITLE
Retain repository context for R21 writes

### DIFF
--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1893,7 +1893,7 @@ _GH_GLOBAL_FLAGS_WITH_ARG = frozenset({"-R", "--repo"})
 
 
 def _split_gh_global_flags(tokens: list[str]) -> tuple[list[str], str | None]:
-    """Split a leading `-R`/`--repo <value>` off `tokens`, returning both halves.
+    """Remove `-R`/`--repo <value>` anywhere in `tokens`, returning its value.
 
     `-R owner/repo` / `--repo owner/repo` is gh's own global flag for
     targeting a repository explicitly -- the standard way to post run state
@@ -1910,15 +1910,20 @@ def _split_gh_global_flags(tokens: list[str]) -> tuple[list[str], str | None]:
     too, and a command with two is already outside what this rule reasons
     about.
 
-    Other value-taking global flags (`--hostname`, `-h`/`--help`) are left
+    `gh` accepts the flag after its subcommand too, which the nightly notifier
+    uses. Other value-taking global flags (`--hostname`, `-h`/`--help`) are left
     alone: none has been observed making R21 fire on correct work, and
     covering gh's full flag surface ahead of an evidenced defect just
     couples this rule to a CLI it does not otherwise track.
     """
-    index = 0
     repository: str | None = None
+    remaining: list[str] = []
+    index = 0
     while index < len(tokens):
         token = tokens[index]
+        if token == "--":
+            remaining.extend(tokens[index:])
+            break
         if token in _GH_GLOBAL_FLAGS_WITH_ARG:
             repository = tokens[index + 1] if index + 1 < len(tokens) else None
             index += 2
@@ -1931,8 +1936,24 @@ def _split_gh_global_flags(tokens: list[str]) -> tuple[list[str], str | None]:
             repository = token[len(matched) + 1:]
             index += 1
             continue
-        break
-    return tokens[index:], repository
+        remaining.append(token)
+        index += 1
+    return remaining, repository
+
+
+def _changed_directory(segment: str, cwd: object) -> str | None:
+    """Return a simple same-shell `cd` target, or None when it is ambiguous."""
+    if not isinstance(cwd, str) or not cwd:
+        return None
+    arguments = _tokens_after_head(segment, frozenset({"cd", "set-location"}))
+    if not arguments:
+        return None
+    if arguments[:1] and arguments[0].lower() in {"-path", "-literalpath"}:
+        arguments = arguments[1:]
+    if len(arguments) != 1 or arguments[0].startswith("-"):
+        return None
+    target = os.path.expanduser(arguments[0])
+    return os.path.abspath(target if os.path.isabs(target) else os.path.join(cwd, target))
 
 
 def _names_this_repository(repository: str, cwd: object) -> bool:
@@ -1949,11 +1970,10 @@ def _names_this_repository(repository: str, cwd: object) -> bool:
     take: an environment that cannot name its own remote is not evidence
     the agent posted to the wrong place.
 
-    Known limits, stated rather than papered over: a `cd ../shafthq.github.io
-    && gh pr create` in another repository's checkout still counts, because
-    no token in it says so. A `-R` / `--repo` flag positioned after the
-    subcommand is similarly not recognized; only leading-position flags are
-    scanned (see #4566).
+    An in-command `cd` / `Set-Location` is compared to the session repository
+    when its following command runs in the same shell. A directory change made
+    by an earlier tool call remains unknowable because every hook invocation is
+    a fresh process (#4566).
     """
     remote = _git_output(["remote", "get-url", "origin"], cwd)
     if not remote:
@@ -1977,7 +1997,15 @@ def _updates_a_tracked_issue(command: str, cwd: object = None) -> bool:
     """
     if not command:
         return False
-    for segment in _command_segments(command):
+    active_cwd = cwd
+    parts = re.split(r"(&&|\|\||;|\||&|\r?\n)", command)
+    for index in range(0, len(parts), 2):
+        segment = parts[index]
+        connector = parts[index + 1] if index + 1 < len(parts) else ""
+        changed_directory = _changed_directory(segment, active_cwd)
+        if changed_directory and connector in ("&&", ";", "\n", "\r\n"):
+            active_cwd = changed_directory
+            continue
         rest = _tokens_after_head(segment, frozenset({"gh"}))
         # None for any segment that is not a `gh` call, which is most of them.
         # Found by a negative fixture: `git commit -m 'comment on the issue'`
@@ -1995,6 +2023,10 @@ def _updates_a_tracked_issue(command: str, cwd: object = None) -> bool:
         # branch, and `-R other/repo` is how that binding is removed.
         if repository and not _names_this_repository(repository, cwd):
             continue
+        if not repository and active_cwd != cwd:
+            remote = _git_output(["remote", "get-url", "origin"], active_cwd)
+            if remote and not _names_this_repository(remote, cwd):
+                continue
         # Any gh call that writes durable prose to an issue or pull request.
         # The first version took `issue comment`, `pr comment` and `issue edit`
         # only, so a session that opened a pull request carrying its full run

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1948,8 +1948,10 @@ def _changed_directory(segment: str, cwd: object) -> str | None:
     arguments = _tokens_after_head(segment, frozenset({"cd", "set-location"}))
     if not arguments:
         return None
-    if arguments[:1] and arguments[0].lower() in {"-path", "-literalpath"}:
-        arguments = arguments[1:]
+    if arguments:
+        option, separator, inline = arguments[0].partition(":")
+        if option.lower() in {"-path", "-literalpath"}:
+            arguments = [inline] if separator and inline else arguments[1:]
     if len(arguments) != 1 or arguments[0].startswith("-"):
         return None
     target = os.path.expanduser(arguments[0])

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -2430,6 +2430,61 @@ class RunStateStopGateTest(unittest.TestCase):
                 with self.subTest(command=command):
                     self.assertFalse(guard._updates_a_tracked_issue(command))
 
+    def test_changing_to_the_companion_repository_before_a_write_does_not_count(self):
+        """#4566: a same-command `cd` is an implicit repository target."""
+        session_root = os.path.abspath(os.path.join(tempfile.gettempdir(), "SHAFT_ENGINE"))
+        companion_root = os.path.normpath(os.path.join(session_root, "..", "shafthq.github.io"))
+
+        def remote(_arguments, command_cwd):
+            if command_cwd == companion_root:
+                return "git@github.com:ShaftHQ/shafthq.github.io.git\n"
+            if command_cwd == session_root:
+                return "git@github.com:ShaftHQ/SHAFT_ENGINE.git\n"
+            self.fail(f"unexpected repository lookup: {command_cwd!r}")
+
+        with patch("scripts.agents.guard._git_output", side_effect=remote):
+            self.assertFalse(
+                guard._updates_a_tracked_issue(
+                    "cd ../shafthq.github.io && gh pr create --title docs --body x", session_root
+                )
+            )
+
+    def test_lowercase_set_location_path_options_do_not_count(self):
+        """PowerShell parameters are case-insensitive (#4566 review)."""
+        session_root = os.path.abspath(os.path.join(tempfile.gettempdir(), "SHAFT_ENGINE"))
+        companion_root = os.path.normpath(os.path.join(session_root, "..", "shafthq.github.io"))
+
+        def remote(_arguments, command_cwd):
+            if command_cwd == companion_root:
+                return "git@github.com:ShaftHQ/shafthq.github.io.git\n"
+            if command_cwd == session_root:
+                return "git@github.com:ShaftHQ/SHAFT_ENGINE.git\n"
+            self.fail(f"unexpected repository lookup: {command_cwd!r}")
+
+        with patch("scripts.agents.guard._git_output", side_effect=remote):
+            for option in ("-path", "-literalpath"):
+                with self.subTest(option=option):
+                    self.assertFalse(
+                        guard._updates_a_tracked_issue(
+                            f"Set-Location {option} ../shafthq.github.io; "
+                            "gh pr create --title docs --body x",
+                            session_root,
+                        )
+                    )
+
+    def test_trailing_repository_flags_for_another_repository_do_not_count(self):
+        """#4566: `gh` accepts `--repo` after the subcommand too."""
+        with patch(
+            "scripts.agents.guard._git_output",
+            return_value="https://github.com/ShaftHQ/SHAFT_ENGINE.git\n",
+        ):
+            for command in (
+                "gh pr create --repo ShaftHQ/shafthq.github.io --title docs --body x",
+                "gh issue comment 12 -R ShaftHQ/shafthq.github.io --body x",
+            ):
+                with self.subTest(command=command):
+                    self.assertFalse(guard._updates_a_tracked_issue(command))
+
     def test_reading_an_issue_is_not_recording_state(self):
         """The boundary, held by what it refuses rather than what it accepts."""
         for command in (

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -2472,6 +2472,27 @@ class RunStateStopGateTest(unittest.TestCase):
                         )
                     )
 
+    def test_colon_set_location_path_options_do_not_count(self):
+        """PowerShell also permits `-Path:<value>` (#4566 final review)."""
+        session_root = os.path.abspath(os.path.join(tempfile.gettempdir(), "SHAFT_ENGINE"))
+        companion_root = os.path.normpath(os.path.join(session_root, "..", "shafthq.github.io"))
+
+        def remote(_arguments, command_cwd):
+            if command_cwd == companion_root:
+                return "git@github.com:ShaftHQ/shafthq.github.io.git\n"
+            if command_cwd == session_root:
+                return "git@github.com:ShaftHQ/SHAFT_ENGINE.git\n"
+            self.fail(f"unexpected repository lookup: {command_cwd!r}")
+
+        with patch("scripts.agents.guard._git_output", side_effect=remote):
+            for option in ("-path:../shafthq.github.io", "-literalpath:../shafthq.github.io"):
+                with self.subTest(option=option):
+                    self.assertFalse(
+                        guard._updates_a_tracked_issue(
+                            f"Set-Location {option}; gh pr create --title docs --body x", session_root
+                        )
+                    )
+
     def test_trailing_repository_flags_for_another_repository_do_not_count(self):
         """#4566: `gh` accepts `--repo` after the subcommand too."""
         with patch(


### PR DESCRIPTION
Closes #4566.

Keeps R21 from treating a companion-repository gh write as SHAFT_ENGINE run state:
- tracks same-shell cd / Set-Location through &&, ;, and newlines;
- recognizes leading and trailing -R/--repo flags;
- supports case-insensitive PowerShell -Path / -LiteralPath, including colon form;
- preserves fail-open behavior when Git cannot identify a remote.

The four commits preserve RED-to-GREEN coverage for each parser gap.