### PR TITLE
test: stabilize mobile web nightly fixture

### DIFF
--- a/shaft-engine/src/test/java/testPackage/appium/MobileWebTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/MobileWebTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 
 public class MobileWebTest {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
+    private static final String TEST_PAGE = "data:text/html;charset=utf-8,<input id='et_pb_contact_name_0'><input id='et_pb_contact_email_0'><textarea id='et_pb_contact_message_0'></textarea><input id='et_pb_contact_name_1'><input id='et_pb_contact_email_1'><textarea id='et_pb_contact_message_1'></textarea><input id='et_pb_contact_name_2'><input id='et_pb_contact_email_2'><textarea id='et_pb_contact_message_2'></textarea>";
     SHAFT.TestData.JSON testData;
 
     @Test
@@ -33,13 +34,13 @@ public class MobileWebTest {
                         and special characters ...######$%^&&*!!""")
                 .captureScreenshot(By.id("et_pb_contact_message_2"))
                 .and().browser().captureScreenshot()
-                .and().assertThat().url().contains("ultimateqa").perform();
+                .and().assertThat().url().contains("data:text/html").perform();
     }
 
     @BeforeMethod
     public void beforeMethod() {
         driver.set(new SHAFT.GUI.WebDriver());
-        driver.get().browser().navigateToURL("https://ultimateqa.com/complicated-page");
+        driver.get().browser().navigateToURL(TEST_PAGE);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/shaft-engine/src/test/java/testPackage/appium/MobileWebTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/MobileWebTest.java
@@ -9,38 +9,21 @@ import org.testng.annotations.Test;
 
 public class MobileWebTest {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
-    private static final String TEST_PAGE = "data:text/html;charset=utf-8,<input id='et_pb_contact_name_0'><input id='et_pb_contact_email_0'><textarea id='et_pb_contact_message_0'></textarea><input id='et_pb_contact_name_1'><input id='et_pb_contact_email_1'><textarea id='et_pb_contact_message_1'></textarea><input id='et_pb_contact_name_2'><input id='et_pb_contact_email_2'><textarea id='et_pb_contact_message_2'></textarea>";
     SHAFT.TestData.JSON testData;
 
     @Test
     public void test() {
-        driver.get().element().type(By.id("et_pb_contact_name_0"), "TEST_NAME")
-                .type(By.id("et_pb_contact_email_0"), "email@email.email")
-                .type(By.id("et_pb_contact_message_0"), """
-                        This is a long message
-                        it will have line breaks
-                        and special characters ...######$%^&&*!!""")
-                .type(By.id("et_pb_contact_name_1"), "TEST_NAME")
-                .type(By.id("et_pb_contact_email_1"), "email@email.email")
-                .type(By.id("et_pb_contact_message_1"), """
-                        This is a long message
-                        it will have line breaks
-                        and special characters ...######$%^&&*!!""")
-                .type(By.id("et_pb_contact_name_2"), "TEST_NAME")
-                .type(By.id("et_pb_contact_email_2"), "email@email.email")
-                .type(By.id("et_pb_contact_message_2"), """
-                        This is a long message
-                        it will have line breaks
-                        and special characters ...######$%^&&*!!""")
-                .captureScreenshot(By.id("et_pb_contact_message_2"))
+        driver.get().element().type(By.id("user-name"), "standard_user")
+                .type(By.id("password"), "secret_sauce")
+                .captureScreenshot(By.id("password"))
                 .and().browser().captureScreenshot()
-                .and().assertThat().url().contains("data:text/html").perform();
+                .and().assertThat().url().contains("saucedemo").perform();
     }
 
     @BeforeMethod
     public void beforeMethod() {
         driver.set(new SHAFT.GUI.WebDriver());
-        driver.get().browser().navigateToURL(TEST_PAGE);
+        driver.get().browser().navigateToURL("https://www.saucedemo.com/");
     }
 
     @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
## Summary

- replace the unavailable UltimateQA dependency in MobileWebTest with the repository's established Sauce Demo fixture
- retain real-device typing and screenshot coverage with Safari-compatible public fields

## Root cause

UltimateQA was unavailable (HTTP 530) and its form identifiers changed. A self-contained data: page passed Android Chrome but iOS Safari on BrowserStack cannot expose its elements, so the revised fixture uses the existing Sauce Demo dependency that is reachable over HTTPS.

## Validation

- git diff --check
- Targeted BrowserStack Android Chrome: passed
- Targeted BrowserStack iOS Safari: passed

Closes #4592
Related to #4543