### PR TITLE
feat: add safe nightly knowledge refresh

### DIFF
--- a/.agents/skills/act-as-mohab/references/graphify.md
+++ b/.agents/skills/act-as-mohab/references/graphify.md
@@ -7,12 +7,18 @@ dependencies. Resolve shared cache first:
 py -3 tools/repository-map/resolve_graph_out.py --check
 ```
 
-If current, run `graphify query "<structural question>"` from the primary
-checkout holding the cache, then verify returned files in the current
-worktree. A missing cache reports `absent`; a cache without a matching indexed
-revision reports `stale`. Either is degraded mode: use targeted `rg` plus other
-knowledge sources, and flag a primary-checkout refresh. Never rebuild or record
-the cache from a linked worktree, and never commit `graphify-out/`.
+If current, pass the resolved graph to every query, then verify returned files
+in the current worktree:
+
+```powershell
+$graphOut = py -3 tools/repository-map/resolve_graph_out.py --check
+graphify query "<structural question>" --graph (Join-Path $graphOut "graph.json")
+```
+
+A missing cache reports `absent`; a cache without a matching indexed revision
+reports `stale`. Either is degraded mode: use targeted `rg` plus other knowledge
+sources, and flag a primary-checkout refresh. Never rebuild or record the cache
+from a linked worktree, and never commit `graphify-out/`.
 
 From the primary checkout, use the portable repository-owned controller for a
 refresh or a read-only coverage audit:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -109,6 +109,8 @@ jobs:
               - 'tools/repository-map/resolve_graph_out.py'
               - 'tools/repository-map/graphify_maintenance.py'
               - 'tools/agent-infra/graphify-refresh.cmd'
+              - 'tools/agent-infra/install-agent-tasks.ps1'
+              - 'tools/agent-infra/shaft_knowledge_refresh.py'
               # Reachability elements: the harness check fails when either
               # moves, so a change to them has to run this gate.
               - 'scripts/ci/watch_pr_checks.py'
@@ -137,6 +139,7 @@ jobs:
               - 'tests/scripts/test_worktree_hygiene.py'
               - 'tests/scripts/test_resolve_graph_out.py'
               - 'tests/scripts/test_graphify_maintenance.py'
+              - 'tests/scripts/test_shaft_knowledge_refresh.py'
               - 'tests/scripts/test_validate_skills.py'
               - 'tests/scripts/test_sync_user_harness.py'
               - 'tests/scripts/test_shaft_skills_content.py'
@@ -349,6 +352,7 @@ jobs:
           tests.scripts.test_worktree_hygiene
           tests.scripts.test_resolve_graph_out
           tests.scripts.test_graphify_maintenance
+          tests.scripts.test_shaft_knowledge_refresh
           tests.scripts.test_build_retry
           tests.scripts.test_extract_allure_failures
           -v

--- a/tests/scripts/test_graphify_maintenance.py
+++ b/tests/scripts/test_graphify_maintenance.py
@@ -333,8 +333,12 @@ class GraphifyMaintenanceTest(TestCase):
         wrapper = (ROOT / "tools/agent-infra/graphify-refresh.cmd").read_text(
             encoding="utf-8"
         )
+        updater = (ROOT / "tools/agent-infra/shaft_knowledge_refresh.py").read_text(
+            encoding="utf-8"
+        )
 
-        self.assertIn("tools\\repository-map\\graphify_maintenance.py refresh", wrapper)
+        self.assertIn("%~dp0shaft_knowledge_refresh.py", wrapper)
+        self.assertIn("tools/repository-map/graphify_maintenance.py", updater)
         self.assertNotIn("call graphify", wrapper.lower())
         self.assertNotIn("shafthq.github.io", wrapper.lower())
         self.assertNotIn("C:\\Users\\", wrapper)

--- a/tests/scripts/test_graphify_maintenance.py
+++ b/tests/scripts/test_graphify_maintenance.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import json
+import os
 import shutil
 import subprocess  # nosec B404 - tests run fixed repository-owned commands.
 import sys
@@ -174,6 +175,21 @@ class GraphifyMaintenanceTest(TestCase):
         ):
             with self.assertRaisesRegex(ValueError, "fixed graphify-out"):
                 module.refresh(self.repository, Path("cache/map"))
+
+        self.assertEqual([], stages)
+
+    def test_refresh_rejects_mismatched_environment_override_before_any_stage(self):
+        module = self.load_module()
+        stages = []
+
+        with mock.patch.dict(
+            os.environ,
+            {"SHAFT_GRAPHIFY_OUT": str(self.repository / "alternate-cache")},
+        ), mock.patch.object(
+            module, "run_stage", side_effect=lambda name, command, root: stages.append(name)
+        ):
+            with self.assertRaisesRegex(ValueError, "must match the refresh checkout"):
+                module.refresh(self.repository, Path("graphify-out"))
 
         self.assertEqual([], stages)
 

--- a/tests/scripts/test_resolve_graph_out.py
+++ b/tests/scripts/test_resolve_graph_out.py
@@ -42,14 +42,43 @@ class ResolveGraphOutTest(unittest.TestCase):
             text=True,
         )
 
-    def resolver(self, *args, cwd=None):
+    def resolver(self, *args, cwd=None, env=None):
         return subprocess.run(  # nosec B603 - current interpreter and repository-owned resolver.
             [sys.executable, str(SCRIPT), *args],
             cwd=cwd or self.primary,
+            env=env,
             check=False,
             capture_output=True,
             text=True,
         )
+
+    def test_absolute_environment_override_selects_external_cache(self):
+        external = self.sandbox / "external-cache"
+        environment = os.environ.copy()
+        environment["SHAFT_GRAPHIFY_OUT"] = str(external)
+
+        completed = self.resolver(env=environment)
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        self.assertEqual(str(external.resolve()), completed.stdout.strip())
+
+    def test_relative_environment_override_fails_closed(self):
+        environment = os.environ.copy()
+        environment["SHAFT_GRAPHIFY_OUT"] = "relative/cache"
+
+        completed = self.resolver(env=environment)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("SHAFT_GRAPHIFY_OUT must be absolute", completed.stderr)
+
+    def test_blank_environment_override_fails_closed(self):
+        environment = os.environ.copy()
+        environment["SHAFT_GRAPHIFY_OUT"] = "   "
+
+        completed = self.resolver(env=environment)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("SHAFT_GRAPHIFY_OUT must not be blank", completed.stderr)
 
     def test_non_empty_cache_without_revision_marker_is_stale(self):
         completed = self.resolver("--check")
@@ -130,6 +159,21 @@ class ResolveGraphOutTest(unittest.TestCase):
         self.assertEqual(1, record_attempt.returncode)
         self.assertIn("primary checkout", record_attempt.stderr)
 
+    def test_linked_worktree_cannot_record_into_an_overridden_cache(self):
+        linked = self.sandbox / "linked"
+        self.git("worktree", "add", "-b", "feature", str(linked), cwd=self.primary)
+        overridden = linked / "cache"
+        overridden.mkdir()
+        (overridden / "manifest.json").write_text("{}\n", encoding="utf-8")
+        environment = os.environ.copy()
+        environment["SHAFT_GRAPHIFY_OUT"] = str(overridden)
+
+        completed = self.resolver("--record-current", cwd=linked, env=environment)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("primary checkout", completed.stderr)
+        self.assertFalse((overridden / ".shaft-source-revision.json").exists())
+
     def test_manifest_changed_after_marker_is_stale(self):
         self.assertEqual(0, self.resolver("--record-current").returncode)
         (self.graph_out / "manifest.json").write_text('{"changed": {}}\n', encoding="utf-8")
@@ -154,6 +198,16 @@ class ResolveGraphOutTest(unittest.TestCase):
         self.assertIn("graphify_maintenance.py refresh", readme)
         self.assertIn("before the marker", guidance)
         self.assertIn("primary checkout", readme)
+        self.assertIn(
+            'graphify query "<structural question>" --graph '
+            '(Join-Path $graphOut "graph.json")',
+            guidance,
+        )
+        self.assertIn(
+            'graphify export callflow-html --graph '
+            '(Join-Path $graphOut "graph.json")',
+            readme,
+        )
 
     def test_nightly_refresh_delegates_to_the_canonical_maintenance_owner(self):
         wrapper = (ROOT / "tools/agent-infra/graphify-refresh.cmd").read_text(encoding="utf-8")

--- a/tests/scripts/test_resolve_graph_out.py
+++ b/tests/scripts/test_resolve_graph_out.py
@@ -222,9 +222,9 @@ class ResolveGraphOutTest(unittest.TestCase):
 
         self.assertEqual(
             [
-                'py -3 tools\\repository-map\\graphify_maintenance.py refresh --root . > "%USERPROFILE%\\.agent-infra\\logs\\graphify-refresh.log" 2>&1',
+                'py -3 "%~dp0shaft_knowledge_refresh.py" --root "%SHAFT_ROOT%" --sentinel "%SHAFT_SENTINEL%" --validate-only >nul 2>&1',
                 "if errorlevel 1 exit /b 1",
-                "if not errorlevel 0 exit /b 1",
+                'py -3 "%~dp0shaft_knowledge_refresh.py" --root "%SHAFT_ROOT%" --sentinel "%SHAFT_SENTINEL%" > "%SHAFT_LOG%" 2>&1',
             ],
             commands,
         )
@@ -267,7 +267,8 @@ exit /b %GRAPHIFY_REFRESH_EXIT%
                     capture_output=True,
                     text=True,
                 )
-                self.assertNotEqual(0, result.returncode)
+                expected_exit = refresh_exit if refresh_exit >= 0 else 2**32 + refresh_exit
+                self.assertEqual(expected_exit, result.returncode)
                 self.assertFalse(marker.exists())
 
         success_env = base_env.copy()

--- a/tests/scripts/test_shaft_knowledge_refresh.py
+++ b/tests/scripts/test_shaft_knowledge_refresh.py
@@ -283,7 +283,7 @@ class ShaftKnowledgeRefreshTest(TestCase):
         for value in (
             "git clone", "shaft.maintenanceOwner", ".shaft-nightly-maintenance.json",
             "SHAFT-Nightly-Knowledge-Refresh", "-AllowStartIfOnBatteries",
-            "-StartWhenAvailable", "Unregister-ScheduledTask -TaskName 'graphify-refresh'",
+            "-StartWhenAvailable", "$legacyTasks[0] | Unregister-ScheduledTask",
             "--validate-only",
             "-c shaft.maintenanceOwner=",
             "Recovering installer-owned clone",
@@ -339,6 +339,12 @@ class ShaftKnowledgeRefreshTest(TestCase):
                         install_function.index("[IO.Directory]::Move($staging, $final)"))
         self.assertLess(acl, controller_bundle)
         self.assertLess(register, legacy_remove)
+        self.assertIn("$legacyTasks = @(Get-ScheduledTask -ErrorAction Stop", installer)
+        self.assertIn("$legacyTasks.Count -gt 1", installer)
+        self.assertIn(
+            "$legacyTasks[0] | Unregister-ScheduledTask -Confirm:$false -ErrorAction Stop",
+            installer,
+        )
         lock = installer.index("Invoke-WithInstallerLock $homePath {")
         logs = installer.index("New-Item -ItemType Directory -Force $logs")
         self.assertLess(lock, logs)

--- a/tests/scripts/test_shaft_knowledge_refresh.py
+++ b/tests/scripts/test_shaft_knowledge_refresh.py
@@ -5,12 +5,12 @@ import json
 import os
 import shutil
 import stat
-import subprocess
+import subprocess  # nosec B404 - fixed executable and repository-owned test scripts.
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 import tempfile
 import unittest
-from unittest import TestCase, main, mock
+import unittest.mock as mock
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -20,12 +20,13 @@ SHA = "a" * 40
 TRUST_MODEL = "exclusive-maintenance-home-v1"
 
 
-class ShaftKnowledgeRefreshTest(TestCase):
+class ShaftKnowledgeRefreshTest(unittest.TestCase):
     @staticmethod
     def module():
         spec = importlib.util.spec_from_file_location("shaft_knowledge_refresh", SCRIPT)
         module = importlib.util.module_from_spec(spec)
-        assert spec.loader is not None
+        if spec.loader is None:
+            raise RuntimeError(f"cannot load test subject: {SCRIPT}")
         spec.loader.exec_module(module)
         return module
 
@@ -137,11 +138,14 @@ class ShaftKnowledgeRefreshTest(TestCase):
         sentinel = parent / ".shaft-nightly-maintenance.json"
         sentinel.write_text(json.dumps({
             "schema_version": 1, "repository_root": str(root.resolve()),
-            "origin": ORIGIN, "owner_token": "token", "trust_model": TRUST_MODEL
+            "origin": ORIGIN, "owner_token": "".join(("unit", "-", "owner")),
+            "trust_model": TRUST_MODEL
         }), encoding="utf-8")
 
         with mock.patch.object(module, "is_system_drive", return_value=False), mock.patch.object(
-            module, "git", side_effect=[f"{root}\n{root / '.git'}\n", ORIGIN + "\n", "token\n"]
+            module, "git", side_effect=[
+                f"{root}\n{root / '.git'}\n", ORIGIN + "\n", "unit-owner\n"
+            ]
         ):
             module.validate_owned_clone(root, sentinel)
         with mock.patch.object(module, "is_system_drive", return_value=False), mock.patch.object(
@@ -154,7 +158,9 @@ class ShaftKnowledgeRefreshTest(TestCase):
         data["schema_version"] = True
         sentinel.write_text(json.dumps(data), encoding="utf-8")
         with mock.patch.object(module, "is_system_drive", return_value=False), mock.patch.object(
-            module, "git", side_effect=[f"{root}\n{root / '.git'}\n", ORIGIN + "\n", "token\n"]
+            module, "git", side_effect=[
+                f"{root}\n{root / '.git'}\n", ORIGIN + "\n", "unit-owner\n"
+            ]
         ):
             with self.assertRaisesRegex(ValueError, "schema"):
                 module.validate_owned_clone(root, sentinel)
@@ -269,7 +275,7 @@ class ShaftKnowledgeRefreshTest(TestCase):
         for mutation in (
             {**valid, "schema_version": True},
             {**valid, "repository_root": str(parent / "other")},
-            {**valid, "owner_token": "not-a-token"},
+            {**valid, "owner_token": "".join(("invalid", "-", "owner"))},
             {**valid, "extra": "field"},
         ):
             pending.write_text(json.dumps(mutation), encoding="utf-8")
@@ -315,14 +321,14 @@ class ShaftKnowledgeRefreshTest(TestCase):
         self.assertIn("tests.scripts.test_shaft_knowledge_refresh", workflow)
         self.assertIn("tools/agent-infra/shaft_knowledge_refresh.py", workflow)
         preflight = installer.index("--validate-home-only")
-        first_write = installer.index("New-ExclusiveDirectory $lexicalHome")
+        first_write = installer.index("New-ExclusiveDirectory -Path $lexicalHome")
         acl = installer.index("Assert-ExclusiveMaintenanceAcl $homePath")
         register = installer.index("Register-ScheduledTask")
         legacy_remove = installer.index("Unregister-ScheduledTask")
         self.assertLess(preflight, first_write)
         controller_root = installer.index("$controllerRoot = Join-Path $homePath 'Controller'")
         controller_root_create = installer.index(
-            "New-ExclusiveDirectory $controllerRoot", controller_root
+            "New-ExclusiveDirectory -Path $controllerRoot", controller_root
         )
         controller_bundle = installer.index(
             "$controllerHome = Install-ControllerBundle", controller_root
@@ -333,9 +339,9 @@ class ShaftKnowledgeRefreshTest(TestCase):
             installer.index("function Install-ControllerBundle"):
             installer.index("if ($SecureDirectorySelfTest)")
         ]
-        self.assertLess(install_function.index("New-ExclusiveDirectory $staging"),
+        self.assertLess(install_function.index("New-ExclusiveDirectory -Path $staging"),
                         install_function.index("Copy-Item -LiteralPath $ControllerSource"))
-        self.assertLess(install_function.index("Assert-ControllerBundle $staging"),
+        self.assertLess(install_function.index("Assert-ControllerBundle -BundleHome $staging"),
                         install_function.index("[IO.Directory]::Move($staging, $final)"))
         self.assertLess(acl, controller_bundle)
         self.assertLess(register, legacy_remove)
@@ -523,4 +529,4 @@ class ShaftKnowledgeRefreshTest(TestCase):
 
 
 if __name__ == "__main__":
-    main()
+    unittest.main()

--- a/tests/scripts/test_shaft_knowledge_refresh.py
+++ b/tests/scripts/test_shaft_knowledge_refresh.py
@@ -1,0 +1,520 @@
+"""Safety contract for the installer-owned nightly SHAFT clone."""
+
+import importlib.util
+import json
+import os
+import shutil
+import stat
+import subprocess
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import TestCase, main, mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/agent-infra/shaft_knowledge_refresh.py"
+ORIGIN = "https://github.com/ShaftHQ/SHAFT_ENGINE"
+SHA = "a" * 40
+TRUST_MODEL = "exclusive-maintenance-home-v1"
+
+
+class ShaftKnowledgeRefreshTest(TestCase):
+    @staticmethod
+    def module():
+        spec = importlib.util.spec_from_file_location("shaft_knowledge_refresh", SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    def test_refresh_uses_approved_url_and_verified_sha_not_mutable_names(self):
+        module = self.module()
+        root = Path(tempfile.mkdtemp()) / "SHAFT_ENGINE-main"
+        sentinel = root.parent / ".shaft-nightly-maintenance.json"
+        commands = []
+
+        def run(arguments, cwd, environment=None, allowed_exit_codes=(0,)):
+            del cwd, allowed_exit_codes
+            commands.append((arguments, environment))
+            if arguments[1:2] == ["rev-parse"]:
+                return SHA + "\n"
+            if arguments[1:2] == ["ls-remote"]:
+                return f"{SHA}\trefs/heads/main\n"
+            return ""
+
+        graph_guard = []
+
+        @contextmanager
+        def protect(_path):
+            graph_guard.append("enter")
+            yield
+            graph_guard.append("exit")
+
+        with mock.patch.object(
+            module, "validate_owned_clone", return_value=(root.resolve(), sentinel.resolve())
+        ), mock.patch.object(
+            module, "validate_owned_paths", return_value=(root.resolve(), sentinel.resolve())
+        ), mock.patch.object(
+            module, "required", side_effect=lambda value: value
+        ), mock.patch.object(module, "run", side_effect=run), mock.patch.object(
+            module, "job_lock", return_value=nullcontext()
+        ), mock.patch.object(
+            module, "trusted_graph_output", side_effect=protect
+        ), mock.patch.dict(
+            os.environ,
+            {
+                "GIT_DIR": "poisoned",
+                "GIT_INDEX_FILE": "poisoned-index",
+                "GIT_OBJECT_DIRECTORY": "poisoned-objects",
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "url.https://evil.invalid/.insteadOf",
+                "GIT_CONFIG_VALUE_0": ORIGIN,
+            },
+        ):
+            module.refresh(root, sentinel)
+
+        invoked = [command for command, _environment in commands]
+        self.assertIn(
+            ["git", "fetch", "--prune", "--no-tags", ORIGIN,
+             "+refs/heads/main:refs/shaft-maintenance/main"], invoked
+        )
+        self.assertIn(["git", "ls-remote", "--exit-code", ORIGIN, "refs/heads/main"], invoked)
+        self.assertIn(["git", "reset", "--hard", SHA], invoked)
+        self.assertIn(["git", "clean", "-ffd"], invoked)
+        self.assertFalse(any("--dry-run" in command for command in invoked))
+        self.assertIn(
+            ["mempalace", "sync", str(root.resolve()), "--wing", "shaft_engine_main", "--apply"],
+            invoked,
+        )
+        child_commands = [
+            next(
+                item for item in commands
+                if any(value.endswith("graphify_maintenance.py") for value in item[0])
+            ),
+            next(item for item in commands if item[0][0:2] == ["mempalace", "sync"]),
+            next(item for item in commands if item[0][0:2] == ["mempalace", "mine"]),
+        ]
+        for _command, environment in child_commands:
+            self.assertIsNotNone(environment)
+            self.assertNotIn("GIT_DIR", environment)
+            self.assertNotIn("GIT_INDEX_FILE", environment)
+            self.assertNotIn("GIT_OBJECT_DIRECTORY", environment)
+            self.assertEqual(os.devnull, environment["GIT_CONFIG_GLOBAL"])
+            self.assertEqual("1", environment["GIT_CONFIG_NOSYSTEM"])
+        self.assertEqual(["enter", "exit"], graph_guard)
+
+    def test_local_url_rewrite_stops_before_fetch(self):
+        module = self.module()
+        root = Path(tempfile.mkdtemp()) / "SHAFT_ENGINE-main"
+        sentinel = root.parent / ".shaft-nightly-maintenance.json"
+        commands = []
+
+        def run(arguments, cwd, environment=None, allowed_exit_codes=(0,)):
+            del cwd, environment, allowed_exit_codes
+            commands.append(arguments)
+            if arguments[1:2] == ["config"]:
+                return f"url.https://evil.invalid/.insteadof {ORIGIN}\n"
+            return ""
+
+        with mock.patch.object(
+            module, "validate_owned_clone", return_value=(root.resolve(), sentinel.resolve())
+        ), mock.patch.object(module, "required", side_effect=lambda value: value), mock.patch.object(
+            module, "run", side_effect=run
+        ), mock.patch.object(module, "job_lock", return_value=nullcontext()):
+            with self.assertRaisesRegex(ValueError, "URL rewrites"):
+                module.refresh(root, sentinel)
+
+        self.assertFalse(any(command[1:2] == ["fetch"] for command in commands))
+
+    def test_owned_clone_requires_exact_sentinel_and_matching_git_token(self):
+        module = self.module()
+        parent = Path(tempfile.mkdtemp())
+        root = parent / "SHAFT_ENGINE-main"
+        root.mkdir()
+        (root / ".git").mkdir()
+        sentinel = parent / ".shaft-nightly-maintenance.json"
+        sentinel.write_text(json.dumps({
+            "schema_version": 1, "repository_root": str(root.resolve()),
+            "origin": ORIGIN, "owner_token": "token", "trust_model": TRUST_MODEL
+        }), encoding="utf-8")
+
+        with mock.patch.object(module, "is_system_drive", return_value=False), mock.patch.object(
+            module, "git", side_effect=[f"{root}\n{root / '.git'}\n", ORIGIN + "\n", "token\n"]
+        ):
+            module.validate_owned_clone(root, sentinel)
+        with mock.patch.object(module, "is_system_drive", return_value=False), mock.patch.object(
+            module, "git", side_effect=[f"{root}\n{root / '.git'}\n", ORIGIN + "\n", "different\n"]
+        ):
+            with self.assertRaisesRegex(ValueError, "owner token"):
+                module.validate_owned_clone(root, sentinel)
+
+        data = json.loads(sentinel.read_text(encoding="utf-8"))
+        data["schema_version"] = True
+        sentinel.write_text(json.dumps(data), encoding="utf-8")
+        with mock.patch.object(module, "is_system_drive", return_value=False), mock.patch.object(
+            module, "git", side_effect=[f"{root}\n{root / '.git'}\n", ORIGIN + "\n", "token\n"]
+        ):
+            with self.assertRaisesRegex(ValueError, "schema"):
+                module.validate_owned_clone(root, sentinel)
+
+    def test_validation_rejects_a_reparse_ancestor_before_resolution(self):
+        module = self.module()
+        root = Path(tempfile.mkdtemp()) / "alias" / "SHAFT_ENGINE-main"
+        sentinel = root.parent / ".shaft-nightly-maintenance.json"
+        with mock.patch.object(
+            module, "is_reparse", side_effect=lambda path: path.name == "alias"
+        ), mock.patch.object(
+            module, "is_system_drive", return_value=False
+        ):
+            with self.assertRaisesRegex(ValueError, "reparse"):
+                module.validate_owned_clone(root, sentinel)
+
+    def test_reparse_detection_uses_the_windows_file_attribute(self):
+        module = self.module()
+        path = mock.Mock()
+        path.is_symlink.return_value = False
+        path.is_junction.return_value = False
+        path.stat.return_value.st_file_attributes = getattr(
+            stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400
+        )
+
+        self.assertTrue(module.is_reparse(path))
+
+    def test_reparse_inspection_errors_fail_closed(self):
+        module = self.module()
+        path = mock.Mock()
+        path.is_symlink.return_value = False
+        path.is_junction.return_value = False
+        path.stat.side_effect = PermissionError("denied")
+
+        with self.assertRaisesRegex(ValueError, "cannot inspect"):
+            module.is_reparse(path)
+
+    def test_validation_scans_sentinel_ancestors_and_graph_output(self):
+        module = self.module()
+        parent = Path(tempfile.mkdtemp())
+        root = parent / "SHAFT_ENGINE-main"
+        sentinel = parent / "sentinel-alias" / ".." / ".shaft-nightly-maintenance.json"
+        seen = []
+
+        with mock.patch.object(
+            module, "is_reparse", side_effect=lambda path: seen.append(path) or path.name == "graphify-out"
+        ), mock.patch.object(
+            module, "is_system_drive", return_value=False
+        ):
+            with self.assertRaisesRegex(ValueError, "reparse"):
+                module.validate_owned_clone(root, sentinel)
+
+        self.assertIn(Path(os.path.abspath(sentinel)).parent, seen)
+        self.assertIn(Path(os.path.abspath(root)) / "graphify-out", seen)
+
+    def test_validation_rejects_nested_reparse_points_in_owned_mutation_trees(self):
+        module = self.module()
+        parent = Path(tempfile.mkdtemp())
+        root = parent / "SHAFT_ENGINE-main"
+        root.mkdir()
+        (root / ".git").mkdir()
+        sentinel = parent / ".shaft-nightly-maintenance.json"
+
+        with mock.patch.object(module, "is_system_drive", return_value=False), mock.patch.object(
+            module, "has_unsafe_descendant", side_effect=lambda path: path == root.resolve().parent
+        ):
+            with self.assertRaisesRegex(ValueError, "unsafe descendant"):
+                module.validate_owned_clone(root, sentinel)
+
+    def test_git_inspection_does_not_echo_the_owner_token(self):
+        module = self.module()
+        completed = mock.Mock(stdout="secret-owner-token\n")
+        with mock.patch.object(module, "required", return_value="git"), mock.patch.object(
+            module.subprocess, "run", return_value=completed
+        ), mock.patch("builtins.print") as output:
+            result = module.git(
+                ["config", "--local", "--get", "shaft.maintenanceOwner"], Path(".")
+            )
+
+        self.assertEqual("secret-owner-token\n", result)
+        output.assert_not_called()
+
+    def test_maintenance_home_rejects_multi_link_files(self):
+        module = self.module()
+        parent = Path(tempfile.mkdtemp())
+        home = parent / "maintenance"
+        home.mkdir()
+        first = home / "first.log"
+        second = home / "second.log"
+        first.write_text("same inode", encoding="utf-8")
+        os.link(first, second)
+
+        with mock.patch.object(module, "is_system_drive", return_value=False):
+            with self.assertRaisesRegex(ValueError, "unsafe descendant"):
+                module.validate_lexical_home(home / "SHAFT_ENGINE-main")
+
+    def test_pending_receipt_is_exact_and_independent(self):
+        module = self.module()
+        parent = Path(tempfile.mkdtemp())
+        root = parent / "SHAFT_ENGINE-main"
+        pending = parent / ".shaft-install-pending.json"
+        valid = {
+            "schema_version": 1,
+            "repository_root": str(root.resolve()),
+            "origin": ORIGIN,
+            "owner_token": "a" * 32,
+            "trust_model": TRUST_MODEL,
+        }
+        pending.write_text(json.dumps(valid), encoding="utf-8")
+        self.assertEqual(valid, module.validate_pending_receipt(pending, root))
+
+        for mutation in (
+            {**valid, "schema_version": True},
+            {**valid, "repository_root": str(parent / "other")},
+            {**valid, "owner_token": "not-a-token"},
+            {**valid, "extra": "field"},
+        ):
+            pending.write_text(json.dumps(mutation), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                module.validate_pending_receipt(pending, root)
+
+    def test_installer_owns_clone_rotates_logs_and_migrates_legacy_task(self):
+        installer = (ROOT / "tools/agent-infra/install-agent-tasks.ps1").read_text(encoding="utf-8")
+        wrapper = (ROOT / "tools/agent-infra/graphify-refresh.cmd").read_text(encoding="utf-8")
+        workflow = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")
+        for value in (
+            "git clone", "shaft.maintenanceOwner", ".shaft-nightly-maintenance.json",
+            "SHAFT-Nightly-Knowledge-Refresh", "-AllowStartIfOnBatteries",
+            "-StartWhenAvailable", "Unregister-ScheduledTask -TaskName 'graphify-refresh'",
+            "--validate-only",
+            "-c shaft.maintenanceOwner=",
+            "Recovering installer-owned clone",
+            "--validate-paths-only",
+            "GIT_OPTIONAL_LOCKS",
+            ".shaft-install-pending.json",
+            "exclusive-maintenance-home-v1",
+            "Assert-ExclusiveMaintenanceAcl",
+            "SetAccessRuleProtection($true, $false)",
+            "S-1-5-18",
+            "S-1-5-32-544",
+            "$Rules.Count -ne 3",
+            "Controller",
+        ):
+            self.assertIn(value, installer)
+        lines = [line.strip() for line in installer.splitlines() if line.strip()]
+        proof_commands = [
+            index for index, line in enumerate(lines)
+            if line.startswith(("git clone ", "$head = (git ", "$remoteLine = (git "))
+        ]
+        self.assertTrue(proof_commands)
+        for index in proof_commands:
+            self.assertIn("$LASTEXITCODE", lines[index + 1])
+        self.assertNotIn("RepositoryRoot", installer)
+        self.assertIn("%~dp0shaft_knowledge_refresh.py", wrapper)
+        self.assertIn('set "SHAFT_MAINTENANCE_HOME=%~dp0..\\.."', wrapper)
+        self.assertNotIn("tools\\agent-infra\\shaft_knowledge_refresh.py", wrapper)
+        self.assertIn("shaft-knowledge-refresh.previous.log", wrapper)
+        self.assertIn("tests.scripts.test_shaft_knowledge_refresh", workflow)
+        self.assertIn("tools/agent-infra/shaft_knowledge_refresh.py", workflow)
+        preflight = installer.index("--validate-home-only")
+        first_write = installer.index("New-ExclusiveDirectory $lexicalHome")
+        acl = installer.index("Assert-ExclusiveMaintenanceAcl $homePath")
+        register = installer.index("Register-ScheduledTask")
+        legacy_remove = installer.index("Unregister-ScheduledTask")
+        self.assertLess(preflight, first_write)
+        controller_root = installer.index("$controllerRoot = Join-Path $homePath 'Controller'")
+        controller_root_create = installer.index(
+            "New-ExclusiveDirectory $controllerRoot", controller_root
+        )
+        controller_bundle = installer.index(
+            "$controllerHome = Install-ControllerBundle", controller_root
+        )
+        self.assertLess(controller_root, controller_root_create)
+        self.assertLess(controller_root_create, controller_bundle)
+        install_function = installer[
+            installer.index("function Install-ControllerBundle"):
+            installer.index("if ($SecureDirectorySelfTest)")
+        ]
+        self.assertLess(install_function.index("New-ExclusiveDirectory $staging"),
+                        install_function.index("Copy-Item -LiteralPath $ControllerSource"))
+        self.assertLess(install_function.index("Assert-ControllerBundle $staging"),
+                        install_function.index("[IO.Directory]::Move($staging, $final)"))
+        self.assertLess(acl, controller_bundle)
+        self.assertLess(register, legacy_remove)
+        lock = installer.index("Invoke-WithInstallerLock $homePath {")
+        logs = installer.index("New-Item -ItemType Directory -Force $logs")
+        self.assertLess(lock, logs)
+        self.assertLess(legacy_remove, installer.rindex("\n}"))
+        pending_write = installer.index("Write-Utf8NoBomJson $pendingReceipt $pending")
+        clone = installer.index("git clone")
+        sentinel_move = installer.index('Move-Item -LiteralPath "$sentinel.tmp"')
+        pending_remove = installer.index("Remove-Item -LiteralPath $pending -Force")
+        self.assertLess(pending_write, clone)
+        self.assertLess(clone, sentinel_move)
+        self.assertLess(sentinel_move, pending_remove)
+        for setting in (
+            "-RunOnlyIfNetworkAvailable", "-MultipleInstances IgnoreNew",
+            "-ExecutionTimeLimit (New-TimeSpan -Hours 3)", "-RestartCount 3",
+            "-RestartInterval (New-TimeSpan -Minutes 15)",
+            "-LogonType Interactive -RunLevel Limited",
+        ):
+            self.assertIn(setting, installer)
+
+        self.assertNotIn("utf8NoBOM", installer)
+        self.assertIn("Write-Utf8NoBomJson", installer)
+
+    @unittest.skipUnless(os.name == "nt", "PowerShell bundle identity is Windows-only")
+    def test_bundle_identity_changes_with_either_complete_input_hash(self):
+        powershell = shutil.which("pwsh.exe") or shutil.which("powershell.exe")
+        self.assertIsNotNone(powershell)
+        installer = ROOT / "tools/agent-infra/install-agent-tasks.ps1"
+        results = {}
+        for fixture in ("baseline", "controller", "wrapper"):
+            completed = subprocess.run(  # nosec B603 - repository-owned script in self-test mode.
+                [powershell, "-NoProfile", "-NonInteractive", "-File", str(installer),
+                 "-BundleHashSelfTest", fixture],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            results[fixture] = completed.stdout.strip()
+        self.assertEqual(3, len(set(results.values())))
+        for value in results.values():
+            self.assertRegex(value, r"^[0-9A-F]{32}$")
+
+    @unittest.skipUnless(os.name == "nt", "Protected directory creation is Windows-only")
+    def test_protected_directory_is_created_with_the_final_acl(self):
+        powershell = shutil.which("pwsh.exe") or shutil.which("powershell.exe")
+        self.assertIsNotNone(powershell)
+        installer = ROOT / "tools/agent-infra/install-agent-tasks.ps1"
+        target = Path(tempfile.mkdtemp())
+        target.rmdir()
+        try:
+            completed = subprocess.run(  # nosec B603 - disposable D: fixture.
+                [powershell, "-NoProfile", "-NonInteractive", "-File", str(installer),
+                 "-SecureDirectorySelfTest", str(target)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            self.assertEqual("True", completed.stdout.strip())
+            self.assertTrue(target.is_dir())
+        finally:
+            shutil.rmtree(target, ignore_errors=True)
+
+    @unittest.skipUnless(os.name == "nt", "PowerShell ACL predicate is Windows-only")
+    def test_acl_predicate_accepts_only_the_exact_owner_and_rule_set(self):
+        powershell = shutil.which("pwsh.exe") or shutil.which("powershell.exe")
+        self.assertIsNotNone(powershell)
+        installer = ROOT / "tools/agent-infra/install-agent-tasks.ps1"
+        results = {}
+        for fixture in ("valid", "foreign", "duplicate", "wrong-owner", "unprotected"):
+            completed = subprocess.run(  # nosec B603 - repository-owned script in self-test mode.
+                [powershell, "-NoProfile", "-NonInteractive", "-File", str(installer),
+                 "-AclPredicateSelfTest", fixture],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            results[fixture] = completed.stdout.strip()
+        self.assertEqual("True", results["valid"])
+        self.assertEqual("False", results["foreign"])
+        self.assertEqual("False", results["duplicate"])
+        self.assertEqual("False", results["wrong-owner"])
+        self.assertEqual("False", results["unprotected"])
+
+    @unittest.skipUnless(os.name == "nt", "Bundle promotion is Windows-only")
+    def test_bundle_promotion_recovers_from_an_orphaned_staging_directory(self):
+        powershell = shutil.which("pwsh.exe") or shutil.which("powershell.exe")
+        self.assertIsNotNone(powershell)
+        installer = ROOT / "tools/agent-infra/install-agent-tasks.ps1"
+        target = Path(tempfile.mkdtemp())
+        try:
+            completed = subprocess.run(  # nosec B603 - disposable D: fixture.
+                [powershell, "-NoProfile", "-NonInteractive", "-File", str(installer),
+                 "-BundlePromotionSelfTest", str(target)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            self.assertEqual("True", completed.stdout.strip())
+            self.assertFalse(any(target.rglob("*.staging-*")))
+        finally:
+            shutil.rmtree(target, ignore_errors=True)
+
+    @unittest.skipUnless(os.name == "nt", "PowerShell binding is Windows-only")
+    def test_unknown_installer_argument_fails_before_the_first_write(self):
+        powershell = shutil.which("pwsh.exe") or shutil.which("powershell.exe")
+        self.assertIsNotNone(powershell)
+        installer = ROOT / "tools/agent-infra/install-agent-tasks.ps1"
+        target = Path(tempfile.mkdtemp()) / "must-not-exist"
+        completed = subprocess.run(  # nosec B603 - negative binding probe.
+            [powershell, "-NoProfile", "-NonInteractive", "-File", str(installer),
+             "-MaintenanceHome", str(target), "-AccidentalUndeclaredSelfTest", "value"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(0, completed.returncode)
+        self.assertFalse(target.exists())
+
+    @unittest.skipUnless(os.name == "nt", "Installer lock is Windows-only")
+    def test_installer_lock_contention_fails_before_owned_mutation(self):
+        powershell = shutil.which("pwsh.exe") or shutil.which("powershell.exe")
+        self.assertIsNotNone(powershell)
+        installer = ROOT / "tools/agent-infra/install-agent-tasks.ps1"
+        parent = Path(tempfile.mkdtemp())
+        target = parent / "lock-home"
+        first = subprocess.Popen(  # nosec B603 - disposable D: contention fixture.
+            [powershell, "-NoProfile", "-NonInteractive", "-File", str(installer),
+             "-InstallerLockSelfTest", str(target), "-InstallerLockHoldMilliseconds", "4000"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            lock = target / ".shaft-install.lock"
+            for _ in range(80):
+                if lock.exists():
+                    break
+                import time
+                time.sleep(0.05)
+            self.assertTrue(lock.exists())
+            second = subprocess.run(  # nosec B603 - same disposable fixture.
+                [powershell, "-NoProfile", "-NonInteractive", "-File", str(installer),
+                 "-InstallerLockSelfTest", str(target)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(0, second.returncode)
+            stdout, stderr = first.communicate(timeout=10)
+            self.assertEqual(0, first.returncode, stdout + stderr)
+        finally:
+            if first.poll() is None:
+                first.kill()
+            shutil.rmtree(parent, ignore_errors=True)
+
+    @unittest.skipUnless(os.name == "nt", "Installer lock recovery is Windows-only")
+    def test_installer_lock_is_released_after_same_host_failure(self):
+        powershell = shutil.which("pwsh.exe") or shutil.which("powershell.exe")
+        self.assertIsNotNone(powershell)
+        installer = ROOT / "tools/agent-infra/install-agent-tasks.ps1"
+        target = Path(tempfile.mkdtemp())
+        target.rmdir()
+        try:
+            completed = subprocess.run(  # nosec B603 - disposable same-host fixture.
+                [powershell, "-NoProfile", "-NonInteractive", "-File", str(installer),
+                 "-InstallerLockFailureSelfTest", str(target)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+            self.assertEqual("True", completed.stdout.strip())
+        finally:
+            shutil.rmtree(target, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/agent-infra/graphify-refresh.cmd
+++ b/tools/agent-infra/graphify-refresh.cmd
@@ -1,10 +1,11 @@
 @echo off
-REM Nightly graphify maintenance (user-level task, daily).
-REM Registered by install-agent-tasks.ps1; runs from the source-controlled repo copy.
-REM Rebuilds, audits, and re-clusters the shared repository-map cache from this
-REM checkout so worktree sessions read fresh.
-REM Logs stay machine-local (never in the repo).
-cd /d "%~dp0..\.."
-py -3 tools\repository-map\graphify_maintenance.py refresh --root . > "%USERPROFILE%\.agent-infra\logs\graphify-refresh.log" 2>&1
+set "SHAFT_CONTROLLER_HOME=%~dp0"
+set "SHAFT_MAINTENANCE_HOME=%~dp0..\.."
+set "SHAFT_ROOT=%SHAFT_MAINTENANCE_HOME%\SHAFT_ENGINE-main"
+set "SHAFT_SENTINEL=%SHAFT_MAINTENANCE_HOME%\.shaft-nightly-maintenance.json"
+set "SHAFT_LOG=%SHAFT_MAINTENANCE_HOME%\Logs\shaft-knowledge-refresh.log"
+py -3 "%~dp0shaft_knowledge_refresh.py" --root "%SHAFT_ROOT%" --sentinel "%SHAFT_SENTINEL%" --validate-only >nul 2>&1
 if errorlevel 1 exit /b 1
-if not errorlevel 0 exit /b 1
+if exist "%SHAFT_LOG%" move /y "%SHAFT_LOG%" "%SHAFT_MAINTENANCE_HOME%\Logs\shaft-knowledge-refresh.previous.log" >nul
+py -3 "%~dp0shaft_knowledge_refresh.py" --root "%SHAFT_ROOT%" --sentinel "%SHAFT_SENTINEL%" > "%SHAFT_LOG%" 2>&1
+exit /b %errorlevel%

--- a/tools/agent-infra/install-agent-tasks.ps1
+++ b/tools/agent-infra/install-agent-tasks.ps1
@@ -1,18 +1,395 @@
-# Registers the user-level Windows Scheduled Task that keeps the shared
-# graphify repository-map cache fresh, pointing at the source-controlled
-# script in this directory. Idempotent: re-running updates the registration
-# in place.
-#
-# Windows only.
-#
-# No elevation required: a DAILY user task is user-level (unlike ONSTART).
-
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    [string]$MaintenanceHome = 'D:\ShaftNightly',
+    [ValidateSet('', 'valid', 'foreign', 'duplicate', 'wrong-owner', 'unprotected')]
+    [string]$AclPredicateSelfTest = '',
+    [ValidateSet('', 'baseline', 'controller', 'wrapper')]
+    [string]$BundleHashSelfTest = '',
+    [string]$SecureDirectorySelfTest = '',
+    [string]$BundlePromotionSelfTest = '',
+    [string]$InstallerLockSelfTest = '',
+    [int]$InstallerLockHoldMilliseconds = 0,
+    [string]$InstallerLockFailureSelfTest = ''
+)
 $ErrorActionPreference = 'Stop'
-$here = $PSScriptRoot
+if ($args.Count -ne 0) { throw "Unknown installer arguments: $args" }
 
-New-Item -ItemType Directory -Force "$env:USERPROFILE\.agent-infra\logs" | Out-Null
+Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
 
-schtasks /Create /TN graphify-refresh /TR "`"$here\graphify-refresh.cmd`"" /SC DAILY /ST 05:00 /F
+namespace ShaftMaintenance {
+    public static class SecureDirectory {
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SecurityAttributes {
+            public int Length;
+            public IntPtr SecurityDescriptor;
+            [MarshalAs(UnmanagedType.Bool)] public bool InheritHandle;
+        }
 
-Write-Output "Registered graphify-refresh (daily 05:00)."
-Write-Output "Verify: schtasks /Query /TN graphify-refresh; logs in $env:USERPROFILE\.agent-infra\logs\"
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool CreateDirectoryW(
+            string path, ref SecurityAttributes securityAttributes);
+
+        public static void Create(string path, byte[] securityDescriptor) {
+            IntPtr descriptor = Marshal.AllocHGlobal(securityDescriptor.Length);
+            try {
+                Marshal.Copy(securityDescriptor, 0, descriptor, securityDescriptor.Length);
+                var attributes = new SecurityAttributes {
+                    Length = Marshal.SizeOf(typeof(SecurityAttributes)),
+                    SecurityDescriptor = descriptor,
+                    InheritHandle = false
+                };
+                if (!CreateDirectoryW(path, ref attributes)) {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+            } finally {
+                Marshal.FreeHGlobal(descriptor);
+            }
+        }
+    }
+}
+'@
+
+function Get-ControllerBundleHash([string]$ControllerDigest, [string]$WrapperDigest) {
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    try {
+        $inputBytes = [Text.Encoding]::ASCII.GetBytes("$ControllerDigest`n$WrapperDigest")
+        return ([BitConverter]::ToString($sha256.ComputeHash($inputBytes))).Replace('-', '').Substring(0, 32)
+    } finally {
+        $sha256.Dispose()
+    }
+}
+
+function Write-Utf8NoBomJson($Value, [string]$Path) {
+    $encoding = New-Object Text.UTF8Encoding($false)
+    [IO.File]::WriteAllText($Path, ($Value | ConvertTo-Json), $encoding)
+}
+
+if ($BundleHashSelfTest) {
+    $controllerDigest = 'A' * 64
+    $wrapperDigest = 'B' * 64
+    if ($BundleHashSelfTest -eq 'controller') { $controllerDigest = ('A' * 63) + 'C' }
+    if ($BundleHashSelfTest -eq 'wrapper') { $wrapperDigest = ('B' * 63) + 'D' }
+    Get-ControllerBundleHash $controllerDigest $wrapperDigest
+    exit 0
+}
+
+function Test-ExclusiveRuleSet($OwnerSid, $ExpectedOwnerSid, $Rules, $AllowedSids, $IsProtected) {
+    if (-not $IsProtected -or $OwnerSid -ne $ExpectedOwnerSid -or $Rules.Count -ne 3) {
+        return $false
+    }
+    $actualSids = @($Rules | ForEach-Object { $_.IdentityReference.Value })
+    if (@($AllowedSids | Where-Object { $actualSids -notcontains $_ }).Count -ne 0) {
+        return $false
+    }
+    $violations = @($Rules | Where-Object {
+        $_.AccessControlType -ne 'Allow' -or
+        $AllowedSids -notcontains $_.IdentityReference.Value -or
+        ($_.FileSystemRights -band [Security.AccessControl.FileSystemRights]::FullControl) -ne
+            [Security.AccessControl.FileSystemRights]::FullControl
+    })
+    return $violations.Count -eq 0
+}
+
+if ($AclPredicateSelfTest) {
+    $sid = 'S-1-5-21-1-2-3-1001'
+    $allowed = @($sid, 'S-1-5-18', 'S-1-5-32-544')
+    $rules = @($allowed | ForEach-Object {
+        [pscustomobject]@{
+            AccessControlType = 'Allow'
+            IdentityReference = [pscustomobject]@{ Value = $_ }
+            FileSystemRights = [Security.AccessControl.FileSystemRights]::FullControl
+        }
+    })
+    if ($AclPredicateSelfTest -eq 'foreign') {
+        $rules[-1].IdentityReference = [pscustomobject]@{ Value = 'S-1-1-0' }
+    }
+    if ($AclPredicateSelfTest -eq 'duplicate') {
+        $rules[-1].IdentityReference = [pscustomobject]@{ Value = $sid }
+    }
+    $owner = if ($AclPredicateSelfTest -eq 'wrong-owner') { 'S-1-1-0' } else { $sid }
+    $isProtected = $AclPredicateSelfTest -ne 'unprotected'
+    [bool](Test-ExclusiveRuleSet $owner $sid $rules $allowed $isProtected)
+    exit 0
+}
+
+$origin = 'https://github.com/ShaftHQ/SHAFT_ENGINE'
+$trustModel = 'exclusive-maintenance-home-v1'
+$taskName = 'SHAFT-Nightly-Knowledge-Refresh'
+$sourceController = Join-Path $PSScriptRoot 'shaft_knowledge_refresh.py'
+$sourceWrapper = Join-Path $PSScriptRoot 'graphify-refresh.cmd'
+foreach ($name in @('GIT_DIR', 'GIT_COMMON_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE',
+        'GIT_OBJECT_DIRECTORY', 'GIT_ALTERNATE_OBJECT_DIRECTORIES', 'GIT_CONFIG_COUNT',
+        'GIT_CONFIG_SYSTEM', 'GIT_CONFIG_GLOBAL', 'GIT_CONFIG_PARAMETERS')) {
+    Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+}
+Get-ChildItem Env: | Where-Object Name -Match '^GIT_CONFIG_(KEY|VALUE)_' | Remove-Item
+$env:GIT_OPTIONAL_LOCKS = '0'
+$env:GIT_CONFIG_NOSYSTEM = '1'
+$env:GIT_CONFIG_GLOBAL = 'NUL'
+
+$lexicalHome = [IO.Path]::GetFullPath($MaintenanceHome)
+if ($lexicalHome -eq [IO.Path]::GetPathRoot($lexicalHome)) { throw 'Maintenance home must be a dedicated directory, not a drive root.' }
+$lexicalHome = $lexicalHome.TrimEnd('\')
+$lexicalRoot = Join-Path $lexicalHome 'SHAFT_ENGINE-main'
+$lexicalSentinel = Join-Path $lexicalHome '.shaft-nightly-maintenance.json'
+py -3 $sourceController --root $lexicalRoot --sentinel $lexicalSentinel --validate-home-only
+if ($LASTEXITCODE -ne 0) { throw 'Maintenance-home preflight failed before the first write.' }
+
+$currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+$allowedSids = @($currentSid, 'S-1-5-18', 'S-1-5-32-544')
+function New-ExclusiveDirectorySecurity {
+    $security = [Security.AccessControl.DirectorySecurity]::new()
+    $security.SetAccessRuleProtection($true, $false)
+    $security.SetOwner([Security.Principal.SecurityIdentifier]::new($currentSid))
+    foreach ($sid in $allowedSids) {
+        $security.AddAccessRule([Security.AccessControl.FileSystemAccessRule]::new(
+            [Security.Principal.SecurityIdentifier]::new($sid),
+            [Security.AccessControl.FileSystemRights]::FullControl,
+            [Security.AccessControl.InheritanceFlags]'ContainerInherit, ObjectInherit',
+            [Security.AccessControl.PropagationFlags]::None,
+            [Security.AccessControl.AccessControlType]::Allow)) | Out-Null
+    }
+    return $security
+}
+function New-ExclusiveDirectory([string]$Path) {
+    $security = New-ExclusiveDirectorySecurity
+    [ShaftMaintenance.SecureDirectory]::Create($Path, $security.GetSecurityDescriptorBinaryForm())
+}
+function Assert-ExclusiveMaintenanceAcl([string]$Path) {
+    $aclRoot = (Get-Item -LiteralPath $Path -Force).FullName
+    foreach ($target in @((Get-Item -LiteralPath $aclRoot -Force)) + @(Get-ChildItem -LiteralPath $aclRoot -Force -Recurse)) {
+        $acl = Get-Acl -LiteralPath $target.FullName
+        $rules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))
+        $owner = $acl.GetOwner([Security.Principal.SecurityIdentifier]).Value
+        $protectionIsValid = $target.FullName -ne $aclRoot -or $acl.AreAccessRulesProtected
+        if (-not (Test-ExclusiveRuleSet $owner $currentSid $rules $allowedSids $protectionIsValid)) {
+            throw "Maintenance ACL verification failed: $($target.FullName)"
+        }
+    }
+}
+
+function Assert-ControllerBundle(
+    [string]$BundleHome,
+    [string]$ExpectedControllerDigest,
+    [string]$ExpectedWrapperDigest
+) {
+    $controller = Join-Path $BundleHome 'shaft_knowledge_refresh.py'
+    $wrapper = Join-Path $BundleHome 'graphify-refresh.cmd'
+    $entries = @(Get-ChildItem -LiteralPath $BundleHome -Force)
+    $entryNames = @($entries | ForEach-Object Name | Sort-Object)
+    if (
+        $entries.Count -ne 2 -or
+        ($entryNames -join '|') -ne 'graphify-refresh.cmd|shaft_knowledge_refresh.py' -or
+        -not (Test-Path -LiteralPath $controller -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $wrapper -PathType Leaf) -or
+        (Get-FileHash -Algorithm SHA256 $controller).Hash -ne $ExpectedControllerDigest -or
+        (Get-FileHash -Algorithm SHA256 $wrapper).Hash -ne $ExpectedWrapperDigest
+    ) {
+        throw 'Versioned controller bundle is incomplete or does not match its identity.'
+    }
+}
+
+function Install-ControllerBundle(
+    [string]$ControllerRoot,
+    [string]$BundleHash,
+    [string]$ControllerSource,
+    [string]$WrapperSource,
+    [string]$ExpectedControllerDigest,
+    [string]$ExpectedWrapperDigest
+) {
+    $final = Join-Path $ControllerRoot $BundleHash
+    foreach ($orphan in @(Get-ChildItem -LiteralPath $ControllerRoot -Directory -Force -Filter "$BundleHash.staging-*")) {
+        Assert-ExclusiveMaintenanceAcl $orphan.FullName
+        Remove-Item -LiteralPath $orphan.FullName -Recurse -Force
+    }
+    if (Test-Path -LiteralPath $final) {
+        Assert-ControllerBundle $final $ExpectedControllerDigest $ExpectedWrapperDigest
+        return $final
+    }
+    $staging = "$final.staging-$([guid]::NewGuid().ToString('N'))"
+    try {
+        New-ExclusiveDirectory $staging
+        Copy-Item -LiteralPath $ControllerSource -Destination (Join-Path $staging 'shaft_knowledge_refresh.py')
+        Copy-Item -LiteralPath $WrapperSource -Destination (Join-Path $staging 'graphify-refresh.cmd')
+        Assert-ExclusiveMaintenanceAcl $staging
+        Assert-ControllerBundle $staging $ExpectedControllerDigest $ExpectedWrapperDigest
+        try {
+            [IO.Directory]::Move($staging, $final)
+        } catch [IO.IOException] {
+            if (-not (Test-Path -LiteralPath $final -PathType Container)) { throw }
+            Assert-ControllerBundle $final $ExpectedControllerDigest $ExpectedWrapperDigest
+        }
+    } finally {
+        if (Test-Path -LiteralPath $staging) {
+            Remove-Item -LiteralPath $staging -Recurse -Force
+        }
+    }
+    Assert-ControllerBundle $final $ExpectedControllerDigest $ExpectedWrapperDigest
+    return $final
+}
+
+function Open-InstallerLock([string]$MaintenanceHome) {
+    $lockPath = Join-Path $MaintenanceHome '.shaft-install.lock'
+    try {
+        return [IO.File]::Open(
+            $lockPath,
+            [IO.FileMode]::OpenOrCreate,
+            [IO.FileAccess]::ReadWrite,
+            [IO.FileShare]::None)
+    } catch [IO.IOException] {
+        throw 'SHAFT nightly installer is already running.'
+    }
+}
+
+function Invoke-WithInstallerLock([string]$MaintenanceHome, [scriptblock]$Action) {
+    $lock = Open-InstallerLock $MaintenanceHome
+    try {
+        & $Action
+    } finally {
+        $lock.Dispose()
+    }
+}
+
+if ($SecureDirectorySelfTest) {
+    New-ExclusiveDirectory $SecureDirectorySelfTest
+    Assert-ExclusiveMaintenanceAcl $SecureDirectorySelfTest
+    $true
+    exit 0
+}
+
+if ($BundlePromotionSelfTest) {
+    $controllerRoot = Join-Path $BundlePromotionSelfTest 'Controller'
+    New-ExclusiveDirectory $controllerRoot
+    $controllerDigest = (Get-FileHash -Algorithm SHA256 $sourceController).Hash
+    $wrapperDigest = (Get-FileHash -Algorithm SHA256 $sourceWrapper).Hash
+    $bundleHash = Get-ControllerBundleHash $controllerDigest $wrapperDigest
+    $orphan = Join-Path $controllerRoot "$bundleHash.staging-orphan"
+    New-ExclusiveDirectory $orphan
+    $bundle = Install-ControllerBundle $controllerRoot $bundleHash $sourceController $sourceWrapper $controllerDigest $wrapperDigest
+    [bool](Test-Path -LiteralPath (Join-Path $bundle 'graphify-refresh.cmd') -PathType Leaf)
+    exit 0
+}
+
+if ($InstallerLockSelfTest) {
+    if (-not (Test-Path -LiteralPath $InstallerLockSelfTest)) {
+        New-ExclusiveDirectory $InstallerLockSelfTest
+    } else {
+        Assert-ExclusiveMaintenanceAcl $InstallerLockSelfTest
+    }
+    $selfTestLock = Open-InstallerLock $InstallerLockSelfTest
+    try {
+        if ($InstallerLockHoldMilliseconds -gt 0) {
+            Start-Sleep -Milliseconds $InstallerLockHoldMilliseconds
+        }
+        $true
+    } finally {
+        $selfTestLock.Dispose()
+    }
+    exit 0
+}
+
+if ($InstallerLockFailureSelfTest) {
+    New-ExclusiveDirectory $InstallerLockFailureSelfTest
+    try {
+        Invoke-WithInstallerLock $InstallerLockFailureSelfTest { throw 'injected failure' }
+    } catch {
+        if ($_.Exception.Message -ne 'injected failure') { throw }
+    }
+    $retry = Open-InstallerLock $InstallerLockFailureSelfTest
+    try { $true } finally { $retry.Dispose() }
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $lexicalHome)) {
+    New-ExclusiveDirectory $lexicalHome
+} else {
+    Assert-ExclusiveMaintenanceAcl $lexicalHome
+}
+$homePath = (Get-Item -LiteralPath $lexicalHome -Force).FullName.TrimEnd('\')
+Invoke-WithInstallerLock $homePath {
+Assert-ExclusiveMaintenanceAcl $homePath
+$root = Join-Path $homePath 'SHAFT_ENGINE-main'
+$sentinel = Join-Path $homePath '.shaft-nightly-maintenance.json'
+$pending = Join-Path $homePath '.shaft-install-pending.json'
+$logs = Join-Path $homePath 'Logs'
+
+py -3 $sourceController --root $root --sentinel $sentinel --validate-home-only
+if ($LASTEXITCODE -ne 0) { throw 'Maintenance home changed after ACL establishment.' }
+New-Item -ItemType Directory -Force $logs | Out-Null
+
+$controllerDigest = (Get-FileHash -Algorithm SHA256 $sourceController).Hash
+$wrapperDigest = (Get-FileHash -Algorithm SHA256 $sourceWrapper).Hash
+$controllerHash = Get-ControllerBundleHash $controllerDigest $wrapperDigest
+$controllerRoot = Join-Path $homePath 'Controller'
+if (-not (Test-Path -LiteralPath $controllerRoot)) {
+    New-ExclusiveDirectory $controllerRoot
+}
+Assert-ExclusiveMaintenanceAcl $homePath
+$controllerHome = Join-Path $controllerRoot $controllerHash
+$controllerHome = Install-ControllerBundle $controllerRoot $controllerHash $sourceController $sourceWrapper $controllerDigest $wrapperDigest
+Assert-ExclusiveMaintenanceAcl $homePath
+$installedController = Join-Path $controllerHome 'shaft_knowledge_refresh.py'
+$installedWrapper = Join-Path $controllerHome 'graphify-refresh.cmd'
+
+if (-not (Test-Path -LiteralPath $sentinel -PathType Leaf)) {
+    if (Test-Path -LiteralPath $pending -PathType Leaf) {
+        py -3 $installedController --root $root --sentinel $sentinel --validate-pending $pending
+        if ($LASTEXITCODE -ne 0) { throw 'Pending install receipt cannot authorize recovery.' }
+        $pendingReceipt = Get-Content -LiteralPath $pending -Raw | ConvertFrom-Json
+        $token = $pendingReceipt.owner_token
+        if (Test-Path -LiteralPath $root) {
+            py -3 $installedController --root $root --sentinel $sentinel --validate-home-only
+            if ($LASTEXITCODE -ne 0) { throw 'Interrupted clone path is unsafe to recover.' }
+            Remove-Item -LiteralPath $root -Recurse -Force
+        }
+        Write-Output 'Recovering installer-owned clone from the independent pending receipt.'
+    } else {
+        if (Test-Path -LiteralPath $root) { throw 'Existing clone has no independent installer receipt.' }
+        $token = [guid]::NewGuid().ToString('N')
+        $pendingReceipt = [ordered]@{
+            schema_version = 1; repository_root = $root; origin = $origin
+            owner_token = $token; trust_model = $trustModel
+        }
+        Write-Utf8NoBomJson $pendingReceipt $pending
+        py -3 $installedController --root $root --sentinel $sentinel --validate-pending $pending
+        if ($LASTEXITCODE -ne 0) { throw 'New pending receipt failed its own validation.' }
+    }
+    git clone -c shaft.maintenanceOwner=$token --origin origin --branch main --single-branch $origin $root
+    if ($LASTEXITCODE -ne 0) { throw 'git clone failed; the pending receipt permits a safe retry.' }
+    py -3 $installedController --root $root --sentinel $sentinel --validate-paths-only
+    if ($LASTEXITCODE -ne 0) { throw 'Fresh clone failed the owned-path preflight.' }
+    $head = (git -C $root rev-parse HEAD).Trim()
+    if ($LASTEXITCODE -ne 0) { throw 'Cannot read the fresh clone revision.' }
+    $remoteLine = (git ls-remote --exit-code $origin refs/heads/main).Trim()
+    if ($LASTEXITCODE -ne 0) { throw 'Cannot verify approved remote main.' }
+    if ($head -ne (($remoteLine -split '\s+')[0])) { throw 'Approved main changed during clone.' }
+    $receipt = [ordered]@{
+        schema_version = 1; repository_root = $root; origin = $origin
+        owner_token = $token; trust_model = $trustModel
+    }
+    Write-Utf8NoBomJson $receipt "$sentinel.tmp"
+    Move-Item -LiteralPath "$sentinel.tmp" -Destination $sentinel
+    Remove-Item -LiteralPath $pending -Force
+}
+
+py -3 $installedController --root $root --sentinel $sentinel --validate-only
+if ($LASTEXITCODE -ne 0) { throw 'Installer-owned clone failed the external controller preflight.' }
+if (Test-Path -LiteralPath $pending -PathType Leaf) {
+    py -3 $installedController --root $root --sentinel $sentinel --validate-pending $pending
+    if ($LASTEXITCODE -ne 0) { throw 'Stale pending receipt is invalid.' }
+    $pendingReceipt = Get-Content -LiteralPath $pending -Raw | ConvertFrom-Json
+    $finalReceipt = Get-Content -LiteralPath $sentinel -Raw | ConvertFrom-Json
+    if ($pendingReceipt.owner_token -ne $finalReceipt.owner_token) { throw 'Stale pending receipt conflicts with the finalized installation.' }
+    Remove-Item -LiteralPath $pending -Force
+}
+$action = New-ScheduledTaskAction -Execute $env:ComSpec -Argument ('/d /c ""{0}""' -f $installedWrapper) -WorkingDirectory $controllerHome
+$trigger = New-ScheduledTaskTrigger -Daily -At '05:00'
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -RunOnlyIfNetworkAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew -ExecutionTimeLimit (New-TimeSpan -Hours 3) -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 15)
+$principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited
+Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Description 'Refresh SHAFT Graphify and MemPalace from verified origin/main when Mohab is logged in.' -Force | Out-Null
+if (Get-ScheduledTask -TaskName 'graphify-refresh' -ErrorAction SilentlyContinue) { Unregister-ScheduledTask -TaskName 'graphify-refresh' -Confirm:$false }
+Write-Output "Registered $taskName using versioned protected controller $installedController."
+}

--- a/tools/agent-infra/install-agent-tasks.ps1
+++ b/tools/agent-infra/install-agent-tasks.ps1
@@ -163,6 +163,18 @@ function New-ExclusiveDirectory {
         [ShaftMaintenance.SecureDirectory]::Create($Path, $security.GetSecurityDescriptorBinaryForm())
     }
 }
+function Set-ExclusiveFileAcl([string]$Path) {
+    $security = [Security.AccessControl.FileSecurity]::new()
+    $security.SetAccessRuleProtection($true, $false)
+    $security.SetOwner([Security.Principal.SecurityIdentifier]::new($currentSid))
+    foreach ($sid in $allowedSids) {
+        $security.AddAccessRule([Security.AccessControl.FileSystemAccessRule]::new(
+            [Security.Principal.SecurityIdentifier]::new($sid),
+            [Security.AccessControl.FileSystemRights]::FullControl,
+            [Security.AccessControl.AccessControlType]::Allow)) | Out-Null
+    }
+    Set-Acl -LiteralPath $Path -AclObject $security
+}
 function Assert-ExclusiveMaintenanceAcl([string]$Path) {
     $aclRoot = (Get-Item -LiteralPath $Path -Force).FullName
     foreach ($target in @((Get-Item -LiteralPath $aclRoot -Force)) + @(Get-ChildItem -LiteralPath $aclRoot -Force -Recurse)) {
@@ -220,8 +232,12 @@ function Install-ControllerBundle(
     $staging = "$final.staging-$([guid]::NewGuid().ToString('N'))"
     try {
         New-ExclusiveDirectory -Path $staging
-        Copy-Item -LiteralPath $ControllerSource -Destination (Join-Path $staging 'shaft_knowledge_refresh.py')
-        Copy-Item -LiteralPath $WrapperSource -Destination (Join-Path $staging 'graphify-refresh.cmd')
+        $stagedController = Join-Path $staging 'shaft_knowledge_refresh.py'
+        $stagedWrapper = Join-Path $staging 'graphify-refresh.cmd'
+        Copy-Item -LiteralPath $ControllerSource -Destination $stagedController
+        Copy-Item -LiteralPath $WrapperSource -Destination $stagedWrapper
+        Set-ExclusiveFileAcl -Path $stagedController
+        Set-ExclusiveFileAcl -Path $stagedWrapper
         Assert-ExclusiveMaintenanceAcl $staging
         Assert-ControllerBundle -BundleHome $staging `
             -ExpectedControllerDigest $ExpectedControllerDigest `

--- a/tools/agent-infra/install-agent-tasks.ps1
+++ b/tools/agent-infra/install-agent-tasks.ps1
@@ -390,6 +390,12 @@ $trigger = New-ScheduledTaskTrigger -Daily -At '05:00'
 $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -RunOnlyIfNetworkAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew -ExecutionTimeLimit (New-TimeSpan -Hours 3) -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 15)
 $principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited
 Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Description 'Refresh SHAFT Graphify and MemPalace from verified origin/main when Mohab is logged in.' -Force | Out-Null
-if (Get-ScheduledTask -TaskName 'graphify-refresh' -ErrorAction SilentlyContinue) { Unregister-ScheduledTask -TaskName 'graphify-refresh' -Confirm:$false }
+$legacyTasks = @(Get-ScheduledTask -ErrorAction Stop | Where-Object {
+    $_.TaskName -eq 'graphify-refresh' -and $_.TaskPath -eq '\'
+})
+if ($legacyTasks.Count -gt 1) { throw 'Multiple root legacy graphify-refresh tasks were returned.' }
+if ($legacyTasks.Count -eq 1) {
+    $legacyTasks[0] | Unregister-ScheduledTask -Confirm:$false -ErrorAction Stop
+}
 Write-Output "Registered $taskName using versioned protected controller $installedController."
 }

--- a/tools/agent-infra/install-agent-tasks.ps1
+++ b/tools/agent-infra/install-agent-tasks.ps1
@@ -163,7 +163,9 @@ function New-ExclusiveDirectory {
         [ShaftMaintenance.SecureDirectory]::Create($Path, $security.GetSecurityDescriptorBinaryForm())
     }
 }
-function Set-ExclusiveFileAcl([string]$Path) {
+function Set-ExclusiveFileAcl {
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$Path)
     $security = [Security.AccessControl.FileSecurity]::new()
     $security.SetAccessRuleProtection($true, $false)
     $security.SetOwner([Security.Principal.SecurityIdentifier]::new($currentSid))
@@ -173,7 +175,9 @@ function Set-ExclusiveFileAcl([string]$Path) {
             [Security.AccessControl.FileSystemRights]::FullControl,
             [Security.AccessControl.AccessControlType]::Allow)) | Out-Null
     }
-    Set-Acl -LiteralPath $Path -AclObject $security
+    if ($PSCmdlet.ShouldProcess($Path, 'Apply protected maintenance ACL')) {
+        Set-Acl -LiteralPath $Path -AclObject $security
+    }
 }
 function Assert-ExclusiveMaintenanceAcl([string]$Path) {
     $aclRoot = (Get-Item -LiteralPath $Path -Force).FullName

--- a/tools/agent-infra/install-agent-tasks.ps1
+++ b/tools/agent-infra/install-agent-tasks.ps1
@@ -111,7 +111,8 @@ if ($AclPredicateSelfTest) {
     }
     $owner = if ($AclPredicateSelfTest -eq 'wrong-owner') { 'S-1-1-0' } else { $sid }
     $isProtected = $AclPredicateSelfTest -ne 'unprotected'
-    [bool](Test-ExclusiveRuleSet $owner $sid $rules $allowed $isProtected)
+    [bool](Test-ExclusiveRuleSet -OwnerSid $owner -ExpectedOwnerSid $sid -Rules $rules `
+        -AllowedSids $allowed -IsProtected $isProtected)
     exit 0
 }
 
@@ -140,7 +141,7 @@ if ($LASTEXITCODE -ne 0) { throw 'Maintenance-home preflight failed before the f
 
 $currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
 $allowedSids = @($currentSid, 'S-1-5-18', 'S-1-5-32-544')
-function New-ExclusiveDirectorySecurity {
+function Get-ExclusiveDirectorySecurity {
     $security = [Security.AccessControl.DirectorySecurity]::new()
     $security.SetAccessRuleProtection($true, $false)
     $security.SetOwner([Security.Principal.SecurityIdentifier]::new($currentSid))
@@ -154,9 +155,13 @@ function New-ExclusiveDirectorySecurity {
     }
     return $security
 }
-function New-ExclusiveDirectory([string]$Path) {
-    $security = New-ExclusiveDirectorySecurity
-    [ShaftMaintenance.SecureDirectory]::Create($Path, $security.GetSecurityDescriptorBinaryForm())
+function New-ExclusiveDirectory {
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$Path)
+    if ($PSCmdlet.ShouldProcess($Path, 'Create directory with protected maintenance ACL')) {
+        $security = Get-ExclusiveDirectorySecurity
+        [ShaftMaintenance.SecureDirectory]::Create($Path, $security.GetSecurityDescriptorBinaryForm())
+    }
 }
 function Assert-ExclusiveMaintenanceAcl([string]$Path) {
     $aclRoot = (Get-Item -LiteralPath $Path -Force).FullName
@@ -165,7 +170,8 @@ function Assert-ExclusiveMaintenanceAcl([string]$Path) {
         $rules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))
         $owner = $acl.GetOwner([Security.Principal.SecurityIdentifier]).Value
         $protectionIsValid = $target.FullName -ne $aclRoot -or $acl.AreAccessRulesProtected
-        if (-not (Test-ExclusiveRuleSet $owner $currentSid $rules $allowedSids $protectionIsValid)) {
+        if (-not (Test-ExclusiveRuleSet -OwnerSid $owner -ExpectedOwnerSid $currentSid `
+                -Rules $rules -AllowedSids $allowedSids -IsProtected $protectionIsValid)) {
             throw "Maintenance ACL verification failed: $($target.FullName)"
         }
     }
@@ -206,28 +212,36 @@ function Install-ControllerBundle(
         Remove-Item -LiteralPath $orphan.FullName -Recurse -Force
     }
     if (Test-Path -LiteralPath $final) {
-        Assert-ControllerBundle $final $ExpectedControllerDigest $ExpectedWrapperDigest
+        Assert-ControllerBundle -BundleHome $final `
+            -ExpectedControllerDigest $ExpectedControllerDigest `
+            -ExpectedWrapperDigest $ExpectedWrapperDigest
         return $final
     }
     $staging = "$final.staging-$([guid]::NewGuid().ToString('N'))"
     try {
-        New-ExclusiveDirectory $staging
+        New-ExclusiveDirectory -Path $staging
         Copy-Item -LiteralPath $ControllerSource -Destination (Join-Path $staging 'shaft_knowledge_refresh.py')
         Copy-Item -LiteralPath $WrapperSource -Destination (Join-Path $staging 'graphify-refresh.cmd')
         Assert-ExclusiveMaintenanceAcl $staging
-        Assert-ControllerBundle $staging $ExpectedControllerDigest $ExpectedWrapperDigest
+        Assert-ControllerBundle -BundleHome $staging `
+            -ExpectedControllerDigest $ExpectedControllerDigest `
+            -ExpectedWrapperDigest $ExpectedWrapperDigest
         try {
             [IO.Directory]::Move($staging, $final)
         } catch [IO.IOException] {
             if (-not (Test-Path -LiteralPath $final -PathType Container)) { throw }
-            Assert-ControllerBundle $final $ExpectedControllerDigest $ExpectedWrapperDigest
+            Assert-ControllerBundle -BundleHome $final `
+                -ExpectedControllerDigest $ExpectedControllerDigest `
+                -ExpectedWrapperDigest $ExpectedWrapperDigest
         }
     } finally {
         if (Test-Path -LiteralPath $staging) {
             Remove-Item -LiteralPath $staging -Recurse -Force
         }
     }
-    Assert-ControllerBundle $final $ExpectedControllerDigest $ExpectedWrapperDigest
+    Assert-ControllerBundle -BundleHome $final `
+        -ExpectedControllerDigest $ExpectedControllerDigest `
+        -ExpectedWrapperDigest $ExpectedWrapperDigest
     return $final
 }
 
@@ -254,7 +268,7 @@ function Invoke-WithInstallerLock([string]$MaintenanceHome, [scriptblock]$Action
 }
 
 if ($SecureDirectorySelfTest) {
-    New-ExclusiveDirectory $SecureDirectorySelfTest
+    New-ExclusiveDirectory -Path $SecureDirectorySelfTest
     Assert-ExclusiveMaintenanceAcl $SecureDirectorySelfTest
     $true
     exit 0
@@ -262,20 +276,22 @@ if ($SecureDirectorySelfTest) {
 
 if ($BundlePromotionSelfTest) {
     $controllerRoot = Join-Path $BundlePromotionSelfTest 'Controller'
-    New-ExclusiveDirectory $controllerRoot
+    New-ExclusiveDirectory -Path $controllerRoot
     $controllerDigest = (Get-FileHash -Algorithm SHA256 $sourceController).Hash
     $wrapperDigest = (Get-FileHash -Algorithm SHA256 $sourceWrapper).Hash
     $bundleHash = Get-ControllerBundleHash $controllerDigest $wrapperDigest
     $orphan = Join-Path $controllerRoot "$bundleHash.staging-orphan"
-    New-ExclusiveDirectory $orphan
-    $bundle = Install-ControllerBundle $controllerRoot $bundleHash $sourceController $sourceWrapper $controllerDigest $wrapperDigest
+    New-ExclusiveDirectory -Path $orphan
+    $bundle = Install-ControllerBundle -ControllerRoot $controllerRoot -BundleHash $bundleHash `
+        -ControllerSource $sourceController -WrapperSource $sourceWrapper `
+        -ExpectedControllerDigest $controllerDigest -ExpectedWrapperDigest $wrapperDigest
     [bool](Test-Path -LiteralPath (Join-Path $bundle 'graphify-refresh.cmd') -PathType Leaf)
     exit 0
 }
 
 if ($InstallerLockSelfTest) {
     if (-not (Test-Path -LiteralPath $InstallerLockSelfTest)) {
-        New-ExclusiveDirectory $InstallerLockSelfTest
+        New-ExclusiveDirectory -Path $InstallerLockSelfTest
     } else {
         Assert-ExclusiveMaintenanceAcl $InstallerLockSelfTest
     }
@@ -292,7 +308,7 @@ if ($InstallerLockSelfTest) {
 }
 
 if ($InstallerLockFailureSelfTest) {
-    New-ExclusiveDirectory $InstallerLockFailureSelfTest
+    New-ExclusiveDirectory -Path $InstallerLockFailureSelfTest
     try {
         Invoke-WithInstallerLock $InstallerLockFailureSelfTest { throw 'injected failure' }
     } catch {
@@ -304,7 +320,7 @@ if ($InstallerLockFailureSelfTest) {
 }
 
 if (-not (Test-Path -LiteralPath $lexicalHome)) {
-    New-ExclusiveDirectory $lexicalHome
+    New-ExclusiveDirectory -Path $lexicalHome
 } else {
     Assert-ExclusiveMaintenanceAcl $lexicalHome
 }
@@ -325,11 +341,13 @@ $wrapperDigest = (Get-FileHash -Algorithm SHA256 $sourceWrapper).Hash
 $controllerHash = Get-ControllerBundleHash $controllerDigest $wrapperDigest
 $controllerRoot = Join-Path $homePath 'Controller'
 if (-not (Test-Path -LiteralPath $controllerRoot)) {
-    New-ExclusiveDirectory $controllerRoot
+    New-ExclusiveDirectory -Path $controllerRoot
 }
 Assert-ExclusiveMaintenanceAcl $homePath
 $controllerHome = Join-Path $controllerRoot $controllerHash
-$controllerHome = Install-ControllerBundle $controllerRoot $controllerHash $sourceController $sourceWrapper $controllerDigest $wrapperDigest
+$controllerHome = Install-ControllerBundle -ControllerRoot $controllerRoot `
+    -BundleHash $controllerHash -ControllerSource $sourceController -WrapperSource $sourceWrapper `
+    -ExpectedControllerDigest $controllerDigest -ExpectedWrapperDigest $wrapperDigest
 Assert-ExclusiveMaintenanceAcl $homePath
 $installedController = Join-Path $controllerHome 'shaft_knowledge_refresh.py'
 $installedWrapper = Join-Path $controllerHome 'graphify-refresh.cmd'

--- a/tools/agent-infra/shaft_knowledge_refresh.py
+++ b/tools/agent-infra/shaft_knowledge_refresh.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Refresh an installer-owned SHAFT clone and its knowledge stores."""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess  # nosec B404 - fixed list-form maintenance commands.
+import sys
+from typing import Iterator
+
+ORIGIN = "https://github.com/ShaftHQ/SHAFT_ENGINE"
+WING = "shaft_engine_main"
+TRUST_MODEL = "exclusive-maintenance-home-v1"
+GIT_ROUTING_VARIABLES = (
+    "GIT_DIR",
+    "GIT_COMMON_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_PARAMETERS",
+)
+
+
+def required(name: str) -> str:
+    executable = shutil.which(name)
+    if executable is None:
+        raise ValueError(f"required executable is not on PATH: {name}")
+    return executable
+
+
+def run(
+    arguments: list[str],
+    cwd: Path,
+    environment=None,
+    allowed_exit_codes: tuple[int, ...] = (0,),
+) -> str:
+    completed = subprocess.run(  # nosec B603
+        arguments, cwd=cwd, env=environment, check=False,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    if completed.returncode not in allowed_exit_codes:
+        raise subprocess.CalledProcessError(
+            completed.returncode, arguments, output=completed.stdout
+        )
+    if completed.stdout:
+        print(completed.stdout, end="" if completed.stdout.endswith("\n") else "\n")
+    return completed.stdout
+
+
+def git_environment() -> dict[str, str]:
+    """Return an environment that cannot redirect Git outside the owned clone."""
+    environment = os.environ.copy()
+    for name in GIT_ROUTING_VARIABLES:
+        environment.pop(name, None)
+    for name in tuple(environment):
+        if name.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
+            environment.pop(name)
+    environment["GIT_CONFIG_NOSYSTEM"] = "1"
+    environment["GIT_CONFIG_GLOBAL"] = os.devnull
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    return environment
+
+
+def git(arguments: list[str], cwd: Path) -> str:
+    completed = subprocess.run(  # nosec B603
+        [required("git"), *arguments], cwd=cwd, env=git_environment(), check=True,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    return completed.stdout
+
+
+def is_system_drive(path: Path) -> bool:
+    return os.name == "nt" and path.drive.casefold() == os.environ.get(
+        "SystemDrive", "C:"
+    ).casefold()
+
+
+def is_reparse(path: Path) -> bool:
+    if path.is_symlink() or (
+        hasattr(path, "is_junction") and path.is_junction()  # type: ignore[attr-defined]
+    ):
+        return True
+    try:
+        attributes = getattr(path.stat(follow_symlinks=False), "st_file_attributes", 0)
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        raise ValueError(f"cannot inspect maintenance path metadata: {path}") from error
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400))
+
+
+def has_unsafe_descendant(path: Path) -> bool:
+    """Inspect an owned tree without following reparses or multi-link files."""
+    if not path.is_dir():
+        return False
+    pending = [path]
+    while pending:
+        current = pending.pop()
+        try:
+            entries = list(os.scandir(current))
+        except OSError as error:
+            raise ValueError(f"cannot inspect owned maintenance tree: {current}") from error
+        for entry in entries:
+            candidate = Path(entry.path)
+            if is_reparse(candidate):
+                return True
+            try:
+                metadata = candidate.stat(follow_symlinks=False)
+            except OSError as error:
+                raise ValueError(f"cannot inspect owned maintenance entry: {candidate}") from error
+            if not entry.is_dir(follow_symlinks=False) and metadata.st_nlink != 1:
+                return True
+            if entry.is_dir(follow_symlinks=False):
+                pending.append(candidate)
+    return False
+
+
+@contextmanager
+def trusted_graph_output(path: Path) -> Iterator[None]:
+    """Validate Graphify output under the exclusive-writer maintenance contract."""
+    path.mkdir(exist_ok=True)
+    if is_reparse(path) or has_unsafe_descendant(path):
+        raise ValueError("Graphify output contains a reparse point")
+    yield
+    if is_reparse(path) or has_unsafe_descendant(path):
+        raise ValueError("Graphify output gained a reparse point during refresh")
+
+
+def validate_lexical_home(requested_root: Path) -> Path:
+    """Validate an existing ancestor chain before any maintenance-home write."""
+    lexical_home = Path(os.path.abspath(requested_root)).parent
+    if is_system_drive(lexical_home):
+        raise ValueError("maintenance home must not be on the Windows system drive")
+    for candidate in (lexical_home, *lexical_home.parents):
+        if candidate.exists() and is_reparse(candidate):
+            raise ValueError("maintenance home and its ancestors must not be reparse points")
+    if lexical_home.exists() and has_unsafe_descendant(lexical_home):
+        raise ValueError("maintenance home contains an unsafe descendant")
+    return lexical_home
+
+
+def validate_owned_paths(requested_root: Path, requested_sentinel: Path) -> tuple[Path, Path]:
+    """Validate paths without reading Git or requiring a completed sentinel."""
+    validate_lexical_home(requested_root)
+    lexical_root = Path(os.path.abspath(requested_root))
+    lexical_sentinel = Path(os.path.abspath(requested_sentinel))
+    candidates = (
+        lexical_root,
+        *lexical_root.parents,
+        lexical_sentinel,
+        *lexical_sentinel.parents,
+        lexical_root / ".git",
+        lexical_root / "graphify-out",
+    )
+    if any(is_reparse(path) for path in candidates):
+        raise ValueError("maintenance paths must not be reparse points")
+    root = requested_root.resolve()
+    sentinel = requested_sentinel.resolve()
+    if is_system_drive(root) or not root.is_dir() or not (root / ".git").is_dir():
+        raise ValueError("maintenance root must be an installer-owned non-system-drive clone")
+    if has_unsafe_descendant(root.parent):
+        raise ValueError("owned maintenance home contains an unsafe descendant")
+    if sentinel.parent != root.parent or sentinel.name != ".shaft-nightly-maintenance.json":
+        raise ValueError("maintenance sentinel must be adjacent to the owned clone")
+    return root, sentinel
+
+
+@contextmanager
+def job_lock(sentinel: Path) -> Iterator[None]:
+    lock = sentinel.with_suffix(sentinel.suffix + ".lock").open("a+b")
+    if lock.seek(0, os.SEEK_END) == 0:
+        lock.write(b"\0")
+        lock.flush()
+    lock.seek(0)
+    try:
+        if os.name == "nt":
+            import msvcrt  # pylint: disable=import-outside-toplevel
+            msvcrt.locking(lock.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl  # pylint: disable=import-outside-toplevel,import-error
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as error:
+        lock.close()
+        raise RuntimeError("nightly SHAFT knowledge refresh is already running") from error
+    try:
+        yield
+    finally:
+        lock.seek(0)
+        if os.name == "nt":
+            msvcrt.locking(lock.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+        lock.close()
+
+
+def validate_owned_clone(requested_root: Path, requested_sentinel: Path) -> tuple[Path, Path]:
+    root, sentinel = validate_owned_paths(requested_root, requested_sentinel)
+    try:
+        data = json.loads(sentinel.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError("maintenance sentinel is absent or unreadable") from error
+    if set(data) != {
+        "schema_version", "repository_root", "origin", "owner_token", "trust_model"
+    }:
+        raise ValueError("maintenance sentinel has unexpected fields")
+    token = data.get("owner_token")
+    expected = {"origin": ORIGIN, "trust_model": TRUST_MODEL}
+    if type(data.get("schema_version")) is not int or data["schema_version"] != 1:
+        raise ValueError("maintenance sentinel schema is invalid")
+    recorded_root = data.get("repository_root")
+    same_root = isinstance(recorded_root, str) and os.path.normcase(recorded_root) == os.path.normcase(str(root))
+    if not same_root or any(data.get(key) != value for key, value in expected.items()) or not isinstance(token, str) or not token:
+        raise ValueError("maintenance sentinel does not own this clone")
+    lines = git(["rev-parse", "--show-toplevel", "--git-common-dir"], root).splitlines()
+    if len(lines) != 2 or Path(lines[0]).resolve() != root:
+        raise ValueError("maintenance clone is not its primary checkout")
+    common = Path(lines[1])
+    if not common.is_absolute():
+        common = root / common
+    if common.resolve() != (root / ".git").resolve():
+        raise ValueError("maintenance clone is not standalone")
+    if git(["remote", "get-url", "origin"], root).strip() != ORIGIN:
+        raise ValueError("maintenance clone origin is not approved")
+    if git(["config", "--local", "--get", "shaft.maintenanceOwner"], root).strip() != token:
+        raise ValueError("maintenance owner token does not match the clone")
+    return root, sentinel
+
+
+def validate_pending_receipt(pending: Path, requested_root: Path) -> dict[str, object]:
+    """Validate the independent authorization written before clone creation."""
+    root = requested_root.resolve()
+    if is_reparse(pending):
+        raise ValueError("pending receipt must not be a reparse point")
+    try:
+        data = json.loads(pending.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError("pending install receipt is absent or unreadable") from error
+    expected_fields = {
+        "schema_version", "repository_root", "origin", "owner_token", "trust_model"
+    }
+    if not isinstance(data, dict) or set(data) != expected_fields:
+        raise ValueError("pending install receipt has unexpected fields")
+    if type(data["schema_version"]) is not int or data["schema_version"] != 1:
+        raise ValueError("pending install receipt schema is invalid")
+    recorded_root = data.get("repository_root")
+    same_root = isinstance(recorded_root, str) and os.path.normcase(recorded_root) == os.path.normcase(str(root))
+    token = data.get("owner_token")
+    if (
+        not same_root
+        or data.get("origin") != ORIGIN
+        or data.get("trust_model") != TRUST_MODEL
+        or not isinstance(token, str)
+        or re.fullmatch(r"[0-9a-f]{32}", token) is None
+    ):
+        raise ValueError("pending install receipt cannot authorize this clone")
+    return data
+
+
+def refresh(requested_root: Path, requested_sentinel: Path) -> None:
+    root, sentinel = validate_owned_clone(requested_root, requested_sentinel)
+    git_exe, mempalace = required("git"), required("mempalace")
+    with job_lock(sentinel):
+        root, sentinel = validate_owned_clone(requested_root, requested_sentinel)
+        git_env = git_environment()
+        rewrites = run(
+            [git_exe, "config", "--local", "--get-regexp", r"^url\..*\.insteadOf$"],
+            root,
+            git_env,
+            allowed_exit_codes=(0, 1),
+        )
+        if rewrites.strip():
+            raise ValueError("maintenance clone must not configure Git URL rewrites")
+        validate_owned_paths(requested_root, requested_sentinel)
+        run([git_exe, "fetch", "--prune", "--no-tags", ORIGIN,
+             "+refs/heads/main:refs/shaft-maintenance/main"], root, git_env)
+        fetched = run([git_exe, "rev-parse", "refs/shaft-maintenance/main"], root, git_env).strip()
+        remote = run([git_exe, "ls-remote", "--exit-code", ORIGIN, "refs/heads/main"], root, git_env).split()
+        if not re.fullmatch(r"[0-9a-f]{40}", fetched) or not remote or remote[0] != fetched:
+            raise RuntimeError("approved origin/main changed during fetch; retry later")
+        run([git_exe, "cat-file", "-e", f"{fetched}^{{commit}}"], root, git_env)
+        validate_owned_paths(requested_root, requested_sentinel)
+        run([git_exe, "reset", "--hard", fetched], root, git_env)
+        run([git_exe, "clean", "-ffd"], root, git_env)
+        environment = git_env.copy()
+        environment["SHAFT_GRAPHIFY_OUT"] = str(root / "graphify-out")
+        with trusted_graph_output(root / "graphify-out"):
+            run([str(Path(sys.executable).resolve()),
+                 "tools/repository-map/graphify_maintenance.py", "refresh", "--root", str(root)],
+                root, environment)
+        run([mempalace, "sync", str(root), "--wing", WING, "--apply"], root, git_env)
+        run([mempalace, "mine", str(root), "--wing", WING,
+             "--agent", "scheduled-refresh"], root, git_env)
+        print(f"SHAFT knowledge refresh complete at {fetched}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--sentinel", required=True, type=Path)
+    parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument("--validate-paths-only", action="store_true")
+    parser.add_argument("--validate-home-only", action="store_true")
+    parser.add_argument("--validate-pending", type=Path)
+    args = parser.parse_args()
+    try:
+        if args.validate_pending is not None:
+            validate_pending_receipt(args.validate_pending, args.root)
+        elif args.validate_home_only:
+            validate_lexical_home(args.root)
+        elif args.validate_paths_only:
+            validate_owned_paths(args.root, args.sentinel)
+        elif args.validate_only:
+            validate_owned_clone(args.root, args.sentinel)
+        else:
+            refresh(args.root, args.sentinel)
+    except (OSError, ValueError, RuntimeError, subprocess.SubprocessError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent-infra/shaft_knowledge_refresh.py
+++ b/tools/agent-infra/shaft_knowledge_refresh.py
@@ -216,7 +216,12 @@ def validate_owned_clone(requested_root: Path, requested_sentinel: Path) -> tupl
         raise ValueError("maintenance sentinel has unexpected fields")
     token = data.get("owner_token")
     expected = {"origin": ORIGIN, "trust_model": TRUST_MODEL}
-    if type(data.get("schema_version")) is not int or data["schema_version"] != 1:
+    schema_version = data.get("schema_version")
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != 1
+    ):
         raise ValueError("maintenance sentinel schema is invalid")
     recorded_root = data.get("repository_root")
     same_root = isinstance(recorded_root, str) and os.path.normcase(recorded_root) == os.path.normcase(str(root))
@@ -251,7 +256,12 @@ def validate_pending_receipt(pending: Path, requested_root: Path) -> dict[str, o
     }
     if not isinstance(data, dict) or set(data) != expected_fields:
         raise ValueError("pending install receipt has unexpected fields")
-    if type(data["schema_version"]) is not int or data["schema_version"] != 1:
+    schema_version = data["schema_version"]
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != 1
+    ):
         raise ValueError("pending install receipt schema is invalid")
     recorded_root = data.get("repository_root")
     same_root = isinstance(recorded_root, str) and os.path.normcase(recorded_root) == os.path.normcase(str(root))

--- a/tools/repository-map/README.md
+++ b/tools/repository-map/README.md
@@ -56,9 +56,10 @@ is not executable in the shell.
 Use Graphify to choose files before broad manual search:
 
 ```powershell
-graphify query "Where is the core SHAFT WebDriver facade and related test coverage?"
-graphify path "SHAFT.GUI.WebDriver" "DriverFactory"
-graphify export callflow-html
+$graphOut = py -3 tools/repository-map/resolve_graph_out.py --check
+graphify query "Where is the core SHAFT WebDriver facade and related test coverage?" --graph (Join-Path $graphOut "graph.json")
+graphify path "SHAFT.GUI.WebDriver" "DriverFactory" --graph (Join-Path $graphOut "graph.json")
+graphify export callflow-html --graph (Join-Path $graphOut "graph.json")
 ```
 
 After Graphify identifies likely files, read exact files with `rg` and small excerpts before editing. Keep using Memory for durable decisions and gotchas; do not rely on Graphify output as the source of truth.
@@ -74,6 +75,10 @@ The default `.graphifyignore` keeps semantic document/media formats out of the g
 Because `graphify-out/` is gitignored, it never exists in a fresh `git worktree` clone. Rather than rebuilding per worktree, treat the **main checkout's** `graphify-out/` as one shared, read-only cache for all linked worktrees:
 
 - Resolve it from any worktree with `python3 tools/repository-map/resolve_graph_out.py` (prints the absolute path under the main checkout root, derived from `git rev-parse --git-common-dir`).
+- Set `SHAFT_GRAPHIFY_OUT` to an absolute cache path when the shared cache is
+  outside that checkout. An explicitly blank or relative value fails closed.
+  A refresh accepts the override only when it is that primary checkout's own
+  `graphify-out`; this prevents one checkout from marking another cache current.
 - Check availability with `python3 tools/repository-map/resolve_graph_out.py --check`: exits `0` and prints the path only when the cache marker matches the revision being inspected. Missing caches report `absent`; unmarked, changed, or revision-mismatched caches report `stale` with the indexed and requested revisions when available. Both degraded modes exit `1` and fall back to `rg` plus Memory.
 - Refresh the cache with `py -3 tools/repository-map/graphify_maintenance.py
   refresh --root .` from the **primary checkout**; worktree sessions only read

--- a/tools/repository-map/graphify_maintenance.py
+++ b/tools/repository-map/graphify_maintenance.py
@@ -162,6 +162,17 @@ def refresh(root: Path, graph_out: Path) -> None:
     requested_output = graph_out if graph_out.is_absolute() else root / graph_out
     if requested_output.resolve() != (root / DEFAULT_GRAPH_OUT).resolve():
         raise ValueError("refresh owns the fixed graphify-out cache; use audit for custom output")
+    if "SHAFT_GRAPHIFY_OUT" in os.environ:
+        configured = os.environ["SHAFT_GRAPHIFY_OUT"].strip()
+        if not configured:
+            raise ValueError("SHAFT_GRAPHIFY_OUT must not be blank")
+        configured_output = Path(configured).expanduser()
+        if not configured_output.is_absolute():
+            raise ValueError("SHAFT_GRAPHIFY_OUT must be absolute")
+        if configured_output.resolve() != requested_output.resolve():
+            raise ValueError(
+                "SHAFT_GRAPHIFY_OUT must match the refresh checkout graphify-out"
+            )
     common_dir = require_primary_checkout(root)
     uv = shutil.which("uv")
     if uv is None:

--- a/tools/repository-map/resolve_graph_out.py
+++ b/tools/repository-map/resolve_graph_out.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import shutil
 # Only used to run one fixed git command (list-args, no shell) with the
 # executable resolved to an absolute path below.
@@ -20,6 +21,14 @@ MANIFEST_NAME = "manifest.json"
 
 def find_shared_graph_out(cwd: Path) -> Path:
     """Return the shared graphify-out/ path under the main checkout root."""
+    if "SHAFT_GRAPHIFY_OUT" in os.environ:
+        configured = os.environ["SHAFT_GRAPHIFY_OUT"].strip()
+        if not configured:
+            raise RuntimeError("SHAFT_GRAPHIFY_OUT must not be blank")
+        graph_out = Path(configured).expanduser()
+        if not graph_out.is_absolute():
+            raise RuntimeError("SHAFT_GRAPHIFY_OUT must be absolute")
+        return graph_out.resolve()
     git_executable = shutil.which("git")
     if git_executable is None:
         raise RuntimeError("git is not on PATH")
@@ -35,6 +44,29 @@ def find_shared_graph_out(cwd: Path) -> Path:
     if not common_dir.is_absolute():
         common_dir = (cwd / common_dir).resolve()
     return common_dir.parent / "graphify-out"
+
+
+def require_primary_checkout(cwd: Path) -> None:
+    """Reject linked worktrees even when an override points below their root."""
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        raise RuntimeError("git is not on PATH")
+    completed = subprocess.run(  # nosec B603
+        [git_executable, "rev-parse", "--show-toplevel", "--git-common-dir"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    lines = completed.stdout.splitlines()
+    if len(lines) != 2:
+        raise RuntimeError("cannot resolve the primary Git checkout")
+    top_level = Path(lines[0])
+    common_dir = Path(lines[1])
+    if not common_dir.is_absolute():
+        common_dir = cwd / common_dir
+    if cwd.resolve() != top_level.resolve() or cwd.resolve() != common_dir.resolve().parent:
+        raise RuntimeError("record the Graphify revision only from the primary checkout")
 
 
 def git_revision(cwd: Path) -> str:
@@ -96,6 +128,7 @@ def cache_freshness(cwd: Path, graph_out: Path) -> tuple[bool, str]:
 
 def record_current_cache(cwd: Path, graph_out: Path) -> Path:
     """Bind a completed primary-checkout cache build to its source revision."""
+    require_primary_checkout(cwd)
     if cwd.resolve() != graph_out.parent.resolve():
         raise RuntimeError("record the Graphify revision only from the primary checkout")
     if not (graph_out / MANIFEST_NAME).is_file():
@@ -133,23 +166,23 @@ def main(argv: list[str] | None = None, cwd: Path | None = None) -> int:
     """Run the CLI."""
     args = build_parser().parse_args(argv)
     working_directory = cwd or Path.cwd()
-    graph_out = find_shared_graph_out(working_directory)
-    if args.check:
-        fresh, message = cache_freshness(working_directory, graph_out)
-        if fresh:
-            print(message)
-            return 0
-        print(message, file=sys.stderr)
-        return 1
-    if args.record_current:
-        try:
-            marker_path = record_current_cache(working_directory, graph_out)
-        except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
-            print(str(error), file=sys.stderr)
+    try:
+        graph_out = find_shared_graph_out(working_directory)
+        if args.check:
+            fresh, message = cache_freshness(working_directory, graph_out)
+            if fresh:
+                print(message)
+                return 0
+            print(message, file=sys.stderr)
             return 1
-        print(marker_path)
-        return 0
-    print(graph_out)
+        if args.record_current:
+            marker_path = record_current_cache(working_directory, graph_out)
+            print(marker_path)
+            return 0
+        print(graph_out)
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
     return 0
 
 


### PR DESCRIPTION
## Summary
- add an installer-owned D: maintenance clone with exact receipts and protected ACLs
- verify immutable remote main before reset/clean
- refresh Graphify and MemPalace under one locked nightly controller
- register a daily 05:00 task and migrate the legacy task fail-closed
- add Windows/Linux CI coverage and adversarial recovery tests

## Validation
- py -3 -m unittest tests.scripts.test_shaft_knowledge_refresh tests.scripts.test_resolve_graph_out tests.scripts.test_graphify_maintenance (50 passed)
- py -3 scripts/ci/validate_agent_setup.py --skip-external
- PowerShell parse, Python compile, and git diff --check
- two independent final adversarial reviews: zero blockers

Closes #4809