### PR TITLE
fix(mcp): bound persisted trace extraction

### DIFF
--- a/shaft-mcp/src/main/java/com/shaft/mcp/TraceService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/TraceService.java
@@ -83,6 +83,7 @@ public class TraceService {
         this.remediationService = remediationService;
     }
 
+
     /**
      * Lists recent persisted SHAFT trace indexes under {@code target/shaft-traces}.
      *
@@ -419,7 +420,7 @@ public class TraceService {
             while ((entry = zip.getNextEntry()) != null) {
                 if ("shaft-trace.json".equals(entry.getName())) {
                     try {
-                        String content = readBoundedUtf8(zip, entry, MAX_TRACE_JSON_BYTES);
+                        String content = readBoundedUtf8(zip, entry, MAX_TRACE_JSON_BYTES, archive.getParent());
                         zip.closeEntry();
                         return new TraceDocument(publicPath, content, JSON.readTree(content));
                     } catch (EntryTooLargeException exception) {
@@ -431,15 +432,20 @@ public class TraceService {
         throw new IllegalArgumentException("Trace archive does not contain shaft-trace.json.");
     }
 
-    private static String readBoundedUtf8(InputStream input, ZipEntry entry, int maxBytes) throws IOException {
+    private static String readBoundedUtf8(InputStream input, ZipEntry entry, int maxBytes, Path stagingDirectory)
+            throws IOException {
         if (entry.getSize() > maxBytes) {
             throw new EntryTooLargeException();
         }
-        byte[] bytes = input.readNBytes(maxBytes + 1);
-        if (bytes.length > maxBytes) {
-            throw new EntryTooLargeException();
+        Path staging = Files.createTempFile(stagingDirectory, ".shaft-trace-json-", ".tmp");
+        try {
+            try (OutputStream output = Files.newOutputStream(staging)) {
+                copyBounded(input, output, maxBytes);
+            }
+            return Files.readString(staging, StandardCharsets.UTF_8);
+        } finally {
+            Files.deleteIfExists(staging);
         }
-        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     private Path archivePath(Path indexPath, JsonNode index) {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/TraceService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/TraceService.java
@@ -25,9 +25,12 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -55,6 +58,8 @@ public class TraceService {
     private static final int DEFAULT_MAX_CHARACTERS = 20_000;
     private static final int MAX_CHARACTERS = 100_000;
     private static final int MAX_FINDINGS = 10;
+    private static final int MAX_TRACE_JSON_BYTES = 64 * 1024 * 1024;
+    private static final long MAX_VIEWER_BYTES = 64L * 1024 * 1024;
     private static final Pattern AUTHORIZATION_PATTERN = Pattern.compile("(?i)(authorization\\s*[:=]\\s*)(bearer\\s+)?[^\\s,;]+");
     private static final Pattern COOKIE_PATTERN = Pattern.compile("(?i)(cookie|set-cookie)(\\s*[:=]\\s*)[^\\n\\r]+");
     private static final Pattern URL_CREDENTIAL_PATTERN = Pattern.compile("(?i)(://[^:/\\s]+:)[^@/\\s]+(@)");
@@ -174,16 +179,61 @@ public class TraceService {
             ZipEntry entry;
             while ((entry = zip.getNextEntry()) != null) {
                 if ("SHAFT Trace Report.html".equals(entry.getName())) {
-                    Files.write(htmlPath, zip.readAllBytes());
-                    return new McpTraceViewerResult("1.0", relative(htmlPath), true, List.of());
+                    try {
+                        extractViewer(zip, entry, htmlPath);
+                        return new McpTraceViewerResult("1.0", relative(htmlPath), true, List.of());
+                    } catch (EntryTooLargeException exception) {
+                        return new McpTraceViewerResult("1.0", "", false,
+                                List.of("Trace viewer exceeds the 64 MiB extraction limit."));
+                    }
                 }
             }
         } catch (IOException exception) {
             return new McpTraceViewerResult("1.0", "", false,
-                    List.of("Trace ZIP could not be read: " + exception.getMessage()));
+                    List.of("Trace ZIP could not be read."));
         }
         return new McpTraceViewerResult("1.0", "", false,
                 List.of("Trace ZIP " + relative(archive) + " does not contain SHAFT Trace Report.html."));
+    }
+
+    private static void extractViewer(ZipInputStream zip, ZipEntry entry, Path htmlPath) throws IOException {
+        if (entry.getSize() > MAX_VIEWER_BYTES) {
+            throw new EntryTooLargeException();
+        }
+        Path staging = Files.createTempFile(htmlPath.getParent(), ".shaft-trace-viewer-", ".tmp");
+        try {
+            try (OutputStream output = Files.newOutputStream(staging)) {
+                copyBounded(zip, output, MAX_VIEWER_BYTES);
+            }
+            zip.closeEntry();
+            moveCompleteFile(staging, htmlPath);
+        } finally {
+            Files.deleteIfExists(staging);
+        }
+    }
+
+    private static void copyBounded(InputStream input, OutputStream output, long maxBytes) throws IOException {
+        byte[] buffer = new byte[16 * 1024];
+        long retained = 0;
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            if (retained > maxBytes - read) {
+                throw new EntryTooLargeException();
+            }
+            output.write(buffer, 0, read);
+            retained += read;
+        }
+    }
+
+    private static void moveCompleteFile(Path staging, Path target) throws IOException {
+        try {
+            Files.move(staging, target, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException exception) {
+            Files.move(staging, target);
+        }
+    }
+
+    private static final class EntryTooLargeException extends IOException {
     }
 
     /**
@@ -368,12 +418,28 @@ public class TraceService {
             ZipEntry entry;
             while ((entry = zip.getNextEntry()) != null) {
                 if ("shaft-trace.json".equals(entry.getName())) {
-                    String content = new String(zip.readAllBytes(), StandardCharsets.UTF_8);
-                    return new TraceDocument(publicPath, content, JSON.readTree(content));
+                    try {
+                        String content = readBoundedUtf8(zip, entry, MAX_TRACE_JSON_BYTES);
+                        zip.closeEntry();
+                        return new TraceDocument(publicPath, content, JSON.readTree(content));
+                    } catch (EntryTooLargeException exception) {
+                        throw new IllegalArgumentException("Trace JSON exceeds the 64 MiB read limit.");
+                    }
                 }
             }
         }
         throw new IllegalArgumentException("Trace archive does not contain shaft-trace.json.");
+    }
+
+    private static String readBoundedUtf8(InputStream input, ZipEntry entry, int maxBytes) throws IOException {
+        if (entry.getSize() > maxBytes) {
+            throw new EntryTooLargeException();
+        }
+        byte[] bytes = input.readNBytes(maxBytes + 1);
+        if (bytes.length > maxBytes) {
+            throw new EntryTooLargeException();
+        }
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     private Path archivePath(Path indexPath, JsonNode index) {

--- a/shaft-mcp/src/test/java/com/shaft/mcp/TraceServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/TraceServiceTest.java
@@ -18,6 +18,8 @@ import java.nio.file.Path;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -391,6 +393,86 @@ class TraceServiceTest {
                 () -> service(temp).traceRead(relative(temp, index), 1000));
 
         assertEquals("Trace JSON exceeds the 64 MiB read limit.", failure.getMessage());
+        try (var files = Files.list(directory)) {
+            assertFalse(files.anyMatch(path -> path.getFileName().toString().contains(".tmp")),
+                    "Rejected JSON must remove private staging files");
+        }
+    }
+
+    @Test
+    void exactViewerExtractionLimitRemainsInclusive(@TempDir Path temp) throws Exception {
+        Path directory = Files.createDirectories(temp.resolve("target/shaft-traces/exact-viewer"));
+        Path archive = directory.resolve("shaft-trace.zip");
+        writeZipWithRepeatedHtml(archive, MAX_VIEWER_BYTES);
+        Path index = writeIndex(temp, directory, archive, "exact-viewer");
+
+        var result = service(temp).traceOpenViewer(relative(temp, index));
+
+        assertTrue(result.extracted());
+        assertEquals(MAX_VIEWER_BYTES, Files.size(temp.resolve(result.viewerPath())));
+    }
+
+    @Test
+    void truncatedViewerArchiveNeverPublishesPartialCanonicalFile(@TempDir Path temp) throws Exception {
+        Path directory = Files.createDirectories(temp.resolve("target/shaft-traces/truncated-viewer"));
+        Path archive = directory.resolve("shaft-trace.zip");
+        writeZipWithRepeatedHtml(archive, 2L * 1024 * 1024);
+        byte[] complete = Files.readAllBytes(archive);
+        Files.write(archive, java.util.Arrays.copyOf(complete, complete.length - 256));
+        Path index = writeIndex(temp, directory, archive, "truncated-viewer");
+
+        var result = service(temp).traceOpenViewer(relative(temp, index));
+
+        assertTrue(result.viewerPath().isBlank());
+        assertEquals(List.of("Trace ZIP could not be read."), result.warnings());
+        assertFalse(Files.exists(directory.resolve("SHAFT Trace Report.html")));
+        try (var files = Files.list(directory)) {
+            assertFalse(files.anyMatch(path -> path.getFileName().toString().contains(".tmp")));
+        }
+    }
+
+    @Test
+    void exactTraceJsonReadLimitRemainsInclusive(@TempDir Path temp) throws Exception {
+        Path directory = Files.createDirectories(temp.resolve("target/shaft-traces/exact-json"));
+        Path archive = directory.resolve("shaft-trace.zip");
+        writeZipWithRepeatedJson(archive, MAX_TRACE_JSON_BYTES);
+        Path index = writeIndex(temp, directory, archive, "exact-json");
+
+        var summary = service(temp).traceSummarize(relative(temp, index));
+
+        assertTrue(summary.testClass().isBlank());
+    }
+
+    @Test
+    void concurrentViewerReaderNeverObservesPartialCanonicalBytes(@TempDir Path temp) throws Exception {
+        Path directory = Files.createDirectories(temp.resolve("target/shaft-traces/concurrent-viewer"));
+        Path archive = directory.resolve("shaft-trace.zip");
+        writeZipWithRepeatedHtml(archive, MAX_VIEWER_BYTES);
+        Path index = writeIndex(temp, directory, archive, "concurrent-viewer");
+        Path viewer = directory.resolve("SHAFT Trace Report.html");
+
+        CompletableFuture<TraceService.McpTraceViewerResult> extraction = CompletableFuture.supplyAsync(
+                () -> service(temp).traceOpenViewer(relative(temp, index)));
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        boolean observedStaging = false;
+        while (!extraction.isDone()) {
+            try (var files = Files.list(directory)) {
+                observedStaging |= files.anyMatch(path -> path.getFileName().toString()
+                        .startsWith(".shaft-trace-viewer-"));
+            }
+            if (Files.exists(viewer)) {
+                assertEquals(MAX_VIEWER_BYTES, Files.size(viewer),
+                        "Canonical viewer readers must see only the complete moved file");
+            }
+            if (System.nanoTime() > deadline) {
+                throw new AssertionError("Timed out waiting for viewer extraction");
+            }
+            Thread.onSpinWait();
+        }
+
+        assertTrue(observedStaging, "Test must observe private staging before canonical publication");
+        assertTrue(extraction.get(10, TimeUnit.SECONDS).extracted());
+        assertEquals(MAX_VIEWER_BYTES, Files.size(viewer));
     }
 
     @Test
@@ -803,6 +885,19 @@ class TraceServiceTest {
                     "json": "shaft-trace.json",
                     "network": "shaft-network.har"
                   }
+                }
+                """.formatted(id, relative(root, archive)), StandardCharsets.UTF_8);
+        return index;
+    }
+
+    private static Path writeIndex(Path root, Path directory, Path archive, String id) throws Exception {
+        Path index = directory.resolve("index.json");
+        Files.writeString(index, """
+                {
+                  "testId": "%s",
+                  "generatedAt": "2026-08-12T15:00:00Z",
+                  "archive": "%s",
+                  "entries": {"html": "SHAFT Trace Report.html", "json": "shaft-trace.json"}
                 }
                 """.formatted(id, relative(root, archive)), StandardCharsets.UTF_8);
         return index;

--- a/shaft-mcp/src/test/java/com/shaft/mcp/TraceServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/TraceServiceTest.java
@@ -30,6 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SuppressWarnings("PMD.AvoidAccessibilityAlteration") // Frozen-consumer proof invokes the internal serializer directly.
 class TraceServiceTest {
     private static final ObjectMapper JSON = new ObjectMapper();
+    private static final long MAX_TRACE_JSON_BYTES = 64L * 1024 * 1024;
+    private static final long MAX_VIEWER_BYTES = 64L * 1024 * 1024;
 
     @Test
     void frozenV1ConsumerSummarizesNewlyEmittedTraceWithNestedV2Session(@TempDir Path temp) throws Exception {
@@ -340,6 +342,55 @@ class TraceServiceTest {
 
         assertTrue(result.viewerPath().isBlank());
         assertTrue(result.warnings().stream().anyMatch(w -> w.contains("does not contain")));
+    }
+
+    @Test
+    void traceOpenViewerRejectsOversizedCompressedEntryWithoutPublishingPartialFile(@TempDir Path temp)
+            throws Exception {
+        Path directory = Files.createDirectories(temp.resolve("target/shaft-traces/oversized-viewer"));
+        Path archive = directory.resolve("shaft-trace.zip");
+        writeZipWithRepeatedHtml(archive, MAX_VIEWER_BYTES + 1);
+        Path index = directory.resolve("index.json");
+        Files.writeString(index, """
+                {
+                  "testId": "oversized-viewer",
+                  "generatedAt": "2026-08-12T15:00:00Z",
+                  "archive": "%s",
+                  "entries": {"html": "SHAFT Trace Report.html", "json": "shaft-trace.json"}
+                }
+                """.formatted(relative(temp, archive)), StandardCharsets.UTF_8);
+
+        var result = service(temp).traceOpenViewer(relative(temp, index));
+
+        assertTrue(result.viewerPath().isBlank());
+        assertFalse(result.extracted());
+        assertEquals(List.of("Trace viewer exceeds the 64 MiB extraction limit."), result.warnings());
+        assertFalse(Files.exists(directory.resolve("SHAFT Trace Report.html")));
+        try (var files = Files.list(directory)) {
+            assertFalse(files.anyMatch(path -> path.getFileName().toString().contains(".tmp")),
+                    "Failed extraction must remove private staging files");
+        }
+    }
+
+    @Test
+    void traceReadRejectsOversizedCompressedJsonBeforeParsing(@TempDir Path temp) throws Exception {
+        Path directory = Files.createDirectories(temp.resolve("target/shaft-traces/oversized-json"));
+        Path archive = directory.resolve("shaft-trace.zip");
+        writeZipWithRepeatedJson(archive, MAX_TRACE_JSON_BYTES + 1);
+        Path index = directory.resolve("index.json");
+        Files.writeString(index, """
+                {
+                  "testId": "oversized-json",
+                  "generatedAt": "2026-08-12T15:00:00Z",
+                  "archive": "%s",
+                  "entries": {"json": "shaft-trace.json"}
+                }
+                """.formatted(relative(temp, archive)), StandardCharsets.UTF_8);
+
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> service(temp).traceRead(relative(temp, index), 1000));
+
+        assertEquals("Trace JSON exceeds the 64 MiB read limit.", failure.getMessage());
     }
 
     @Test
@@ -772,6 +823,44 @@ class TraceServiceTest {
             zip.closeEntry();
             zip.putNextEntry(new ZipEntry("SHAFT Trace Report.html"));
             zip.write(html.getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
+    }
+
+    private static void writeZipWithRepeatedHtml(Path archive, long htmlBytes) throws Exception {
+        byte[] block = new byte[8192];
+        java.util.Arrays.fill(block, (byte) 'x');
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(archive))) {
+            zip.putNextEntry(new ZipEntry("shaft-trace.json"));
+            zip.write(traceJson("\"actions\": [], \"network\": [], \"console\": []")
+                    .getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+            zip.putNextEntry(new ZipEntry("SHAFT Trace Report.html"));
+            long remaining = htmlBytes;
+            while (remaining > 0) {
+                int count = (int) Math.min(block.length, remaining);
+                zip.write(block, 0, count);
+                remaining -= count;
+            }
+            zip.closeEntry();
+        }
+    }
+
+    private static void writeZipWithRepeatedJson(Path archive, long jsonBytes) throws Exception {
+        byte[] prefix = "{\"padding\":\"".getBytes(StandardCharsets.UTF_8);
+        byte[] suffix = "\"}".getBytes(StandardCharsets.UTF_8);
+        byte[] block = new byte[8192];
+        java.util.Arrays.fill(block, (byte) 'x');
+        long paddingBytes = jsonBytes - prefix.length - suffix.length;
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(archive))) {
+            zip.putNextEntry(new ZipEntry("shaft-trace.json"));
+            zip.write(prefix);
+            while (paddingBytes > 0) {
+                int count = (int) Math.min(block.length, paddingBytes);
+                zip.write(block, 0, count);
+                paddingBytes -= count;
+            }
+            zip.write(suffix);
             zip.closeEntry();
         }
     }


### PR DESCRIPTION
## Summary
- bound persisted trace JSON and offline-viewer ZIP reads at 64 MiB using authoritative decompressed streaming limits
- stage JSON/viewer entries privately, publish only a complete viewer with same-directory atomic move/fallback, and clean every staging file
- preserve frozen v1/v2 consumers while rejecting oversized/corrupt inputs with fixed payload/path-safe errors

## Tracking
Closes #4806
Contributes to #4727

## Evidence
- RED: oversized compressed viewer published before fix (1/1 expected failure)
- RED: oversized compressed JSON parsed before fix (1/1 expected failure)
- low-heap RED: max+1 JSON heap allocation produced `OutOfMemoryError` under `-Xmx64m`
- low-heap GREEN: same oversized compressed JSON test 1/0/0/0 after bounded disk staging under `-Xmx64m`
- final `TraceServiceTest`: 47/0/0/0
- exact 64 MiB JSON and viewer accepted; +1 rejected
- truncated ZIP publishes no canonical file and leaves no staging residue
- concurrent reader must observe staging and sees canonical absent or exactly complete
- `mvn -pl shaft-mcp package -DskipTests -Dallure.automaticallyOpen=false -Djacoco.skip=true` passed
- `git diff --check` clean apart from checkout line-ending notices
- final independent adversarial review: zero blockers and zero nonblocking findings