### PR TITLE
test: use Selenium-owned stable nightly form fixture

### DIFF
--- a/shaft-engine/src/test/java/junitTestPackage/JunitTest.java
+++ b/shaft-engine/src/test/java/junitTestPackage/JunitTest.java
@@ -7,38 +7,36 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
 public class JunitTest {
-    private static final By USERNAME = By.id("user-name");
-    private static final By PASSWORD = By.id("password");
-    private static final By LOGIN = By.id("login-button");
-    private static final By INVENTORY = By.id("inventory_container");
+    private static final String FORM_URL = "https://www.selenium.dev/selenium/web/web-form.html";
+    private static final By TEXT_INPUT = By.id("my-text-id");
+    private static final By PASSWORD = By.name("my-password");
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
 
     @Test
     void testMethod() {
-        loginAndCaptureEvidence();
-        driver.get().assertThat().browser().url().contains("inventory.html").perform();
+        enterFormAndCaptureEvidence();
+        driver.get().assertThat().browser().url().contains("web-form.html").perform();
     }
 
     @Test
     void testMethod2() {
-        loginAndCaptureEvidence();
-        driver.get().element().captureScreenshot(INVENTORY)
+        enterFormAndCaptureEvidence();
+        driver.get().element().captureScreenshot(TEXT_INPUT)
                 .and().browser().captureScreenshot();
-        driver.get().assertThat().element(INVENTORY).exists().perform();
+        driver.get().assertThat().element(TEXT_INPUT).exists().perform();
     }
 
-    private void loginAndCaptureEvidence() {
-        driver.get().element().type(USERNAME, "standard_user")
-                .type(PASSWORD, "secret_sauce")
+    private void enterFormAndCaptureEvidence() {
+        driver.get().element().type(TEXT_INPUT, "SHAFT")
+                .type(PASSWORD, "stable fixture")
                 .captureScreenshot(PASSWORD)
                 .and().browser().captureScreenshot();
-        driver.get().element().click(LOGIN);
     }
 
     @BeforeEach
     void beforeEach() {
         driver.set(new SHAFT.GUI.WebDriver());
-        driver.get().browser().navigateToURL("https://www.saucedemo.com/");
+        driver.get().browser().navigateToURL(FORM_URL);
     }
 
     @AfterEach

--- a/shaft-engine/src/test/java/testPackage/appium/MobileWebTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/MobileWebTest.java
@@ -8,22 +8,25 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class MobileWebTest {
+    private static final String FORM_URL = "https://www.selenium.dev/selenium/web/web-form.html";
+    private static final By TEXT_INPUT = By.id("my-text-id");
+    private static final By PASSWORD = By.name("my-password");
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
     SHAFT.TestData.JSON testData;
 
     @Test
     public void test() {
-        driver.get().element().type(By.id("user-name"), "standard_user")
-                .type(By.id("password"), "secret_sauce")
-                .captureScreenshot(By.id("password"))
+        driver.get().element().type(TEXT_INPUT, "SHAFT")
+                .type(PASSWORD, "stable fixture")
+                .captureScreenshot(PASSWORD)
                 .and().browser().captureScreenshot()
-                .and().assertThat().url().contains("saucedemo").perform();
+                .and().assertThat().url().contains("web-form.html").perform();
     }
 
     @BeforeMethod
     public void beforeMethod() {
         driver.set(new SHAFT.GUI.WebDriver());
-        driver.get().browser().navigateToURL("https://www.saucedemo.com/");
+        driver.get().browser().navigateToURL(FORM_URL);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/shaft-engine/src/test/java/testPackage/legacy/BigPageActionsTest.java
+++ b/shaft-engine/src/test/java/testPackage/legacy/BigPageActionsTest.java
@@ -7,38 +7,36 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class BigPageActionsTest {
-    private static final By USERNAME = By.id("user-name");
-    private static final By PASSWORD = By.id("password");
-    private static final By LOGIN = By.id("login-button");
-    private static final By INVENTORY = By.id("inventory_container");
+    private static final String FORM_URL = "https://www.selenium.dev/selenium/web/web-form.html";
+    private static final By TEXT_INPUT = By.id("my-text-id");
+    private static final By PASSWORD = By.name("my-password");
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
 
     @Test
     public void virtualThreads_1_sequential() {
-        loginAndCaptureEvidence();
-        driver.get().assertThat().browser().url().contains("inventory.html").perform();
+        enterFormAndCaptureEvidence();
+        driver.get().assertThat().browser().url().contains("web-form.html").perform();
     }
 
     @Test
     public void bigTest_1_Sequential() {
-        loginAndCaptureEvidence();
-        driver.get().element().captureScreenshot(INVENTORY)
+        enterFormAndCaptureEvidence();
+        driver.get().element().captureScreenshot(TEXT_INPUT)
                 .and().browser().captureScreenshot();
-        driver.get().assertThat().element(INVENTORY).exists().perform();
+        driver.get().assertThat().element(TEXT_INPUT).exists().perform();
     }
 
-    private void loginAndCaptureEvidence() {
-        driver.get().element().type(USERNAME, "standard_user")
-                .type(PASSWORD, "secret_sauce")
+    private void enterFormAndCaptureEvidence() {
+        driver.get().element().type(TEXT_INPUT, "SHAFT")
+                .type(PASSWORD, "stable fixture")
                 .captureScreenshot(PASSWORD)
                 .and().browser().captureScreenshot();
-        driver.get().element().click(LOGIN);
     }
 
     @BeforeMethod
     public void beforeMethod() {
         driver.set(new SHAFT.GUI.WebDriver());
-        driver.get().browser().navigateToURL("https://www.saucedemo.com/");
+        driver.get().browser().navigateToURL(FORM_URL);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/shaft-engine/src/test/java/testPackage/legacy/RetiredUltimateQaFixtureGuardTest.java
+++ b/shaft-engine/src/test/java/testPackage/legacy/RetiredUltimateQaFixtureGuardTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RetiredUltimateQaFixtureGuardTest {
     private static final List<Path> NIGHTLY_FIXTURES = List.of(
@@ -17,11 +18,14 @@ class RetiredUltimateQaFixtureGuardTest {
     );
 
     @Test
-    void nightlyFixturesDoNotUseTheRetiredUltimateQaForm() throws IOException {
+    void nightlyFixturesUseTheSeleniumOwnedForm() throws IOException {
         for (Path fixture : NIGHTLY_FIXTURES) {
             String source = Files.readString(fixture);
             assertFalse(source.contains("ultimateqa.com/complicated-page"), fixture + " still uses UltimateQA");
             assertFalse(source.contains("et_pb_contact_name_0"), fixture + " still uses the retired form");
+            assertFalse(source.contains("saucedemo.com"), fixture + " still uses Sauce Demo");
+            assertTrue(source.contains("https://www.selenium.dev/selenium/web/web-form.html"),
+                    fixture + " must use Selenium's owned web form");
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace Sauce Demo in the three active nightly form tests with Selenium's owned static web form
- retain typing, element/browser screenshots, URL assertions, and element-existence coverage
- guard all three fixtures against both UltimateQA and Sauce Demo regressions

## Validation

- observed RED: source guard rejected the existing Sauce Demo references in all three tests
- observed GREEN: source guard passed after migration; `git diff --check` passed
- local Maven test compilation is blocked by the host cache artifact `netty-nio-client-2.27.14.jar` with `ZipException: invalid CEN header`; CI uses a clean cache

Closes #4610