### PR TITLE
fix: identify installer metadata probe

### DIFF
--- a/scripts/ci/verify_shaft_mcp_installer_release.py
+++ b/scripts/ci/verify_shaft_mcp_installer_release.py
@@ -32,7 +32,11 @@ def shaft_cli_published() -> bool:
     first release cut since then; until that release, --install-shaft-cli can only 404 and
     its verification must be skipped rather than failing every PR and main build.
     """
-    request = urllib.request.Request(SHAFT_CLI_METADATA_URL, method="HEAD")
+    request = urllib.request.Request(
+        SHAFT_CLI_METADATA_URL,
+        headers={"User-Agent": "SHAFT-Engine-release-verifier"},
+        method="HEAD",
+    )
     try:
         with urllib.request.urlopen(request, timeout=30):  # nosec B310 - fixed https URL.
             return True

--- a/tests/scripts/test_verify_shaft_mcp_installer_release.py
+++ b/tests/scripts/test_verify_shaft_mcp_installer_release.py
@@ -45,6 +45,15 @@ class ShaftCliPublishedTest(unittest.TestCase):
             self.assertTrue(verify.shaft_cli_published())
         response.__enter__.assert_called_once()
 
+    def test_metadata_probe_identifies_the_release_verifier(self):
+        response = unittest.mock.MagicMock()
+        with unittest.mock.patch.object(
+            verify.urllib.request, "urlopen", return_value=response
+        ) as urlopen:
+            verify.shaft_cli_published()
+        request = urlopen.call_args.args[0]
+        self.assertEqual("SHAFT-Engine-release-verifier", request.get_header("User-agent"))
+
     def test_missing_metadata_means_unpublished(self):
         error = verify.urllib.error.HTTPError(
             verify.SHAFT_CLI_METADATA_URL, 404, "Not Found", None, None


### PR DESCRIPTION
Closes #4604

## Summary
- identify the Maven Central metadata HEAD request with a stable User-Agent
- preserve 404-as-not-yet-published behavior and propagate all other HTTP errors

## Validation
- `py -3 -m unittest tests.scripts.test_verify_shaft_mcp_installer_release` (9 tests)