### PR TITLE
Consolidate agent routing and CI Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,16 @@ updates:
       - "dependencies"
       - "github-actions"
 
+  # Maintain Python dependencies installed by CI workflows
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+      timezone: "Africa/Cairo"
+    labels:
+      - "dependencies"
+
   # Maintain dependencies for maven
   - package-ecosystem: "maven"
     directories:

--- a/.github/workflows/agent-plugin-acceptance.yml
+++ b/.github/workflows/agent-plugin-acceptance.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
-      - name: Install PyYAML
-        run: python -m pip install pyyaml --quiet
+      - name: Install managed CI Python dependencies
+        run: python -m pip install --no-deps --requirement requirements-ci.txt --quiet
       - name: Set up Node.js 24
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -200,7 +200,7 @@ jobs:
           container-name: shaft-pilot-release-smoke
           client-name: release-smoke
       - name: Install Agent Plugin release prerequisites
-        run: python3 -m pip install pyyaml --quiet
+        run: python3 -m pip install --no-deps --requirement requirements-ci.txt --quiet
       - name: Build portable Agent Plugin release assets
         run: python3 scripts/ci/agent_plugin_release.py agent-plugin-release-assets
       - name: Upload portable Agent Plugin release assets

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -187,8 +187,15 @@ jobs:
               - '**/pom.xml'
               - '**/build.gradle.kts'
               - '**/gradle.properties'
+              - 'requirements-ci.txt'
+              - '.github/dependabot.yml'
               - '.github/dependency-review-config.yml'
+              - '.github/workflows/agent-plugin-acceptance.yml'
+              - '.github/workflows/mavenCentral_cd.yml'
+              - '.github/workflows/pr-gate.yml'
+              - '.github/workflows/publish-shaft-mcp.yml'
               - 'scripts/ci/dependency_review_changes.py'
+              - 'tests/scripts/test_ci_python_dependencies.py'
               - 'tests/scripts/test_dependency_review_changes.py'
             # Core Java modules with a unit-test leg (issue #3849): shaft-engine and
             # its downstream Pilot-family modules. shaft-cli/shaft-intellij already have
@@ -288,8 +295,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: "3.13"
-      - name: Install PyYAML
-        run: python -m pip install pyyaml --quiet
+      - name: Install managed CI Python dependencies
+        run: python -m pip install --no-deps --requirement requirements-ci.txt --quiet
       - name: Set up Node.js 24 for native client smoke
         uses: actions/setup-node@v6
         with:
@@ -690,8 +697,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: "3.13"
-      - name: Install PyYAML
-        run: python3 -m pip install pyyaml --quiet
+      - name: Install managed CI Python dependencies
+        run: python3 -m pip install --no-deps --requirement requirements-ci.txt --quiet
       - name: Run workflow timeout guard unit tests
         run: >-
           python3 -m unittest
@@ -849,7 +856,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Test dependency diff classifier
-        run: python3 -m unittest tests.scripts.test_dependency_review_changes -v
+        run: >-
+          python3 -m unittest
+          tests.scripts.test_ci_python_dependencies
+          tests.scripts.test_dependency_review_changes
+          -v
       - name: Detect dependency-bearing diff
         id: diff
         env:

--- a/.github/workflows/publish-shaft-mcp.yml
+++ b/.github/workflows/publish-shaft-mcp.yml
@@ -28,6 +28,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
       - name: Set up JDK 25
         uses: actions/setup-java@v5.7.0
         with:
@@ -64,7 +68,7 @@ jobs:
           path.write_text(rendered, encoding="utf-8")
           json.loads(rendered)
           PY
-          python3 -m pip install jsonschema --quiet
+          python3 -m pip install --no-deps --requirement ../requirements-ci.txt --quiet
           python3 - <<'PY'
           import json
           import urllib.request

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,6 @@
+attrs==26.1.0
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+PyYAML==6.0.3
+referencing==0.37.0
+rpds-py==2026.6.3

--- a/scripts/ci/dependency_review_changes.py
+++ b/scripts/ci/dependency_review_changes.py
@@ -8,6 +8,7 @@ import re
 
 
 DEPENDENCY_CONFIG = ".github/dependency-review-config.yml"
+CI_PYTHON_REQUIREMENTS = "requirements-ci.txt"
 DEPENDENCY_SUFFIXES = ("/pom.xml", ".pom.xml")
 GRADLE_BUILD_SUFFIX = ".gradle.kts"
 GRADLE_PROPERTIES_SUFFIX = "/gradle.properties"
@@ -45,6 +46,8 @@ def needs_review(base: str, head: str) -> bool:
     if DEPENDENCY_CONFIG in changed:
         return True
     for path in changed:
+        if path == CI_PYTHON_REQUIREMENTS:
+            return True
         before, after = content(base, path), content(head, path)
         if path == "pom.xml" or path.endswith(DEPENDENCY_SUFFIXES):
             if before is None or after is None:

--- a/tests/scripts/test_agent_plugin_release.py
+++ b/tests/scripts/test_agent_plugin_release.py
@@ -121,7 +121,10 @@ class AgentPluginReleaseTest(unittest.TestCase):
         install_index, install_step = steps_by_name["Install Agent Plugin release prerequisites"]
         build_index, build_step = steps_by_name["Build portable Agent Plugin release assets"]
         deploy_index, _ = steps_by_name["Deploy to Maven Central"]
-        self.assertEqual(install_step["run"], "python3 -m pip install pyyaml --quiet")
+        self.assertEqual(
+            install_step["run"],
+            "python3 -m pip install --no-deps --requirement requirements-ci.txt --quiet",
+        )
         self.assertEqual(
             build_step["run"],
             "python3 scripts/ci/agent_plugin_release.py agent-plugin-release-assets",

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1149,13 +1149,14 @@ class CiGateIsBlockingTest(unittest.TestCase):
         summary, _ = self.summary_step()
         self.assertIn("module-boundary", summary["needs"])
 
-    def test_the_guidance_gate_installs_what_its_tests_import(self):
+    def test_the_guidance_gate_installs_the_managed_ci_dependencies(self):
         """The runner's tool-cache Python has no PyYAML; the frontmatter test
         imports it, so the job must install it or fail on every run."""
         _, jobs = self.summary_step()
         steps = jobs["agent-guidance"]["steps"]
         commands = " ".join(str(step.get("run", "")) for step in steps)
-        self.assertIn("pyyaml", commands.lower())
+        self.assertIn("--requirement requirements-ci.txt", commands)
+        self.assertIn("--no-deps", commands)
 
     def test_the_guidance_filter_covers_what_the_validator_checks(self):
         yaml = __import__("yaml")
@@ -1199,8 +1200,15 @@ class CiGateIsBlockingTest(unittest.TestCase):
                 "**/pom.xml",
                 "**/build.gradle.kts",
                 "**/gradle.properties",
+                "requirements-ci.txt",
+                ".github/dependabot.yml",
                 ".github/dependency-review-config.yml",
+                ".github/workflows/agent-plugin-acceptance.yml",
+                ".github/workflows/mavenCentral_cd.yml",
+                ".github/workflows/pr-gate.yml",
+                ".github/workflows/publish-shaft-mcp.yml",
                 "scripts/ci/dependency_review_changes.py",
+                "tests/scripts/test_ci_python_dependencies.py",
                 "tests/scripts/test_dependency_review_changes.py",
             },
         )

--- a/tests/scripts/test_ci_python_dependencies.py
+++ b/tests/scripts/test_ci_python_dependencies.py
@@ -1,0 +1,129 @@
+"""Contract tests for Python dependencies installed by CI workflows (#4650)."""
+
+from __future__ import annotations
+
+import re
+import shlex
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REQUIREMENTS = ROOT / "requirements-ci.txt"
+EXPECTED_PINS = {
+    "attrs": "26.1.0",
+    "jsonschema": "4.26.0",
+    "jsonschema-specifications": "2025.9.1",
+    "pyyaml": "6.0.3",
+    "referencing": "0.37.0",
+    "rpds-py": "2026.6.3",
+}
+EXPECTED_INSTALLS = {
+    ".github/workflows/agent-plugin-acceptance.yml": (
+        "python -m pip install --no-deps --requirement requirements-ci.txt --quiet",
+    ),
+    ".github/workflows/mavenCentral_cd.yml": (
+        "python3 -m pip install --no-deps --requirement requirements-ci.txt --quiet",
+    ),
+    ".github/workflows/pr-gate.yml": (
+        "python -m pip install --no-deps --requirement requirements-ci.txt --quiet",
+        "python3 -m pip install --no-deps --requirement requirements-ci.txt --quiet",
+    ),
+    ".github/workflows/publish-shaft-mcp.yml": (
+        "python3 -m pip install --no-deps --requirement ../requirements-ci.txt --quiet",
+    ),
+}
+
+
+class CiPythonDependenciesTest(unittest.TestCase):
+    def test_workflow_dependencies_are_exact_centralized_and_automated(self):
+        self.assertTrue(REQUIREMENTS.is_file(), "requirements-ci.txt must own CI Python versions")
+        entries = [
+            line.strip()
+            for line in REQUIREMENTS.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        parsed: dict[str, str] = {}
+        for entry in entries:
+            self.assertEqual(entry.count("=="), 1, f"CI dependency must use one exact pin: {entry}")
+            name, version = entry.split("==", 1)
+            self.assertTrue(name and version and not re.search(r"\s", entry), entry)
+            parsed[name.lower()] = version
+        self.assertEqual(len(parsed), len(entries), "CI dependency pins must not be duplicated")
+        self.assertEqual(parsed, EXPECTED_PINS)
+        self.assertEqual(
+            entries,
+            sorted(entries, key=lambda entry: entry.split("==", 1)[0].lower()),
+            "CI dependency pins must stay sorted by package name",
+        )
+
+        actual_installs: dict[str, tuple[str, ...]] = {}
+        workflow_root = ROOT / ".github/workflows"
+        workflow_paths = set(workflow_root.glob("*.yml")) | set(workflow_root.glob("*.yaml"))
+        for path in sorted(workflow_paths):
+            commands = tuple(
+                match.group(0).strip()
+                for match in re.finditer(
+                    r"(?:(?:python|python3) -m pip|pip3?) install[^\r\n]*",
+                    path.read_text(encoding="utf-8"),
+                )
+            )
+            if commands:
+                actual_installs[path.relative_to(ROOT).as_posix()] = commands
+        self.assertEqual(actual_installs, EXPECTED_INSTALLS)
+
+        dependabot = (ROOT / ".github/dependabot.yml").read_text(encoding="utf-8")
+        self.assertRegex(
+            dependabot,
+            r'(?ms)- package-ecosystem: "pip"\s+directory: "/"\s+schedule:\s+'
+            r'interval: "daily"\s+time: "00:00"\s+timezone: "Africa/Cairo"\s+'
+            r'labels:\s+- "dependencies"',
+        )
+
+    def workflow_install_steps(self):
+        yaml = __import__("yaml")
+        for relative_path in EXPECTED_INSTALLS:
+            workflow_path = ROOT / relative_path
+            workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+            for job_name, job in workflow["jobs"].items():
+                job_working_directory = (
+                    job.get("defaults", {}).get("run", {}).get("working-directory", ".")
+                )
+                steps = job["steps"]
+                for index, step in enumerate(steps):
+                    for command in str(step.get("run", "")).splitlines():
+                        if re.search(r"(?:(?:python|python3) -m pip|pip3?) install", command):
+                            yield (
+                                relative_path,
+                                job_name,
+                                steps,
+                                index,
+                                step.get("working-directory", job_working_directory),
+                                command.strip(),
+                            )
+
+    def test_requirement_paths_exist_from_each_effective_working_directory(self):
+        installs = list(self.workflow_install_steps())
+        self.assertEqual(len(installs), 5)
+        for relative_path, job_name, _, _, working_directory, command in installs:
+            with self.subTest(workflow=relative_path, job=job_name):
+                arguments = shlex.split(command)
+                requirement = arguments[arguments.index("--requirement") + 1]
+                resolved = (ROOT / working_directory / requirement).resolve()
+                self.assertEqual(resolved, REQUIREMENTS.resolve())
+                self.assertTrue(resolved.is_file())
+
+    def test_each_install_job_sets_up_supported_python_before_installing(self):
+        for relative_path, job_name, steps, install_index, _, _ in self.workflow_install_steps():
+            with self.subTest(workflow=relative_path, job=job_name):
+                setup_steps = [
+                    step
+                    for step in steps[:install_index]
+                    if step.get("uses") == "actions/setup-python@v7"
+                ]
+                self.assertTrue(setup_steps, "install job must set up repository-standard Python")
+                self.assertEqual(setup_steps[-1].get("with", {}).get("python-version"), "3.13")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_dependency_review_changes.py
+++ b/tests/scripts/test_dependency_review_changes.py
@@ -17,6 +17,24 @@ class DependencyReviewChangesTest(unittest.TestCase):
             ):
                 self.assertFalse(dependency_review_changes.needs_review("base", "head"))
 
+    def test_unequal_width_child_parent_version_only_edit_skips_dependency_review(self):
+        dependency = (
+            "<dependencies><dependency><groupId>a</groupId><artifactId>b</artifactId>"
+            "<version>1</version></dependency></dependencies>"
+        )
+        with patch(
+            "scripts.ci.dependency_review_changes.git",
+            return_value="shaft-engine/pom.xml\n",
+        ):
+            with patch(
+                "scripts.ci.dependency_review_changes.content",
+                side_effect=[
+                    f"<project><parent><version>10.3.20260809</version></parent>{dependency}</project>",
+                    f"<project><parent><version>10.3.202608091</version></parent>{dependency}</project>",
+                ],
+            ):
+                self.assertFalse(dependency_review_changes.needs_review("base", "head"))
+
     def test_changed_maven_dependency_requires_dependency_review(self):
         with patch("scripts.ci.dependency_review_changes.git", return_value="pom.xml\n"):
             with patch(
@@ -27,3 +45,10 @@ class DependencyReviewChangesTest(unittest.TestCase):
                 ],
             ):
                 self.assertTrue(dependency_review_changes.needs_review("base", "head"))
+
+    def test_changed_ci_python_requirements_requires_dependency_review(self):
+        with patch(
+            "scripts.ci.dependency_review_changes.git",
+            return_value="requirements-ci.txt\n",
+        ):
+            self.assertTrue(dependency_review_changes.needs_review("base", "head"))


### PR DESCRIPTION
## Scope that merged

This PR merged the managed CI Python-dependency work for #4650 only.

Closes #4650

## Merged change

- root `requirements-ci.txt` pins the CI Python dependency closure;
- all workflow install sites consume that single file from their effective working directory;
- Dependabot and the dependency-review path classifier cover the manifest.

## Verified for this merged patch

- the reviewed head was `3f0a7d7bc93391af7eca3bbace9d74a0e20851a8`;
- the merge commit is `2d7d00730a74c426f4f8a3360ecd23a58ddeef14`;
- the patch contains the CI/dependency files listed by the pull-request diff.

## Post-merge audit correction

The previous description incorrectly included later work that was committed after this pull request merged. That work is not in this merged patch and remains tracked separately. Its attributable recovery pull request will be linked in a follow-up comment.