### PR TITLE
fix: skip dependency review for release version edits

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -20,9 +20,9 @@ name: PR Gate
 # documented "long-lived branch" behavior) rather than a PR base -- see the
 # dorny/paths-filter README at the pinned SHA for the exact semantics. The
 # `changes` job carries no `if:`, so it always runs on both event types, and
-# the `dependency-review` job's own `if: github.event_name == 'pull_request'`
-# makes it report `skipped` (not a failure) on push, which the summary job's
-# success|skipped leg check already accepts.
+# the `dependency-review` job's own conditional makes it report `skipped` (not
+# a failure) on pushes and pull requests with no dependency-bearing diff, which
+# the summary job's success|skipped leg check already accepts.
 
 on:
   pull_request:
@@ -48,6 +48,7 @@ jobs:
       capture: ${{ steps.filter.outputs.capture }}
       templates: ${{ steps.filter.outputs.templates }}
       javacore: ${{ steps.filter.outputs.javacore }}
+      dependencies: ${{ steps.filter.outputs.dependencies }}
       infra: ${{ steps.filter.outputs.infra }}
       workflows: ${{ steps.filter.outputs.workflows }}
       agent_guidance: ${{ steps.filter.outputs.agent_guidance }}
@@ -153,6 +154,15 @@ jobs:
               - 'shaft-skills/**'
               - 'shaft-mcp/src/main/java/com/shaft/mcp/ShaftProjectService.java'
               - 'shaft-mcp/src/test/java/com/shaft/mcp/ShaftProjectServiceTest.java'
+            # Dependency Review only needs a diff that can change the resolved
+            # dependency graph or its review policy. Keeping it path-scoped
+            # prevents unrelated release/version PRs from waiting on an
+            # external action with nothing relevant to inspect (#4602).
+            dependencies:
+              - '**/pom.xml'
+              - '**/build.gradle.kts'
+              - '**/gradle.properties'
+              - '.github/dependency-review-config.yml'
             # Core Java modules with a unit-test leg (issue #3849): shaft-engine and
             # its downstream Pilot-family modules. shaft-cli/shaft-intellij already have
             # dedicated legs above and are intentionally not repeated here. shaft-capture
@@ -740,15 +750,14 @@ jobs:
           PR_COMMITS_JSON: ${{ steps.pr-commits.outputs.commits_json }}
         run: python3 scripts/ci/validate_pr_closing_keywords.py
 
-  # Moved from security.yml's dependency-review job. Runs unconditionally on
-  # every pull_request (no path leg matches it in the `changes` job, mirroring
-  # its unconditional-per-PR behavior in security.yml today) and temporarily
-  # double-runs alongside security.yml's own dependency-review job until
-  # Phase 3 removes it from security.yml.
+  # Moved from security.yml's dependency-review job. It stays required for a
+  # dependency-bearing PR, but an unrelated diff has no graph or policy for
+  # the external action to inspect (#4602).
   dependency-review:
     name: Dependency Review
     needs: changes
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' && needs.changes.outputs.dependencies == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -163,6 +163,8 @@ jobs:
               - '**/build.gradle.kts'
               - '**/gradle.properties'
               - '.github/dependency-review-config.yml'
+              - 'scripts/ci/dependency_review_changes.py'
+              - 'tests/scripts/test_dependency_review_changes.py'
             # Core Java modules with a unit-test leg (issue #3849): shaft-engine and
             # its downstream Pilot-family modules. shaft-cli/shaft-intellij already have
             # dedicated legs above and are intentionally not repeated here. shaft-capture
@@ -755,9 +757,9 @@ jobs:
   # the external action to inspect (#4602).
   dependency-review:
     name: Dependency Review
-    needs: changes
+    needs: [changes, dependency-changes]
     if: >-
-      github.event_name == 'pull_request' && needs.changes.outputs.dependencies == 'true'
+      github.event_name == 'pull_request' && needs.dependency-changes.outputs.review == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:
@@ -770,6 +772,29 @@ jobs:
         uses: actions/dependency-review-action@v5
         with:
           config-file: './.github/dependency-review-config.yml'
+
+  dependency-changes:
+    name: Detect dependency changes
+    needs: changes
+    if: >-
+      github.event_name == 'pull_request' && needs.changes.outputs.dependencies == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      review: ${{ steps.diff.outputs.review }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Test dependency diff classifier
+        run: python3 -m unittest tests.scripts.test_dependency_review_changes -v
+      - name: Detect dependency-bearing diff
+        id: diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: echo "review=$(python3 scripts/ci/dependency_review_changes.py "$BASE_SHA" "$HEAD_SHA")" >> "$GITHUB_OUTPUT"
 
   summary:
     name: PR Gate Summary
@@ -787,6 +812,7 @@ jobs:
       - module-boundary
       - orphaned-suite-files
       - pr-body-autoclose-guard
+      - dependency-changes
       - dependency-review
     if: always()
     runs-on: ubuntu-22.04
@@ -807,6 +833,7 @@ jobs:
           MODULE_BOUNDARY_RESULT: ${{ needs.module-boundary.result }}
           ORPHANED_SUITE_FILES_RESULT: ${{ needs.orphaned-suite-files.result }}
           PR_BODY_AUTOCLOSE_GUARD_RESULT: ${{ needs.pr-body-autoclose-guard.result }}
+          DEPENDENCY_CHANGES_RESULT: ${{ needs.dependency-changes.result }}
           DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency-review.result }}
         run: |
           set -uo pipefail
@@ -827,6 +854,7 @@ jobs:
             echo "| module-boundary | ${MODULE_BOUNDARY_RESULT} |"
             echo "| orphaned-suite-files | ${ORPHANED_SUITE_FILES_RESULT} |"
             echo "| pr-body-autoclose-guard | ${PR_BODY_AUTOCLOSE_GUARD_RESULT} |"
+            echo "| dependency-changes | ${DEPENDENCY_CHANGES_RESULT} |"
             echo "| dependency-review | ${DEPENDENCY_REVIEW_RESULT} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -836,7 +864,7 @@ jobs:
           fi
 
           status=0
-          for result in "${DOCS_RESULT}" "${AGENT_GUIDANCE_RESULT}" "${INTELLIJ_VERIFY_RESULT}" "${INTELLIJ_BUILD_RESULT}" "${CLI_RESULT}" "${CAPTURE_RESULT}" "${UNIT_TESTS_RESULT}" "${TEMPLATES_RESULT}" "${WORKFLOW_TIMEOUTS_RESULT}" "${MODULE_BOUNDARY_RESULT}" "${ORPHANED_SUITE_FILES_RESULT}" "${PR_BODY_AUTOCLOSE_GUARD_RESULT}" "${DEPENDENCY_REVIEW_RESULT}"; do
+            for result in "${DOCS_RESULT}" "${AGENT_GUIDANCE_RESULT}" "${INTELLIJ_VERIFY_RESULT}" "${INTELLIJ_BUILD_RESULT}" "${CLI_RESULT}" "${CAPTURE_RESULT}" "${UNIT_TESTS_RESULT}" "${TEMPLATES_RESULT}" "${WORKFLOW_TIMEOUTS_RESULT}" "${MODULE_BOUNDARY_RESULT}" "${ORPHANED_SUITE_FILES_RESULT}" "${PR_BODY_AUTOCLOSE_GUARD_RESULT}" "${DEPENDENCY_CHANGES_RESULT}" "${DEPENDENCY_REVIEW_RESULT}"; do
             case "$result" in
               success|skipped) ;;
               *)

--- a/scripts/ci/dependency_review_changes.py
+++ b/scripts/ci/dependency_review_changes.py
@@ -27,7 +27,7 @@ def content(revision: str, path: str) -> str | None:
 
 
 def maven_dependencies(source: str) -> tuple[str, ...]:
-    return tuple(re.findall(r"<dependencies\\b[^>]*>.*?</dependencies>", source, re.DOTALL))
+    return tuple(re.findall(r"<dependencies\b[^>]*>.*?</dependencies>", source, re.DOTALL))
 
 
 def gradle_properties(source: str) -> dict[str, str]:

--- a/scripts/ci/dependency_review_changes.py
+++ b/scripts/ci/dependency_review_changes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
-import xml.etree.ElementTree as ET
+import re
 
 
 DEPENDENCY_CONFIG = ".github/dependency-review-config.yml"
@@ -14,30 +14,20 @@ GRADLE_PROPERTIES_SUFFIX = "/gradle.properties"
 
 
 def git(*arguments: str) -> str:
-    return subprocess.check_output(["git", *arguments], text=True, encoding="utf-8")
+    return subprocess.check_output(  # nosec B603 B607 - fixed read-only Git command.
+        ["git", *arguments], text=True, encoding="utf-8"
+    )
 
 
 def content(revision: str, path: str) -> str | None:
-    result = subprocess.run(
+    result = subprocess.run(  # nosec B603 B607 - fixed read-only Git command.
         ["git", "show", f"{revision}:{path}"], capture_output=True, text=True, encoding="utf-8"
     )
     return result.stdout if result.returncode == 0 else None
 
 
-def local_name(tag: str) -> str:
-    return tag.rsplit("}", 1)[-1]
-
-
-def maven_dependencies(source: str) -> tuple[str, ...] | None:
-    try:
-        root = ET.fromstring(source)
-    except ET.ParseError:
-        return None
-    return tuple(
-        ET.tostring(element, encoding="unicode")
-        for element in root.iter()
-        if local_name(element.tag) == "dependencies"
-    )
+def maven_dependencies(source: str) -> tuple[str, ...]:
+    return tuple(re.findall(r"<dependencies\\b[^>]*>.*?</dependencies>", source, re.DOTALL))
 
 
 def gradle_properties(source: str) -> dict[str, str]:
@@ -61,7 +51,7 @@ def needs_review(base: str, head: str) -> bool:
                 return True
             old_dependencies = maven_dependencies(before)
             new_dependencies = maven_dependencies(after)
-            if old_dependencies is None or new_dependencies is None or old_dependencies != new_dependencies:
+            if old_dependencies != new_dependencies:
                 return True
         elif path.endswith(GRADLE_BUILD_SUFFIX):
             return True

--- a/scripts/ci/dependency_review_changes.py
+++ b/scripts/ci/dependency_review_changes.py
@@ -1,0 +1,83 @@
+"""Print whether a revision range changes dependencies that need GitHub review."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+
+DEPENDENCY_CONFIG = ".github/dependency-review-config.yml"
+DEPENDENCY_SUFFIXES = ("/pom.xml", ".pom.xml")
+GRADLE_BUILD_SUFFIX = ".gradle.kts"
+GRADLE_PROPERTIES_SUFFIX = "/gradle.properties"
+
+
+def git(*arguments: str) -> str:
+    return subprocess.check_output(["git", *arguments], text=True, encoding="utf-8")
+
+
+def content(revision: str, path: str) -> str | None:
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{path}"], capture_output=True, text=True, encoding="utf-8"
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def maven_dependencies(source: str) -> tuple[str, ...] | None:
+    try:
+        root = ET.fromstring(source)
+    except ET.ParseError:
+        return None
+    return tuple(
+        ET.tostring(element, encoding="unicode")
+        for element in root.iter()
+        if local_name(element.tag) == "dependencies"
+    )
+
+
+def gradle_properties(source: str) -> dict[str, str]:
+    return {
+        key.strip(): value.strip()
+        for line in source.splitlines()
+        if "=" in line and not line.lstrip().startswith("#")
+        for key, value in [line.split("=", 1)]
+        if key.strip() != "pluginVersion"
+    }
+
+
+def needs_review(base: str, head: str) -> bool:
+    changed = git("diff", "--name-only", base, head).splitlines()
+    if DEPENDENCY_CONFIG in changed:
+        return True
+    for path in changed:
+        before, after = content(base, path), content(head, path)
+        if path == "pom.xml" or path.endswith(DEPENDENCY_SUFFIXES):
+            if before is None or after is None:
+                return True
+            old_dependencies = maven_dependencies(before)
+            new_dependencies = maven_dependencies(after)
+            if old_dependencies is None or new_dependencies is None or old_dependencies != new_dependencies:
+                return True
+        elif path.endswith(GRADLE_BUILD_SUFFIX):
+            return True
+        elif path.endswith(GRADLE_PROPERTIES_SUFFIX):
+            if before is None or after is None or gradle_properties(before) != gradle_properties(after):
+                return True
+    return False
+
+
+def main(arguments: list[str]) -> int:
+    if len(arguments) != 2:
+        print("usage: dependency_review_changes.py <base> <head>", file=sys.stderr)
+        return 2
+    print(str(needs_review(*arguments)).lower())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1167,6 +1167,26 @@ class CiGateIsBlockingTest(unittest.TestCase):
         outputs = workflow["jobs"]["changes"]["outputs"]
         self.assertIn("agent_guidance", outputs, "filter result is never exported")
 
+    def test_dependency_review_runs_only_for_dependency_bearing_diffs(self):
+        yaml = __import__("yaml")
+        workflow = yaml.safe_load(self.WORKFLOW.read_text(encoding="utf-8"))
+        changes = workflow["jobs"]["changes"]
+        filters = yaml.safe_load(changes["steps"][1]["with"]["filters"])
+        self.assertIn("dependencies", changes["outputs"])
+        self.assertEqual(
+            set(filters["dependencies"]),
+            {
+                "**/pom.xml",
+                "**/build.gradle.kts",
+                "**/gradle.properties",
+                ".github/dependency-review-config.yml",
+            },
+        )
+        self.assertIn(
+            "needs.changes.outputs.dependencies == 'true'",
+            workflow["jobs"]["dependency-review"]["if"],
+        )
+
 
 class GlobFilesHelperTest(unittest.TestCase):
     """The resolver every GUIDANCE_GLOBS consumer in this file shares.

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1180,12 +1180,18 @@ class CiGateIsBlockingTest(unittest.TestCase):
                 "**/build.gradle.kts",
                 "**/gradle.properties",
                 ".github/dependency-review-config.yml",
+                "scripts/ci/dependency_review_changes.py",
+                "tests/scripts/test_dependency_review_changes.py",
             },
         )
         self.assertIn("dependency-changes", workflow["jobs"])
         classifier = workflow["jobs"].get("dependency-changes", {})
         self.assertIn("dependencies", classifier["if"])
         self.assertEqual(classifier["outputs"]["review"], "${{ steps.diff.outputs.review }}")
+        self.assertIn(
+            "tests.scripts.test_dependency_review_changes",
+            " ".join(str(step.get("run", "")) for step in classifier["steps"]),
+        )
         self.assertIn(
             "needs.dependency-changes.outputs.review == 'true'",
             workflow["jobs"]["dependency-review"]["if"],

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1182,8 +1182,12 @@ class CiGateIsBlockingTest(unittest.TestCase):
                 ".github/dependency-review-config.yml",
             },
         )
+        self.assertIn("dependency-changes", workflow["jobs"])
+        classifier = workflow["jobs"].get("dependency-changes", {})
+        self.assertIn("dependencies", classifier["if"])
+        self.assertEqual(classifier["outputs"]["review"], "${{ steps.diff.outputs.review }}")
         self.assertIn(
-            "needs.changes.outputs.dependencies == 'true'",
+            "needs.dependency-changes.outputs.review == 'true'",
             workflow["jobs"]["dependency-review"]["if"],
         )
 

--- a/tests/scripts/test_dependency_review_changes.py
+++ b/tests/scripts/test_dependency_review_changes.py
@@ -1,57 +1,29 @@
 from __future__ import annotations
 
-import subprocess
-import sys
-import tempfile
 import unittest
-from pathlib import Path
+from unittest.mock import patch
 
-
-ROOT = Path(__file__).resolve().parents[2]
-SCRIPT = ROOT / "scripts" / "ci" / "dependency_review_changes.py"
-
+from scripts.ci import dependency_review_changes
 
 class DependencyReviewChangesTest(unittest.TestCase):
-    def classify(self, before: str, after: str, path: str = "pom.xml") -> str:
-        with tempfile.TemporaryDirectory() as directory:
-            repository = Path(directory)
-            subprocess.run(["git", "init", "--quiet"], cwd=repository, check=True)
-            subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repository, check=True)
-            subprocess.run(["git", "config", "user.name", "Test"], cwd=repository, check=True)
-            target = repository / path
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(before, encoding="utf-8")
-            subprocess.run(["git", "add", "."], cwd=repository, check=True)
-            subprocess.run(["git", "commit", "--quiet", "-m", "before"], cwd=repository, check=True)
-            base = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repository, text=True).strip()
-            target.write_text(after, encoding="utf-8")
-            subprocess.run(["git", "add", "."], cwd=repository, check=True)
-            subprocess.run(["git", "commit", "--quiet", "-m", "after"], cwd=repository, check=True)
-            head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repository, text=True).strip()
-            result = subprocess.run(
-                [sys.executable, str(SCRIPT), base, head],
-                cwd=repository,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-        self.assertEqual(result.returncode, 0, result.stderr)
-        return result.stdout.strip()
-
     def test_release_version_only_pom_edit_skips_dependency_review(self):
-        self.assertEqual(
-            "false",
-            self.classify(
-                "<project><version>1.0.0</version></project>",
-                "<project><version>1.0.1</version></project>",
-            ),
-        )
+        with patch("scripts.ci.dependency_review_changes.git", return_value="pom.xml\n"):
+            with patch(
+                "scripts.ci.dependency_review_changes.content",
+                side_effect=[
+                    "<project><version>1.0.0</version></project>",
+                    "<project><version>1.0.1</version></project>",
+                ],
+            ):
+                self.assertFalse(dependency_review_changes.needs_review("base", "head"))
 
     def test_changed_maven_dependency_requires_dependency_review(self):
-        self.assertEqual(
-            "true",
-            self.classify(
-                "<project><dependencies><dependency><groupId>a</groupId><artifactId>b</artifactId><version>1</version></dependency></dependencies></project>",
-                "<project><dependencies><dependency><groupId>a</groupId><artifactId>b</artifactId><version>2</version></dependency></dependencies></project>",
-            ),
-        )
+        with patch("scripts.ci.dependency_review_changes.git", return_value="pom.xml\n"):
+            with patch(
+                "scripts.ci.dependency_review_changes.content",
+                side_effect=[
+                    "<project><dependencies><dependency><groupId>a</groupId><artifactId>b</artifactId><version>1</version></dependency></dependencies></project>",
+                    "<project><dependencies><dependency><groupId>a</groupId><artifactId>b</artifactId><version>2</version></dependency></dependencies></project>",
+                ],
+            ):
+                self.assertTrue(dependency_review_changes.needs_review("base", "head"))

--- a/tests/scripts/test_dependency_review_changes.py
+++ b/tests/scripts/test_dependency_review_changes.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "ci" / "dependency_review_changes.py"
+
+
+class DependencyReviewChangesTest(unittest.TestCase):
+    def classify(self, before: str, after: str, path: str = "pom.xml") -> str:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = Path(directory)
+            subprocess.run(["git", "init", "--quiet"], cwd=repository, check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repository, check=True)
+            subprocess.run(["git", "config", "user.name", "Test"], cwd=repository, check=True)
+            target = repository / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(before, encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=repository, check=True)
+            subprocess.run(["git", "commit", "--quiet", "-m", "before"], cwd=repository, check=True)
+            base = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repository, text=True).strip()
+            target.write_text(after, encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=repository, check=True)
+            subprocess.run(["git", "commit", "--quiet", "-m", "after"], cwd=repository, check=True)
+            head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repository, text=True).strip()
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), base, head],
+                cwd=repository,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout.strip()
+
+    def test_release_version_only_pom_edit_skips_dependency_review(self):
+        self.assertEqual(
+            "false",
+            self.classify(
+                "<project><version>1.0.0</version></project>",
+                "<project><version>1.0.1</version></project>",
+            ),
+        )
+
+    def test_changed_maven_dependency_requires_dependency_review(self):
+        self.assertEqual(
+            "true",
+            self.classify(
+                "<project><dependencies><dependency><groupId>a</groupId><artifactId>b</artifactId><version>1</version></dependency></dependencies></project>",
+                "<project><dependencies><dependency><groupId>a</groupId><artifactId>b</artifactId><version>2</version></dependency></dependencies></project>",
+            ),
+        )


### PR DESCRIPTION
Closes #4602

## Summary
- classify dependency-bearing changes rather than treating every manifest edit as a dependency graph change
- keep Dependency Review required for changed Maven dependencies, Gradle build files, review policy, and non-release Gradle properties
- skip the external review action for release-only version updates, while making the classifier and its tests part of the required PR Gate

## Validation
- `py -3 -m unittest tests.scripts.test_dependency_review_changes tests.scripts.test_agent_router_contract` (108 tests)
- `py -3 scripts/ci/validate_workflow_timeouts.py`
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`