### PR TITLE
test: avoid duplicate Windows CLI packaging in PR gate

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -415,7 +415,10 @@ jobs:
           check-latest: true
       - name: Cache Maven repository
         uses: ./.github/actions/cache-maven-repo
-      - name: Install shaft-cli reactor dependencies
+      # `install` packages the CLI JAR as well as installing its reactor
+      # dependencies. Reuse that artifact after tests instead of running a
+      # second package lifecycle in this 10-minute Windows job (#4606).
+      - name: Install shaft-cli reactor dependencies and package binary
         run: mvn --batch-mode -pl shaft-cli -am -DskipTests install -q '-DheadlessExecution=true' '-Dgpg.skip' '-Dcyclonedx.skip'
       # -Dshaft.intellij.liveToolE2E=true with no liveMcpCommand set (issue #3932a):
       # exercises ShaftCliLiveE2ETest's 3 offline methods (tools --cached, codegen,
@@ -424,10 +427,9 @@ jobs:
       # the live-server trio only runs in live-tools-nightly.yml.
       - name: Test shaft-cli
         run: mvn --batch-mode -pl shaft-cli test '-DheadlessExecution=true' '-Dshaft.intellij.liveToolE2E=true'
-      - name: Package shaft-cli and run the binary
+      - name: Run packaged shaft-cli binary
         shell: bash
         run: |
-          mvn --batch-mode -pl shaft-cli package -DskipTests '-DheadlessExecution=true' -q
           java -jar shaft-cli/target/shaft-cli-*[0-9].jar --version
           java -jar shaft-cli/target/shaft-cli-*[0-9].jar --help
 

--- a/tests/scripts/test_validate_workflow_timeouts.py
+++ b/tests/scripts/test_validate_workflow_timeouts.py
@@ -142,3 +142,21 @@ class TimeoutGuardIsReRunByItsOwnEditsTest(unittest.TestCase):
             [],
             "a check whose own edits do not re-run it can be weakened green",
         )
+
+
+class CliGatePackagingContractTest(unittest.TestCase):
+    """#4606: keep the CLI binary smoke test without packaging the same JAR twice."""
+
+    WORKFLOW = Path(__file__).resolve().parents[2] / ".github/workflows/pr-gate.yml"
+
+    def test_cli_smoke_reuses_the_jar_created_by_reactor_install(self):
+        content = self.WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "mvn --batch-mode -pl shaft-cli -am -DskipTests install -q",
+            content,
+        )
+        self.assertIn("- name: Run packaged shaft-cli binary", content)
+        self.assertNotIn(
+            "mvn --batch-mode -pl shaft-cli package -DskipTests",
+            content,
+        )


### PR DESCRIPTION
## Summary
- reuse the `shaft-cli` JAR produced by the existing reactor `install` step
- retain the version and help binary smoke coverage without a second Maven package lifecycle
- pin the optimized workflow shape with the timeout-guard test suite

## Validation
- `py -3 -m unittest tests.scripts.test_validate_workflow_timeouts -v`
- `py -3 scripts/ci/validate_workflow_timeouts.py`
- Local Maven reactor package/smoke was blocked by a separately running process locking a corrupt `netty-nio-client-2.27.14.jar` cache entry; the CI matrix will run the actual Windows path.

Closes #4606