### PR TITLE
fix(intellij): complete Password Safe agent connection

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -1236,7 +1236,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
             String cloudVariable = useGeminiEnvironment.isSelected()
                     ? settings.providerApiKeyEnvironmentVariable("gemini") : "";
             if (cloudVariable.isBlank()) {
-                applyChosenAgentCheckResult(verifySelectedAgentReadiness(cloudCredentialReadiness("")));
+                applyConnectAgentResult(verifySelectedAgentReadiness(cloudCredentialReadiness("")));
                 return;
             }
             CompletableFuture.supplyAsync(() -> cloudCredentialReadiness(cloudVariable),

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2261,6 +2261,9 @@ class ShaftPanelSetupTest {
         ((JCheckBox) getField(panel, "useGeminiEnvironment")).setSelected(false);
         showTestResult(panel, ShaftMcpToolResult.success("Probe OK"));
         JButton connectAgent = findByAccessibleName(panel, "Connect SHAFT agent", JButton.class);
+        settings.agentLaneReady = false;
+        invokeApplyConnectAgentResult(panel, ShaftMcpToolResult.failure("retry required"));
+        assertTrue(connectAgent.isVisible());
 
         connectAgent.doClick();
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -2246,6 +2246,32 @@ class ShaftPanelSetupTest {
     }
 
     @Test
+    void connectAgentWithPasswordSafeGeminiKeyTransitionsTheReadyStep() throws Exception {
+        java.util.Map<String, String> storedKeys = new java.util.HashMap<>();
+        storedKeys.put("GEMINI_API_KEY", "stored-secret");
+        ShaftSettingsState.Settings settings = connectedMcpSettings();
+        settings.assistantProviderType = "CLOUD";
+        settings.cloudProvider = "gemini";
+        ShaftMcpSetupPanel panel = new ShaftMcpSetupPanel(fakeProject(), settings, () -> {
+        }, readyProbe(), fakeKeyStore(storedKeys));
+        setField(panel, "providerEnvironmentLookup",
+                (java.util.function.Function<String, String>) ignored -> null);
+        JComboBox<?> agent = findByAccessibleName(panel, "Assistant agent", JComboBox.class);
+        selectDisplayValue(agent, "Gemini in IntelliJ");
+        ((JCheckBox) getField(panel, "useGeminiEnvironment")).setSelected(false);
+        showTestResult(panel, ShaftMcpToolResult.success("Probe OK"));
+        JButton connectAgent = findByAccessibleName(panel, "Connect SHAFT agent", JButton.class);
+
+        connectAgent.doClick();
+
+        assertAll(
+                () -> assertTrue(settings.agentLaneReady),
+                () -> assertTrue(findByAccessibleName(panel, "Start chatting with SHAFT Assistant", JButton.class)
+                        .isVisible()),
+                () -> assertFalse(connectAgent.isVisible()));
+    }
+
+    @Test
     void setupPanelUsesConfiguredGeminiEnvironmentWithoutCopyingItsValue() throws Exception {
         java.util.Map<String, String> storedKeys = new java.util.HashMap<>();
         ShaftSettingsState.Settings settings = unverifiedMcpSettings();


### PR DESCRIPTION
Fixes the final independent-review finding that arrived as #4778 auto-merged: the Gemini Password Safe branch of **Connect agent** must use the Ready-step completion owner, not the standalone Choose-step completion owner.

Validation:
- focused `ShaftPanelSetupTest.connectAgentWithPasswordSafeGeminiKeyTransitionsTheReadyStep` passed under JDK 25 / Gradle 9.3

Related to #4771
Follow-up to #4778
