### PR TITLE
Enhance OpenCV, OCR, and mobile visual automation

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
@@ -12,10 +12,19 @@ import com.shaft.gui.element.internal.MobileSessionStateManager;
 import com.shaft.gui.internal.healing.HealingManager;
 import com.shaft.gui.internal.healing.HealingResolution;
 import com.shaft.gui.internal.image.ScreenshotManager;
+import com.shaft.gui.internal.image.ImageProcessingActions;
+import com.shaft.gui.internal.image.ImageCoordinateMapper;
+import com.shaft.gui.internal.ocr.OcrProcessingActions;
+import com.shaft.gui.internal.ocr.OcrWebDriverPointerActions;
+import com.shaft.gui.image.ImageMatch;
+import com.shaft.gui.image.ImageTarget;
+import com.shaft.gui.ocr.OcrTarget;
+import com.shaft.gui.ocr.OcrRectangle;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.validation.internal.WebDriverElementValidationsBuilder;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.Setting;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.flutter.FlutterIntegrationTestDriver;
 import io.appium.java_client.flutter.SupportsFlutterCameraMocking;
@@ -34,6 +43,9 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.ByteArrayInputStream;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Collections;
@@ -41,8 +53,11 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
+import java.util.Base64;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.Arrays;
 
 import static java.util.Arrays.asList;
 
@@ -64,6 +79,7 @@ import static java.util.Arrays.asList;
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class TouchActions extends FluentWebDriverAction {
+    private Boolean appiumImagesAvailable;
     public TouchActions() {
         initialize();
     }
@@ -182,6 +198,36 @@ public class TouchActions extends FluentWebDriverAction {
             elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null,
                     Thread.currentThread().getStackTrace()[1].getMethodName(),
                     "referenceImage=" + elementReferenceScreenshot + ", coordinates=" + coordinates, attachments, null);
+        }
+        return this;
+    }
+
+    /** Taps a target resolved locally from the current screenshot, with Appium Images as a capability fallback. */
+    public TouchActions tap(ImageTarget target) {
+        try {
+            byte[] screenshot = new ScreenshotManager().takeViewportScreenshot(driverFactoryHelper.getDriver());
+            Optional<ImageMatch> match = findLocalImage(target, screenshot);
+            if (match.isPresent()) {
+                performCoordinateTap(mapImageCoordinates(match.orElseThrow(), screenshot));
+            } else if (!tapUsingAppiumImages(target)) {
+                throw new IllegalStateException("Image target was not found by OpenCV or Appium Images.");
+            }
+            elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null,
+                    Thread.currentThread().getStackTrace()[1].getMethodName(), "typed image target", null, null);
+        } catch (Throwable throwable) {
+            elementActionsHelper.failAction(driverFactoryHelper.getDriver(), "typed image target", null, throwable);
+        }
+        return this;
+    }
+
+    /** Taps visible text resolved from a screenshot by the configured OCR provider. */
+    public TouchActions tap(OcrTarget target) {
+        try {
+            OcrWebDriverPointerActions.click(driverFactoryHelper.getDriver(), target);
+            elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null,
+                    Thread.currentThread().getStackTrace()[1].getMethodName(), "OCR target=" + target.expectedText(), null, null);
+        } catch (Throwable throwable) {
+            elementActionsHelper.failAction(driverFactoryHelper.getDriver(), "OCR target=" + target.expectedText(), null, throwable);
         }
         return this;
     }
@@ -663,6 +709,68 @@ public class TouchActions extends FluentWebDriverAction {
      */
     public TouchActions swipeElementIntoView(String elementReferenceScreenshot, SwipeDirection swipeDirection) {
         return swipeElementIntoView(null, elementReferenceScreenshot, swipeDirection);
+    }
+
+    /** Scrolls in any supported direction until a screenshot target is visible. */
+    public TouchActions swipeElementIntoView(ImageTarget target, SwipeDirection swipeDirection) {
+        return swipeImageOrTextIntoView(null, target, null, swipeDirection);
+    }
+
+    /** Scrolls inside a container in any supported direction until a screenshot target is visible. */
+    public TouchActions swipeElementIntoView(By scrollableElementLocator, ImageTarget target,
+                                             SwipeDirection swipeDirection) {
+        return swipeImageOrTextIntoView(scrollableElementLocator, target, null, swipeDirection);
+    }
+
+    /** Scrolls in any supported direction until OCR resolves the requested visible text. */
+    public TouchActions swipeElementIntoView(OcrTarget target, SwipeDirection swipeDirection) {
+        return swipeImageOrTextIntoView(null, null, target, swipeDirection);
+    }
+
+    /** Scrolls inside a container in any supported direction until OCR resolves the visible text. */
+    public TouchActions swipeElementIntoView(By scrollableElementLocator, OcrTarget target,
+                                             SwipeDirection swipeDirection) {
+        return swipeImageOrTextIntoView(scrollableElementLocator, null, target, swipeDirection);
+    }
+
+    private TouchActions swipeImageOrTextIntoView(By scrollableElementLocator, ImageTarget imageTarget, OcrTarget ocrTarget,
+                                                   SwipeDirection swipeDirection) {
+        try {
+            boolean firstAttempt = true;
+            int[] previousPixels = null;
+            int stableFrames = 0;
+            for (int attempt = 0; attempt < 30; attempt++) {
+                byte[] screenshot = new ScreenshotManager().takeViewportScreenshot(driverFactoryHelper.getDriver());
+                int[] currentPixels = stablePixels(screenshot, scrollableElementLocator);
+                ImageTarget effectiveImageTarget = imageTarget == null ? null
+                        : constrainToContainer(imageTarget, scrollableElementLocator, screenshot);
+                OcrTarget effectiveOcrTarget = ocrTarget == null ? null
+                        : constrainToContainer(ocrTarget, scrollableElementLocator, screenshot);
+                boolean found = imageTarget != null
+                        ? findLocalImage(effectiveImageTarget, screenshot).isPresent()
+                            || findUsingAppiumImages(effectiveImageTarget).isPresent()
+                        : findOcr(effectiveOcrTarget, screenshot);
+                if (found) {
+                    elementActionsHelper.passAction(driverFactoryHelper.getDriver(), null,
+                            Thread.currentThread().getStackTrace()[1].getMethodName(), "direction=" + swipeDirection, null, null);
+                    return this;
+                }
+                stableFrames = previousPixels != null && Arrays.equals(previousPixels, currentPixels)
+                        ? stableFrames + 1 : 0;
+                if (stableFrames >= 2) {
+                    break;
+                }
+                previousPixels = currentPixels;
+                if (!performImageScrollStep(scrollableElementLocator, swipeDirection, firstAttempt)) {
+                    break;
+                }
+                firstAttempt = false;
+            }
+            throw new IllegalStateException("Target was not found before the view reached its scroll boundary.");
+        } catch (Throwable throwable) {
+            elementActionsHelper.failAction(driverFactoryHelper.getDriver(), "direction=" + swipeDirection, null, throwable);
+            return this;
+        }
     }
 
     /**
@@ -1201,6 +1309,187 @@ public class TouchActions extends FluentWebDriverAction {
         tap.addAction(new Pause(input, Duration.ofMillis(200)));
         tap.addAction(input.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
         ((RemoteWebDriver) driverFactoryHelper.getDriver()).perform(ImmutableList.of(tap));
+    }
+
+    private Optional<ImageMatch> findLocalImage(ImageTarget target, byte[] screenshot) {
+        try {
+            return ImageProcessingActions.findImageWithinCurrentPage(target, screenshot);
+        } catch (IllegalStateException missingProvider) {
+            if (!(driverFactoryHelper.getDriver() instanceof AppiumDriver)
+                    || missingProvider.getMessage() == null
+                    || !missingProvider.getMessage().startsWith("Optional visual processing requires")) {
+                throw missingProvider;
+            }
+            ReportManager.logDiscrete("Local visual provider unavailable; attempting Appium Images.");
+            return Optional.empty();
+        }
+    }
+
+    private List<Integer> mapImageCoordinates(ImageMatch match, byte[] screenshot) {
+        try {
+            BufferedImage image = ImageIO.read(new ByteArrayInputStream(screenshot));
+            if (image == null) {
+                throw new IllegalArgumentException("WebDriver returned an unreadable screenshot.");
+            }
+            Dimension viewport = imageViewportSize(image);
+            int[] point = ImageCoordinateMapper.toPointerCenter(match, image.getWidth(), image.getHeight(),
+                    viewport.getWidth(), viewport.getHeight());
+            return List.of(point[0], point[1]);
+        } catch (IOException exception) {
+            throw new IllegalArgumentException("WebDriver returned an unreadable screenshot.", exception);
+        }
+    }
+
+    private Optional<WebElement> findUsingAppiumImages(ImageTarget target) {
+        if (!(driverFactoryHelper.getDriver() instanceof AppiumDriver appiumDriver)) {
+            return Optional.empty();
+        }
+        if (Boolean.FALSE.equals(appiumImagesAvailable)) {
+            return Optional.empty();
+        }
+        if (target.minimumConfidence().isPresent() || target.searchRegion().isPresent()
+                || target.matchingMode() != com.shaft.gui.image.ImageMatchingMode.AUTO) {
+            throw new UnsupportedOperationException(
+                    "Appium Images fallback cannot safely enforce confidence, region, or explicit matching-mode constraints.");
+        }
+        try {
+            String encodedTarget = Base64.getEncoder().encodeToString(target.imageBytes());
+            double threshold = SHAFT.Properties.visuals.visualMatchingThreshold();
+            List<WebElement> matches;
+            synchronized (appiumDriver) {
+                Object previousThreshold = appiumDriver.getSettings()
+                        .getOrDefault(Setting.IMAGE_MATCH_THRESHOLD.toString(), 0.4);
+                try {
+                    appiumDriver.setSetting(Setting.IMAGE_MATCH_THRESHOLD, threshold);
+                    matches = appiumDriver.findElements(AppiumBy.image(encodedTarget));
+                } finally {
+                    appiumDriver.setSetting(Setting.IMAGE_MATCH_THRESHOLD, previousThreshold);
+                }
+            }
+            appiumImagesAvailable = true;
+            if (target.occurrence().isPresent()) {
+                int occurrence = target.occurrence().getAsInt();
+                return occurrence < matches.size() ? Optional.of(matches.get(occurrence)) : Optional.empty();
+            }
+            if (matches.size() > 1) {
+                throw new IllegalStateException("Appium Images target is ambiguous: " + matches.size()
+                        + " elements matched. Select an occurrence.");
+            }
+            return matches.stream().findFirst();
+        } catch (UnsupportedCommandException unsupportedImagesCapability) {
+            appiumImagesAvailable = false;
+            ReportManager.logDiscrete("Appium Images fallback is not available for this session.");
+            return Optional.empty();
+        }
+    }
+
+    private Dimension imageViewportSize(BufferedImage screenshot) {
+        if (driverFactoryHelper.getDriver() instanceof AppiumDriver) {
+            return new Dimension(screenshot.getWidth(), screenshot.getHeight());
+        }
+        if (driverFactoryHelper.getDriver() instanceof JavascriptExecutor javascriptExecutor) {
+            Object dimensions = javascriptExecutor.executeScript("return [window.innerWidth, window.innerHeight];");
+            if (dimensions instanceof List<?> values && values.size() == 2
+                    && values.get(0) instanceof Number width && values.get(1) instanceof Number height
+                    && width.intValue() > 0 && height.intValue() > 0) {
+                return new Dimension(width.intValue(), height.intValue());
+            }
+        }
+        return driverFactoryHelper.getDriver().manage().window().getSize();
+    }
+
+    private ImageTarget constrainToContainer(ImageTarget target, By container, byte[] screenshot) {
+        if (container == null) return target;
+        ImageRectanglePixels pixels = containerPixels(container, screenshot);
+        com.shaft.gui.image.ImageRectangle containerRegion = new com.shaft.gui.image.ImageRectangle(
+                pixels.x(), pixels.y(), pixels.width(), pixels.height());
+        com.shaft.gui.image.ImageRectangle intersection = target.searchRegion()
+                .map(region -> intersect(region, containerRegion)).orElse(containerRegion);
+        return target.within(intersection);
+    }
+
+    private OcrTarget constrainToContainer(OcrTarget target, By container, byte[] screenshot) {
+        if (container == null) return target;
+        ImageRectanglePixels pixels = containerPixels(container, screenshot);
+        OcrRectangle containerRegion = new OcrRectangle(pixels.x(), pixels.y(), pixels.width(), pixels.height());
+        OcrRectangle configured = target.options().region();
+        return target.within(configured == null ? containerRegion : intersect(configured, containerRegion));
+    }
+
+    private com.shaft.gui.image.ImageRectangle intersect(com.shaft.gui.image.ImageRectangle first,
+                                                          com.shaft.gui.image.ImageRectangle second) {
+        int x = Math.max(first.x(), second.x());
+        int y = Math.max(first.y(), second.y());
+        int right = Math.min(first.x() + first.width(), second.x() + second.width());
+        int bottom = Math.min(first.y() + first.height(), second.y() + second.height());
+        if (right <= x || bottom <= y) throw new IllegalArgumentException("Image target region does not intersect the scroll container.");
+        return new com.shaft.gui.image.ImageRectangle(x, y, right - x, bottom - y);
+    }
+
+    private OcrRectangle intersect(OcrRectangle first, OcrRectangle second) {
+        int x = Math.max(first.x(), second.x());
+        int y = Math.max(first.y(), second.y());
+        int right = Math.min(first.right(), second.right());
+        int bottom = Math.min(first.bottom(), second.bottom());
+        if (right <= x || bottom <= y) throw new IllegalArgumentException("OCR target region does not intersect the scroll container.");
+        return new OcrRectangle(x, y, right - x, bottom - y);
+    }
+
+    private int[] stablePixels(byte[] screenshotBytes, By container) {
+        try {
+            BufferedImage screenshot = ImageIO.read(new ByteArrayInputStream(screenshotBytes));
+            if (screenshot == null) throw new IllegalArgumentException("WebDriver returned an unreadable screenshot.");
+            if (container == null) {
+                return screenshot.getRGB(0, 0, screenshot.getWidth(), screenshot.getHeight(), null, 0, screenshot.getWidth());
+            }
+            ImageRectanglePixels pixels = containerPixels(container, screenshotBytes);
+            int x = Math.max(0, Math.min(screenshot.getWidth() - 1, pixels.x()));
+            int y = Math.max(0, Math.min(screenshot.getHeight() - 1, pixels.y()));
+            int width = Math.min(pixels.width(), screenshot.getWidth() - x);
+            int height = Math.min(pixels.height(), screenshot.getHeight() - y);
+            return screenshot.getRGB(x, y, width, height, null, 0, width);
+        } catch (IOException exception) {
+            throw new IllegalArgumentException("WebDriver returned an unreadable screenshot.", exception);
+        }
+    }
+
+    private ImageRectanglePixels containerPixels(By container, byte[] screenshotBytes) {
+        try {
+            BufferedImage screenshot = ImageIO.read(new ByteArrayInputStream(screenshotBytes));
+            Rectangle rectangle = ((WebElement) elementActionsHelper.identifyUniqueElement(
+                    driverFactoryHelper.getDriver(), container).get(1)).getRect();
+            Dimension viewport = imageViewportSize(screenshot);
+            double xScale = (double) screenshot.getWidth() / viewport.getWidth();
+            double yScale = (double) screenshot.getHeight() / viewport.getHeight();
+            return new ImageRectanglePixels((int) Math.round(rectangle.getX() * xScale),
+                    (int) Math.round(rectangle.getY() * yScale),
+                    Math.max(1, (int) Math.round(rectangle.getWidth() * xScale)),
+                    Math.max(1, (int) Math.round(rectangle.getHeight() * yScale)));
+        } catch (IOException exception) {
+            throw new IllegalArgumentException("WebDriver returned an unreadable screenshot.", exception);
+        }
+    }
+
+    private record ImageRectanglePixels(int x, int y, int width, int height) {
+    }
+
+    private boolean tapUsingAppiumImages(ImageTarget target) {
+        Optional<WebElement> element = findUsingAppiumImages(target);
+        element.ifPresent(WebElement::click);
+        return element.isPresent();
+    }
+
+    private boolean findOcr(OcrTarget target, byte[] screenshot) {
+        try {
+            OcrProcessingActions.find(screenshot, target);
+            return true;
+        } catch (IllegalStateException noMatch) {
+            if (noMatch.getMessage() != null && (noMatch.getMessage().startsWith("No OCR match")
+                    || noMatch.getMessage().contains("OCR occurrence"))) {
+                return false;
+            }
+            throw noMatch;
+        }
     }
 
     private boolean performImageScrollStep(By scrollableElementLocator, SwipeDirection swipeDirection, boolean isFirstAttempt) {

--- a/shaft-engine/src/main/java/com/shaft/gui/image/ImageMatch.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/image/ImageMatch.java
@@ -1,0 +1,36 @@
+package com.shaft.gui.image;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A geometrically located screenshot match with the evidence used to rank it.
+ *
+ * @param bounds      match bounds in screenshot pixels
+ * @param confidence normalized confidence from 0 through 1
+ * @param scale       scale of the matched target relative to its source image
+ * @param algorithm   algorithm that produced the match
+ * @param diagnostics immutable provider-specific diagnostic values
+ */
+public record ImageMatch(ImageRectangle bounds, double confidence, double scale,
+                         ImageMatchingAlgorithm algorithm, Map<String, String> diagnostics) {
+    public ImageMatch {
+        Objects.requireNonNull(bounds, "Image match bounds cannot be null.");
+        Objects.requireNonNull(algorithm, "Image matching algorithm cannot be null.");
+        if (!Double.isFinite(confidence) || confidence < 0 || confidence > 1) {
+            throw new IllegalArgumentException("Image match confidence must be a finite value from 0 through 1.");
+        }
+        if (!Double.isFinite(scale) || scale <= 0) {
+            throw new IllegalArgumentException("Image match scale must be a positive finite value.");
+        }
+        diagnostics = diagnostics == null ? Map.of() : Map.copyOf(diagnostics);
+    }
+
+    public int centerX() {
+        return bounds.centerX();
+    }
+
+    public int centerY() {
+        return bounds.centerY();
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/image/ImageMatchingAlgorithm.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/image/ImageMatchingAlgorithm.java
@@ -1,0 +1,11 @@
+package com.shaft.gui.image;
+
+/** Identifies the algorithm that produced an {@link ImageMatch}. */
+public enum ImageMatchingAlgorithm {
+    TEMPLATE_COLOR,
+    TEMPLATE_GRAYSCALE,
+    TEMPLATE_CLAHE,
+    TEMPLATE_EDGE,
+    FEATURE_HOMOGRAPHY,
+    APPIUM_IMAGES
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/image/ImageMatchingMode.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/image/ImageMatchingMode.java
@@ -1,0 +1,11 @@
+package com.shaft.gui.image;
+
+/** Selects the visual matching strategy for an {@link ImageTarget}. */
+public enum ImageMatchingMode {
+    /** Chooses the strongest suitable strategy and may use a fallback. */
+    AUTO,
+    /** Uses multi-scale template matching. */
+    TEMPLATE,
+    /** Uses local feature matching and geometric verification. */
+    FEATURE
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/image/ImageRectangle.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/image/ImageRectangle.java
@@ -1,0 +1,34 @@
+package com.shaft.gui.image;
+
+/**
+ * An immutable rectangle expressed in screenshot pixels.
+ *
+ * @param x      left coordinate
+ * @param y      top coordinate
+ * @param width  rectangle width
+ * @param height rectangle height
+ */
+public record ImageRectangle(int x, int y, int width, int height) {
+    public ImageRectangle {
+        if (x < 0 || y < 0) {
+            throw new IllegalArgumentException("Image rectangle coordinates cannot be negative.");
+        }
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("Image rectangle dimensions must be positive.");
+        }
+        try {
+            Math.addExact(x, width);
+            Math.addExact(y, height);
+        } catch (ArithmeticException exception) {
+            throw new IllegalArgumentException("Image rectangle edges must fit within integer coordinates.", exception);
+        }
+    }
+
+    public int centerX() {
+        return Math.addExact(x, width / 2);
+    }
+
+    public int centerY() {
+        return Math.addExact(y, height / 2);
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/image/ImageTarget.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/image/ImageTarget.java
@@ -1,0 +1,162 @@
+package com.shaft.gui.image;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+
+/**
+ * An immutable screenshot target and its matching constraints.
+ */
+public final class ImageTarget {
+    static final int MAX_ENCODED_IMAGE_BYTES = 20 * 1024 * 1024;
+    private static final long MAX_IMAGE_PIXELS = 100_000_000L;
+
+    private final byte[] imageBytes;
+    private final Path sourcePath;
+    private final Double minimumConfidence;
+    private final Integer occurrence;
+    private final ImageRectangle searchRegion;
+    private final ImageMatchingMode matchingMode;
+
+    private ImageTarget(byte[] imageBytes, Path sourcePath, Double minimumConfidence, Integer occurrence,
+                        ImageRectangle searchRegion, ImageMatchingMode matchingMode) {
+        this.imageBytes = imageBytes.clone();
+        this.sourcePath = sourcePath;
+        this.minimumConfidence = minimumConfidence;
+        this.occurrence = occurrence;
+        this.searchRegion = searchRegion;
+        this.matchingMode = matchingMode;
+    }
+
+    public static ImageTarget fromPath(Path imagePath) {
+        Objects.requireNonNull(imagePath, "Image path cannot be null.");
+        Path normalizedPath = imagePath.toAbsolutePath().normalize();
+        try {
+            byte[] bytes = readBounded(normalizedPath);
+            validateEncodedImage(bytes);
+            return new ImageTarget(bytes, normalizedPath, null,
+                    null, null, ImageMatchingMode.AUTO);
+        } catch (IOException exception) {
+            throw new IllegalArgumentException("Could not read image target: " + normalizedPath, exception);
+        }
+    }
+
+    public static ImageTarget fromPath(String imagePath) {
+        Objects.requireNonNull(imagePath, "Image path cannot be null.");
+        return fromPath(Path.of(imagePath));
+    }
+
+    public static ImageTarget fromBytes(byte[] imageBytes) {
+        if (imageBytes == null || imageBytes.length == 0) {
+            throw new IllegalArgumentException("Image target bytes cannot be null or empty.");
+        }
+        if (imageBytes.length > MAX_ENCODED_IMAGE_BYTES) {
+            throw new IllegalArgumentException("Image target exceeds the 20 MiB encoded-size limit.");
+        }
+        validateEncodedImage(imageBytes);
+        return new ImageTarget(imageBytes, null, null, null, null,
+                ImageMatchingMode.AUTO);
+    }
+
+    public ImageTarget minimumConfidence(double confidence) {
+        if (!Double.isFinite(confidence) || confidence < 0 || confidence > 1) {
+            throw new IllegalArgumentException("Minimum confidence must be a finite value from 0 through 1.");
+        }
+        return new ImageTarget(imageBytes, sourcePath, confidence, occurrence, searchRegion, matchingMode);
+    }
+
+    public ImageTarget occurrence(int zeroBasedOccurrence) {
+        if (zeroBasedOccurrence < 0) {
+            throw new IllegalArgumentException("Image occurrence cannot be negative.");
+        }
+        return new ImageTarget(imageBytes, sourcePath, minimumConfidence, zeroBasedOccurrence, searchRegion,
+                matchingMode);
+    }
+
+    public ImageTarget within(ImageRectangle region) {
+        return new ImageTarget(imageBytes, sourcePath, minimumConfidence, occurrence,
+                Objects.requireNonNull(region, "Image search region cannot be null."), matchingMode);
+    }
+
+    public ImageTarget matchingMode(ImageMatchingMode mode) {
+        return new ImageTarget(imageBytes, sourcePath, minimumConfidence, occurrence, searchRegion,
+                Objects.requireNonNull(mode, "Image matching mode cannot be null."));
+    }
+
+    public byte[] imageBytes() {
+        return imageBytes.clone();
+    }
+
+    public Optional<Path> sourcePath() {
+        return Optional.ofNullable(sourcePath);
+    }
+
+    public OptionalDouble minimumConfidence() {
+        return minimumConfidence == null ? OptionalDouble.empty() : OptionalDouble.of(minimumConfidence);
+    }
+
+    public OptionalInt occurrence() {
+        return occurrence == null ? OptionalInt.empty() : OptionalInt.of(occurrence);
+    }
+
+    public Optional<ImageRectangle> searchRegion() {
+        return Optional.ofNullable(searchRegion);
+    }
+
+    public ImageMatchingMode matchingMode() {
+        return matchingMode;
+    }
+
+    private static byte[] readBounded(Path imagePath) throws IOException {
+        if (Files.size(imagePath) > MAX_ENCODED_IMAGE_BYTES) {
+            throw new IllegalArgumentException("Image target exceeds the 20 MiB encoded-size limit: " + imagePath);
+        }
+        try (InputStream input = Files.newInputStream(imagePath)) {
+            byte[] bytes = input.readNBytes(MAX_ENCODED_IMAGE_BYTES + 1);
+            if (bytes.length > MAX_ENCODED_IMAGE_BYTES) {
+                throw new IllegalArgumentException("Image target exceeds the 20 MiB encoded-size limit: " + imagePath);
+            }
+            return bytes;
+        }
+    }
+
+    private static void validateEncodedImage(byte[] imageBytes) {
+        try (ImageInputStream input = ImageIO.createImageInputStream(new ByteArrayInputStream(imageBytes))) {
+            if (input == null) {
+                throw new IllegalArgumentException("Image target is not a supported encoded image.");
+            }
+            var readers = ImageIO.getImageReaders(input);
+            if (!readers.hasNext()) {
+                throw new IllegalArgumentException("Image target is not a supported encoded image.");
+            }
+            ImageReader reader = readers.next();
+            try {
+                reader.setInput(input, true, true);
+                int width = reader.getWidth(0);
+                int height = reader.getHeight(0);
+                if (width <= 0 || height <= 0 || (long) width * height > MAX_IMAGE_PIXELS) {
+                    throw new IllegalArgumentException("Image target dimensions are invalid or exceed 100 megapixels.");
+                }
+                if (reader.read(0) == null) {
+                    throw new IllegalArgumentException("Image target could not be decoded.");
+                }
+            } finally {
+                reader.dispose();
+            }
+        } catch (IOException | RuntimeException exception) {
+            if (exception instanceof IllegalArgumentException illegalArgumentException) {
+                throw illegalArgumentException;
+            }
+            throw new IllegalArgumentException("Image target is corrupt or uses an unsupported encoding.", exception);
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageCoordinateMapper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageCoordinateMapper.java
@@ -1,0 +1,19 @@
+package com.shaft.gui.internal.image;
+
+import com.shaft.gui.image.ImageMatch;
+
+/** Maps screenshot-pixel image matches into W3C viewport pointer coordinates. */
+public final class ImageCoordinateMapper {
+    private ImageCoordinateMapper() {
+    }
+
+    public static int[] toPointerCenter(ImageMatch match, int screenshotWidth, int screenshotHeight,
+                                        int viewportWidth, int viewportHeight) {
+        if (screenshotWidth <= 0 || screenshotHeight <= 0 || viewportWidth <= 0 || viewportHeight <= 0) {
+            throw new IllegalArgumentException("Screenshot and viewport dimensions must be positive.");
+        }
+        int x = (int) Math.round(match.centerX() * ((double) viewportWidth / screenshotWidth));
+        int y = (int) Math.round(match.centerY() * ((double) viewportHeight / screenshotHeight));
+        return new int[]{Math.max(0, Math.min(viewportWidth - 1, x)), Math.max(0, Math.min(viewportHeight - 1, y))};
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ImageProcessingActions.java
@@ -1,5 +1,7 @@
 package com.shaft.gui.internal.image;
 
+import com.shaft.gui.image.ImageMatch;
+import com.shaft.gui.image.ImageTarget;
 import com.shaft.tools.io.internal.CheckpointStatus;
 import io.qameta.allure.model.Status;
 import com.google.common.hash.Hashing;
@@ -27,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("SpellCheckingInspection")
@@ -166,6 +169,31 @@ public class ImageProcessingActions {
     public static List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot) {
         return VisualProcessingProviderRegistry.requireProvider()
                 .findImageWithinCurrentPage(referenceImagePath, currentPageScreenshot);
+    }
+
+    /**
+     * Resolves a typed target in a screenshot. An unspecified occurrence requires a unique match so repeated
+     * controls cannot be clicked nondeterministically.
+     *
+     * @return the selected match, or empty when no requested occurrence is present
+     * @throws IllegalStateException when an occurrence is not specified and more than one match is present
+     */
+    public static Optional<ImageMatch> findImageWithinCurrentPage(ImageTarget target, byte[] currentPageScreenshot) {
+        Objects.requireNonNull(target, "Image target cannot be null.");
+        if (currentPageScreenshot == null || currentPageScreenshot.length == 0) {
+            return Optional.empty();
+        }
+        List<ImageMatch> matches = VisualProcessingProviderRegistry.requireProvider()
+                .findImageMatches(target, currentPageScreenshot);
+        if (target.occurrence().isPresent()) {
+            int occurrence = target.occurrence().getAsInt();
+            return occurrence < matches.size() ? Optional.of(matches.get(occurrence)) : Optional.empty();
+        }
+        if (matches.size() > 1) {
+            throw new IllegalStateException("Image target is ambiguous: " + matches.size()
+                    + " matches met the confidence threshold. Select an occurrence or narrow the search region.");
+        }
+        return matches.stream().findFirst();
     }
 
     private static final ConcurrentHashMap<String, String> locatorHashMapping = new ConcurrentHashMap<>();

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/VisualProcessingProvider.java
@@ -1,5 +1,9 @@
 package com.shaft.gui.internal.image;
 
+import com.shaft.gui.image.ImageMatch;
+import com.shaft.gui.image.ImageMatchingAlgorithm;
+import com.shaft.gui.image.ImageRectangle;
+import com.shaft.gui.image.ImageTarget;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
@@ -20,6 +24,27 @@ public interface VisualProcessingProvider {
      * @return the matched x/y coordinates, or an empty list when no match is found
      */
     List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot);
+
+    /**
+     * Finds all confident, non-overlapping occurrences of a typed image target.
+     *
+     * <p>The compatibility implementation delegates path-backed targets to the legacy coordinate contract.
+     * Providers should override this method to supply true bounds, confidence, scale, and diagnostics.</p>
+     */
+    default List<ImageMatch> findImageMatches(ImageTarget target, byte[] currentPageScreenshot) {
+        if (target.minimumConfidence().isPresent() || target.searchRegion().isPresent()
+                || target.matchingMode() != com.shaft.gui.image.ImageMatchingMode.AUTO) {
+            throw new UnsupportedOperationException("The configured visual provider does not support typed image constraints.");
+        }
+        return target.sourcePath()
+                .map(path -> findImageWithinCurrentPage(path.toString(), currentPageScreenshot))
+                .filter(coordinates -> coordinates.size() >= 2)
+                .map(coordinates -> List.of(new ImageMatch(
+                        new ImageRectangle(coordinates.get(0), coordinates.get(1), 1, 1),
+                        1.0, 1.0, ImageMatchingAlgorithm.TEMPLATE_COLOR,
+                        java.util.Map.of("provider", getClass().getName(), "compatibility", "legacy-center"))))
+                .orElseGet(List::of);
+    }
 
     /**
      * Compares an element screenshot against its visual baseline using the requested optional engine.

--- a/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java
+++ b/shaft-engine/src/main/java/com/shaft/validation/internal/WebDriverElementValidationsBuilder.java
@@ -99,7 +99,7 @@ public class WebDriverElementValidationsBuilder implements com.shaft.gui.driver.
     public ValidationsExecutor matchesReferenceImage() {
         this.validationType = ValidationEnums.ValidationType.POSITIVE;
         this.validationMethod = "elementMatches";
-        this.visualValidationEngine = ValidationEnums.VisualValidationEngine.EXACT_SHUTTERBUG;
+        this.visualValidationEngine = ValidationEnums.VisualValidationEngine.EXACT_OPENCV;
         appendVisualValidationMessage(true);
         var executor = new ValidationsExecutor(this);
         executor.internalPerform();

--- a/shaft-engine/src/test/java/com/shaft/gui/image/ImagePublicContractTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/image/ImagePublicContractTest.java
@@ -1,0 +1,90 @@
+package com.shaft.gui.image;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.OptionalDouble;
+
+public class ImagePublicContractTest {
+    @Test
+    public void imageTargetAndRichMatchTypesShouldExposeTheTypedVisualContract() throws IOException {
+        try {
+            Class<?> targetType = Class.forName("com.shaft.gui.image.ImageTarget");
+            Class<?> matchType = Class.forName("com.shaft.gui.image.ImageMatch");
+            Class<?> rectangleType = Class.forName("com.shaft.gui.image.ImageRectangle");
+            Class<?> modeType = Class.forName("com.shaft.gui.image.ImageMatchingMode");
+
+            Assert.assertNotNull(targetType.getMethod("fromPath", Path.class));
+            Assert.assertNotNull(targetType.getMethod("fromBytes", byte[].class));
+            Assert.assertNotNull(targetType.getMethod("minimumConfidence", double.class));
+            Assert.assertNotNull(targetType.getMethod("occurrence", int.class));
+            Assert.assertNotNull(targetType.getMethod("within", rectangleType));
+            Assert.assertNotNull(targetType.getMethod("matchingMode", modeType));
+
+            Method bytesAccessor = targetType.getMethod("imageBytes");
+            Object target = targetType.getMethod("fromBytes", byte[].class)
+                    .invoke(null, (Object) createPng());
+            byte[] firstRead = (byte[]) bytesAccessor.invoke(target);
+            firstRead[0] = 99;
+            byte[] secondRead = (byte[]) bytesAccessor.invoke(target);
+            Assert.assertNotEquals(secondRead[0], firstRead[0], "ImageTarget must own defensive byte copies.");
+
+            Assert.assertNotNull(matchType.getMethod("bounds"));
+            Assert.assertNotNull(matchType.getMethod("centerX"));
+            Assert.assertNotNull(matchType.getMethod("centerY"));
+            Assert.assertNotNull(matchType.getMethod("confidence"));
+            Assert.assertNotNull(matchType.getMethod("scale"));
+            Assert.assertNotNull(matchType.getMethod("algorithm"));
+            Assert.assertNotNull(matchType.getMethod("diagnostics"));
+        } catch (ReflectiveOperationException exception) {
+            Assert.fail("Typed image identification contract is missing or incomplete.", exception);
+        }
+    }
+
+    @Test
+    public void imageTargetShouldRejectInvalidAndOversizedEncodedInput() throws IOException {
+        Assert.expectThrows(IllegalArgumentException.class, () -> ImageTarget.fromBytes(new byte[]{1, 2, 3}));
+        byte[] validPng = createPng();
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> ImageTarget.fromBytes(Arrays.copyOf(validPng, validPng.length / 2)));
+
+        Path oversized = Files.createTempFile("shaft-image-target", ".png");
+        try {
+            Files.write(oversized, new byte[ImageTarget.MAX_ENCODED_IMAGE_BYTES + 1]);
+            Assert.expectThrows(IllegalArgumentException.class, () -> ImageTarget.fromPath(oversized));
+        } finally {
+            Files.deleteIfExists(oversized);
+        }
+    }
+
+    @Test
+    public void imageTargetShouldPreserveConfiguredConfidencePrecedence() throws IOException {
+        ImageTarget defaultTarget = ImageTarget.fromBytes(createPng());
+        Assert.assertEquals(defaultTarget.minimumConfidence(), OptionalDouble.empty());
+        Assert.assertEquals(defaultTarget.minimumConfidence(0.73).minimumConfidence(), OptionalDouble.of(0.73));
+    }
+
+    @Test
+    public void imageRectangleShouldRejectOverflowingEdges() {
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new ImageRectangle(Integer.MAX_VALUE, 0, 1, 1));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> new ImageRectangle(0, Integer.MAX_VALUE, 1, 1));
+    }
+
+    private byte[] createPng() throws IOException {
+        BufferedImage image = new BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB);
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            ImageIO.write(image, "png", output);
+            return output.toByteArray();
+        }
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/image/ImagePublicContractTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/image/ImagePublicContractTest.java
@@ -21,6 +21,8 @@ public class ImagePublicContractTest {
             Class<?> matchType = Class.forName("com.shaft.gui.image.ImageMatch");
             Class<?> rectangleType = Class.forName("com.shaft.gui.image.ImageRectangle");
             Class<?> modeType = Class.forName("com.shaft.gui.image.ImageMatchingMode");
+            Class<?> providerType = Class.forName("com.shaft.gui.internal.image.VisualProcessingProvider");
+            Class<?> actionsType = Class.forName("com.shaft.gui.internal.image.ImageProcessingActions");
 
             Assert.assertNotNull(targetType.getMethod("fromPath", Path.class));
             Assert.assertNotNull(targetType.getMethod("fromBytes", byte[].class));
@@ -44,6 +46,8 @@ public class ImagePublicContractTest {
             Assert.assertNotNull(matchType.getMethod("scale"));
             Assert.assertNotNull(matchType.getMethod("algorithm"));
             Assert.assertNotNull(matchType.getMethod("diagnostics"));
+            Assert.assertNotNull(providerType.getMethod("findImageMatches", targetType, byte[].class));
+            Assert.assertNotNull(actionsType.getMethod("findImageWithinCurrentPage", targetType, byte[].class));
         } catch (ReflectiveOperationException exception) {
             Assert.fail("Typed image identification contract is missing or incomplete.", exception);
         }

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageCoordinateMapperTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ImageCoordinateMapperTest.java
@@ -1,0 +1,29 @@
+package com.shaft.gui.internal.image;
+
+import com.shaft.gui.image.ImageMatch;
+import com.shaft.gui.image.ImageMatchingAlgorithm;
+import com.shaft.gui.image.ImageRectangle;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class ImageCoordinateMapperTest {
+    @Test
+    public void preservesNativeScreenshotPixelsWhenTargetDimensionsMatch() {
+        ImageMatch match = new ImageMatch(new ImageRectangle(200, 300, 40, 20), 0.95, 1,
+                ImageMatchingAlgorithm.TEMPLATE_COLOR, Map.of());
+
+        Assert.assertEquals(ImageCoordinateMapper.toPointerCenter(match, 1080, 1920, 1080, 1920),
+                new int[]{220, 310});
+    }
+
+    @Test
+    public void scalesBrowserScreenshotPixelsToInnerViewportAndClampsEdges() {
+        ImageMatch match = new ImageMatch(new ImageRectangle(1900, 1000, 20, 20), 0.95, 1,
+                ImageMatchingAlgorithm.TEMPLATE_COLOR, Map.of());
+
+        Assert.assertEquals(ImageCoordinateMapper.toPointerCenter(match, 1920, 1080, 960, 540),
+                new int[]{955, 505});
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistryTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualProcessingProviderRegistryTest.java
@@ -1,5 +1,8 @@
 package com.shaft.gui.internal.image;
 
+import com.shaft.gui.image.ImageTarget;
+import com.shaft.gui.image.ImageRectangle;
+import com.shaft.gui.image.ImageMatchingMode;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.testng.Assert;
@@ -8,6 +11,7 @@ import org.testng.annotations.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.nio.file.Path;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -59,6 +63,21 @@ public class VisualProcessingProviderRegistryTest {
         ImageProcessingActions.loadOpenCVIfAvailable();
 
         verify(provider).load();
+    }
+
+    @Test
+    public void legacyProviderShouldFailClosedForTypedConstraints() {
+        ImageTarget target = ImageTarget.fromPath(
+                Path.of("src", "test", "resources", "testDataFiles", "youtube.png"));
+        AlphaProvider provider = new AlphaProvider();
+
+        Assert.expectThrows(UnsupportedOperationException.class,
+                () -> provider.findImageMatches(target.minimumConfidence(0.92), new byte[]{1}));
+        Assert.expectThrows(UnsupportedOperationException.class,
+                () -> provider.findImageMatches(target.within(new ImageRectangle(0, 0, 10, 10)), new byte[]{1}));
+        Assert.expectThrows(UnsupportedOperationException.class,
+                () -> provider.findImageMatches(target.matchingMode(ImageMatchingMode.FEATURE), new byte[]{1}));
+        Assert.assertTrue(provider.findImageMatches(target, new byte[]{1}).isEmpty());
     }
 
     private static class AlphaProvider implements VisualProcessingProvider {

--- a/shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/validation/internal/WebDriverElementValidationsBuilderCoverageUnitTest.java
@@ -42,7 +42,7 @@ public class WebDriverElementValidationsBuilderCoverageUnitTest {
                 ValidationEnums.ValidationType.NEGATIVE, "elementExists", null, null, "does not exist.");
         assertExecutorInvocationState(newBuilder(), WebDriverElementValidationsBuilder::matchesReferenceImage,
                 ValidationEnums.ValidationType.POSITIVE, "elementMatches",
-                ValidationEnums.VisualValidationEngine.EXACT_SHUTTERBUG, null, "matches the reference image.");
+                ValidationEnums.VisualValidationEngine.EXACT_OPENCV, null, "matches the reference image.");
         assertExecutorInvocationState(newBuilder(),
                 builder -> builder.matchesReferenceImage(ValidationEnums.VisualValidationEngine.EXACT_OPENCV),
                 ValidationEnums.ValidationType.POSITIVE, "elementMatches",

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.opentest4j.AssertionFailedError;
 import org.testng.annotations.AfterMethod;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -60,6 +61,45 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class AndroidTouchActionsCoverageUnitTest {
+    @Test
+    public void touchActionsShouldExposeTypedImageAndOcrFourDirectionScrolling() throws Exception {
+        Assert.assertNotNull(TouchActions.class.getMethod("tap", com.shaft.gui.image.ImageTarget.class));
+        Assert.assertNotNull(TouchActions.class.getMethod("tap", com.shaft.gui.ocr.OcrTarget.class));
+        Assert.assertNotNull(TouchActions.class.getMethod("swipeElementIntoView",
+                com.shaft.gui.image.ImageTarget.class, TouchActions.SwipeDirection.class));
+        Assert.assertNotNull(TouchActions.class.getMethod("swipeElementIntoView",
+                com.shaft.gui.ocr.OcrTarget.class, TouchActions.SwipeDirection.class));
+        Assert.assertNotNull(TouchActions.class.getMethod("swipeElementIntoView", By.class,
+                com.shaft.gui.image.ImageTarget.class, TouchActions.SwipeDirection.class));
+        Assert.assertNotNull(TouchActions.class.getMethod("swipeElementIntoView", By.class,
+                com.shaft.gui.ocr.OcrTarget.class, TouchActions.SwipeDirection.class));
+        Assert.assertEquals(TouchActions.SwipeDirection.values().length, 4);
+    }
+
+    @Test
+    public void appiumImagesFallbackShouldSelectOccurrenceAndRestoreDefaultThreshold() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        WebElement first = mock(WebElement.class);
+        WebElement second = mock(WebElement.class);
+        when(driver.getSettings()).thenReturn(Map.of());
+        when(driver.setSetting(any(io.appium.java_client.Setting.class), any())).thenReturn(driver);
+        when(driver.findElements(any(By.class))).thenReturn(List.of(first, second));
+        SHAFT.Properties.visuals.set().visualMatchingThreshold(0.91);
+        TouchActions touchActions = new TouchActions(driver);
+        Method fallback = TouchActions.class.getDeclaredMethod("findUsingAppiumImages",
+                com.shaft.gui.image.ImageTarget.class);
+        fallback.setAccessible(true);
+
+        Object selected = fallback.invoke(touchActions,
+                com.shaft.gui.image.ImageTarget.fromPath(Path.of("src", "test", "resources",
+                        "testDataFiles", "youtube.png")).occurrence(1));
+
+        Assert.assertEquals(selected, java.util.Optional.of(second));
+        var order = org.mockito.Mockito.inOrder(driver);
+        order.verify(driver).setSetting(io.appium.java_client.Setting.IMAGE_MATCH_THRESHOLD, 0.91);
+        order.verify(driver).findElements(any(By.class));
+        order.verify(driver).setSetting(io.appium.java_client.Setting.IMAGE_MATCH_THRESHOLD, 0.4);
+    }
     private static final Path TEMP_DIR = Path.of("target", "temp", "touchActionsCoverage");
     private static final Path ROOT_PULL_PATH = Path.of("touchActions-root-pulled.txt");
     private boolean originalWaitForLazyLoading;

--- a/shaft-ocr/src/main/java/com/shaft/ocr/internal/OcrImagePreprocessor.java
+++ b/shaft-ocr/src/main/java/com/shaft/ocr/internal/OcrImagePreprocessor.java
@@ -21,15 +21,14 @@ final class OcrImagePreprocessor {
                 throw new IllegalArgumentException("Tesseract could not decode the OCR image.");
             }
             BufferedImage processed = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_GRAY);
+            int autoThreshold = mode == OcrPreprocessingMode.AUTO ? otsuThreshold(image) : 128;
             for (int y = 0; y < image.getHeight(); y++) {
                 for (int x = 0; x < image.getWidth(); x++) {
                     int rgb = image.getRGB(x, y);
-                    int red = rgb >>> 16 & 0xff;
-                    int green = rgb >>> 8 & 0xff;
-                    int blue = rgb & 0xff;
-                    int gray = (299 * red + 587 * green + 114 * blue) / 1000;
+                    int gray = luminanceOnWhite(rgb);
                     int value = switch (mode) {
-                        case BINARY, AUTO -> gray >= 128 ? 255 : 0;
+                        case BINARY -> gray >= 128 ? 255 : 0;
+                        case AUTO -> gray > autoThreshold ? 255 : 0;
                         case INVERT -> 255 - gray;
                         case GRAYSCALE -> gray;
                         case NONE -> throw new IllegalStateException("NONE returns before image decoding.");
@@ -45,5 +44,51 @@ final class OcrImagePreprocessor {
         } catch (Exception exception) {
             throw new IllegalArgumentException("Tesseract could not preprocess the OCR image.", exception);
         }
+    }
+
+    private static int otsuThreshold(BufferedImage image) {
+        long[] histogram = new long[256];
+        long weightedTotal = 0;
+        long pixelCount = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int argb = image.getRGB(x, y);
+                if ((argb >>> 24 & 0xff) == 0) continue;
+                int gray = luminanceOnWhite(argb);
+                histogram[gray]++;
+                weightedTotal += gray;
+                pixelCount++;
+            }
+        }
+        if (pixelCount == 0) return 127;
+        long backgroundWeight = 0;
+        long backgroundSum = 0;
+        double bestVariance = -1;
+        int threshold = 127;
+        for (int value = 0; value < histogram.length; value++) {
+            backgroundWeight += histogram[value];
+            if (backgroundWeight == 0) continue;
+            long foregroundWeight = pixelCount - backgroundWeight;
+            if (foregroundWeight == 0) break;
+            backgroundSum += (long) value * histogram[value];
+            double backgroundMean = (double) backgroundSum / backgroundWeight;
+            double foregroundMean = (double) (weightedTotal - backgroundSum) / foregroundWeight;
+            double variance = (double) backgroundWeight * foregroundWeight
+                    * (backgroundMean - foregroundMean) * (backgroundMean - foregroundMean);
+            if (variance > bestVariance) {
+                bestVariance = variance;
+                threshold = value;
+            }
+        }
+        return threshold;
+    }
+
+    private static int luminanceOnWhite(int argb) {
+        int alpha = argb >>> 24 & 0xff;
+        int red = argb >>> 16 & 0xff;
+        int green = argb >>> 8 & 0xff;
+        int blue = argb & 0xff;
+        int gray = (299 * red + 587 * green + 114 * blue) / 1000;
+        return (gray * alpha + 255 * (255 - alpha)) / 255;
     }
 }

--- a/shaft-ocr/src/test/java/com/shaft/ocr/internal/OcrImagePreprocessorTest.java
+++ b/shaft-ocr/src/test/java/com/shaft/ocr/internal/OcrImagePreprocessorTest.java
@@ -37,6 +37,42 @@ public class OcrImagePreprocessorTest {
         Assert.assertSame(OcrImagePreprocessor.apply(image, OcrPreprocessingMode.NONE), image);
     }
 
+    @Test
+    public void autoUsesImageAdaptiveThresholdForLowContrastText() throws Exception {
+        BufferedImage source = new BufferedImage(2, 1, BufferedImage.TYPE_INT_RGB);
+        source.setRGB(0, 0, new Color(110, 110, 110).getRGB());
+        source.setRGB(1, 0, new Color(120, 120, 120).getRGB());
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(source, "png", output);
+
+        BufferedImage result = decode(OcrImagePreprocessor.apply(output.toByteArray(), OcrPreprocessingMode.AUTO));
+
+        Assert.assertNotEquals(result.getRaster().getSample(0, 0, 0), result.getRaster().getSample(1, 0, 0));
+    }
+
+    @Test
+    public void autoIgnoresHiddenRgbInTransparentPadding() throws Exception {
+        BufferedImage source = new BufferedImage(6, 1, BufferedImage.TYPE_INT_ARGB);
+        for (int x = 0; x < 4; x++) source.setRGB(x, 0, 0x00000000);
+        source.setRGB(4, 0, new Color(110, 110, 110).getRGB());
+        source.setRGB(5, 0, new Color(120, 120, 120).getRGB());
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(source, "png", output);
+
+        BufferedImage result = decode(OcrImagePreprocessor.apply(output.toByteArray(), OcrPreprocessingMode.AUTO));
+
+        Assert.assertNotEquals(result.getRaster().getSample(4, 0, 0), result.getRaster().getSample(5, 0, 0));
+        Assert.assertEquals(result.getRaster().getSample(0, 0, 0), 255);
+    }
+
+    @Test
+    public void autoHandlesUniformImagesDeterministically() throws Exception {
+        BufferedImage result = decode(OcrImagePreprocessor.apply(pixel(new Color(117, 117, 117)),
+                OcrPreprocessingMode.AUTO));
+
+        Assert.assertEquals(result.getRaster().getSample(0, 0, 0), 0);
+    }
+
     private static byte[] pixel(Color color) {
         try {
             BufferedImage image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);

--- a/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
+++ b/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
@@ -13,6 +13,10 @@ import com.assertthat.selenium_shutterbug.utils.image.UnableToCompareImagesExcep
 import com.shaft.cli.FileActions;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import com.shaft.gui.image.ImageMatch;
+import com.shaft.gui.image.ImageMatchingAlgorithm;
+import com.shaft.gui.image.ImageRectangle;
+import com.shaft.gui.image.ImageTarget;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.ReportManagerHelper;
 import nu.pattern.OpenCV;
@@ -36,6 +40,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * OpenCV-backed implementation of SHAFT visual processing supplied by the optional
@@ -419,6 +426,168 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
                 actual.release();
             }
         }
+    }
+
+    @Override
+    public List<ImageMatch> findImageMatches(ImageTarget target, byte[] currentPageScreenshot) {
+        if (target == null || currentPageScreenshot == null || currentPageScreenshot.length == 0) {
+            return List.of();
+        }
+        Mat screenshot = null;
+        Mat reference = null;
+        Mat searchHeader = null;
+        Mat searchImage = null;
+        try {
+            screenshot = decodeImage(currentPageScreenshot, Imgcodecs.IMREAD_COLOR);
+            reference = decodeImage(target.imageBytes(), Imgcodecs.IMREAD_UNCHANGED);
+            if (screenshot.empty() || reference.empty()) {
+                return List.of();
+            }
+
+            ImageRectangle region = target.searchRegion().orElse(
+                    new ImageRectangle(0, 0, screenshot.cols(), screenshot.rows()));
+            if ((long) region.x() + region.width() > screenshot.cols()
+                    || (long) region.y() + region.height() > screenshot.rows()) {
+                throw new IllegalArgumentException("Image search region lies outside the screenshot bounds.");
+            }
+            searchHeader = screenshot.submat(region.y(), region.y() + region.height(),
+                    region.x(), region.x() + region.width());
+            searchImage = searchHeader.clone();
+            double threshold = target.minimumConfidence().orElseGet(
+                    () -> SHAFT.Properties.visuals.visualMatchingThreshold());
+            List<RichTemplateMatch> candidates = switch (target.matchingMode()) {
+                case AUTO, TEMPLATE -> findTemplateMatches(searchImage, reference, threshold);
+                case FEATURE -> throw new UnsupportedOperationException(
+                        "OpenCV feature matching is not available for this target.");
+            };
+            return suppressOverlappingMatches(candidates).stream()
+                    .sorted(Comparator.comparingInt((RichTemplateMatch match) -> match.bounds().y())
+                            .thenComparingInt(match -> match.bounds().x()))
+                    .map(match -> new ImageMatch(
+                            new ImageRectangle(match.bounds().x() + region.x(), match.bounds().y() + region.y(),
+                                    match.bounds().width(), match.bounds().height()),
+                            Math.max(0, Math.min(1, match.confidence())), match.scale(), match.algorithm(),
+                            Map.of("matcher", "opencv", "mode", target.matchingMode().name().toLowerCase(Locale.ROOT))))
+                    .toList();
+        } finally {
+            if (searchImage != null) searchImage.release();
+            if (searchHeader != null) searchHeader.release();
+            if (screenshot != null) screenshot.release();
+            if (reference != null) reference.release();
+        }
+    }
+
+    private static List<RichTemplateMatch> findTemplateMatches(Mat searchImage, Mat reference, double threshold) {
+        Mat graySearch = toGray(searchImage);
+        List<RichTemplateMatch> matches = new ArrayList<>();
+        try {
+            for (double scale : validScales(reference, searchImage)) {
+                Mat scaledReference = scaleReference(reference, scale);
+                Mat matchReference = new Mat();
+                Mat alphaMask = new Mat();
+                try {
+                    if (scaledReference.channels() == 4) {
+                        Imgproc.cvtColor(scaledReference, matchReference, Imgproc.COLOR_BGRA2BGR);
+                        Core.extractChannel(scaledReference, alphaMask, 3);
+                        Imgproc.threshold(alphaMask, alphaMask, 0, 255, Imgproc.THRESH_BINARY);
+                    } else if (scaledReference.channels() == 3) {
+                        scaledReference.copyTo(matchReference);
+                    } else {
+                        scaledReference.copyTo(matchReference);
+                    }
+                    Mat compatibleSearch = matchReference.channels() == searchImage.channels() ? searchImage : graySearch;
+                    if (matchReference.cols() > compatibleSearch.cols() || matchReference.rows() > compatibleSearch.rows()) {
+                        continue;
+                    }
+                    collectTemplateMatches(compatibleSearch, matchReference, alphaMask, threshold, scale, matches);
+                } finally {
+                    alphaMask.release();
+                    matchReference.release();
+                    if (scaledReference != reference) {
+                        scaledReference.release();
+                    }
+                }
+            }
+            return matches;
+        } finally {
+            graySearch.release();
+        }
+    }
+
+    private static void collectTemplateMatches(Mat image, Mat template, Mat alphaMask, double threshold, double scale,
+                                               List<RichTemplateMatch> matches) {
+        Mat result = new Mat();
+        MatOfDouble mean = new MatOfDouble();
+        MatOfDouble standardDeviation = new MatOfDouble();
+        try {
+            boolean hasAlphaMask = !alphaMask.empty() && Core.countNonZero(alphaMask) < alphaMask.total();
+            Core.meanStdDev(template, mean, standardDeviation);
+            boolean flatTemplate = Arrays.stream(standardDeviation.toArray()).allMatch(value -> value < 0.5);
+            int method = hasAlphaMask ? Imgproc.TM_CCORR_NORMED
+                    : flatTemplate ? Imgproc.TM_SQDIFF : Imgproc.TM_CCOEFF_NORMED;
+            if (hasAlphaMask) {
+                Imgproc.matchTemplate(image, template, result, method, alphaMask);
+            } else {
+                Imgproc.matchTemplate(image, template, result, method);
+            }
+            for (int matchCount = 0; matchCount < 100; matchCount++) {
+                Core.MinMaxLocResult extrema = Core.minMaxLoc(result);
+                boolean squaredDifference = method == Imgproc.TM_SQDIFF;
+                double rawScore = squaredDifference ? extrema.minVal : extrema.maxVal;
+                double maximumSquaredError = (double) template.total() * template.channels() * 255 * 255;
+                double confidence = squaredDifference ? 1 - rawScore / maximumSquaredError : rawScore;
+                Point location = squaredDifference ? extrema.minLoc : extrema.maxLoc;
+                if (!Double.isFinite(confidence) || confidence < threshold) {
+                    break;
+                }
+                int x = (int) Math.round(location.x);
+                int y = (int) Math.round(location.y);
+                matches.add(new RichTemplateMatch(new ImageRectangle(x, y, template.cols(), template.rows()),
+                        confidence, scale, template.channels() > 1 ? ImageMatchingAlgorithm.TEMPLATE_COLOR
+                        : ImageMatchingAlgorithm.TEMPLATE_GRAYSCALE));
+
+                int suppressionLeft = Math.max(0, x - template.cols() / 2);
+                int suppressionTop = Math.max(0, y - template.rows() / 2);
+                int suppressionRight = Math.min(result.cols() - 1, x + template.cols() / 2);
+                int suppressionBottom = Math.min(result.rows() - 1, y + template.rows() / 2);
+                Imgproc.rectangle(result, new Point(suppressionLeft, suppressionTop),
+                        new Point(suppressionRight, suppressionBottom),
+                        new Scalar(squaredDifference ? maximumSquaredError + 1 : -1), -1);
+            }
+        } finally {
+            standardDeviation.release();
+            mean.release();
+            result.release();
+        }
+    }
+
+    private static List<RichTemplateMatch> suppressOverlappingMatches(List<RichTemplateMatch> candidates) {
+        List<RichTemplateMatch> retained = new ArrayList<>();
+        candidates.stream()
+                .sorted(Comparator.comparingDouble(RichTemplateMatch::confidence).reversed()
+                        .thenComparingDouble(match -> Math.abs(1.0 - match.scale())))
+                .forEach(candidate -> {
+                    boolean overlaps = retained.stream().anyMatch(existing -> intersectionOverUnion(
+                            candidate.bounds(), existing.bounds()) >= 0.30);
+                    if (!overlaps) {
+                        retained.add(candidate);
+                    }
+                });
+        return retained;
+    }
+
+    private static double intersectionOverUnion(ImageRectangle first, ImageRectangle second) {
+        int left = Math.max(first.x(), second.x());
+        int top = Math.max(first.y(), second.y());
+        int right = Math.min(first.x() + first.width(), second.x() + second.width());
+        int bottom = Math.min(first.y() + first.height(), second.y() + second.height());
+        long intersection = (long) Math.max(0, right - left) * Math.max(0, bottom - top);
+        long union = (long) first.width() * first.height() + (long) second.width() * second.height() - intersection;
+        return union == 0 ? 0 : (double) intersection / union;
+    }
+
+    private record RichTemplateMatch(ImageRectangle bounds, double confidence, double scale,
+                                     ImageMatchingAlgorithm algorithm) {
     }
 
     private static Mat decodeImage(byte[] imageBytes, int mode) {

--- a/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
+++ b/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
@@ -24,6 +24,9 @@ import org.opencv.core.*;
 import org.opencv.highgui.HighGui;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.opencv.imgproc.Imgproc;
+import org.opencv.calib3d.Calib3d;
+import org.opencv.features2d.DescriptorMatcher;
+import org.opencv.features2d.SIFT;
 import org.openqa.selenium.By;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
@@ -456,10 +459,18 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
             double threshold = target.minimumConfidence().orElseGet(
                     () -> SHAFT.Properties.visuals.visualMatchingThreshold());
             List<RichTemplateMatch> candidates = switch (target.matchingMode()) {
-                case AUTO, TEMPLATE -> findTemplateMatches(searchImage, reference, threshold);
-                case FEATURE -> throw new UnsupportedOperationException(
-                        "OpenCV feature matching is not available for this target.");
+                case TEMPLATE -> findTemplateMatches(searchImage, reference, threshold);
+                case FEATURE -> findFeatureMatches(searchImage, reference, threshold);
+                case AUTO -> {
+                    List<RichTemplateMatch> templateMatches = findTemplateMatches(searchImage, reference, threshold);
+                    yield templateMatches.isEmpty() ? findFeatureMatches(searchImage, reference, threshold) : templateMatches;
+                }
             };
+            if (target.occurrence().orElse(0) > 0 && candidates.stream()
+                    .anyMatch(match -> match.algorithm() == ImageMatchingAlgorithm.FEATURE_HOMOGRAPHY)) {
+                throw new UnsupportedOperationException(
+                        "Feature matching currently resolves one geometrically verified occurrence; use TEMPLATE or narrow the region.");
+            }
             return suppressOverlappingMatches(candidates).stream()
                     .sorted(Comparator.comparingInt((RichTemplateMatch match) -> match.bounds().y())
                             .thenComparingInt(match -> match.bounds().x()))
@@ -574,6 +585,164 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
                     }
                 });
         return retained;
+    }
+
+    private static List<RichTemplateMatch> findFeatureMatches(Mat searchImage, Mat reference, double threshold) {
+        Mat graySearch = new Mat();
+        Mat grayReference = new Mat();
+        Mat referenceMask = new Mat();
+        Mat opaqueReference = null;
+        Mat emptyMask = new Mat();
+        Mat referenceDescriptors = new Mat();
+        Mat searchDescriptors = new Mat();
+        MatOfKeyPoint referenceKeyPoints = new MatOfKeyPoint();
+        MatOfKeyPoint searchKeyPoints = new MatOfKeyPoint();
+        MatOfPoint2f referencePoints = new MatOfPoint2f();
+        MatOfPoint2f searchPoints = new MatOfPoint2f();
+        Mat inlierMask = new Mat();
+        Mat homography = null;
+        MatOfPoint2f referenceCorners = new MatOfPoint2f();
+        MatOfPoint2f projectedCorners = new MatOfPoint2f();
+        SIFT sift = null;
+        DescriptorMatcher matcher = null;
+        List<MatOfDMatch> nearestMatches = new ArrayList<>();
+        try {
+            if (searchImage.channels() == 1) searchImage.copyTo(graySearch);
+            else Imgproc.cvtColor(searchImage, graySearch, Imgproc.COLOR_BGR2GRAY);
+            if (reference.channels() == 4) {
+                Core.extractChannel(reference, referenceMask, 3);
+                Imgproc.threshold(referenceMask, referenceMask, 0, 255, Imgproc.THRESH_BINARY);
+                opaqueReference = new Mat(reference.rows(), reference.cols(), CvType.CV_8UC3,
+                        new Scalar(255, 255, 255));
+                for (int row = 0; row < reference.rows(); row++) {
+                    for (int column = 0; column < reference.cols(); column++) {
+                        double[] bgra = reference.get(row, column);
+                        double alpha = bgra[3] / 255.0;
+                        opaqueReference.put(row, column,
+                                bgra[0] * alpha + 255 * (1 - alpha),
+                                bgra[1] * alpha + 255 * (1 - alpha),
+                                bgra[2] * alpha + 255 * (1 - alpha));
+                    }
+                }
+                Imgproc.cvtColor(opaqueReference, grayReference, Imgproc.COLOR_BGR2GRAY);
+            } else if (reference.channels() == 1) reference.copyTo(grayReference);
+            else Imgproc.cvtColor(reference, grayReference, Imgproc.COLOR_BGR2GRAY);
+            sift = SIFT.create();
+            matcher = DescriptorMatcher.create(DescriptorMatcher.FLANNBASED);
+            sift.detectAndCompute(grayReference, referenceMask.empty() ? emptyMask : referenceMask,
+                    referenceKeyPoints, referenceDescriptors);
+            sift.detectAndCompute(graySearch, emptyMask, searchKeyPoints, searchDescriptors);
+            if (referenceDescriptors.empty() || searchDescriptors.empty()) return List.of();
+            matcher.knnMatch(referenceDescriptors, searchDescriptors, nearestMatches, 2);
+            KeyPoint[] referenceKeys = referenceKeyPoints.toArray();
+            KeyPoint[] searchKeys = searchKeyPoints.toArray();
+            List<Point> source = new ArrayList<>();
+            List<Point> destination = new ArrayList<>();
+            for (MatOfDMatch nearest : nearestMatches) {
+                DMatch[] pair = nearest.toArray();
+                if (pair.length >= 2 && pair[0].distance < 0.75f * pair[1].distance) {
+                    source.add(referenceKeys[pair[0].queryIdx].pt);
+                    destination.add(searchKeys[pair[0].trainIdx].pt);
+                }
+            }
+            if (source.size() < 8) return List.of();
+            referencePoints.fromList(source);
+            searchPoints.fromList(destination);
+            homography = Calib3d.findHomography(referencePoints, searchPoints, Calib3d.RANSAC, 3.0, inlierMask);
+            if (homography.empty()) return List.of();
+            int inliers = Core.countNonZero(inlierMask);
+            double inlierRatio = (double) inliers / source.size();
+            double confidence = 0.75 + 0.25 * inlierRatio;
+            if (inliers < 6 || inlierRatio < 0.60 || confidence < threshold
+                    || !hasDistributedInliers(source, inlierMask, reference.cols(), reference.rows())) return List.of();
+
+            referenceCorners.fromArray(new Point(0, 0), new Point(reference.cols(), 0),
+                    new Point(reference.cols(), reference.rows()), new Point(0, reference.rows()));
+            Core.perspectiveTransform(referenceCorners, projectedCorners, homography);
+            Point[] corners = projectedCorners.toArray();
+            if (corners.length != 4 || Arrays.stream(corners).anyMatch(point -> !Double.isFinite(point.x)
+                    || !Double.isFinite(point.y) || point.x < 0 || point.y < 0
+                    || point.x > searchImage.cols() || point.y > searchImage.rows())) return List.of();
+            MatOfPoint polygon = new MatOfPoint(corners);
+            try {
+                double projectedArea = Math.abs(Imgproc.contourArea(polygon));
+                double areaRatio = projectedArea / ((double) reference.cols() * reference.rows());
+                if (!Imgproc.isContourConvex(polygon) || projectedArea < 16 || areaRatio < 0.10 || areaRatio > 10
+                        || !hasPlausibleEdges(corners, (double) reference.cols() / reference.rows())) return List.of();
+            } finally {
+                polygon.release();
+            }
+            double minX = Arrays.stream(corners).mapToDouble(point -> point.x).min().orElseThrow();
+            double minY = Arrays.stream(corners).mapToDouble(point -> point.y).min().orElseThrow();
+            double maxX = Arrays.stream(corners).mapToDouble(point -> point.x).max().orElseThrow();
+            double maxY = Arrays.stream(corners).mapToDouble(point -> point.y).max().orElseThrow();
+            int x = Math.max(0, (int) Math.floor(minX));
+            int y = Math.max(0, (int) Math.floor(minY));
+            int width = Math.min(searchImage.cols() - x, Math.max(1, (int) Math.ceil(maxX) - x));
+            int height = Math.min(searchImage.rows() - y, Math.max(1, (int) Math.ceil(maxY) - y));
+            double scale = Math.sqrt((double) width * height / ((double) reference.cols() * reference.rows()));
+            return List.of(new RichTemplateMatch(new ImageRectangle(x, y, width, height), confidence, scale,
+                    ImageMatchingAlgorithm.FEATURE_HOMOGRAPHY));
+        } finally {
+            nearestMatches.forEach(Mat::release);
+            safelyClear(matcher);
+            safelyClear(sift);
+            projectedCorners.release();
+            referenceCorners.release();
+            if (homography != null) homography.release();
+            inlierMask.release();
+            searchPoints.release();
+            referencePoints.release();
+            searchKeyPoints.release();
+            referenceKeyPoints.release();
+            searchDescriptors.release();
+            referenceDescriptors.release();
+            emptyMask.release();
+            if (opaqueReference != null) opaqueReference.release();
+            grayReference.release();
+            referenceMask.release();
+            graySearch.release();
+        }
+    }
+
+    private static void safelyClear(org.opencv.core.Algorithm algorithm) {
+        if (algorithm == null) return;
+        try {
+            algorithm.clear();
+        } catch (Throwable ignored) {
+            // Some packaged OpenCV feature algorithms do not implement clear; their native wrapper finalizer owns it.
+        }
+    }
+
+    private static boolean hasDistributedInliers(List<Point> sourcePoints, Mat inlierMask,
+                                                  int referenceWidth, int referenceHeight) {
+        List<Point> inliers = new ArrayList<>();
+        for (int index = 0; index < sourcePoints.size(); index++) {
+            if (inlierMask.get(index, 0)[0] != 0) inliers.add(sourcePoints.get(index));
+        }
+        if (inliers.isEmpty()) return false;
+        double spreadX = inliers.stream().mapToDouble(point -> point.x).max().orElse(0)
+                - inliers.stream().mapToDouble(point -> point.x).min().orElse(0);
+        double spreadY = inliers.stream().mapToDouble(point -> point.y).max().orElse(0)
+                - inliers.stream().mapToDouble(point -> point.y).min().orElse(0);
+        return spreadX >= referenceWidth * 0.20 && spreadY >= referenceHeight * 0.20;
+    }
+
+    private static boolean hasPlausibleEdges(Point[] corners, double referenceAspectRatio) {
+        double top = distance(corners[0], corners[1]);
+        double right = distance(corners[1], corners[2]);
+        double bottom = distance(corners[2], corners[3]);
+        double left = distance(corners[3], corners[0]);
+        double shortest = Math.min(Math.min(top, bottom), Math.min(left, right));
+        double longest = Math.max(Math.max(top, bottom), Math.max(left, right));
+        if (shortest < 4 || longest / shortest > 10) return false;
+        double projectedAspectRatio = ((top + bottom) / 2) / ((left + right) / 2);
+        double distortion = projectedAspectRatio / referenceAspectRatio;
+        return distortion >= 1.0 / 3.0 && distortion <= 3.0;
+    }
+
+    private static double distance(Point first, Point second) {
+        return Math.hypot(first.x - second.x, first.y - second.y);
     }
 
     private static double intersectionOverUnion(ImageRectangle first, ImageRectangle second) {

--- a/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
+++ b/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
@@ -390,7 +390,44 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
             saveReferenceImage(referenceImagePath, elementScreenshot);
             return true;
         }
-        return !findImageWithinCurrentPage(referenceImagePath, elementScreenshot).isEmpty();
+        if (elementScreenshot == null || elementScreenshot.length == 0) {
+            return false;
+        }
+        byte[] referenceBytes;
+        try {
+            referenceBytes = Files.readAllBytes(Paths.get(referenceImagePath));
+        } catch (IOException exception) {
+            ReportManagerHelper.logDiscrete(exception);
+            return false;
+        }
+        Mat reference = null;
+        Mat actual = null;
+        try {
+            reference = decodeImage(referenceBytes, Imgcodecs.IMREAD_UNCHANGED);
+            actual = decodeImage(elementScreenshot, Imgcodecs.IMREAD_UNCHANGED);
+            return !reference.empty()
+                    && !actual.empty()
+                    && reference.rows() == actual.rows()
+                    && reference.cols() == actual.cols()
+                    && reference.type() == actual.type()
+                    && Core.norm(reference, actual, Core.NORM_INF) == 0;
+        } finally {
+            if (reference != null) {
+                reference.release();
+            }
+            if (actual != null) {
+                actual.release();
+            }
+        }
+    }
+
+    private static Mat decodeImage(byte[] imageBytes, int mode) {
+        MatOfByte buffer = new MatOfByte(imageBytes);
+        try {
+            return Imgcodecs.imdecode(buffer, mode);
+        } finally {
+            buffer.release();
+        }
     }
 
     private boolean compareUsingEyes(byte[] elementScreenshot,

--- a/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
+++ b/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
@@ -14,6 +14,10 @@ import com.assertthat.selenium_shutterbug.utils.image.UnableToCompareImagesExcep
 import com.shaft.cli.FileActions;
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import com.shaft.gui.image.ImageMatch;
+import com.shaft.gui.image.ImageRectangle;
+import com.shaft.gui.image.ImageMatchingMode;
+import com.shaft.gui.image.ImageTarget;
 import com.shaft.properties.internal.Properties;
 import nu.pattern.OpenCV;
 import org.mockito.MockedConstruction;
@@ -275,6 +279,112 @@ public class ImageProcessingActionsCoverageUnitTest {
 
         Assert.assertFalse(ImageProcessingActions.compareAgainstBaseline(mock(WebDriver.class), failingLocator, new byte[0],
                 ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV));
+    }
+
+    @Test
+    public void typedImageMatchingShouldReturnEveryOccurrenceWithRichBounds() {
+        BufferedImage targetImage = createReferenceTarget(20, 16);
+        BufferedImage screenshotImage = createImage(100, 70, Color.WHITE);
+        Graphics2D graphics = screenshotImage.createGraphics();
+        graphics.drawImage(targetImage, 8, 10, null);
+        graphics.drawImage(targetImage, 62, 39, null);
+        graphics.dispose();
+
+        ImageTarget target = ImageTarget.fromBytes(encodePng(targetImage)).minimumConfidence(0.95);
+        List<ImageMatch> matches = new OpenCvVisualProcessingProvider()
+                .findImageMatches(target, encodePng(screenshotImage));
+
+        Assert.assertEquals(matches.size(), 2);
+        Assert.assertEquals(matches.get(0).bounds(), new ImageRectangle(8, 10, 20, 16));
+        Assert.assertEquals(matches.get(1).bounds(), new ImageRectangle(62, 39, 20, 16));
+        Assert.assertTrue(matches.stream().allMatch(match -> match.confidence() >= 0.95));
+    }
+
+    @Test
+    public void typedImageMatchingShouldHonorSearchRegionAndOccurrence() {
+        BufferedImage targetImage = createReferenceTarget(20, 16);
+        BufferedImage screenshotImage = createImage(100, 70, Color.WHITE);
+        Graphics2D graphics = screenshotImage.createGraphics();
+        graphics.drawImage(targetImage, 8, 10, null);
+        graphics.drawImage(targetImage, 62, 39, null);
+        graphics.dispose();
+        byte[] screenshot = encodePng(screenshotImage);
+
+        ImageTarget target = ImageTarget.fromBytes(encodePng(targetImage))
+                .minimumConfidence(0.95)
+                .within(new ImageRectangle(50, 30, 50, 40));
+        List<ImageMatch> matches = new OpenCvVisualProcessingProvider().findImageMatches(target, screenshot);
+
+        Assert.assertEquals(matches.size(), 1);
+        Assert.assertEquals(matches.get(0).bounds(), new ImageRectangle(62, 39, 20, 16));
+    }
+
+    @Test
+    public void typedImageMatchingShouldUseAlphaMaskAndIgnoreHiddenRgb() {
+        BufferedImage targetImage = new BufferedImage(24, 20, BufferedImage.TYPE_INT_ARGB);
+        for (int y = 0; y < targetImage.getHeight(); y++) {
+            for (int x = 0; x < targetImage.getWidth(); x++) {
+                targetImage.setRGB(x, y, 0x00ff0000);
+            }
+        }
+        Graphics2D targetGraphics = targetImage.createGraphics();
+        drawReferenceTarget(targetGraphics, 5, 4, 14, 12);
+        targetGraphics.dispose();
+        BufferedImage screenshotImage = createImage(80, 60, Color.CYAN);
+        Graphics2D screenshotGraphics = screenshotImage.createGraphics();
+        screenshotGraphics.drawImage(targetImage, 31, 22, null);
+        screenshotGraphics.dispose();
+
+        List<ImageMatch> matches = new OpenCvVisualProcessingProvider().findImageMatches(
+                ImageTarget.fromBytes(encodePng(targetImage)).minimumConfidence(0.98),
+                encodePng(screenshotImage));
+
+        Assert.assertFalse(matches.isEmpty());
+        Assert.assertEquals(matches.get(0).bounds(), new ImageRectangle(31, 22, 24, 20));
+    }
+
+    @Test
+    public void typedImageMatchingShouldHandleFlatTemplatesWithoutFalsePerfectMatches() {
+        BufferedImage screenshotImage = createImage(50, 40, Color.WHITE);
+        Graphics2D graphics = screenshotImage.createGraphics();
+        graphics.setColor(Color.BLACK);
+        graphics.fillRect(17, 13, 8, 8);
+        graphics.dispose();
+        OpenCvVisualProcessingProvider provider = new OpenCvVisualProcessingProvider();
+
+        List<ImageMatch> positive = provider.findImageMatches(
+                ImageTarget.fromBytes(createPng(8, 8, Color.BLACK)).minimumConfidence(0.999),
+                encodePng(screenshotImage));
+        List<ImageMatch> negative = provider.findImageMatches(
+                ImageTarget.fromBytes(createPng(8, 8, Color.RED)).minimumConfidence(0.999),
+                encodePng(screenshotImage));
+
+        Assert.assertTrue(positive.stream().anyMatch(match -> match.bounds().x() == 17 && match.bounds().y() == 13));
+        Assert.assertTrue(negative.isEmpty());
+    }
+
+    @Test
+    public void typedImageMatchingShouldRejectIsoluminantWrongColorAtDefaultThreshold() {
+        BufferedImage screenshotImage = createImage(50, 40, Color.WHITE);
+        Graphics2D graphics = screenshotImage.createGraphics();
+        graphics.setColor(new Color(0, 130, 0));
+        graphics.fillRect(17, 13, 8, 8);
+        graphics.dispose();
+
+        List<ImageMatch> matches = new OpenCvVisualProcessingProvider().findImageMatches(
+                ImageTarget.fromBytes(createPng(8, 8, Color.RED)), encodePng(screenshotImage));
+
+        Assert.assertTrue(matches.isEmpty());
+    }
+
+    @Test
+    public void explicitFeatureModeShouldFailClosedUntilFeatureMatcherRuns() {
+        ImageTarget target = ImageTarget.fromBytes(encodePng(createReferenceTarget(20, 16)))
+                .matchingMode(ImageMatchingMode.FEATURE);
+        byte[] screenshot = encodePng(createScreenshotWithReferenceTarget(70, 60, 10, 12, 20, 16));
+
+        Assert.expectThrows(UnsupportedOperationException.class,
+                () -> new OpenCvVisualProcessingProvider().findImageMatches(target, screenshot));
     }
 
     @Test

--- a/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
+++ b/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
@@ -278,6 +278,54 @@ public class ImageProcessingActionsCoverageUnitTest {
     }
 
     @Test
+    public void compareAgainstBaselineExactOpenCvShouldRejectBaselineContainedInsideLargerActualImage() {
+        By locator = By.id("open-cv-exact-containment-regression");
+        String hash = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        byte[] reference = createPng(20, 20, Color.GRAY);
+        FILE_ACTIONS.writeToFile(tempDir.resolve(hash + ".png").toString(), reference);
+
+        BufferedImage largerActual = new BufferedImage(40, 40, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = largerActual.createGraphics();
+        graphics.setColor(Color.WHITE);
+        graphics.fillRect(0, 0, 40, 40);
+        graphics.setColor(Color.GRAY);
+        graphics.fillRect(10, 10, 20, 20);
+        graphics.dispose();
+
+        Assert.assertFalse(ImageProcessingActions.compareAgainstBaseline(mock(WebDriver.class), locator,
+                        encodePng(largerActual), ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV),
+                "EXACT_OPENCV must compare the complete image instead of accepting template containment.");
+    }
+
+    @Test
+    public void compareAgainstBaselineExactOpenCvShouldRejectOneChangedPixelAtEqualDimensions() {
+        By locator = By.id("open-cv-exact-one-pixel-regression");
+        String hash = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        byte[] reference = createPng(20, 20, Color.GRAY);
+        FILE_ACTIONS.writeToFile(tempDir.resolve(hash + ".png").toString(), reference);
+
+        BufferedImage actual = createImage(20, 20, Color.GRAY);
+        actual.setRGB(10, 10, Color.RED.getRGB());
+
+        Assert.assertFalse(ImageProcessingActions.compareAgainstBaseline(mock(WebDriver.class), locator,
+                encodePng(actual), ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV));
+    }
+
+    @Test
+    public void compareAgainstBaselineExactOpenCvShouldRejectOneChangedAlphaValue() {
+        By locator = By.id("open-cv-exact-alpha-regression");
+        String hash = ImageProcessingActions.formatElementLocatorToImagePath(locator);
+        BufferedImage reference = createArgbImage(20, 20, new Color(20, 40, 60, 255));
+        FILE_ACTIONS.writeToFile(tempDir.resolve(hash + ".png").toString(), encodePng(reference));
+
+        BufferedImage actual = createArgbImage(20, 20, new Color(20, 40, 60, 255));
+        actual.setRGB(10, 10, new Color(20, 40, 60, 128).getRGB());
+
+        Assert.assertFalse(ImageProcessingActions.compareAgainstBaseline(mock(WebDriver.class), locator,
+                encodePng(actual), ImageProcessingActions.VisualValidationEngine.EXACT_OPENCV));
+    }
+
+    @Test
     public void compareAgainstBaselineExactShutterbugShouldCreateMissingReference() {
         By locator = By.id("new-shutterbug-baseline");
         byte[] screenshot = createPng(12, 12, Color.ORANGE);
@@ -591,6 +639,15 @@ public class ImageProcessingActionsCoverageUnitTest {
 
     private static BufferedImage createImage(int width, int height, Color color) {
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setColor(color);
+        graphics.fillRect(0, 0, width, height);
+        graphics.dispose();
+        return image;
+    }
+
+    private static BufferedImage createArgbImage(int width, int height, Color color) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
         Graphics2D graphics = image.createGraphics();
         graphics.setColor(color);
         graphics.fillRect(0, 0, width, height);

--- a/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
+++ b/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
@@ -378,13 +378,95 @@ public class ImageProcessingActionsCoverageUnitTest {
     }
 
     @Test
-    public void explicitFeatureModeShouldFailClosedUntilFeatureMatcherRuns() {
-        ImageTarget target = ImageTarget.fromBytes(encodePng(createReferenceTarget(20, 16)))
+    public void explicitFeatureModeShouldLocateRotatedDetailedTarget() {
+        BufferedImage targetImage = createFeatureTarget(100, 80);
+        BufferedImage screenshot = createImage(260, 210, Color.WHITE);
+        Graphics2D graphics = screenshot.createGraphics();
+        graphics.translate(130, 105);
+        graphics.rotate(Math.toRadians(12));
+        graphics.drawImage(targetImage, -50, -40, null);
+        graphics.dispose();
+        ImageTarget target = ImageTarget.fromBytes(encodePng(targetImage))
                 .matchingMode(ImageMatchingMode.FEATURE);
-        byte[] screenshot = encodePng(createScreenshotWithReferenceTarget(70, 60, 10, 12, 20, 16));
+
+        List<ImageMatch> matches = new OpenCvVisualProcessingProvider().findImageMatches(target, encodePng(screenshot));
+
+        Assert.assertEquals(matches.size(), 1);
+        Assert.assertEquals(matches.get(0).algorithm(), com.shaft.gui.image.ImageMatchingAlgorithm.FEATURE_HOMOGRAPHY);
+        Assert.assertTrue(Math.abs(matches.get(0).centerX() - 130) < 12);
+        Assert.assertTrue(Math.abs(matches.get(0).centerY() - 105) < 12);
+    }
+
+    @Test
+    public void featureModeShouldAcceptGrayscaleReferences() {
+        BufferedImage color = createFeatureTarget(100, 80);
+        BufferedImage gray = new BufferedImage(100, 80, BufferedImage.TYPE_BYTE_GRAY);
+        Graphics2D grayGraphics = gray.createGraphics();
+        grayGraphics.drawImage(color, 0, 0, null);
+        grayGraphics.dispose();
+        ImageTarget target = ImageTarget.fromBytes(encodePng(gray)).matchingMode(ImageMatchingMode.FEATURE);
+
+        List<ImageMatch> matches = new OpenCvVisualProcessingProvider().findImageMatches(target,
+                encodePng(rotatedScreenshot(gray, 12)));
+
+        Assert.assertEquals(matches.size(), 1);
+    }
+
+    @Test
+    public void featureModeShouldIgnoreHiddenRgbUnderTransparentPadding() {
+        BufferedImage redHidden = transparentFeatureTarget(120, 100, 0x00ff0000);
+        BufferedImage blueHidden = transparentFeatureTarget(120, 100, 0x000000ff);
+        byte[] screenshot = encodePng(rotatedScreenshot(redHidden, 12));
+        OpenCvVisualProcessingProvider provider = new OpenCvVisualProcessingProvider();
+
+        List<ImageMatch> first = provider.findImageMatches(ImageTarget.fromBytes(encodePng(redHidden))
+                .matchingMode(ImageMatchingMode.FEATURE), screenshot);
+        List<ImageMatch> second = provider.findImageMatches(ImageTarget.fromBytes(encodePng(blueHidden))
+                .matchingMode(ImageMatchingMode.FEATURE), screenshot);
+
+        Assert.assertEquals(first.size(), 1);
+        Assert.assertEquals(second.size(), 1);
+        Assert.assertTrue(Math.abs(first.get(0).centerX() - second.get(0).centerX()) < 3);
+    }
+
+    @Test
+    public void autoModeShouldUseFeatureFallbackAtDefaultThreshold() {
+        BufferedImage targetImage = createFeatureTarget(100, 80);
+
+        List<ImageMatch> matches = new OpenCvVisualProcessingProvider().findImageMatches(
+                ImageTarget.fromBytes(encodePng(targetImage)), encodePng(rotatedScreenshot(targetImage, 25)));
+
+        Assert.assertEquals(matches.size(), 1);
+        Assert.assertEquals(matches.get(0).algorithm(), com.shaft.gui.image.ImageMatchingAlgorithm.FEATURE_HOMOGRAPHY);
+    }
+
+    @Test
+    public void featureModeShouldFailClosedForLaterOccurrence() {
+        BufferedImage targetImage = createFeatureTarget(100, 80);
+        ImageTarget target = ImageTarget.fromBytes(encodePng(targetImage))
+                .matchingMode(ImageMatchingMode.FEATURE).occurrence(1);
 
         Assert.expectThrows(UnsupportedOperationException.class,
-                () -> new OpenCvVisualProcessingProvider().findImageMatches(target, screenshot));
+                () -> new OpenCvVisualProcessingProvider().findImageMatches(target,
+                        encodePng(rotatedScreenshot(targetImage, 12))));
+    }
+
+    @Test
+    public void featureModeShouldRejectRepeatedLocalizedFragments() {
+        BufferedImage target = createFeatureTarget(100, 80);
+        BufferedImage fragment = target.getSubimage(35, 25, 25, 20);
+        BufferedImage screenshot = createImage(260, 210, Color.WHITE);
+        Graphics2D graphics = screenshot.createGraphics();
+        for (int y = 20; y < 180; y += 40) for (int x = 20; x < 230; x += 45) {
+            graphics.drawImage(fragment, x, y, null);
+        }
+        graphics.dispose();
+
+        List<ImageMatch> matches = new OpenCvVisualProcessingProvider().findImageMatches(
+                ImageTarget.fromBytes(encodePng(target)).matchingMode(ImageMatchingMode.FEATURE),
+                encodePng(screenshot));
+
+        Assert.assertTrue(matches.isEmpty());
     }
 
     @Test
@@ -754,6 +836,44 @@ public class ImageProcessingActionsCoverageUnitTest {
         graphics.fillRect(0, 0, width, height);
         graphics.dispose();
         return image;
+    }
+
+    private static BufferedImage createFeatureTarget(int width, int height) {
+        BufferedImage image = createImage(width, height, Color.WHITE);
+        Graphics2D graphics = image.createGraphics();
+        for (int y = 0; y < height; y += 10) {
+            for (int x = 0; x < width; x += 10) {
+                graphics.setColor(((x + y) / 10) % 2 == 0 ? Color.BLACK : Color.ORANGE);
+                graphics.fillRect(x, y, 8, 8);
+            }
+        }
+        graphics.setColor(Color.BLUE);
+        graphics.drawString("SHAFT", 28, 44);
+        graphics.setColor(Color.RED);
+        graphics.fillOval(9, 12, 17, 23);
+        graphics.dispose();
+        return image;
+    }
+
+    private static BufferedImage transparentFeatureTarget(int width, int height, int hiddenRgb) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        for (int y = 0; y < height; y++) for (int x = 0; x < width; x++) {
+            image.setRGB(x, y, hiddenRgb | 0x01000000);
+        }
+        Graphics2D graphics = image.createGraphics();
+        graphics.drawImage(createFeatureTarget(100, 80), 10, 10, null);
+        graphics.dispose();
+        return image;
+    }
+
+    private static BufferedImage rotatedScreenshot(BufferedImage target, double degrees) {
+        BufferedImage screenshot = createImage(260, 210, Color.WHITE);
+        Graphics2D graphics = screenshot.createGraphics();
+        graphics.translate(130, 105);
+        graphics.rotate(Math.toRadians(degrees));
+        graphics.drawImage(target, -target.getWidth() / 2, -target.getHeight() / 2, null);
+        graphics.dispose();
+        return screenshot;
     }
 
     private static BufferedImage createArgbImage(int width, int height, Color color) {


### PR DESCRIPTION
## Summary

Implements the high-accuracy visual/OCR program tracked by #4829.

- make `EXACT_OPENCV` fully pixel exact, including dimensions and alpha, and use OpenCV as the no-argument reference-assertion default
- add immutable validated `ImageTarget`, `ImageMatch`, confidence, occurrence, region, and algorithm contracts
- add color-aware, alpha-masked, multi-scale OpenCV matching with non-maximum suppression and ambiguity rejection
- add SIFT/Lowe/RANSAC homography fallback with inlier and geometry verification
- add typed image and OCR tap/scroll actions for up, down, left, and right, including nested containers
- prefer local OpenCV/Tesseract; use capability-checked Appium Images fallback without weakening thresholds
- improve OCR AUTO preprocessing with alpha-safe adaptive Otsu thresholding

## Tracking

Closes #4830
Closes #4831
Closes #4832
Closes #4833

Companion documentation: ShaftHQ/shafthq.github.io#950

## Evidence

- integrated affected suite: shaft-engine 20 tests, shaft-visual 48 tests, shaft-ocr preprocessing 6 tests; 0 failures/errors/skips
- affected reactor package: `mvn -pl shaft-visual,shaft-ocr -am -DskipTests package` passed
- exact comparison regression suite includes dimensions, RGB, and alpha
- matching regressions include repeated targets, regions, isoluminant colors, transparent references, flat templates, rotation, grayscale, hidden RGB, default AUTO fallback, repeated-feature rejection, and occurrence safety
- mobile regressions cover public four-direction contracts, screenshot/viewport coordinate mapping, Appium threshold restoration, and occurrence selection
- independent adversarial review: three rounds per behavior-changing slice; all findings addressed
- docs: `yarn test`, `yarn typecheck`, `yarn build`, and `yarn test:playwright` passed

## Acceptance note

No local emulator or external cloud-device suite was launched because repository policy requires separate confirmation for emulator/inspector/cloud infrastructure. Android and iOS command paths are covered by the existing mocked Appium suites and focused unit tests.