### PR TITLE
feat(mobile): add bounded Appium performance data

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -9,6 +9,7 @@ import com.shaft.gui.browser.internal.BidiNetworkActivitySource;
 import com.shaft.gui.browser.internal.BidiConsoleLogSource;
 import com.shaft.gui.browser.internal.BidiPermissionState;
 import com.shaft.gui.mobile.internal.MobileLogSource;
+import com.shaft.gui.mobile.internal.MobilePerformanceState;
 import com.shaft.gui.browser.internal.BrowserEmulationManager;
 import com.shaft.gui.browser.internal.BrowserNetworkInterceptionRule;
 import com.shaft.gui.browser.internal.BrowserNetworkInterceptor;
@@ -905,6 +906,7 @@ public class DriverFactoryHelper {
                 BidiNetworkActivitySource.closeAndRemove(driver);
                 BidiConsoleLogSource.closeAndRemove(driver);
                 MobileLogSource.closeAndRemove(driver);
+                MobilePerformanceState.closeAndRemove(driver);
                 BidiPermissionState.clearAndRemove(driver);
                 BrowserEmulationManager.clearAndRemove(driver);
                 FailureTraceReporter.clearPersistentSensitiveBrowserState(driver);

--- a/shaft-engine/src/main/java/com/shaft/gui/driver/MobilePerformanceActionsContract.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/MobilePerformanceActionsContract.java
@@ -1,6 +1,33 @@
 package com.shaft.gui.driver;
 
+import java.util.List;
+
 /** Mobile performance-data actions. */
 public interface MobilePerformanceActionsContract {
+    /** Returns the performance-data types advertised by the live provider. */
+    default List<String> supportedTypes() {
+        throw unsupported();
+    }
+
+    /** Captures one performance-data sample for the requested application and data type. */
+    default MobilePerformanceSample sample(String applicationId, String dataType) {
+        throw unsupported();
+    }
+
+    /** Returns an immutable snapshot of the newest 100 samples captured for this session. */
+    default List<MobilePerformanceSample> history() {
+        throw unsupported();
+    }
+
+    /** Clears captured performance history for this session. */
+    default MobilePerformanceActionsContract clear() {
+        throw unsupported();
+    }
+
+    /** Returns the owning mobile namespace. */
     MobileActionsContract and();
+
+    private static UnsupportedOperationException unsupported() {
+        return new UnsupportedOperationException("Mobile performance actions are not supported by this implementation.");
+    }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/driver/MobilePerformanceSample.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/driver/MobilePerformanceSample.java
@@ -1,0 +1,81 @@
+package com.shaft.gui.driver;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** One immutable, tabular mobile performance sample returned by Appium. */
+public record MobilePerformanceSample(Instant capturedAt, String applicationId, String dataType,
+                                      List<String> columns, List<List<Object>> rows) {
+    private static final Set<Class<?>> IMMUTABLE_NUMBER_TYPES = Set.of(
+            Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class,
+            BigInteger.class, BigDecimal.class);
+
+    public MobilePerformanceSample {
+        capturedAt = Objects.requireNonNull(capturedAt, "capture time");
+        applicationId = required(applicationId, "application id");
+        dataType = required(dataType, "data type");
+        columns = copyColumns(columns);
+        rows = copyRows(rows, columns.size());
+    }
+
+    @Override
+    public List<String> columns() {
+        return List.copyOf(columns);
+    }
+
+    @Override
+    public List<List<Object>> rows() {
+        return rows;
+    }
+
+    private static List<String> copyColumns(List<String> source) {
+        Objects.requireNonNull(source, "columns");
+        if (source.isEmpty()) {
+            throw new IllegalArgumentException("performance data must contain at least one column");
+        }
+        List<String> copy = source.stream().map(column -> required(column, "column name")).toList();
+        if (new HashSet<>(copy).size() != copy.size()) {
+            throw new IllegalArgumentException("performance data column names must be unique");
+        }
+        return copy;
+    }
+
+    private static List<List<Object>> copyRows(List<List<Object>> source, int width) {
+        Objects.requireNonNull(source, "rows");
+        List<List<Object>> copy = new ArrayList<>(source.size());
+        for (List<Object> row : source) {
+            Objects.requireNonNull(row, "performance data row");
+            if (row.size() != width) {
+                throw new IllegalArgumentException("performance data row width must match its columns");
+            }
+            ArrayList<Object> rowCopy = new ArrayList<>(row.size());
+            for (Object value : row) {
+                if (!isImmutableScalar(value)) {
+                    throw new IllegalArgumentException("performance data values must be immutable JSON scalars");
+                }
+                rowCopy.add(value);
+            }
+            copy.add(Collections.unmodifiableList(rowCopy));
+        }
+        return Collections.unmodifiableList(copy);
+    }
+
+    private static boolean isImmutableScalar(Object value) {
+        return value == null || value instanceof String || value instanceof Boolean
+                || IMMUTABLE_NUMBER_TYPES.contains(value.getClass());
+    }
+
+    private static String required(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/mobile/MobileActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/mobile/MobileActions.java
@@ -16,6 +16,7 @@ import com.shaft.gui.driver.MobileRecordingActionsContract;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.PerformsTouchActions;
 import io.appium.java_client.android.ListensToLogcatMessages;
+import io.appium.java_client.android.HasSupportedPerformanceDataType;
 import io.appium.java_client.android.AuthenticatesByFinger;
 import io.appium.java_client.ios.ListensToSyslogMessages;
 import io.appium.java_client.ios.PerformsTouchID;
@@ -80,7 +81,12 @@ public final class MobileActions implements MobileActionsContract {
 
     @Override
     public MobilePerformanceActionsContract performance() {
-        throw unsupported("performance data");
+        AppiumDriver liveDriver = driver();
+        if (!(liveDriver instanceof HasSupportedPerformanceDataType)) {
+            throw new UnsupportedOperationException(
+                    "The live Appium session does not support performance data.");
+        }
+        return new PerformanceActions(this);
     }
 
     @Override

--- a/shaft-engine/src/main/java/com/shaft/gui/mobile/PerformanceActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/mobile/PerformanceActions.java
@@ -1,0 +1,140 @@
+package com.shaft.gui.mobile;
+
+import com.shaft.gui.capabilities.AutomationBackend;
+import com.shaft.gui.driver.MobileActionsContract;
+import com.shaft.gui.driver.MobilePerformanceActionsContract;
+import com.shaft.gui.driver.MobilePerformanceSample;
+import com.shaft.gui.mobile.internal.MobilePerformanceState;
+import com.shaft.tools.io.internal.FailureTraceReporter;
+import com.shaft.tools.io.internal.TraceEventRecorder;
+import io.appium.java_client.android.HasSupportedPerformanceDataType;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/** Appium implementation of the categorized mobile performance-data facade. */
+final class PerformanceActions implements MobilePerformanceActionsContract {
+    private static final int LEGACY_FALLBACK_READ_ATTEMPTS = 5;
+    private final MobileActions mobile;
+
+    PerformanceActions(MobileActions mobile) {
+        this.mobile = Objects.requireNonNull(mobile, "mobile");
+    }
+
+    @Override
+    public List<String> supportedTypes() {
+        return query("supported-types", () -> {
+            List<String> types = Objects.requireNonNull(provider().getSupportedPerformanceDataTypes(),
+                    "supported performance data types").stream()
+                    .map(type -> {
+                        registerSensitive(type);
+                        return required(type, "performance data type");
+                    })
+                    .toList();
+            if (new HashSet<>(types).size() != types.size()) {
+                throw new IllegalArgumentException("supported performance data types must be unique");
+            }
+            return types;
+        }, types -> Map.of("typeCount", Integer.toString(types.size())));
+    }
+
+    @Override
+    public MobilePerformanceSample sample(String applicationId, String dataType) {
+        registerSensitive(applicationId);
+        registerSensitive(dataType);
+        return query("sample", () -> {
+            HasSupportedPerformanceDataType provider = provider();
+            String requestedApplication = required(applicationId, "application id");
+            String requestedType = required(dataType, "performance data type");
+            List<List<Object>> table = Objects.requireNonNull(provider.getPerformanceData(
+                    requestedApplication, requestedType, LEGACY_FALLBACK_READ_ATTEMPTS), "performance data");
+            if (table.isEmpty()) {
+                throw new IllegalArgumentException("performance data must contain a header row");
+            }
+            List<Object> header = Objects.requireNonNull(table.getFirst(), "performance data header row");
+            List<String> columns = header.stream().map(value -> {
+                if (!(value instanceof String column)) {
+                    throw new IllegalArgumentException("performance data column names must be strings");
+                }
+                return column;
+            }).toList();
+            MobilePerformanceSample sample = new MobilePerformanceSample(Instant.now(), requestedApplication,
+                    requestedType, columns, table.subList(1, table.size()));
+            registerSensitiveSample(sample);
+            MobilePerformanceState.append(mobile.driver(), sample);
+            return sample;
+        }, sample -> Map.of("columnCount", Integer.toString(sample.columns().size()),
+                "rowCount", Integer.toString(sample.rows().size())));
+    }
+
+    @Override
+    public List<MobilePerformanceSample> history() {
+        return query("history", () -> MobilePerformanceState.history(mobile.driver()),
+                samples -> Map.of("sampleCount", Integer.toString(samples.size())));
+    }
+
+    @Override
+    public MobilePerformanceActionsContract clear() {
+        query("clear", () -> {
+            return MobilePerformanceState.clearAndCount(mobile.driver());
+        }, count -> Map.of("clearedCount", Integer.toString(count)));
+        return this;
+    }
+
+    @Override
+    public MobileActionsContract and() {
+        return mobile;
+    }
+
+    private HasSupportedPerformanceDataType provider() {
+        if (mobile.driver() instanceof HasSupportedPerformanceDataType provider) {
+            return provider;
+        }
+        throw new UnsupportedOperationException(
+                "The live Appium session does not support performance data.");
+    }
+
+    private <T> T query(String operation, Supplier<T> action, Function<T, Map<String, String>> metadata) {
+        TraceEventRecorder.Event event = TraceEventRecorder.startForBackend(
+                "mobile/performance", operation, "<performance-data>", AutomationBackend.APPIUM);
+        try {
+            T result = action.get();
+            TraceEventRecorder.finish(event, "passed", "Mobile performance action completed.", null,
+                    metadata.apply(result), List.of());
+            return result;
+        } catch (RuntimeException exception) {
+            FailureTraceReporter.registerSensitiveThrowable(exception);
+            TraceEventRecorder.finish(event, "failed", "Mobile performance action failed.", exception,
+                    Map.of(), List.of());
+            throw exception;
+        }
+    }
+
+    private static void registerSensitiveSample(MobilePerformanceSample sample) {
+        sample.columns().forEach(PerformanceActions::registerSensitive);
+        for (List<Object> row : sample.rows()) {
+            row.stream().filter(Objects::nonNull).map(String::valueOf)
+                    .forEach(PerformanceActions::registerSensitive);
+        }
+    }
+
+    private static void registerSensitive(String value) {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        FailureTraceReporter.registerSensitiveSourceValue(value);
+        FailureTraceReporter.registerSensitiveValue(value);
+    }
+
+    private static String required(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/mobile/internal/MobilePerformanceState.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/mobile/internal/MobilePerformanceState.java
@@ -1,0 +1,144 @@
+package com.shaft.gui.mobile.internal;
+
+import com.shaft.gui.driver.MobilePerformanceSample;
+import io.appium.java_client.AppiumDriver;
+import org.openqa.selenium.WebDriver;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Session-identity-keyed bounded storage for Appium performance samples. */
+public final class MobilePerformanceState {
+    private static final int MAX_SAMPLES = 100;
+    private static final ReferenceQueue<AppiumDriver> STALE_DRIVERS = new ReferenceQueue<>();
+    private static final Map<IdentityWeakReference, State> STATES = new HashMap<>();
+
+    private MobilePerformanceState() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static void append(AppiumDriver driver, MobilePerformanceSample sample) {
+        State state = state(driver);
+        synchronized (state) {
+            requireOpen(state);
+            while (state.samples.size() >= MAX_SAMPLES) {
+                state.samples.removeFirst();
+            }
+            state.samples.addLast(Objects.requireNonNull(sample, "performance sample"));
+        }
+    }
+
+    public static List<MobilePerformanceSample> history(AppiumDriver driver) {
+        State state = state(driver);
+        synchronized (state) {
+            requireOpen(state);
+            return List.copyOf(state.samples);
+        }
+    }
+
+    public static void clear(AppiumDriver driver) {
+        clearAndCount(driver);
+    }
+
+    /** Atomically clears and returns the number of samples removed. */
+    public static int clearAndCount(AppiumDriver driver) {
+        State state = state(driver);
+        synchronized (state) {
+            requireOpen(state);
+            int count = state.samples.size();
+            state.samples.clear();
+            return count;
+        }
+    }
+
+    /** Removes buffered state without issuing commands to a closing session. */
+    public static void closeAndRemove(WebDriver driver) {
+        if (!(driver instanceof AppiumDriver appiumDriver)) {
+            return;
+        }
+        State state;
+        synchronized (STATES) {
+            expungeStaleDrivers();
+            IdentityWeakReference lookup = new IdentityWeakReference(appiumDriver);
+            state = STATES.get(lookup);
+            if (state == null) {
+                state = new State();
+                STATES.put(new IdentityWeakReference(appiumDriver, STALE_DRIVERS), state);
+            }
+        }
+        synchronized (state) {
+            state.samples.clear();
+            state.closed = true;
+        }
+    }
+
+    private static State state(AppiumDriver driver) {
+        Objects.requireNonNull(driver, "Appium driver");
+        synchronized (STATES) {
+            expungeStaleDrivers();
+            IdentityWeakReference lookup = new IdentityWeakReference(driver);
+            State state = STATES.get(lookup);
+            if (state != null) {
+                return state;
+            }
+            State created = new State();
+            STATES.put(new IdentityWeakReference(driver, STALE_DRIVERS), created);
+            return created;
+        }
+    }
+
+    private static void expungeStaleDrivers() {
+        IdentityWeakReference stale;
+        while ((stale = (IdentityWeakReference) STALE_DRIVERS.poll()) != null) {
+            STATES.remove(stale);
+        }
+    }
+
+    private static void requireOpen(State state) {
+        if (state.closed) {
+            throw new UnsupportedOperationException("The Appium performance-data session has been closed.");
+        }
+    }
+
+    private static final class State {
+        private final Deque<MobilePerformanceSample> samples = new ArrayDeque<>();
+        private boolean closed;
+    }
+
+    private static final class IdentityWeakReference extends WeakReference<AppiumDriver> {
+        private final int identityHash;
+
+        private IdentityWeakReference(AppiumDriver driver) {
+            super(driver);
+            identityHash = System.identityHashCode(driver);
+        }
+
+        private IdentityWeakReference(AppiumDriver driver, ReferenceQueue<AppiumDriver> queue) {
+            super(driver, queue);
+            identityHash = System.identityHashCode(driver);
+        }
+
+        @Override
+        public int hashCode() {
+            return identityHash;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof IdentityWeakReference reference)) {
+                return false;
+            }
+            AppiumDriver driver = get();
+            return driver != null && driver == reference.get();
+        }
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/driver/MobileNamespaceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/driver/MobileNamespaceTest.java
@@ -58,12 +58,34 @@ public class MobileNamespaceTest {
 
         for (String contract : Set.of(
                 "MobileEvidenceActionsContract",
-                "MobilePerformanceActionsContract",
                 "MobileRecordingActionsContract")) {
             Assert.assertNotNull(Class.forName("com.shaft.gui.driver." + contract));
             Assert.assertEquals(descriptors("com.shaft.gui.driver." + contract),
                     Set.of("and[]->MobileActionsContract"));
         }
+        Assert.assertEquals(descriptors("com.shaft.gui.driver.MobilePerformanceActionsContract"), Set.of(
+                "and[]->MobileActionsContract",
+                "clear[]->MobilePerformanceActionsContract",
+                "history[]->List",
+                "sample[class java.lang.String, class java.lang.String]->MobilePerformanceSample",
+                "supportedTypes[]->List"));
+        Class<?> performanceContract = Class.forName("com.shaft.gui.driver.MobilePerformanceActionsContract");
+        Assert.assertTrue(Arrays.stream(performanceContract.getDeclaredMethods())
+                .filter(method -> Modifier.isPublic(method.getModifiers()) && !method.getName().equals("and"))
+                .allMatch(Method::isDefault));
+        Assert.assertEquals(performanceContract.getMethod("history").getGenericReturnType().getTypeName(),
+                "java.util.List<com.shaft.gui.driver.MobilePerformanceSample>");
+        Assert.assertEquals(performanceContract.getMethod("supportedTypes").getGenericReturnType().getTypeName(),
+                "java.util.List<java.lang.String>");
+        assertRecord("com.shaft.gui.driver.MobilePerformanceSample", List.of(
+                "capturedAt:java.time.Instant", "applicationId:java.lang.String", "dataType:java.lang.String",
+                "columns:java.util.List", "rows:java.util.List"));
+        Class<?> sample = Class.forName("com.shaft.gui.driver.MobilePerformanceSample");
+        Assert.assertTrue(Modifier.isPublic(sample.getModifiers()));
+        Assert.assertEquals(Arrays.stream(sample.getRecordComponents())
+                .map(component -> component.getGenericType().getTypeName()).toList(), List.of(
+                "java.time.Instant", "java.lang.String", "java.lang.String", "java.util.List<java.lang.String>",
+                "java.util.List<java.util.List<java.lang.Object>>"));
         Assert.assertEquals(descriptors("com.shaft.gui.driver.MobileBiometricActionsContract"), Set.of(
                 "and[]->MobileActionsContract",
                 "fingerprint[]->MobileFingerprintActionsContract",
@@ -180,6 +202,21 @@ public class MobileNamespaceTest {
         Assert.assertEquals(enumValues("com.shaft.gui.driver.MobileApplicationState"), Set.of(
                 "NOT_INSTALLED", "NOT_RUNNING", "RUNNING_IN_BACKGROUND_SUSPENDED",
                 "RUNNING_IN_BACKGROUND", "RUNNING_IN_FOREGROUND"));
+    }
+
+    @Test
+    public void existingPerformanceContractImplementationsShouldRemainSourceAndBinaryCompatible() {
+        MobilePerformanceActionsContract oldConsumer = new MobilePerformanceActionsContract() {
+            @Override
+            public MobileActionsContract and() {
+                return null;
+            }
+        };
+
+        Assert.expectThrows(UnsupportedOperationException.class, oldConsumer::supportedTypes);
+        Assert.expectThrows(UnsupportedOperationException.class, () -> oldConsumer.sample("app", "cpuinfo"));
+        Assert.expectThrows(UnsupportedOperationException.class, oldConsumer::history);
+        Assert.expectThrows(UnsupportedOperationException.class, oldConsumer::clear);
     }
 
     @Test

--- a/shaft-engine/src/test/java/com/shaft/gui/driver/MobilePerformanceSampleTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/driver/MobilePerformanceSampleTest.java
@@ -1,0 +1,69 @@
+package com.shaft.gui.driver;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MobilePerformanceSampleTest {
+    @Test
+    public void sampleShouldDeepCopyInputsAndExposeAnImmutableTable() {
+        List<String> columns = new ArrayList<>(List.of("user", "system"));
+        List<Object> mutableRow = new ArrayList<>(List.of(12, new BigDecimal("3.5")));
+        List<List<Object>> rows = new ArrayList<>();
+        rows.add(mutableRow);
+
+        MobilePerformanceSample sample = new MobilePerformanceSample(
+                Instant.EPOCH, "com.example.app", "cpuinfo", columns, rows);
+        columns.set(0, "changed");
+        mutableRow.set(0, 99);
+        rows.clear();
+
+        Assert.assertEquals(sample.columns(), List.of("user", "system"));
+        Assert.assertEquals(sample.rows(), List.of(List.of(12, new BigDecimal("3.5"))));
+        Assert.expectThrows(UnsupportedOperationException.class, () -> sample.columns().add("total"));
+        Assert.expectThrows(UnsupportedOperationException.class, () -> sample.rows().add(List.of(1, 2)));
+        Assert.expectThrows(UnsupportedOperationException.class, () -> sample.rows().getFirst().set(0, 4));
+    }
+
+    @Test
+    public void sampleShouldPreserveNullJsonScalars() {
+        MobilePerformanceSample sample = new MobilePerformanceSample(
+                Instant.EPOCH, "com.example.app", "memoryinfo", List.of("value"),
+                java.util.Collections.singletonList(java.util.Collections.singletonList(null)));
+
+        Assert.assertNull(sample.rows().getFirst().getFirst());
+    }
+
+    @Test
+    public void sampleShouldRejectMalformedTables() {
+        Instant now = Instant.EPOCH;
+        Assert.expectThrows(NullPointerException.class,
+                () -> new MobilePerformanceSample(null, "app", "cpu", List.of("value"), List.of()));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new MobilePerformanceSample(now, " ", "cpu", List.of("value"), List.of()));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new MobilePerformanceSample(now, "app", " ", List.of("value"), List.of()));
+        Assert.expectThrows(NullPointerException.class,
+                () -> new MobilePerformanceSample(now, "app", "cpu", null, List.of()));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new MobilePerformanceSample(now, "app", "cpu", List.of(), List.of()));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new MobilePerformanceSample(now, "app", "cpu", List.of("value", "value"), List.of()));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new MobilePerformanceSample(now, "app", "cpu", List.of(" "), List.of()));
+        Assert.expectThrows(NullPointerException.class,
+                () -> new MobilePerformanceSample(now, "app", "cpu", List.of("value"), null));
+        Assert.expectThrows(NullPointerException.class,
+                () -> new MobilePerformanceSample(now, "app", "cpu", List.of("value"),
+                        java.util.Collections.singletonList(null)));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new MobilePerformanceSample(now, "app", "cpu", List.of("value"), List.of(List.of(1, 2))));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new MobilePerformanceSample(now, "app", "cpu", List.of("value"),
+                        List.of(List.of(new StringBuilder("mutable")))));
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/mobile/MobilePerformanceActionsTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/mobile/MobilePerformanceActionsTest.java
@@ -1,0 +1,408 @@
+package com.shaft.gui.mobile;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import com.shaft.gui.driver.MobileActionsContract;
+import com.shaft.gui.driver.MobilePerformanceActionsContract;
+import com.shaft.gui.driver.MobilePerformanceSample;
+import com.shaft.gui.mobile.internal.MobilePerformanceState;
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.android.HasSupportedPerformanceDataType;
+import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.mac.Mac2Driver;
+import io.appium.java_client.windows.WindowsDriver;
+import org.mockito.Mockito;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.ImmutableCapabilities;
+import org.openqa.selenium.remote.HttpCommandExecutor;
+import org.openqa.selenium.remote.SessionId;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class MobilePerformanceActionsTest {
+    @Test
+    public void supportedTypesAndSamplesShouldDelegateToTheExactAppiumInterface() {
+        AndroidDriver driver = liveAndroid("performance-android");
+        List<String> providerTypes = new ArrayList<>(List.of("cpuinfo", "memoryinfo"));
+        Mockito.when(driver.getSupportedPerformanceDataTypes()).thenReturn(providerTypes);
+        Mockito.when(driver.getPerformanceData("com.example.app", "cpuinfo", 5)).thenReturn(table(
+                row("user", "system"), row(12, 4)));
+        MobileActions mobile = new SHAFT.GUI.WebDriver(driver).mobile();
+
+        MobilePerformanceActionsContract performance = mobile.performance();
+        List<String> types = performance.supportedTypes();
+        providerTypes.set(0, "changed");
+        MobilePerformanceSample sample = performance.sample("com.example.app", "cpuinfo");
+
+        Assert.assertEquals(types, List.of("cpuinfo", "memoryinfo"));
+        Assert.expectThrows(UnsupportedOperationException.class, () -> types.add("batteryinfo"));
+        Assert.assertEquals(sample.applicationId(), "com.example.app");
+        Assert.assertEquals(sample.dataType(), "cpuinfo");
+        Assert.assertEquals(sample.columns(), List.of("user", "system"));
+        Assert.assertEquals(sample.rows(), List.of(row(12, 4)));
+        Assert.assertEquals(performance.history(), List.of(sample));
+        Assert.assertSame(performance.and(), mobile);
+        Mockito.verify(driver).getPerformanceData("com.example.app", "cpuinfo", 5);
+    }
+
+    @Test
+    public void customExactInterfaceShouldBeSupportedWithoutPlatformNameInference() {
+        AppiumDriver driver = liveCustom("performance-custom");
+        HasSupportedPerformanceDataType provider = (HasSupportedPerformanceDataType) driver;
+        Mockito.when(provider.getSupportedPerformanceDataTypes()).thenReturn(List.of("batteryinfo"));
+        Mockito.when(provider.getPerformanceData("custom.app", "batteryinfo", 5)).thenReturn(table(
+                row("level"), row(92)));
+
+        MobilePerformanceSample sample = new SHAFT.GUI.WebDriver(driver).mobile().performance()
+                .sample("custom.app", "batteryinfo");
+
+        Assert.assertEquals(sample.rows(), List.of(row(92)));
+    }
+
+    @Test
+    public void unsupportedDriverFamiliesShouldFailClosed() {
+        for (AppiumDriver driver : List.of(
+                live(AppiumDriver.class, "generic-performance"),
+                live(IOSDriver.class, "ios-performance"),
+                live(WindowsDriver.class, "windows-performance"),
+                live(Mac2Driver.class, "mac-performance"))) {
+            Assert.expectThrows(UnsupportedOperationException.class,
+                    () -> new SHAFT.GUI.WebDriver(driver).mobile().performance());
+        }
+    }
+
+    @Test
+    public void staleNamespaceShouldRecheckLivenessBeforeEveryProviderCall() {
+        AndroidDriver driver = Mockito.mock(AndroidDriver.class);
+        Mockito.when(driver.getSessionId()).thenReturn(
+                new SessionId("closing-performance"), new SessionId("closing-performance"), null);
+        MobilePerformanceActionsContract performance = new SHAFT.GUI.WebDriver(driver).mobile().performance();
+
+        Assert.expectThrows(UnsupportedOperationException.class, performance::supportedTypes);
+        Mockito.verify(driver, Mockito.never()).getSupportedPerformanceDataTypes();
+    }
+
+    @Test
+    public void invalidRequestsAndMalformedProviderTablesShouldNotEnterHistory() {
+        AndroidDriver driver = liveAndroid("malformed-performance");
+        Mockito.when(driver.getPerformanceData("app", "empty", 5)).thenReturn(List.of());
+        Mockito.when(driver.getPerformanceData("app", "duplicate", 5)).thenReturn(table(row("value", "value")));
+        Mockito.when(driver.getPerformanceData("app", "width", 5)).thenReturn(table(row("one"), row(1, 2)));
+        Mockito.when(driver.getPerformanceData("app", "non-string-header", 5)).thenReturn(table(row(1)));
+        Mockito.when(driver.getPerformanceData("app", "null-header", 5)).thenReturn(
+                java.util.Collections.singletonList(null));
+        Mockito.when(driver.getPerformanceData("app", "explosive-value", 5)).thenReturn(
+                table(row("value"), row(new ExplosiveValue())));
+        MobilePerformanceActionsContract performance = new SHAFT.GUI.WebDriver(driver).mobile().performance();
+
+        Assert.expectThrows(IllegalArgumentException.class, () -> performance.sample(" ", "cpuinfo"));
+        Assert.expectThrows(IllegalArgumentException.class, () -> performance.sample("app", " "));
+        Mockito.verify(driver, Mockito.never()).getPerformanceData(Mockito.anyString(), Mockito.anyString(), Mockito.anyInt());
+        Assert.expectThrows(IllegalArgumentException.class, () -> performance.sample("app", "empty"));
+        Assert.expectThrows(IllegalArgumentException.class, () -> performance.sample("app", "duplicate"));
+        Assert.expectThrows(IllegalArgumentException.class, () -> performance.sample("app", "width"));
+        Assert.expectThrows(IllegalArgumentException.class, () -> performance.sample("app", "non-string-header"));
+        Assert.expectThrows(NullPointerException.class, () -> performance.sample("app", "null-header"));
+        IllegalArgumentException malformedValue = Assert.expectThrows(IllegalArgumentException.class,
+                () -> performance.sample("app", "explosive-value"));
+        Assert.assertTrue(malformedValue.getMessage().contains("immutable JSON scalars"));
+        Assert.assertTrue(performance.history().isEmpty());
+    }
+
+    @Test
+    public void supportedTypesShouldRejectMalformedProviderValuesAndRetainExceptionIdentity() {
+        AndroidDriver nullTypes = liveAndroid("null-types");
+        Mockito.when(nullTypes.getSupportedPerformanceDataTypes()).thenReturn(null);
+        Assert.expectThrows(NullPointerException.class,
+                () -> new SHAFT.GUI.WebDriver(nullTypes).mobile().performance().supportedTypes());
+
+        AndroidDriver blankTypes = liveAndroid("blank-types");
+        Mockito.when(blankTypes.getSupportedPerformanceDataTypes()).thenReturn(List.of("cpuinfo", " "));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new SHAFT.GUI.WebDriver(blankTypes).mobile().performance().supportedTypes());
+
+        AndroidDriver duplicateTypes = liveAndroid("duplicate-types");
+        Mockito.when(duplicateTypes.getSupportedPerformanceDataTypes()).thenReturn(List.of("cpuinfo", "cpuinfo"));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new SHAFT.GUI.WebDriver(duplicateTypes).mobile().performance().supportedTypes());
+
+        AndroidDriver failedTypes = liveAndroid("failed-types");
+        IllegalStateException providerFailure = new IllegalStateException("types failed");
+        Mockito.when(failedTypes.getSupportedPerformanceDataTypes()).thenThrow(providerFailure);
+        RuntimeException observed = Assert.expectThrows(RuntimeException.class,
+                () -> new SHAFT.GUI.WebDriver(failedTypes).mobile().performance().supportedTypes());
+        Assert.assertSame(observed, providerFailure);
+    }
+
+    @Test
+    public void providerExceptionsShouldRetainIdentityAndLeaveHistoryUntouched() {
+        AndroidDriver driver = liveAndroid("failed-performance");
+        IllegalStateException providerFailure = new IllegalStateException("provider failed");
+        Mockito.when(driver.getPerformanceData("app", "cpuinfo", 5)).thenThrow(providerFailure);
+        MobilePerformanceActionsContract performance = new SHAFT.GUI.WebDriver(driver).mobile().performance();
+
+        RuntimeException observed = Assert.expectThrows(RuntimeException.class,
+                () -> performance.sample("app", "cpuinfo"));
+
+        Assert.assertSame(observed, providerFailure);
+        Assert.assertTrue(performance.history().isEmpty());
+    }
+
+    @Test
+    public void historyShouldBeBoundedClearableAndIsolatedByDriverIdentity() {
+        AndroidDriver first = liveAndroid("same-session-id");
+        AndroidDriver second = liveAndroid("same-session-id");
+        AtomicInteger sequence = new AtomicInteger();
+        Mockito.when(first.getPerformanceData(Mockito.eq("first.app"), Mockito.eq("cpuinfo"), Mockito.eq(5)))
+                .thenAnswer(ignored -> table(row("sequence"), row(sequence.getAndIncrement())));
+        Mockito.when(second.getPerformanceData(Mockito.eq("second.app"), Mockito.eq("cpuinfo"), Mockito.eq(5)))
+                .thenReturn(table(row("sequence"), row(2)));
+        MobilePerformanceActionsContract firstPerformance = new SHAFT.GUI.WebDriver(first).mobile().performance();
+        MobilePerformanceActionsContract secondPerformance = new SHAFT.GUI.WebDriver(second).mobile().performance();
+
+        for (int index = 0; index < 101; index++) {
+            firstPerformance.sample("first.app", "cpuinfo");
+        }
+        secondPerformance.sample("second.app", "cpuinfo");
+
+        List<MobilePerformanceSample> snapshot = firstPerformance.history();
+        Assert.assertEquals(snapshot.size(), 100);
+        Assert.assertEquals(snapshot.getFirst().rows(), List.of(row(1)));
+        Assert.assertEquals(snapshot.getLast().rows(), List.of(row(100)));
+        Assert.assertTrue(snapshot.stream()
+                .allMatch(sample -> sample.applicationId().equals("first.app")));
+        Assert.assertEquals(secondPerformance.history().size(), 1);
+        Assert.assertSame(firstPerformance.clear(), firstPerformance);
+        Assert.assertTrue(firstPerformance.history().isEmpty());
+        Assert.assertEquals(snapshot.size(), 100);
+        Assert.assertEquals(snapshot.getFirst().rows(), List.of(row(1)));
+        Assert.expectThrows(UnsupportedOperationException.class, () -> snapshot.add(snapshot.getFirst()));
+        Assert.assertEquals(secondPerformance.history().size(), 1);
+        Assert.expectThrows(UnsupportedOperationException.class,
+                () -> firstPerformance.history().add(secondPerformance.history().getFirst()));
+    }
+
+    @Test
+    public void teardownShouldRemoveOnlyTheClosingDriversHistory() {
+        AndroidDriver closing = liveAndroid("closing-history");
+        AndroidDriver retained = liveAndroid("retained-history");
+        Mockito.when(closing.getPerformanceData("closing.app", "cpuinfo", 5))
+                .thenReturn(table(row("value"), row(1)));
+        Mockito.when(retained.getPerformanceData("retained.app", "cpuinfo", 5))
+                .thenReturn(table(row("value"), row(2)));
+        MobilePerformanceActionsContract closingPerformance =
+                new SHAFT.GUI.WebDriver(closing).mobile().performance();
+        MobilePerformanceActionsContract retainedPerformance =
+                new SHAFT.GUI.WebDriver(retained).mobile().performance();
+        closingPerformance.sample("closing.app", "cpuinfo");
+        retainedPerformance.sample("retained.app", "cpuinfo");
+
+        new DriverFactoryHelper().closeDriver(closing);
+
+        Assert.expectThrows(UnsupportedOperationException.class, closingPerformance::history);
+        Assert.assertEquals(retainedPerformance.history().size(), 1);
+    }
+
+    @Test
+    public void equalButDistinctDriversShouldRetainIdentityIsolatedState() {
+        EqualPerformanceDriver first = new EqualPerformanceDriver("equal-first", 1);
+        EqualPerformanceDriver second = new EqualPerformanceDriver("equal-second", 2);
+        MobilePerformanceActionsContract firstPerformance = new SHAFT.GUI.WebDriver(first).mobile().performance();
+        MobilePerformanceActionsContract secondPerformance = new SHAFT.GUI.WebDriver(second).mobile().performance();
+        firstPerformance.sample("first.app", "cpuinfo");
+        secondPerformance.sample("second.app", "cpuinfo");
+
+        firstPerformance.clear();
+
+        Assert.assertTrue(firstPerformance.history().isEmpty());
+        Assert.assertEquals(secondPerformance.history().getFirst().rows(), List.of(row(2)));
+        MobilePerformanceState.closeAndRemove(first);
+        Assert.expectThrows(UnsupportedOperationException.class, firstPerformance::history);
+        Assert.assertEquals(secondPerformance.history().size(), 1);
+    }
+
+    @Test
+    public void inFlightSampleShouldNotRecreateStateAfterDriverTeardown() throws Exception {
+        AndroidDriver closing = liveAndroid("in-flight-history");
+        CountDownLatch providerStarted = new CountDownLatch(1);
+        CountDownLatch providerRelease = new CountDownLatch(1);
+        Mockito.when(closing.getPerformanceData("closing.app", "cpuinfo", 5)).thenAnswer(ignored -> {
+            providerStarted.countDown();
+            if (!providerRelease.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("provider release timed out");
+            }
+            return table(row("value"), row(1));
+        });
+        MobilePerformanceActionsContract performance =
+                new SHAFT.GUI.WebDriver(closing).mobile().performance();
+
+        try (var executor = Executors.newSingleThreadExecutor()) {
+            Future<MobilePerformanceSample> future = executor.submit(
+                    () -> performance.sample("closing.app", "cpuinfo"));
+            Assert.assertTrue(providerStarted.await(10, TimeUnit.SECONDS));
+            new DriverFactoryHelper().closeDriver(closing);
+            providerRelease.countDown();
+            ExecutionException failure = Assert.expectThrows(ExecutionException.class,
+                    () -> future.get(10, TimeUnit.SECONDS));
+            Assert.assertTrue(failure.getCause() instanceof UnsupportedOperationException);
+        }
+        Assert.expectThrows(UnsupportedOperationException.class, performance::history);
+    }
+
+    @Test
+    public void concurrentSamplesShouldRetainTheNewestBoundWithoutCorruptingHistory() throws Exception {
+        AndroidDriver driver = liveAndroid("parallel-performance");
+        Mockito.when(driver.getPerformanceData("parallel.app", "cpuinfo", 5))
+                .thenReturn(table(row("value"), row(1)));
+        MobilePerformanceActionsContract performance = new SHAFT.GUI.WebDriver(driver).mobile().performance();
+
+        try (var executor = Executors.newFixedThreadPool(8)) {
+            List<Future<MobilePerformanceSample>> futures = new ArrayList<>();
+            for (int index = 0; index < 160; index++) {
+                futures.add(executor.submit(() -> performance.sample("parallel.app", "cpuinfo")));
+            }
+            for (Future<MobilePerformanceSample> future : futures) {
+                Assert.assertNotNull(future.get(10, TimeUnit.SECONDS));
+            }
+            executor.shutdown();
+            Assert.assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+
+        Assert.assertEquals(performance.history().size(), 100);
+    }
+
+    @Test
+    public void clearAndCountShouldLinearizeWithConcurrentAppends() throws Exception {
+        AndroidDriver driver = liveAndroid("atomic-clear-performance");
+        MobilePerformanceSample sample = new MobilePerformanceSample(
+                java.time.Instant.EPOCH, "atomic.app", "cpuinfo", List.of("value"), List.of(row(1)));
+
+        try (var executor = Executors.newFixedThreadPool(2)) {
+            for (int iteration = 0; iteration < 100; iteration++) {
+                MobilePerformanceState.clear(driver);
+                MobilePerformanceState.append(driver, sample);
+                CountDownLatch start = new CountDownLatch(1);
+                Future<Integer> cleared = executor.submit(() -> {
+                    start.await();
+                    return MobilePerformanceState.clearAndCount(driver);
+                });
+                Future<?> appended = executor.submit(() -> {
+                    start.await();
+                    MobilePerformanceState.append(driver, sample);
+                    return null;
+                });
+                start.countDown();
+                int clearedCount = cleared.get(10, TimeUnit.SECONDS);
+                appended.get(10, TimeUnit.SECONDS);
+                Assert.assertEquals(clearedCount + MobilePerformanceState.history(driver).size(), 2);
+            }
+        }
+    }
+
+    @Test
+    public void everyOperationShouldRejectAClosedSessionWithoutCallingTheProvider() {
+        MobilePerformanceActionsContract supportedTypes = stalePerformance("closed-types");
+        Assert.expectThrows(UnsupportedOperationException.class, supportedTypes::supportedTypes);
+
+        MobilePerformanceActionsContract sample = stalePerformance("closed-sample");
+        Assert.expectThrows(UnsupportedOperationException.class, () -> sample.sample("app", "cpuinfo"));
+
+        MobilePerformanceActionsContract history = stalePerformance("closed-history");
+        Assert.expectThrows(UnsupportedOperationException.class, history::history);
+
+        MobilePerformanceActionsContract clear = stalePerformance("closed-clear");
+        Assert.expectThrows(UnsupportedOperationException.class, clear::clear);
+    }
+
+    private static AndroidDriver liveAndroid(String id) {
+        return live(AndroidDriver.class, id);
+    }
+
+    private static AppiumDriver liveCustom(String id) {
+        AppiumDriver driver = Mockito.mock(AppiumDriver.class,
+                Mockito.withSettings().extraInterfaces(HasSupportedPerformanceDataType.class));
+        Mockito.when(driver.getSessionId()).thenReturn(new SessionId(id));
+        return driver;
+    }
+
+    private static MobilePerformanceActionsContract stalePerformance(String id) {
+        AndroidDriver driver = Mockito.mock(AndroidDriver.class);
+        SessionId live = new SessionId(id);
+        Mockito.when(driver.getSessionId()).thenReturn(live, live, null);
+        return new SHAFT.GUI.WebDriver(driver).mobile().performance();
+    }
+
+    private static <T extends AppiumDriver> T live(Class<T> type, String id) {
+        T driver = Mockito.mock(type);
+        Mockito.when(driver.getSessionId()).thenReturn(new SessionId(id));
+        return driver;
+    }
+
+    @SafeVarargs
+    private static List<List<Object>> table(List<Object>... rows) {
+        return List.of(rows);
+    }
+
+    private static List<Object> row(Object... values) {
+        return List.of(values);
+    }
+
+    private static final class EqualPerformanceDriver extends AppiumDriver
+            implements HasSupportedPerformanceDataType {
+        private final SessionId sessionId;
+        private final int value;
+
+        private EqualPerformanceDriver(String id, int value) {
+            super(Mockito.mock(HttpCommandExecutor.class), new ImmutableCapabilities());
+            sessionId = new SessionId(id);
+            this.value = value;
+        }
+
+        @Override
+        protected void startSession(Capabilities capabilities) {
+            // No remote session is needed for this identity-state regression fixture.
+        }
+
+        @Override
+        public SessionId getSessionId() {
+            return sessionId;
+        }
+
+        @Override
+        public List<String> getSupportedPerformanceDataTypes() {
+            return List.of("cpuinfo");
+        }
+
+        @Override
+        public List<List<Object>> getPerformanceData(String packageName, String dataType, int dataReadTimeout) {
+            return table(row("value"), row(value));
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof EqualPerformanceDriver;
+        }
+
+        @Override
+        public int hashCode() {
+            return 1;
+        }
+    }
+
+    private static final class ExplosiveValue {
+        @Override
+        public String toString() {
+            throw new IllegalStateException("provider value toString must not run");
+        }
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/mobile/MobilePerformanceActionsTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/mobile/MobilePerformanceActionsTest.java
@@ -2,7 +2,6 @@ package com.shaft.gui.mobile;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
-import com.shaft.gui.driver.MobileActionsContract;
 import com.shaft.gui.driver.MobilePerformanceActionsContract;
 import com.shaft.gui.driver.MobilePerformanceSample;
 import com.shaft.gui.mobile.internal.MobilePerformanceState;

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/MobilePerformanceNamespaceTraceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/MobilePerformanceNamespaceTraceTest.java
@@ -1,0 +1,190 @@
+package com.shaft.tools.io.internal;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.capabilities.AutomationBackend;
+import com.shaft.gui.driver.MobilePerformanceActionsContract;
+import com.shaft.listeners.internal.TestExecutionInfo;
+import io.appium.java_client.android.AndroidDriver;
+import org.mockito.Mockito;
+import org.openqa.selenium.remote.SessionId;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class MobilePerformanceNamespaceTraceTest {
+    @AfterMethod
+    public void clearTrace() {
+        TraceEventRecorder.clear();
+        ReportContext.clear();
+    }
+
+    @Test
+    public void everyOperationShouldEmitOnePayloadFreeAppiumEvent() {
+        String applicationId = "private.performance.app.7281";
+        String dataType = "private-cpu-type-491";
+        String supportedOnlyType = "private-supported-only-type-673";
+        String payload = "private-performance-value-881";
+        long numericPayload = 947362815L;
+        AndroidDriver driver = liveDriver("performance-trace");
+        Mockito.when(driver.getSupportedPerformanceDataTypes()).thenReturn(List.of(supportedOnlyType));
+        Mockito.when(driver.getPerformanceData(applicationId, dataType, 5)).thenReturn(table(
+                row("value", "numeric"), row(payload, numericPayload)));
+        MobilePerformanceActionsContract performance = new SHAFT.GUI.WebDriver(driver).mobile().performance();
+
+        performance.supportedTypes();
+        performance.sample(applicationId, dataType);
+        performance.history();
+        performance.clear();
+
+        List<TraceEventRecorder.ActionEvent> events = TraceEventRecorder.snapshot();
+        Assert.assertEquals(events.stream().map(TraceEventRecorder.ActionEvent::name).toList(),
+                List.of("supported-types", "sample", "history", "clear"));
+        Assert.assertEquals(events.get(0).metadata(), java.util.Map.of("typeCount", "1"));
+        Assert.assertEquals(events.get(1).metadata(), java.util.Map.of("columnCount", "2", "rowCount", "1"));
+        Assert.assertEquals(events.get(2).metadata(), java.util.Map.of("sampleCount", "1"));
+        Assert.assertEquals(events.get(3).metadata(), java.util.Map.of("clearedCount", "1"));
+        for (TraceEventRecorder.ActionEvent event : events) {
+            Assert.assertEquals(event.category(), "mobile/performance");
+            Assert.assertEquals(event.status(), "passed");
+            Assert.assertEquals(event.backend(), AutomationBackend.APPIUM);
+            Assert.assertEquals(event.locator(), "<performance-data>");
+            Assert.assertTrue(event.domSnapshotBefore().isEmpty());
+            Assert.assertTrue(event.domSnapshotAfter().isEmpty());
+            Assert.assertTrue(event.screenshot().isEmpty());
+            String rendered = event.toString();
+            Assert.assertFalse(rendered.contains(applicationId), rendered);
+            Assert.assertFalse(rendered.contains(dataType), rendered);
+            Assert.assertFalse(rendered.contains(payload), rendered);
+        }
+        IllegalStateException laterFailure = new IllegalStateException(
+                "Later echo " + applicationId + " " + dataType + " " + supportedOnlyType
+                        + " " + payload + " " + numericPayload);
+        String laterReport = FailureTraceReporter.renderTraceJson(
+                info(laterFailure), laterFailure.getMessage(), List.of());
+        Assert.assertFalse(laterReport.contains(applicationId), laterReport);
+        Assert.assertFalse(laterReport.contains(dataType), laterReport);
+        Assert.assertFalse(laterReport.contains(supportedOnlyType), laterReport);
+        Assert.assertFalse(laterReport.contains(payload), laterReport);
+        Assert.assertFalse(laterReport.contains(Long.toString(numericPayload)), laterReport);
+    }
+
+    @Test
+    public void providerFailureShouldPreserveIdentityAndRedactInputsAndThrowablePayload() {
+        String applicationId = "private.failed.app.552";
+        String dataType = "private-failed-type-914";
+        String payload = "private-provider-payload-331";
+        AndroidDriver driver = liveDriver("performance-provider-failure");
+        IllegalStateException providerFailure = new IllegalStateException(
+                "Rejected " + applicationId + " " + dataType + " " + payload);
+        Mockito.when(driver.getPerformanceData(applicationId, dataType, 5)).thenThrow(providerFailure);
+        MobilePerformanceActionsContract performance = new SHAFT.GUI.WebDriver(driver).mobile().performance();
+
+        RuntimeException thrown = Assert.expectThrows(RuntimeException.class,
+                () -> performance.sample(applicationId, dataType));
+
+        Assert.assertSame(thrown, providerFailure);
+        assertSingleFailed("sample", IllegalStateException.class.getName());
+        String report = FailureTraceReporter.renderTraceJson(info(thrown), thrown.getMessage(), List.of());
+        Assert.assertFalse(report.contains(applicationId), report);
+        Assert.assertFalse(report.contains(dataType), report);
+        Assert.assertFalse(report.contains(payload), report);
+        Assert.assertTrue(report.contains(IllegalStateException.class.getName()), report);
+    }
+
+    @Test
+    public void validationAndStaleFailuresShouldEmitOneOwnerEventWithoutProviderCalls() {
+        AndroidDriver driver = liveDriver("performance-validation-trace");
+        MobilePerformanceActionsContract performance = new SHAFT.GUI.WebDriver(driver).mobile().performance();
+
+        Assert.expectThrows(IllegalArgumentException.class, () -> performance.sample(" ", "cpuinfo"));
+        assertSingleFailed("sample", IllegalArgumentException.class.getName());
+        Mockito.verify(driver, Mockito.never()).getPerformanceData(
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyInt());
+        TraceEventRecorder.clear();
+
+        Mockito.when(driver.getSessionId()).thenReturn(null);
+        Assert.expectThrows(UnsupportedOperationException.class, performance::history);
+        assertSingleFailed("history", UnsupportedOperationException.class.getName());
+    }
+
+    @Test
+    public void publicClearShouldReportTheExactCountAcrossAConcurrentAppend() throws Exception {
+        AndroidDriver driver = liveDriver("public-atomic-clear");
+        Mockito.when(driver.getPerformanceData("atomic.app", "cpuinfo", 5))
+                .thenReturn(table(row("value"), row(1)));
+        MobilePerformanceActionsContract performance = new SHAFT.GUI.WebDriver(driver).mobile().performance();
+        performance.sample("atomic.app", "cpuinfo");
+        TraceEventRecorder.clear();
+        Thread clearingThread = Thread.currentThread();
+        AtomicInteger clearingThreadLivenessCalls = new AtomicInteger();
+        CountDownLatch splitCallGap = new CountDownLatch(1);
+        CountDownLatch concurrentAppendFinished = new CountDownLatch(1);
+        SessionId live = new SessionId("public-atomic-clear");
+        Mockito.doAnswer(ignored -> {
+            if (Thread.currentThread() == clearingThread
+                    && clearingThreadLivenessCalls.incrementAndGet() == 2) {
+                splitCallGap.countDown();
+                if (!concurrentAppendFinished.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("concurrent append timed out");
+                }
+            }
+            return live;
+        }).when(driver).getSessionId();
+
+        try (var executor = Executors.newSingleThreadExecutor()) {
+            Future<?> appended = executor.submit(() -> {
+                splitCallGap.await(300, TimeUnit.MILLISECONDS);
+                try {
+                    return performance.sample("atomic.app", "cpuinfo");
+                } finally {
+                    concurrentAppendFinished.countDown();
+                }
+            });
+            performance.clear();
+            appended.get(10, TimeUnit.SECONDS);
+        }
+
+        TraceEventRecorder.ActionEvent clearEvent = TraceEventRecorder.snapshot().getFirst();
+        int clearedCount = Integer.parseInt(clearEvent.metadata().get("clearedCount"));
+        Assert.assertEquals(clearedCount + performance.history().size(), 2);
+    }
+
+    private static AndroidDriver liveDriver(String id) {
+        AndroidDriver driver = Mockito.mock(AndroidDriver.class);
+        Mockito.when(driver.getSessionId()).thenReturn(new SessionId(id));
+        return driver;
+    }
+
+    @SafeVarargs
+    private static List<List<Object>> table(List<Object>... rows) {
+        return List.of(rows);
+    }
+
+    private static List<Object> row(Object... values) {
+        return List.of(values);
+    }
+
+    private static void assertSingleFailed(String operation, String exceptionType) {
+        List<TraceEventRecorder.ActionEvent> events = TraceEventRecorder.snapshot();
+        Assert.assertEquals(events.size(), 1);
+        TraceEventRecorder.ActionEvent event = events.getFirst();
+        Assert.assertEquals(event.category(), "mobile/performance");
+        Assert.assertEquals(event.name(), operation);
+        Assert.assertEquals(event.status(), "failed");
+        Assert.assertEquals(event.backend(), AutomationBackend.APPIUM);
+        Assert.assertEquals(event.locator(), "<performance-data>");
+        Assert.assertEquals(event.exceptionType(), exceptionType);
+    }
+
+    private static TestExecutionInfo info(Throwable throwable) {
+        return new TestExecutionInfo("mobile-performance-id", MobilePerformanceNamespaceTraceTest.class.getName(),
+                "providerFailure", "providerFailure", "mobile performance trace", null, throwable, false);
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/MobilePerformanceNamespaceTraceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/MobilePerformanceNamespaceTraceTest.java
@@ -128,7 +128,7 @@ public class MobilePerformanceNamespaceTraceTest {
         CountDownLatch concurrentAppendFinished = new CountDownLatch(1);
         SessionId live = new SessionId("public-atomic-clear");
         Mockito.doAnswer(ignored -> {
-            if (Thread.currentThread() == clearingThread
+            if (Thread.currentThread().equals(clearingThread)
                     && clearingThreadLivenessCalls.incrementAndGet() == 2) {
                 splitCallGap.countDown();
                 if (!concurrentAppendFinished.await(10, TimeUnit.SECONDS)) {

--- a/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
+++ b/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
@@ -28,11 +28,11 @@ public class AndroidBasicInteractionsTests extends MobileTest {
     public void performanceDataShouldExposeAProviderSampleAndBoundedHistory() {
         var performance = driver.get().mobile().performance();
 
-        Assert.assertTrue(performance.supportedTypes().contains("cpuinfo"));
-        var sample = performance.sample(PACKAGE, "cpuinfo");
+        Assert.assertTrue(performance.supportedTypes().contains("memoryinfo"));
+        var sample = performance.sample(PACKAGE, "memoryinfo");
 
         Assert.assertEquals(sample.applicationId(), PACKAGE);
-        Assert.assertEquals(sample.dataType(), "cpuinfo");
+        Assert.assertEquals(sample.dataType(), "memoryinfo");
         Assert.assertFalse(sample.columns().isEmpty());
         Assert.assertEquals(performance.history(), java.util.List.of(sample));
     }

--- a/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
+++ b/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
@@ -6,6 +6,7 @@ import com.shaft.gui.element.TouchActions;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.AndroidDriver;
 import org.openqa.selenium.By;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.time.Duration;
@@ -20,6 +21,20 @@ public class AndroidBasicInteractionsTests extends MobileTest {
     @Test(groups = {"ApiDemosDebug"})
     public void testAppLaunch() {
         driver.get().assertThat().element(By.xpath("//android.widget.TextView[@text='API Demos']")).exists().perform();
+    }
+
+    /** Real-provider acceptance for the bounded Android performance-data namespace. */
+    @Test(groups = {"ApiDemosDebug"})
+    public void performanceDataShouldExposeAProviderSampleAndBoundedHistory() {
+        var performance = driver.get().mobile().performance();
+
+        Assert.assertTrue(performance.supportedTypes().contains("cpuinfo"));
+        var sample = performance.sample(PACKAGE, "cpuinfo");
+
+        Assert.assertEquals(sample.applicationId(), PACKAGE);
+        Assert.assertEquals(sample.dataType(), "cpuinfo");
+        Assert.assertFalse(sample.columns().isEmpty());
+        Assert.assertEquals(performance.history(), java.util.List.of(sample));
     }
 
     @Test(groups = {"ApiDemosDebug"})

--- a/shaft-engine/src/test/java/testPackage/unitTests/AutomationCapabilityResolverUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AutomationCapabilityResolverUnitTest.java
@@ -12,6 +12,7 @@ import com.shaft.gui.capabilities.internal.AutomationCapabilityResolver;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.android.HasSupportedPerformanceDataType;
 import io.appium.java_client.android.ListensToLogcatMessages;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.ios.ListensToSyslogMessages;
@@ -197,11 +198,21 @@ public class AutomationCapabilityResolverUnitTest {
         Mac2Driver mac = mock(Mac2Driver.class);
         when(mac.getSessionId()).thenReturn(new SessionId("mac-profile"));
         when(mac.getCapabilities()).thenReturn(appiumCapabilities("Mac2", "mac"));
+        AppiumDriver customPerformance = mock(AppiumDriver.class,
+                withSettings().extraInterfaces(HasSupportedPerformanceDataType.class));
+        when(customPerformance.getSessionId()).thenReturn(new SessionId("custom-performance"));
+        when(customPerformance.getCapabilities()).thenReturn(appiumCapabilities("custom", "custom"));
+        AppiumDriver generic = mock(AppiumDriver.class);
+        when(generic.getSessionId()).thenReturn(new SessionId("generic-profile"));
+        when(generic.getCapabilities()).thenReturn(appiumCapabilities("custom", "custom"));
 
         AutomationCapabilities androidCapabilities = AutomationCapabilityResolver.forWebDriver(android);
         AutomationCapabilities iosCapabilities = AutomationCapabilityResolver.forWebDriver(ios);
         AutomationCapabilities windowsCapabilities = AutomationCapabilityResolver.forWebDriver(windows);
         AutomationCapabilities macCapabilities = AutomationCapabilityResolver.forWebDriver(mac);
+        AutomationCapabilities customPerformanceCapabilities =
+                AutomationCapabilityResolver.forWebDriver(customPerformance);
+        AutomationCapabilities genericCapabilities = AutomationCapabilityResolver.forWebDriver(generic);
 
         Assert.assertTrue(androidCapabilities.supports(AutomationFeature.PERFORMANCE_DATA));
         Assert.assertTrue(androidCapabilities.supports(AutomationFeature.DEVICE_CONTROL));
@@ -213,6 +224,8 @@ public class AutomationCapabilityResolverUnitTest {
         Assert.assertTrue(iosCapabilities.supports(AutomationFeature.BIOMETRICS));
         Assert.assertTrue(iosCapabilities.supports(AutomationFeature.DEVICE_LOGS));
         Assert.assertFalse(iosCapabilities.supports(AutomationFeature.PERFORMANCE_DATA));
+        Assert.assertTrue(customPerformanceCapabilities.supports(AutomationFeature.PERFORMANCE_DATA));
+        Assert.assertFalse(genericCapabilities.supports(AutomationFeature.PERFORMANCE_DATA));
         Assert.assertTrue(windowsCapabilities.supports(AutomationFeature.TOUCH_GESTURES));
         Assert.assertTrue(windowsCapabilities.supports(AutomationFeature.FILE_TRANSFER));
         Assert.assertTrue(windowsCapabilities.supports(AutomationFeature.SCREEN_RECORDING));
@@ -220,12 +233,16 @@ public class AutomationCapabilityResolverUnitTest {
         Assert.assertFalse(windowsCapabilities.supports(AutomationFeature.BIOMETRICS));
         Assert.assertFalse(windowsCapabilities.supports(AutomationFeature.DEVICE_CONTROL));
         Assert.assertFalse(windowsCapabilities.supports(AutomationFeature.DEVICE_LOGS));
+        Assert.assertFalse(windowsCapabilities.supports(AutomationFeature.PERFORMANCE_DATA));
         Assert.assertFalse(macCapabilities.supports(AutomationFeature.MOBILE_AUTOMATION));
         Assert.assertFalse(macCapabilities.supports(AutomationFeature.DEVICE_LOGS));
+        Assert.assertFalse(macCapabilities.supports(AutomationFeature.PERFORMANCE_DATA));
 
         when(android.getSessionId()).thenReturn(null);
         Assert.assertFalse(AutomationCapabilityResolver.forWebDriver(android)
                 .supports(AutomationFeature.DEVICE_LOGS));
+        Assert.assertFalse(AutomationCapabilityResolver.forWebDriver(android)
+                .supports(AutomationFeature.PERFORMANCE_DATA));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace the empty `mobile().performance()` shell with exact live-Appium performance support
- add immutable typed samples and newest-100 identity-isolated session history
- preserve old contract implementers through fail-closed default methods
- add teardown/race safety and one backend-only, payload-safe trace event per operation
- add Android real-provider acceptance to the existing `ApiDemosDebug` workflow

## Provider semantics

The pinned Appium 10.1.1 modern command path does not transmit its integer fallback argument, so this API intentionally exposes only `sample(applicationId, dataType)` rather than fictional caller-controlled attempts. Runtime and capability discovery both gate on `HasSupportedPerformanceDataType` plus a live session.

## Verification

- affected mobile/trace/capability aggregate: **94 tests, 0 failures, 0 errors, 0 skipped**
- post-rebase `mvn -pl shaft-engine -Dallure.automaticallyOpen=false -DskipTests package`: passed (test compile, JAR, sources, Javadocs)
- compatibility, generic API shape, provider positives/negatives, malformed data, immutable snapshots, exact eviction, concurrency, equal-driver identity collisions, teardown races, trace truthfulness, exception identity, and downstream redaction are covered
- three independent adversarial review lenses report zero code/API/security/test blockers

## External acceptance

The real Android acceptance test is compiled and selected by the existing Android BrowserStack workflow. No device, Appium endpoint, or BrowserStack credentials were available locally, so its actual provider result must come from CI/approved infrastructure before merge.

Closes #4728
Refs #4727
Refs #4693
