### PR TITLE
fix(capture): preserve replay failures and input fidelity

### DIFF
--- a/shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java
@@ -252,10 +252,7 @@ public class GeneratedTestValidator {
             properties.load(reader);
         }
         String configured = properties.getProperty("headlessExecution", "").trim();
-        if ("false".equalsIgnoreCase(configured)) {
-            return false;
-        }
-        return true;
+        return !"false".equalsIgnoreCase(configured);
     }
 
     private static String attemptDiagnostic(Path replayDirectory) {

--- a/shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/generate/GeneratedTestValidator.java
@@ -13,11 +13,14 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
@@ -89,16 +92,33 @@ public class GeneratedTestValidator {
             Path resourcesDirectory,
             Path workDirectory,
             Duration timeout) {
-        Path replayDirectory = workDirectory.resolve("target/shaft-capture/replay");
+        Path replayDirectory = workDirectory.resolve("target/shaft-capture/replay")
+                .resolve("attempt-" + UUID.randomUUID());
         Path allureResults = replayDirectory.resolve("allure-results");
         Path testngOutput = replayDirectory.resolve("testng-output");
         Path outputLog = replayDirectory.resolve("replay.log");
         Path chromeDriverLog = replayDirectory.resolve("chromedriver.log");
         Process process = null;
         try {
+            Files.createDirectories(replayDirectory);
             Files.createDirectories(allureResults);
             Files.createDirectories(testngOutput);
-            seedHeadlessCustomProperties(workDirectory);
+            boolean headlessExecution = configuredHeadlessExecution(workDirectory);
+            Path bootstrapDirectory = replayDirectory.resolve("properties");
+            Files.createDirectories(bootstrapDirectory);
+            Path projectProperties = workDirectory.resolve("src/main/resources/properties");
+            if (Files.isDirectory(projectProperties, LinkOption.NOFOLLOW_LINKS)) {
+                List<Path> propertyFiles;
+                try (Stream<Path> files = Files.list(projectProperties)) {
+                    propertyFiles = files
+                            .filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
+                            .filter(path -> path.getFileName().toString().endsWith(".properties"))
+                            .toList();
+                }
+                for (Path propertyFile : propertyFiles) {
+                    Files.copy(propertyFile, bootstrapDirectory.resolve(propertyFile.getFileName()));
+                }
+            }
             String classpath = classesDirectory.toAbsolutePath().normalize()
                     + File.pathSeparator
                     + resourcesDirectory.toAbsolutePath().normalize()
@@ -111,10 +131,9 @@ public class GeneratedTestValidator {
             StringBuilder argsContent = new StringBuilder();
             argsContent.append(argFileQuote(
                     "-Dallure.results.directory=" + allureResults.toAbsolutePath().normalize())).append('\n');
-            // Always headless regardless of the outer process's own headlessExecution setting
-            // (e.g. shaft-capture's custom.properties defaults to false for local interactive
-            // development) -- this replay is a non-interactive validation run.
-            argsContent.append("-DheadlessExecution=true").append('\n');
+            argsContent.append("-DheadlessExecution=").append(headlessExecution).append('\n');
+            argsContent.append(argFileQuote("-Dshaft.properties.bootstrapDirectory="
+                    + bootstrapDirectory.toAbsolutePath().normalize())).append('\n');
             argsContent.append("-Dwebdriver.chrome.verboseLogging=true").append('\n');
             argsContent.append(argFileQuote(
                     "-Dwebdriver.chrome.logfile=" + chromeDriverLog.toAbsolutePath().normalize())).append('\n');
@@ -141,10 +160,11 @@ public class GeneratedTestValidator {
                 // destroyForcibly() only kills the forked TestNG JVM itself -- it leaves
                 // ChromeDriver/Chrome (its descendants) running as orphans, especially on Windows.
                 destroyProcessTree(process);
-                return failed("Generated test replay timed out.");
+                return failed("Generated test replay timed out. " + attemptDiagnostic(replayDirectory));
             }
             AllureSummary allure = allure(allureResults);
             List<String> diagnostics = new ArrayList<>();
+            diagnostics.add(attemptDiagnostic(replayDirectory));
             if (process.exitValue() != 0) {
                 diagnostics.add("TestNG replay exited with code " + process.exitValue() + ".");
             }
@@ -166,13 +186,14 @@ public class GeneratedTestValidator {
             if (process != null) {
                 destroyProcessTree(process);
             }
-            return failed("Generated test replay could not be launched: " + exception.getMessage());
+            return failed("Generated test replay could not be launched: " + exception.getMessage()
+                    + ". " + attemptDiagnostic(replayDirectory));
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             if (process != null) {
                 destroyProcessTree(process);
             }
-            return failed("Generated test replay was interrupted.");
+            return failed("Generated test replay was interrupted. " + attemptDiagnostic(replayDirectory));
         }
     }
 
@@ -221,25 +242,24 @@ public class GeneratedTestValidator {
         return '"' + value.replace("\\", "/").replace("\"", "\\\"") + '"';
     }
 
-    /**
-     * Pre-seeds a {@code custom.properties} at the path SHAFT's engine bootstrap looks for one
-     * relative to the replay's working directory, forcing headless/CI-safe Chrome flags.
-     *
-     * <p>Without this, the engine's own "create custom.properties from the bundled template if
-     * missing" bootstrap step fills that same file with the template's {@code headlessExecution=false}
-     * default and reloads it into system properties, silently discarding any headless override
-     * passed to the replay subprocess on the command line — Chrome then launches without
-     * {@code --headless} and crashes on runners with no display.
-     *
-     * @param workDirectory the replay subprocess's working directory
-     */
-    private static void seedHeadlessCustomProperties(Path workDirectory) throws IOException {
+    private static boolean configuredHeadlessExecution(Path workDirectory) throws IOException {
         Path customProperties = workDirectory.resolve("src/main/resources/properties/custom.properties");
-        Files.createDirectories(customProperties.getParent());
-        Files.writeString(customProperties,
-                "headlessExecution=true" + System.lineSeparator()
-                        + "automaticallyAddRecommendedChromeOptions=true" + System.lineSeparator(),
-                StandardCharsets.UTF_8);
+        if (!Files.isRegularFile(customProperties)) {
+            return true;
+        }
+        Properties properties = new Properties();
+        try (var reader = Files.newBufferedReader(customProperties, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        }
+        String configured = properties.getProperty("headlessExecution", "").trim();
+        if ("false".equalsIgnoreCase(configured)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static String attemptDiagnostic(Path replayDirectory) {
+        return "Replay attempt artifacts: " + replayDirectory.toAbsolutePath().normalize();
     }
 
     private static AllureSummary allure(Path directory) throws IOException {

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -17,10 +17,12 @@ import com.shaft.capture.privacy.ClassifiedValue;
 import com.shaft.capture.storage.CaptureSessionStore;
 import com.shaft.capture.storage.ExternalTestDataWriter;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -37,6 +39,7 @@ import java.util.function.Consumer;
  * Converts low-level browser signals into ordered privacy-safe semantic events.
  */
 final class CaptureEventPipeline implements AutoCloseable {
+    private static final String CONTEXT_SCOPED_ACTION_PREFIX = "ctx:";
     private static final Duration CLICK_DEBOUNCE = Duration.ofMillis(300);
     // Same-URL navigations within this window are one navigation delivered twice (racing
     // channels, or BiDi's commit racing the recorder's own explicit OPEN across a slow load).
@@ -408,7 +411,7 @@ final class CaptureEventPipeline implements AutoCloseable {
      * step syncs across navigations and can be edited or deleted like any other step.
      */
     private void attachOverlayIdentity(BrowserSignal signal, String url) {
-        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        String clientActionId = clientActionId(signal);
         if (clientActionId.isBlank()) {
             return;
         }
@@ -487,7 +490,7 @@ final class CaptureEventPipeline implements AutoCloseable {
         if (!oneShotStep) {
             return false;
         }
-        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        String clientActionId = clientActionId(signal);
         if (clientActionId.isBlank()) {
             return false;
         }
@@ -518,7 +521,7 @@ final class CaptureEventPipeline implements AutoCloseable {
     }
 
     private void emitInput(BrowserSignal signal) {
-        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        String clientActionId = clientActionId(signal);
         if (!clientActionId.isBlank() && deletedClientActionIds.contains(clientActionId)) {
             return;
         }
@@ -834,7 +837,7 @@ final class CaptureEventPipeline implements AutoCloseable {
     }
 
     private void updateStep(BrowserSignal signal) {
-        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        String clientActionId = clientActionId(signal);
         String description = privacy.sanitizeText(signal.dataString("description")).value();
         if (clientActionId.isBlank() || description.isBlank()) {
             warningConsumer.accept("A browser step edit was ignored because it was incomplete.");
@@ -848,7 +851,7 @@ final class CaptureEventPipeline implements AutoCloseable {
     }
 
     private void deleteStep(BrowserSignal signal) {
-        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        String clientActionId = clientActionId(signal);
         if (clientActionId.isBlank()) {
             warningConsumer.accept("A browser step deletion was ignored because it was incomplete.");
             return;
@@ -871,7 +874,7 @@ final class CaptureEventPipeline implements AutoCloseable {
     }
 
     private void reorderStep(BrowserSignal signal) {
-        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        String clientActionId = clientActionId(signal);
         String direction = privacy.sanitizeText(signal.dataString("direction")).value().toLowerCase(Locale.ROOT);
         if (clientActionId.isBlank() || (!direction.equals("up") && !direction.equals("down"))) {
             warningConsumer.accept("A browser step reorder was ignored because it was incomplete.");
@@ -936,7 +939,7 @@ final class CaptureEventPipeline implements AutoCloseable {
             SafePage page,
             Map<String, JsonNode> extensions) {
         Map<String, JsonNode> result = new LinkedHashMap<>();
-        String clientActionId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        String clientActionId = clientActionId(signal);
         if (!clientActionId.isBlank()) {
             result.put("clientActionId", StringNode.valueOf(clientActionId));
         }
@@ -1079,17 +1082,32 @@ final class CaptureEventPipeline implements AutoCloseable {
     }
 
     private String inputTargetKey(BrowserSignal signal) {
-        String contextId = signal.browsingContextId();
-        if (BrowserEventSink.LOOPBACK_BROWSING_CONTEXT_ID.equals(contextId)
-                && !currentRealBrowsingContextId.isBlank()) {
-            contextId = currentRealBrowsingContextId;
-        }
-        String contextScope = contextId + "|" + string(signal.page().get("framePath"));
-        String clientActionId = signal.dataString("clientActionId");
+        String clientActionId = clientActionId(signal);
         if (!clientActionId.isBlank()) {
-            return "action|" + contextScope + "|" + clientActionId;
+            return "action|" + clientActionId;
         }
+        String contextScope = resolveBrowsingContextId(signal)
+                + "|" + string(signal.page().get("framePath"));
         return "target|" + contextScope + "|" + targetKey(signal);
+    }
+
+    /**
+     * Returns the globally unique action id persisted in event metadata. Browser-generated ids are
+     * only unique inside one session-storage snapshot; a newly opened same-origin tab can inherit
+     * that snapshot and reuse an id. Prefixing the resolved browsing context and frame preserves the
+     * global uniqueness required by edit/delete/reorder controls. A server-synced scoped id is
+     * already authoritative and must survive when an overlay sends it back from any tab.
+     */
+    private String clientActionId(BrowserSignal signal) {
+        String rawId = privacy.sanitizeText(signal.dataString("clientActionId")).value();
+        if (rawId.isBlank() || rawId.startsWith(CONTEXT_SCOPED_ACTION_PREFIX)) {
+            return rawId;
+        }
+        String scope = resolveBrowsingContextId(signal)
+                + "|" + string(signal.page().get("framePath"));
+        String encodedScope = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(scope.getBytes(StandardCharsets.UTF_8));
+        return CONTEXT_SCOPED_ACTION_PREFIX + encodedScope + ":" + rawId;
     }
 
     private static boolean inputPrecedes(BrowserSignal candidate, BrowserSignal current) {

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -1079,18 +1079,17 @@ final class CaptureEventPipeline implements AutoCloseable {
     }
 
     private String inputTargetKey(BrowserSignal signal) {
-        String clientActionId = signal.dataString("clientActionId");
-        if (!clientActionId.isBlank()) {
-            return "action|" + clientActionId;
-        }
         String contextId = signal.browsingContextId();
         if (BrowserEventSink.LOOPBACK_BROWSING_CONTEXT_ID.equals(contextId)
                 && !currentRealBrowsingContextId.isBlank()) {
             contextId = currentRealBrowsingContextId;
         }
-        return "target|" + contextId
-                + "|" + string(signal.page().get("framePath"))
-                + "|" + targetKey(signal);
+        String contextScope = contextId + "|" + string(signal.page().get("framePath"));
+        String clientActionId = signal.dataString("clientActionId");
+        if (!clientActionId.isBlank()) {
+            return "action|" + contextScope + "|" + clientActionId;
+        }
+        return "target|" + contextScope + "|" + targetKey(signal);
     }
 
     private static boolean inputPrecedes(BrowserSignal candidate, BrowserSignal current) {

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -61,6 +61,8 @@ final class CaptureEventPipeline implements AutoCloseable {
     private final Consumer<String> warningConsumer;
     private final List<ClassifiedValue> classifiedValues = new ArrayList<>();
     private final Map<String, BrowserSignal> pendingInputs = new LinkedHashMap<>();
+    /** Newest input signal seen per browser action, retained after flush to reject delayed copies. */
+    private final Map<String, BrowserSignal> latestInputs = new LinkedHashMap<>();
     /** Last flushed input value per target, to drop the duplicate change-on-submit re-emission. */
     private final Map<String, String> lastEmittedInputValues = new LinkedHashMap<>();
     private final Map<String, BrowserSignal> pendingClicks = new LinkedHashMap<>();
@@ -150,7 +152,16 @@ final class CaptureEventPipeline implements AutoCloseable {
         try {
             switch (signal.kind()) {
                 case "input" -> {
-                    pendingInputs.put(targetKey(signal), signal);
+                    // BiDi, polling, and the loopback sink can deliver the same input stream out
+                    // of order, including after a newer value was already committed and flushed.
+                    // Retain the ordering watermark for the whole browser action (#4715).
+                    String inputKey = inputTargetKey(signal);
+                    BrowserSignal latest = latestInputs.get(inputKey);
+                    if (latest != null && inputPrecedes(signal, latest)) {
+                        return;
+                    }
+                    latestInputs.put(inputKey, signal);
+                    pendingInputs.put(inputKey, signal);
                     if (signal.dataBoolean("committed")) {
                         // This commit flushes immediately, bypassing flushPendingBefore; an
                         // older buffered navigation must still be appended first so persisted
@@ -158,7 +169,7 @@ final class CaptureEventPipeline implements AutoCloseable {
                         List<BrowserSignal> readyNavigations = new ArrayList<>();
                         collectReady(pendingNavigations, signal.timestamp(), readyNavigations);
                         flushOrdered(readyNavigations);
-                        flushSignal(pendingInputs.remove(targetKey(signal)));
+                        flushSignal(pendingInputs.remove(inputKey));
                     }
                 }
                 case "click" -> pendingClicks.put(targetKey(signal), signal);
@@ -515,11 +526,12 @@ final class CaptureEventPipeline implements AutoCloseable {
         String value = signal.dataString("value");
         // Form submission re-fires "change" with the value that was already flushed for this
         // element: appending it again duplicated the type step (issue #3426 B2).
-        String lastEmitted = lastEmittedInputValues.get(targetKey(signal));
+        String inputKey = inputTargetKey(signal);
+        String lastEmitted = lastEmittedInputValues.get(inputKey);
         if (!value.isEmpty() && value.equals(lastEmitted)) {
             return;
         }
-        lastEmittedInputValues.put(targetKey(signal), value);
+        lastEmittedInputValues.put(inputKey, value);
         if (value.isEmpty()) {
             append(new CaptureEvent.ClearEvent(context(signal), target.snapshot()),
                     target.summary(), List.of());
@@ -1064,6 +1076,30 @@ final class CaptureEventPipeline implements AutoCloseable {
     private static String targetKey(BrowserSignal signal) {
         String target = string(signal.target().get("logicalElementId"));
         return target.isBlank() ? signal.kind() + "-" + signal.browsingContextId() : target;
+    }
+
+    private String inputTargetKey(BrowserSignal signal) {
+        String clientActionId = signal.dataString("clientActionId");
+        if (!clientActionId.isBlank()) {
+            return "action|" + clientActionId;
+        }
+        String contextId = signal.browsingContextId();
+        if (BrowserEventSink.LOOPBACK_BROWSING_CONTEXT_ID.equals(contextId)
+                && !currentRealBrowsingContextId.isBlank()) {
+            contextId = currentRealBrowsingContextId;
+        }
+        return "target|" + contextId
+                + "|" + string(signal.page().get("framePath"))
+                + "|" + targetKey(signal);
+    }
+
+    private static boolean inputPrecedes(BrowserSignal candidate, BrowserSignal current) {
+        int candidateSequence = candidate.dataInt("captureSignalSequence", -1);
+        int currentSequence = current.dataInt("captureSignalSequence", -1);
+        if (candidateSequence >= 0 && currentSequence >= 0 && candidateSequence != currentSequence) {
+            return candidateSequence < currentSequence;
+        }
+        return candidate.timestamp().isBefore(current.timestamp());
     }
 
     private static boolean isStandaloneEditingKey(BrowserSignal signal) {

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -64,6 +64,7 @@
     suppressedEvents: [],
     actions: [],
     pendingSignals: [],
+    signalSequence: 0,
     nextId: 1,
     instanceId: "",
     currentInputActionKey: "",
@@ -74,6 +75,7 @@
   uiState.actions = Array.isArray(uiState.actions) ? uiState.actions.slice(-80) : [];
   uiState.pendingSignals = Array.isArray(uiState.pendingSignals) ? uiState.pendingSignals.slice(-200) : [];
   uiState.nextId = Number(uiState.nextId || uiState.actions.length + 1);
+  uiState.signalSequence = Number(uiState.signalSequence) || 0;
   uiState.instanceId = text(uiState.instanceId) || String(Date.now()) + "-" + Math.random().toString(36).slice(2);
   uiState.currentInputActionKey = text(uiState.currentInputActionKey);
   uiState.assertionMode = Boolean(uiState.assertionMode);
@@ -117,6 +119,7 @@
         suppressedEvents: uiState.suppressedEvents.slice(-50),
         actions: uiState.actions.slice(-80),
         pendingSignals: uiState.pendingSignals.slice(-200),
+        signalSequence: uiState.signalSequence,
         nextId: uiState.nextId,
         instanceId: uiState.instanceId,
         currentInputActionKey: uiState.currentInputActionKey,
@@ -143,6 +146,8 @@
   };
   const send = payload => {
     payload.timestamp = Date.now();
+    payload.data = payload.data && typeof payload.data === "object" ? payload.data : {};
+    payload.data.captureSignalSequence = ++uiState.signalSequence;
     uiState.pendingSignals.push(payload);
     uiState.pendingSignals = uiState.pendingSignals.slice(-200);
     persist();

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/GeneratedTestValidatorReplayIsolationTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/GeneratedTestValidatorReplayIsolationTest.java
@@ -1,0 +1,107 @@
+package com.shaft.capture.generate;
+
+import com.shaft.driver.SHAFT;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testng.Assert;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GeneratedTestValidatorReplayIsolationTest {
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void replayPreservesAndHonorsTheProjectsHeadedConfiguration() throws Exception {
+        Path customProperties = temp.resolve("src/main/resources/properties/custom.properties");
+        Files.createDirectories(customProperties.getParent());
+        String original = "headlessExecution=false" + System.lineSeparator()
+                + "customReplaySetting=keep-me" + System.lineSeparator();
+        Files.writeString(customProperties, original, StandardCharsets.UTF_8);
+
+        replayMissingClass();
+
+        assertEquals(original, Files.readString(customProperties, StandardCharsets.UTF_8),
+                "Replay validation must not rewrite the project's source configuration");
+        String args = Files.readString(
+                onlyAttemptDirectory().resolve("replay.args"), StandardCharsets.UTF_8);
+        assertTrue(args.contains("-DheadlessExecution=false"),
+                "The replay subprocess must honor the project's configured headed mode");
+        assertFalse(args.contains("-DheadlessExecution=true"));
+    }
+
+    @Test
+    void replayDoesNotCountAnAllureResultFromAnEarlierAttempt() throws Exception {
+        Path allureResults = temp.resolve("target/shaft-capture/replay/allure-results");
+        Files.createDirectories(allureResults);
+        Files.writeString(allureResults.resolve("stale-result.json"),
+                "{\"name\":\"stale failure\",\"status\":\"failed\"}", StandardCharsets.UTF_8);
+
+        CaptureGenerationReport.Validation result = replayMissingClass();
+
+        assertEquals(0, result.allureResultCount(),
+                "Only Allure results created by the current replay attempt may be counted");
+        assertTrue(Files.exists(allureResults.resolve("stale-result.json")),
+                "Replay isolation must not delete artifacts owned by an earlier attempt");
+        assertTrue(result.diagnostics().stream().anyMatch(message -> message.contains("attempt-")),
+                "A failed replay must identify the unique attempt directory that owns its diagnostics");
+    }
+
+    @Test
+    void realShaftBootstrapStaysInsideTheAttemptDirectory() throws Exception {
+        Path projectProperties = temp.resolve("src/main/resources/properties");
+        Files.createDirectories(projectProperties);
+        Path siblingProperties = projectProperties.resolve("replay-probe.properties");
+        String siblingContents = "replayProbeSetting=preserved" + System.lineSeparator();
+        Files.writeString(siblingProperties, siblingContents, StandardCharsets.UTF_8);
+
+        CaptureGenerationReport.Validation result = replayClass(ShaftBootstrapProbe.class.getName());
+
+        assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED, result.status(),
+                result.diagnostics().toString());
+        assertFalse(Files.exists(temp.resolve("src/main/resources/properties/custom.properties")),
+                "A real SHAFT bootstrap must not create configuration inside project sources");
+        assertEquals(siblingContents, Files.readString(siblingProperties, StandardCharsets.UTF_8),
+                "Replay must leave every sibling project property file byte-for-byte unchanged");
+    }
+
+    private CaptureGenerationReport.Validation replayMissingClass() {
+        return replayClass("generated.capture.ClassThatDoesNotExist");
+    }
+
+    private CaptureGenerationReport.Validation replayClass(String className) {
+        Path classes = temp.resolve("classes");
+        Path resources = temp.resolve("src/test/resources");
+        return new GeneratedTestValidator().replay(
+                className,
+                classes,
+                resources,
+                temp,
+                Duration.ofSeconds(30));
+    }
+
+    private Path onlyAttemptDirectory() throws Exception {
+        try (var attempts = Files.list(temp.resolve("target/shaft-capture/replay"))) {
+            return attempts.filter(Files::isDirectory)
+                    .filter(path -> path.getFileName().toString().startsWith("attempt-"))
+                    .findFirst()
+                    .orElseThrow();
+        }
+    }
+
+    public static class ShaftBootstrapProbe {
+        @org.testng.annotations.Test
+        public void initializesShaftPropertiesWithoutTouchingProjectSources() {
+            Assert.assertTrue(SHAFT.Properties.web.headlessExecution());
+            Assert.assertEquals(System.getProperty("replayProbeSetting"), "preserved");
+        }
+    }
+}

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/GeneratedTestValidatorReplayIsolationTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/GeneratedTestValidatorReplayIsolationTest.java
@@ -85,7 +85,7 @@ class GeneratedTestValidatorReplayIsolationTest {
                 classes,
                 resources,
                 temp,
-                Duration.ofSeconds(30));
+                Duration.ofSeconds(90));
     }
 
     private Path onlyAttemptDirectory() throws Exception {

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -242,9 +242,9 @@ class CaptureEventPipelineTest {
                 });
 
         pipeline.accept(signalFromContext("input", START.plusMillis(20), "tab-2", usernameTarget(),
-                Map.of("value", "second-tab", "captureSignalSequence", 2), Map.of()));
+                Map.of("value", "second-tab", "captureSignalSequence", 2, "clientActionId", "ui-1"), Map.of()));
         pipeline.accept(signalFromContext("input", START.plusMillis(10), "tab-1", usernameTarget(),
-                Map.of("value", "first-tab", "captureSignalSequence", 1), Map.of()));
+                Map.of("value", "first-tab", "captureSignalSequence", 1, "clientActionId", "ui-1"), Map.of()));
         pipeline.close();
 
         assertEquals(2, store.read().events().stream()

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -190,6 +190,72 @@ class CaptureEventPipelineTest {
     }
 
     @Test
+    void lateDeliveryOfAnOlderInputSignalCannotTruncateTheRecordedValue(@TempDir Path temp) throws Exception {
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("input", START.plusMillis(20), usernameTarget(),
+                Map.of("value", "shaft_engine", "committed", true), Map.of()));
+        pipeline.accept(signal("input", START.plusMillis(10), usernameTarget(),
+                Map.of("value", "shaft_engin"), Map.of()));
+        pipeline.close();
+
+        assertEquals(1, store.read().events().size());
+        String dataJson = Files.readString(temp.resolve("capture-data.json"), StandardCharsets.UTF_8);
+        assertTrue(dataJson.contains("\"shaft_engine\""),
+                "A late duplicate from another collector must not replace a newer complete input value");
+        assertFalse(dataJson.contains("\"shaft_engin\""),
+                "The stale prefix must not survive as the externalized replay value");
+    }
+
+    @Test
+    void browserSignalSequenceOrdersDistinctInputValuesWithinOneMillisecond(@TempDir Path temp) throws Exception {
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signal("input", START, usernameTarget(),
+                Map.of("value", "shaft_engine", "captureSignalSequence", 12), Map.of()));
+        pipeline.accept(signal("input", START, usernameTarget(),
+                Map.of("value", "shaft_engin", "captureSignalSequence", 11), Map.of()));
+        pipeline.close();
+
+        String dataJson = Files.readString(temp.resolve("capture-data.json"), StandardCharsets.UTF_8);
+        assertTrue(dataJson.contains("\"shaft_engine\""));
+        assertFalse(dataJson.contains("\"shaft_engin\""));
+    }
+
+    @Test
+    void identicalElementIdsInDifferentBrowsingContextsKeepDistinctInputStreams(@TempDir Path temp) throws Exception {
+        Path output = temp.resolve("session.json");
+        CaptureSessionStore store = startedStore(output);
+        CaptureEventPipeline pipeline = new CaptureEventPipeline(
+                store, output, CapturePrivacyPolicy.defaults(), ignored -> {
+                }, ignored -> {
+                });
+
+        pipeline.accept(signalFromContext("input", START.plusMillis(20), "tab-2", usernameTarget(),
+                Map.of("value", "second-tab", "captureSignalSequence", 2), Map.of()));
+        pipeline.accept(signalFromContext("input", START.plusMillis(10), "tab-1", usernameTarget(),
+                Map.of("value", "first-tab", "captureSignalSequence", 1), Map.of()));
+        pipeline.close();
+
+        assertEquals(2, store.read().events().stream()
+                .filter(CaptureEvent.TypeEvent.class::isInstance)
+                .count());
+        String dataJson = Files.readString(temp.resolve("capture-data.json"), StandardCharsets.UTF_8);
+        assertTrue(dataJson.contains("\"first-tab\""));
+        assertTrue(dataJson.contains("\"second-tab\""));
+    }
+
+    @Test
     void suppressesBrowserSynthesizedClickOnInvisibleTarget(@TempDir Path temp) {
         // Issue #3426 B2: pressing Enter in a form makes the browser "click" the form's default
         // submit button even when it is invisible. A real user can never click an element with no

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -242,17 +242,31 @@ class CaptureEventPipelineTest {
                 });
 
         pipeline.accept(signalFromContext("input", START.plusMillis(20), "tab-2", usernameTarget(),
-                Map.of("value", "second-tab", "captureSignalSequence", 2, "clientActionId", "ui-1"), Map.of()));
+                Map.of("value", "second-tab", "committed", true,
+                        "captureSignalSequence", 2, "clientActionId", "ui-1"), Map.of()));
         pipeline.accept(signalFromContext("input", START.plusMillis(10), "tab-1", usernameTarget(),
-                Map.of("value", "first-tab", "captureSignalSequence", 1, "clientActionId", "ui-1"), Map.of()));
+                Map.of("value", "first-tab", "committed", true,
+                        "captureSignalSequence", 1, "clientActionId", "ui-1"), Map.of()));
+
+        List<CaptureEvent> typedEvents = store.read().events().stream()
+                .filter(CaptureEvent.TypeEvent.class::isInstance)
+                .toList();
+        assertEquals(2, typedEvents.size());
+        String firstActionId = typedEvents.getFirst().context().extensions().get("clientActionId").asText();
+        String secondActionId = typedEvents.get(1).context().extensions().get("clientActionId").asText();
+        assertFalse(firstActionId.equals(secondActionId),
+                "The persisted action id must remain globally unique for downstream step controls");
+
+        pipeline.accept(signalFromContext("step_delete", START.plusMillis(30), "tab-1", Map.of(),
+                Map.of("clientActionId", firstActionId), Map.of()));
         pipeline.close();
 
-        assertEquals(2, store.read().events().stream()
-                .filter(CaptureEvent.TypeEvent.class::isInstance)
-                .count());
+        assertEquals(1, store.read().events().stream()
+                        .filter(CaptureEvent.TypeEvent.class::isInstance)
+                        .count(),
+                "Deleting one context-scoped action must not delete the colliding action from another tab");
         String dataJson = Files.readString(temp.resolve("capture-data.json"), StandardCharsets.UTF_8);
-        assertTrue(dataJson.contains("\"first-tab\""));
-        assertTrue(dataJson.contains("\"second-tab\""));
+        assertTrue(dataJson.contains("\"first-tab\"") || dataJson.contains("\"second-tab\""));
     }
 
     @Test
@@ -439,7 +453,7 @@ class CaptureEventPipelineTest {
         List<CaptureEvent> events = store.read().events();
         assertEquals(2, events.size());
         assertInstanceOf(CaptureEvent.TypeEvent.class, events.get(0));
-        assertEquals("ui-1", events.get(0).context().extensions().get("clientActionId").asText());
+        assertTrue(events.get(0).context().extensions().get("clientActionId").asText().endsWith(":ui-1"));
         assertInstanceOf(CaptureEvent.KeyboardEvent.class, events.get(1));
         String dataJson = Files.readString(output.getParent().resolve("capture-data.json"),
                 StandardCharsets.UTF_8);
@@ -769,10 +783,10 @@ class CaptureEventPipelineTest {
                 "The click-consequence navigation is suppressed but the user's back traversal "
                         + "must be recorded.");
         assertEquals("https://example.test/a", navigations.get(1).targetUrl());
-        assertEquals("traversal-9",
-                navigations.get(1).context().extensions().get("clientActionId").asText());
+        assertTrue(navigations.get(1).context().extensions().get("clientActionId").asText()
+                .endsWith(":traversal-9"));
         assertTrue(store.steps().stream()
-                        .anyMatch(step -> "traversal-9".equals(step.clientActionId())),
+                        .anyMatch(step -> step.clientActionId().endsWith(":traversal-9")),
                 "The traversal must surface in the server-backed step list.");
     }
 
@@ -800,7 +814,7 @@ class CaptureEventPipelineTest {
         assertEquals(1, events.size(), "The annotation must never append a second open event.");
         CaptureEvent.NavigationEvent navigation =
                 assertInstanceOf(CaptureEvent.NavigationEvent.class, events.getFirst());
-        assertEquals("open-1", navigation.context().extensions().get("clientActionId").asText());
+        assertTrue(navigation.context().extensions().get("clientActionId").asText().endsWith(":open-1"));
         assertEquals("Open https://example.test/home",
                 navigation.context().extensions().get("stepDescription").asText());
         assertEquals(1, store.steps().size());
@@ -893,8 +907,8 @@ class CaptureEventPipelineTest {
                 Map.of("clientActionId", "ui-6", "direction", "up"), Map.of()));
 
         List<CaptureEvent> reordered = store.read().events();
-        assertEquals("ui-6", reordered.get(0).context().extensions().get("clientActionId").asText());
-        assertEquals("ui-5", reordered.get(1).context().extensions().get("clientActionId").asText());
+        assertTrue(reordered.get(0).context().extensions().get("clientActionId").asText().endsWith(":ui-6"));
+        assertTrue(reordered.get(1).context().extensions().get("clientActionId").asText().endsWith(":ui-5"));
         assertEquals(1, reordered.get(0).context().sequence());
         assertEquals(2, reordered.get(1).context().sequence());
     }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderControlTest.java
@@ -162,19 +162,26 @@ class ManagedCaptureRecorderControlTest {
 
         recorder.acceptSignal(userTraversal("ui-keep", "https://example.test/keep"));
         recorder.acceptSignal(userTraversal("ui-drop", "https://example.test/drop"));
-        assertTrue(store.steps().stream().anyMatch(step -> "ui-keep".equals(step.clientActionId())),
+        assertTrue(store.steps().stream().anyMatch(step -> step.clientActionId().endsWith(":ui-keep")),
                 "The kept step must be persisted before stop.");
-        assertTrue(store.steps().stream().anyMatch(step -> "ui-drop".equals(step.clientActionId())),
+        String droppedActionId = store.steps().stream()
+                .map(step -> step.clientActionId())
+                .filter(clientActionId -> clientActionId.endsWith(":ui-drop"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "The soft-deleted step must still be persisted server-side before stop."));
+        assertTrue(droppedActionId.startsWith("ctx:"),
                 "The soft-deleted step is still persisted server-side until the delete is committed.");
 
-        // The overlay reports "ui-drop" as soft-deleted but not yet committed when stop is pressed.
-        recorder.pendingBrowserDeletesReaderForTesting(() -> List.of("ui-drop"));
+        // The overlay reports the server-synced, globally unique id as soft-deleted but not yet
+        // committed when stop is pressed.
+        recorder.pendingBrowserDeletesReaderForTesting(() -> List.of(droppedActionId));
         CaptureStatus status = recorder.stop(false);
 
         assertEquals(CaptureStatus.State.COMPLETED, status.state());
-        assertTrue(store.steps().stream().anyMatch(step -> "ui-keep".equals(step.clientActionId())),
+        assertTrue(store.steps().stream().anyMatch(step -> step.clientActionId().endsWith(":ui-keep")),
                 "The step the user did not delete must survive.");
-        assertFalse(store.steps().stream().anyMatch(step -> "ui-drop".equals(step.clientActionId())),
+        assertFalse(store.steps().stream().anyMatch(step -> step.clientActionId().endsWith(":ui-drop")),
                 "A step soft-deleted in the undo grace window must not resurface after stop.");
     }
 

--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -1558,11 +1558,11 @@ public class CaptureService {
 
     /**
      * Whether the generated code itself is worth returning to the caller: generation produced a
-     * source file and it compiled. A replay failure marks the overall result unsuccessful but
-     * must not swallow the generated, compiling code blocks — the failure report tells the user
-     * what to fix, and returning nothing turned every replay hiccup into a silent "no code"
-     * dead end (issue #3409). Generation-level failures (for example the privacy gate) keep
-     * suppressing code blocks because compilation never passed for them.
+     * promoted source file and it compiled. A replay failure marks the overall result unsuccessful;
+     * when a prior source survives rollback it remains usable, while a first-generation failure has
+     * no final source to read and returns the structured failure without code blocks (issue #4719).
+     * Generation-level failures (for example the privacy gate) keep suppressing code blocks because
+     * compilation never passed for them.
      */
     private static boolean generatedCodeUsable(CaptureGenerationResult result) {
         return sourceUsable(result.sourcePath(), result.report());
@@ -1570,9 +1570,9 @@ public class CaptureService {
 
     /**
      * Whether a generated source is worth returning to the caller as copy-paste code blocks:
-     * generation produced a source file and either the report is a confirmed {@code SUCCESS} or
-     * compilation itself passed. A replay failure/skip marks the overall result unsuccessful but
-     * must not swallow generated, compiling code -- the API codegen path
+     * generation produced a regular source file and either the report is a confirmed {@code SUCCESS}
+     * or compilation itself passed. A replay failure/skip marks the overall result unsuccessful but
+     * must not swallow generated, compiling code when the final source exists -- the API codegen path
      * ({@link #generateApi}) hit exactly this gap (issue #4311): it gated {@code codeBlocks} on
      * {@code status() == SUCCESS} alone, so a deliberately replay-skipped {@code UNCONFIRMED}
      * report (#4220) always returned an empty {@code codeBlocks} list even though the generated
@@ -1581,6 +1581,7 @@ public class CaptureService {
      */
     private static boolean sourceUsable(Path sourcePath, CaptureGenerationReport report) {
         return sourcePath != null
+                && Files.isRegularFile(sourcePath)
                 && report != null
                 && (report.status() == CaptureGenerationReport.Status.SUCCESS
                 || report.compilation().status() == CaptureGenerationReport.Validation.ValidationStatus.PASSED);

--- a/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/CaptureService.java
@@ -1532,7 +1532,7 @@ public class CaptureService {
                 : workspacePolicy.output(value, label).toString();
     }
 
-    private McpCaptureReplayResult replayResult(CaptureGenerationResult result, String driverVariableName) {
+    McpCaptureReplayResult replayResult(CaptureGenerationResult result, String driverVariableName) {
         return replayResult(result, driverVariableName, null, "");
     }
 

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -637,11 +636,8 @@ class CaptureServiceTest {
         CaptureService service = service();
         McpCaptureReplayResult result;
         try {
-            Method replayResult = CaptureService.class.getDeclaredMethod(
-                    "replayResult", CaptureGenerationResult.class, String.class);
-            replayResult.setAccessible(true);
             result = assertDoesNotThrow(
-                    () -> (McpCaptureReplayResult) replayResult.invoke(service, generation, "driver"),
+                    () -> service.replayResult(generation, "driver"),
                     "A failed replay must return its structured result instead of throwing while reading an absent source");
         } finally {
             service.close();

--- a/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/CaptureServiceTest.java
@@ -1,6 +1,7 @@
 package com.shaft.mcp;
 
 import com.shaft.capture.format.CaptureJsonCodec;
+import com.shaft.capture.generate.CaptureGenerationResult;
 import com.shaft.capture.generate.CaptureGenerationReport;
 import com.shaft.capture.model.BrowserMetadata;
 import com.shaft.capture.model.CaptureEvent;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -598,6 +601,60 @@ class CaptureServiceTest {
                 result.report().replay().status());
         assertTrue(Files.isRegularFile(result.sourcePath()),
                 "compiled-but-unconfirmed generation must still return a usable source file");
+    }
+
+    @Test
+    void replayFailureWithNoPromotedSourceReturnsTheStructuredFailure() throws Exception {
+        Path missingSource = temp.resolve("generated/RecordedFlowTest.java");
+        CaptureGenerationReport report = new CaptureGenerationReport(
+                CaptureGenerationReport.CURRENT_SCHEMA_VERSION,
+                "failed-replay-session",
+                CaptureGenerationReport.Status.FAILED,
+                "generated/RecordedFlowTest.java",
+                "",
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of("Replay failed before the generated source could be promoted."),
+                new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                        List.of(),
+                        0),
+                new CaptureGenerationReport.Validation(
+                        CaptureGenerationReport.Validation.ValidationStatus.FAILED,
+                        List.of("NoSuchElementException: recorded assertion target was not found"),
+                        0),
+                CaptureGenerationReport.Enrichment.notRequested());
+        CaptureGenerationResult generation = new CaptureGenerationResult(
+                missingSource,
+                temp.resolve("generated/recorded-flow-test.json"),
+                temp.resolve("generated/capture-generation-report.json"),
+                null,
+                report);
+
+        CaptureService service = service();
+        McpCaptureReplayResult result;
+        try {
+            Method replayResult = CaptureService.class.getDeclaredMethod(
+                    "replayResult", CaptureGenerationResult.class, String.class);
+            replayResult.setAccessible(true);
+            result = assertDoesNotThrow(
+                    () -> (McpCaptureReplayResult) replayResult.invoke(service, generation, "driver"),
+                    "A failed replay must return its structured result instead of throwing while reading an absent source");
+        } finally {
+            service.close();
+        }
+
+        assertFalse(result.successful());
+        assertEquals(CaptureGenerationReport.Validation.ValidationStatus.FAILED,
+                result.report().replay().status());
+        assertTrue(result.codeBlocks().isEmpty(),
+                "An absent final source cannot be exposed as generated code blocks");
+        assertTrue(result.report().replay().diagnostics().stream()
+                .anyMatch(message -> message.contains("NoSuchElementException")),
+                "The original replay diagnostic must survive the MCP result boundary");
     }
 
     @Test

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -588,14 +588,13 @@ class InstallShaftMcpTest(unittest.TestCase):
         self.assertEqual(expected, listed)
         self.assertIn("./shaft-developer", listed)
 
-    def test_readme_routes_setup_through_router_and_current_tools(self):
+    def test_readme_routes_agent_setup_to_the_current_skills_guide(self):
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertIn("--skill '*'", readme)
-        self.assertIn("--install-shaft-skills --json", readme)
         self.assertIn("`$shaft-developer`", readme)
-        self.assertIn("shaft_project_init_agents", readme)
-        self.assertIn('shaft-cli guide search query="browser assertions" maxResults=3 --json', readme)
+        self.assertIn("https://shafthq.github.io/docs/agentic/skills", readme)
+        self.assertIn("shaft-skills/references/shaft-mcp-tools.md", readme)
+        self.assertIn("shaft-skills/references/shaft-cli-commands.md", readme)
         self.assertNotIn("act-as-shaft-dev", readme)
         self.assertNotIn("writing-shaft-tests", readme)
 

--- a/tools/intellij-plugin-recording/RUNBOOK.md
+++ b/tools/intellij-plugin-recording/RUNBOOK.md
@@ -2,26 +2,30 @@
 
 Tracking issue: [#4299](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/4299).
 
-## Delivered reference take
+## Withdrawn reference take
 
 Executed on Windows on 2026-08-11 with sandboxed IntelliJ 2024.3 and
 SHAFT 10.3.20260809.
 
-- Video: [SHAFT-IntelliJ-Assistant-demo-issue-4299-final.mp4](https://drive.google.com/file/d/1Tyuo6HJ9MNRd0AKaFrESIP1JpU0mlJFM/view)
+- Withdrawn video: [SHAFT-IntelliJ-Assistant-demo-issue-4299-final.mp4](https://drive.google.com/file/d/1Tyuo6HJ9MNRd0AKaFrESIP1JpU0mlJFM/view)
 - Processed media: 2560 x 1440, 15 fps, 152.33 seconds, 11,553,949 bytes.
 - Preserved concatenated raw media: 1,022 seconds, 71,296,536 bytes. The
-  reference take used four bounded segments, assembled as documented below.
-- Replay: TestNG 1 test, 0 failures, 0 errors. The closing frames show the
-  generated test, Page Object, data file, and 100% Allure result.
+  withdrawn take used four bounded segments, assembled as documented below.
+- Rejection reason: the Assistant visibly reports that `capture_generate_replay`
+  could not finish because the promoted generated source is missing. The later
+  appended manual replay is a different execution and does not repair that failed
+  Assistant flow. This file is retained only as a defect artifact and is not
+  acceptance evidence for #4299.
 
 The Drive file ID and preview were verified after upload. General access is
 **Anyone with the link -> Viewer**. An independent permission read returned
 `type=anyone`, `role=reader`, and `allowFileDiscovery=false`; an unauthenticated
-request returned HTTP 200 with the expected filename. The connector's earlier
+request returned HTTP 200 with the expected filename. Those checks prove access
+to the withdrawn artifact, not product acceptance. The connector's earlier
 organization-share attempt returned `permission.domain: invalid or not
 applicable`, so the owner completed the general-access change in Drive's UI.
 Upload success alone does not prove public access; verify permission metadata
-and signed-out access separately as this take did.
+and signed-out access separately for the replacement take.
 
 ## Safety boundary
 


### PR DESCRIPTION
## Summary
- preserve the structured replay failure when first-generation replay rolls back before promoting source
- isolate replay artifacts and copied properties per attempt, preserving headed project configuration
- keep the newest browser input signal across flush boundaries and contexts
- withdraw the invalid #4299 video from acceptance documentation

## Verification
- clean affected reactor package: `mvn -pl shaft-mcp -am clean package -DskipTests -Dmaven.javadoc.skip=true -Dallure.automaticallyOpen=false`
- capture regressions: 35 tests, 0 failures, 0 errors
- MCP regressions: 24 tests, 0 failures, 0 errors
- generated replay browser E2E: 1 test, 0 failures, 0 errors
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- `git diff --check`

#4299 remains open until a fresh IntelliJ Assistant video shows the same successful generated replay and public sharing is independently verified.

Closes #4715
Closes #4716
Closes #4719
- installer verification: 123 tests, 0 failures

Closes #4725

