### PR TITLE
Fix #4546: report stale foreign worktrees

### DIFF
--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -3191,6 +3191,73 @@ def check_r21_run_state_not_recorded(hook_input: dict) -> str | None:
     )
 
 
+def check_r24_foreign_worktree_left_behind(hook_input: dict, report: dict | None) -> str | None:
+    """Report stale foreign worktrees from the already-fetched hygiene report (#4546)."""
+    # This rule is deliberately pure over `report`: Stop tests disable every
+    # subprocess and require identical outcomes, while the reporter remains
+    # the single live reader. `hook_input` stays in the signature so all Stop
+    # rules have one shape for isolation and dispatch.
+    del hook_input
+    if not isinstance(report, dict):
+        return None
+    worktrees = report.get("worktrees")
+    if not isinstance(worktrees, list):
+        return None
+    threshold = report.get("foreign_worktree_stale_hours")
+    if not isinstance(threshold, (int, float)) or isinstance(threshold, bool) or threshold < 0:
+        threshold = None
+
+    candidates: list[str] = []
+    for entry in worktrees:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("is_current") or entry.get("is_remote_only"):
+            continue
+        state = entry.get("state")
+        path = entry.get("path")
+        if state not in ("corrupt", "unknown", "uncommitted", "abandoned") or not isinstance(
+            path, str
+        ) or not path:
+            continue
+
+        if state in ("uncommitted", "abandoned"):
+            if "age_hours" not in entry:
+                continue
+            age = entry["age_hours"]
+            if age is None:
+                age_description = "its age could not be determined"
+            elif (
+                threshold is not None
+                and isinstance(age, (int, float))
+                and not isinstance(age, bool)
+                and age >= threshold
+            ):
+                age_description = f"{age:.1f} hour(s) since recorded activity"
+            else:
+                continue
+        else:
+            age_description = "age-independent"
+
+        lock_description = ""
+        if entry.get("locked"):
+            reason = entry.get("lock_reason")
+            lock_description = f"; locked: {reason}" if isinstance(reason, str) and reason else "; locked"
+        candidates.append(f"{path} ({state}; {age_description}{lock_description})")
+
+    if not candidates:
+        return None
+    shown = "; ".join(candidates[:3])
+    remaining = "" if len(candidates) <= 3 else f" Showing 3 of {len(candidates)} worktrees."
+    return (
+        f"Foreign worktree report: {shown}.{remaining} Run `py -3 scripts/ci/"
+        "worktree_hygiene.py --check-pull-requests` to inspect the current state. "
+        "This interrupts once per turn: `stop_hook_active` makes the retry proceed. "
+        "For any worktree you do not own, do not commit on its behalf; name it with "
+        "`gh issue comment <tracker>` so it outlives this session. Only after confirming "
+        "ownership and redundancy should any cleanup be considered."
+    )
+
+
 def run_stop(hook_input: dict) -> int:
     """Continue incomplete repository work once, without creating a Stop loop."""
     if hook_input.get("stop_hook_active") is True:
@@ -3203,6 +3270,7 @@ def run_stop(hook_input: dict) -> int:
     # that worse. It is also better for the reader -- an agent ending its
     # turn learns everything it owes at once, instead of discovering the
     # next duty only after satisfying the previous one.
+    report = _worktree_report(_hook_working_directory(hook_input))
     reasons = [
         item
         for item in (
@@ -3211,10 +3279,10 @@ def run_stop(hook_input: dict) -> int:
             check_r18_unpushed_work(hook_input),
             check_r20_user_harness_drift(hook_input),
             check_r21_run_state_not_recorded(hook_input),
+            check_r24_foreign_worktree_left_behind(hook_input, report),
         )
         if item is not None
     ]
-    report = _worktree_report(_hook_working_directory(hook_input))
     if report is None:
         reason = "Completion hygiene could not be verified; inspect the current worktree."
     else:
@@ -3474,6 +3542,7 @@ _SELF_TEST_COVERAGE: dict[str, str] = {
     "check_r20_user_harness_drift": "run_required_action_self_test",
     "check_r21_run_state_not_recorded": "run_required_action_self_test",
     "check_r22_dispatch_adapter": "run_required_action_self_test",
+    "check_r24_foreign_worktree_left_behind": "run_required_action_self_test",
 }
 
 
@@ -3555,6 +3624,19 @@ _STOP_RULE_RENDERERS = {
     "check_r21_run_state_not_recorded": lambda: _with_stubs(
         {"ledger_events": lambda payload: ["delegate-dispatch", "commit"]},
         lambda: check_r21_run_state_not_recorded({"session_id": "s"}),
+    ),
+    "check_r24_foreign_worktree_left_behind": lambda: check_r24_foreign_worktree_left_behind(
+        {},
+        {
+            "foreign_worktree_stale_hours": 12,
+            "worktrees": [
+                {
+                    "path": "C:/foreign/stale",
+                    "state": "uncommitted",
+                    "age_hours": 24,
+                }
+            ]
+        },
     ),
 }
 
@@ -3873,6 +3955,36 @@ def run_required_action_self_test() -> int:
         _with_stubs(
             {"ledger_events": lambda payload: ["commit"]},
             lambda: check_r21_run_state_not_recorded({"session_id": "s"}),
+        )
+        is None,
+    )
+
+    # R24: a stale foreign worktree is report-only and carries no live reader.
+    foreign_report = {
+        "foreign_worktree_stale_hours": 12,
+        "worktrees": [
+            {"path": "C:/current", "is_current": True, "state": "clean"},
+            {
+                "path": "C:/foreign/stale",
+                "state": "uncommitted",
+                "age_hours": 12,
+            },
+        ]
+    }
+    check(
+        "R24 reports foreign uncommitted work at the twelve-hour threshold",
+        check_r24_foreign_worktree_left_behind({}, foreign_report) is not None,
+    )
+    check(
+        "R24 is silent for fresh foreign uncommitted work",
+        check_r24_foreign_worktree_left_behind(
+            {},
+            {
+                "foreign_worktree_stale_hours": 12,
+                "worktrees": [
+                    {"path": "C:/foreign/fresh", "state": "uncommitted", "age_hours": 1}
+                ],
+            },
         )
         is None,
     )

--- a/scripts/ci/worktree_hygiene.py
+++ b/scripts/ci/worktree_hygiene.py
@@ -58,6 +58,12 @@ MAX_REPORTED_WORKTREES = 50
 # has had a chance to open a pull request.
 DEFAULT_STALE_DAYS = 3
 SECONDS_PER_DAY = 86400
+# A local worktree can hold the only copy of uncommitted work, so its advisory
+# clock is deliberately much shorter than the three-day remote-branch clock.
+FOREIGN_WORKTREE_STALE_HOURS = 12
+# Keep activity inspection bounded like the NUL scan. A truncated list still
+# has a known activity floor; it is not silently treated as unknown.
+MAX_ACTIVITY_PATHS = 2000
 
 ADVISORY_STATES = ("corrupt", "abandoned", "superseded", "uncommitted", "unknown", "orphaned")
 
@@ -91,7 +97,13 @@ def _parse_worktree_list(output: str) -> list[dict]:
     current: dict = {}
 
     def blank() -> dict:
-        return {"path": None, "branch": None, "locked": False, "prunable": False}
+        return {
+            "path": None,
+            "branch": None,
+            "locked": False,
+            "lock_reason": None,
+            "prunable": False,
+        }
 
     for line in output.splitlines():
         if not line.strip():
@@ -111,6 +123,7 @@ def _parse_worktree_list(output: str) -> list[dict]:
             current["branch"] = None
         elif key == "locked":
             current["locked"] = True
+            current["lock_reason"] = value or None
         elif key == "prunable":
             current["prunable"] = True
     if current:
@@ -118,14 +131,90 @@ def _parse_worktree_list(output: str) -> list[dict]:
     return [entry for entry in entries if entry.get("path")]
 
 
-def _uncommitted_files(worktree: Path) -> int | None:
-    """Count changed paths, or None when git could not answer."""
+def _uncommitted_paths(worktree: Path) -> list[str] | None:
+    """Changed paths, or None when git could not answer."""
     # None is not zero. Reading a failed query as "clean" would feed the
     # superseded verdict, which tells the reader to delete the branch.
-    output = _git(worktree, "status", "--porcelain")
+    output = _git(worktree, "status", "--porcelain=v1", "-z")
     if output is None:
         return None
-    return len([line for line in output.splitlines() if line.strip()])
+    paths: list[str] = []
+    records = output.split("\0")
+    index = 0
+    while index < len(records):
+        record = records[index]
+        index += 1
+        if not record:
+            continue
+        if len(record) < 4 or record[2] != " ":
+            return None
+        paths.append(record[3:])
+        # A rename/copy record carries its source path after the destination.
+        # It is not a second changed path in this worktree, and may no longer
+        # exist, so skip it without another status query.
+        if "R" in record[:2] or "C" in record[:2]:
+            if index >= len(records):
+                return None
+            index += 1
+    return paths
+
+
+def _uncommitted_files(worktree: Path) -> int | None:
+    """Count changed paths from the reporter's one status query."""
+    paths = _uncommitted_paths(worktree)
+    return len(paths) if paths is not None else None
+
+
+def _activity_epoch(
+    root: Path, worktree: Path, committish: str | None, paths: list[str] | None
+) -> float | None:
+    """Freshest non-self-contaminating activity signal for one worktree."""
+    signals: list[float] = []
+    if committish is not None:
+        last_commit_epoch = _last_commit_epoch(root, committish)
+        if last_commit_epoch is not None:
+            signals.append(float(last_commit_epoch))
+    if paths is not None:
+        try:
+            resolved_worktree = worktree.resolve()
+        except OSError:
+            resolved_worktree = None
+        if resolved_worktree is not None:
+            for relative_path in paths[:MAX_ACTIVITY_PATHS]:
+                try:
+                    candidate = (worktree / relative_path).resolve()
+                    candidate.relative_to(resolved_worktree)
+                    signals.append(candidate.stat().st_mtime)
+                except FileNotFoundError:
+                    # A deletion has no file mtime. Its parent changes when
+                    # the deletion happens, which is the bounded, local
+                    # proxy that keeps fresh destructive edits from reading
+                    # as stale without using the self-refreshing index mtime.
+                    parent = candidate.parent
+                    while True:
+                        try:
+                            signals.append(parent.stat().st_mtime)
+                            break
+                        except FileNotFoundError:
+                            if parent == resolved_worktree:
+                                break
+                            parent = parent.parent
+                        except OSError:
+                            break
+                except OSError:
+                    continue
+                except ValueError:
+                    continue
+    try:
+        git_marker = worktree / ".git"
+        # Linked worktrees have a private .git file whose mtime is their
+        # creation floor. The primary checkout has the shared admin directory
+        # instead, and fetches elsewhere can refresh it indefinitely.
+        if git_marker.is_file():
+            signals.append(git_marker.stat().st_mtime)
+    except OSError:
+        pass
+    return max(signals) if signals else None
 
 
 def _unique_commits(root: Path, committish: str | None) -> int | None:
@@ -335,6 +424,7 @@ def collect_worktree_report(
     except OSError:
         return []
 
+    reference_time = time.time() if now is None else now
     report: list[dict] = []
     for index, record in enumerate(_parse_worktree_list(listing)[:MAX_REPORTED_WORKTREES]):
         if record["prunable"]:
@@ -351,6 +441,8 @@ def collect_worktree_report(
         committish = branch or head
         corrupt, _, scan_truncated = scan_for_nul_corruption(str(worktree))
         ahead, behind = _ahead_behind(root, committish)
+        uncommitted_paths = _uncommitted_paths(worktree)
+        last_activity_epoch = _activity_epoch(root, worktree, committish, uncommitted_paths)
 
         pull_requests: int | None = None
         if open_pull_requests is not None and branch is not None:
@@ -365,7 +457,16 @@ def collect_worktree_report(
             "is_main": index == 0,
             "is_current": resolved == current,
             "locked": record["locked"],
-            "uncommitted_files": _uncommitted_files(worktree),
+            "lock_reason": record["lock_reason"],
+            "uncommitted_files": (
+                len(uncommitted_paths) if uncommitted_paths is not None else None
+            ),
+            "last_activity_epoch": last_activity_epoch,
+            "age_hours": (
+                max(0.0, reference_time - last_activity_epoch) / 3600
+                if last_activity_epoch is not None
+                else None
+            ),
             "corrupt_files": len(corrupt),
             "corrupt_paths": corrupt[:5],
             "scan_truncated": scan_truncated,
@@ -384,7 +485,7 @@ def collect_worktree_report(
             worktree_branches,
             open_pull_requests=open_pull_requests,
             stale_days=stale_days,
-            now=now,
+            now=reference_time,
         )
     )
     return report
@@ -509,7 +610,16 @@ def main() -> int:
         open_pull_requests=open_pull_requests_via_gh if args.check_pull_requests else None,
     )
     if args.format == "json":
-        print(json.dumps({"worktrees": report, "advisories": format_advisories(report)}, indent=2))
+        print(
+            json.dumps(
+                {
+                    "foreign_worktree_stale_hours": FOREIGN_WORKTREE_STALE_HOURS,
+                    "worktrees": report,
+                    "advisories": format_advisories(report),
+                },
+                indent=2,
+            )
+        )
         return 0
     advisories = format_advisories(report)
     if not advisories:

--- a/scripts/ci/worktree_hygiene.py
+++ b/scripts/ci/worktree_hygiene.py
@@ -213,6 +213,9 @@ def _activity_epoch(
         if git_marker.is_file():
             signals.append(git_marker.stat().st_mtime)
     except OSError:
+        # The marker is advisory activity evidence, not a required report
+        # dependency; an unreadable marker must not turn a usable git report
+        # into an unknown worktree.
         pass
     return max(signals) if signals else None
 

--- a/scripts/ci/worktree_hygiene.py
+++ b/scripts/ci/worktree_hygiene.py
@@ -216,7 +216,7 @@ def _activity_epoch(
         # The marker is advisory activity evidence, not a required report
         # dependency; an unreadable marker must not turn a usable git report
         # into an unknown worktree.
-        pass
+        return max(signals) if signals else None
     return max(signals) if signals else None
 
 

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -46,6 +46,7 @@ ISOLATED_STOP_RULES = (
     # exists for, caught by the equality pin in the commit that added it.
     "check_r20_user_harness_drift",
     "check_r21_run_state_not_recorded",
+    "check_r24_foreign_worktree_left_behind",
 )
 
 
@@ -1925,6 +1926,148 @@ class _NoSubprocess:
         raise OSError("subprocess disabled for the determinism check")
 
 
+class ForeignWorktreeStopGateTest(unittest.TestCase):
+    """R24 / #4546: surface stale foreign work without refusing the Stop retry."""
+
+    def setUp(self):
+        isolate_stop_rules(self, except_for=("check_r24_foreign_worktree_left_behind",))
+
+    def stop(self, payload: dict) -> dict | None:
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            self.assertEqual(guard.run_stop(payload), 0)
+        text = stream.getvalue().strip()
+        return json.loads(text) if text else None
+
+    def test_stale_foreign_uncommitted_work_reaches_stop(self):
+        """Reachability through `run_stop` prevents a defined but inert report rule."""
+        report = {
+            "foreign_worktree_stale_hours": 12,
+            "worktrees": [
+                {"path": "C:/current", "is_current": True, "state": "clean"},
+                {
+                    "path": "C:/foreign/still-working",
+                    "is_current": False,
+                    "is_remote_only": False,
+                    "state": "uncommitted",
+                    "age_hours": 24,
+                },
+            ]
+        }
+        with patch("scripts.agents.guard._worktree_report", return_value=report):
+            output = self.stop({"cwd": "."})
+
+        self.assertIsNotNone(output)
+        self.assertIn("C:/foreign/still-working", output["reason"])
+        self.assertIn("worktree_hygiene.py --check-pull-requests", output["reason"])
+
+    def test_threshold_is_inclusive_and_fresh_work_is_silent(self):
+        """The 12-hour boundary is exact; a one-second drift changes the safety outcome."""
+        for age, expected in ((12, True), (12 - (1 / 3600), False)):
+            with self.subTest(age=age):
+                reason = guard.check_r24_foreign_worktree_left_behind(
+                    {},
+                    {
+                        "foreign_worktree_stale_hours": 12,
+                        "worktrees": [
+                            {"path": "C:/foreign", "state": "uncommitted", "age_hours": age}
+                        ]
+                    },
+                )
+                self.assertEqual(reason is not None, expected)
+
+    def test_reporter_owned_threshold_controls_foreign_age_selection(self):
+        """#4546: Stop must follow the reporter's one threshold source, not a literal."""
+        worktree = {"path": "C:/foreign", "state": "uncommitted", "age_hours": 24}
+        self.assertIsNone(
+            guard.check_r24_foreign_worktree_left_behind(
+                {}, {"foreign_worktree_stale_hours": 25, "worktrees": [worktree]}
+            )
+        )
+        self.assertIsNotNone(
+            guard.check_r24_foreign_worktree_left_behind(
+                {}, {"foreign_worktree_stale_hours": 24, "worktrees": [worktree]}
+            )
+        )
+
+    def test_unknown_age_and_urgent_states_are_reported_without_waiting(self):
+        """Unknown, corrupt, and unanswerable states cannot be safely aged away."""
+        cases = (
+            {"path": "C:/foreign/unknown-age", "state": "uncommitted", "age_hours": None},
+            {"path": "C:/foreign/corrupt", "state": "corrupt", "age_hours": 0.01},
+            {"path": "C:/foreign/unknown", "state": "unknown", "age_hours": 0.01},
+        )
+        for entry in cases:
+            with self.subTest(entry=entry):
+                reason = guard.check_r24_foreign_worktree_left_behind({}, {"worktrees": [entry]})
+                self.assertIsNotNone(reason)
+        unknown_age = guard.check_r24_foreign_worktree_left_behind(
+            {}, {"worktrees": [cases[0]]}
+        )
+        self.assertIn("age could not be determined", unknown_age)
+
+    def test_current_remote_only_and_nonpreserving_states_stay_silent(self):
+        """R24 does not duplicate current-state gates or surface deletion-oriented advice."""
+        worktrees = [
+            {
+                "path": "C:/current",
+                "is_current": True,
+                "state": "uncommitted",
+                "age_hours": 30,
+            },
+            {
+                "path": "origin/foreign",
+                "is_remote_only": True,
+                "state": "unknown",
+                "age_hours": None,
+            },
+            *[
+                {"path": f"C:/foreign/{state}", "state": state, "age_hours": 30}
+                for state in ("pending", "superseded", "clean", "orphaned")
+            ],
+        ]
+        self.assertIsNone(guard.check_r24_foreign_worktree_left_behind({}, {"worktrees": worktrees}))
+        with patch("scripts.agents.guard._worktree_report", return_value={"worktrees": [worktrees[0]]}):
+            output = self.stop({"cwd": "."})
+        self.assertIsNotNone(output)
+        self.assertIn("Current worktree has uncommitted work", output["reason"])
+        self.assertNotIn("Foreign worktree report", output["reason"])
+
+    def test_message_caps_paths_names_locks_and_avoids_unconfirmed_cleanup_commands(self):
+        """A long report remains actionable without suggesting another agent's work be destroyed."""
+        worktrees = [
+            {
+                "path": f"C:/foreign/{index}",
+                "state": "uncommitted",
+                "age_hours": 24,
+                "locked": index == 0,
+                "lock_reason": "agent session" if index == 0 else None,
+            }
+            for index in range(20)
+        ]
+        reason = guard.check_r24_foreign_worktree_left_behind(
+            {}, {"foreign_worktree_stale_hours": 12, "worktrees": worktrees}
+        )
+        self.assertIsNotNone(reason)
+        self.assertIn("C:/foreign/0", reason)
+        self.assertIn("C:/foreign/1", reason)
+        self.assertIn("C:/foreign/2", reason)
+        self.assertNotIn("C:/foreign/3", reason)
+        self.assertIn("Showing 3 of 20 worktrees", reason)
+        self.assertIn("locked: agent session", reason)
+        self.assertIn("worktree_hygiene.py --check-pull-requests", reason)
+        self.assertNotIn("git worktree remove", reason)
+        self.assertNotIn("git branch -D", reason)
+        self.assertIn("do not commit on its behalf", reason)
+        self.assertIn("gh issue comment <tracker>", reason)
+
+    def test_malformed_reports_are_silent_rather_than_raising(self):
+        """A corrupt helper payload cannot kill the hook process."""
+        for report in (None, {}, {"worktrees": {}}, {"worktrees": [{"state": "uncommitted"}]}):
+            with self.subTest(report=report):
+                self.assertIsNone(guard.check_r24_foreign_worktree_left_behind({}, report))
+
+
 class StopTestsAreIndependentOfLiveStateTest(unittest.TestCase):
     """#4555: assert determinism directly instead of enumerating the readers.
 
@@ -1957,6 +2100,7 @@ class StopTestsAreIndependentOfLiveStateTest(unittest.TestCase):
         "UnpushedWorkStopGateTest",
         "LearningLoopStopGateTest",
         "RunStateStopGateTest",
+        "ForeignWorktreeStopGateTest",
     )
 
     def subjects(self) -> unittest.TestSuite:

--- a/tests/scripts/test_worktree_hygiene.py
+++ b/tests/scripts/test_worktree_hygiene.py
@@ -10,8 +10,11 @@
 
 from __future__ import annotations
 
+import json
 import os
+import shutil
 import subprocess  # nosec B404 - tests drive the local git binary on fixtures.
+import sys
 import tempfile
 import time
 import unittest
@@ -19,6 +22,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 from scripts.ci.worktree_hygiene import (
+    FOREIGN_WORKTREE_STALE_HOURS,
+    _activity_epoch,
     collect_worktree_report,
     format_advisories,
     open_pull_requests_via_gh,
@@ -114,6 +119,78 @@ class WorktreeHygieneTest(unittest.TestCase):
         self.assertTrue(report[0]["is_current"])
         self.assertEqual(report[0]["state"], "clean")
         self.assertEqual(format_advisories(report), [])
+
+    def test_local_worktree_exposes_its_activity_age(self):
+        """#4546: foreign-worktree Stop reporting needs a reporter-owned clock."""
+        worktree = self.add_worktree("active", "ChaosEngine/active")
+        self.write(worktree, "notes.md", "still in progress\n")
+
+        entry = self.entry(collect_worktree_report(self.main), "active")
+
+        self.assertIn("last_activity_epoch", entry)
+        self.assertIn("age_hours", entry)
+        self.assertIsNotNone(entry["last_activity_epoch"])
+        self.assertIsNotNone(entry["age_hours"])
+
+    def test_json_report_exposes_the_foreign_worktree_threshold(self):
+        """#4546: Stop receives its age threshold from the reporter, not a duplicate literal."""
+        helper = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "worktree_hygiene.py"
+        completed = subprocess.run(  # nosec B603 - fixed tracked helper on a temp fixture.
+            [sys.executable, str(helper), "--root", str(self.main), "--format", "json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(
+            json.loads(completed.stdout)["foreign_worktree_stale_hours"],
+            FOREIGN_WORKTREE_STALE_HOURS,
+        )
+
+    def test_deleted_path_activity_uses_its_parent_directory_mtime(self):
+        """#4546: a fresh deletion must not look stale just because its file is gone."""
+        worktree = self.add_worktree("deleted", "ChaosEngine/deleted")
+        changed = self.write(worktree, "tracked.txt", "tracked\n")
+        git(worktree, "add", "tracked.txt")
+        git(worktree, "commit", "-qm", "track it")
+        changed.unlink()
+        old_epoch = time.time() - (10 * 24 * 60 * 60)
+        os.utime(worktree / ".git", (old_epoch, old_epoch))
+
+        with patch("scripts.ci.worktree_hygiene._last_commit_epoch", return_value=int(old_epoch)):
+            activity = _activity_epoch(self.main, worktree, "ChaosEngine/deleted", ["tracked.txt"])
+
+        self.assertIsNotNone(activity)
+        self.assertGreater(activity, old_epoch + 1)
+
+    def test_primary_git_directory_is_not_an_activity_creation_marker(self):
+        """#4546: shared admin writes must not keep a stale primary tree fresh."""
+        old_epoch = time.time() - (10 * 24 * 60 * 60)
+        os.utime(self.main / ".git", None)
+
+        with patch("scripts.ci.worktree_hygiene._last_commit_epoch", return_value=int(old_epoch)):
+            activity = _activity_epoch(self.main, self.main, "main", [])
+
+        self.assertEqual(activity, float(int(old_epoch)))
+
+    def test_recursive_deletion_uses_the_nearest_existing_parent_mtime(self):
+        """#4546: deleting a directory tree is fresh work even after its parent is gone."""
+        worktree = self.add_worktree("recursive-delete", "ChaosEngine/recursive-delete")
+        changed = self.write(worktree, "nested/tracked.txt", "tracked\n")
+        git(worktree, "add", "nested/tracked.txt")
+        git(worktree, "commit", "-qm", "track nested file")
+        shutil.rmtree(changed.parent)
+        old_epoch = time.time() - (10 * 24 * 60 * 60)
+        os.utime(worktree / ".git", (old_epoch, old_epoch))
+
+        with patch("scripts.ci.worktree_hygiene._last_commit_epoch", return_value=int(old_epoch)):
+            activity = _activity_epoch(
+                self.main, worktree, "ChaosEngine/recursive-delete", ["nested/tracked.txt"]
+            )
+
+        self.assertIsNotNone(activity)
+        self.assertGreater(activity, old_epoch + 1)
 
     def test_directory_outside_any_repository_reports_nothing(self):
         with tempfile.TemporaryDirectory() as outside:


### PR DESCRIPTION
Closes #4546. Adds bounded reporter-owned activity metadata and a pure, report-only R24 Stop advisory for stale foreign worktrees; preserves current/remote-only and deletion-oriented exclusions; covers age, lock, malformed-payload, and determinism regressions.