### PR TITLE
test: run mobile recording on a compatible Appium provider

### DIFF
--- a/shaft-engine/src/test/java/testPackage/appium/MobileTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/MobileTest.java
@@ -7,7 +7,14 @@ import org.openqa.selenium.Platform;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+
 public abstract class MobileTest {
+    private static final String COMPATIBLE_PROVIDER = "shaft.mobile.compatibleProvider";
+    private static final String EXECUTION_ADDRESS = "executionAddress";
+    private static final String MOBILE_APP = "mobile_app";
     public static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
 
     @BeforeMethod(onlyForGroups = {"NativeAndroidDemo"})
@@ -72,13 +79,15 @@ public abstract class MobileTest {
 //        SHAFT.Properties.platform.set().executionAddress("localhost:4725");
 //        SHAFT.Properties.mobile.set().app("src/test/resources/testDataFiles/apps/ApiDemos-debug.apk");
 
-        // remote browserstack server (new app version)
-        SHAFT.Properties.platform.set().executionAddress("browserstack");
-        SHAFT.Properties.browserStack.set().platformVersion("13.0");
-        SHAFT.Properties.browserStack.set().deviceName("Google Pixel 7");
-        SHAFT.Properties.browserStack.set().appName("ApiDemos-debug.apk");
-        SHAFT.Properties.browserStack.set().appRelativeFilePath("src/test/resources/testDataFiles/apps/ApiDemos-debug.apk");
-        SHAFT.Properties.browserStack.set().appUrl("");
+        if (!configureCompatibleProvider()) {
+            // remote browserstack server (new app version)
+            SHAFT.Properties.platform.set().executionAddress("browserstack");
+            SHAFT.Properties.browserStack.set().platformVersion("13.0");
+            SHAFT.Properties.browserStack.set().deviceName("Google Pixel 7");
+            SHAFT.Properties.browserStack.set().appName("ApiDemos-debug.apk");
+            SHAFT.Properties.browserStack.set().appRelativeFilePath("src/test/resources/testDataFiles/apps/ApiDemos-debug.apk");
+            SHAFT.Properties.browserStack.set().appUrl("");
+        }
 
         // remote browserstack server (existing app version)
 //        SHAFT.Properties.platform.set().executionAddress("browserstack");
@@ -87,7 +96,34 @@ public abstract class MobileTest {
 //        SHAFT.Properties.browserStack.set().appName("ApiDemos-debug.apk");
 //        SHAFT.Properties.browserStack.set().appRelativeFilePath("");
 //        SHAFT.Properties.browserStack.set().appUrl("bs://61abe95b5ed5bb6dc169f8df6b7141db120167d3");
+        createDriver();
+    }
+
+    void createDriver() {
         driver.set(new SHAFT.GUI.WebDriver());
+    }
+
+    private boolean configureCompatibleProvider() {
+        if (!Boolean.parseBoolean(System.getProperty(COMPATIBLE_PROVIDER, "false"))) {
+            return false;
+        }
+        String executionAddress = System.getProperty(EXECUTION_ADDRESS, "").trim();
+        if (executionAddress.isEmpty()) {
+            throw new IllegalArgumentException("Compatible mobile provider requires executionAddress.");
+        }
+        String configuredApp = System.getProperty(MOBILE_APP, "").trim();
+        Path app;
+        try {
+            app = Path.of(configuredApp).toAbsolutePath().normalize();
+        } catch (InvalidPathException exception) {
+            throw new IllegalArgumentException("Compatible mobile provider requires an existing mobile_app APK.");
+        }
+        if (!Files.isRegularFile(app)) {
+            throw new IllegalArgumentException("Compatible mobile provider requires an existing mobile_app APK.");
+        }
+        SHAFT.Properties.platform.set().executionAddress(executionAddress);
+        SHAFT.Properties.mobile.set().app(app.toString());
+        return true;
     }
 
     @AfterMethod(alwaysRun = true)

--- a/shaft-engine/src/test/java/testPackage/appium/MobileTestConfigurationTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/MobileTestConfigurationTest.java
@@ -1,0 +1,107 @@
+package testPackage.appium;
+
+import com.shaft.driver.SHAFT;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+
+public class MobileTestConfigurationTest {
+    private static final String COMPATIBLE_PROVIDER = "shaft.mobile.compatibleProvider";
+    private static final String EXECUTION_ADDRESS = "executionAddress";
+    private static final String MOBILE_APP = "mobile_app";
+
+    private boolean facadeCreated;
+    private String originalCompatibleProvider;
+    private String originalExecutionAddress;
+    private String originalMobileApp;
+    private final MobileTest fixture = new MobileTest() {
+        @Override
+        void createDriver() {
+            facadeCreated = true;
+        }
+    };
+
+    @BeforeMethod
+    public void captureProperties() {
+        originalCompatibleProvider = System.getProperty(COMPATIBLE_PROVIDER);
+        originalExecutionAddress = System.getProperty(EXECUTION_ADDRESS);
+        originalMobileApp = System.getProperty(MOBILE_APP);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void restoreProperties() {
+        fixture.teardown();
+        facadeCreated = false;
+        restoreProperty(COMPATIBLE_PROVIDER, originalCompatibleProvider);
+        restoreProperty(EXECUTION_ADDRESS, originalExecutionAddress);
+        restoreProperty(MOBILE_APP, originalMobileApp);
+    }
+
+    @Test
+    public void compatibleProviderShouldHonorExplicitEndpointAndApplication() {
+        String app = Path.of("src/test/resources/testDataFiles/apps/ApiDemos-debug.apk")
+                .toAbsolutePath().normalize().toString();
+        System.setProperty(COMPATIBLE_PROVIDER, "true");
+        System.setProperty(EXECUTION_ADDRESS, "http://127.0.0.1:4723");
+        System.setProperty(MOBILE_APP, app);
+
+        fixture.setupApiDemosDebug();
+
+        Assert.assertTrue("http://127.0.0.1:4723".equals(SHAFT.Properties.platform.executionAddress()),
+                "Compatible provider endpoint was not retained.");
+        Assert.assertEquals(SHAFT.Properties.mobile.app(), app);
+        Assert.assertTrue(facadeCreated);
+    }
+
+    @Test
+    public void defaultConfigurationShouldRemainOnBrowserStack() {
+        System.clearProperty(COMPATIBLE_PROVIDER);
+
+        fixture.setupApiDemosDebug();
+
+        String executionAddress = SHAFT.Properties.platform.executionAddress();
+        Assert.assertTrue(executionAddress != null && executionAddress.contains("browserstack"),
+                "Default mobile provider was changed.");
+        Assert.assertTrue(facadeCreated);
+    }
+
+    @Test
+    public void compatibleProviderShouldRejectMissingEndpointBeforeCreatingFacade() {
+        System.setProperty(COMPATIBLE_PROVIDER, "true");
+        System.clearProperty(EXECUTION_ADDRESS);
+        System.setProperty(MOBILE_APP, Path.of("src/test/resources/testDataFiles/apps/ApiDemos-debug.apk")
+                .toAbsolutePath().normalize().toString());
+
+        IllegalArgumentException failure = Assert.expectThrows(IllegalArgumentException.class,
+                fixture::setupApiDemosDebug);
+
+        Assert.assertEquals(failure.getMessage(), "Compatible mobile provider requires executionAddress.");
+        Assert.assertNull(MobileTest.driver.get());
+        Assert.assertFalse(facadeCreated);
+    }
+
+    @Test
+    public void compatibleProviderShouldRejectMissingApplicationBeforeCreatingFacade() {
+        System.setProperty(COMPATIBLE_PROVIDER, "true");
+        System.setProperty(EXECUTION_ADDRESS, "http://127.0.0.1:4723");
+        System.clearProperty(MOBILE_APP);
+
+        IllegalArgumentException failure = Assert.expectThrows(IllegalArgumentException.class,
+                fixture::setupApiDemosDebug);
+
+        Assert.assertEquals(failure.getMessage(), "Compatible mobile provider requires an existing mobile_app APK.");
+        Assert.assertNull(MobileTest.driver.get());
+        Assert.assertFalse(facadeCreated);
+    }
+
+    private static void restoreProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- preserve the existing BrowserStack fixture as the default
- add an explicit fail-closed compatible-provider opt-in using `executionAddress` and `mobile_app`
- bind configuration precedence, missing-input rejection, and ambient JVM-property isolation
- execute the existing positive recording acceptance on a local Appium Android provider

## Verification
- `mvn -pl shaft-engine -am test "-Dtest=MobileTestConfigurationTest,MobileRecordingActionsTest,MobileNamespaceTest" "-Dallure.automaticallyOpen=false" "-Djacoco.skip=true"` — 35/0/0/0
- exact live `AndroidBasicInteractionsTests#screenRecordingShouldReturnAndSaveBoundedMedia` against Appium 3.6.0 / UiAutomator2 7.6.2 / Android 36 — 1/0/0/0
- `git diff --check` — clean apart from checkout line-ending notices

## Provider boundary
The opt-in is explicit and test-fixture-only. It does not infer support from the provider, does not replace the BrowserStack negative coverage, and does not substitute provider session video for Appium recording-command bytes.

Closes #4751
