### PR TITLE
fix(agents): require PR at reviewed checkpoint

### DIFF
--- a/.agents/skills/act-as-mohab/references/work-github-playbook.md
+++ b/.agents/skills/act-as-mohab/references/work-github-playbook.md
@@ -18,6 +18,33 @@ A subagent's report describes intent, not necessarily its actual work. Before re
 Commit one reviewed sub-item at a time using the repository's normal message
 convention, including its issue number.
 
+### First retained checkpoint: make delivery visible immediately
+
+After the first reviewed implementation commit succeeds and remains at `HEAD`,
+stop behavior work and make that exact checkpoint visible before another
+behavior change or commit:
+
+1. Resolve repository identity from the active worktree, then bind the full
+   `HEAD` SHA and implementation branch. Never infer an issue number from a
+   branch name.
+2. Push the branch and create or discover its open draft or ready PR. PR
+   creation always names `--base` explicitly; stacked and dependent work uses
+   its intended branch base, never an assumed default branch.
+3. Require the PR to cover the exact checkpoint SHA. Persist its canonical
+   `baseRefName`, PR identity, and `closingIssuesReferences`; those closing
+   references, not branch text, supply the issue mapping.
+4. Keep the PR body/checklist and linked tracker current as later commits land.
+
+Read-only work, failed commit attempts, and sessions with no retained
+implementation commit owe no PR. For an already-running session whose first
+checkpoint predates this rule, perform steps 1–3 before resuming behavior. An
+older-head PR does not repair the state: push/update it until its head is exact.
+If the exact PR lacks a closing issue reference, add one. If GitHub is
+unavailable, report that concrete blocker and retry; do not treat unknown as no
+PR or continue accumulating commits. The guard leaves the inspection, push,
+explicit-base PR creation/update, and narrowly defined checkpoint-repair paths
+available while this duty is pending.
+
 ## 5. Docs, catalog, and screenshots — only where real
 
 Update user documentation and the feature catalog only for shipped behavior.
@@ -63,7 +90,9 @@ performs and verifies the repair or revert.
 
 ## 7. Push, PR, green, merge, compact
 
-- Push the branch and open the agreed PR shape with a description that lists each sub-item and its commit.
+- For work not already covered by the first-checkpoint rule, push the branch and
+  open the agreed PR shape. Keep every PR description current with each sub-item
+  and its commit.
 - Verify `closingIssuesReferences` after opening: GitHub matches closing words
   even inside negated or illustrative prose, so partial work says `Related to
   #N`, never a closing keyword adjacent to an issue number. If it lists an issue

--- a/.agents/skills/act-as-mohab/references/work-github-playbook.md
+++ b/.agents/skills/act-as-mohab/references/work-github-playbook.md
@@ -96,8 +96,9 @@ performs and verifies the repair or revert.
 ## 7. Push, PR, green, merge, compact
 
 - For work not already covered by the first-checkpoint rule, push the branch and
-  open the agreed PR shape. Keep every PR description current with each sub-item
-  and its commit.
+  open the agreed PR shape with a
+  description that lists each sub-item and its commit. Keep that description
+  current as later commits land.
 - Verify `closingIssuesReferences` after opening: GitHub matches closing words
   even inside negated or illustrative prose, so partial work says `Related to
   #N`, never a closing keyword adjacent to an issue number. If it lists an issue

--- a/.agents/skills/act-as-mohab/references/work-github-playbook.md
+++ b/.agents/skills/act-as-mohab/references/work-github-playbook.md
@@ -32,7 +32,12 @@ behavior change or commit:
    its intended branch base, never an assumed default branch.
 3. Require the PR to cover the exact checkpoint SHA. Persist its canonical
    `baseRefName`, PR identity, and `closingIssuesReferences`; those closing
-   references, not branch text, supply the issue mapping.
+   references, not branch text, supply the issue mapping. GitHub ignores
+   closing keywords when a PR targets a non-default stacked base. Only in that
+   state, an explicit, unambiguous same-repository closing keyword in the PR
+   body supplies the fallback issue mapping until the stack reaches the
+   default branch; titles, branch names, ordinary references, and malformed or
+   cross-repository clauses never do.
 4. Keep the PR body/checklist and linked tracker current as later commits land.
 
 Read-only work, failed commit attempts, and sessions with no retained

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -62,10 +62,12 @@ import json
 import os
 import posixpath
 import re
+import shutil
 import subprocess  # nosec B404 - R10 runs one fixed, read-only git query.
 import sys
 import tempfile
 import time
+from pathlib import Path
 from typing import NamedTuple
 from urllib.parse import urlparse
 
@@ -73,6 +75,10 @@ _HARNESS_IMPORT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.a
 if _HARNESS_IMPORT_ROOT not in sys.path:
     sys.path.insert(0, _HARNESS_IMPORT_ROOT)
 from scripts.agents import learning_loop as _learning_loop
+from scripts.agents.repository_context import (
+    RepositoryContextError,
+    resolve_repository_context,
+)
 
 # ---------------------------------------------------------------------------
 # R1: Maven test scoping + headless execution
@@ -1497,6 +1503,8 @@ _FIELD_ALIASES = {
     "toolInput": "tool_input",
     "sessionId": "session_id",
     "agentType": "agent_type",
+    "toolResponse": "tool_response",
+    "toolResult": "tool_result",
 }
 _TOOL_ALIASES = {
     "bash": "Bash",
@@ -2040,6 +2048,15 @@ def _shell_is_mutation(command: str) -> bool:
         if re.search(r"\bmemory\s+(?:remember|delete|supersede|patch)\b", lowered):
             return True
         if re.search(r"\bmempalace\s+(?:add|delete|mine|sync|sweep|update|checkpoint)\b", lowered):
+            return True
+    return False
+
+
+def _is_git_commit_command(command: str) -> bool:
+    """True when a shell command contains an actual git commit invocation."""
+    for segment in _git_segments(command):
+        rest = _tokens_after_head(segment, _GIT_NAMES)
+        if rest is not None and _split_global_options(rest)[0] == "commit":
             return True
     return False
 
@@ -2726,6 +2743,253 @@ def _ledger_records_a_review(hook_input: object, branch: object) -> bool:
     return f"review:{branch}" in set(ledger_events(hook_input))
 
 
+def _checkpoint_json_event(prefix: str, repository: str, branch: str, head: str, **extra) -> str:
+    payload = {"repository": repository, "branch": branch, "head": head, **extra}
+    return prefix + ":" + json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _checkpoint_event_payload(event: object, prefix: str) -> dict | None:
+    marker = prefix + ":"
+    if not isinstance(event, str) or not event.startswith(marker):
+        return None
+    try:
+        payload = json.loads(event[len(marker):])
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if not all(isinstance(payload.get(key), str) and payload[key] for key in ("repository", "branch", "head")):
+        return None
+    return payload
+
+
+def _bounded_repository_context_runner(arguments, **kwargs):
+    """Run shared context probes inside the guard's remaining hook budget."""
+    kwargs["timeout"] = _subprocess_timeout()
+    return subprocess.run(arguments, **kwargs)  # nosec B603 - resolver owns fixed argv.
+
+
+def _checkpoint_identity(hook_input: dict) -> tuple[str, str, str] | None:
+    """Return explicit repository, branch and full HEAD without guessing issue/base."""
+    cwd = _hook_working_directory(hook_input)
+    root = _repository_root(cwd)
+    branch = _current_branch(cwd)
+    head = (_git_output(["rev-parse", "HEAD"], cwd) or "").strip()
+    if not root or not branch or not re.fullmatch(r"[0-9a-fA-F]{40}", head):
+        return None
+    try:
+        context = resolve_repository_context(
+            explicit_repo=None,
+            pr=None,
+            explicit_root=Path(root),
+            cwd=Path(root),
+            runner=_bounded_repository_context_runner,
+        )
+    except (RepositoryContextError, OSError, ValueError):
+        return None
+    return context.repo, branch, head.lower()
+
+
+def _review_checkpoint_event(hook_input: dict, review_event: str | None) -> str | None:
+    """Bind an observed reviewer dispatch to its repository, branch and pre-commit HEAD."""
+    if not review_event:
+        return None
+    identity = _checkpoint_identity(hook_input)
+    if identity is None or review_event != f"review:{identity[1]}":
+        return None
+    return _checkpoint_json_event("review-head", *identity)
+
+
+def _record_successful_commit_checkpoint(hook_input: dict) -> None:
+    """Persist a reviewed commit only after successful PostToolUse retained a new HEAD."""
+    identity = _checkpoint_identity(hook_input)
+    if identity is None:
+        return
+    repository, branch, head = identity
+    reviewed_heads = [
+        payload
+        for payload in (
+            _checkpoint_event_payload(event, "review-head")
+            for event in ledger_events(hook_input)
+        )
+        if payload
+        and payload["repository"] == repository
+        and payload["branch"] == branch
+    ]
+    if not reviewed_heads or reviewed_heads[-1]["head"].lower() == head.lower():
+        return
+    ledger_record(hook_input, _checkpoint_json_event("checkpoint", *identity))
+
+
+def _exact_head_pull_request(repository: str, branch: str, head: str) -> tuple[str, dict | None]:
+    """Return exact-head PR state: exact, unmapped, none, or unavailable."""
+    executable = shutil.which("gh")
+    if executable is None:
+        return "unavailable", None
+    fields = "number,url,state,isDraft,headRefName,headRefOid,baseRefName,closingIssuesReferences"
+    try:
+        completed = subprocess.run(  # nosec B603 - fixed read-only gh query.
+            [executable, "pr", "list", "--repo", repository, "--head", branch,
+             "--state", "open", "--json", fields],
+            capture_output=True,
+            text=True,
+            timeout=_subprocess_timeout(),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unavailable", None
+    if completed.returncode != 0:
+        return "unavailable", None
+    try:
+        pull_requests = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return "unavailable", None
+    if not isinstance(pull_requests, list):
+        return "unavailable", None
+    exact = next(
+        (
+            item for item in pull_requests
+            if isinstance(item, dict)
+            and str(item.get("state", "")).upper() == "OPEN"
+            and item.get("headRefName") == branch
+            and str(item.get("headRefOid", "")).lower() == head.lower()
+        ),
+        None,
+    )
+    if exact is None:
+        return "none", None
+    base = exact.get("baseRefName")
+    issues = exact.get("closingIssuesReferences")
+    if not isinstance(base, str) or not base or not isinstance(issues, list) or not issues:
+        return "unmapped", exact
+    issue_numbers = sorted(
+        {item.get("number") for item in issues if isinstance(item, dict) and isinstance(item.get("number"), int)}
+    )
+    if not issue_numbers:
+        return "unmapped", exact
+    exact = dict(exact)
+    exact["issueNumbers"] = issue_numbers
+    return "exact", exact
+
+
+def _r27_recovery_command(
+    command: str, *, allow_checkpoint_repair: bool = False
+) -> tuple[bool, str | None]:
+    """Classify one whole command that can repair a blocked checkpoint."""
+    segments, separators = _top_level_shell_parts(_sanitize_for_command_head(command))
+    nonempty = [segment for segment in segments if segment.strip()]
+    if separators or len(nonempty) != 1:
+        return False, None
+    segment = nonempty[0]
+    git = _tokens_after_head(segment, _GIT_NAMES)
+    git_subcommand, _, git_arguments_index = _split_global_options(git or [])
+    if git_subcommand == "push":
+        return True, None
+    if git_subcommand == "commit":
+        options = {token.lower() for token in (git or [])[git_arguments_index:]}
+        if allow_checkpoint_repair and options == {"--amend", "--no-edit"}:
+            return True, None
+        return False, None
+    gh = _tokens_after_head(segment, frozenset({"gh"})) or []
+    if gh[:2] == ["pr", "create"]:
+        has_base = any(token.lower().startswith("--base=") for token in gh[2:]) or any(
+            token.lower() == "--base" and index + 1 < len(gh)
+            for index, token in enumerate(gh[2:], start=2)
+        )
+        if not has_base:
+            return False, "R27 blocked: `gh pr create` requires an explicit `--base`; never infer a default base for stacked work."
+        return True, None
+    if gh[:2] in (["pr", "view"], ["pr", "list"], ["pr", "edit"], ["pr", "comment"], ["issue", "comment"]):
+        return True, None
+    return False, None
+
+
+def check_r27_checkpoint_pull_request(
+    hook_input: dict, tool_name: str | None = None, *, stopping: bool = False
+) -> str | None:
+    """Require the first reviewed retained checkpoint to have an exact-head PR."""
+    identity = _checkpoint_identity(hook_input)
+    if identity is None:
+        return None
+    repository, branch, head = identity
+    events = ledger_events(hook_input)
+    checkpoints = [
+        payload
+        for payload in (
+            _checkpoint_event_payload(event, "checkpoint")
+            for event in events
+        )
+        if payload
+        and payload["repository"] == repository
+        and payload["branch"] == branch
+        and payload["head"].lower() == head.lower()
+    ]
+    reviewed_head_indexes = [
+        index
+        for index, event in enumerate(events)
+        if (payload := _checkpoint_event_payload(event, "review-head"))
+        and payload["repository"] == repository
+        and payload["branch"] == branch
+        and payload["head"].lower() != head.lower()
+    ]
+    uncertified_commit = bool(
+        not checkpoints
+        and reviewed_head_indexes
+        and "commit" in events[reviewed_head_indexes[-1] + 1:]
+    )
+    if not checkpoints and not uncertified_commit:
+        return None
+    if any(
+        payload
+        and payload["repository"] == repository
+        and payload["branch"] == branch
+        and payload["head"].lower() == head.lower()
+        for payload in (_checkpoint_event_payload(event, "checkpoint-pr") for event in events)
+    ):
+        return None
+    if not stopping and tool_name in {"Bash", "PowerShell"}:
+        recovery, recovery_error = _r27_recovery_command(
+            _extract_command(hook_input),
+            allow_checkpoint_repair=uncertified_commit,
+        )
+        if recovery_error:
+            return recovery_error
+        if recovery:
+            return None
+    if not stopping and not _is_implementation_mutation(tool_name or "", hook_input.get("tool_input")):
+        return None
+    if uncertified_commit:
+        return (
+            "R27 blocked: a successful reviewed commit was observed, but its exact "
+            "repository/branch/HEAD checkpoint was not durably appended. Restore the "
+            "session ledger and repeat an explicit reviewed checkpoint commit."
+        )
+    status, pull_request = _exact_head_pull_request(repository, branch, head)
+    if status == "exact" and pull_request is not None:
+        recorded = ledger_record(
+            hook_input,
+            _checkpoint_json_event(
+                "checkpoint-pr", repository, branch, head,
+                pr=pull_request.get("number"),
+                url=pull_request.get("url"),
+                draft=bool(pull_request.get("isDraft")),
+                base=pull_request["baseRefName"],
+                issues=pull_request["issueNumbers"],
+            ),
+        )
+        if recorded:
+            return None
+        return "R27 blocked: the exact-head PR was found, but its checkpoint mapping could not be durably appended; restore the session ledger and retry."
+    if status == "unavailable":
+        return "R27 blocked: GitHub exact-head PR status is unavailable; restore `gh` authentication/network access and retry."
+    if status == "unmapped":
+        return "R27 blocked: the exact-head open PR has no closing issue reference (for example `Closes #4745`); add one and retry."
+    return (
+        "R27 blocked: the reviewed retained checkpoint has no open PR at this exact HEAD. "
+        "Push it, then create a draft or ready PR with an explicit `--base` and a closing issue reference."
+    )
+
+
 def _independent_reviews(reviews: object, author: object) -> list:
     """Reviews by somebody other than the author that render a verdict.
 
@@ -2859,6 +3123,9 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
     review_event = _reviewer_dispatch_event(hook_input, tool_name)
     if review_event:
         ledger_record(hook_input, review_event)
+        review_checkpoint = _review_checkpoint_event(hook_input, review_event)
+        if review_checkpoint:
+            ledger_record(hook_input, review_checkpoint)
     if tool_name in DISPATCH_TOOLS:
         ledger_record(hook_input, "delegate-dispatch")
 
@@ -2872,6 +3139,11 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
         return 0
 
     reason = check_r19_fresh_base(hook_input, tool_name)
+    if reason is not None:
+        _record_guard_block_and_deny(hook_input, reason, host)
+        return 0
+
+    reason = check_r27_checkpoint_pull_request(hook_input, tool_name)
     if reason is not None:
         _record_guard_block_and_deny(hook_input, reason, host)
         return 0
@@ -2914,12 +3186,6 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
         # fresh process with no memory of it.
         if looks_like_a_test_run(command):
             ledger_record(hook_input, "test-run")
-        if any(
-            _tokens_after_head(segment, frozenset({"git"}))[:1] == ["commit"]
-            for segment in _git_segments(command)
-            if _tokens_after_head(segment, frozenset({"git"}))
-        ):
-            ledger_record(hook_input, "commit")
         if _updates_a_tracked_issue(command, _hook_working_directory(hook_input)):
             ledger_record(hook_input, "issue-update")
         return 0
@@ -2936,6 +3202,7 @@ def run_posttooluse(hook_input: dict) -> int:
         isinstance(result, dict)
         and (
             result.get("isError") is True
+            or result.get("interrupted") is True
             or str(result.get("status", "")).lower() in {"error", "failed", "failure"}
             or result.get("exit_code", result.get("exitCode", 0)) not in {0, None}
         )
@@ -2946,6 +3213,9 @@ def run_posttooluse(hook_input: dict) -> int:
         ledger_record(hook_input, "memory-write")
     if tool_name in ("Bash", "PowerShell"):
         command = _extract_command(hook_input)
+        if not result_failed and _is_git_commit_command(command):
+            _record_successful_commit_checkpoint(hook_input)
+            ledger_record(hook_input, "commit")
         if not result_failed and _is_learning_write_command(command):
             ledger_record(hook_input, "memory-write")
         if not result_failed:
@@ -3862,6 +4132,7 @@ def run_stop(hook_input: dict) -> int:
             check_r20_user_harness_drift(hook_input),
             check_r21_run_state_not_recorded(hook_input),
             check_r24_foreign_worktree_left_behind(hook_input, report),
+            check_r27_checkpoint_pull_request(hook_input, stopping=True),
         )
         if item is not None
     ]
@@ -4129,6 +4400,7 @@ _SELF_TEST_COVERAGE: dict[str, str] = {
     "check_r22_dispatch_adapter": "run_required_action_self_test",
     "check_r24_foreign_worktree_left_behind": "run_required_action_self_test",
     "check_r25_research_before_implementation": "run_required_action_self_test",
+    "check_r27_checkpoint_pull_request": "run_required_action_self_test",
 }
 
 
@@ -4223,6 +4495,16 @@ _STOP_RULE_RENDERERS = {
                 }
             ]
         },
+    ),
+    "check_r27_checkpoint_pull_request": lambda: _with_stubs(
+        {
+            "_checkpoint_identity": lambda payload: ("owner/repo", "ChaosEngine/x", "b" * 40),
+            "ledger_events": lambda payload: [
+                _checkpoint_json_event("checkpoint", "owner/repo", "ChaosEngine/x", "b" * 40)
+            ],
+            "_exact_head_pull_request": lambda repository, branch, head: ("none", None),
+        },
+        lambda: check_r27_checkpoint_pull_request({}, stopping=True),
     ),
 }
 

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -2821,12 +2821,65 @@ def _record_successful_commit_checkpoint(hook_input: dict) -> None:
     ledger_record(hook_input, _checkpoint_json_event("checkpoint", *identity))
 
 
+_CLOSING_KEYWORD_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b", re.IGNORECASE
+)
+_SAME_REPOSITORY_CLOSING_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*#([1-9][0-9]*)\b",
+    re.IGNORECASE,
+)
+
+
+def _stacked_body_closing_issues(body: object) -> list[int]:
+    """Return explicit unambiguous same-repository closing refs, or none."""
+    if not isinstance(body, str):
+        return []
+    keywords = list(_CLOSING_KEYWORD_RE.finditer(body))
+    matches = list(_SAME_REPOSITORY_CLOSING_RE.finditer(body))
+    if not matches or len(matches) != len(keywords):
+        return []
+    for match in matches:
+        clause_prefix = re.split(r"[.!?\n]", body[:match.start()])[-1]
+        if re.search(r"\b(?:not|never|no)\b|n't", clause_prefix, re.IGNORECASE):
+            return []
+        following = body[match.end():]
+        if re.match(
+            r"\s*(?:/|,|\b(?:or|and)\b)[^.\n]*#",
+            following,
+            re.IGNORECASE,
+        ):
+            return []
+    return sorted({int(match.group(1)) for match in matches})
+
+
+def _repository_default_branch(executable: str, repository: str) -> str | None:
+    """Read the canonical default branch; never guess main or master."""
+    try:
+        completed = subprocess.run(  # nosec B603 - fixed read-only gh query.
+            [executable, "repo", "view", repository, "--json", "defaultBranchRef"],
+            capture_output=True,
+            text=True,
+            timeout=_subprocess_timeout(),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    try:
+        payload = json.loads(completed.stdout)
+        branch = payload["defaultBranchRef"]["name"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return None
+    return branch if isinstance(branch, str) and branch else None
+
+
 def _exact_head_pull_request(repository: str, branch: str, head: str) -> tuple[str, dict | None]:
     """Return exact-head PR state: exact, unmapped, none, or unavailable."""
     executable = shutil.which("gh")
     if executable is None:
         return "unavailable", None
-    fields = "number,url,state,isDraft,headRefName,headRefOid,baseRefName,closingIssuesReferences"
+    fields = "number,url,state,isDraft,headRefName,headRefOid,baseRefName,body,closingIssuesReferences"
     try:
         completed = subprocess.run(  # nosec B603 - fixed read-only gh query.
             [executable, "pr", "list", "--repo", repository, "--head", branch,
@@ -2860,11 +2913,17 @@ def _exact_head_pull_request(repository: str, branch: str, head: str) -> tuple[s
         return "none", None
     base = exact.get("baseRefName")
     issues = exact.get("closingIssuesReferences")
-    if not isinstance(base, str) or not base or not isinstance(issues, list) or not issues:
+    if not isinstance(base, str) or not base or not isinstance(issues, list):
         return "unmapped", exact
     issue_numbers = sorted(
         {item.get("number") for item in issues if isinstance(item, dict) and isinstance(item.get("number"), int)}
     )
+    if not issue_numbers:
+        default_branch = _repository_default_branch(executable, repository)
+        if default_branch is None:
+            return "unavailable", None
+        if base != default_branch:
+            issue_numbers = _stacked_body_closing_issues(exact.get("body"))
     if not issue_numbers:
         return "unmapped", exact
     exact = dict(exact)

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -50,7 +50,272 @@ ISOLATED_STOP_RULES = (
     "check_r20_user_harness_drift",
     "check_r21_run_state_not_recorded",
     "check_r24_foreign_worktree_left_behind",
+    "check_r27_checkpoint_pull_request",
 )
+
+
+class CheckpointPullRequestGateTest(unittest.TestCase):
+    """R27: only a retained, reviewed commit starts the exact-head PR gate."""
+
+    def test_failed_commit_attempt_does_not_create_a_commit_event(self):
+        events: list[str] = []
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git commit -m checkpoint"},
+            "session_id": "r27-failed-commit",
+            "cwd": ".",
+        }
+        observed = [*guard.RESEARCH_PREFLIGHT_EVENTS, "test-run", "review:ChaosEngine/r27"]
+        with patch("scripts.agents.guard.ledger_events", return_value=observed):
+            with patch("scripts.agents.guard._current_branch", return_value="ChaosEngine/r27"):
+                with patch("scripts.agents.guard.ledger_record", side_effect=lambda _p, event: events.append(event) or True):
+                    guard.run_pretooluse(payload)
+                    guard.run_posttooluse(
+                        {**payload, "tool_response": {"status": "failed", "exit_code": 1}}
+                    )
+        self.assertNotIn("commit", events)
+
+    @staticmethod
+    def checkpoint(repo="ShaftHQ/SHAFT_ENGINE", branch="ChaosEngine/r27", head="b" * 40):
+        return "checkpoint:" + json.dumps(
+            {"repository": repo, "branch": branch, "head": head},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def test_successful_reviewed_retained_commit_records_exact_identity(self):
+        events: list[str] = []
+        before = "a" * 40
+        identity = ("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)
+        payload = {
+            "tool_name": "PowerShell",
+            "tool_input": {"command": "git commit -m checkpoint"},
+            "tool_response": {"status": "success", "exitCode": 0},
+            "session_id": "r27-success",
+            "cwd": ".",
+        }
+        review = guard._checkpoint_json_event(
+            "review-head", identity[0], identity[1], before
+        )
+        with patch("scripts.agents.guard._checkpoint_identity", return_value=identity):
+            with patch("scripts.agents.guard.ledger_events", return_value=[review]):
+                with patch("scripts.agents.guard.ledger_record", side_effect=lambda _p, event: events.append(event) or True):
+                    guard.run_posttooluse(payload)
+        self.assertIn("commit", events)
+        self.assertIn(self.checkpoint(), events)
+
+    def test_unchanged_head_does_not_create_a_checkpoint(self):
+        head = "b" * 40
+        identity = ("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", head)
+        review = guard._checkpoint_json_event("review-head", *identity)
+        events: list[str] = []
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git commit --allow-empty -m no-change"},
+            "tool_result": {"status": "completed", "exit_code": 0},
+            "session_id": "r27-unchanged",
+            "cwd": ".",
+        }
+        with patch("scripts.agents.guard._checkpoint_identity", return_value=identity):
+            with patch("scripts.agents.guard.ledger_events", return_value=[review]):
+                with patch("scripts.agents.guard.ledger_record", side_effect=lambda _p, event: events.append(event) or True):
+                    guard.run_posttooluse(payload)
+        self.assertFalse(any(event.startswith("checkpoint:") for event in events))
+
+    def test_cross_host_result_alias_is_normalized_before_failure_check(self):
+        normalized = guard.normalize_hook_input(
+            {"toolName": "shell_command", "toolInput": {"command": "git commit -m x"},
+             "toolResponse": {"status": "failed", "exitCode": 1}}
+        )
+        self.assertEqual(normalized["tool_response"]["status"], "failed")
+
+    def test_interrupted_posttooluse_is_not_a_successful_commit(self):
+        events: list[str] = []
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git commit -m interrupted"},
+            "tool_response": {"interrupted": True},
+        }
+        with patch("scripts.agents.guard.ledger_record", side_effect=lambda _p, event: events.append(event) or True):
+            guard.run_posttooluse(payload)
+        self.assertNotIn("commit", events)
+
+    def test_git_executable_and_global_options_are_commit_invocations(self):
+        for command in (
+            "git.exe commit -m x",
+            "git -C . commit -m x",
+            "git -c user.name=checkpoint commit -m x",
+        ):
+            with self.subTest(command=command):
+                self.assertTrue(guard._is_git_commit_command(command))
+
+    def test_shared_repository_resolution_is_capped_by_the_hook_budget(self):
+        with patch("scripts.agents.guard._subprocess_timeout", return_value=0.125):
+            with patch("scripts.agents.guard.subprocess.run", return_value=mock.Mock()) as runner:
+                guard._bounded_repository_context_runner(
+                    ["gh", "repo", "view"], capture_output=True, text=True, check=False
+                )
+        self.assertEqual(runner.call_args.kwargs["timeout"], 0.125)
+
+    def test_no_exact_head_pr_blocks_behavior_but_allows_read_only_and_recovery(self):
+        checkpoint = self.checkpoint()
+        with patch("scripts.agents.guard._checkpoint_identity", return_value=("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)):
+            with patch("scripts.agents.guard.ledger_events", return_value=[checkpoint]):
+                with patch("scripts.agents.guard._exact_head_pull_request", return_value=("none", None)):
+                    self.assertIn("R27", guard.check_r27_checkpoint_pull_request(
+                        {"tool_input": {"file_path": "shaft-engine/X.java"}}, "Write"
+                    ))
+                    self.assertIsNone(guard.check_r27_checkpoint_pull_request(
+                        {"tool_input": {"command": "git status"}}, "Bash"
+                    ))
+                    self.assertIsNone(guard.check_r27_checkpoint_pull_request(
+                        {"tool_input": {"command": "git push -u origin ChaosEngine/r27"}}, "Bash"
+                    ))
+                    self.assertIn("R27", guard.check_r27_checkpoint_pull_request(
+                        {"tool_input": {"command": "git commit -m next"}}, "Bash"
+                    ))
+                    self.assertIn("R27", guard.check_r27_checkpoint_pull_request(
+                        {"tool_input": {"command": "gh pr view; Set-Content shaft-engine/X.java x"}}, "PowerShell"
+                    ))
+
+    def test_pr_create_recovery_requires_explicit_stacked_base(self):
+        checkpoint = self.checkpoint()
+        identity = ("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)
+        with patch("scripts.agents.guard._checkpoint_identity", return_value=identity):
+            with patch("scripts.agents.guard.ledger_events", return_value=[checkpoint]):
+                self.assertIn("--base", guard.check_r27_checkpoint_pull_request(
+                    {"tool_input": {"command": "gh pr create --draft"}}, "Bash"
+                ))
+                self.assertIsNone(guard.check_r27_checkpoint_pull_request(
+                    {"tool_input": {"command": "gh pr create --draft --base ChaosEngine/issue-4726-portable-runtime"}}, "Bash"
+                ))
+
+    def test_draft_and_ready_exact_head_prs_persist_issue_and_stacked_base(self):
+        for draft in (True, False):
+            with self.subTest(draft=draft):
+                response = [{
+                    "number": 4800,
+                    "url": "https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4800",
+                    "state": "OPEN",
+                    "isDraft": draft,
+                    "headRefName": "ChaosEngine/r27",
+                    "headRefOid": "b" * 40,
+                    "baseRefName": "ChaosEngine/issue-4726-portable-runtime",
+                    "closingIssuesReferences": [{"number": 4745}],
+                }]
+                completed = mock.Mock(returncode=0, stdout=json.dumps(response))
+                with patch("scripts.agents.guard.shutil.which", return_value="gh"):
+                    with patch("scripts.agents.guard.subprocess.run", return_value=completed):
+                        status, pull_request = guard._exact_head_pull_request(
+                            "ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40
+                        )
+                self.assertEqual(status, "exact")
+                self.assertEqual(pull_request["baseRefName"], "ChaosEngine/issue-4726-portable-runtime")
+                self.assertEqual(pull_request["issueNumbers"], [4745])
+
+    def test_wrong_or_old_head_is_not_accepted(self):
+        response = [{
+            "number": 4799, "url": "https://example.invalid/4799", "state": "OPEN",
+            "isDraft": True, "headRefName": "ChaosEngine/r27", "headRefOid": "a" * 40,
+            "baseRefName": "ChaosEngine/issue-4726-portable-runtime",
+            "closingIssuesReferences": [{"number": 4745}],
+        }]
+        with patch("scripts.agents.guard.shutil.which", return_value="gh"):
+            with patch("scripts.agents.guard.subprocess.run", return_value=mock.Mock(returncode=0, stdout=json.dumps(response))):
+                self.assertEqual(
+                    guard._exact_head_pull_request("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40),
+                    ("none", None),
+                )
+
+    def test_github_unavailable_is_distinct_from_no_pr(self):
+        with patch("scripts.agents.guard.shutil.which", return_value="gh"):
+            with patch("scripts.agents.guard.subprocess.run", return_value=mock.Mock(returncode=1, stdout="")):
+                self.assertEqual(
+                    guard._exact_head_pull_request("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)[0],
+                    "unavailable",
+                )
+
+    def test_exact_head_pr_without_closing_issue_is_unmapped(self):
+        response = [{
+            "number": 4800, "url": "https://example.invalid/4800", "state": "OPEN",
+            "isDraft": True, "headRefName": "ChaosEngine/r27", "headRefOid": "b" * 40,
+            "baseRefName": "ChaosEngine/issue-4726-portable-runtime",
+            "closingIssuesReferences": [],
+        }]
+        with patch("scripts.agents.guard.shutil.which", return_value="gh"):
+            with patch("scripts.agents.guard.subprocess.run", return_value=mock.Mock(returncode=0, stdout=json.dumps(response))):
+                self.assertEqual(
+                    guard._exact_head_pull_request("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)[0],
+                    "unmapped",
+                )
+
+    def test_exact_mapping_append_failure_fails_closed(self):
+        identity = ("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)
+        pull_request = {
+            "number": 4800, "url": "https://example.invalid/4800", "isDraft": True,
+            "baseRefName": "ChaosEngine/issue-4726-portable-runtime", "issueNumbers": [4745],
+        }
+        with patch("scripts.agents.guard._checkpoint_identity", return_value=identity):
+            with patch("scripts.agents.guard.ledger_events", return_value=[self.checkpoint()]):
+                with patch("scripts.agents.guard._exact_head_pull_request", return_value=("exact", pull_request)):
+                    with patch("scripts.agents.guard.ledger_record", return_value=False):
+                        reason = guard.check_r27_checkpoint_pull_request(
+                            {"tool_input": {"file_path": "shaft-engine/X.java"}}, "Write"
+                        )
+        self.assertIn("durably appended", reason)
+
+    def test_checkpoint_append_loss_leaves_a_fail_closed_commit_receipt(self):
+        identity = ("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)
+        review = guard._checkpoint_json_event("review-head", identity[0], identity[1], "a" * 40)
+        recorded: list[str] = []
+
+        def append(_payload, event):
+            if event.startswith("checkpoint:"):
+                return False
+            recorded.append(event)
+            return True
+
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git commit -m checkpoint"},
+            "tool_response": {"status": "success", "exit_code": 0},
+        }
+        with patch("scripts.agents.guard._checkpoint_identity", return_value=identity):
+            with patch("scripts.agents.guard.ledger_events", return_value=[review]):
+                with patch("scripts.agents.guard.ledger_record", side_effect=append):
+                    guard.run_posttooluse(payload)
+        self.assertEqual(recorded, ["commit"])
+        with patch("scripts.agents.guard._checkpoint_identity", return_value=identity):
+            with patch("scripts.agents.guard.ledger_events", return_value=[review, "commit"]):
+                reason = guard.check_r27_checkpoint_pull_request(
+                    {"tool_input": {"file_path": "shaft-engine/X.java"}}, "Write"
+                )
+        self.assertIn("not durably appended", reason)
+
+    def test_no_checkpoint_leaves_read_only_behavior_and_stop_untouched(self):
+        identity = ("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)
+        with patch("scripts.agents.guard._checkpoint_identity", return_value=identity):
+            with patch("scripts.agents.guard.ledger_events", return_value=[]):
+                self.assertIsNone(guard.check_r27_checkpoint_pull_request(
+                    {"tool_input": {"command": "git status"}}, "Bash"
+                ))
+                self.assertIsNone(guard.check_r27_checkpoint_pull_request({}, stopping=True))
+
+    def test_ordinary_stop_reaches_r27_and_recursive_stop_is_allowed(self):
+        isolate_stop_rules(self, except_for=("check_r27_checkpoint_pull_request",))
+        identity = ("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)
+        with patch("scripts.agents.guard._checkpoint_identity", return_value=identity):
+            with patch("scripts.agents.guard.ledger_events", return_value=[self.checkpoint()]):
+                with patch("scripts.agents.guard._exact_head_pull_request", return_value=("none", None)):
+                    with patch("scripts.agents.guard._worktree_report", return_value={"worktrees": [{"is_current": True, "state": "clean"}]}):
+                        output = io.StringIO()
+                        with redirect_stdout(output):
+                            guard.run_stop({"session_id": "r27-stop"})
+                        self.assertIn("R27 blocked", output.getvalue())
+                        output = io.StringIO()
+                        with redirect_stdout(output):
+                            guard.run_stop({"session_id": "r27-stop", "stop_hook_active": True})
+                        self.assertEqual(output.getvalue(), "")
 
 
 def isolate_stop_rules(case: unittest.TestCase, except_for: tuple[str, ...] = ()) -> None:

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -243,11 +243,95 @@ class CheckpointPullRequestGateTest(unittest.TestCase):
             "closingIssuesReferences": [],
         }]
         with patch("scripts.agents.guard.shutil.which", return_value="gh"):
-            with patch("scripts.agents.guard.subprocess.run", return_value=mock.Mock(returncode=0, stdout=json.dumps(response))):
+            with patch("scripts.agents.guard.subprocess.run", side_effect=[
+                mock.Mock(returncode=0, stdout=json.dumps(response)),
+                mock.Mock(returncode=0, stdout=json.dumps({"defaultBranchRef": {"name": "main"}})),
+            ]):
                 self.assertEqual(
                     guard._exact_head_pull_request("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)[0],
                     "unmapped",
                 )
+
+    def test_stacked_exact_head_pr_uses_explicit_body_closing_keyword(self):
+        response = [{
+            "number": 4756, "url": "https://github.com/ShaftHQ/SHAFT_ENGINE/pull/4756",
+            "state": "OPEN", "isDraft": True,
+            "headRefName": "ChaosEngine/r27", "headRefOid": "b" * 40,
+            "baseRefName": "ChaosEngine/issue-4726-portable-runtime",
+            "closingIssuesReferences": [], "body": "Closes #4745",
+        }]
+        with patch("scripts.agents.guard.shutil.which", return_value="gh"):
+            with patch("scripts.agents.guard.subprocess.run", side_effect=[
+                mock.Mock(returncode=0, stdout=json.dumps(response)),
+                mock.Mock(returncode=0, stdout=json.dumps({"defaultBranchRef": {"name": "main"}})),
+            ]):
+                status, pull_request = guard._exact_head_pull_request(
+                    "ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40
+                )
+        self.assertEqual(status, "exact")
+        self.assertEqual(pull_request["issueNumbers"], [4745])
+
+    def test_stacked_body_fallback_rejects_ambiguous_malformed_and_free_refs(self):
+        for body in (
+            "Closes #4745 or #4746",
+            "Closes #4745 and #4746",
+            "Closes #4745, #4746",
+            "Does not fix #4745",
+            "This does not fully resolve #4745",
+            "Closes #4745 or ShaftHQ/SHAFT_ENGINE#4746",
+            "Closes #4745, ShaftHQ/SHAFT_ENGINE#4746",
+            "Closes #4745 and ShaftHQ/SHAFT_ENGINE#4746",
+            "Closes ShaftHQ/SHAFT_ENGINE#4745",
+            "Closes issue #4745",
+            "Related to #4745",
+        ):
+            with self.subTest(body=body):
+                response = [{
+                    "number": 4756, "url": "https://example.invalid/4756", "state": "OPEN",
+                    "isDraft": True, "headRefName": "ChaosEngine/r27", "headRefOid": "b" * 40,
+                    "baseRefName": "ChaosEngine/issue-4726-portable-runtime",
+                    "closingIssuesReferences": [], "body": body,
+                }]
+                with patch("scripts.agents.guard.shutil.which", return_value="gh"):
+                    with patch("scripts.agents.guard.subprocess.run", side_effect=[
+                        mock.Mock(returncode=0, stdout=json.dumps(response)),
+                        mock.Mock(returncode=0, stdout=json.dumps({"defaultBranchRef": {"name": "main"}})),
+                    ]):
+                        status, _ = guard._exact_head_pull_request(
+                            "ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40
+                        )
+                self.assertEqual(status, "unmapped")
+
+    def test_default_branch_pr_never_uses_the_stacked_body_fallback(self):
+        response = [{
+            "number": 4756, "url": "https://example.invalid/4756", "state": "OPEN",
+            "isDraft": True, "headRefName": "ChaosEngine/r27", "headRefOid": "b" * 40,
+            "baseRefName": "main", "closingIssuesReferences": [], "body": "Closes #4745",
+        }]
+        with patch("scripts.agents.guard.shutil.which", return_value="gh"):
+            with patch("scripts.agents.guard.subprocess.run", side_effect=[
+                mock.Mock(returncode=0, stdout=json.dumps(response)),
+                mock.Mock(returncode=0, stdout=json.dumps({"defaultBranchRef": {"name": "main"}})),
+            ]):
+                status, _ = guard._exact_head_pull_request(
+                    "ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40
+                )
+        self.assertEqual(status, "unmapped")
+
+    def test_default_branch_lookup_uses_gh_repo_view_positional_repository(self):
+        completed = mock.Mock(
+            returncode=0,
+            stdout=json.dumps({"defaultBranchRef": {"name": "main"}}),
+        )
+        with patch("scripts.agents.guard.subprocess.run", return_value=completed) as runner:
+            self.assertEqual(
+                guard._repository_default_branch("gh", "ShaftHQ/SHAFT_ENGINE"),
+                "main",
+            )
+        self.assertEqual(
+            runner.call_args.args[0],
+            ["gh", "repo", "view", "ShaftHQ/SHAFT_ENGINE", "--json", "defaultBranchRef"],
+        )
 
     def test_exact_mapping_append_failure_fails_closed(self):
         identity = ("ShaftHQ/SHAFT_ENGINE", "ChaosEngine/r27", "b" * 40)


### PR DESCRIPTION
Closes #4745.

Implements R27: successful reviewed retained commits are bound to explicit repository, branch, and full HEAD. Further behavior and ordinary Stop require an exact-head open draft or ready PR. Canonical `closingIssuesReferences` are preferred; exact-head non-default stacked PRs use only an explicit, unambiguous same-repository closing-keyword body fallback because GitHub ignores closing keywords for non-default bases. Canonical `baseRefName` is persisted, no issue/default base is inferred, unavailable/no-PR/unmapped states remain distinct, and recovery is narrowly parsed.

Validation: 222 lifecycle tests, guard self-test, agent setup validation, live exact-head acceptance against this stacked PR, and two independent adversarial approval passes. Auto-merge remains disabled.