### PR TITLE
feat(ci): add Agent Plugin phase-0 contract validation

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -291,7 +291,8 @@ py -3 scripts/ci/validate_agent_setup.py --skip-external
 ```
 
 That command drives `scripts/ci/validate_agent_guidance.py` and
-`scripts/ci/validate_skills.py`, reading its ceilings from
+`scripts/ci/validate_skills.py`, while the Agent Plugin contract is checked by
+`scripts/ci/validate_agent_plugins.py`; its ceilings come from
 `scripts/ci/agent_guidance_budget.json` and the cross-host capability matrix
 from `scripts/ci/agent_harness_parity.json`.
 
@@ -306,6 +307,7 @@ change it:
 | `tests/scripts/test_agent_harness_adherence.py` | Reviewed deterministic episodes, unknown evidence, and fail-closed adherence comparison. |
 | `tests/scripts/test_agent_harness_reachability.py` | That every element on this page is reachable from the entrypoint, and that the duties below stay unqualified. |
 | `tests/scripts/test_validate_agent_guidance.py` | The budget validator itself. |
+| `tests/scripts/test_validate_agent_plugins.py` | Portable Agent Plugin manifests, Agent Skills, and containment. |
 | `tests/scripts/test_validate_agent_setup.py` | The aggregate gate and the host-parity matrix. |
 | `tests/scripts/test_validate_skills.py` | Skill frontmatter, names, and body limits. |
 | `tests/scripts/test_guard_lifecycle.py`, `tests/scripts/test_guard_nul_corruption.py` | The lifecycle guard's decisions and its behaviour on a corrupt state file. |

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -90,6 +90,7 @@ jobs:
               - 'scripts/agents/**'
               - 'scripts/ci/validate_agent_setup.py'
               - 'scripts/ci/validate_agent_guidance.py'
+              - 'scripts/ci/validate_agent_plugins.py'
               - 'scripts/ci/validate_red_before_green.py'
               - 'scripts/ci/validate_skills.py'
               - 'scripts/ci/worktree_hygiene.py'
@@ -108,6 +109,7 @@ jobs:
               - 'tests/scripts/test_guard*.py'
               - 'tests/scripts/test_validate_red_before_green.py'
               - 'tests/scripts/test_validate_agent_guidance.py'
+              - 'tests/scripts/test_validate_agent_plugins.py'
               - 'tests/scripts/test_validate_agent_setup.py'
               - 'tests/scripts/test_worktree_hygiene.py'
               - 'tests/scripts/test_validate_skills.py'
@@ -277,6 +279,7 @@ jobs:
           tests.scripts.test_guard_lifecycle
           tests.scripts.test_validate_red_before_green
           tests.scripts.test_validate_agent_guidance
+          tests.scripts.test_validate_agent_plugins
           tests.scripts.test_validate_agent_setup
           tests.scripts.test_validate_skills
           tests.scripts.test_sync_user_harness

--- a/scripts/ci/agent_guidance_budget.json
+++ b/scripts/ci/agent_guidance_budget.json
@@ -185,6 +185,7 @@
       "scripts/ci/agent_harness_parity.json",
       "scripts/ci/local_gate.py",
       "scripts/ci/validate_agent_guidance.py",
+      "scripts/ci/validate_agent_plugins.py",
       "scripts/ci/validate_agent_setup.py",
       "scripts/ci/validate_skills.py",
       "scripts/ci/watch_pr_checks.py",

--- a/scripts/ci/validate_agent_plugins.py
+++ b/scripts/ci/validate_agent_plugins.py
@@ -6,7 +6,7 @@ import os
 import re
 from pathlib import Path
 
-from scripts.ci.validate_agent_guidance import parse_frontmatter
+import yaml
 
 SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
 MANIFEST_PATH = "plugin.json"
@@ -43,6 +43,24 @@ def resolves_inside(root: Path, candidate: Path) -> bool:
 def has_directory_entry(path: Path) -> bool:
     """Detect a path entry without following a dangling link or junction."""
     return os.path.lexists(path)
+
+
+def parse_skill_frontmatter(content: str) -> dict | None:
+    """Load complete YAML frontmatter without accepting an unclosed marker."""
+    content = content.replace("\r\n", "\n").replace("\r", "\n")
+    if not content.startswith("---\n"):
+        return None
+    marker = content.find("\n---", 4)
+    if marker < 0:
+        return None
+    after_marker = content[marker + 4 :]
+    if after_marker and not after_marker.startswith("\n"):
+        return None
+    try:
+        frontmatter = yaml.safe_load(content[4:marker])
+    except yaml.YAMLError:
+        return None
+    return frontmatter if isinstance(frontmatter, dict) else None
 
 
 def manifest_field_errors(manifest: dict) -> list[dict[str, str]]:
@@ -143,7 +161,7 @@ def validate_skills(root: Path) -> list[dict[str, str]]:
         except (OSError, UnicodeDecodeError) as error:
             findings.append(issue("skill-read", relative_path, f"SKILL.md cannot be read: {error}"))
             continue
-        frontmatter = parse_frontmatter(skill.replace("\r\n", "\n").replace("\r", "\n"))
+        frontmatter = parse_skill_frontmatter(skill)
         if frontmatter is None:
             findings.append(issue("skill-frontmatter", relative_path, "SKILL.md must start with YAML frontmatter"))
             continue
@@ -157,6 +175,19 @@ def validate_skills(root: Path) -> list[dict[str, str]]:
             findings.append(
                 issue("skill-description", relative_path, "frontmatter description must contain 1-1024 characters")
             )
+        optional_string_limits = {"license": None, "compatibility": 500, "allowed-tools": None}
+        for field, maximum_length in optional_string_limits.items():
+            if field not in frontmatter:
+                continue
+            value = frontmatter[field]
+            if not isinstance(value, str) or (maximum_length is not None and not 1 <= len(value) <= maximum_length):
+                findings.append(issue("skill-field", relative_path, f"{field} must be a valid string"))
+        if "metadata" in frontmatter:
+            metadata = frontmatter["metadata"]
+            if not isinstance(metadata, dict) or not all(
+                isinstance(key, str) and isinstance(value, str) for key, value in metadata.items()
+            ):
+                findings.append(issue("skill-field", relative_path, "metadata must map string keys to string values"))
     return findings
 
 

--- a/scripts/ci/validate_agent_plugins.py
+++ b/scripts/ci/validate_agent_plugins.py
@@ -137,57 +137,69 @@ def validate_manifest(root: Path) -> tuple[dict | None, list[dict[str, str]]]:
     return manifest, findings
 
 
-def validate_skills(root: Path) -> list[dict[str, str]]:
-    """Validate immediate Agent Skills without requiring host-specific policy."""
+def skills_component(root: Path) -> tuple[Path | None, list[dict[str, str]]]:
+    """Return the discoverable skills directory or its component finding."""
     skills_path = root / "skills"
     if not has_directory_entry(skills_path):
-        return []
+        return None, []
     if not resolves_inside(root, skills_path):
-        return [issue("component-escapes-root", "skills", "skills must remain inside the package")]
+        return None, [issue("component-escapes-root", "skills", "skills must remain inside the package")]
     if not skills_path.is_dir():
-        return [issue("component-invalid", "skills", "skills must be a directory when present")]
+        return None, [issue("component-invalid", "skills", "skills must be a directory when present")]
+    return skills_path, []
 
+
+def skill_metadata_errors(frontmatter: dict, directory_name: str, relative_path: Path) -> list[dict[str, str]]:
+    """Validate required and optional Agent Skills metadata."""
     findings: list[dict[str, str]] = []
+    name = frontmatter.get("name")
+    if not isinstance(name, str) or not SKILL_NAME.fullmatch(name) or name != directory_name:
+        findings.append(issue("skill-name", relative_path, "frontmatter name must be a valid skill name matching its directory"))
+    description = frontmatter.get("description")
+    if not isinstance(description, str) or not 1 <= len(description) <= 1024:
+        findings.append(issue("skill-description", relative_path, "frontmatter description must contain 1-1024 characters"))
+    optional_string_limits = {"license": None, "compatibility": 500, "allowed-tools": None}
+    for field, maximum_length in optional_string_limits.items():
+        value = frontmatter.get(field)
+        if field in frontmatter and (
+            not isinstance(value, str) or (maximum_length is not None and not 1 <= len(value) <= maximum_length)
+        ):
+            findings.append(issue("skill-field", relative_path, f"{field} must be a valid string"))
+    metadata = frontmatter.get("metadata")
+    if "metadata" in frontmatter and (
+        not isinstance(metadata, dict)
+        or not all(isinstance(key, str) and isinstance(value, str) for key, value in metadata.items())
+    ):
+        findings.append(issue("skill-field", relative_path, "metadata must map string keys to string values"))
+    return findings
+
+
+def validate_skill(root: Path, child: Path) -> list[dict[str, str]]:
+    """Validate one directly-discoverable skill directory."""
+    skill_path = child / "SKILL.md"
+    if not child.is_dir() or not has_directory_entry(skill_path):
+        return []
+    relative_path = skill_path.relative_to(root)
+    if not resolves_inside(root, skill_path):
+        return [issue("component-escapes-root", relative_path, "SKILL.md must remain inside the package")]
+    try:
+        skill = skill_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        return [issue("skill-read", relative_path, f"SKILL.md cannot be read: {error}")]
+    frontmatter = parse_skill_frontmatter(skill)
+    if frontmatter is None:
+        return [issue("skill-frontmatter", relative_path, "SKILL.md must start with YAML frontmatter")]
+    return skill_metadata_errors(frontmatter, child.name, relative_path)
+
+
+def validate_skills(root: Path) -> list[dict[str, str]]:
+    """Validate immediate Agent Skills without requiring host-specific policy."""
+    skills_path, findings = skills_component(root)
+    if skills_path is None:
+        return findings
+
     for child in sorted(skills_path.iterdir(), key=lambda entry: entry.name):
-        skill_path = child / "SKILL.md"
-        if not child.is_dir() or not has_directory_entry(skill_path):
-            continue
-        relative_path = skill_path.relative_to(root)
-        if not resolves_inside(root, skill_path):
-            findings.append(issue("component-escapes-root", relative_path, "SKILL.md must remain inside the package"))
-            continue
-        try:
-            skill = skill_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError) as error:
-            findings.append(issue("skill-read", relative_path, f"SKILL.md cannot be read: {error}"))
-            continue
-        frontmatter = parse_skill_frontmatter(skill)
-        if frontmatter is None:
-            findings.append(issue("skill-frontmatter", relative_path, "SKILL.md must start with YAML frontmatter"))
-            continue
-        name = frontmatter.get("name")
-        if not isinstance(name, str) or not SKILL_NAME.fullmatch(name) or name != child.name:
-            findings.append(
-                issue("skill-name", relative_path, "frontmatter name must be a valid skill name matching its directory")
-            )
-        description = frontmatter.get("description")
-        if not isinstance(description, str) or not 1 <= len(description) <= 1024:
-            findings.append(
-                issue("skill-description", relative_path, "frontmatter description must contain 1-1024 characters")
-            )
-        optional_string_limits = {"license": None, "compatibility": 500, "allowed-tools": None}
-        for field, maximum_length in optional_string_limits.items():
-            if field not in frontmatter:
-                continue
-            value = frontmatter[field]
-            if not isinstance(value, str) or (maximum_length is not None and not 1 <= len(value) <= maximum_length):
-                findings.append(issue("skill-field", relative_path, f"{field} must be a valid string"))
-        if "metadata" in frontmatter:
-            metadata = frontmatter["metadata"]
-            if not isinstance(metadata, dict) or not all(
-                isinstance(key, str) and isinstance(value, str) for key, value in metadata.items()
-            ):
-                findings.append(issue("skill-field", relative_path, "metadata must map string keys to string values"))
+        findings.extend(validate_skill(root, child))
     return findings
 
 

--- a/scripts/ci/validate_agent_plugins.py
+++ b/scripts/ci/validate_agent_plugins.py
@@ -1,0 +1,127 @@
+"""Validate the portable Agent Plugin v1.0.0 package contract (#4576)."""
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+MANIFEST_PATH = "plugin.json"
+ALLOWED_MANIFEST_FIELDS = {
+    "$schema",
+    "name",
+    "version",
+    "description",
+    "author",
+    "homepage",
+    "repository",
+    "license",
+    "keywords",
+    "extensions",
+}
+PLUGIN_NAME = re.compile(r"^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]{0,62}[a-z0-9])?$")
+
+
+def issue(code: str, path: Path | str, message: str, severity: str = "error") -> dict[str, str]:
+    """Return one stable, machine-readable validation finding."""
+    return {"code": code, "path": str(path).replace("\\", "/"), "message": message, "severity": severity}
+
+
+def resolves_inside(root: Path, candidate: Path) -> bool:
+    """Whether `candidate`, including links, remains within package `root`."""
+    try:
+        candidate.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def validate_manifest(root: Path) -> tuple[dict | None, list[dict[str, str]]]:
+    """Load and validate the required core manifest."""
+    manifest_path = root / MANIFEST_PATH
+    if not resolves_inside(root, manifest_path):
+        return None, [issue("component-escapes-root", MANIFEST_PATH, "plugin.json must remain inside the package")]
+    if not manifest_path.is_file():
+        return None, [issue("plugin-manifest", MANIFEST_PATH, "plugin.json must be a file")]
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        return None, [issue("plugin-manifest", MANIFEST_PATH, f"plugin.json is not valid JSON: {error}")]
+    if not isinstance(manifest, dict):
+        return None, [issue("plugin-manifest", MANIFEST_PATH, "plugin.json must contain a JSON object")]
+
+    findings: list[dict[str, str]] = []
+    if manifest.get("$schema") != SCHEMA_URL:
+        findings.append(issue("plugin-schema", MANIFEST_PATH, f"$schema must be {SCHEMA_URL}"))
+    name = manifest.get("name")
+    if not isinstance(name, str) or not PLUGIN_NAME.fullmatch(name):
+        findings.append(
+            issue(
+                "plugin-name",
+                MANIFEST_PATH,
+                "name must be 1-64 lowercase letters, digits, dots, or hyphens without repeated dots or hyphens",
+            )
+        )
+    for field in sorted(set(manifest) - ALLOWED_MANIFEST_FIELDS):
+        findings.append(
+            issue(
+                "manifest-unknown-field",
+                MANIFEST_PATH,
+                f"unknown manifest field is ignored for forward compatibility: {field}",
+                "warning",
+            )
+        )
+    return manifest, findings
+
+
+def validate_skills(root: Path) -> list[dict[str, str]]:
+    """Validate immediate Agent Skills without requiring host-specific policy."""
+    skills_path = root / "skills"
+    if not skills_path.exists():
+        return []
+    if not resolves_inside(root, skills_path):
+        return [issue("component-escapes-root", "skills", "skills must remain inside the package")]
+    if not skills_path.is_dir():
+        return [issue("component-invalid", "skills", "skills must be a directory when present")]
+
+    findings: list[dict[str, str]] = []
+    for child in sorted(skills_path.iterdir(), key=lambda entry: entry.name):
+        skill_path = child / "SKILL.md"
+        if not child.is_dir() or not skill_path.exists():
+            continue
+        relative_path = skill_path.relative_to(root)
+        if not resolves_inside(root, skill_path):
+            findings.append(issue("component-escapes-root", relative_path, "SKILL.md must remain inside the package"))
+            continue
+        try:
+            skill = skill_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            findings.append(issue("skill-read", relative_path, f"SKILL.md cannot be read: {error}"))
+            continue
+        if not skill.startswith("---\n"):
+            findings.append(issue("skill-frontmatter", relative_path, "SKILL.md must start with YAML frontmatter"))
+    return findings
+
+
+def validate_package(root: Path) -> list[dict[str, str]]:
+    """Return contract findings for one portable Agent Plugin package root."""
+    root = Path(root)
+    manifest, findings = validate_manifest(root)
+    if manifest is None:
+        return findings
+    return findings + validate_skills(root)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package", type=Path, help="Agent Plugin package root")
+    arguments = parser.parse_args()
+    findings = validate_package(arguments.package)
+    for finding in findings:
+        print(f"{finding['severity']}: {finding['path']}: {finding['code']}: {finding['message']}")
+    return 1 if any(finding["severity"] == "error" for finding in findings) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate_agent_plugins.py
+++ b/scripts/ci/validate_agent_plugins.py
@@ -2,9 +2,11 @@
 
 import argparse
 import json
+import os
 import re
 from pathlib import Path
 
+from scripts.ci.validate_agent_guidance import parse_frontmatter
 
 SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
 MANIFEST_PATH = "plugin.json"
@@ -21,6 +23,7 @@ ALLOWED_MANIFEST_FIELDS = {
     "extensions",
 }
 PLUGIN_NAME = re.compile(r"^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]{0,62}[a-z0-9])?$")
+SKILL_NAME = re.compile(r"^(?!.*--)[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
 
 
 def issue(code: str, path: Path | str, message: str, severity: str = "error") -> dict[str, str]:
@@ -35,6 +38,46 @@ def resolves_inside(root: Path, candidate: Path) -> bool:
     except (OSError, ValueError):
         return False
     return True
+
+
+def has_directory_entry(path: Path) -> bool:
+    """Detect a path entry without following a dangling link or junction."""
+    return os.path.lexists(path)
+
+
+def manifest_field_errors(manifest: dict) -> list[dict[str, str]]:
+    """Validate every schema-governed manifest field that is present."""
+    findings: list[dict[str, str]] = []
+    string_fields = {"version", "description", "homepage", "repository", "license"}
+    for field in sorted(string_fields & set(manifest)):
+        if not isinstance(manifest[field], str):
+            findings.append(issue("manifest-field", MANIFEST_PATH, f"{field} must be a string"))
+    if "keywords" in manifest and (
+        not isinstance(manifest["keywords"], list) or not all(isinstance(item, str) for item in manifest["keywords"])
+    ):
+        findings.append(issue("manifest-field", MANIFEST_PATH, "keywords must be an array of strings"))
+    if "author" in manifest:
+        author = manifest["author"]
+        if (
+            not isinstance(author, dict)
+            or set(author) - {"name", "email", "url"}
+            or not all(isinstance(value, str) for value in author.values())
+        ):
+            findings.append(issue("manifest-field", MANIFEST_PATH, "author must contain only string name, email, or url fields"))
+    if "extensions" in manifest:
+        extensions = manifest["extensions"]
+        if not isinstance(extensions, dict):
+            findings.append(
+                issue(
+                    "extensions-invalid",
+                    MANIFEST_PATH,
+                    "extensions must be an object and is ignored by this validator",
+                    "warning",
+                )
+            )
+        elif not all(isinstance(value, dict) for value in extensions.values()):
+            findings.append(issue("manifest-field", MANIFEST_PATH, "each extensions namespace must contain an object"))
+    return findings
 
 
 def validate_manifest(root: Path) -> tuple[dict | None, list[dict[str, str]]]:
@@ -63,6 +106,7 @@ def validate_manifest(root: Path) -> tuple[dict | None, list[dict[str, str]]]:
                 "name must be 1-64 lowercase letters, digits, dots, or hyphens without repeated dots or hyphens",
             )
         )
+    findings.extend(manifest_field_errors(manifest))
     for field in sorted(set(manifest) - ALLOWED_MANIFEST_FIELDS):
         findings.append(
             issue(
@@ -78,7 +122,7 @@ def validate_manifest(root: Path) -> tuple[dict | None, list[dict[str, str]]]:
 def validate_skills(root: Path) -> list[dict[str, str]]:
     """Validate immediate Agent Skills without requiring host-specific policy."""
     skills_path = root / "skills"
-    if not skills_path.exists():
+    if not has_directory_entry(skills_path):
         return []
     if not resolves_inside(root, skills_path):
         return [issue("component-escapes-root", "skills", "skills must remain inside the package")]
@@ -88,7 +132,7 @@ def validate_skills(root: Path) -> list[dict[str, str]]:
     findings: list[dict[str, str]] = []
     for child in sorted(skills_path.iterdir(), key=lambda entry: entry.name):
         skill_path = child / "SKILL.md"
-        if not child.is_dir() or not skill_path.exists():
+        if not child.is_dir() or not has_directory_entry(skill_path):
             continue
         relative_path = skill_path.relative_to(root)
         if not resolves_inside(root, skill_path):
@@ -99,8 +143,20 @@ def validate_skills(root: Path) -> list[dict[str, str]]:
         except (OSError, UnicodeDecodeError) as error:
             findings.append(issue("skill-read", relative_path, f"SKILL.md cannot be read: {error}"))
             continue
-        if not skill.startswith("---\n"):
+        frontmatter = parse_frontmatter(skill.replace("\r\n", "\n").replace("\r", "\n"))
+        if frontmatter is None:
             findings.append(issue("skill-frontmatter", relative_path, "SKILL.md must start with YAML frontmatter"))
+            continue
+        name = frontmatter.get("name")
+        if not isinstance(name, str) or not SKILL_NAME.fullmatch(name) or name != child.name:
+            findings.append(
+                issue("skill-name", relative_path, "frontmatter name must be a valid skill name matching its directory")
+            )
+        description = frontmatter.get("description")
+        if not isinstance(description, str) or not 1 <= len(description) <= 1024:
+            findings.append(
+                issue("skill-description", relative_path, "frontmatter description must contain 1-1024 characters")
+            )
     return findings
 
 
@@ -109,6 +165,8 @@ def validate_package(root: Path) -> list[dict[str, str]]:
     root = Path(root)
     manifest, findings = validate_manifest(root)
     if manifest is None:
+        return findings
+    if any(finding["severity"] == "error" for finding in findings):
         return findings
     return findings + validate_skills(root)
 

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -119,7 +119,7 @@ BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 # from the boundary was invisible. Equality makes shrinking the boundary a
 # deliberate two-line edit that shows up in review, which is the only place the
 # question "why is the harness smaller today" gets asked.
-EXPECTED_ELEMENT_COUNT = 126
+EXPECTED_ELEMENT_COUNT = 128
 
 ATX_HEADING = re.compile(r"(?m)^#{1,6}\s+(.+?)\s*$")
 

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1167,6 +1167,21 @@ class CiGateIsBlockingTest(unittest.TestCase):
         outputs = workflow["jobs"]["changes"]["outputs"]
         self.assertIn("agent_guidance", outputs, "filter result is never exported")
 
+    def test_agent_plugin_contract_validator_is_registered_in_the_guidance_gate(self):
+        yaml = __import__("yaml")
+        workflow = yaml.safe_load(self.WORKFLOW.read_text(encoding="utf-8"))
+        filters = yaml.safe_load(workflow["jobs"]["changes"]["steps"][1]["with"]["filters"])
+        guarded = set(filters["agent_guidance"])
+        for required in (
+            "scripts/ci/validate_agent_plugins.py",
+            "tests/scripts/test_validate_agent_plugins.py",
+        ):
+            self.assertIn(required, guarded, f"guidance filter misses {required}")
+        commands = " ".join(
+            str(step.get("run", "")) for step in workflow["jobs"]["agent-guidance"]["steps"]
+        )
+        self.assertIn("tests.scripts.test_validate_agent_plugins", commands)
+
     def test_dependency_review_runs_only_for_dependency_bearing_diffs(self):
         yaml = __import__("yaml")
         workflow = yaml.safe_load(self.WORKFLOW.read_text(encoding="utf-8"))

--- a/tests/scripts/test_validate_agent_plugins.py
+++ b/tests/scripts/test_validate_agent_plugins.py
@@ -76,6 +76,13 @@ class ValidateAgentPluginsTest(unittest.TestCase):
         self.assertEqual([issue["code"] for issue in issues], ["manifest-unknown-field"])
         self.assertEqual(issues[0]["severity"], "warning")
 
+    def test_warning_only_extensions_problem_does_not_skip_skill_validation(self):
+        self.manifest["extensions"] = "old client data"
+        self.write_manifest()
+        self.write("skills/broken/SKILL.md", "# Missing frontmatter\n")
+
+        self.assertEqual(self.codes(), {"extensions-invalid", "skill-frontmatter"})
+
     def test_reports_invalid_skill_component_without_masking_valid_manifest(self):
         self.write("skills/broken/SKILL.md", "# Missing frontmatter\n")
 

--- a/tests/scripts/test_validate_agent_plugins.py
+++ b/tests/scripts/test_validate_agent_plugins.py
@@ -1,0 +1,80 @@
+"""Phase-0 Agent Plugin contract validator tests (#4576)."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from scripts.ci.validate_agent_plugins import validate_package
+except ModuleNotFoundError:
+    validate_package = None
+
+
+SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+
+
+class ValidateAgentPluginsTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name) / "fixture-plugin"
+        self.root.mkdir()
+        self.manifest = {"$schema": SCHEMA_URL, "name": "fixture-plugin"}
+        self.write_manifest()
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write(self, relative_path, content):
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def write_manifest(self):
+        self.write("plugin.json", json.dumps(self.manifest))
+
+    def codes(self):
+        self.assertTrue(callable(validate_package), "validate_package must be available")
+        return {issue["code"] for issue in validate_package(self.root)}
+
+    def test_valid_minimal_package_passes(self):
+        self.assertTrue(callable(validate_package), "validate_package must be available")
+        self.assertEqual(validate_package(self.root), [])
+
+    def test_rejects_invalid_required_manifest_fields(self):
+        self.manifest = {"$schema": "https://example.invalid/schema.json", "name": "Not Valid"}
+        self.write_manifest()
+
+        self.assertEqual(
+            self.codes(),
+            {"plugin-schema", "plugin-name"},
+        )
+
+    def test_reports_unknown_manifest_fields_without_rejecting_the_package(self):
+        self.manifest["future-field"] = {"kept": "for a newer host"}
+        self.write_manifest()
+
+        self.assertTrue(callable(validate_package), "validate_package must be available")
+        issues = validate_package(self.root)
+
+        self.assertEqual([issue["code"] for issue in issues], ["manifest-unknown-field"])
+        self.assertEqual(issues[0]["severity"], "warning")
+
+    def test_reports_invalid_skill_component_without_masking_valid_manifest(self):
+        self.write("skills/broken/SKILL.md", "# Missing frontmatter\n")
+
+        self.assertEqual(self.codes(), {"skill-frontmatter"})
+
+    def test_rejects_a_skills_directory_that_resolves_outside_the_package(self):
+        outside = self.root.parent / "outside"
+        outside.mkdir()
+        try:
+            (self.root / "skills").symlink_to(outside, target_is_directory=True)
+        except OSError as error:  # unprivileged Windows runner
+            self.skipTest(f"symlinks unavailable: {error}")
+
+        self.assertEqual(self.codes(), {"component-escapes-root"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_validate_agent_plugins.py
+++ b/tests/scripts/test_validate_agent_plugins.py
@@ -104,6 +104,40 @@ class ValidateAgentPluginsTest(unittest.TestCase):
             ["warning"],
         )
 
+    def test_rejects_each_invalid_permitted_manifest_field(self):
+        invalid_fields = {
+            "version": 7,
+            "description": ["not a string"],
+            "homepage": 7,
+            "repository": 7,
+            "license": 7,
+            "author": {"unexpected": "field"},
+            "keywords": ["valid", 7],
+            "extensions": {"org.example": "not an object"},
+        }
+        for field, value in invalid_fields.items():
+            with self.subTest(field=field):
+                self.manifest = {"$schema": SCHEMA_URL, "name": "fixture-plugin", field: value}
+                self.write_manifest()
+                self.assertEqual(self.codes(), {"manifest-field"})
+
+    def test_accepts_a_complete_valid_manifest(self):
+        self.manifest.update(
+            {
+                "version": "1.0.0",
+                "description": "A portable package fixture.",
+                "author": {"name": "ShaftHQ", "email": "maintainers@example.test", "url": "https://example.test"},
+                "homepage": "https://example.test",
+                "repository": "https://github.com/ShaftHQ/SHAFT_ENGINE",
+                "license": "MIT",
+                "keywords": ["agent", "fixture"],
+                "extensions": {"org.example": {"host-setting": "enabled"}},
+            }
+        )
+        self.write_manifest()
+
+        self.assertEqual(validate_package(self.root), [])
+
     def test_accepts_complete_crlf_skill_frontmatter(self):
         self.write_skill(line_ending="\r\n")
 
@@ -123,10 +157,58 @@ class ValidateAgentPluginsTest(unittest.TestCase):
 
         self.assertEqual(self.codes(), {"skill-name"})
 
+    def test_rejects_each_invalid_optional_skill_field(self):
+        invalid_fields = {
+            "license": "license: []",
+            "compatibility": "compatibility: []",
+            "metadata": "metadata: []",
+            "allowed-tools": "allowed-tools: []",
+        }
+        for field, line in invalid_fields.items():
+            with self.subTest(field=field):
+                self.write(
+                    "skills/valid-skill/SKILL.md",
+                    "---\n"
+                    "name: valid-skill\n"
+                    "description: A valid skill with one invalid optional field.\n"
+                    f"{line}\n"
+                    "---\n",
+                )
+                self.assertEqual(self.codes(), {"skill-field"})
+
+    def test_accepts_valid_optional_skill_fields(self):
+        self.write(
+            "skills/valid-skill/SKILL.md",
+            "---\n"
+            "name: valid-skill\n"
+            "description: A valid skill with optional metadata for testing.\n"
+            "license: MIT\n"
+            "compatibility: Requires Python.\n"
+            "metadata:\n"
+            "  author: ShaftHQ\n"
+            "  version: \"1.0\"\n"
+            "allowed-tools: Read Bash(git:*)\n"
+            "---\n",
+        )
+
+        self.assertEqual(validate_package(self.root), [])
+
     def test_containment_predicate_rejects_a_lexical_escape_without_symlink_support(self):
         self.assertTrue(callable(resolves_inside), "resolves_inside must be available")
 
         self.assertFalse(resolves_inside(self.root, self.root / ".." / "outside"))
+
+    def test_absent_skills_component_is_ignored(self):
+        self.assertEqual(validate_package(self.root), [])
+
+    def test_rejects_a_dangling_skills_link_outside_the_package(self):
+        outside = self.root.parent / "missing-outside"
+        try:
+            (self.root / "skills").symlink_to(outside, target_is_directory=True)
+        except OSError as error:  # unprivileged Windows runner
+            self.skipTest(f"symlinks unavailable: {error}")
+
+        self.assertEqual(self.codes(), {"component-escapes-root"})
 
     def test_rejects_a_skills_directory_that_resolves_outside_the_package(self):
         outside = self.root.parent / "outside"

--- a/tests/scripts/test_validate_agent_plugins.py
+++ b/tests/scripts/test_validate_agent_plugins.py
@@ -6,8 +6,9 @@ import unittest
 from pathlib import Path
 
 try:
-    from scripts.ci.validate_agent_plugins import validate_package
+    from scripts.ci.validate_agent_plugins import resolves_inside, validate_package
 except ModuleNotFoundError:
+    resolves_inside = None
     validate_package = None
 
 
@@ -37,6 +38,21 @@ class ValidateAgentPluginsTest(unittest.TestCase):
         self.assertTrue(callable(validate_package), "validate_package must be available")
         return {issue["code"] for issue in validate_package(self.root)}
 
+    def write_skill(self, name="valid-skill", line_ending="\n"):
+        self.write(
+            f"skills/{name}/SKILL.md",
+            line_ending.join(
+                [
+                    "---",
+                    f"name: {name}",
+                    "description: A valid skill used when validating a portable package.",
+                    "---",
+                    "",
+                    "# Instructions",
+                ]
+            ),
+        )
+
     def test_valid_minimal_package_passes(self):
         self.assertTrue(callable(validate_package), "validate_package must be available")
         self.assertEqual(validate_package(self.root), [])
@@ -64,6 +80,53 @@ class ValidateAgentPluginsTest(unittest.TestCase):
         self.write("skills/broken/SKILL.md", "# Missing frontmatter\n")
 
         self.assertEqual(self.codes(), {"skill-frontmatter"})
+
+    def test_rejects_invalid_manifest_field_types_but_ignores_non_object_extensions(self):
+        self.manifest.update(
+            {
+                "version": 7,
+                "description": ["not a string"],
+                "author": {"name": 2},
+                "keywords": "not an array",
+                "extensions": "old client data",
+            }
+        )
+        self.write_manifest()
+
+        issues = validate_package(self.root)
+
+        self.assertEqual(
+            {issue["code"] for issue in issues},
+            {"manifest-field", "extensions-invalid"},
+        )
+        self.assertEqual(
+            [issue["severity"] for issue in issues if issue["code"] == "extensions-invalid"],
+            ["warning"],
+        )
+
+    def test_accepts_complete_crlf_skill_frontmatter(self):
+        self.write_skill(line_ending="\r\n")
+
+        self.assertEqual(validate_package(self.root), [])
+
+    def test_rejects_unclosed_or_incomplete_skill_frontmatter(self):
+        self.write("skills/broken/SKILL.md", "---\nname: broken\n")
+
+        self.assertEqual(self.codes(), {"skill-frontmatter"})
+
+    def test_rejects_skill_name_that_does_not_match_its_directory(self):
+        self.write_skill(name="actual-name")
+        self.write(
+            "skills/actual-name/SKILL.md",
+            "---\nname: different-name\ndescription: A valid description with the wrong name.\n---\n",
+        )
+
+        self.assertEqual(self.codes(), {"skill-name"})
+
+    def test_containment_predicate_rejects_a_lexical_escape_without_symlink_support(self):
+        self.assertTrue(callable(resolves_inside), "resolves_inside must be available")
+
+        self.assertFalse(resolves_inside(self.root, self.root / ".." / "outside"))
 
     def test_rejects_a_skills_directory_that_resolves_outside_the_package(self):
         outside = self.root.parent / "outside"


### PR DESCRIPTION
## Summary\n\n- add an Agent Plugins v1.0.0 manifest, Agent Skills, and package-containment validator\n- cover valid and invalid contract fixtures, CRLF frontmatter, warning continuation, and dangling links\n- register the validator in the PyYAML-enabled agent-guidance gate and reachability inventory\n\n## Commits\n\n- b9eb741 feat(ci): validate portable agent plugin contracts\n- d2dc628 fix(ci): enforce agent plugin manifest contract\n- daba6ae test(ci): cover agent plugin contract boundaries\n- 995ee5c ci: register agent plugin contract validation\n\n## Validation\n\n- py -3 -m unittest tests.scripts.test_validate_agent_plugins tests.scripts.test_agent_harness_reachability tests.scripts.test_agent_router_contract -v\n- py -3 scripts/ci/validate_agent_setup.py --skip-external\n- py -3 -m py_compile scripts/ci/validate_agent_plugins.py\n- git diff --check origin/main...HEAD\n\nCloses #4620\n\nRelated to #4576