### PR TITLE
ci: generate JavaDocs before publishing

### DIFF
--- a/.github/workflows/publishJavaDocs.yml
+++ b/.github/workflows/publishJavaDocs.yml
@@ -64,5 +64,5 @@ jobs:
           javadoc-branch: javadoc
           java-version: 25
           project: maven
-          custom-command: mvn --batch-mode clean install "-DskipTests" "-Dgpg.skip" && python3 scripts/ci/assemble_javadocs.py
+          custom-command: mvn --batch-mode clean install "-DskipTests" "-Dgpg.skip" && mvn --batch-mode javadoc:javadoc && python3 scripts/ci/assemble_javadocs.py
           javadoc-source-folder: target/javadocs

--- a/scripts/ci/validate_maven_publication.py
+++ b/scripts/ci/validate_maven_publication.py
@@ -213,6 +213,8 @@ def validate_publication(root: Path = ROOT, check_build_outputs: bool = False,
         errors.append("JavaDocs publication must require a successful Maven Central workflow")
     if "scripts/ci/assemble_javadocs.py" not in javadocs_workflow:
         errors.append("JavaDocs workflow must assemble all Java-bearing module documentation")
+    if "mvn --batch-mode javadoc:javadoc" not in javadocs_workflow:
+        errors.append("JavaDocs workflow must generate per-module JavaDocs before assembly")
     if "javadoc-source-folder: target/javadocs" not in javadocs_workflow:
         errors.append("JavaDocs workflow must publish the assembled root target/javadocs site")
 

--- a/tests/scripts/test_validate_maven_publication.py
+++ b/tests/scripts/test_validate_maven_publication.py
@@ -63,6 +63,21 @@ class MavenPublicationValidationTest(unittest.TestCase):
             document.write(pom, encoding="utf-8", xml_declaration=True)
             self.assertTrue(any("inherited" in error for error in MODULE.validate_publication(root)))
 
+    def test_rejects_javadocs_workflow_without_per_module_generation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._copy_contract(root)
+            workflow = root / ".github" / "workflows" / "publishJavaDocs.yml"
+            workflow.write_text(
+                workflow.read_text(encoding="utf-8").replace(
+                    "mvn --batch-mode javadoc:javadoc && ",
+                    "",
+                ),
+                encoding="utf-8",
+            )
+            self.assertTrue(any("generate per-module JavaDocs" in error
+                                for error in MODULE.validate_publication(root)))
+
     def test_signed_outputs_require_aggregate_sbom_signature(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
Closes #4633

## Summary
- run Maven's per-module Javadoc goal before assembling the publishable site
- make the publication validator reject a workflow without that generation step

## Evidence
- RED: new validator mutation test failed before the guard existed
- `py -3 -m unittest tests.scripts.test_validate_maven_publication`: 11 passed
- exact local publisher sequence (`clean install -DskipTests -Dgpg.skip`, `javadoc:javadoc`, assembly) passed and created `report-aggregate/target/reports/apidocs/index.html`
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`: passed