### PR TITLE
fix(intellij): complete plugin issue follow-ups

### DIFF
--- a/scripts/mcp/install_shaft_mcp.py
+++ b/scripts/mcp/install_shaft_mcp.py
@@ -66,6 +66,7 @@ RETIRED_SHAFT_SKILL_DIRECTORIES = frozenset((
 # fails when this list falls behind them.
 AGENT_VALIDATION_SCRIPT_FILES = (
     "scripts/agents/guard.py",
+    "scripts/agents/learning_loop.py",
     "scripts/ci/validate_agent_setup.py",
     "scripts/ci/validate_agent_guidance.py",
     "scripts/ci/harness_reachability.py",

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureEventPipeline.java
@@ -924,7 +924,9 @@ final class CaptureEventPipeline implements AutoCloseable {
                 candidate.uniquenessCount(),
                 candidate.visible(),
                 candidate.stable(),
-                signals);
+                signals,
+                candidate.replayXpath(),
+                candidate.roleXpathVerified());
     }
 
     private void append(

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartOptions.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartOptions.java
@@ -76,6 +76,10 @@ public record CaptureStartOptions(
     public CaptureStartOptions {
         targetLanguage = text(targetLanguage);
         testIdAttribute = text(testIdAttribute);
+        if (!testIdAttribute.isBlank() && !testIdAttribute.matches("[A-Za-z_][A-Za-z0-9_.-]*")) {
+            throw new IllegalArgumentException(
+                    "Capture test id attribute must be a namespace-free HTML attribute name.");
+        }
         channel = text(channel);
         deviceName = text(deviceName);
         viewportSize = text(viewportSize);

--- a/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartOptions.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/runtime/CaptureStartOptions.java
@@ -75,7 +75,7 @@ public record CaptureStartOptions(
      */
     public CaptureStartOptions {
         targetLanguage = text(targetLanguage);
-        testIdAttribute = text(testIdAttribute);
+        testIdAttribute = text(testIdAttribute).toLowerCase(Locale.ROOT);
         if (!testIdAttribute.isBlank() && !testIdAttribute.matches("[A-Za-z_][A-Za-z0-9_.-]*")) {
             throw new IllegalArgumentException(
                     "Capture test id attribute must be a namespace-free HTML attribute name.");

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -560,7 +560,7 @@
   // <a> becoming a nested <span>). Invalid custom attribute names, duplicate values, and values
   // that do not resolve back to this exact element all fail closed with no replay XPath.
   const computeTestIdReplayXpath = (element, attribute, value) => {
-    if (!/^[A-Za-z_][A-Za-z0-9_.:-]*$/.test(attribute)) return "";
+    if (!/^[A-Za-z_][A-Za-z0-9_.-]*$/.test(attribute)) return "";
     const xpath = `//*[@${attribute}=${xpathLiteral(value)}]`;
     const {count, includesElement} = evaluateXpath(xpath, element);
     return count === 1 && includesElement ? xpath : "";
@@ -852,6 +852,36 @@
         : [...existing, withUserProvidedSignal(candidate)]
     };
   };
+  const revalidatedTestIdCandidate = (element, candidate) => {
+    if (!candidate || candidate.strategy !== "TEST_ID") return candidate;
+    const fresh = element && element.isConnected
+      ? locators(element).find(item =>
+        item.strategy === candidate.strategy && item.expression === candidate.expression)
+      : null;
+    return fresh || {
+      ...candidate,
+      uniquenessCount: 0,
+      visible: false,
+      stable: false,
+      replayXpath: ""
+    };
+  };
+  const revalidateSelectedTestId = (target, element) => {
+    if (!target) return target;
+    const existing = target.locators || [];
+    const selected = existing.find(candidate =>
+      candidate.strategy === "TEST_ID"
+      && (candidate.signals || []).includes("USER_PROVIDED"));
+    if (!selected) return target;
+    const replacement = withUserProvidedSignal(revalidatedTestIdCandidate(element, selected));
+    return {
+      ...target,
+      locators: existing.map(candidate =>
+        candidate.strategy === selected.strategy && candidate.expression === selected.expression
+          ? replacement
+          : candidate)
+    };
+  };
   const eventElement = event => {
     const path = event.composedPath ? event.composedPath() : [];
     return path.find(item => item && item.nodeType === Node.ELEMENT_NODE) || event.target;
@@ -1010,10 +1040,16 @@
       .find(name => element && element.hasAttribute && element.hasAttribute(name)) || "value";
   // Renders the same SHAFT locator syntax CaptureGenerator emits (see
   // CaptureGenerator#locatorExpression) so the picker shows exactly what generated code will use.
+  const javaStringLiteral = value => String(value || "")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
   const shaftLocatorSyntax = candidate => {
     const expression = String(candidate.expression || "");
     switch (candidate.strategy) {
       case "TEST_ID":
+        return candidate.replayXpath
+          ? 'By.xpath("' + javaStringLiteral(candidate.replayXpath) + '")'
+          : 'SHAFT.GUI.Locator.cssSelector("' + expression + '")';
       case "CSS":
         return `SHAFT.GUI.Locator.cssSelector("${expression}")`;
       case "ID":
@@ -1246,7 +1282,7 @@
       const summary = negated
         ? "Assert not " + catalogEntry.label.toLowerCase() + " on " + name
         : "Assert " + catalogEntry.label.toLowerCase() + " on " + name;
-      finishAssertion(target, payload, summary);
+      finishAssertion(revalidateSelectedTestId(target, element), payload, summary);
     });
     const actions = cancelAssertionRow(closeAssertionPanel);
     actions.appendChild(confirm);
@@ -1280,7 +1316,10 @@
       choose.type = "button";
       choose.textContent = "Use this locator";
       choose.addEventListener("click", () =>
-        showAssertionCatalogStep(ELEMENT_ASSERTIONS, withLocatorPreference(target, item.candidate), element));
+        showAssertionCatalogStep(
+          ELEMENT_ASSERTIONS,
+          withLocatorPreference(target, revalidatedTestIdCandidate(element, item.candidate)),
+          element));
       row.append(expression, meta, choose);
       list.appendChild(row);
     });

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -1042,6 +1042,9 @@
   // CaptureGenerator#locatorExpression) so the picker shows exactly what generated code will use.
   const javaStringLiteral = value => String(value || "")
     .replace(/\\/g, "\\\\")
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t")
     .replace(/"/g, '\\"');
   const shaftLocatorSyntax = candidate => {
     const expression = String(candidate.expression || "");

--- a/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
+++ b/shaft-capture/src/main/resources/browser/shaft-capture-recorder.js
@@ -554,6 +554,17 @@
     const {count, includesElement} = evaluateXpath("(" + union + ")", element);
     return count === 1 && includesElement;
   };
+  // A selected TEST_ID cannot clear the native-locator ladder on preference score alone: it needs
+  // the same live-DOM, self-verified XPath evidence as every other rung-2 candidate. Keep the tag
+  // wildcard so a stable authored identity survives equivalent markup changes (for example an
+  // <a> becoming a nested <span>). Invalid custom attribute names, duplicate values, and values
+  // that do not resolve back to this exact element all fail closed with no replay XPath.
+  const computeTestIdReplayXpath = (element, attribute, value) => {
+    if (!/^[A-Za-z_][A-Za-z0-9_.:-]*$/.test(attribute)) return "";
+    const xpath = `//*[@${attribute}=${xpathLiteral(value)}]`;
+    const {count, includesElement} = evaluateXpath(xpath, element);
+    return count === 1 && includesElement ? xpath : "";
+  };
   const cssPath = element => {
     const parts = [];
     let current = element;
@@ -637,7 +648,10 @@
       const value = element.getAttribute(attribute);
       if (value) {
         const selector = `[${attribute}="${cssEscape(value)}"]`;
-        add("TEST_ID", selector, selector, !dynamic(value), ["TEST_ATTRIBUTE", "STABLE_ATTRIBUTE"]);
+        const stable = !dynamic(value);
+        const replayXpath = stable ? computeTestIdReplayXpath(element, attribute, value) : "";
+        add("TEST_ID", selector, selector, stable,
+          ["TEST_ATTRIBUTE", "STABLE_ATTRIBUTE"], replayXpath);
       }
     });
     if (element.id) {

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java
@@ -25,7 +25,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -85,110 +84,6 @@ class CaptureGeneratedReplayBrowserTest {
         } finally {
             server.stop(0);
         }
-    }
-
-    @Test
-    void selectedTestIdReplaysAcrossEquivalentResultTitleMarkup() throws Exception {
-        AtomicReference<String> resultMarkup = new AtomicReference<>(
-                "<h2><a data-testid=\"result-title-a\" href=\"/detail\">ShaftHQ result</a></h2>");
-        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-        server.createContext("/results", exchange -> {
-            byte[] response = ("<!doctype html><html><body><article>"
-                    + resultMarkup.get() + "</article></body></html>").getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().set("Content-Type", "text/html; charset=utf-8");
-            exchange.sendResponseHeaders(200, response.length);
-            exchange.getResponseBody().write(response);
-            exchange.close();
-        });
-        server.start();
-        try {
-            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/results";
-            Path sessionPath = temp.resolve("selected-test-id-capture.json");
-            new CaptureJsonCodec().write(sessionPath, selectedTestIdSession(url));
-            writeExpected("data.expected-title", "ShaftHQ");
-
-            CaptureGenerationResult linkResult = new CaptureGenerator().generate(replayRequest(
-                    sessionPath, temp.resolve("selected-test-id-link"), "SelectedTestIdLinkReplayTest"));
-            assertTrue(linkResult.successful(), linkResult.report().replay().diagnostics().toString());
-
-            resultMarkup.set(
-                    "<h2><span data-testid=\"result-title-a\">ShaftHQ result</span></h2>");
-            CaptureGenerationResult spanResult = new CaptureGenerator().generate(replayRequest(
-                    sessionPath, temp.resolve("selected-test-id-span"), "SelectedTestIdSpanReplayTest"));
-
-            assertTrue(spanResult.successful(), spanResult.report().replay().diagnostics().toString());
-            assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
-                    linkResult.report().replay().status());
-            assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
-                    spanResult.report().replay().status());
-            String linkSource = Files.readString(linkResult.sourcePath());
-            String spanSource = Files.readString(spanResult.sourcePath());
-            assertTrue(linkSource.contains("By.xpath(\"//*[@data-testid=\\\"result-title-a\\\"]\")"),
-                    linkSource);
-            assertTrue(spanSource.contains("By.xpath(\"//*[@data-testid=\\\"result-title-a\\\"]\")"),
-                    spanSource);
-        } finally {
-            server.stop(0);
-        }
-    }
-
-    private CaptureGenerationRequest replayRequest(Path sessionPath, Path output, String className) {
-        return new CaptureGenerationRequest(
-                sessionPath,
-                output,
-                "generated.capture",
-                className,
-                false,
-                true,
-                true,
-                Duration.ofMinutes(2),
-                CaptureGenerationRequest.EnrichmentMode.NONE,
-                null,
-                false,
-                ApprovalPolicy.denyAll());
-    }
-
-    private CaptureSession selectedTestIdSession(String url) {
-        ExternalTestDataReference expected = reference("data.expected-title", "expected-title");
-        String stableXpath = "//*[@data-testid=\"result-title-a\"]";
-        ElementSnapshot resultTitle = new ElementSnapshot(
-                "result-title",
-                "a",
-                "link",
-                "ShaftHQ result",
-                "ShaftHQ result",
-                Map.of("data-testid", "result-title-a"),
-                List.of(new LocatorCandidate(
-                        LocatorCandidate.LocatorStrategy.TEST_ID,
-                        "[data-testid=\"result-title-a\"]",
-                        1,
-                        true,
-                        true,
-                        Set.of(
-                                LocatorCandidate.LocatorSignal.TEST_ATTRIBUTE,
-                                LocatorCandidate.LocatorSignal.STABLE_ATTRIBUTE,
-                                LocatorCandidate.LocatorSignal.USER_PROVIDED),
-                        stableXpath)),
-                true,
-                true,
-                false);
-        return new CaptureSession(
-                CaptureSession.CURRENT_SCHEMA_VERSION,
-                "selected-test-id-replay",
-                CaptureSession.SessionStatus.COMPLETED,
-                CaptureFixtures.STARTED,
-                CaptureFixtures.STARTED.plusSeconds(5),
-                CaptureFixtures.browser(),
-                List.of(
-                        new CaptureEvent.NavigationEvent(
-                                CaptureFixtures.context(1), CaptureEvent.NavigationAction.OPEN, url),
-                        new CaptureEvent.VerificationEvent(
-                                CaptureFixtures.context(2), CaptureEvent.VerificationKind.TEXT_CONTAINS,
-                                resultTitle, expected, false)),
-                List.of(),
-                List.of(expected),
-                RedactionSummary.empty(),
-                Map.of());
     }
 
     private CaptureSession session(String url) {
@@ -298,11 +193,4 @@ class CaptureGeneratedReplayBrowserTest {
                 JSON.writerWithDefaultPrettyPrinter().writeValueAsString(root), StandardCharsets.UTF_8);
     }
 
-    private void writeExpected(String id, String value) throws Exception {
-        ObjectNode root = JSON.createObjectNode();
-        root.put("schemaVersion", "1.0");
-        root.putObject("values").put(id, value);
-        Files.writeString(temp.resolve("capture-data.json"),
-                JSON.writerWithDefaultPrettyPrinter().writeValueAsString(root), StandardCharsets.UTF_8);
-    }
 }

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratedReplayBrowserTest.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -84,6 +85,110 @@ class CaptureGeneratedReplayBrowserTest {
         } finally {
             server.stop(0);
         }
+    }
+
+    @Test
+    void selectedTestIdReplaysAcrossEquivalentResultTitleMarkup() throws Exception {
+        AtomicReference<String> resultMarkup = new AtomicReference<>(
+                "<h2><a data-testid=\"result-title-a\" href=\"/detail\">ShaftHQ result</a></h2>");
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/results", exchange -> {
+            byte[] response = ("<!doctype html><html><body><article>"
+                    + resultMarkup.get() + "</article></body></html>").getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "text/html; charset=utf-8");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+        try {
+            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/results";
+            Path sessionPath = temp.resolve("selected-test-id-capture.json");
+            new CaptureJsonCodec().write(sessionPath, selectedTestIdSession(url));
+            writeExpected("data.expected-title", "ShaftHQ");
+
+            CaptureGenerationResult linkResult = new CaptureGenerator().generate(replayRequest(
+                    sessionPath, temp.resolve("selected-test-id-link"), "SelectedTestIdLinkReplayTest"));
+            assertTrue(linkResult.successful(), linkResult.report().replay().diagnostics().toString());
+
+            resultMarkup.set(
+                    "<h2><span data-testid=\"result-title-a\">ShaftHQ result</span></h2>");
+            CaptureGenerationResult spanResult = new CaptureGenerator().generate(replayRequest(
+                    sessionPath, temp.resolve("selected-test-id-span"), "SelectedTestIdSpanReplayTest"));
+
+            assertTrue(spanResult.successful(), spanResult.report().replay().diagnostics().toString());
+            assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                    linkResult.report().replay().status());
+            assertEquals(CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                    spanResult.report().replay().status());
+            String linkSource = Files.readString(linkResult.sourcePath());
+            String spanSource = Files.readString(spanResult.sourcePath());
+            assertTrue(linkSource.contains("By.xpath(\"//*[@data-testid=\\\"result-title-a\\\"]\")"),
+                    linkSource);
+            assertTrue(spanSource.contains("By.xpath(\"//*[@data-testid=\\\"result-title-a\\\"]\")"),
+                    spanSource);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private CaptureGenerationRequest replayRequest(Path sessionPath, Path output, String className) {
+        return new CaptureGenerationRequest(
+                sessionPath,
+                output,
+                "generated.capture",
+                className,
+                false,
+                true,
+                true,
+                Duration.ofMinutes(2),
+                CaptureGenerationRequest.EnrichmentMode.NONE,
+                null,
+                false,
+                ApprovalPolicy.denyAll());
+    }
+
+    private CaptureSession selectedTestIdSession(String url) {
+        ExternalTestDataReference expected = reference("data.expected-title", "expected-title");
+        String stableXpath = "//*[@data-testid=\"result-title-a\"]";
+        ElementSnapshot resultTitle = new ElementSnapshot(
+                "result-title",
+                "a",
+                "link",
+                "ShaftHQ result",
+                "ShaftHQ result",
+                Map.of("data-testid", "result-title-a"),
+                List.of(new LocatorCandidate(
+                        LocatorCandidate.LocatorStrategy.TEST_ID,
+                        "[data-testid=\"result-title-a\"]",
+                        1,
+                        true,
+                        true,
+                        Set.of(
+                                LocatorCandidate.LocatorSignal.TEST_ATTRIBUTE,
+                                LocatorCandidate.LocatorSignal.STABLE_ATTRIBUTE,
+                                LocatorCandidate.LocatorSignal.USER_PROVIDED),
+                        stableXpath)),
+                true,
+                true,
+                false);
+        return new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "selected-test-id-replay",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(5),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(
+                                CaptureFixtures.context(1), CaptureEvent.NavigationAction.OPEN, url),
+                        new CaptureEvent.VerificationEvent(
+                                CaptureFixtures.context(2), CaptureEvent.VerificationKind.TEXT_CONTAINS,
+                                resultTitle, expected, false)),
+                List.of(),
+                List.of(expected),
+                RedactionSummary.empty(),
+                Map.of());
     }
 
     private CaptureSession session(String url) {
@@ -189,6 +294,14 @@ class CaptureGeneratedReplayBrowserTest {
         ObjectNode values = root.putObject("values");
         values.put("data.username", "Alice");
         values.put("data.expected-message", "Alice");
+        Files.writeString(temp.resolve("capture-data.json"),
+                JSON.writerWithDefaultPrettyPrinter().writeValueAsString(root), StandardCharsets.UTF_8);
+    }
+
+    private void writeExpected(String id, String value) throws Exception {
+        ObjectNode root = JSON.createObjectNode();
+        root.put("schemaVersion", "1.0");
+        root.putObject("values").put(id, value);
         Files.writeString(temp.resolve("capture-data.json"),
                 JSON.writerWithDefaultPrettyPrinter().writeValueAsString(root), StandardCharsets.UTF_8);
     }

--- a/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/generate/CaptureGeneratorTest.java
@@ -1305,6 +1305,63 @@ class CaptureGeneratorTest {
                         + "rung-2 evidence is present: " + source);
     }
 
+    @Test
+    void selectedStableTestIdOutranksVolatileExactTextFallback() throws Exception {
+        ExternalTestDataReference expected = CaptureFixtures.ordinary();
+        String volatileXpath = "//a[normalize-space(.)=\"ShaftHQ / SHAFT_ENGINE — volatile rendering A\"]";
+        String stableXpath = "//*[@data-testid=\"result-title-a\"]";
+        ElementSnapshot resultTitle = new ElementSnapshot(
+                "result-title",
+                "a",
+                "link",
+                "ShaftHQ / SHAFT_ENGINE — volatile rendering A",
+                "ShaftHQ / SHAFT_ENGINE — volatile rendering A",
+                Map.of("data-testid", "result-title-a"),
+                List.of(
+                        new LocatorCandidate(LocatorCandidate.LocatorStrategy.XPATH,
+                                volatileXpath, 1, true, true,
+                                java.util.Set.of(LocatorCandidate.LocatorSignal.ACCESSIBLE), volatileXpath),
+                        new LocatorCandidate(LocatorCandidate.LocatorStrategy.TEST_ID,
+                                "[data-testid=\"result-title-a\"]", 1, true, true,
+                                java.util.Set.of(
+                                        LocatorCandidate.LocatorSignal.TEST_ATTRIBUTE,
+                                        LocatorCandidate.LocatorSignal.STABLE_ATTRIBUTE,
+                                        LocatorCandidate.LocatorSignal.USER_PROVIDED),
+                                stableXpath)),
+                true,
+                true,
+                false);
+        CaptureSession capture = new CaptureSession(
+                CaptureSession.CURRENT_SCHEMA_VERSION,
+                "selected-test-id-session",
+                CaptureSession.SessionStatus.COMPLETED,
+                CaptureFixtures.STARTED,
+                CaptureFixtures.STARTED.plusSeconds(3),
+                CaptureFixtures.browser(),
+                List.of(
+                        new CaptureEvent.NavigationEvent(CaptureFixtures.context(1),
+                                CaptureEvent.NavigationAction.OPEN, "https://example.test/results"),
+                        new CaptureEvent.VerificationEvent(CaptureFixtures.context(2),
+                                CaptureEvent.VerificationKind.TEXT_CONTAINS,
+                                resultTitle, expected, false)),
+                List.of(),
+                List.of(expected),
+                com.shaft.capture.model.RedactionSummary.empty(),
+                Map.of());
+        Path session = session(capture);
+        writeCaptureData("ShaftHQ");
+
+        CaptureGenerationResult result = new CaptureGenerator()
+                .generate(request(session, temp.resolve("selected-test-id")));
+
+        assertGeneratedUnconfirmed(result);
+        String source = Files.readString(result.sourcePath());
+        assertTrue(source.contains("By.xpath(\"//*[@data-testid=\\\"result-title-a\\\"]\")"),
+                "the selected stable test ID must remain the generated assertion locator: " + source);
+        assertFalse(source.contains(volatileXpath),
+                "the selected stable test ID must not be replaced by volatile exact text: " + source);
+    }
+
     private static CaptureSession cssStrategyReplayXpathSession() {
         ElementSnapshot submitButton = new ElementSnapshot(
                 "submit-button",

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureEventPipelineTest.java
@@ -417,7 +417,9 @@ class CaptureEventPipelineTest {
                         "uniquenessCount", 1,
                         "visible", true,
                         "stable", true,
-                        "signals", List.of("GENERATED"))));
+                        "signals", List.of("GENERATED"),
+                        "replayXpath", "//*[@data-testid=\"submit\"]",
+                        "roleXpathVerified", true)));
 
         pipeline.accept(signal("locator_preference", START, target,
                 Map.of("logicalElementId", "submit", "strategy", "CSS", "expression", "form > button"), Map.of()));
@@ -430,6 +432,8 @@ class CaptureEventPipelineTest {
         LocatorCandidate preferred = click.target().locatorCandidates().getFirst();
         assertEquals(LocatorCandidate.LocatorStrategy.CSS, preferred.strategy());
         assertTrue(preferred.signals().contains(LocatorCandidate.LocatorSignal.USER_PROVIDED));
+        assertEquals("//*[@data-testid=\"submit\"]", preferred.replayXpath());
+        assertTrue(preferred.roleXpathVerified());
     }
 
     @Test

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureRuntimePortabilityTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureRuntimePortabilityTest.java
@@ -125,6 +125,16 @@ class CaptureRuntimePortabilityTest {
     }
 
     @Test
+    void normalizesCustomTestIdAttributeForHtmlXpathMatching() {
+        CaptureStartOptions options = new CaptureStartOptions(
+                "", "DATA-PW", "", "", "", "", "", false, false,
+                "", "", "", "", "", "", "", "", Duration.ZERO, "", null);
+
+        assertEquals("data-pw", options.testIdAttribute());
+        assertEquals("data-pw", options.testIdAttributes().getFirst());
+    }
+
+    @Test
     void nativeCaptureOptionsDoNotReportMetadataOnlyWarnings(@TempDir Path temp) {
         CaptureStartOptions options = new CaptureStartOptions(
                 "java",

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureRuntimePortabilityTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/CaptureRuntimePortabilityTest.java
@@ -115,6 +115,16 @@ class CaptureRuntimePortabilityTest {
     }
 
     @Test
+    void rejectsTestIdAttributeThatRequiresAnXpathNamespaceResolver() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> new CaptureStartOptions(
+                        "", "svg:test-id", "", "", "", "", "", false, false,
+                        "", "", "", "", "", "", "", "", Duration.ZERO, "", null));
+
+        assertTrue(exception.getMessage().contains("test id attribute"));
+    }
+
+    @Test
     void nativeCaptureOptionsDoNotReportMetadataOnlyWarnings(@TempDir Path temp) {
         CaptureStartOptions options = new CaptureStartOptions(
                 "java",

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -36,6 +36,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1588,7 +1589,13 @@ class ManagedCaptureRecorderBrowserTest {
                     + " and starts-with(normalize-space(),'TEST_ID')]]"
                     + "//button[normalize-space()='Use this locator']");
             waitFor(() -> elementPresent(driver, selectedTestId));
-            driver.findElement(selectedTestId).click();
+            WebElement selectedTestIdButton = driver.findElement(selectedTestId);
+            assertEquals(
+                    "By.xpath(\"//*[@data-testid=\\\"result-title-a\\\"]\")",
+                    selectedTestIdButton.findElement(By.xpath("./ancestor::li[1]"))
+                            .findElement(By.cssSelector(".locator-expression"))
+                            .getText());
+            selectedTestIdButton.click();
             waitFor(() -> elementPresent(driver, By.cssSelector(
                     "#shaft-capture-assertion-panel button[data-assertion-kind='TEXT_CONTAINS']")));
             driver.findElement(By.cssSelector(
@@ -1653,6 +1660,218 @@ class ManagedCaptureRecorderBrowserTest {
                         .noneMatch(candidate -> candidate.strategy() == LocatorCandidate.LocatorStrategy.TEST_ID)),
                 () -> assertTrue(clickTarget(session, "unconfigured-test-id").target().locatorCandidates().stream()
                         .noneMatch(candidate -> candidate.strategy() == LocatorCandidate.LocatorStrategy.TEST_ID)));
+    }
+
+    @Test
+    void selectedTestIdEvidenceIsRevalidatedWhenTheAssertionIsSaved(@TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve("stale-selected-test-id.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/selected-test-id",
+                CaptureBrowser.parse("chrome"),
+                output,
+                temp.resolve("stale-selected-test-id-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-assert")));
+
+            driver.findElement(By.id("shaft-capture-assert")).click();
+            waitFor(() -> elementPresent(driver, assertionChoice("Element")));
+            driver.findElement(assertionChoice("Element")).click();
+            driver.findElement(By.id("stale-result")).click();
+            By selectedTestId = By.xpath("//*[@id='shaft-capture-assertion-panel']"
+                    + "//li[.//span[contains(@class,'locator-meta')"
+                    + " and starts-with(normalize-space(),'TEST_ID')]]"
+                    + "//button[normalize-space()='Use this locator']");
+            waitFor(() -> elementPresent(driver, selectedTestId));
+            driver.findElement(selectedTestId).click();
+            waitFor(() -> elementPresent(driver, By.cssSelector(
+                    "#shaft-capture-assertion-panel button[data-assertion-kind='ELEMENT_PRESENT']")));
+
+            ((JavascriptExecutor) driver).executeScript("""
+                    const duplicate = document.createElement('span');
+                    duplicate.id = 'stale-result-duplicate';
+                    duplicate.setAttribute('data-testid', 'stale-result-a');
+                    duplicate.textContent = 'Inserted after locator selection';
+                    document.body.appendChild(duplicate);
+                    """);
+            driver.findElement(By.cssSelector(
+                    "#shaft-capture-assertion-panel button[data-assertion-kind='ELEMENT_PRESENT']")).click();
+            waitFor(() -> elementPresent(driver, By.cssSelector(
+                    "#shaft-capture-assertion-panel select[name='expectedBoolean']")));
+            driver.findElement(By.xpath(
+                    "//*[@id='shaft-capture-assertion-panel']//button[normalize-space()='Save assertion']"))
+                    .click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.startsWith("Assert element exists")));
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+
+        CaptureEvent.VerificationEvent verification = new CaptureJsonCodec().read(output).events().stream()
+                .filter(CaptureEvent.VerificationEvent.class::isInstance)
+                .map(CaptureEvent.VerificationEvent.class::cast)
+                .filter(event -> event.verification() == CaptureEvent.VerificationKind.ELEMENT_PRESENT)
+                .findFirst()
+                .orElseThrow();
+        LocatorCandidate selected = verification.target().locatorCandidates().stream()
+                .filter(candidate -> candidate.strategy() == LocatorCandidate.LocatorStrategy.TEST_ID)
+                .filter(candidate -> candidate.signals().contains(LocatorCandidate.LocatorSignal.USER_PROVIDED))
+                .findFirst()
+                .orElseThrow();
+        assertAll(
+                () -> assertEquals(2, selected.uniquenessCount()),
+                () -> assertTrue(selected.replayXpath().isBlank()));
+    }
+
+    @Test
+    void recordedSelectedTestIdGeneratesAndReplaysAcrossEquivalentMarkup(@TempDir Path temp) throws Exception {
+        AtomicReference<String> resultMarkup = new AtomicReference<>(
+                "<h2><a data-testid=\"result-title-a\" href=\"/detail\">"
+                        + "ShaftHQ result</a></h2>"
+                        + "<a href=\"/other\">ShaftHQ result</a>");
+        HttpServer server = localFixture(resultMarkup);
+        Path output = temp.resolve("recorded-selected-test-id.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/selected-test-id",
+                CaptureBrowser.parse("chrome"),
+                output,
+                temp.resolve("recorded-selected-test-id-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-assert")));
+            driver.findElement(By.id("shaft-capture-assert")).click();
+            waitFor(() -> elementPresent(driver, assertionChoice("Element")));
+            driver.findElement(assertionChoice("Element")).click();
+            driver.findElement(By.cssSelector("[data-testid='result-title-a']")).click();
+            By selectedTestId = By.xpath("//*[@id='shaft-capture-assertion-panel']"
+                    + "//li[.//span[contains(@class,'locator-meta')"
+                    + " and starts-with(normalize-space(),'TEST_ID')]]"
+                    + "//button[normalize-space()='Use this locator']");
+            waitFor(() -> elementPresent(driver, selectedTestId));
+            driver.findElement(selectedTestId).click();
+            waitFor(() -> elementPresent(driver, By.cssSelector(
+                    "#shaft-capture-assertion-panel button[data-assertion-kind='TEXT_CONTAINS']")));
+            driver.findElement(By.cssSelector(
+                    "#shaft-capture-assertion-panel button[data-assertion-kind='TEXT_CONTAINS']")).click();
+            waitFor(() -> elementPresent(driver, By.cssSelector(
+                    "#shaft-capture-assertion-panel input[name='expected']")));
+            WebElement expected = driver.findElement(By.cssSelector(
+                    "#shaft-capture-assertion-panel input[name='expected']"));
+            expected.clear();
+            expected.sendKeys("ShaftHQ");
+            driver.findElement(By.xpath(
+                    "//*[@id='shaft-capture-assertion-panel']//button[normalize-space()='Save assertion']"))
+                    .click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.startsWith("Assert text contains")));
+            recorder.stop(false);
+
+            com.shaft.capture.generate.CaptureGenerationResult linkResult =
+                    new com.shaft.capture.generate.CaptureGenerator().generate(
+                            selectedTestIdReplayRequest(
+                                    output,
+                                    temp.resolve("recorded-selected-test-id-link"),
+                                    "RecordedSelectedTestIdLinkReplayTest"));
+            resultMarkup.set(
+                    "<h2><span data-testid=\"result-title-a\">"
+                            + "ShaftHQ result</span></h2>"
+                            + "<a href=\"/other\">ShaftHQ result</a>");
+            com.shaft.capture.generate.CaptureGenerationResult spanResult =
+                    new com.shaft.capture.generate.CaptureGenerator().generate(
+                            selectedTestIdReplayRequest(
+                                    output,
+                                    temp.resolve("recorded-selected-test-id-span"),
+                                    "RecordedSelectedTestIdSpanReplayTest"));
+
+            assertAll(
+                    () -> assertTrue(linkResult.successful(),
+                            linkResult.report().replay().diagnostics().toString()),
+                    () -> assertTrue(spanResult.successful(),
+                            spanResult.report().replay().diagnostics().toString()),
+                    () -> assertEquals(
+                            com.shaft.capture.generate.CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                            linkResult.report().replay().status()),
+                    () -> assertEquals(
+                            com.shaft.capture.generate.CaptureGenerationReport.Validation.ValidationStatus.PASSED,
+                            spanResult.report().replay().status()),
+                    () -> assertTrue(Files.readString(linkResult.sourcePath())
+                                    .contains("By.xpath(\"//*[@data-testid=\\\"result-title-a\\\"]\")"),
+                            Files.readString(linkResult.sourcePath())),
+                    () -> assertTrue(Files.readString(spanResult.sourcePath())
+                                    .contains("By.xpath(\"//*[@data-testid=\\\"result-title-a\\\"]\")"),
+                            Files.readString(spanResult.sourcePath())));
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void configuredCustomTestIdAttributeCarriesVerifiedReplayXpath(@TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve("custom-test-id.json");
+        CaptureStartOptions options = new CaptureStartOptions(
+                "", "data-pw", "", "", "", "", "", false, false,
+                "", "", "", "", "", "", "", "", Duration.ZERO, "", null);
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/selected-test-id",
+                CaptureBrowser.CHROME,
+                output,
+                temp.resolve("custom-test-id-runtime"),
+                true,
+                options));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            driver.findElement(By.id("unconfigured-test-id")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.contains("Unconfigured test id")));
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+
+        LocatorCandidate custom = locatorCandidateFor(
+                new CaptureJsonCodec().read(output),
+                "unconfigured-test-id",
+                LocatorCandidate.LocatorStrategy.TEST_ID);
+        assertAll(
+                () -> assertEquals("[data-pw=\"unconfigured-result\"]", custom.expression()),
+                () -> assertEquals(1, custom.uniquenessCount()),
+                () -> assertEquals("//*[@data-pw=\"unconfigured-result\"]", custom.replayXpath()));
+    }
+
+    private static com.shaft.capture.generate.CaptureGenerationRequest selectedTestIdReplayRequest(
+            Path sessionPath,
+            Path output,
+            String className) {
+        return new com.shaft.capture.generate.CaptureGenerationRequest(
+                sessionPath,
+                output,
+                "generated.capture",
+                className,
+                false,
+                true,
+                true,
+                Duration.ofMinutes(2),
+                com.shaft.capture.generate.CaptureGenerationRequest.EnrichmentMode.NONE,
+                null,
+                false,
+                com.shaft.pilot.ai.ApprovalPolicy.denyAll());
     }
 
     private static CaptureEvent.ClickEvent clickTarget(CaptureSession session, String logicalElementId) {
@@ -1841,6 +2060,10 @@ class ManagedCaptureRecorderBrowserTest {
     }
 
     private static HttpServer localFixture() throws IOException {
+        return localFixture(null);
+    }
+
+    private static HttpServer localFixture(AtomicReference<String> selectedTestIdMarkup) throws IOException {
         HttpServer server = HttpServer.create(
                 new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0), 0);
         server.createContext("/", exchange -> respond(exchange, """
@@ -2053,7 +2276,8 @@ class ManagedCaptureRecorderBrowserTest {
                 </body>
                 </html>
                 """));
-        server.createContext("/selected-test-id", exchange -> respond(exchange, """
+        server.createContext("/selected-test-id", exchange -> respond(exchange,
+                selectedTestIdMarkup == null ? """
                 <!doctype html>
                 <html>
                 <head><title>Selected Test ID Fixture</title></head>
@@ -2066,9 +2290,16 @@ class ManagedCaptureRecorderBrowserTest {
                   <button id="dynamic-test-id" data-testid="result-12345678">Dynamic test id</button>
                   <button id="missing-test-id">Missing test id</button>
                   <button id="unconfigured-test-id" data-pw="unconfigured-result">Unconfigured test id</button>
+                  <a id="stale-result" data-testid="stale-result-a" href="/stale">Stale result</a>
                 </body>
                 </html>
-                """));
+                """ : """
+                <!doctype html>
+                <html>
+                <head><title>Selected Test ID Fixture</title></head>
+                <body><article>%s</article></body>
+                </html>
+                """.formatted(selectedTestIdMarkup.get())));
         server.start();
         return server;
     }

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -1855,6 +1855,51 @@ class ManagedCaptureRecorderBrowserTest {
                 () -> assertEquals("//*[@data-pw=\"unconfigured-result\"]", custom.replayXpath()));
     }
 
+    @Test
+    void selectedTestIdPreviewEscapesJavaControlCharacters(@TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/selected-test-id",
+                CaptureBrowser.CHROME,
+                temp.resolve("control-character-test-id.json"),
+                temp.resolve("control-character-test-id-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-assert")));
+            WebElement target = driver.findElement(By.id("stale-result"));
+            ((JavascriptExecutor) driver).executeScript(
+                    "arguments[0].setAttribute('data-testid', arguments[1]);",
+                    target,
+                    "line\r\n\t\"quoted");
+
+            driver.findElement(By.id("shaft-capture-assert")).click();
+            waitFor(() -> elementPresent(driver, assertionChoice("Element")));
+            driver.findElement(assertionChoice("Element")).click();
+            target.click();
+            By selectedTestId = By.xpath("//*[@id='shaft-capture-assertion-panel']"
+                    + "//li[.//span[contains(@class,'locator-meta')"
+                    + " and starts-with(normalize-space(),'TEST_ID')]]"
+                    + "//button[normalize-space()='Use this locator']");
+            waitFor(() -> elementPresent(driver, selectedTestId));
+            WebElement selectedTestIdButton = driver.findElement(selectedTestId);
+            WebElement preview = selectedTestIdButton.findElement(By.xpath("./ancestor::li[1]"))
+                    .findElement(By.cssSelector(".locator-expression"));
+
+            assertEquals(
+                    "By.xpath(\"//*[@data-testid='line\\r\\n\\t\\\"quoted']\")",
+                    ((JavascriptExecutor) driver).executeScript(
+                            "return arguments[0].textContent;",
+                            preview));
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+    }
+
     private static com.shaft.capture.generate.CaptureGenerationRequest selectedTestIdReplayRequest(
             Path sessionPath,
             Path output,

--- a/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/runtime/ManagedCaptureRecorderBrowserTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1557,6 +1558,103 @@ class ManagedCaptureRecorderBrowserTest {
         }
     }
 
+    /**
+     * Issue #4717: choosing a stable TEST_ID for an element assertion must carry enough verified
+     * evidence for code generation to preserve that choice. The selected result title deliberately
+     * has volatile visible text, while duplicate and dynamic test IDs prove the recorder fails
+     * closed instead of manufacturing rung-2 evidence.
+     */
+    @Test
+    void selectedStableTestIdCarriesSelfVerifiedRelativeXpath(@TempDir Path temp) throws Exception {
+        HttpServer server = localFixture();
+        Path output = temp.resolve("selected-test-id.json");
+        ManagedCaptureRecorder recorder = new ManagedCaptureRecorder(new CaptureStartRequest(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/selected-test-id",
+                CaptureBrowser.parse("chrome"),
+                output,
+                temp.resolve("selected-test-id-runtime"),
+                true));
+        try {
+            recorder.start();
+            WebDriver driver = recorder.driverForTesting();
+            waitFor(() -> elementPresent(driver, By.id("shaft-capture-assert")));
+
+            driver.findElement(By.id("shaft-capture-assert")).click();
+            waitFor(() -> elementPresent(driver, assertionChoice("Element")));
+            driver.findElement(assertionChoice("Element")).click();
+            driver.findElement(By.id("result-title")).click();
+            By selectedTestId = By.xpath("//*[@id='shaft-capture-assertion-panel']"
+                    + "//li[.//span[contains(@class,'locator-meta')"
+                    + " and starts-with(normalize-space(),'TEST_ID')]]"
+                    + "//button[normalize-space()='Use this locator']");
+            waitFor(() -> elementPresent(driver, selectedTestId));
+            driver.findElement(selectedTestId).click();
+            waitFor(() -> elementPresent(driver, By.cssSelector(
+                    "#shaft-capture-assertion-panel button[data-assertion-kind='TEXT_CONTAINS']")));
+            driver.findElement(By.cssSelector(
+                    "#shaft-capture-assertion-panel button[data-assertion-kind='TEXT_CONTAINS']")).click();
+            waitFor(() -> elementPresent(driver, By.cssSelector(
+                    "#shaft-capture-assertion-panel input[name='expected']")));
+            WebElement expected = driver.findElement(By.cssSelector(
+                    "#shaft-capture-assertion-panel input[name='expected']"));
+            expected.clear();
+            expected.sendKeys("ShaftHQ");
+            driver.findElement(By.xpath(
+                    "//*[@id='shaft-capture-assertion-panel']//button[normalize-space()='Save assertion']"))
+                    .click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.startsWith("Assert text contains")));
+
+            driver.findElement(By.id("duplicate-a")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.contains("Duplicate A")));
+            driver.findElement(By.id("dynamic-test-id")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.contains("Dynamic test id")));
+            driver.findElement(By.id("missing-test-id")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.contains("Missing test id")));
+            driver.findElement(By.id("unconfigured-test-id")).click();
+            waitFor(() -> stepDescriptions(recorder).stream()
+                    .anyMatch(description -> description.contains("Unconfigured test id")));
+            recorder.stop(false);
+        } finally {
+            if (recorder.status().state() == CaptureStatus.State.ACTIVE) {
+                recorder.interrupt();
+            }
+            server.stop(0);
+        }
+
+        CaptureSession session = new CaptureJsonCodec().read(output);
+        CaptureEvent.VerificationEvent verification = session.events().stream()
+                .filter(CaptureEvent.VerificationEvent.class::isInstance)
+                .map(CaptureEvent.VerificationEvent.class::cast)
+                .filter(event -> event.verification() == CaptureEvent.VerificationKind.TEXT_CONTAINS)
+                .findFirst()
+                .orElseThrow();
+        LocatorCandidate selected = verification.target().locatorCandidates().stream()
+                .filter(candidate -> candidate.strategy() == LocatorCandidate.LocatorStrategy.TEST_ID)
+                .findFirst()
+                .orElseThrow();
+        assertAll(
+                () -> assertTrue(selected.signals().contains(LocatorCandidate.LocatorSignal.USER_PROVIDED)),
+                () -> assertEquals("//*[@data-testid=\"result-title-a\"]", selected.replayXpath()));
+
+        LocatorCandidate duplicate = locatorCandidateFor(
+                session, "duplicate-result", LocatorCandidate.LocatorStrategy.TEST_ID);
+        LocatorCandidate dynamic = locatorCandidateFor(
+                session, "result-12345678", LocatorCandidate.LocatorStrategy.TEST_ID);
+        assertAll(
+                () -> assertEquals(2, duplicate.uniquenessCount()),
+                () -> assertTrue(duplicate.replayXpath().isBlank()),
+                () -> assertFalse(dynamic.stable()),
+                () -> assertTrue(dynamic.replayXpath().isBlank()),
+                () -> assertTrue(clickTarget(session, "missing-test-id").target().locatorCandidates().stream()
+                        .noneMatch(candidate -> candidate.strategy() == LocatorCandidate.LocatorStrategy.TEST_ID)),
+                () -> assertTrue(clickTarget(session, "unconfigured-test-id").target().locatorCandidates().stream()
+                        .noneMatch(candidate -> candidate.strategy() == LocatorCandidate.LocatorStrategy.TEST_ID)));
+    }
+
     private static CaptureEvent.ClickEvent clickTarget(CaptureSession session, String logicalElementId) {
         return session.events().stream()
                 .filter(CaptureEvent.ClickEvent.class::isInstance)
@@ -1952,6 +2050,22 @@ class ManagedCaptureRecorderBrowserTest {
                   <label for="labeled-input">Username</label>
                   <input id="labeled-input" type="text" aria-label="Enter your username">
                   <span id="roleless-text" onclick="void 0">Click me plain span</span>
+                </body>
+                </html>
+                """));
+        server.createContext("/selected-test-id", exchange -> respond(exchange, """
+                <!doctype html>
+                <html>
+                <head><title>Selected Test ID Fixture</title></head>
+                <body>
+                  <article><h2><a id="result-title" data-testid="result-title-a" href="/detail">
+                    ShaftHQ / SHAFT_ENGINE — volatile rendering A
+                  </a></h2></article>
+                  <button id="duplicate-a" data-testid="duplicate-result">Duplicate A</button>
+                  <button id="duplicate-b" data-testid="duplicate-result">Duplicate B</button>
+                  <button id="dynamic-test-id" data-testid="result-12345678">Dynamic test id</button>
+                  <button id="missing-test-id">Missing test id</button>
+                  <button id="unconfigured-test-id" data-pw="unconfigured-result">Unconfigured test id</button>
                 </body>
                 </html>
                 """));

--- a/shaft-intellij/build.gradle.kts
+++ b/shaft-intellij/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 plugins {
     java
     jacoco
-    id("org.jetbrains.intellij.platform") version "2.17.0"
+    id("org.jetbrains.intellij.platform") version "2.18.1"
 }
 
 group = providers.gradleProperty("pluginGroup").get()

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -3732,18 +3732,24 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
         if (family.equals(modelListFamily) || (modelListRefreshing && family.equals(modelListRefreshingFamily))) {
             return;
         }
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("client", AssistantCommand.Selection.local(family, "CLI").client());
+        CompletableFuture<AssistantLocalAgentRunner.ModelDiscovery> discovery = CompletableFuture.supplyAsync(
+                () -> AssistantLocalAgentRunner.discoverModels(arguments),
+                ShaftPluginExecutor.getInstance().executor());
+        startLocalModelDiscovery(family, discovery);
+    }
+
+    void startLocalModelDiscovery(
+            String family, CompletableFuture<AssistantLocalAgentRunner.ModelDiscovery> discovery) {
         modelListRefreshing = true;
         modelListRefreshingFamily = family;
         setLocalModelStatus("Checking model catalog…");
         long requestGeneration = ++modelListRequestGeneration;
-        JsonObject arguments = new JsonObject();
-        arguments.addProperty("client", AssistantCommand.Selection.local(family, "CLI").client());
-        CompletableFuture.supplyAsync(() -> AssistantLocalAgentRunner.discoverModels(arguments),
-                        ShaftPluginExecutor.getInstance().executor())
-                .whenComplete((models, error) -> runOnEdt(
-                        () -> applyLocalModels(family, error == null ? models
-                                : new AssistantLocalAgentRunner.ModelDiscovery(List.of(),
-                                        AssistantLocalAgentRunner.ModelDiscoveryState.FAILED), requestGeneration)));
+        discovery.whenComplete((models, error) -> runOnEdt(
+                () -> applyLocalModels(family, error == null ? models
+                        : new AssistantLocalAgentRunner.ModelDiscovery(List.of(),
+                                AssistantLocalAgentRunner.ModelDiscoveryState.FAILED), requestGeneration)));
     }
 
     private void applyLocalModels(String family, List<String> models) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2308,6 +2308,34 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void modelDiscoveryCheckingStateIsVisibleAndAccessibleUntilCompletion() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        JLabel status = findByAccessibleName(panel, "Local model discovery status", JLabel.class);
+        CompletableFuture<AssistantLocalAgentRunner.ModelDiscovery> discovery = new CompletableFuture<>();
+
+        panel.startLocalModelDiscovery("CODEX", discovery);
+
+        assertAll(
+                () -> assertFalse(discovery.isDone()),
+                () -> assertEquals("Checking model catalog…", status.getText()),
+                () -> assertEquals("Checking model catalog…",
+                        status.getAccessibleContext().getAccessibleDescription()),
+                () -> assertTrue((Boolean) getField(panel, "modelListRefreshing")),
+                () -> assertEquals("CODEX", getField(panel, "modelListRefreshingFamily")));
+
+        discovery.complete(new AssistantLocalAgentRunner.ModelDiscovery(
+                List.of("gpt-5.6-sol"), AssistantLocalAgentRunner.ModelDiscoveryState.AVAILABLE));
+        pumpEdt();
+
+        assertAll(
+                () -> assertEquals("Ready · 1 models + CLI default", status.getText()),
+                () -> assertEquals(status.getText(),
+                        status.getAccessibleContext().getAccessibleDescription()),
+                () -> assertFalse((Boolean) getField(panel, "modelListRefreshing")),
+                () -> assertEquals("", getField(panel, "modelListRefreshingFamily")));
+    }
+
+    @Test
     void assistantModelFailureStatusesRemainAccessibleAndFitNarrowSettings() throws Exception {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         JLabel status = findByAccessibleName(panel, "Local model discovery status", JLabel.class);

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -203,7 +203,7 @@ class InstallShaftMcpTest(unittest.TestCase):
                 "import scripts.agents.guard; "
                 "import scripts.ci.validate_agent_setup"
             )
-            completed = subprocess.run(
+            completed = subprocess.run(  # nosec B603 - fixed interpreter and generated local import script.
                 [sys.executable, "-I", "-S", "-c", command],
                 cwd=target,
                 capture_output=True,

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -204,7 +204,7 @@ class InstallShaftMcpTest(unittest.TestCase):
                 "import scripts.ci.validate_agent_setup"
             )
             completed = subprocess.run(
-                [sys.executable, "-I", "-c", command],
+                [sys.executable, "-I", "-S", "-c", command],
                 cwd=target,
                 capture_output=True,
                 text=True,

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -1,3 +1,4 @@
+import ast
 import importlib.util
 import contextlib
 import hashlib
@@ -6,6 +7,7 @@ import json
 import os
 import re
 import subprocess  # nosec B404 -- Windows junction test uses resolved System32 cmd.exe only.
+import sys
 import tempfile
 import unittest
 import zipfile
@@ -169,24 +171,89 @@ class InstallShaftMcpTest(unittest.TestCase):
         # module it imports at module scope must travel with it or the
         # installed validator dies on ImportError. Checked by reading the real
         # import statements rather than by listing them again here.
-        repository_root = Path(__file__).resolve().parents[2]
         shipped = set(MODULE.AGENT_VALIDATION_SCRIPT_FILES)
+        self.assertEqual(self.agent_validation_manifest_missing_imports(shipped), [])
+
+    def test_agent_validation_manifest_guard_detects_parenthesized_import_omission(self):
+        shipped = set(MODULE.AGENT_VALIDATION_SCRIPT_FILES)
+        shipped.remove("scripts/ci/worktree_hygiene.py")
+
+        self.assertIn(
+            "scripts/ci/validate_agent_setup.py imports scripts.ci.worktree_hygiene",
+            self.agent_validation_manifest_missing_imports(shipped),
+        )
+
+    def test_downloaded_agent_validation_bundle_imports_from_isolated_project(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir)
+            (target / "AGENTS.md").write_text("# Installed guidance\n", encoding="utf-8")
+
+            def install_repository_file(_url, destination, _label, **_kwargs):
+                relative = destination.relative_to(target)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_bytes((REPO_ROOT / relative).read_bytes())
+
+            with mock.patch.object(MODULE, "download_file", side_effect=install_repository_file):
+                MODULE.download_agent_validation_script_files(target)
+
+            self.assertTrue((target / "scripts" / "agents" / "learning_loop.py").is_file())
+            command = (
+                "import sys; "
+                f"sys.path.insert(0, {str(target)!r}); "
+                "import scripts.agents.guard; "
+                "import scripts.ci.validate_agent_setup"
+            )
+            completed = subprocess.run(
+                [sys.executable, "-I", "-c", command],
+                cwd=target,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(0, completed.returncode, completed.stderr)
+
+    @staticmethod
+    def agent_validation_manifest_missing_imports(shipped):
         missing = set()
+        repository_root = Path(__file__).resolve().parents[2]
+
+        def module_file(module):
+            relative = module.replace(".", "/") + ".py"
+            return relative if (repository_root / relative).is_file() else None
+
         for relative in sorted(shipped):
             if not relative.endswith(".py"):
                 continue
-            source = (repository_root / relative).read_text(encoding="utf-8")
-            for module, imported_name in re.findall(
-                    r"(?m)^from (scripts[\w.]*) import ([A-Za-z_]\w*)", source):
-                module_path = module.replace(".", "/")
-                candidates = (
-                    module_path + ".py",
-                    module_path + "/__init__.py",
-                    module_path + "/" + imported_name + ".py",
-                )
-                if not any(candidate in shipped for candidate in candidates):
-                    missing.add(f"{relative} imports {module}.{imported_name}")
-        self.assertEqual(sorted(missing), [])
+            tree = ast.parse((repository_root / relative).read_text(encoding="utf-8"), filename=relative)
+            for node in ast.walk(tree):
+                dependencies = []
+                if isinstance(node, ast.Import):
+                    dependencies.extend(
+                        dependency
+                        for alias in node.names
+                        if alias.name.startswith("scripts.")
+                        and (dependency := module_file(alias.name)) is not None
+                    )
+                elif (isinstance(node, ast.ImportFrom)
+                      and node.level == 0
+                      and node.module
+                      and node.module.startswith("scripts.")):
+                    direct = module_file(node.module)
+                    if direct is not None:
+                        dependencies.append(direct)
+                    else:
+                        dependencies.extend(
+                            dependency
+                            for alias in node.names
+                            if alias.name != "*"
+                            and (dependency := module_file(
+                                node.module + "." + alias.name)) is not None
+                        )
+                for dependency in dependencies:
+                    if dependency not in shipped:
+                        missing.add(
+                            f"{relative} imports {dependency[:-3].replace('/', '.')}")
+        return sorted(missing)
 
     def test_render_client_menu_groups_ai_agents_and_advanced_sections(self):
         lines = MODULE.render_client_menu()

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -185,7 +185,7 @@ class InstallShaftMcpTest(unittest.TestCase):
 
     def test_downloaded_agent_validation_bundle_imports_from_isolated_project(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            target = Path(temp_dir)
+            target = Path(temp_dir).resolve()
             (target / "AGENTS.md").write_text("# Installed guidance\n", encoding="utf-8")
 
             def install_repository_file(_url, destination, _label, **_kwargs):

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -176,10 +176,16 @@ class InstallShaftMcpTest(unittest.TestCase):
             if not relative.endswith(".py"):
                 continue
             source = (repository_root / relative).read_text(encoding="utf-8")
-            for module in re.findall(r"(?m)^from (scripts[\w.]*) import", source):
-                required = module.replace(".", "/") + ".py"
-                if required not in shipped:
-                    missing.add(f"{relative} imports {module}")
+            for module, imported_name in re.findall(
+                    r"(?m)^from (scripts[\w.]*) import ([A-Za-z_]\w*)", source):
+                module_path = module.replace(".", "/")
+                candidates = (
+                    module_path + ".py",
+                    module_path + "/__init__.py",
+                    module_path + "/" + imported_name + ".py",
+                )
+                if not any(candidate in shipped for candidate in candidates):
+                    missing.add(f"{relative} imports {module}.{imported_name}")
         self.assertEqual(sorted(missing), [])
 
     def test_render_client_menu_groups_ai_agents_and_advanced_sections(self):


### PR DESCRIPTION
## Summary
- upgrade the IntelliJ Platform Gradle Plugin from 2.17.0 to 2.18.1
- keep the local-model discovery checking state visible and accessible until async discovery completes
- preserve user-selected stable test IDs as live-verified wildcard XPath evidence through recording, pinning, generation, and replay
- revalidate selected test IDs at selection/save so SPA DOM changes fail closed
- normalize and validate custom HTML test-ID attributes and make picker syntax match generated Java

## Verification
- `shaft-capture`: 383 tests across 48 suites, 0 failures/errors/skips; package produced main, sources, and javadoc JARs
- capture browser E2E: 5 tests, 0 failures/errors/skips, including exact recorder artifact -> generator -> replay across `<a>`/`<span>` markup
- IntelliJ focused regression: 1 test, 0 failures/errors/skips on JDK 21
- `buildPlugin verifyPlugin -x test`: compatible with IU-243.21565.193 and IU-262.8665.81
- independent final review of exact rebased HEAD: no findings

## Known CI gap
The complete IntelliJ test task on this Windows host still has 35 MCP subprocess failures from `CreateProcess error=206` (command line too long); tracked separately in #4755. The affected test and plugin verifier are green.

Related program tracker: #4752

Closes #4686
Closes #4678
Closes #4717