### PR TITLE
feat(agents): modernize candidate intake

### DIFF
--- a/agent-plugins/shaft-skills/candidate-intake/README.md
+++ b/agent-plugins/shaft-skills/candidate-intake/README.md
@@ -20,9 +20,16 @@ pinned source into a disposable quarantine outside the repository, record it in
    enforced.
 4. **Local evaluation.** Evaluate the smallest relevant SHAFT fixtures and routing cases. Missing
    evidence is unknown, never a pass.
-5. **Promotion.** Code can move only through a small, separate adoption PR that repeats the
-   evidence, names the source and license, contains focused tests, and receives independent
-   review. This intake/report PR adopts no candidate code.
+5. **Promotion.** Code or an executable tool can move only through a small, separate adoption PR
+   that repeats the evidence, names the source and license, contains focused tests, and receives
+   independent review. Tool evidence also pins the exact version plus a SHA-256 digest for every
+   policy-required host platform artifact. Promotion requires current source evidence no older
+   than the policy freshness window. This intake/report PR adopts no candidate code or tool.
+
+Discovery paths and freshness are explicit evidence. Record every URL used to discover the
+candidate, the date its upstream head was checked, that head's full commit SHA, and whether the
+record is current, outdated, or retired. Structural validation remains deterministic; run the
+optional freshness check when reviewing or refreshing external sources.
 
 ## HALT conditions
 
@@ -35,10 +42,13 @@ regression; incomplete evidence; or vendor-specific policy duplication. Every la
 ## Decisions
 
 - **adopt code** — all four gates passed and a separate adoption PR is linked.
+- **adopt tool** — all four gates passed, supported artifacts are version-and-hash pinned, and a
+  separate promotion PR is linked.
 - **adopt a pattern** — reimplement a portable idea locally; copy no candidate files.
 - **retain a test target** — keep a specification or example only as external conformance input.
 - **reject** — record the candidate and the HALT reason; do not silently drop it.
 
-Run `python scripts/ci/shaft_skill_candidate_intake.py` and
+Run `python scripts/ci/shaft_skill_candidate_intake.py` and, when checking upstream currency,
+`python scripts/ci/shaft_skill_candidate_intake.py --check-freshness`. Then run
 `python -m unittest tests.scripts.test_shaft_skill_candidate_intake -v` after changing the
 policy, report, scanner, or promotion rules.

--- a/agent-plugins/shaft-skills/candidate-intake/candidates.json
+++ b/agent-plugins/shaft-skills/candidate-intake/candidates.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": 1,
-  "reviewed_at": "2026-08-09",
+  "schema_version": 2,
+  "reviewed_at": "2026-08-11",
   "code_adopted": false,
   "review_scope": {
     "candidate_ids": [
@@ -9,12 +9,24 @@
       "agent-plugins-v1-specification",
       "microsoft-cross-client-manifest-layout",
       "microsoft-azure-skill-content",
-      "openai-plugin-examples"
+      "openai-plugin-examples",
+      "claude-engineer-runtime",
+      "awesome-claude-code-catalog",
+      "nvidia-skillspector",
+      "agnix-guidance-linter",
+      "infrastructure-showcase-routing",
+      "compass-guardrail-corpus",
+      "presence-outcome-memory",
+      "claude-code-harness-runtime"
     ],
     "rejected_candidate_ids": [
       "anthropic-document-skills",
       "microsoft-azure-skill-content",
-      "openai-plugin-examples"
+      "openai-plugin-examples",
+      "claude-engineer-runtime",
+      "infrastructure-showcase-routing",
+      "presence-outcome-memory",
+      "claude-code-harness-runtime"
     ]
   },
   "candidates": [
@@ -57,9 +69,18 @@
       "evaluation": "Not evaluated because the provenance/license gate halted adoption.",
       "decision": "reject",
       "decision_reason": "Reject code adoption because the reviewed terms are not an open-source grant and the workflows duplicate first-party capabilities.",
+      "discovered_via": [
+        "https://github.com/anthropics/skills"
+      ],
+      "freshness": {
+        "checked_at": "2026-08-11",
+        "upstream_head": "f17010c9bb483898c1d9c9f42dde2b3a98889434",
+        "status": "current"
+      },
       "vendor_policy_duplication": false,
       "promotion_pr": null,
-      "adopted_files": []
+      "adopted_files": [],
+      "tool": null
     },
     {
       "id": "anthropic-skill-creator-eval-pattern",
@@ -98,9 +119,18 @@
       "evaluation": "Pattern passed through the local 30-case #4642 corpus and strict generated-drift checks.",
       "decision": "adopt-pattern",
       "decision_reason": "Adopt only the reviewed cases-plus-expectations pattern; retain SHAFT prompts, assertions, data, runners, and policy locally.",
+      "discovered_via": [
+        "https://github.com/anthropics/skills"
+      ],
+      "freshness": {
+        "checked_at": "2026-08-11",
+        "upstream_head": "f17010c9bb483898c1d9c9f42dde2b3a98889434",
+        "status": "current"
+      },
       "vendor_policy_duplication": false,
       "promotion_pr": null,
-      "adopted_files": []
+      "adopted_files": [],
+      "tool": null
     },
     {
       "id": "agent-plugins-v1-specification",
@@ -140,9 +170,18 @@
       "evaluation": "Retained as the portable package conformance target; native install and routing evidence remain independent.",
       "decision": "retain-test-target",
       "decision_reason": "Keep the official v1 specification as an external conformance target without copying policy or implementation code.",
+      "discovered_via": [
+        "https://github.com/agentplugins/agent-plugins-spec"
+      ],
+      "freshness": {
+        "checked_at": "2026-08-11",
+        "upstream_head": "bd383552095128f6effe895b9257cfd580a6d179",
+        "status": "current"
+      },
       "vendor_policy_duplication": false,
       "promotion_pr": null,
-      "adopted_files": []
+      "adopted_files": [],
+      "tool": null
     },
     {
       "id": "microsoft-cross-client-manifest-layout",
@@ -184,9 +223,18 @@
       "evaluation": "The locally authored adapter arrangement passes both pinned native clients without importing upstream manifests.",
       "decision": "adopt-pattern",
       "decision_reason": "Retain the thin-adapter idea only; SHAFT's manifests and client contracts remain locally authored and tested.",
+      "discovered_via": [
+        "https://github.com/MicrosoftDocs/Agent-Skills"
+      ],
+      "freshness": {
+        "checked_at": "2026-08-11",
+        "upstream_head": "00be373fec26109c3087728188f6a45554c47617",
+        "status": "outdated"
+      },
       "vendor_policy_duplication": false,
       "promotion_pr": null,
-      "adopted_files": []
+      "adopted_files": [],
+      "tool": null
     },
     {
       "id": "microsoft-azure-skill-content",
@@ -225,9 +273,18 @@
       "evaluation": "Rejected at static scope/overlap review before execution.",
       "decision": "reject",
       "decision_reason": "Reject vendor-specific policy duplication; the manifest pattern is reviewed separately.",
+      "discovered_via": [
+        "https://github.com/MicrosoftDocs/Agent-Skills"
+      ],
+      "freshness": {
+        "checked_at": "2026-08-11",
+        "upstream_head": "00be373fec26109c3087728188f6a45554c47617",
+        "status": "outdated"
+      },
       "vendor_policy_duplication": true,
       "promotion_pr": null,
-      "adopted_files": []
+      "adopted_files": [],
+      "tool": null
     },
     {
       "id": "openai-plugin-examples",
@@ -267,9 +324,363 @@
       "evaluation": "Rejected before execution; retained only as a cited official example source in this report.",
       "decision": "reject",
       "decision_reason": "Reject code adoption because repository-wide licensing is unresolved and the provider-specific catalog exceeds the narrow need.",
+      "discovered_via": [
+        "https://github.com/openai/plugins"
+      ],
+      "freshness": {
+        "checked_at": "2026-08-11",
+        "upstream_head": "11c74d6ba24d3a6d48f54a194cd00ef3beea18f9",
+        "status": "current"
+      },
       "vendor_policy_duplication": false,
       "promotion_pr": null,
-      "adopted_files": []
+      "adopted_files": [],
+      "tool": null
+    },
+    {
+      "id": "claude-engineer-runtime",
+      "category": "agent-runtime",
+      "source_url": "https://github.com/Doriandarko/claude-engineer",
+      "source_paths": [
+        "ce3.py",
+        "prompts/system_prompts.py",
+        "tools"
+      ],
+      "revision": "0a9e4b309bf6b2eda05dcf073cf5094beb08e0c8",
+      "version": "0.1.0",
+      "official_source": true,
+      "license": "MIT declared in pyproject.toml; no root LICENSE file detected by GitHub",
+      "permissions": "Dynamic tools can read and write files, launch a browser, capture the screen, install packages, and execute code.",
+      "network": "Uses hosted model, search, scraping, package, and E2B services and can open the system browser.",
+      "scripts": "Dynamically imports every tools module and can generate and hot-load new Python tools.",
+      "overlap": "Native host tools, Ponytail, plugin/skill creation, and quarantined candidate intake already own the useful capability-gap behavior with stronger controls.",
+      "material_kind": "code",
+      "stage_results": {
+        "provenance_license": {
+          "status": "pass",
+          "evidence": "Official repository and immutable revision are known; the package metadata declares MIT although repository-level license discovery is absent."
+        },
+        "static_review": {
+          "status": "halt",
+          "evidence": "The runtime permits self-modification, automatic package installation, GUI launch, screen capture, recursive tool execution, and broad network access while its tracked tests do not exercise those contracts."
+        },
+        "quarantine_trial": {
+          "status": "not_run",
+          "evidence": "Not run after the static safety and overlap HALT."
+        },
+        "local_evaluation": {
+          "status": "not_run",
+          "evidence": "Not run after HALT; local host-native tools and creation gates remain the baseline."
+        }
+      },
+      "evaluation": "Rejected after source-level comparison against the live ChaosEngine harness.",
+      "decision": "reject",
+      "decision_reason": "Reject runtime and code adoption because no unique capability outweighs its trust-boundary, GUI, dependency, and test-evidence gaps.",
+      "discovered_via": [
+        "https://github.com/Doriandarko/claude-engineer"
+      ],
+      "freshness": {
+        "checked_at": "2026-08-11",
+        "upstream_head": "0a9e4b309bf6b2eda05dcf073cf5094beb08e0c8",
+        "status": "current"
+      },
+      "vendor_policy_duplication": false,
+      "promotion_pr": null,
+      "adopted_files": [],
+      "tool": null
+    },
+    {
+      "id": "awesome-claude-code-catalog",
+      "category": "catalog",
+      "source_url": "https://github.com/hesreallyhim/awesome-claude-code",
+      "source_paths": [
+        "THE_RESOURCES_TABLE_NEW.csv",
+        "config.yaml",
+        "resources",
+        "tests"
+      ],
+      "revision": "b45279417f51010b9b5bd8db7aa8fb10ec255806",
+      "version": null,
+      "official_source": true,
+      "license": "CC-BY-NC-ND-4.0",
+      "permissions": "Catalog data and maintenance scripts operate on repository files and GitHub issue/PR metadata.",
+      "network": "Repository metadata and ticker maintenance query GitHub; the adopted local pattern performs no implicit network call.",
+      "scripts": "CSV validation, duplicate guards, generated README maintenance, issue intake, and freshness fields.",
+      "overlap": "Candidate intake already records provenance and decisions but lacks per-candidate freshness, policy-owned categories, and a tool-adoption decision.",
+      "material_kind": "pattern",
+      "stage_results": {
+        "provenance_license": {
+          "status": "pass",
+          "evidence": "Official repository and immutable revision are known; the restrictive license permits studying but not copying or modifying the catalog implementation."
+        },
+        "static_review": {
+          "status": "pass",
+          "evidence": "Reviewed the schema and maintenance flow; selected only generic freshness, category ownership, and duplicate-source concepts."
+        },
+        "quarantine_trial": {
+          "status": "not_applicable",
+          "evidence": "Pattern-only local reimplementation; no upstream code or data executed."
+        },
+        "local_evaluation": {
+          "status": "pass",
+          "evidence": "The locally authored v2 validator and mutation tests exercise freshness, categories, and tool evidence without copying upstream content."
+        }
+      },
+      "evaluation": "The maintenance pattern closes concrete lifecycle gaps while preserving the existing local JSON owner.",
+      "decision": "adopt-pattern",
+      "decision_reason": "Adopt only the catalog-maintenance concepts through locally authored validation and data fields.",
+      "discovered_via": [
+        "https://github.com/hesreallyhim/awesome-claude-code"
+      ],
+      "freshness": {
+        "checked_at": "2026-08-11",
+        "upstream_head": "b45279417f51010b9b5bd8db7aa8fb10ec255806",
+        "status": "current"
+      },
+      "vendor_policy_duplication": false,
+      "promotion_pr": null,
+      "adopted_files": [],
+      "tool": null
+    },
+    {
+      "id": "nvidia-skillspector",
+      "category": "security-scanner",
+      "source_url": "https://github.com/NVIDIA/SkillSpector",
+      "source_paths": [
+        "src/skillspector/nodes/analyzers",
+        "src/skillspector/cli.py",
+        "tests"
+      ],
+      "revision": "81e2c4d30c175fce8b6f622e84c54bc399a756ce",
+      "version": "v2.9.2",
+      "official_source": true,
+      "license": "Apache-2.0",
+      "permissions": "Reads candidate files; optional providers can use credentials, but the proposed path disables LLM analysis and credentials.",
+      "network": "Static SC4 can query OSV with offline fallback; promotion must enforce a no-network scan container.",
+      "scripts": "Python scanner with static, AST, taint, YARA, MCP, and optional semantic analyzers.",
+      "overlap": "The current intake inventories executables, hooks, secrets, and containment but does not detect malicious instruction or behavior patterns.",
+      "material_kind": "test-target",
+      "stage_results": {
+        "provenance_license": {
+          "status": "pass",
+          "evidence": "Official NVIDIA source, Apache-2.0 license, release v2.9.2, and immutable revision are known."
+        },
+        "static_review": {
+          "status": "pass",
+          "evidence": "Reviewed the static-only CLI contract, 68-pattern catalog, JSON output, exit semantics, network fallback, and test tree."
+        },
+        "quarantine_trial": {
+          "status": "not_applicable",
+          "evidence": "Retained only as an external target in this intake PR; executable promotion is issue #4703."
+        },
+        "local_evaluation": {
+          "status": "pass",
+          "evidence": "Source comparison proves a concrete malicious-skill detection gap; no claim of executable acceptance is made before #4703."
+        }
+      },
+      "evaluation": "Strong candidate for isolated promotion after a real pinned Docker trial.",
+      "decision": "retain-test-target",
+      "decision_reason": "Retain the scanner contract and pinned source pending the separate executable promotion gate.",
+      "discovered_via": [
+        "https://github.com/hesreallyhim/awesome-claude-code"
+      ],
+      "freshness": {
+        "checked_at": "2026-08-11",
+        "upstream_head": "81e2c4d30c175fce8b6f622e84c54bc399a756ce",
+        "status": "current"
+      },
+      "vendor_policy_duplication": false,
+      "promotion_pr": null,
+      "adopted_files": [],
+      "tool": null
+    },
+    {
+      "id": "agnix-guidance-linter",
+      "category": "guidance-linter",
+      "source_url": "https://github.com/agent-sh/agnix",
+      "source_paths": [
+        "crates/agnix-core/src/rules",
+        "crates/agnix-cli",
+        "tests"
+      ],
+      "revision": "3792c6cfdf2e56ddf205340fb5afe8f272218501",
+      "version": "v0.48.0",
+      "official_source": true,
+      "license": "Apache-2.0",
+      "permissions": "Reads agent configuration files; autofix and editor modes can write, but the proposed validation path is read-only.",
+      "network": "Standalone linting is local; telemetry is opt-in and disabled in CI and will also be explicitly disabled.",
+      "scripts": "Rust CLI and LSP with cross-client rules, machine-readable output, and release binaries.",
+      "overlap": "Local validators own repository-specific budgets and reachability; agnix adds broad official-format and cross-client conformance coverage.",
+      "material_kind": "test-target",
+      "stage_results": {
+        "provenance_license": {
+          "status": "pass",
+          "evidence": "Official source, Apache-2.0 license, v0.48.0 release, and immutable revision are known."
+        },
+        "static_review": {
+          "status": "pass",
+          "evidence": "Reviewed supported file types, rule families, release assets, telemetry default-off behavior, and CI interfaces."
+        },
+        "quarantine_trial": {
+          "status": "not_applicable",
+          "evidence": "Retained only as an external target in this intake PR; executable promotion is issue #4702."
+        },
+        "local_evaluation": {
+          "status": "pass",
+          "evidence": "Source comparison identifies format coverage outside the current repository-specific validators without claiming a trial result."
+        }
+      },
+      "evaluation": "Strong candidate for a pinned read-only promotion after Docker evidence and baseline triage.",
+      "decision": "retain-test-target",
+      "decision_reason": "Retain the conformance contract pending the separate executable promotion gate.",
+      "discovered_via": [
+        "https://github.com/hesreallyhim/awesome-claude-code"
+      ],
+      "freshness": {
+        "checked_at": "2026-08-11",
+        "upstream_head": "3792c6cfdf2e56ddf205340fb5afe8f272218501",
+        "status": "current"
+      },
+      "vendor_policy_duplication": false,
+      "promotion_pr": null,
+      "adopted_files": [],
+      "tool": null
+    },
+    {
+      "id": "infrastructure-showcase-routing",
+      "category": "skill-routing",
+      "source_url": "https://github.com/diet103/claude-code-infrastructure-showcase",
+      "source_paths": [
+        ".claude/hooks/skill-activation-prompt.ts",
+        ".claude/hooks/skill-verification-guard.ts",
+        ".claude/hooks/README.md"
+      ],
+      "revision": "07f75ce3c301259e857343596e7883b8ce5a9f50",
+      "version": null,
+      "official_source": true,
+      "license": "MIT",
+      "permissions": "Hooks read prompts, files, session state, and skill rules and can inject context.",
+      "network": "Optional classification and vector search use multiple hosted or local providers.",
+      "scripts": "Node/TypeScript hooks with npm dependencies, shell adapters, session state, embeddings, and provider clients.",
+      "overlap": "act-as-mohab already provides one deterministic, cross-host router with reachability and routing-corpus tests.",
+      "material_kind": "code",
+      "stage_results": {
+        "provenance_license": {"status": "pass", "evidence": "Official repository, MIT license, and immutable revision are known."},
+        "static_review": {"status": "halt", "evidence": "Provider-specific prompt classification, npm hook dependencies, fallback behavior, and no focused tracked tests add cost and ambiguity without closing a local routing gap."},
+        "quarantine_trial": {"status": "not_run", "evidence": "Not run after overlap and portability HALT."},
+        "local_evaluation": {"status": "not_run", "evidence": "Not run after HALT; local routing corpus and guard remain authoritative."}
+      },
+      "evaluation": "Rejected after comparing the activation flow with the live single-entrypoint router.",
+      "decision": "reject",
+      "decision_reason": "Reject because it duplicates routing with a larger provider-specific and dependency-bearing surface.",
+      "discovered_via": ["https://github.com/hesreallyhim/awesome-claude-code"],
+      "freshness": {"checked_at": "2026-08-11", "upstream_head": "07f75ce3c301259e857343596e7883b8ce5a9f50", "status": "current"},
+      "vendor_policy_duplication": true,
+      "promotion_pr": null,
+      "adopted_files": [],
+      "tool": null
+    },
+    {
+      "id": "compass-guardrail-corpus",
+      "category": "guardrail-evaluation",
+      "source_url": "https://github.com/dshakes/compass",
+      "source_paths": [
+        "scripts/guardrail-corpus.tsv",
+        "docs/18-benchmark.md"
+      ],
+      "revision": "fb41822123b4b556079b9a1c945c2521404ec978",
+      "version": null,
+      "official_source": true,
+      "license": "MIT",
+      "permissions": "Read-only labeled corpus and benchmark documentation.",
+      "network": "No runtime network is required after the pinned corpus is fetched and hash-verified.",
+      "scripts": "Offline TSV scoring reference; broader compass runtime is outside the selected paths.",
+      "overlap": "ChaosEngine has extensive self-tests but lacks an independently authored external destructive-command corpus.",
+      "material_kind": "test-target",
+      "stage_results": {
+        "provenance_license": {"status": "pass", "evidence": "Official repository, MIT license, and immutable revision are known."},
+        "static_review": {"status": "pass", "evidence": "Reviewed the corpus schema, labels, stated precision/recall floors, and offline execution contract."},
+        "quarantine_trial": {"status": "not_applicable", "evidence": "Plain-text external conformance target; no upstream executable is adopted."},
+        "local_evaluation": {"status": "pass", "evidence": "The applicable command rows map to ChaosEngine's PreToolUse command boundary; executable scoring is issue #4704."}
+      },
+      "evaluation": "Useful independent test target; the compass runtime and policy remain out of scope.",
+      "decision": "retain-test-target",
+      "decision_reason": "Retain the pinned corpus for a separate hash-verified external evaluation lane.",
+      "discovered_via": ["https://github.com/hesreallyhim/awesome-claude-code"],
+      "freshness": {"checked_at": "2026-08-11", "upstream_head": "fb41822123b4b556079b9a1c945c2521404ec978", "status": "current"},
+      "vendor_policy_duplication": false,
+      "promotion_pr": null,
+      "adopted_files": [],
+      "tool": null
+    },
+    {
+      "id": "presence-outcome-memory",
+      "category": "outcome-memory",
+      "source_url": "https://github.com/sara-star-quant/presence",
+      "source_paths": [
+        "skills/confidence-gate/SKILL.md",
+        "skills/outcome-check/SKILL.md",
+        "docs/security.md"
+      ],
+      "revision": "6e8c301b0a1d5c254c4325e8df116b9ee2c577fc",
+      "version": null,
+      "official_source": true,
+      "license": "Apache-2.0",
+      "permissions": "Hooks read local transcripts and persist per-user state under a provider-specific home directory.",
+      "network": "Default local-only behavior has optional release, pull-request, and webhook calls.",
+      "scripts": "Shell hooks, Python daemon and MCP code, local telemetry, redaction, encryption, and provider adapters.",
+      "overlap": "Native Memory, MemPalace, Graphify, evidence rules, review findings, and PR ownership already cover the useful outcomes without a fourth memory layer.",
+      "material_kind": "code",
+      "stage_results": {
+        "provenance_license": {"status": "pass", "evidence": "Official repository, Apache-2.0 license, and immutable revision are known."},
+        "static_review": {"status": "halt", "evidence": "The provider-specific transcript and user-state runtime duplicates the established three-store retrieval contract and adds hooks, daemon state, and optional network paths."},
+        "quarantine_trial": {"status": "not_run", "evidence": "Not run after architecture-overlap HALT."},
+        "local_evaluation": {"status": "not_run", "evidence": "Not run after HALT; current retrieval and evidence gates remain the baseline."}
+      },
+      "evaluation": "Rejected as a parallel memory and telemetry stack.",
+      "decision": "reject",
+      "decision_reason": "Reject because it duplicates durable knowledge ownership and adds provider-specific persisted state.",
+      "discovered_via": ["https://github.com/hesreallyhim/awesome-claude-code"],
+      "freshness": {"checked_at": "2026-08-11", "upstream_head": "6e8c301b0a1d5c254c4325e8df116b9ee2c577fc", "status": "current"},
+      "vendor_policy_duplication": true,
+      "promotion_pr": null,
+      "adopted_files": [],
+      "tool": null
+    },
+    {
+      "id": "claude-code-harness-runtime",
+      "category": "cross-client-harness",
+      "source_url": "https://github.com/Chachamaru127/claude-code-harness",
+      "source_paths": [
+        "agents/reviewer.md",
+        "skills",
+        "go",
+        "scripts"
+      ],
+      "revision": "9736a5b4eba7d836b31df85d73dc4722a464d9c4",
+      "version": null,
+      "official_source": true,
+      "license": "MIT",
+      "permissions": "Broad multi-host plugin runtime with setup scripts, hooks, state, subprocesses, and release workflows.",
+      "network": "Installation, companion clients, release, and cross-model review paths can use network services.",
+      "scripts": "Large Go, shell, JavaScript, plugin, schema, benchmark, and multi-host adapter surface.",
+      "overlap": "ChaosEngine already has stricter RED/GREEN, independent evidence-block reviews, capability-level roles, single-entry routing, and PR merge ownership.",
+      "material_kind": "code",
+      "stage_results": {
+        "provenance_license": {"status": "pass", "evidence": "Official repository, MIT license, and immutable revision are known."},
+        "static_review": {"status": "halt", "evidence": "The runtime substantially duplicates the local harness, includes provider/model pins in tracked guidance, and would replace rather than narrow an invariant owner."},
+        "quarantine_trial": {"status": "not_run", "evidence": "Not run after duplication and policy HALT."},
+        "local_evaluation": {"status": "not_run", "evidence": "Not run after HALT; local review format and lifecycle tests are stronger and already enforced."}
+      },
+      "evaluation": "Rejected as a competing harness rather than an incremental capability.",
+      "decision": "reject",
+      "decision_reason": "Reject runtime adoption; keep the existing provider-agnostic root owners.",
+      "discovered_via": ["https://github.com/hesreallyhim/awesome-claude-code"],
+      "freshness": {"checked_at": "2026-08-11", "upstream_head": "9736a5b4eba7d836b31df85d73dc4722a464d9c4", "status": "current"},
+      "vendor_policy_duplication": true,
+      "promotion_pr": null,
+      "adopted_files": [],
+      "tool": null
     }
   ]
 }

--- a/agent-plugins/shaft-skills/candidate-intake/policy.json
+++ b/agent-plugins/shaft-skills/candidate-intake/policy.json
@@ -1,11 +1,35 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "decision_kinds": [
     "adopt-code",
     "adopt-pattern",
+    "adopt-tool",
     "retain-test-target",
     "reject"
   ],
+  "allowed_categories": [
+    "agent-runtime",
+    "catalog",
+    "cross-client-harness",
+    "cross-client-packaging",
+    "documents",
+    "guardrail-evaluation",
+    "guidance-linter",
+    "outcome-memory",
+    "plugin-evaluation",
+    "security-scanner",
+    "skill-routing"
+  ],
+  "freshness_contract": {
+    "max_age_days": 90
+  },
+  "tool_contract": {
+    "required_platforms": [
+      "linux-x86_64",
+      "macos-aarch64",
+      "windows-x86_64"
+    ]
+  },
   "required_stages": [
     "provenance_license",
     "static_review",

--- a/scripts/ci/shaft_skill_candidate_intake.py
+++ b/scripts/ci/shaft_skill_candidate_intake.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import stat
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 
@@ -15,10 +16,11 @@ INTAKE_ROOT = Path("agent-plugins/shaft-skills/candidate-intake")
 POLICY_PATH = INTAKE_ROOT / "policy.json"
 REVIEW_PATH = INTAKE_ROOT / "candidates.json"
 README_PATH = INTAKE_ROOT / "README.md"
-DECISIONS = {"adopt-code", "adopt-pattern", "retain-test-target", "reject"}
+DECISIONS = {"adopt-code", "adopt-pattern", "adopt-tool", "retain-test-target", "reject"}
 STAGES = ("provenance_license", "static_review", "quarantine_trial", "local_evaluation")
 STAGE_STATUSES = {"pass", "halt", "not_run", "not_applicable"}
-REQUIRED_CATEGORIES = {"documents", "plugin-evaluation", "cross-client-packaging"}
+FRESHNESS_STATUSES = {"current", "outdated", "retired"}
+MATERIAL_KINDS = {"code", "pattern", "test-target", "tool"}
 REQUIRED_CANDIDATE_FIELDS = {
     "id",
     "category",
@@ -37,9 +39,12 @@ REQUIRED_CANDIDATE_FIELDS = {
     "evaluation",
     "decision",
     "decision_reason",
+    "discovered_via",
+    "freshness",
     "vendor_policy_duplication",
     "promotion_pr",
     "adopted_files",
+    "tool",
 }
 EXECUTABLE_SUFFIXES = {
     ".bat",
@@ -220,12 +225,31 @@ def quarantine_command(
 def validate_policy(policy: dict) -> list[dict]:
     defects: list[dict] = []
     schema_version = policy.get("schema_version")
-    if type(schema_version) is not int or schema_version != 1:  # pylint: disable=unidiomatic-typecheck  # Exact type rejects bool aliases.
-        defects.append(_defect("policy-schema", "policy schema_version must be 1"))
+    if type(schema_version) is not int or schema_version != 2:  # pylint: disable=unidiomatic-typecheck  # Exact type rejects bool aliases.
+        defects.append(_defect("policy-schema", "policy schema_version must be 2"))
     if set(policy.get("decision_kinds", [])) != DECISIONS:
-        defects.append(_defect("policy-decisions", "policy must declare all four decision kinds"))
+        defects.append(_defect("policy-decisions", "policy must declare all five decision kinds"))
+    categories = policy.get("allowed_categories")
+    if not isinstance(categories, list) or not categories or not all(
+        isinstance(category, str) and re.fullmatch(r"[a-z0-9-]+", category)
+        for category in categories
+    ) or len(categories) != len(set(categories)):
+        defects.append(_defect("policy-categories", "policy must declare unique lowercase allowed_categories"))
     if tuple(policy.get("required_stages", [])) != STAGES:
         defects.append(_defect("policy-stages", "policy stages or order drifted"))
+    freshness_contract = policy.get("freshness_contract")
+    if not isinstance(freshness_contract, dict) or set(freshness_contract) != {"max_age_days"} or (
+        type(freshness_contract.get("max_age_days")) is not int  # pylint: disable=unidiomatic-typecheck
+        or freshness_contract["max_age_days"] <= 0
+    ):
+        defects.append(_defect("freshness-contract", "policy must declare a positive integer max_age_days"))
+    tool_contract = policy.get("tool_contract")
+    required_platforms = tool_contract.get("required_platforms") if isinstance(tool_contract, dict) else None
+    if not isinstance(required_platforms, list) or not required_platforms or not all(
+        isinstance(platform, str) and re.fullmatch(r"[a-z0-9_-]+", platform)
+        for platform in required_platforms
+    ) or len(required_platforms) != len(set(required_platforms)):
+        defects.append(_defect("tool-contract", "policy must declare unique lowercase required tool platforms"))
     trial = policy.get("trial_contract", {})
     required_trial = {
         "container_only": True,
@@ -252,17 +276,101 @@ def validate_policy(policy: dict) -> list[dict]:
     return defects
 
 
-def validate_review(review: dict, policy: dict) -> list[dict]:  # noqa: MC0001  # Ordered fail-closed schema gate is intentionally linear.
+def _valid_iso_date(value: object) -> bool:
+    try:
+        return isinstance(value, str) and date.fromisoformat(value).isoformat() == value
+    except ValueError:
+        return False
+
+
+def _validate_freshness(candidate: dict, path: str) -> list[dict]:
     defects: list[dict] = []
+    freshness = candidate.get("freshness")
+    if not isinstance(freshness, dict):
+        return [_defect("candidate-freshness", "freshness must be an object", path)]
+    if set(freshness) != {"checked_at", "upstream_head", "status"}:
+        defects.append(_defect("candidate-freshness", "freshness must contain checked_at, upstream_head, and status", path))
+    if not _valid_iso_date(freshness.get("checked_at")):
+        defects.append(_defect("candidate-freshness", "freshness checked_at must be an ISO calendar date", path))
+    upstream_head = freshness.get("upstream_head")
+    if not isinstance(upstream_head, str) or not re.fullmatch(r"[0-9a-f]{40}", upstream_head):
+        defects.append(_defect("candidate-freshness", "freshness upstream_head must be a full commit SHA", path))
+    status = freshness.get("status")
+    if status not in FRESHNESS_STATUSES:
+        defects.append(_defect("candidate-freshness", "freshness status is invalid", path))
+    revision = candidate.get("revision")
+    if status == "current" and upstream_head != revision:
+        defects.append(_defect("candidate-freshness", "current freshness requires upstream_head to equal revision", path))
+    if status == "outdated" and upstream_head == revision:
+        defects.append(_defect("candidate-freshness", "outdated freshness requires a changed upstream_head", path))
+    return defects
+
+
+def _validate_tool(candidate: dict, policy: dict, path: str) -> list[dict]:
+    defects: list[dict] = []
+    tool = candidate.get("tool")
+    if candidate.get("decision") != "adopt-tool":
+        if tool is not None:
+            defects.append(_defect("tool-evidence", "tool evidence is reserved for adopt-tool", path))
+        return defects
+    if candidate.get("material_kind") != "tool" or not isinstance(tool, dict):
+        return [_defect("tool-evidence", "adopt-tool requires material_kind tool and a tool object", path)]
+    if set(tool) != {"version", "execution", "artifacts"}:
+        defects.append(_defect("tool-evidence", "tool must contain version, execution, and artifacts", path))
+    version = tool.get("version")
+    if not isinstance(version, str) or not version.strip() or candidate.get("version") != version:
+        defects.append(_defect("tool-evidence", "tool version must be non-empty and match candidate version", path))
+    if not isinstance(tool.get("execution"), str) or not tool.get("execution", "").strip():
+        defects.append(_defect("tool-evidence", "tool execution boundary is required", path))
+    artifacts = tool.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        defects.append(_defect("tool-artifact", "tool requires at least one platform artifact", path))
+        return defects
+    platforms: list[str] = []
+    for index, artifact in enumerate(artifacts):
+        artifact_path = f"{path}.tool.artifacts[{index}]"
+        if not isinstance(artifact, dict) or set(artifact) != {"platform", "url", "sha256"}:
+            defects.append(_defect("tool-artifact", "artifact must contain platform, url, and sha256", artifact_path))
+            continue
+        platform = artifact.get("platform")
+        url = artifact.get("url")
+        digest = artifact.get("sha256")
+        if not isinstance(platform, str) or not re.fullmatch(r"[a-z0-9_-]+", platform):
+            defects.append(_defect("tool-artifact", "artifact platform is invalid", artifact_path))
+        else:
+            platforms.append(platform)
+        if not isinstance(url, str) or not url.startswith("https://"):
+            defects.append(_defect("tool-artifact", "artifact URL must use HTTPS", artifact_path))
+        if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            defects.append(_defect("tool-artifact", "artifact sha256 must contain 64 lowercase hex characters", artifact_path))
+    if len(platforms) != len(set(platforms)):
+        defects.append(_defect("tool-artifact", "tool artifact platforms must be unique", path))
+    tool_contract = policy.get("tool_contract", {})
+    required_platforms = set(tool_contract.get("required_platforms", [])) if isinstance(tool_contract, dict) else set()
+    if set(platforms) != required_platforms:
+        defects.append(_defect("tool-artifact", "tool artifacts must cover every policy-required platform", path))
+    return defects
+
+
+def validate_review(  # noqa: MC0001  # Ordered fail-closed schema gate is intentionally linear.
+    review: dict,
+    policy: dict,
+    *,
+    as_of: date | None = None,
+) -> list[dict]:
+    defects: list[dict] = []
+    validation_date = as_of or date.today()
     schema_version = review.get("schema_version")
-    if type(schema_version) is not int or schema_version != 1:  # pylint: disable=unidiomatic-typecheck  # Exact type rejects bool, subclasses, and __class__ spoofing.
-        defects.append(_defect("review-schema", "review schema_version must be integer 1"))
+    if type(schema_version) is not int or schema_version != 2:  # pylint: disable=unidiomatic-typecheck  # Exact type rejects bool, subclasses, and __class__ spoofing.
+        defects.append(_defect("review-schema", "review schema_version must be integer 2"))
     reviewed_at = review.get("reviewed_at")
     try:
         if not isinstance(reviewed_at, str) or date.fromisoformat(reviewed_at).isoformat() != reviewed_at:
             raise ValueError
     except ValueError:
         defects.append(_defect("review-date", "reviewed_at must be an ISO calendar date"))
+    if _valid_iso_date(reviewed_at) and date.fromisoformat(reviewed_at) > validation_date:
+        defects.append(_defect("review-date", "reviewed_at cannot be later than the validation date"))
     candidates = review.get("candidates")
     if not isinstance(candidates, list):
         return [_defect("review-shape", "candidates must be a list")]
@@ -284,6 +392,8 @@ def validate_review(review: dict, policy: dict) -> list[dict]:  # noqa: MC0001  
         category = candidate.get("category")
         if isinstance(category, str):
             categories.add(category)
+            if category not in set(policy.get("allowed_categories", [])):
+                defects.append(_defect("candidate-category", "candidate category is not allowed by policy", path))
         revision = candidate.get("revision")
         if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40}", revision):
             defects.append(_defect("immutable-revision", "candidate revision must be a full immutable commit SHA", path))
@@ -307,8 +417,19 @@ def validate_review(review: dict, policy: dict) -> list[dict]:  # noqa: MC0001  
             isinstance(item, str) and item.strip() for item in source_paths
         ):
             defects.append(_defect("candidate-evidence", "source_paths evidence is required", path))
-        if candidate.get("material_kind") not in {"code", "pattern", "test-target"}:
+        if candidate.get("material_kind") not in MATERIAL_KINDS:
             defects.append(_defect("candidate-evidence", "material_kind is invalid", path))
+        discovered_via = candidate.get("discovered_via")
+        if not isinstance(discovered_via, list) or not discovered_via or not all(
+            isinstance(item, str) and item.startswith("https://") for item in discovered_via
+        ):
+            defects.append(_defect("candidate-evidence", "discovered_via must be a list of HTTPS URLs", path))
+        defects.extend(_validate_freshness(candidate, path))
+        freshness = candidate.get("freshness")
+        if isinstance(freshness, dict) and _valid_iso_date(freshness.get("checked_at")) and _valid_iso_date(reviewed_at):
+            checked_at = date.fromisoformat(freshness["checked_at"])
+            if checked_at > date.fromisoformat(reviewed_at) or checked_at > validation_date:
+                defects.append(_defect("candidate-freshness", "freshness check cannot be later than reviewed_at or the validation date", path))
         decision = candidate.get("decision")
         if decision not in DECISIONS:
             defects.append(_defect("candidate-decision", "unknown candidate decision", path))
@@ -347,6 +468,32 @@ def validate_review(review: dict, policy: dict) -> list[dict]:  # noqa: MC0001  
                 r"https://github\.com/ShaftHQ/SHAFT_ENGINE/pull/\d+", promotion
             ):
                 defects.append(_defect("promotion-pr", "code adoption requires a separate SHAFT promotion PR", path))
+        if decision == "adopt-tool":
+            if any(stages.get(stage, {}).get("status") != "pass" for stage in STAGES):
+                defects.append(_defect("adopt-tool-gates", "tool adoption requires every gate to pass", path))
+            promotion = candidate.get("promotion_pr")
+            if not isinstance(promotion, str) or not re.fullmatch(
+                r"https://github\.com/ShaftHQ/SHAFT_ENGINE/pull/\d+", promotion
+            ):
+                defects.append(_defect("promotion-pr", "tool adoption requires a separate SHAFT promotion PR", path))
+        defects.extend(_validate_tool(candidate, policy, path))
+        if decision in {"adopt-code", "adopt-tool"}:
+            freshness = candidate.get("freshness", {})
+            freshness_contract = policy.get("freshness_contract", {})
+            max_age_days = freshness_contract.get("max_age_days") if isinstance(freshness_contract, dict) else None
+            current_enough = False
+            if (
+                isinstance(freshness, dict)
+                and freshness.get("status") == "current"
+                and _valid_iso_date(freshness.get("checked_at"))
+                and _valid_iso_date(reviewed_at)
+                and type(max_age_days) is int  # pylint: disable=unidiomatic-typecheck
+                and max_age_days > 0
+            ):
+                checked_at = date.fromisoformat(freshness["checked_at"])
+                current_enough = validation_date - timedelta(days=max_age_days) <= checked_at <= validation_date
+            if not current_enough:
+                defects.append(_defect("promotion-freshness", "code and tool promotion require current, unexpired freshness", path))
         if decision in {"adopt-pattern", "retain-test-target"}:
             required = ("provenance_license", "static_review", "local_evaluation")
             if any(stages.get(stage, {}).get("status") != "pass" for stage in required):
@@ -363,8 +510,9 @@ def validate_review(review: dict, policy: dict) -> list[dict]:  # noqa: MC0001  
             defects.append(_defect("candidate-code", "this review PR must not contain adopted candidate files", path))
     if len(ids) != len(set(ids)):
         defects.append(_defect("candidate-id", "candidate ids must be unique"))
-    if categories != REQUIRED_CATEGORIES:
-        defects.append(_defect("candidate-categories", "review must cover documents, plugin evaluation, and cross-client packaging"))
+    allowed_categories = set(policy.get("allowed_categories", []))
+    if categories != allowed_categories:
+        defects.append(_defect("candidate-categories", "review must cover every policy-owned candidate category"))
     scope = review.get("review_scope", {})
     if not isinstance(scope, dict):
         defects.append(_defect("review-scope", "review_scope must be an object"))
@@ -377,6 +525,29 @@ def validate_review(review: dict, policy: dict) -> list[dict]:  # noqa: MC0001  
     if review.get("code_adopted") is not False:
         defects.append(_defect("candidate-code", "candidate code must not enter the intake PR"))
     return defects
+
+
+def freshness_findings(review: dict, *, max_age_days: int, as_of: date | None = None) -> list[dict]:
+    """Report candidates that need a metadata recheck without mutating the ledger."""
+    today = as_of or date.today()
+    threshold = today - timedelta(days=max_age_days)
+    findings: list[dict] = []
+    reviewed_at = review.get("reviewed_at")
+    if _valid_iso_date(reviewed_at) and date.fromisoformat(reviewed_at) > today:
+        findings.append(_defect("review-future", "reviewed_at is later than the validation date"))
+    for index, candidate in enumerate(review.get("candidates", [])):
+        if not isinstance(candidate, dict):
+            continue
+        freshness = candidate.get("freshness", {})
+        checked_at = freshness.get("checked_at") if isinstance(freshness, dict) else None
+        status = freshness.get("status") if isinstance(freshness, dict) else None
+        if _valid_iso_date(checked_at) and date.fromisoformat(checked_at) > today:
+            findings.append(_defect("candidate-stale", "freshness check is later than the validation date", f"candidates[{index}]"))
+        elif status in {"outdated", "retired"}:
+            findings.append(_defect("candidate-stale", f"freshness status is {status}", f"candidates[{index}]"))
+        elif _valid_iso_date(checked_at) and date.fromisoformat(checked_at) < threshold:
+            findings.append(_defect("candidate-stale", f"freshness check is older than {max_age_days} days", f"candidates[{index}]"))
+    return findings
 
 
 def validate_repository(root: Path = ROOT) -> list[dict]:
@@ -394,6 +565,7 @@ def validate_repository(root: Path = ROOT) -> list[dict]:
         "No host fallback",
         "separate adoption PR",
         "adopt code",
+        "adopt tool",
         "adopt a pattern",
         "retain a test target",
         "reject",
@@ -403,13 +575,27 @@ def validate_repository(root: Path = ROOT) -> list[dict]:
     return defects
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check-freshness", action="store_true")
+    parser.add_argument("--max-age-days", type=int)
+    args = parser.parse_args(argv)
+    if args.max_age_days is not None and args.max_age_days <= 0:
+        parser.error("--max-age-days must be a positive integer")
     defects = validate_repository()
     if defects:
         for defect in defects:
             print(f"{defect['code']}: {defect['path']}: {defect['message']}")
         return 1
     review = json.loads((ROOT / REVIEW_PATH).read_text(encoding="utf-8"))
+    if args.check_freshness:
+        policy = json.loads((ROOT / POLICY_PATH).read_text(encoding="utf-8"))
+        max_age_days = args.max_age_days or policy["freshness_contract"]["max_age_days"]
+        stale = freshness_findings(review, max_age_days=max_age_days)
+        if stale:
+            for defect in stale:
+                print(f"{defect['code']}: {defect['path']}: {defect['message']}")
+            return 1
     print(f"SHAFT candidate intake is valid: {len(review['candidates'])} reviewed candidates")
     return 0
 

--- a/tests/scripts/test_shaft_skill_candidate_intake.py
+++ b/tests/scripts/test_shaft_skill_candidate_intake.py
@@ -4,12 +4,14 @@ import json
 import os
 import tempfile
 import unittest
+from datetime import date
 from inspect import signature
 from pathlib import Path
 
 try:
     from scripts.ci.shaft_skill_candidate_intake import (
         quarantine_command,
+        freshness_findings,
         scan_candidate,
         validate_policy,
         validate_repository,
@@ -17,6 +19,7 @@ try:
     )
 except ImportError:
     quarantine_command = None
+    freshness_findings = None
     scan_candidate = None
     validate_repository = None
     validate_review = None
@@ -29,6 +32,115 @@ REVIEW_PATH = ROOT / "agent-plugins/shaft-skills/candidate-intake/candidates.jso
 
 
 class ShaftSkillCandidateIntakeTest(unittest.TestCase):
+    def test_v2_policy_owns_categories_and_tool_adoption(self):
+        policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+        self.assertEqual(policy["schema_version"], 2)
+        self.assertIn("adopt-tool", policy["decision_kinds"])
+        self.assertEqual(policy["freshness_contract"], {"max_age_days": 90})
+        self.assertEqual(
+            set(policy["tool_contract"]["required_platforms"]),
+            {"linux-x86_64", "macos-aarch64", "windows-x86_64"},
+        )
+        self.assertEqual(
+            set(policy["allowed_categories"]),
+            {
+                "agent-runtime",
+                "catalog",
+                "cross-client-harness",
+                "cross-client-packaging",
+                "documents",
+                "guardrail-evaluation",
+                "guidance-linter",
+                "outcome-memory",
+                "plugin-evaluation",
+                "security-scanner",
+                "skill-routing",
+            },
+        )
+
+    def test_every_candidate_has_consistent_freshness_metadata(self):
+        policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+        review = json.loads(REVIEW_PATH.read_text(encoding="utf-8"))
+
+        self.assertEqual(validate_review(review, policy), [])
+        for candidate in review["candidates"]:
+            freshness = candidate["freshness"]
+            self.assertRegex(freshness["upstream_head"], r"^[0-9a-f]{40}$")
+            if freshness["status"] == "current":
+                self.assertEqual(freshness["upstream_head"], candidate["revision"])
+            elif freshness["status"] == "outdated":
+                self.assertNotEqual(freshness["upstream_head"], candidate["revision"])
+
+    def test_adopt_tool_requires_pinned_platform_artifacts_and_promotion(self):
+        policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+        review = json.loads(REVIEW_PATH.read_text(encoding="utf-8"))
+        candidate = review["candidates"][0]
+        candidate["material_kind"] = "tool"
+        candidate["decision"] = "adopt-tool"
+        candidate["version"] = "v1.2.3"
+        candidate["tool"] = {
+            "version": "v1.2.3",
+            "execution": "read-only no-network container",
+            "artifacts": [
+                {
+                    "platform": "linux-x86_64",
+                    "url": "https://example.test/tool.tar.gz",
+                    "sha256": "0" * 64,
+                },
+                {
+                    "platform": "macos-aarch64",
+                    "url": "https://example.test/tool-macos.tar.gz",
+                    "sha256": "1" * 64,
+                },
+                {
+                    "platform": "windows-x86_64",
+                    "url": "https://example.test/tool-windows.zip",
+                    "sha256": "2" * 64,
+                }
+            ],
+        }
+        candidate["promotion_pr"] = "https://github.com/ShaftHQ/SHAFT_ENGINE/pull/9999"
+        candidate["stage_results"] = {
+            stage: {"status": "pass", "evidence": f"passed {stage}"}
+            for stage in policy["required_stages"]
+        }
+        review["review_scope"]["rejected_candidate_ids"] = [
+            row["id"] for row in review["candidates"] if row["decision"] == "reject"
+        ]
+
+        def validate_tool_review():
+            return validate_review(review, policy, as_of=date(2026, 8, 11))
+
+        self.assertEqual(validate_tool_review(), [])
+
+        candidate["tool"]["artifacts"][0]["sha256"] = "short"
+        defects = validate_tool_review()
+        self.assertIn("tool-artifact", {defect["code"] for defect in defects})
+        candidate["tool"]["artifacts"][0]["sha256"] = "0" * 64
+
+        linux_artifact = candidate["tool"]["artifacts"].pop(0)
+        self.assertIn("tool-artifact", {defect["code"] for defect in validate_tool_review()})
+        candidate["tool"]["artifacts"].insert(0, linux_artifact)
+
+        candidate["tool"]["version"] = ""
+        self.assertIn("tool-evidence", {defect["code"] for defect in validate_tool_review()})
+        candidate["tool"]["version"] = candidate["version"]
+
+        candidate["promotion_pr"] = None
+        self.assertIn("promotion-pr", {defect["code"] for defect in validate_tool_review()})
+        candidate["promotion_pr"] = "https://github.com/ShaftHQ/SHAFT_ENGINE/pull/9999"
+
+        candidate["freshness"]["status"] = "outdated"
+        candidate["freshness"]["upstream_head"] = "f" * 40
+        self.assertIn("promotion-freshness", {defect["code"] for defect in validate_tool_review()})
+        candidate["freshness"] = {
+            "checked_at": "2026-05-11",
+            "upstream_head": candidate["revision"],
+            "status": "current",
+        }
+        self.assertIn("promotion-freshness", {defect["code"] for defect in validate_tool_review()})
+
     def test_candidate_intake_api_is_available(self):
         self.assertTrue(callable(validate_repository))
         self.assertTrue(callable(validate_review))
@@ -43,7 +155,7 @@ class ShaftSkillCandidateIntakeTest(unittest.TestCase):
         decisions = {candidate["decision"] for candidate in review["candidates"]}
         self.assertEqual(
             set(policy["decision_kinds"]),
-            {"adopt-code", "adopt-pattern", "retain-test-target", "reject"},
+            {"adopt-code", "adopt-pattern", "adopt-tool", "retain-test-target", "reject"},
         )
         self.assertTrue({"adopt-pattern", "retain-test-target", "reject"}.issubset(decisions))
         self.assertFalse(review["code_adopted"])
@@ -65,12 +177,13 @@ class ShaftSkillCandidateIntakeTest(unittest.TestCase):
                 self.assertIn("trial-contract", {row["code"] for row in validate_policy(policy)})
 
     def test_review_covers_each_required_candidate_category_and_every_rejection(self):
+        policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
         review = json.loads(REVIEW_PATH.read_text(encoding="utf-8"))
         candidates = review["candidates"]
 
         self.assertEqual(
             {candidate["category"] for candidate in candidates},
-            {"documents", "plugin-evaluation", "cross-client-packaging"},
+            set(policy["allowed_categories"]),
         )
         self.assertEqual(
             set(review["review_scope"]["candidate_ids"]),
@@ -80,6 +193,47 @@ class ShaftSkillCandidateIntakeTest(unittest.TestCase):
             set(review["review_scope"]["rejected_candidate_ids"]),
             {candidate["id"] for candidate in candidates if candidate["decision"] == "reject"},
         )
+
+    def test_freshness_check_reports_outdated_and_expired_records(self):
+        review = json.loads(REVIEW_PATH.read_text(encoding="utf-8"))
+        review["candidates"] = review["candidates"][:2]
+        review["candidates"][0]["freshness"] = {
+            "checked_at": "2026-08-11",
+            "upstream_head": "f" * 40,
+            "status": "outdated",
+        }
+        review["candidates"][1]["freshness"] = {
+            "checked_at": "2026-01-01",
+            "upstream_head": review["candidates"][1]["revision"],
+            "status": "current",
+        }
+
+        findings = freshness_findings(review, as_of=date(2026, 8, 11), max_age_days=90)
+
+        self.assertEqual([finding["code"] for finding in findings], ["candidate-stale", "candidate-stale"])
+
+    def test_review_rejects_future_dated_freshness(self):
+        policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+        review = json.loads(REVIEW_PATH.read_text(encoding="utf-8"))
+        review["reviewed_at"] = "2099-01-01"
+        review["candidates"][0]["freshness"]["checked_at"] = "2099-01-01"
+
+        codes = {
+            defect["code"]
+            for defect in validate_review(review, policy, as_of=date(2026, 8, 11))
+        }
+        finding_codes = {
+            finding["code"]
+            for finding in freshness_findings(
+                review,
+                as_of=date(2026, 8, 11),
+                max_age_days=90,
+            )
+        }
+
+        self.assertIn("candidate-freshness", codes)
+        self.assertIn("review-date", codes)
+        self.assertEqual(finding_codes, {"candidate-stale", "review-future"})
 
     def test_review_rejects_mutable_or_incomplete_provenance(self):
         policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
@@ -91,6 +245,20 @@ class ShaftSkillCandidateIntakeTest(unittest.TestCase):
 
         self.assertTrue(any(defect["code"] == "immutable-revision" for defect in defects))
         self.assertTrue(any(defect["code"] == "candidate-field" for defect in defects))
+
+    def test_review_rejects_empty_discovery_paths_and_incomplete_category_coverage(self):
+        policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+        review = json.loads(REVIEW_PATH.read_text(encoding="utf-8"))
+        review["candidates"][0]["discovered_via"] = []
+        removed = review["candidates"].pop()
+        review["review_scope"]["candidate_ids"].remove(removed["id"])
+        if removed["id"] in review["review_scope"]["rejected_candidate_ids"]:
+            review["review_scope"]["rejected_candidate_ids"].remove(removed["id"])
+
+        codes = {defect["code"] for defect in validate_review(review, policy)}
+
+        self.assertIn("candidate-evidence", codes)
+        self.assertIn("candidate-categories", codes)
 
     def test_adopt_code_requires_all_gates_and_a_separate_promotion_pr(self):
         policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Outcome
- migrate the external candidate ledger and policy to schema v2
- record the eight reviewed harness sources at immutable revisions with explicit accept/reject evidence
- add policy-owned categories, discovery provenance, freshness, and a quarantined `adopt-tool` decision
- fail closed on stale, expired, or future promotion evidence and require hash-pinned artifacts for every supported host platform
- copy or execute no upstream candidate code

## Verification
- `py -3 -m unittest tests.scripts.test_shaft_skill_candidate_intake -v` — 25 passed, 1 expected Windows symlink skip
- `py -3 scripts/ci/shaft_skill_candidate_intake.py` — 14 reviewed candidates valid
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` — valid
- `git diff --check` — clean
- independent adversarial review — clean after three fail-closed findings were fixed

## Freshness evidence
`--check-freshness` intentionally reports the two Microsoft records whose upstream heads changed; they cannot be promoted while outdated.

Closes #4701
Part of #4700