### PR TITLE
fix(intellij): dispose terminal typing timer

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftTerminalCommands.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftTerminalCommands.java
@@ -1,8 +1,11 @@
 package com.shaft.intellij.ui;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
 
+import javax.swing.Timer;
 import java.lang.reflect.Method;
 import java.util.function.Consumer;
 
@@ -56,7 +59,7 @@ final class ShaftTerminalCommands {
             if (widget == null) {
                 return false;
             }
-            scheduleCommandTyping(widget, command, onOutcome);
+            scheduleCommandTyping(project, widget, command, onOutcome);
             return true;
         } catch (Throwable terminalUnavailable) {
             // Terminal plugin disabled/missing, or its API drifted: the clipboard fallback covers it.
@@ -88,9 +91,9 @@ final class ShaftTerminalCommands {
      * genuine success or genuine failure (retry-exhaustion or a thrown {@code write()}) — never on
      * a still-retrying attempt (issue #3551).
      */
-    private static void scheduleCommandTyping(Object widget, String command, Consumer<Boolean> onOutcome) {
+    static Timer scheduleCommandTyping(Disposable owner, Object widget, String command, Consumer<Boolean> onOutcome) {
         java.util.concurrent.atomic.AtomicInteger attempts = new java.util.concurrent.atomic.AtomicInteger();
-        javax.swing.Timer typeSoon = new javax.swing.Timer(TYPE_RETRY_DELAY_MILLIS, null);
+        Timer typeSoon = new Timer(TYPE_RETRY_DELAY_MILLIS, null);
         typeSoon.setInitialDelay(SHELL_READY_DELAY_MILLIS);
         typeSoon.addActionListener(event -> {
             boolean typed = false;
@@ -113,7 +116,9 @@ final class ShaftTerminalCommands {
             }
         });
         typeSoon.setRepeats(true);
+        Disposer.register(owner, typeSoon::stop);
         typeSoon.start();
+        return typeSoon;
     }
 
     private static Object ttyConnector(Object widget) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/CliTerminalSupportTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/CliTerminalSupportTest.java
@@ -1,9 +1,14 @@
 package com.shaft.intellij.ui;
 
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.util.Disposer;
 import org.junit.jupiter.api.Test;
+
+import javax.swing.Timer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The additive raw-CLI terminal tab (issue #3959) reuses {@link ShaftTerminalCommands}'s existing
@@ -29,5 +34,18 @@ class CliTerminalSupportTest {
     @Test
     void isExecutableOnPathReturnsFalseForAnObviouslyMissingCommand() {
         assertFalse(CliTerminalSupport.isExecutableOnPath("definitely-not-a-real-cli-xyz123"));
+    }
+
+    @Test
+    void disposingTheTerminalOwnerStopsPendingCommandTypingRetries() {
+        Disposable owner = Disposer.newDisposable();
+        Timer retryTimer = ShaftTerminalCommands.scheduleCommandTyping(
+                owner, new Object(), "shaft-mcp", typed -> { });
+        assertTrue(retryTimer.isRunning(), "Precondition: terminal typing must own a pending retry timer");
+
+        Disposer.dispose(owner);
+
+        assertFalse(retryTimer.isRunning(),
+                "Disposing the terminal project must stop its retry timer before it can outlive the tool window");
     }
 }


### PR DESCRIPTION
## Summary
- register terminal command-typing retry timers under the project `Disposer` lifecycle
- keep the existing 10-attempt behavior while ensuring tool-window/project teardown stops pending retries
- cover disposal through the scheduler's package-private lifecycle seam

Closes #4518

## Validation
- RED: `CliTerminalSupportTest.disposingTheTerminalOwnerStopsPendingCommandTypingRetries` failed because no owner-aware scheduler existed
- `JAVA_HOME=C:\Users\Mohab\.jdks\ms-21.0.11 .\gradlew.bat test --tests com.shaft.intellij.ui.CliTerminalSupportTest --tests com.shaft.intellij.ui.GuidedWorkflowPanelTest --tests com.shaft.intellij.ui.ApiRecordingSessionPanelTest --tests com.shaft.intellij.ui.ShaftAssistantPanelDisposalTest --console=plain`
  - 4 + 22 + 12 + 7 tests; zero failures/errors
- `memory check`
- `git diff --check`