### PR TITLE
fix(trace): make browser observability session-owned

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BidiConsoleLogSource.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BidiConsoleLogSource.java
@@ -18,6 +18,7 @@ public final class BidiConsoleLogSource implements AutoCloseable {
     private static final ReferenceQueue<WebDriver> STALE_DRIVERS = new ReferenceQueue<>();
     private static final Map<IdentityWeakReference, Entry> CACHE = new HashMap<>();
     private final List<BrowserObservabilityRecorder.ConsoleSnapshotEntry> events = new ArrayList<>();
+    private boolean oldestEventOmitted;
     private final BrowserObservabilityRecorder.ObservationBinding observationBinding =
             BrowserObservabilityRecorder.captureBinding();
     private LogInspector inspector;
@@ -108,7 +109,11 @@ public final class BidiConsoleLogSource implements AutoCloseable {
         }
         BrowserObservabilityRecorder.ObservationSession owner =
                 BrowserObservabilityRecorder.resolveSession(source.observationBinding);
-        for (BrowserObservabilityRecorder.ConsoleSnapshotEntry entry : source.takeEvents()) {
+        ConsoleBatch batch = source.takeEvents();
+        if (batch.oldestOmitted()) {
+            BrowserObservabilityRecorder.recordConsoleOmission(owner);
+        }
+        for (BrowserObservabilityRecorder.ConsoleSnapshotEntry entry : batch.events()) {
             BrowserObservabilityRecorder.recordConsole(owner,
                     entry.source(), entry.level(), entry.message(), entry.timestamp());
         }
@@ -192,6 +197,7 @@ public final class BidiConsoleLogSource implements AutoCloseable {
         }
         if (events.size() >= EVENT_LIMIT) {
             events.removeFirst();
+            oldestEventOmitted = true;
         }
         events.add(BrowserObservabilityRecorder.consoleEntry("bidi", level, text, timestamp));
     }
@@ -202,13 +208,18 @@ public final class BidiConsoleLogSource implements AutoCloseable {
 
     private synchronized void clearEvents() {
         events.clear();
+        oldestEventOmitted = false;
     }
 
-    private synchronized List<BrowserObservabilityRecorder.ConsoleSnapshotEntry> takeEvents() {
-        List<BrowserObservabilityRecorder.ConsoleSnapshotEntry> snapshot = List.copyOf(events);
+    private synchronized ConsoleBatch takeEvents() {
+        ConsoleBatch snapshot = new ConsoleBatch(List.copyOf(events), oldestEventOmitted);
         events.clear();
+        oldestEventOmitted = false;
         return snapshot;
     }
+
+    private record ConsoleBatch(List<BrowserObservabilityRecorder.ConsoleSnapshotEntry> events,
+                                boolean oldestOmitted) { }
 
     @Override
     public void close() {
@@ -216,6 +227,7 @@ public final class BidiConsoleLogSource implements AutoCloseable {
         synchronized (this) {
             healthy = false;
             events.clear();
+            oldestEventOmitted = false;
             currentInspector = inspector;
             inspector = null;
         }

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BidiConsoleLogSource.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BidiConsoleLogSource.java
@@ -18,6 +18,8 @@ public final class BidiConsoleLogSource implements AutoCloseable {
     private static final ReferenceQueue<WebDriver> STALE_DRIVERS = new ReferenceQueue<>();
     private static final Map<IdentityWeakReference, Entry> CACHE = new HashMap<>();
     private final List<BrowserObservabilityRecorder.ConsoleSnapshotEntry> events = new ArrayList<>();
+    private final BrowserObservabilityRecorder.ObservationBinding observationBinding =
+            BrowserObservabilityRecorder.captureBinding();
     private LogInspector inspector;
     private volatile boolean healthy;
 
@@ -104,8 +106,11 @@ public final class BidiConsoleLogSource implements AutoCloseable {
         if (source == null) {
             return;
         }
+        BrowserObservabilityRecorder.ObservationSession owner =
+                BrowserObservabilityRecorder.resolveSession(source.observationBinding);
         for (BrowserObservabilityRecorder.ConsoleSnapshotEntry entry : source.takeEvents()) {
-            BrowserObservabilityRecorder.recordConsole(entry.source(), entry.level(), entry.message(), entry.timestamp());
+            BrowserObservabilityRecorder.recordConsole(owner,
+                    entry.source(), entry.level(), entry.message(), entry.timestamp());
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptor.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserNetworkInterceptor.java
@@ -32,6 +32,7 @@ public class BrowserNetworkInterceptor implements AutoCloseable {
     private boolean observing;
     private boolean closed;
     private final Counter counter = new Counter();
+    private final BrowserObservabilityRecorder.ObservationBinding observationBinding;
 
     /**
      * Creates a browser network interceptor backed by Selenium DevTools.
@@ -45,6 +46,7 @@ public class BrowserNetworkInterceptor implements AutoCloseable {
     BrowserNetworkInterceptor(WebDriver driver, InterceptorFactory interceptorFactory) {
         this.driver = driver;
         this.interceptorFactory = interceptorFactory;
+        this.observationBinding = BrowserObservabilityRecorder.captureBinding();
         counter.owner(this);
         synchronized (COUNTERS) {
             expungeStaleDrivers();
@@ -232,7 +234,8 @@ public class BrowserNetworkInterceptor implements AutoCloseable {
     private Filter createFilter() {
         return next -> request -> {
             counter.increment();
-            BrowserObservabilityRecorder.NetworkExchange exchange = BrowserObservabilityRecorder.startNetwork(request);
+            BrowserObservabilityRecorder.NetworkExchange exchange =
+                    BrowserObservabilityRecorder.startNetwork(observationBinding, request);
             BrowserNetworkInterceptionRule rule = findMatchingRule(request);
             try {
                 HttpResponse response;

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java
@@ -46,6 +46,7 @@ public final class PlaywrightSession implements AutoCloseable {
     private final Set<Page> observedPages = Collections.newSetFromMap(new IdentityHashMap<>());
     private final Set<Page> downloadObservedPages = Collections.newSetFromMap(new IdentityHashMap<>());
     private final List<BrowserObservabilityRecorder.ConsoleSnapshotEntry> consoleEvents = new ArrayList<>();
+    private boolean oldestConsoleEventOmitted;
     private final BrowserObservabilityRecorder.ObservationBinding observationBinding;
     private final List<Download> downloads = new ArrayList<>();
     private int nextPageHandleIndex = 1;
@@ -208,6 +209,7 @@ public final class PlaywrightSession implements AutoCloseable {
     /** Clears only this Playwright session's console observations. */
     public synchronized void clearConsole() {
         consoleEvents.clear();
+        oldestConsoleEventOmitted = false;
     }
 
     /** @return immutable native download handles owned by this session, oldest first */
@@ -296,9 +298,15 @@ public final class PlaywrightSession implements AutoCloseable {
         BrowserObservabilityRecorder.ObservationSession owner =
                 BrowserObservabilityRecorder.resolveSession(observationBinding);
         List<BrowserObservabilityRecorder.ConsoleSnapshotEntry> snapshot;
+        boolean oldestOmitted;
         synchronized (this) {
             snapshot = List.copyOf(consoleEvents);
             consoleEvents.clear();
+            oldestOmitted = oldestConsoleEventOmitted;
+            oldestConsoleEventOmitted = false;
+        }
+        if (oldestOmitted) {
+            BrowserObservabilityRecorder.recordConsoleOmission(owner);
         }
         for (BrowserObservabilityRecorder.ConsoleSnapshotEntry entry : snapshot) {
             BrowserObservabilityRecorder.recordConsole(owner,
@@ -309,6 +317,7 @@ public final class PlaywrightSession implements AutoCloseable {
     private synchronized void recordConsole(String level, String message) {
         if (consoleEvents.size() >= CONSOLE_EVENT_LIMIT) {
             consoleEvents.removeFirst();
+            oldestConsoleEventOmitted = true;
         }
         consoleEvents.add(BrowserObservabilityRecorder.consoleEntry(
                 "playwright", level, message, System.currentTimeMillis()));

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java
@@ -2,7 +2,6 @@ package com.shaft.gui.playwright.internal;
 
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserContext;
-import com.microsoft.playwright.Dialog;
 import com.microsoft.playwright.Download;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;

--- a/shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/playwright/internal/PlaywrightSession.java
@@ -46,6 +46,7 @@ public final class PlaywrightSession implements AutoCloseable {
     private final Set<Page> observedPages = Collections.newSetFromMap(new IdentityHashMap<>());
     private final Set<Page> downloadObservedPages = Collections.newSetFromMap(new IdentityHashMap<>());
     private final List<BrowserObservabilityRecorder.ConsoleSnapshotEntry> consoleEvents = new ArrayList<>();
+    private final BrowserObservabilityRecorder.ObservationBinding observationBinding;
     private final List<Download> downloads = new ArrayList<>();
     private int nextPageHandleIndex = 1;
 
@@ -56,6 +57,7 @@ public final class PlaywrightSession implements AutoCloseable {
         this.browserContext = browserContext;
         this.page = page;
         this.traceManager = traceManager;
+        this.observationBinding = BrowserObservabilityRecorder.captureBinding();
         this.networkInterceptor = new PlaywrightNetworkInterceptor(browserContext);
         registerDownloadContextBridge();
         registerDialogBridge(page);
@@ -291,13 +293,16 @@ public final class PlaywrightSession implements AutoCloseable {
 
     /** Atomically transfers this session's console observations to failure-trace storage. */
     public void drainConsoleToRecorder() {
+        BrowserObservabilityRecorder.ObservationSession owner =
+                BrowserObservabilityRecorder.resolveSession(observationBinding);
         List<BrowserObservabilityRecorder.ConsoleSnapshotEntry> snapshot;
         synchronized (this) {
             snapshot = List.copyOf(consoleEvents);
             consoleEvents.clear();
         }
         for (BrowserObservabilityRecorder.ConsoleSnapshotEntry entry : snapshot) {
-            BrowserObservabilityRecorder.recordConsole(entry.source(), entry.level(), entry.message(), entry.timestamp());
+            BrowserObservabilityRecorder.recordConsole(owner,
+                    entry.source(), entry.level(), entry.message(), entry.timestamp());
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java
@@ -554,10 +554,6 @@ public final class BrowserObservabilityRecorder {
                 """.formatted(networkJson == null || networkJson.isBlank() ? "[]" : networkJson);
     }
 
-    private static boolean isNetworkEnabled() {
-        return isTraceEnabled() && SHAFT.Properties.reporting.traceIncludeNetwork();
-    }
-
     private static boolean isConsoleEnabled() {
         return isTraceEnabled() && SHAFT.Properties.reporting.traceIncludeConsole();
     }
@@ -766,7 +762,6 @@ public final class BrowserObservabilityRecorder {
         }
         private synchronized List<NetworkEvent> networkSnapshot() { return List.copyOf(network); }
         private synchronized List<ConsoleEvent> consoleSnapshot() { return List.copyOf(console); }
-        private synchronized List<WarningEvent> warningSnapshot() { return effectiveWarnings(); }
         private synchronized List<NetworkEvent> takeNetwork() {
             List<NetworkEvent> result = List.copyOf(network);
             network.clear();
@@ -803,9 +798,7 @@ public final class BrowserObservabilityRecorder {
                     "A network exchange was omitted because the in-flight session limit was reached."));
             return List.copyOf(result);
         }
-        private synchronized void clearNetwork() { network.clear(); nextNetworkId = 0; }
         private synchronized void clearConsole() { console.clear(); }
-        private synchronized void clearWarnings() { warnings.clear(); }
 
         @Override
         public synchronized void close() {

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java
@@ -162,7 +162,7 @@ public final class BrowserObservabilityRecorder {
             BidiConsoleLogSource.drainToRecorder(driver);
             return;
         }
-        if (!currentSession().consoleEnabled()) {
+        if (!currentSession().consoleEnabled() || !isConsoleEnabled()) {
             return;
         }
         if (!tryCollectConsole(driver)) {
@@ -333,11 +333,11 @@ public final class BrowserObservabilityRecorder {
     }
 
     static String drainConsoleJson() {
-        if (!isConsoleEnabled()) {
-            currentSession().clearConsole();
+        ObservationSession session = currentSession();
+        if (!session.consoleEnabled()) {
+            session.clearConsole();
             return "[]";
         }
-        ObservationSession session = currentSession();
         String json = consoleJson(session.takeConsole());
         return json;
     }
@@ -441,6 +441,11 @@ public final class BrowserObservabilityRecorder {
                 return true;
             }
         }
+    }
+
+    /** Marks that a provider omitted its oldest buffered console event before transfer. */
+    public static void recordConsoleOmission(ObservationSession session) {
+        if (session != null) session.markConsoleLimit();
     }
 
     private static boolean retainReservedExchange(NetworkExchange exchange, ObservationSession owner) {
@@ -713,6 +718,7 @@ public final class BrowserObservabilityRecorder {
         private boolean closed;
         private boolean exchangeLimitWarned;
         private boolean networkLimitWarned;
+        private boolean consoleLimitWarned;
         private boolean warningLimitWarned;
         private final boolean traceEnabled = isTraceEnabled();
         private final boolean networkEnabled = traceEnabled && SHAFT.Properties.reporting.traceIncludeNetwork();
@@ -734,9 +740,15 @@ public final class BrowserObservabilityRecorder {
         }
         private synchronized void addConsole(ConsoleEvent event) {
             if (!closed) {
-                if (console.size() >= CONSOLE_EVENT_LIMIT) console.removeFirst();
+                if (console.size() >= CONSOLE_EVENT_LIMIT) {
+                    console.removeFirst();
+                    consoleLimitWarned = true;
+                }
                 console.add(event);
             }
+        }
+        private synchronized void markConsoleLimit() {
+            if (!closed && consoleEnabled) consoleLimitWarned = true;
         }
         private synchronized void addWarning(WarningEvent event) {
             if (!closed) {
@@ -772,17 +784,21 @@ public final class BrowserObservabilityRecorder {
             warningLimitWarned = false;
             exchangeLimitWarned = false;
             networkLimitWarned = false;
+            consoleLimitWarned = false;
             return result;
         }
         private synchronized List<WarningEvent> effectiveWarnings() {
             List<WarningEvent> result = new ArrayList<>(warnings);
-            int markerCount = (networkLimitWarned ? 1 : 0) + (exchangeLimitWarned ? 1 : 0)
+            int markerCount = (networkLimitWarned ? 1 : 0) + (consoleLimitWarned ? 1 : 0)
+                    + (exchangeLimitWarned ? 1 : 0)
                     + (warningLimitWarned ? 1 : 0);
             while (result.size() + markerCount > WARNING_EVENT_LIMIT) result.removeFirst();
             if (warningLimitWarned) result.add(new WarningEvent("observability",
                     "The oldest browser observability warnings were omitted because the session limit was reached."));
             if (networkLimitWarned) result.add(new WarningEvent("network",
                     "The oldest network events were omitted because the session limit was reached."));
+            if (consoleLimitWarned) result.add(new WarningEvent("console",
+                    "The oldest console events were omitted because the session limit was reached."));
             if (exchangeLimitWarned) result.add(new WarningEvent("network",
                     "A network exchange was omitted because the in-flight session limit was reached."));
             return List.copyOf(result);
@@ -799,6 +815,7 @@ public final class BrowserObservabilityRecorder {
             warnings.clear();
             nextNetworkId = 0;
             networkLimitWarned = false;
+            consoleLimitWarned = false;
             warningLimitWarned = false;
             exchangeLimitWarned = false;
         }

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java
@@ -28,7 +28,9 @@ import java.lang.ref.WeakReference;
  */
 public final class BrowserObservabilityRecorder {
     private static final int BODY_PREVIEW_LIMIT = 2048;
+    private static final int NETWORK_EVENT_LIMIT = 1000;
     private static final int CONSOLE_EVENT_LIMIT = 1000;
+    private static final int WARNING_EVENT_LIMIT = 100;
     private static final int IN_FLIGHT_EXCHANGE_LIMIT = 1000;
     private static final ThreadLocal<ObservationSession> CURRENT = new ThreadLocal<>();
     private static final ThreadLocal<ObservationBinding> CURRENT_BINDING =
@@ -247,11 +249,17 @@ public final class BrowserObservabilityRecorder {
      * @return recorded warnings
      */
     public static List<String> drainWarnings() {
-        ObservationSession session = currentSession();
-        List<String> warnings = session.takeWarnings().stream()
+        return drainWarnings(currentSession());
+    }
+
+    /** Returns and clears warnings for an explicitly owned observation session. */
+    public static List<String> drainWarnings(ObservationSession session) {
+        if (session == null) {
+            return List.of();
+        }
+        return session.takeWarnings().stream()
                 .map(warning -> warning.source() + ": " + warning.message())
                 .toList();
-        return warnings;
     }
 
     static String drainNetworkJson() {
@@ -370,10 +378,15 @@ public final class BrowserObservabilityRecorder {
     /** Starts and binds a fresh browser-observation session to the current report thread. */
     public static ObservationSession startSession() {
         clear();
-        ObservationSession session = new ObservationSession();
+        ObservationSession session = createSession();
         CURRENT.set(session);
         CURRENT_BINDING.get().bind(session);
         return session;
+    }
+
+    /** Creates a detached observation session for a concurrently active browser owner. */
+    public static ObservationSession createSession() {
+        return new ObservationSession();
     }
 
     /** Captures the current observation owner for use by asynchronous callbacks. */
@@ -686,6 +699,8 @@ public final class BrowserObservabilityRecorder {
         private int nextNetworkId;
         private boolean closed;
         private boolean exchangeLimitWarned;
+        private boolean networkLimitWarned;
+        private boolean warningLimitWarned;
         private final boolean traceEnabled = isTraceEnabled();
         private final boolean networkEnabled = traceEnabled && SHAFT.Properties.reporting.traceIncludeNetwork();
         private final boolean consoleEnabled = traceEnabled && SHAFT.Properties.reporting.traceIncludeConsole();
@@ -695,24 +710,38 @@ public final class BrowserObservabilityRecorder {
         private boolean traceEnabled() { return traceEnabled; }
         private boolean networkEnabled() { return networkEnabled; }
         private boolean consoleEnabled() { return consoleEnabled; }
-        private synchronized void addNetwork(NetworkEvent event) { if (!closed) network.add(event); }
+        private synchronized void addNetwork(NetworkEvent event) {
+            if (!closed) {
+                if (network.size() >= NETWORK_EVENT_LIMIT) {
+                    network.removeFirst();
+                    networkLimitWarned = true;
+                }
+                network.add(event);
+            }
+        }
         private synchronized void addConsole(ConsoleEvent event) {
             if (!closed) {
                 if (console.size() >= CONSOLE_EVENT_LIMIT) console.removeFirst();
                 console.add(event);
             }
         }
-        private synchronized void addWarning(WarningEvent event) { if (!closed) warnings.add(event); }
+        private synchronized void addWarning(WarningEvent event) {
+            if (!closed) {
+                if (warnings.size() >= WARNING_EVENT_LIMIT) {
+                    warnings.removeFirst();
+                    warningLimitWarned = true;
+                }
+                warnings.add(event);
+            }
+        }
         private synchronized void warnExchangeLimitOnce() {
             if (!closed && !exchangeLimitWarned) {
                 exchangeLimitWarned = true;
-                warnings.add(new WarningEvent("network",
-                        "A network exchange was omitted because the in-flight session limit was reached."));
             }
         }
         private synchronized List<NetworkEvent> networkSnapshot() { return List.copyOf(network); }
         private synchronized List<ConsoleEvent> consoleSnapshot() { return List.copyOf(console); }
-        private synchronized List<WarningEvent> warningSnapshot() { return List.copyOf(warnings); }
+        private synchronized List<WarningEvent> warningSnapshot() { return effectiveWarnings(); }
         private synchronized List<NetworkEvent> takeNetwork() {
             List<NetworkEvent> result = List.copyOf(network);
             network.clear();
@@ -725,9 +754,25 @@ public final class BrowserObservabilityRecorder {
             return result;
         }
         private synchronized List<WarningEvent> takeWarnings() {
-            List<WarningEvent> result = List.copyOf(warnings);
+            List<WarningEvent> result = effectiveWarnings();
             warnings.clear();
+            warningLimitWarned = false;
+            exchangeLimitWarned = false;
+            networkLimitWarned = false;
             return result;
+        }
+        private synchronized List<WarningEvent> effectiveWarnings() {
+            List<WarningEvent> result = new ArrayList<>(warnings);
+            int markerCount = (networkLimitWarned ? 1 : 0) + (exchangeLimitWarned ? 1 : 0)
+                    + (warningLimitWarned ? 1 : 0);
+            while (result.size() + markerCount > WARNING_EVENT_LIMIT) result.removeFirst();
+            if (warningLimitWarned) result.add(new WarningEvent("observability",
+                    "The oldest browser observability warnings were omitted because the session limit was reached."));
+            if (networkLimitWarned) result.add(new WarningEvent("network",
+                    "The oldest network events were omitted because the session limit was reached."));
+            if (exchangeLimitWarned) result.add(new WarningEvent("network",
+                    "A network exchange was omitted because the in-flight session limit was reached."));
+            return List.copyOf(result);
         }
         private synchronized void clearNetwork() { network.clear(); nextNetworkId = 0; }
         private synchronized void clearConsole() { console.clear(); }
@@ -740,6 +785,9 @@ public final class BrowserObservabilityRecorder {
             console.clear();
             warnings.clear();
             nextNetworkId = 0;
+            networkLimitWarned = false;
+            warningLimitWarned = false;
+            exchangeLimitWarned = false;
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java
@@ -13,22 +13,29 @@ import org.openqa.selenium.remote.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 
 /**
- * Thread-local browser network, console, and capability metadata recorder for SHAFT trace artifacts.
+ * Session-owned browser network, console, and capability metadata recorder for SHAFT trace artifacts.
  */
 public final class BrowserObservabilityRecorder {
     private static final int BODY_PREVIEW_LIMIT = 2048;
     private static final int CONSOLE_EVENT_LIMIT = 1000;
-    private static final ThreadLocal<List<NetworkEvent>> NETWORK = ThreadLocal.withInitial(ArrayList::new);
-    private static final ThreadLocal<List<ConsoleEvent>> CONSOLE = ThreadLocal.withInitial(ArrayList::new);
-    private static final ThreadLocal<List<WarningEvent>> WARNINGS = ThreadLocal.withInitial(ArrayList::new);
-    private static final ThreadLocal<Integer> NEXT_NETWORK_ID = ThreadLocal.withInitial(() -> 0);
+    private static final int IN_FLIGHT_EXCHANGE_LIMIT = 1000;
+    private static final ThreadLocal<ObservationSession> CURRENT = new ThreadLocal<>();
+    private static final ThreadLocal<ObservationBinding> CURRENT_BINDING =
+            ThreadLocal.withInitial(ObservationBinding::new);
+    private static final ReferenceQueue<NetworkExchange> STALE_EXCHANGES = new ReferenceQueue<>();
+    private static final Map<IdentityWeakReference, ObservationSession> EXCHANGE_OWNERS = new HashMap<>();
+    private static final AtomicInteger IN_FLIGHT_EXCHANGES = new AtomicInteger();
 
     private BrowserObservabilityRecorder() {
         throw new IllegalStateException("Utility class");
@@ -41,14 +48,35 @@ public final class BrowserObservabilityRecorder {
      * @return exchange handle, or a disabled handle when trace network capture is disabled
      */
     public static NetworkExchange startNetwork(HttpRequest request) {
-        if (!isNetworkEnabled() || request == null) {
+        return startNetwork(currentSession(), request);
+    }
+
+    /** Starts a network exchange owned by an explicitly captured observation session. */
+    public static NetworkExchange startNetwork(ObservationSession session, HttpRequest request) {
+        if (request == null) {
             return NetworkExchange.disabled();
         }
-        int index = NEXT_NETWORK_ID.get() + 1;
-        NEXT_NETWORK_ID.set(index);
-        byte[] requestBody = copyRequestBody(request);
-        return new NetworkExchange(true, "network-" + index, value(request.getMethod().name()),
-                value(request.getUri()), headers(request), requestBody.length, System.nanoTime());
+        ObservationSession owner = valid(session);
+        if (owner == null || !owner.networkEnabled()) {
+            return NetworkExchange.disabled();
+        }
+        if (!reserveExchange(owner)) {
+            return NetworkExchange.disabled();
+        }
+        int index = owner.nextNetworkId();
+        try {
+            byte[] requestBody = copyRequestBody(request);
+            NetworkExchange exchange = new NetworkExchange(true, "network-" + index,
+                    value(request.getMethod().name()), value(request.getUri()), headers(request),
+                    requestBody.length, System.nanoTime());
+            if (retainReservedExchange(exchange, owner)) {
+                return exchange;
+            }
+        } catch (RuntimeException e) {
+            IN_FLIGHT_EXCHANGES.decrementAndGet();
+            throw e;
+        }
+        return NetworkExchange.disabled();
     }
 
     /**
@@ -63,7 +91,15 @@ public final class BrowserObservabilityRecorder {
             return;
         }
         byte[] responseBody = copyResponseBody(response);
-        recordNetwork(new NetworkObservation(
+        ObservationSession owner;
+        synchronized (EXCHANGE_OWNERS) {
+            expungeStaleExchanges();
+            owner = EXCHANGE_OWNERS.remove(new IdentityWeakReference(exchange));
+        }
+        if (owner != null) {
+            IN_FLIGHT_EXCHANGES.decrementAndGet();
+        }
+        recordNetwork(owner == null ? currentSession() : owner, new NetworkObservation(
                 exchange.method(),
                 exchange.url(),
                 response == null ? 0 : response.getStatus(),
@@ -82,10 +118,21 @@ public final class BrowserObservabilityRecorder {
      * @param observation network exchange details
      */
     public static void recordNetwork(NetworkObservation observation) {
-        if (!isNetworkEnabled()) {
+        recordNetwork(currentSession(), observation);
+    }
+
+    /** Starts a network exchange using a callback binding that follows report-session rollover. */
+    public static NetworkExchange startNetwork(ObservationBinding binding, HttpRequest request) {
+        return startNetwork(binding == null ? null : binding.session(), request);
+    }
+
+    /** Records a network event into an explicitly captured observation session. */
+    public static void recordNetwork(ObservationSession session, NetworkObservation observation) {
+        ObservationSession owner = valid(session);
+        if (owner == null || !owner.networkEnabled() || observation == null) {
             return;
         }
-        NETWORK.get().add(new NetworkEvent(
+        owner.addNetwork(new NetworkEvent(
                 value(observation.method()),
                 value(observation.url()),
                 observation.status(),
@@ -164,11 +211,16 @@ public final class BrowserObservabilityRecorder {
      * @param timestamp epoch timestamp in milliseconds
      */
     public static void recordConsole(String source, String level, String message, long timestamp) {
-        List<ConsoleEvent> events = CONSOLE.get();
-        if (events.size() >= CONSOLE_EVENT_LIMIT) {
-            events.removeFirst();
+        recordConsole(currentSession(), source, level, message, timestamp);
+    }
+
+    /** Records a console event into an explicitly captured observation session. */
+    public static void recordConsole(ObservationSession session, String source, String level, String message,
+                                     long timestamp) {
+        ObservationSession owner = valid(session);
+        if (owner != null && owner.consoleEnabled()) {
+            owner.addConsole(new ConsoleEvent(value(source), value(level), value(message), Math.max(0, timestamp)));
         }
-        events.add(new ConsoleEvent(value(source), value(level), value(message), Math.max(0, timestamp)));
     }
 
     /**
@@ -178,10 +230,15 @@ public final class BrowserObservabilityRecorder {
      * @param message warning message
      */
     public static void recordWarning(String source, String message) {
-        if (!isTraceEnabled()) {
-            return;
+        recordWarning(currentSession(), source, message);
+    }
+
+    /** Records a warning into an explicitly captured observation session. */
+    public static void recordWarning(ObservationSession session, String source, String message) {
+        ObservationSession owner = valid(session);
+        if (owner != null && owner.traceEnabled()) {
+            owner.addWarning(new WarningEvent(value(source), value(message)));
         }
-        WARNINGS.get().add(new WarningEvent(value(source), value(message)));
     }
 
     /**
@@ -190,17 +247,16 @@ public final class BrowserObservabilityRecorder {
      * @return recorded warnings
      */
     public static List<String> drainWarnings() {
-        List<String> warnings = WARNINGS.get().stream()
+        ObservationSession session = currentSession();
+        List<String> warnings = session.takeWarnings().stream()
                 .map(warning -> warning.source() + ": " + warning.message())
                 .toList();
-        WARNINGS.get().clear();
         return warnings;
     }
 
     static String drainNetworkJson() {
-        String json = networkJson(NETWORK.get());
-        NETWORK.get().clear();
-        NEXT_NETWORK_ID.set(0);
+        ObservationSession session = currentSession();
+        String json = networkJson(session.takeNetwork());
         return json;
     }
 
@@ -213,7 +269,12 @@ public final class BrowserObservabilityRecorder {
      * @return immutable snapshot of currently recorded network transactions, oldest first
      */
     public static List<NetworkSnapshotEntry> snapshot() {
-        List<NetworkEvent> events = NETWORK.get();
+        return snapshot(currentSession());
+    }
+
+    /** Returns an immutable snapshot for an explicitly captured observation session. */
+    public static List<NetworkSnapshotEntry> snapshot(ObservationSession session) {
+        List<NetworkEvent> events = session == null ? List.of() : session.networkSnapshot();
         List<NetworkSnapshotEntry> snapshot = new ArrayList<>(events.size());
         for (int i = 0; i < events.size(); i++) {
             NetworkEvent event = events.get(i);
@@ -257,17 +318,22 @@ public final class BrowserObservabilityRecorder {
 
     static String drainConsoleJson() {
         if (!isConsoleEnabled()) {
-            CONSOLE.get().clear();
+            currentSession().clearConsole();
             return "[]";
         }
-        String json = consoleJson(CONSOLE.get());
-        CONSOLE.get().clear();
+        ObservationSession session = currentSession();
+        String json = consoleJson(session.takeConsole());
         return json;
     }
 
     /** @return immutable, redacted current-thread console snapshot, oldest first */
     public static List<ConsoleSnapshotEntry> snapshotConsole() {
-        return CONSOLE.get().stream()
+        return snapshotConsole(currentSession());
+    }
+
+    /** Returns an immutable console snapshot for an explicitly captured observation session. */
+    public static List<ConsoleSnapshotEntry> snapshotConsole(ObservationSession session) {
+        return (session == null ? List.<ConsoleEvent>of() : session.consoleSnapshot()).stream()
                 .map(event -> new ConsoleSnapshotEntry(event.source(), event.level(),
                         FailureTraceReporter.redact(event.message()), event.timestamp()))
                 .toList();
@@ -281,12 +347,12 @@ public final class BrowserObservabilityRecorder {
 
     /** Clears current-thread console observations without affecting network evidence. */
     public static void clearConsole() {
-        CONSOLE.get().clear();
+        currentSession().clearConsole();
     }
 
     static String drainMetadataJson() {
-        String json = metadataJson(WARNINGS.get());
-        WARNINGS.get().clear();
+        ObservationSession session = currentSession();
+        String json = metadataJson(session.takeWarnings());
         return json;
     }
 
@@ -294,10 +360,84 @@ public final class BrowserObservabilityRecorder {
      * Clears current-thread browser observability state.
      */
     public static void clear() {
-        NETWORK.remove();
-        CONSOLE.remove();
-        WARNINGS.remove();
-        NEXT_NETWORK_ID.remove();
+        ObservationSession session = CURRENT.get();
+        if (session != null) {
+            session.close();
+        }
+        CURRENT.remove();
+    }
+
+    /** Starts and binds a fresh browser-observation session to the current report thread. */
+    public static ObservationSession startSession() {
+        clear();
+        ObservationSession session = new ObservationSession();
+        CURRENT.set(session);
+        CURRENT_BINDING.get().bind(session);
+        return session;
+    }
+
+    /** Captures the current observation owner for use by asynchronous callbacks. */
+    public static ObservationSession captureSession() {
+        return currentSession();
+    }
+
+    /** Captures a stable callback binding whose target follows current-thread report-session rollover. */
+    public static ObservationBinding captureBinding() {
+        currentSession();
+        return CURRENT_BINDING.get();
+    }
+
+    private static ObservationSession currentSession() {
+        ObservationSession session = CURRENT.get();
+        if (session == null || session.closed()) {
+            session = new ObservationSession();
+            CURRENT.set(session);
+            CURRENT_BINDING.get().bind(session);
+        }
+        return session;
+    }
+
+    private static ObservationSession valid(ObservationSession session) {
+        return session == null || session.closed() ? null : session;
+    }
+
+    private static boolean reserveExchange(ObservationSession owner) {
+        while (true) {
+            synchronized (EXCHANGE_OWNERS) {
+                expungeStaleExchanges();
+            }
+            int current = IN_FLIGHT_EXCHANGES.get();
+            if (current >= IN_FLIGHT_EXCHANGE_LIMIT) {
+                owner.warnExchangeLimitOnce();
+                return false;
+            }
+            if (IN_FLIGHT_EXCHANGES.compareAndSet(current, current + 1)) {
+                return true;
+            }
+        }
+    }
+
+    private static boolean retainReservedExchange(NetworkExchange exchange, ObservationSession owner) {
+        synchronized (owner) {
+            if (owner.closed()) {
+                IN_FLIGHT_EXCHANGES.decrementAndGet();
+                return false;
+            }
+            synchronized (EXCHANGE_OWNERS) {
+                expungeStaleExchanges();
+                EXCHANGE_OWNERS.put(new IdentityWeakReference(exchange, STALE_EXCHANGES), owner);
+                return true;
+            }
+        }
+    }
+
+    private static void expungeStaleExchanges() {
+        IdentityWeakReference stale;
+        while ((stale = (IdentityWeakReference) STALE_EXCHANGES.poll()) != null) {
+            if (EXCHANGE_OWNERS.remove(stale) != null) {
+                IN_FLIGHT_EXCHANGES.decrementAndGet();
+            }
+        }
     }
 
     private static String networkJson(List<NetworkEvent> events) {
@@ -535,6 +675,118 @@ public final class BrowserObservabilityRecorder {
                                   Map<String, String> requestHeaders, long requestSizeBytes, long startNanos) {
         static NetworkExchange disabled() {
             return new NetworkExchange(false, "", "", "", Map.of(), 0L, 0L);
+        }
+    }
+
+    /** Opaque owner handle captured by asynchronous browser callbacks. */
+    public static final class ObservationSession implements AutoCloseable {
+        private final List<NetworkEvent> network = new ArrayList<>();
+        private final List<ConsoleEvent> console = new ArrayList<>();
+        private final List<WarningEvent> warnings = new ArrayList<>();
+        private int nextNetworkId;
+        private boolean closed;
+        private boolean exchangeLimitWarned;
+        private final boolean traceEnabled = isTraceEnabled();
+        private final boolean networkEnabled = traceEnabled && SHAFT.Properties.reporting.traceIncludeNetwork();
+        private final boolean consoleEnabled = traceEnabled && SHAFT.Properties.reporting.traceIncludeConsole();
+
+        private synchronized int nextNetworkId() { return ++nextNetworkId; }
+        private synchronized boolean closed() { return closed; }
+        private boolean traceEnabled() { return traceEnabled; }
+        private boolean networkEnabled() { return networkEnabled; }
+        private boolean consoleEnabled() { return consoleEnabled; }
+        private synchronized void addNetwork(NetworkEvent event) { if (!closed) network.add(event); }
+        private synchronized void addConsole(ConsoleEvent event) {
+            if (!closed) {
+                if (console.size() >= CONSOLE_EVENT_LIMIT) console.removeFirst();
+                console.add(event);
+            }
+        }
+        private synchronized void addWarning(WarningEvent event) { if (!closed) warnings.add(event); }
+        private synchronized void warnExchangeLimitOnce() {
+            if (!closed && !exchangeLimitWarned) {
+                exchangeLimitWarned = true;
+                warnings.add(new WarningEvent("network",
+                        "A network exchange was omitted because the in-flight session limit was reached."));
+            }
+        }
+        private synchronized List<NetworkEvent> networkSnapshot() { return List.copyOf(network); }
+        private synchronized List<ConsoleEvent> consoleSnapshot() { return List.copyOf(console); }
+        private synchronized List<WarningEvent> warningSnapshot() { return List.copyOf(warnings); }
+        private synchronized List<NetworkEvent> takeNetwork() {
+            List<NetworkEvent> result = List.copyOf(network);
+            network.clear();
+            nextNetworkId = 0;
+            return result;
+        }
+        private synchronized List<ConsoleEvent> takeConsole() {
+            List<ConsoleEvent> result = List.copyOf(console);
+            console.clear();
+            return result;
+        }
+        private synchronized List<WarningEvent> takeWarnings() {
+            List<WarningEvent> result = List.copyOf(warnings);
+            warnings.clear();
+            return result;
+        }
+        private synchronized void clearNetwork() { network.clear(); nextNetworkId = 0; }
+        private synchronized void clearConsole() { console.clear(); }
+        private synchronized void clearWarnings() { warnings.clear(); }
+
+        @Override
+        public synchronized void close() {
+            closed = true;
+            network.clear();
+            console.clear();
+            warnings.clear();
+            nextNetworkId = 0;
+        }
+    }
+
+    private static final class IdentityWeakReference extends WeakReference<NetworkExchange> {
+        private final int identityHash;
+
+        private IdentityWeakReference(NetworkExchange exchange) {
+            super(exchange);
+            identityHash = System.identityHashCode(exchange);
+        }
+
+        private IdentityWeakReference(NetworkExchange exchange, ReferenceQueue<NetworkExchange> queue) {
+            super(exchange, queue);
+            identityHash = System.identityHashCode(exchange);
+        }
+
+        @Override
+        public int hashCode() {
+            return identityHash;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof IdentityWeakReference reference)) {
+                return false;
+            }
+            NetworkExchange exchange = get();
+            return exchange != null && exchange == reference.get();
+        }
+    }
+
+    /** Stable callback owner whose current session is replaced by the runner lifecycle. */
+    public static final class ObservationBinding {
+        private volatile ObservationSession session;
+
+        private ObservationBinding() {
+        }
+
+        private void bind(ObservationSession session) {
+            this.session = session;
+        }
+
+        private ObservationSession session() {
+            return session;
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/BrowserObservabilityRecorder.java
@@ -154,16 +154,18 @@ public final class BrowserObservabilityRecorder {
      * @param driver active driver, or {@code null}
      */
     public static void collectConsole(WebDriver driver) {
-        if (!isConsoleEnabled()) {
-            return;
-        }
         if (driver == null && PlaywrightSessionManager.currentSession() != null) {
             PlaywrightSessionManager.currentSession().drainConsoleToRecorder();
             return;
         }
         if (BidiConsoleLogSource.isHealthy(driver)) {
             BidiConsoleLogSource.drainToRecorder(driver);
-        } else if (!tryCollectConsole(driver)) {
+            return;
+        }
+        if (!currentSession().consoleEnabled()) {
+            return;
+        }
+        if (!tryCollectConsole(driver)) {
             recordWarning("console", driver == null
                     ? "Console capture is unavailable because no active driver is registered."
                     : "Browser console logs are not supported by this driver.");
@@ -233,6 +235,12 @@ public final class BrowserObservabilityRecorder {
      */
     public static void recordWarning(String source, String message) {
         recordWarning(currentSession(), source, message);
+    }
+
+    /** Records a console event using a callback binding that follows report-session rollover. */
+    public static void recordConsole(ObservationBinding binding, String source, String level, String message,
+                                     long timestamp) {
+        recordConsole(binding == null ? null : binding.session(), source, level, message, timestamp);
     }
 
     /** Records a warning into an explicitly captured observation session. */
@@ -398,6 +406,11 @@ public final class BrowserObservabilityRecorder {
     public static ObservationBinding captureBinding() {
         currentSession();
         return CURRENT_BINDING.get();
+    }
+
+    /** Resolves one callback binding once so a whole provider batch keeps one immutable owner. */
+    public static ObservationSession resolveSession(ObservationBinding binding) {
+        return binding == null ? null : binding.session();
     }
 
     private static ObservationSession currentSession() {

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportContext.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportContext.java
@@ -32,7 +32,7 @@ public final class ReportContext {
         output.get().clear();
         attachments.get().clear();
         TraceEventRecorder.clearForNewTest();
-        BrowserObservabilityRecorder.clear();
+        BrowserObservabilityRecorder.startSession();
         logSink.remove();
         status.remove();
     }

--- a/shaft-engine/src/test/java/com/shaft/gui/browser/internal/BidiConsoleLogSourceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/browser/internal/BidiConsoleLogSourceTest.java
@@ -1,5 +1,6 @@
 package com.shaft.gui.browser.internal;
 
+import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.tools.io.internal.BrowserObservabilityRecorder;
 import org.mockito.Mockito;
@@ -12,6 +13,8 @@ import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.Logs;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.annotations.AfterMethod;
+import com.shaft.properties.internal.Properties;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +25,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.Optional;
 
 public class BidiConsoleLogSourceTest {
+    @AfterMethod
+    public void clearObservationContext() {
+        com.shaft.tools.io.internal.ReportContext.clear();
+        Properties.clearForCurrentThread();
+    }
     @Test
     public void websocketThreadEventsShouldBeVisibleAndClearableFromTheOwningTestThread() throws Exception {
         WebDriver driver = Mockito.mock(WebDriver.class);
@@ -254,5 +262,44 @@ public class BidiConsoleLogSourceTest {
         Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().size(), eventCount);
         BrowserObservabilityRecorder.clearConsole();
         BidiConsoleLogSource.closeAndRemove(driver);
+    }
+
+    @Test
+    public void asyncDrainShouldFollowReportSessionRolloverInsteadOfExecutorThread() throws Exception {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeConsole(true);
+        WebDriver driver = Mockito.mock(WebDriver.class);
+        com.shaft.tools.io.internal.ReportContext.start(new com.shaft.listeners.internal.TestExecutionInfo(
+                "bidi-setup", getClass().getName(), "setup", "setup", "setup", null, null, false));
+        BidiConsoleLogSource source = new BidiConsoleLogSource();
+        BidiConsoleLogSource.install(driver, source);
+        com.shaft.tools.io.internal.ReportContext.start(new com.shaft.listeners.internal.TestExecutionInfo(
+                "bidi-test", getClass().getName(), "test", "test", "test", null, null, false));
+
+        try (var executor = Executors.newSingleThreadExecutor()) {
+            executor.submit(() -> {
+                SHAFT.Properties.reporting.set().traceIncludeConsole(false);
+                source.record("error", "async-owner-message", 42);
+                BrowserObservabilityRecorder.collectConsole(driver);
+            }).get();
+        }
+
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().size(), 1);
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().getFirst().message(),
+                "async-owner-message");
+        BidiConsoleLogSource.closeAndRemove(driver);
+    }
+
+    @Test
+    public void disabledLegacyCollectionShouldNotConsumeDriverLogsOrWarn() {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeConsole(false);
+        com.shaft.tools.io.internal.ReportContext.start(new com.shaft.listeners.internal.TestExecutionInfo(
+                "legacy-disabled", getClass().getName(), "disabled", "disabled", "disabled",
+                null, null, false));
+        WebDriver driver = Mockito.mock(WebDriver.class);
+
+        BrowserObservabilityRecorder.collectConsole(driver);
+
+        Mockito.verify(driver, Mockito.never()).manage();
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings().isEmpty());
     }
 }

--- a/shaft-engine/src/test/java/com/shaft/gui/browser/internal/BidiConsoleLogSourceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/browser/internal/BidiConsoleLogSourceTest.java
@@ -302,4 +302,35 @@ public class BidiConsoleLogSourceTest {
         Mockito.verify(driver, Mockito.never()).manage();
         Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings().isEmpty());
     }
+
+    @Test
+    public void providerOverflowShouldReportOldestConsoleOmission() {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeConsole(true);
+        com.shaft.tools.io.internal.ReportContext.start(new com.shaft.listeners.internal.TestExecutionInfo(
+                "bidi-overflow", getClass().getName(), "overflow", "overflow", "overflow",
+                null, null, false));
+        WebDriver driver = Mockito.mock(WebDriver.class);
+        BidiConsoleLogSource source = new BidiConsoleLogSource();
+        BidiConsoleLogSource.install(driver, source);
+        for (int index = 0; index <= 1000; index++) {
+            source.record("log", "bidi-" + index, index);
+        }
+        Assert.assertEquals(BidiConsoleLogSource.snapshot(driver).size(), 1000);
+        Assert.assertEquals(BidiConsoleLogSource.snapshot(driver).getFirst().message(), "bidi-1");
+        Assert.assertEquals(BidiConsoleLogSource.snapshot(driver).getLast().message(), "bidi-1000");
+
+        BidiConsoleLogSource.drainToRecorder(driver);
+
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().size(), 1000);
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().getFirst().message(), "bidi-1");
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings().stream()
+                .anyMatch(warning -> warning.contains("oldest console")));
+        BrowserObservabilityRecorder.clearConsole();
+        source.record("log", "next-batch", 1001);
+        BidiConsoleLogSource.drainToRecorder(driver);
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().size(), 1);
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().getFirst().message(), "next-batch");
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings().isEmpty());
+        BidiConsoleLogSource.closeAndRemove(driver);
+    }
 }

--- a/shaft-engine/src/test/java/com/shaft/gui/playwright/internal/PlaywrightConsoleBridgeTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/playwright/internal/PlaywrightConsoleBridgeTest.java
@@ -13,6 +13,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.util.function.Consumer;
+import java.util.concurrent.Executors;
+import com.shaft.driver.SHAFT;
+import com.shaft.tools.io.internal.ReportContext;
+import com.shaft.listeners.internal.TestExecutionInfo;
 
 public class PlaywrightConsoleBridgeTest {
     @AfterMethod
@@ -73,6 +77,27 @@ public class PlaywrightConsoleBridgeTest {
         second.close();
     }
 
+    @Test
+    public void asyncDrainShouldFollowReportSessionRolloverInsteadOfExecutorThread() throws Exception {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeConsole(true);
+        ReportContext.start(info("setup"));
+        Page page = Mockito.mock(Page.class);
+        PlaywrightSession session = new PlaywrightSession(Mockito.mock(Playwright.class), Mockito.mock(Browser.class),
+                Mockito.mock(BrowserContext.class), page, null);
+        ArgumentCaptor<Consumer<ConsoleMessage>> listener = consumerCaptor();
+        Mockito.verify(page).onConsoleMessage(listener.capture());
+        ReportContext.start(info("test"));
+
+        try (var executor = Executors.newSingleThreadExecutor()) {
+            executor.submit(() -> listener.getValue().accept(message("async-playwright-owner"))).get();
+        }
+        session.drainConsoleToRecorder();
+
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().size(), 1);
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().getFirst().message(),
+                "async-playwright-owner");
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     private static <T> ArgumentCaptor<Consumer<T>> consumerCaptor() {
         return ArgumentCaptor.forClass((Class) Consumer.class);
@@ -83,5 +108,10 @@ public class PlaywrightConsoleBridgeTest {
         Mockito.when(message.type()).thenReturn("log");
         Mockito.when(message.text()).thenReturn(text);
         return message;
+    }
+
+    private static TestExecutionInfo info(String method) {
+        return new TestExecutionInfo("playwright-" + method, PlaywrightConsoleBridgeTest.class.getName(),
+                method, method, method, null, null, false);
     }
 }

--- a/shaft-engine/src/test/java/com/shaft/gui/playwright/internal/PlaywrightConsoleBridgeTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/playwright/internal/PlaywrightConsoleBridgeTest.java
@@ -98,6 +98,36 @@ public class PlaywrightConsoleBridgeTest {
                 "async-playwright-owner");
     }
 
+    @Test
+    public void providerOverflowShouldReportOldestConsoleOmission() {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeConsole(true);
+        ReportContext.start(info("overflow"));
+        Page page = Mockito.mock(Page.class);
+        PlaywrightSession session = new PlaywrightSession(Mockito.mock(Playwright.class), Mockito.mock(Browser.class),
+                Mockito.mock(BrowserContext.class), page, null);
+        ArgumentCaptor<Consumer<ConsoleMessage>> listener = consumerCaptor();
+        Mockito.verify(page).onConsoleMessage(listener.capture());
+        for (int index = 0; index <= 1000; index++) {
+            listener.getValue().accept(message("playwright-" + index));
+        }
+        Assert.assertEquals(session.consoleSnapshot().size(), 1000);
+        Assert.assertEquals(session.consoleSnapshot().getFirst().message(), "playwright-1");
+        Assert.assertEquals(session.consoleSnapshot().getLast().message(), "playwright-1000");
+
+        session.drainConsoleToRecorder();
+
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().size(), 1000);
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().getFirst().message(), "playwright-1");
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings().stream()
+                .anyMatch(warning -> warning.contains("oldest console")));
+        BrowserObservabilityRecorder.clearConsole();
+        listener.getValue().accept(message("next-batch"));
+        session.drainConsoleToRecorder();
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().size(), 1);
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole().getFirst().message(), "next-batch");
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings().isEmpty());
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     private static <T> ArgumentCaptor<Consumer<T>> consumerCaptor() {
         return ArgumentCaptor.forClass((Class) Consumer.class);

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserObservabilityRecorderSessionTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserObservabilityRecorderSessionTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import org.openqa.selenium.remote.http.Contents;
+import java.util.Map;
 
 public class BrowserObservabilityRecorderSessionTest {
     @AfterMethod
@@ -102,6 +103,100 @@ public class BrowserObservabilityRecorderSessionTest {
                     "Mutable public record contents must not change identity-based session ownership.");
             Assert.assertEquals(BrowserObservabilityRecorder.snapshot(owner).getFirst().status(), 201);
         }
+    }
+
+    @Test
+    public void sessionShouldBoundNetworkEvidenceAndReportOldestEventOmission() {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeNetwork(true);
+        BrowserObservabilityRecorder.ObservationSession session = BrowserObservabilityRecorder.startSession();
+
+        for (int index = 0; index <= 1000; index++) {
+            BrowserObservabilityRecorder.recordNetwork(session, new BrowserObservabilityRecorder.NetworkObservation(
+                    "GET", "https://example.com/event-" + index, 200, Map.of(), Map.of(),
+                    1, 0, 0, "", ""));
+        }
+
+        var snapshot = BrowserObservabilityRecorder.snapshot(session);
+        Assert.assertEquals(snapshot.size(), 1000);
+        Assert.assertEquals(snapshot.getFirst().url(), "https://example.com/event-1");
+        Assert.assertEquals(snapshot.getLast().url(), "https://example.com/event-1000");
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings().stream()
+                .anyMatch(warning -> warning.contains("oldest network")),
+                "Trace metadata must explain bounded evidence omission.");
+    }
+
+    @Test
+    public void explicitCallbackOwnerShouldStayIsolatedFromSiblingSession() throws Exception {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeNetwork(true).traceIncludeConsole(true);
+        BrowserObservabilityRecorder.ObservationSession owner = BrowserObservabilityRecorder.startSession();
+        BrowserObservabilityRecorder.ObservationSession sibling = BrowserObservabilityRecorder.createSession();
+        try (var callbackExecutor = Executors.newSingleThreadExecutor()) {
+            callbackExecutor.submit(() -> {
+                BrowserObservabilityRecorder.recordNetwork(owner,
+                        new BrowserObservabilityRecorder.NetworkObservation("GET", "https://example.com/owner",
+                                200, Map.of(), Map.of(), 1, 0, 0, "", ""));
+                BrowserObservabilityRecorder.recordConsole(owner, "bidi", "info", "owner-console", 10);
+            }).get();
+        }
+
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshot(owner).size(), 1);
+        Assert.assertEquals(BrowserObservabilityRecorder.snapshotConsole(owner).size(), 1);
+        Assert.assertTrue(BrowserObservabilityRecorder.snapshot(sibling).isEmpty());
+        Assert.assertTrue(BrowserObservabilityRecorder.snapshotConsole(sibling).isEmpty());
+    }
+
+    @Test
+    public void closedOwnerShouldRejectLateCallbackWithoutFallingBackToCurrentSession() throws Exception {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeNetwork(true).traceIncludeConsole(true);
+        BrowserObservabilityRecorder.ObservationSession closed = BrowserObservabilityRecorder.startSession();
+        BrowserObservabilityRecorder.NetworkExchange exchange = BrowserObservabilityRecorder.startNetwork(
+                closed, new HttpRequest(HttpMethod.GET, "https://example.com/late"));
+        for (int index = 0; index <= 1000; index++) {
+            BrowserObservabilityRecorder.recordNetwork(closed,
+                    new BrowserObservabilityRecorder.NetworkObservation("GET", "https://example.com/seed-" + index,
+                            200, Map.of(), Map.of(), 1, 0, 0, "", ""));
+        }
+        Assert.assertFalse(BrowserObservabilityRecorder.drainWarnings(closed).isEmpty(),
+                "The close regression must first prove an omission marker exists.");
+        BrowserObservabilityRecorder.recordNetwork(closed,
+                new BrowserObservabilityRecorder.NetworkObservation("GET", "https://example.com/seed-again",
+                        200, Map.of(), Map.of(), 1, 0, 0, "", ""));
+        closed.close();
+        BrowserObservabilityRecorder.ObservationSession current = BrowserObservabilityRecorder.startSession();
+
+        try (var callbackExecutor = Executors.newSingleThreadExecutor()) {
+            callbackExecutor.submit(() -> {
+                BrowserObservabilityRecorder.finishNetwork(exchange, new HttpResponse().setStatus(200), "");
+                BrowserObservabilityRecorder.recordConsole(closed, "bidi", "error", "late-console", 20);
+            }).get();
+        }
+
+        Assert.assertTrue(BrowserObservabilityRecorder.snapshot(closed).isEmpty());
+        Assert.assertTrue(BrowserObservabilityRecorder.snapshotConsole(closed).isEmpty());
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings(closed).isEmpty());
+        Assert.assertTrue(BrowserObservabilityRecorder.snapshot(current).isEmpty(),
+                "A late callback must not fall back to the current test session.");
+        Assert.assertTrue(BrowserObservabilityRecorder.snapshotConsole(current).isEmpty());
+    }
+
+    @Test
+    public void detachedSessionShouldKeepOmissionMarkersWithinWarningLimit() {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeNetwork(true);
+        BrowserObservabilityRecorder.ObservationSession detached = BrowserObservabilityRecorder.createSession();
+        for (int index = 0; index <= 1000; index++) {
+            BrowserObservabilityRecorder.recordNetwork(detached,
+                    new BrowserObservabilityRecorder.NetworkObservation("GET", "https://example.com/" + index,
+                            200, Map.of(), Map.of(), 1, 0, 0, "", ""));
+        }
+        for (int index = 0; index <= 100; index++) {
+            BrowserObservabilityRecorder.recordWarning(detached, "provider", "warning-" + index);
+        }
+
+        var warnings = BrowserObservabilityRecorder.drainWarnings(detached);
+        Assert.assertTrue(warnings.size() <= 100);
+        Assert.assertTrue(warnings.stream().anyMatch(warning -> warning.contains("oldest network")));
+        Assert.assertTrue(warnings.stream().anyMatch(warning -> warning.contains("oldest browser observability")));
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings(detached).isEmpty());
     }
 
     private static TestExecutionInfo info(String method) {

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserObservabilityRecorderSessionTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserObservabilityRecorderSessionTest.java
@@ -199,6 +199,44 @@ public class BrowserObservabilityRecorderSessionTest {
         Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings(detached).isEmpty());
     }
 
+    @Test
+    public void sessionShouldBoundConsoleEvidenceAndReportOldestEventOmission() {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeConsole(true);
+        BrowserObservabilityRecorder.ObservationSession session = BrowserObservabilityRecorder.startSession();
+        for (int index = 0; index <= 1000; index++) {
+            BrowserObservabilityRecorder.recordConsole(session, "bidi", "info", "console-" + index, index);
+        }
+
+        var snapshot = BrowserObservabilityRecorder.snapshotConsole(session);
+        Assert.assertEquals(snapshot.size(), 1000);
+        Assert.assertEquals(snapshot.getFirst().message(), "console-1");
+        Assert.assertEquals(snapshot.getLast().message(), "console-1000");
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings(session).stream()
+                .anyMatch(warning -> warning.contains("oldest console")));
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings(session).isEmpty());
+    }
+
+    @Test
+    public void closedOwnerShouldRejectLateProviderOmissionMarker() {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeConsole(true);
+        BrowserObservabilityRecorder.ObservationSession session = BrowserObservabilityRecorder.startSession();
+        session.close();
+
+        BrowserObservabilityRecorder.recordConsoleOmission(session);
+
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings(session).isEmpty());
+    }
+
+    @Test
+    public void disabledOwnerShouldRejectProviderOmissionMarker() {
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeConsole(false);
+        BrowserObservabilityRecorder.ObservationSession session = BrowserObservabilityRecorder.startSession();
+
+        BrowserObservabilityRecorder.recordConsoleOmission(session);
+
+        Assert.assertTrue(BrowserObservabilityRecorder.drainWarnings(session).isEmpty());
+    }
+
     private static TestExecutionInfo info(String method) {
         return new TestExecutionInfo("observability-" + method, BrowserObservabilityRecorderSessionTest.class.getName(),
                 method, method, method, null, null, false);

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserObservabilityRecorderSessionTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserObservabilityRecorderSessionTest.java
@@ -1,0 +1,111 @@
+package com.shaft.tools.io.internal;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.gui.browser.internal.BrowserNetworkInterceptor;
+import com.shaft.properties.internal.Properties;
+import com.shaft.listeners.internal.TestExecutionInfo;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.devtools.HasDevTools;
+import org.openqa.selenium.devtools.NetworkInterceptor;
+import org.openqa.selenium.remote.http.Filter;
+import org.openqa.selenium.remote.http.HttpMethod;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import org.openqa.selenium.remote.http.Contents;
+
+public class BrowserObservabilityRecorderSessionTest {
+    @AfterMethod
+    public void clearRecorder() {
+        BrowserObservabilityRecorder.clear();
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void seleniumCallbackOnAnotherThreadShouldRemainVisibleToItsOwningTraceSession() throws Exception {
+        AtomicReference<Filter> filterReference = new AtomicReference<>();
+        WebDriver driver = Mockito.mock(WebDriver.class, Mockito.withSettings().extraInterfaces(HasDevTools.class));
+        try (MockedConstruction<NetworkInterceptor> ignored = Mockito.mockConstruction(NetworkInterceptor.class,
+                (mock, context) -> filterReference.set((Filter) context.arguments().get(1)));
+             var callbackExecutor = Executors.newSingleThreadExecutor()) {
+            SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeNetwork(true);
+            BrowserNetworkInterceptor interceptor = new BrowserNetworkInterceptor(driver);
+            Assert.assertTrue(interceptor.startObserving());
+
+            HttpRequest request = new HttpRequest(HttpMethod.GET, "https://example.com/async");
+            HttpResponse response = new HttpResponse().setStatus(204);
+            Future<HttpResponse> callback = callbackExecutor.submit(
+                    () -> filterReference.get().apply(ignoredRequest -> response).execute(request));
+
+            Assert.assertSame(callback.get(), response);
+            Assert.assertEquals(BrowserObservabilityRecorder.snapshot().size(), 1,
+                    "The filter callback must record into the session that installed it, not its executor thread.");
+            Assert.assertEquals(BrowserObservabilityRecorder.snapshot().getFirst().url(),
+                    "https://example.com/async");
+        }
+    }
+
+    @Test
+    public void cachedInterceptorShouldFollowTestSessionAndOwnerCapturePolicy() throws Exception {
+        AtomicReference<Filter> filterReference = new AtomicReference<>();
+        WebDriver driver = Mockito.mock(WebDriver.class, Mockito.withSettings().extraInterfaces(HasDevTools.class));
+        try (MockedConstruction<NetworkInterceptor> ignored = Mockito.mockConstruction(NetworkInterceptor.class,
+                (mock, context) -> filterReference.set((Filter) context.arguments().get(1)));
+             var callbackExecutor = Executors.newSingleThreadExecutor()) {
+            SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeNetwork(true);
+            ReportContext.start(info("setup"));
+            BrowserNetworkInterceptor interceptor = new BrowserNetworkInterceptor(driver);
+            Assert.assertTrue(interceptor.startObserving());
+
+            ReportContext.start(info("test"));
+            Future<HttpResponse> callback = callbackExecutor.submit(() -> {
+                SHAFT.Properties.reporting.set().traceIncludeNetwork(false);
+                try {
+                    return filterReference.get().apply(ignoredRequest -> new HttpResponse().setStatus(200))
+                            .execute(new HttpRequest(HttpMethod.GET, "https://example.com/test-session"));
+                } finally {
+                    Properties.clearForCurrentThread();
+                }
+            });
+
+            Assert.assertEquals(callback.get().getStatus(), 200);
+            Assert.assertEquals(BrowserObservabilityRecorder.snapshot().size(), 1,
+                    "A cached interceptor must follow the active test session and its owner-thread capture policy.");
+            Assert.assertEquals(BrowserObservabilityRecorder.snapshot().getFirst().url(),
+                    "https://example.com/test-session");
+        }
+    }
+
+    @Test
+    public void exchangeOwnerShouldUseIdentityWhenPublicRecordContentsMutate() throws Exception {
+        try (var callbackExecutor = Executors.newSingleThreadExecutor()) {
+            SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeNetwork(true);
+            BrowserObservabilityRecorder.ObservationSession owner = BrowserObservabilityRecorder.startSession();
+            HttpRequest request = new HttpRequest(HttpMethod.GET, "https://example.com/mutable-record");
+            request.addHeader("X-Initial", "one");
+            BrowserObservabilityRecorder.NetworkExchange exchange =
+                    BrowserObservabilityRecorder.startNetwork(owner, request);
+            exchange.requestHeaders().put("X-Later", "two");
+            HttpResponse response = new HttpResponse().setStatus(201).setContent(Contents.utf8String("ok"));
+
+            callbackExecutor.submit(() -> BrowserObservabilityRecorder.finishNetwork(exchange, response, "")).get();
+
+            Assert.assertEquals(BrowserObservabilityRecorder.snapshot(owner).size(), 1,
+                    "Mutable public record contents must not change identity-based session ownership.");
+            Assert.assertEquals(BrowserObservabilityRecorder.snapshot(owner).getFirst().status(), 201);
+        }
+    }
+
+    private static TestExecutionInfo info(String method) {
+        return new TestExecutionInfo("observability-" + method, BrowserObservabilityRecorderSessionTest.class.getName(),
+                method, method, method, null, null, false);
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/MobileEvidenceNamespaceTraceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/MobileEvidenceNamespaceTraceTest.java
@@ -1,6 +1,7 @@
 package com.shaft.tools.io.internal;
 
 import com.shaft.driver.SHAFT;
+import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.gui.capabilities.AutomationBackend;
 import com.shaft.gui.driver.MobileEvidenceBundle;
 import com.shaft.listeners.internal.TestExecutionInfo;
@@ -106,6 +107,25 @@ public class MobileEvidenceNamespaceTraceTest {
         } finally {
             Files.deleteIfExists(target);
             Files.deleteIfExists(directory);
+        }
+    }
+
+    @Test
+    public void backendOwnedTraceStartShouldNotResolveAnUnrelatedActiveDriver() {
+        AppiumDriver unrelated = Mockito.mock(AppiumDriver.class);
+        DriverFactoryHelper helper = new DriverFactoryHelper();
+        helper.setDriver(unrelated);
+        try {
+            Mockito.clearInvocations(unrelated);
+            SHAFT.Properties.reporting.set().traceEnabled(true);
+
+            TraceEventRecorder.Event event = TraceEventRecorder.startForBackend(
+                    "mobile/evidence", "capture", "<evidence-bundle>", AutomationBackend.APPIUM);
+
+            Assert.assertTrue(event.enabled());
+            Mockito.verifyNoInteractions(unrelated);
+        } finally {
+            helper.setDriver(null);
         }
     }
 


### PR DESCRIPTION
Closes #4825.

## Outcome
- owns Selenium network and console observations by bounded report session across asynchronous callbacks
- follows setup-to-test session rollover without callback-thread property leakage
- preserves the public `NetworkExchange` record and legacy recorder entry points
- bounds network, console, warning, provider-buffer, and in-flight evidence with explicit omission metadata
- keeps BiDi and Playwright console batches atomic, isolated, and fail-closed after session close
- proves backend-owned trace events never resolve an unrelated active provider

## Evidence
- post-sync affected suite: 92 tests, 0 failures, 0 errors, 0 skipped
- `shaft-engine` package: success
- changed production files: 0 PMD findings (repository-wide direct PMD goal retains 157 unrelated baseline findings)
- independent correctness, reproduction, and blast-radius reviews: zero blockers
- synchronized with `origin/main` at `d781683e84`