### PR TITLE
fix: require immutable reconciliation source

### DIFF
--- a/.github/workflows/maven-central-reconcile.yml
+++ b/.github/workflows/maven-central-reconcile.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
       source_ref:
-        description: "Immutable commit SHA or tag containing the release source."
+        description: "Full 40-character commit SHA containing the release source."
         required: true
         type: string
       dry_run:
@@ -52,6 +52,15 @@ jobs:
       # is a PAT, so its release does trigger those workflows (mirrors announce_release).
       GH_TOKEN: ${{ secrets.BOT_TOKEN }}
     steps:
+      - name: Validate immutable source commit
+        env:
+          SOURCE_COMMIT: ${{ inputs.source_ref }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${SOURCE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::source_ref must be a full lowercase 40-character commit SHA."
+            exit 1
+          fi
       - name: Checkout Code
         uses: actions/checkout@v7
         with:

--- a/tests/scripts/test_agent_plugin_release.py
+++ b/tests/scripts/test_agent_plugin_release.py
@@ -121,6 +121,20 @@ class AgentPluginReleaseTest(unittest.TestCase):
             workflow.index("- name: Deploy to Maven Central"),
         )
 
+    def test_reconciliation_rejects_a_mutable_source_ref_before_checkout(self):
+        workflow = (
+            Path(__file__).resolve().parents[2] / ".github/workflows/maven-central-reconcile.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('description: "Full 40-character commit SHA containing the release source."', workflow)
+        self.assertIn("- name: Validate immutable source commit", workflow)
+        self.assertIn("SOURCE_COMMIT: ${{ inputs.source_ref }}", workflow)
+        self.assertIn('[[ ! "${SOURCE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]', workflow)
+        self.assertLess(
+            workflow.index("- name: Validate immutable source commit"),
+            workflow.index("- name: Checkout Code"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- require Maven Central reconciliation to receive a full lowercase 40-character commit SHA
- reject mutable branches and tags before checkout
- add a regression that enforces validation ordering

Follow-up hardening for #4576.

## Verification
- py -3 -m unittest tests.scripts.test_agent_plugin_release tests.scripts.test_reconcile_maven_central_release tests.scripts.test_assemble_act_as_mohab_plugin tests.scripts.test_assemble_shaft_skills_plugin tests.scripts.test_agent_harness_reachability -v
- py -3 scripts/ci/validate_documentation_boundaries.py
- py -3 scripts/ci/validate_agent_setup.py --skip-external