### PR TITLE
test: isolate parallel storage-state cleanup

### DIFF
--- a/shaft-engine/src/test/java/com/shaft/gui/browser/internal/BrowserStorageStateManagerTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/browser/internal/BrowserStorageStateManagerTest.java
@@ -29,12 +29,14 @@ public class BrowserStorageStateManagerTest {
             + "for (const [key, value] of Object.entries(arguments[1])) { window.sessionStorage.setItem(key, value); }";
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
-    private Path storageStateFile;
+    private final ThreadLocal<Path> storageStateFile = new ThreadLocal<>();
 
     @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
-        if (storageStateFile != null) {
-            Files.deleteIfExists(storageStateFile);
+        Path file = storageStateFile.get();
+        if (file != null) {
+            Files.deleteIfExists(file);
+            storageStateFile.remove();
         }
     }
 
@@ -78,11 +80,11 @@ public class BrowserStorageStateManagerTest {
                 "localStorage", Map.of("authToken", "storage-secret"),
                 "sessionStorage", Map.of("tab", "checkout")));
 
-        storageStateFile = Files.createTempFile("shaft-storage-state", ".json");
-        BrowserStorageStateManager.save(driver, storageStateFile.toString());
+        storageStateFile.set(Files.createTempFile("shaft-storage-state", ".json"));
+        BrowserStorageStateManager.save(driver, storageStateFile.get().toString());
 
         BrowserStorageStateManager.StorageState state =
-                JSON.readValue(storageStateFile.toFile(), BrowserStorageStateManager.StorageState.class);
+                JSON.readValue(storageStateFile.get().toFile(), BrowserStorageStateManager.StorageState.class);
 
         Assert.assertEquals(state.schemaVersion, "1.0");
         Assert.assertEquals(state.origin, "https://example.com");
@@ -105,8 +107,8 @@ public class BrowserStorageStateManagerTest {
         WebDriver.Options options = mock(WebDriver.Options.class);
         when(driver.manage()).thenReturn(options);
 
-        storageStateFile = Files.createTempFile("shaft-storage-state", ".json");
-        Files.writeString(storageStateFile, """
+        storageStateFile.set(Files.createTempFile("shaft-storage-state", ".json"));
+        Files.writeString(storageStateFile.get(), """
                 {
                   "schemaVersion" : "1.0",
                   "origin" : "https://example.com",
@@ -128,7 +130,7 @@ public class BrowserStorageStateManagerTest {
                 }
                 """);
 
-        BrowserStorageStateManager.load(driver, storageStateFile.toString());
+        BrowserStorageStateManager.load(driver, storageStateFile.get().toString());
 
         verify(options, times(1)).deleteAllCookies();
         var cookieCaptor = org.mockito.ArgumentCaptor.forClass(Cookie.class);
@@ -162,8 +164,8 @@ public class BrowserStorageStateManagerTest {
         WebDriver.Options options = mock(WebDriver.Options.class);
         when(driver.manage()).thenReturn(options);
 
-        storageStateFile = Files.createTempFile("shaft-storage-state-empty", ".json");
-        Files.writeString(storageStateFile, """
+        storageStateFile.set(Files.createTempFile("shaft-storage-state-empty", ".json"));
+        Files.writeString(storageStateFile.get(), """
                 {
                   "schemaVersion" : "1.0",
                   "origin" : "https://example.com",
@@ -172,7 +174,7 @@ public class BrowserStorageStateManagerTest {
                 }
                 """);
 
-        BrowserStorageStateManager.load(driver, storageStateFile.toString());
+        BrowserStorageStateManager.load(driver, storageStateFile.get().toString());
 
         verify(options, times(1)).deleteAllCookies();
         verify(options, never()).addCookie(any(Cookie.class));

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/MobileSessionStateManagerTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/MobileSessionStateManagerTest.java
@@ -22,12 +22,14 @@ import static org.mockito.Mockito.when;
 public class MobileSessionStateManagerTest {
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
-    private Path stateFile;
+    private final ThreadLocal<Path> stateFile = new ThreadLocal<>();
 
     @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
-        if (stateFile != null) {
-            Files.deleteIfExists(stateFile);
+        Path file = stateFile.get();
+        if (file != null) {
+            Files.deleteIfExists(file);
+            stateFile.remove();
         }
     }
 
@@ -76,11 +78,11 @@ public class MobileSessionStateManagerTest {
         capabilities.setCapability("appium:appPackage", "com.example.app");
         when(driver.getCapabilities()).thenReturn(capabilities);
 
-        stateFile = Files.createTempFile("shaft-mobile-capabilities", ".json");
-        MobileSessionStateManager.saveCapabilities(driver, stateFile.toString());
+        stateFile.set(Files.createTempFile("shaft-mobile-capabilities", ".json"));
+        MobileSessionStateManager.saveCapabilities(driver, stateFile.get().toString());
 
         MobileSessionStateManager.SessionCapabilitiesState state =
-                JSON.readValue(stateFile.toFile(), MobileSessionStateManager.SessionCapabilitiesState.class);
+                JSON.readValue(stateFile.get().toFile(), MobileSessionStateManager.SessionCapabilitiesState.class);
 
         Assert.assertEquals(state.schemaVersion, "1.0");
         // Selenium's MutableCapabilities canonicalizes "platformName" into the Platform enum's name.
@@ -91,8 +93,8 @@ public class MobileSessionStateManagerTest {
 
     @Test
     public void shouldLoadCapabilitiesRoundTrip() throws Exception {
-        stateFile = Files.createTempFile("shaft-mobile-capabilities-load", ".json");
-        Files.writeString(stateFile, """
+        stateFile.set(Files.createTempFile("shaft-mobile-capabilities-load", ".json"));
+        Files.writeString(stateFile.get(), """
                 {
                   "schemaVersion" : "1.0",
                   "platformName" : "Android",
@@ -105,7 +107,7 @@ public class MobileSessionStateManagerTest {
                 }
                 """);
 
-        MutableCapabilities capabilities = MobileSessionStateManager.loadCapabilities(stateFile.toString());
+        MutableCapabilities capabilities = MobileSessionStateManager.loadCapabilities(stateFile.get().toString());
 
         // Selenium's MutableCapabilities canonicalizes "platformName" into a Platform enum value.
         Assert.assertEquals(String.valueOf(capabilities.getCapability("platformName")), "ANDROID");
@@ -135,11 +137,11 @@ public class MobileSessionStateManagerTest {
         when(options.window()).thenReturn(window);
         when(window.getSize()).thenReturn(new Dimension(1080, 1920));
 
-        stateFile = Files.createTempFile("shaft-mobile-app-state", ".json");
-        MobileSessionStateManager.saveAppState(driver, stateFile.toString());
+        stateFile.set(Files.createTempFile("shaft-mobile-app-state", ".json"));
+        MobileSessionStateManager.saveAppState(driver, stateFile.get().toString());
 
         MobileSessionStateManager.AppStateSnapshot state =
-                JSON.readValue(stateFile.toFile(), MobileSessionStateManager.AppStateSnapshot.class);
+                JSON.readValue(stateFile.get().toFile(), MobileSessionStateManager.AppStateSnapshot.class);
 
         Assert.assertEquals(state.schemaVersion, "1.0");
         Assert.assertEquals(state.appPackage, "com.example.app");
@@ -161,8 +163,8 @@ public class MobileSessionStateManagerTest {
         AndroidDriver driver = mock(AndroidDriver.class);
         when(driver.getContext()).thenReturn("NATIVE_APP");
 
-        stateFile = Files.createTempFile("shaft-mobile-app-state-load", ".json");
-        Files.writeString(stateFile, """
+        stateFile.set(Files.createTempFile("shaft-mobile-app-state-load", ".json"));
+        Files.writeString(stateFile.get(), """
                 {
                   "schemaVersion" : "1.0",
                   "appPackage" : "com.example.app",
@@ -174,7 +176,7 @@ public class MobileSessionStateManagerTest {
                 }
                 """);
 
-        MobileSessionStateManager.loadAppState(driver, stateFile.toString());
+        MobileSessionStateManager.loadAppState(driver, stateFile.get().toString());
 
         verify(driver).activateApp("com.example.app");
         verify(driver).context("WEBVIEW_1");
@@ -186,8 +188,8 @@ public class MobileSessionStateManagerTest {
         AndroidDriver driver = mock(AndroidDriver.class);
         when(driver.getContext()).thenReturn("NATIVE_APP");
 
-        stateFile = Files.createTempFile("shaft-mobile-app-state-same-context", ".json");
-        Files.writeString(stateFile, """
+        stateFile.set(Files.createTempFile("shaft-mobile-app-state-same-context", ".json"));
+        Files.writeString(stateFile.get(), """
                 {
                   "schemaVersion" : "1.0",
                   "appPackage" : null,
@@ -199,7 +201,7 @@ public class MobileSessionStateManagerTest {
                 }
                 """);
 
-        MobileSessionStateManager.loadAppState(driver, stateFile.toString());
+        MobileSessionStateManager.loadAppState(driver, stateFile.get().toString());
 
         verify(driver, never()).context(org.mockito.ArgumentMatchers.anyString());
         verify(driver, never()).activateApp(org.mockito.ArgumentMatchers.anyString());
@@ -211,8 +213,8 @@ public class MobileSessionStateManagerTest {
         AndroidDriver driver = mock(AndroidDriver.class);
         when(driver.getContext()).thenReturn("NATIVE_APP");
 
-        stateFile = Files.createTempFile("shaft-mobile-app-state-empty", ".json");
-        Files.writeString(stateFile, """
+        stateFile.set(Files.createTempFile("shaft-mobile-app-state-empty", ".json"));
+        Files.writeString(stateFile.get(), """
                 {
                   "schemaVersion" : "1.0",
                   "appPackage" : null,
@@ -224,7 +226,7 @@ public class MobileSessionStateManagerTest {
                 }
                 """);
 
-        MobileSessionStateManager.loadAppState(driver, stateFile.toString());
+        MobileSessionStateManager.loadAppState(driver, stateFile.get().toString());
 
         verify(driver, never()).activateApp(org.mockito.ArgumentMatchers.anyString());
         verify(driver, never()).context(org.mockito.ArgumentMatchers.anyString());
@@ -236,8 +238,8 @@ public class MobileSessionStateManagerTest {
         IOSDriver driver = mock(IOSDriver.class);
         when(driver.getContext()).thenReturn("NATIVE_APP");
 
-        stateFile = Files.createTempFile("shaft-mobile-app-state-ios", ".json");
-        Files.writeString(stateFile, """
+        stateFile.set(Files.createTempFile("shaft-mobile-app-state-ios", ".json"));
+        Files.writeString(stateFile.get(), """
                 {
                   "schemaVersion" : "1.0",
                   "appPackage" : null,
@@ -249,7 +251,7 @@ public class MobileSessionStateManagerTest {
                 }
                 """);
 
-        MobileSessionStateManager.loadAppState(driver, stateFile.toString());
+        MobileSessionStateManager.loadAppState(driver, stateFile.get().toString());
 
         verify(driver).activateApp("com.example.iosApp");
         verify(driver).rotate(ScreenOrientation.PORTRAIT);
@@ -260,8 +262,8 @@ public class MobileSessionStateManagerTest {
     public void shouldSkipRestoreStepsWhenUnsupportedByDriver() throws Exception {
         WebDriver driver = mock(WebDriver.class);
 
-        stateFile = Files.createTempFile("shaft-mobile-app-state-unsupported", ".json");
-        Files.writeString(stateFile, """
+        stateFile.set(Files.createTempFile("shaft-mobile-app-state-unsupported", ".json"));
+        Files.writeString(stateFile.get(), """
                 {
                   "schemaVersion" : "1.0",
                   "appPackage" : "com.example.app",
@@ -273,7 +275,7 @@ public class MobileSessionStateManagerTest {
                 }
                 """);
 
-        MobileSessionStateManager.loadAppState(driver, stateFile.toString());
+        MobileSessionStateManager.loadAppState(driver, stateFile.get().toString());
         // No interfaces implemented by the plain WebDriver mock, so every restore step must be skipped silently.
     }
 }


### PR DESCRIPTION
## Summary

- isolate each parallel TestNG method's temporary storage-state path
- clean up the path on the owning worker thread

## Root cause

Two test classes kept their temporary file path in an instance field while SHAFT runs TestNG methods in parallel. A concurrent method could overwrite that field before cleanup, causing another test to load or delete the wrong file.

## Validation

- `git diff --check`
- Focused Maven tests were attempted with dynamic method parallelism, but a locked corrupted local Maven cache artifact (`netty-nio-client-2.27.14.jar`) prevented test compilation. Repository CI will run the clean validation.

Closes #4590
Related to #4543
