### PR TITLE
fix: run Graphify refresh through installed CLI

### DIFF
--- a/tests/scripts/test_resolve_graph_out.py
+++ b/tests/scripts/test_resolve_graph_out.py
@@ -158,15 +158,17 @@ class ResolveGraphOutTest(unittest.TestCase):
         commands = [
             line.strip()
             for line in wrapper.splitlines()
-            if line.strip().lower().startswith(("py ", "if errorlevel", "if not errorlevel"))
+            if line.strip().lower().startswith(
+                ("call graphify ", "py ", "if errorlevel", "if not errorlevel")
+            )
         ]
 
         self.assertEqual(
             [
-                'py -3 -m graphify . > "%USERPROFILE%\\.agent-infra\\logs\\graphify-refresh.log" 2>&1',
+                'call graphify . > "%USERPROFILE%\\.agent-infra\\logs\\graphify-refresh.log" 2>&1',
                 "if errorlevel 1 exit /b 1",
                 "if not errorlevel 0 exit /b 1",
-                'py -3 -m graphify cluster-only . >> "%USERPROFILE%\\.agent-infra\\logs\\graphify-refresh.log" 2>&1',
+                'call graphify cluster-only . >> "%USERPROFILE%\\.agent-infra\\logs\\graphify-refresh.log" 2>&1',
                 "if errorlevel 1 exit /b 1",
                 "if not errorlevel 0 exit /b 1",
                 'py -3 tools\\repository-map\\resolve_graph_out.py --record-current >> "%USERPROFILE%\\.agent-infra\\logs\\graphify-refresh.log" 2>&1',
@@ -181,17 +183,13 @@ class ResolveGraphOutTest(unittest.TestCase):
         wrapper_dir.mkdir(parents=True)
         wrapper = wrapper_dir / "graphify-refresh.cmd"
         shutil.copy2(ROOT / "tools/agent-infra/graphify-refresh.cmd", wrapper)
-        fake_python = self.sandbox / "fake-python"
-        fake_python.mkdir()
-        (fake_python / "graphify.py").write_text(
-            """import os
-import sys
-
-if sys.argv[1:] == ["."]:
-    raise SystemExit(int(os.environ["GRAPHIFY_BUILD_EXIT"]))
-if sys.argv[1:] == ["cluster-only", "."]:
-    raise SystemExit(int(os.environ["GRAPHIFY_CLUSTER_EXIT"]))
-raise SystemExit(99)
+        fake_bin = self.sandbox / "fake-bin"
+        fake_bin.mkdir()
+        (fake_bin / "graphify.cmd").write_text(
+            """@echo off
+if "%~1"=="." exit /b %GRAPHIFY_BUILD_EXIT%
+if "%~1"=="cluster-only" if "%~2"=="." exit /b %GRAPHIFY_CLUSTER_EXIT%
+exit /b 99
 """,
             encoding="utf-8",
         )
@@ -209,7 +207,7 @@ Path(os.environ["GRAPHIFY_MARKER"]).touch()
         )
 
         base_env = os.environ.copy()
-        base_env["PYTHONPATH"] = str(fake_python)
+        base_env["PATH"] = str(fake_bin) + os.pathsep + base_env["PATH"]
         base_env["USERPROFILE"] = str(self.sandbox)
         base_env["GRAPHIFY_MARKER"] = str(marker)
         cmd_executable = shutil.which("cmd.exe")
@@ -245,6 +243,13 @@ Path(os.environ["GRAPHIFY_MARKER"]).touch()
         )
         self.assertEqual(0, success.returncode, success.stderr)
         self.assertTrue(marker.exists())
+
+    def test_install_guidance_uses_upgradeable_official_graphify_tool(self):
+        readme = (ROOT / "tools/repository-map/README.md").read_text(encoding="utf-8")
+
+        self.assertIn("uv tool install graphifyy", readme)
+        self.assertIn("uv tool upgrade graphifyy", readme)
+        self.assertNotIn("graphifyy==0.9.17", readme)
 
 
 if __name__ == "__main__":

--- a/tools/agent-infra/graphify-refresh.cmd
+++ b/tools/agent-infra/graphify-refresh.cmd
@@ -5,10 +5,10 @@ REM Rebuilds + re-clusters the shared repository-map cache (graphify-out/) from
 REM this checkout so worktree sessions read fresh.
 REM Logs stay machine-local (never in the repo).
 cd /d "%~dp0..\.."
-py -3 -m graphify . > "%USERPROFILE%\.agent-infra\logs\graphify-refresh.log" 2>&1
+call graphify . > "%USERPROFILE%\.agent-infra\logs\graphify-refresh.log" 2>&1
 if errorlevel 1 exit /b 1
 if not errorlevel 0 exit /b 1
-py -3 -m graphify cluster-only . >> "%USERPROFILE%\.agent-infra\logs\graphify-refresh.log" 2>&1
+call graphify cluster-only . >> "%USERPROFILE%\.agent-infra\logs\graphify-refresh.log" 2>&1
 if errorlevel 1 exit /b 1
 if not errorlevel 0 exit /b 1
 py -3 tools\repository-map\resolve_graph_out.py --record-current >> "%USERPROFILE%\.agent-infra\logs\graphify-refresh.log" 2>&1

--- a/tools/repository-map/README.md
+++ b/tools/repository-map/README.md
@@ -7,14 +7,19 @@ SHAFT_ENGINE uses Graphify for an optional local repository map. The checked-in 
 Use the official package name, `graphifyy`; the CLI command is still `graphify`.
 
 ```powershell
-# preferred when uv is installed
-uv tool install graphifyy==0.9.17
+# preferred isolated install
+uv tool install graphifyy
+
+# update an existing isolated install
+uv tool upgrade graphifyy
 
 # Windows fallback
-py -3 -m pip install --user graphifyy==0.9.17
+py -3 -m pip install --user --upgrade graphifyy
 ```
 
-If `pip` installs `graphify.exe` outside PATH, open a new terminal after updating the user PATH, or run commands as `py -3 -m graphify ...`.
+If `graphify` is not found after the uv install, run `uv tool update-shell` and
+open a new terminal. A plain-pip fallback may likewise require adding its
+Scripts directory to PATH.
 
 ## Build
 


### PR DESCRIPTION
## Summary

- run the nightly Graphify build and cluster stages through the official installed `graphify` CLI
- retain fail-closed positive and negative Windows exit handling before recording freshness
- update repository-map guidance to the upgradeable isolated `graphifyy` workflow
- adapt the Windows wrapper regression to exercise a real PATH-resolved `graphify.cmd`

Closes #4672

## Verification

- `py -3 -m unittest tests.scripts.test_resolve_graph_out` — 11 passed
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- `cmd /c tools\agent-infra\graphify-refresh.cmd` — exit 0
- `py -3 tools/repository-map/resolve_graph_out.py --check` — current
- `git diff --check`

## Runtime update

- Graphify migrated from conflicting plain-pip installs (0.8.50/0.9.12/0.9.17) to one isolated `graphifyy[sql]` 0.9.38 uv tool
- post-commit/post-checkout hooks refreshed
- upstream ignored-file merge-attribute mismatch tracked at Graphify-Labs/graphify#2595