### PR TITLE
fix(harness): pass complete delivery context

### DIFF
--- a/scripts/agents/act_as_mohab_cli.py
+++ b/scripts/agents/act_as_mohab_cli.py
@@ -480,7 +480,10 @@ def main(argv: list[str] | None = None) -> int:
             manifest = json.loads(parsed.manifest.read_text(encoding="utf-8"))
             if not isinstance(manifest, dict):
                 raise ValueError("delivery manifest must be an object")
-            context = resolve_repository_context(explicit_root=parsed.root.resolve(), cwd=parsed.root.resolve())
+            context = resolve_repository_context(
+                explicit_repo=None, pr=None,
+                explicit_root=parsed.root.resolve(), cwd=parsed.root.resolve(),
+            )
             payload = evaluate_delivery(
                 manifest, collect_delivery(manifest, default_root=context.root), inspect_cleanup(manifest),
                 execution_repository=context.repo, execution_head=local_head(context),

--- a/tests/scripts/test_act_as_mohab_runtime.py
+++ b/tests/scripts/test_act_as_mohab_runtime.py
@@ -7,7 +7,9 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from unittest import mock
 
+from scripts.agents import act_as_mohab_cli
 from scripts.agents.act_as_mohab_cli import checkpoint_status
 from scripts.agents.repository_context import RepositoryContext, RepositoryContextError
 from scripts.ci.assemble_act_as_mohab_plugin import assemble
@@ -27,6 +29,35 @@ class ActAsMohabRuntimeTest(unittest.TestCase):
     def assemble_runtime(self) -> Path:
         assemble(ROOT, self.package_root)
         return self.package_root / "bin/act-as-mohab.pyz"
+
+    def test_delivery_status_passes_complete_repository_context_arguments(self):
+        manifest = self.base / "manifest.json"
+        receipt = self.base / "receipt.json"
+        manifest.write_text('{"ownedPullRequests": []}', encoding="utf-8")
+        context = RepositoryContext("consumer/project", self.base, None)
+        allowed = {"decision": "allow"}
+        with (
+            mock.patch.object(
+                act_as_mohab_cli, "resolve_repository_context", autospec=True,
+                return_value=context,
+            ) as resolve,
+            mock.patch.object(act_as_mohab_cli, "collect_delivery", return_value=[]),
+            mock.patch.object(act_as_mohab_cli, "inspect_cleanup", return_value={}),
+            mock.patch.object(act_as_mohab_cli, "evaluate_delivery", return_value=allowed),
+            mock.patch.object(act_as_mohab_cli, "local_head", return_value="abc"),
+        ):
+            try:
+                result = act_as_mohab_cli.main([
+                    "delivery-status", "--manifest", str(manifest),
+                    "--root", str(self.base), "--receipt-out", str(receipt),
+                ])
+            except TypeError as error:
+                self.fail(f"delivery-status omitted required context arguments: {error}")
+
+        self.assertEqual(0, result)
+        resolve.assert_called_once_with(
+            explicit_repo=None, pr=None, explicit_root=self.base.resolve(), cwd=self.base.resolve()
+        )
 
     def test_runtime_exposes_all_public_commands_from_canonical_modules(self):
         runtime = self.assemble_runtime()


### PR DESCRIPTION
## Summary

- passes the complete repository-context contract from `delivery-status`
- adds a load-bearing regression that fails by assertion on the merged parent
- restores the live post-merge delivery receipt flow discovered while completing #4777

## Verification

- RED: focused regression failed with missing `explicit_repo`
- GREEN: `tests.scripts.test_act_as_mohab_runtime` — 7/7 passed
- Python compileall passed using isolated D: temporary storage
- `git diff --check`
- independent correctness review: zero blockers

Closes #4784
