### PR TITLE
fix: make ledger reaping race-safe

### DIFF
--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -2487,7 +2487,14 @@ def _reap_stale_ledgers(directory: str) -> None:
         cutoff = time.time() - LEDGER_RETENTION_SECONDS
         for name in os.listdir(directory):
             if name.endswith(_REAP_MARK_SUFFIX):
-                continue  # visited alongside its ledger, never on its own
+                mark = os.path.join(directory, name)
+                ledger = mark[: -len(_REAP_MARK_SUFFIX)]
+                try:
+                    if not os.path.exists(ledger):
+                        os.remove(mark)
+                except OSError:
+                    pass
+                continue
             path = os.path.join(directory, name)
             mark = path + _REAP_MARK_SUFFIX
             try:
@@ -2502,6 +2509,12 @@ def _reap_stale_ledgers(directory: str) -> None:
                     continue
                 if os.path.isfile(mark):
                     if os.path.getmtime(mark) < cutoff:
+                        # A writer may have resumed the ledger after the
+                        # first staleness observation. Re-stat immediately
+                        # before deleting and leave cleanup for a later sweep
+                        # whenever the safe answer is uncertain.
+                        if os.path.getmtime(path) >= cutoff:
+                            continue
                         os.remove(path)
                         os.remove(mark)
                 else:

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1737,6 +1737,42 @@ class DormantSessionLedgerIsNotReapedByAnotherSessionTest(unittest.TestCase):
                     "a session dormant for two full retention windows must be reaped",
                 )
 
+    def test_a_write_during_sweep_prevents_the_ledger_from_being_deleted(self):
+        with tempfile.TemporaryDirectory() as directory:
+            ledger = os.path.join(directory, "concurrent.json")
+            mark = ledger + guard._REAP_MARK_SUFFIX
+            with open(ledger, "w", encoding="utf-8") as handle:
+                handle.write('"old"\n')
+            with open(mark, "w", encoding="utf-8"):
+                pass
+            old = time.time() - guard.LEDGER_RETENTION_SECONDS - 60
+            os.utime(ledger, (old, old))
+            os.utime(mark, (old, old))
+
+            original_getmtime = os.path.getmtime
+
+            def mtime(path):
+                if path == mark:
+                    with open(ledger, "a", encoding="utf-8") as handle:
+                        handle.write('"resumed"\n')
+                return original_getmtime(path)
+
+            with patch("scripts.agents.guard.os.path.getmtime", side_effect=mtime):
+                guard._reap_stale_ledgers(directory)
+
+            self.assertTrue(os.path.exists(ledger))
+            self.assertIn("resumed", open(ledger, encoding="utf-8").read())
+
+    def test_an_orphaned_reap_mark_is_removed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            mark = os.path.join(directory, "orphan.json" + guard._REAP_MARK_SUFFIX)
+            with open(mark, "w", encoding="utf-8"):
+                pass
+
+            guard._reap_stale_ledgers(directory)
+
+            self.assertFalse(os.path.exists(mark))
+
 
 class SelfTestCoversEveryRuleTest(unittest.TestCase):
     """`--self-test` must exercise every rule, and `main` must run it (#4551).

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1761,7 +1761,8 @@ class DormantSessionLedgerIsNotReapedByAnotherSessionTest(unittest.TestCase):
                 guard._reap_stale_ledgers(directory)
 
             self.assertTrue(os.path.exists(ledger))
-            self.assertIn("resumed", open(ledger, encoding="utf-8").read())
+            with open(ledger, encoding="utf-8") as handle:
+                self.assertIn("resumed", handle.read())
 
     def test_an_orphaned_reap_mark_is_removed(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- re-stat a stale ledger immediately before deletion and skip cleanup if a concurrent write resumed it
- remove orphaned `.reap-mark` sidecars when their ledger no longer exists
- preserve an observed RED commit before the green reaper implementation

## Validation

- `py -3 -m unittest tests.scripts.test_guard_lifecycle.DormantSessionLedgerIsNotReapedByAnotherSessionTest`
- `py -3 -m unittest tests.scripts.test_guard_lifecycle` (191 tests)
- `py -3 scripts/agents/guard.py --self-test`
- `git diff --check`

Closes #4562