### PR TITLE
fix: make harness sync failures actionable

### DIFF
--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -2385,7 +2385,7 @@ def _sync_advisory() -> str | None:
         return None
     try:
         completed = subprocess.run(  # nosec B603 - fixed repository helper.
-            [sys.executable, helper],
+            [sys.executable, helper, "--json"],
             cwd=_harness_root(),
             capture_output=True,
             text=True,
@@ -2396,6 +2396,11 @@ def _sync_advisory() -> str | None:
         return "User harness sync check was unavailable; verify it before completion."
     if completed.returncode == 0:
         return None
+    if completed.returncode == 2:
+        return (
+            "User harness sync has a hard failure. Inspect the reported missing, invalid, "
+            "or conflicting target before completion; it needs a decision rather than deployment."
+        )
     return (
         "User harness drift detected. Review the tracked harness, then run "
         "`py -3 scripts/agents/sync_user_harness.py --apply` and re-check it."
@@ -3026,8 +3031,8 @@ def _branch_edits_harness_sources(cwd: object = None) -> bool:
     Deliberately coarse, and the trade is stated rather than hidden: this also
     silences genuine staleness for the life of such a branch. The precise
     version compares drift per file against what the branch touched, which
-    needs a machine-readable mode on the sync tool that does not exist yet --
-    filed rather than approximated here, because parsing its printed labels
+    needs the machine-readable mode tracked in #4557 rather than parsing printed
+    labels, because parsing its printed labels
     would couple this rule to a print format.
 
     Committed and uncommitted both count: an edit in the working tree changes

--- a/scripts/agents/sync_user_harness.py
+++ b/scripts/agents/sync_user_harness.py
@@ -124,6 +124,7 @@ def sources(
 
 def main() -> int:
     apply_mode = "--apply" in sys.argv[1:]
+    json_mode = "--json" in sys.argv[1:]
     root = repo_root()
     claude_dir = user_claude_dir()
     manifest = sources(
@@ -133,22 +134,48 @@ def main() -> int:
         user_codex_dir(claude_dir),
     )
 
-    missing_sources = [str(source) for source, _ in manifest.values() if not source.is_file()]
+    entries: list[dict[str, object]] = []
+
+    def record(
+        state: str, label: str, source: Path, target: Path, **details: str
+    ) -> None:
+        entries.append(
+            {"state": state, "label": label, "source": str(source), "target": str(target), **details}
+        )
+
+    def finish(code: int) -> int:
+        if json_mode:
+            print(json.dumps({"entries": entries, "exit_code": code}))
+        return code
+
+    missing_sources = [
+        (label, source, target)
+        for label, (source, target) in manifest.items()
+        if not source.is_file()
+    ]
     if missing_sources:
-        print("ERROR: manifest source file(s) missing: " + ", ".join(missing_sources))
-        return 2
+        for label, source, target in missing_sources:
+            record("ERROR", label, source, target)
+        if not json_mode:
+            print("ERROR: manifest source file(s) missing: " + ", ".join(str(source) for _, source, _ in missing_sources))
+        return finish(2)
 
     all_in_sync = True
     hard_failure = False
     for label, (source, target) in manifest.items():
         source_bytes = source.read_bytes()
         if not target.is_file():
-            print(f"MISSING  {label}  (target absent: {target})")
+            details = {}
+            if not json_mode:
+                print(f"MISSING  {label}  (target absent: {target})")
             all_in_sync = False
             if apply_mode:
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_bytes(source_bytes)
-                print(f"  -> deployed {target}")
+                if not json_mode:
+                    print(f"  -> deployed {target}")
+                details["deployed"] = str(target)
+            record("MISSING", label, source, target, **details)
             continue
 
         target_bytes = target.read_bytes()
@@ -158,7 +185,9 @@ def main() -> int:
                 owned = json.loads(source_bytes)
                 existing = json.loads(target_bytes)
             except (UnicodeDecodeError, json.JSONDecodeError):
-                print(f"INVALID  {label}  (target is not valid JSON: {target})")
+                if not json_mode:
+                    print(f"INVALID  {label}  (target is not valid JSON: {target})")
+                record("INVALID", label, source, target)
                 all_in_sync = False
                 hard_failure = True
                 continue
@@ -168,28 +197,40 @@ def main() -> int:
             desired_bytes = (json.dumps(desired, indent=2) + "\n").encode("utf-8")
 
         if normalize(desired_bytes) == normalize(target_bytes):
-            print(f"IN-SYNC  {label}")
+            if not json_mode:
+                print(f"IN-SYNC  {label}")
+            record("IN-SYNC", label, source, target)
             continue
 
         all_in_sync = False
         if not is_owned_codex_target(label, target_bytes):
-            print(f"CONFLICT  {label}  (unowned target exists: {target})")
+            if not json_mode:
+                print(f"CONFLICT  {label}  (unowned target exists: {target})")
+            record("CONFLICT", label, source, target)
             hard_failure = True
             continue
-        print(f"DRIFTED  {label}  (differs from {target})")
+        if not json_mode:
+            print(f"DRIFTED  {label}  (differs from {target})")
+        details = {}
         if apply_mode:
             backup = target.with_name(target.name + ".bak")
             if backup.exists():
-                print(f"  -> preserved existing backup {backup}")
+                if not json_mode:
+                    print(f"  -> preserved existing backup {backup}")
             else:
                 backup.write_bytes(target_bytes)
-                print(f"  -> backed up to {backup}")
+                if not json_mode:
+                    print(f"  -> backed up to {backup}")
+            details["backup"] = str(backup)
             target.write_bytes(desired_bytes)
-            print(f"  -> deployed {target}")
+            if not json_mode:
+                print(f"  -> deployed {target}")
+            details["deployed"] = str(target)
+        record("DRIFTED", label, source, target, **details)
 
     if hard_failure:
-        return 2
-    return 0 if apply_mode or all_in_sync else 1
+        return finish(2)
+    return finish(0 if apply_mode or all_in_sync else 1)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1529,6 +1529,16 @@ class UserHarnessDriftStopGateTest(unittest.TestCase):
         with patch("scripts.agents.guard._uncommitted_file_count", return_value=4):
             self.assertIsNone(guard.check_r14_hard_reset(remedy, "Bash", "."))
 
+    @patch(
+        "scripts.agents.guard.subprocess.run",
+        return_value=subprocess.CompletedProcess([], 2, "", ""),
+    )
+    def test_hard_sync_failure_does_not_recommend_apply(self, _run):
+        advisory = guard._sync_advisory()
+        self.assertIsNotNone(advisory)
+        self.assertIn("hard failure", advisory)
+        self.assertNotIn("--apply", advisory)
+
 
 class LedgerIsAppendOnlyAndReapedTest(unittest.TestCase):
     """#4552: a read-modify-write loses whole events, and files lived forever.

--- a/tests/scripts/test_sync_user_harness.py
+++ b/tests/scripts/test_sync_user_harness.py
@@ -161,6 +161,24 @@ class SyncUserHarnessTest(unittest.TestCase):
         self.assertIn(personal_marker, target.read_text(encoding="utf-8"))
         self.assertFalse(target.with_name("coder.toml.bak").exists())
 
+    def test_json_reports_a_hard_conflict_without_exposing_target_contents(self):
+        personal_marker = "personal-agent-must-survive"
+        target = self.codex_target / "agents" / "coder.toml"
+        target.parent.mkdir(parents=True)
+        target.write_text(personal_marker, encoding="utf-8")
+
+        completed = self.run_sync("--json", "--apply")
+
+        self.assertEqual(completed.returncode, 2)
+        report = json.loads(completed.stdout)
+        conflict = next(
+            entry for entry in report["entries"]
+            if entry["label"] == "../.codex/agents/coder.toml"
+        )
+        self.assertEqual(conflict["state"], "CONFLICT")
+        self.assertEqual(conflict["target"], str(target))
+        self.assertNotIn(personal_marker, completed.stdout + completed.stderr)
+
     def test_legacy_codex_harness_agent_migrates_safely(self):
         target = self.codex_target / "agents" / "coder.toml"
         target.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- add a machine-readable `--json` report to the user-harness sync tool
- report per-file source, target, and state, plus deployments and backups in apply mode
- make R20 distinguish a hard sync failure from ordinary drift and avoid naming an unusable deployment command
- correct the stale #4557 reference in the suppression rationale

## Validation

- RED: JSON contract test failed because `--json` emitted no JSON
- RED: exit-2 guard test showed the ordinary drift remedy
- GREEN: `py -3 -m unittest tests.scripts.test_sync_user_harness tests.scripts.test_guard_lifecycle.UserHarnessDriftStopGateTest -v`
- GREEN: `py -3 scripts/ci/validate_agent_setup.py --skip-external`

Closes #4557
Closes #4558