### PR TITLE
fix: route guard blocks through learning loop

### DIFF
--- a/.agents/skills/act-as-mohab/SKILL.md
+++ b/.agents/skills/act-as-mohab/SKILL.md
@@ -232,7 +232,9 @@ task that opened the PR:
 Before reporting done, run the
 [learned-lessons workflow](references/work-github-playbook.md#learned-lessons-workflow):
 route every learning exactly once. One row per learning; never two, never a
-diary.
+diary. Before routing, scan the session for failures, traps, and guard blocks:
+if a refusal was correct, capture the lesson; if it was wrong or needs follow-up,
+search for and update the issue.
 
 | What surfaced | Where it goes |
 | --- | --- |

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1371,6 +1371,12 @@ def _print_deny(reason: str, host: str) -> None:
     print(json.dumps(output))
 
 
+def _record_guard_block_and_deny(hook_input: dict, reason: str, host: str) -> None:
+    """Preserve an observed refusal for R16 before returning the denial."""
+    ledger_record(hook_input, "guard-block")
+    _print_deny(reason, host)
+
+
 # R12: iron law 3 -- no production code before an observed failing test.
 # Production means compiled source under any module's src/main/. Guidance,
 # configuration, tests, scripts and docs are excluded because the entrypoint
@@ -2262,7 +2268,7 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
 
     reason = check_r22_dispatch_adapter(hook_input, tool_name)
     if reason is not None:
-        _print_deny(reason, host)
+        _record_guard_block_and_deny(hook_input, reason, host)
         return 0
 
     # Observed, not judged, and first: a reviewer dispatch is not a call this
@@ -2280,12 +2286,12 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
         hook_input.get("tool_input"),
     )
     if reason is not None:
-        _print_deny(reason, host)
+        _record_guard_block_and_deny(hook_input, reason, host)
         return 0
 
     reason = check_r19_fresh_base(hook_input, tool_name)
     if reason is not None:
-        _print_deny(reason, host)
+        _record_guard_block_and_deny(hook_input, reason, host)
         return 0
 
     reason = check_r12_test_before_production(hook_input, tool_name)
@@ -2298,7 +2304,7 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
     ):
         ledger_record(hook_input, "memory-write")
     if reason is not None:
-        _print_deny(reason, host)
+        _record_guard_block_and_deny(hook_input, reason, host)
         return 0
 
     if tool_name in ("Bash", "PowerShell"):
@@ -2321,7 +2327,7 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
                 command, tool_name, _hook_working_directory(hook_input)
             )
         if reason is not None:
-            _print_deny(reason, host)
+            _record_guard_block_and_deny(hook_input, reason, host)
             return 0
         if _is_learning_write_command(command):
             ledger_record(hook_input, "memory-write")
@@ -2809,7 +2815,7 @@ def _open_pull_request_count(branch: str | None, cwd: object = None) -> int | No
 
 
 def check_r16_learning_loop(hook_input: dict) -> str | None:
-    """Interrupt once when a session changed things and routed no learning.
+    """Interrupt once when a session changed or a guard refused un-routed work.
 
     The entrypoint requires the learned-lessons workflow before reporting
     done, and it had no mechanism. This session is the evidence: an iteration
@@ -2826,10 +2832,22 @@ def check_r16_learning_loop(hook_input: dict) -> str | None:
     second attempt always proceeds.
     """
     events = ledger_events(hook_input)
-    if "commit" not in events:
+    guard_blocked = "guard-block" in events
+    if "commit" not in events and not guard_blocked:
         return None  # a read-only session owes no learning
     if "memory-write" in events or any(event.startswith("learning-none:") for event in events):
         return None
+    if guard_blocked:
+        if "issue-update" in events:
+            return None
+        return (
+            "Learning loop: this session had an observed guard refusal with no route. "
+            "Before reporting done, route it once: if the refusal was correct, write the "
+            "lesson to native Memory with its evidence; if it was wrong or needs follow-up, "
+            "search for and update the issue. Nothing durable is a valid result -- say so "
+            "and end the turn. This interrupts once per turn: `stop_hook_active` makes the "
+            "retry proceed, and it is owed again next turn until it is satisfied."
+        )
     return (
         "Learning loop: this session committed work and routed no learning. Before "
         "reporting done, run the routing table once -- a fact that cost you time to "
@@ -3670,6 +3688,22 @@ def run_required_action_self_test() -> int:
         "R16 is satisfied once a learning is routed",
         _with_stubs(
             {"ledger_events": lambda payload: {"commit", "memory-write"}},
+            lambda: check_r16_learning_loop({"session_id": "s"}),
+        )
+        is None,
+    )
+    check(
+        "R16 reports an observed guard block with no route",
+        _with_stubs(
+            {"ledger_events": lambda payload: {"guard-block"}},
+            lambda: check_r16_learning_loop({"session_id": "s"}),
+        )
+        is not None,
+    )
+    check(
+        "R16 accepts an issue update for an observed guard block",
+        _with_stubs(
+            {"ledger_events": lambda payload: {"guard-block", "issue-update"}},
             lambda: check_r16_learning_loop({"session_id": "s"}),
         )
         is None,

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1473,6 +1473,7 @@ class RetrievalParityTest(unittest.TestCase):
             self.assertIn(destination, content, f"learning loop omits {destination}")
         self.assertRegex(content, r"nothing durable is a valid result|no durable learning")
         self.assertRegex(content, r"search before writing|search first", "must prevent duplicates")
+        self.assertRegex(content, r"scan.{0,80}(failure|trap|guard block)")
 
 
 class SoloOrOrchestrateTest(unittest.TestCase):

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1119,6 +1119,18 @@ class LearningLoopStopGateTest(unittest.TestCase):
         ):
             self.assertIsNone(guard.check_r16_learning_loop({"session_id": "s"}))
 
+    def test_a_guard_block_requires_a_route_but_allows_issue_or_no_learning(self):
+        """A refusal is observed work even when PreToolUse cannot see command exit."""
+        with patch("scripts.agents.guard.ledger_events", return_value=["guard-block"]):
+            self.assertIn("refusal", guard.check_r16_learning_loop({"session_id": "s"}))
+        for resolution in ("issue-update", "learning-none:nothing-recurred"):
+            with self.subTest(resolution=resolution):
+                with patch(
+                    "scripts.agents.guard.ledger_events",
+                    return_value=["guard-block", resolution],
+                ):
+                    self.assertIsNone(guard.check_r16_learning_loop({"session_id": "s"}))
+
     def test_a_session_that_changed_nothing_is_never_interrupted(self):
         """A read-only session owes no learning; asking would train the block away."""
         with patch("scripts.agents.guard.ledger_events", return_value=["test-run"]):
@@ -1206,6 +1218,9 @@ class LearningWriteObservationTest(unittest.TestCase):
         )
         self.assertNotIn("memory-write", self.events_after("mcp__mempalace__mempalace_sync"))
         self.assertNotIn("memory-write", self.events_after("Bash", 'echo "memory remember"'))
+
+    def test_a_denied_command_is_recorded_as_a_guard_block(self):
+        self.assertIn("guard-block", self.events_after("Bash", "git stash pop"))
 
     def test_a_non_dry_memories_deletion_counts_as_a_write(self):
         self.assertIn(


### PR DESCRIPTION
Closes #4560

## Summary
- record every PreToolUse refusal as a `guard-block` ledger event
- require the R16 learning loop to route an observed guard refusal to a lesson, issue update, or honest no-learning result
- tell the entrypoint to review session failures, traps, and guard blocks before routing learnings

## Validation
- `py -3 -m unittest tests.scripts.test_guard_lifecycle` (193 tests)
- `py -3 -m unittest tests.scripts.test_agent_router_contract` (105 tests)
- `py -3 scripts/agents/guard.py --self-test`
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- red-before-green replay against `4500bf9a53`