### PR TITLE
Complete visual/OCR accuracy and mobile acceptance

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -780,7 +780,7 @@ jobs:
           "-DbrowserStack.appiumVersion=3.3.0" "-DbrowserStack.platformVersion=13.0"
           "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl="
           "-DgenerateAllureReportArchive=true"
-          "-Dtest=AndroidBasicInteractionsTests#visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls+visualAndOcrTargetsShouldScrollHorizontallyInsideNativeControl"
+          "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'AndroidBasicInteractionsTests#visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls+visualAndOcrTargetsShouldScrollHorizontallyInsideNativeControl' }}"
       - name: Verify Android screenshot and OCR acceptance executed
         run: >-
           python3 scripts/ci/assert_tests_executed.py
@@ -838,7 +838,7 @@ jobs:
           "-DbrowserStack.appiumVersion=3.3.0" "-DbrowserStack.platformVersion=16"
           "-DbrowserStack.deviceName=iPhone 14" "-DbrowserStack.appUrl="
           "-Dshaft.enableNativeIosE2E=true" "-DgenerateAllureReportArchive=true"
-          "-Dtest=IOSBasicInteractionsTest#visualAndOcrTargetsShouldInteractWithNativeControls"
+          "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'IOSBasicInteractionsTest#visualAndOcrTargetsShouldInteractWithNativeControls' }}"
       - name: Verify iOS screenshot and OCR acceptance executed
         run: >-
           python3 scripts/ci/assert_tests_executed.py

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -94,6 +94,8 @@ jobs:
       - Ubuntu_Playwright_GalaxyS26Ultra
       - Ubuntu_Playwright_IPhone17ProMax
       - Android_Native_BrowserStack
+      - Android_Visual_Ocr_BrowserStack
+      - iOS_Visual_Ocr_BrowserStack
       - Android_Recording_BrowserStack
       - iOS_Recording_BrowserStack
       - Android_Evidence_BrowserStack
@@ -740,6 +742,114 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Android_Native_BrowserStack
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  Android_Visual_Ocr_BrowserStack:
+    if: github.event_name == 'workflow_dispatch' && contains(format(',{0},', github.event.inputs.jobs), ',Android_Visual_Ocr_BrowserStack,')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      job: ${{ steps.post_test_report.outputs.job }}
+      total: ${{ steps.post_test_report.outputs.total }}
+      passed: ${{ steps.post_test_report.outputs.passed }}
+      failed: ${{ steps.post_test_report.outputs.failed }}
+      broken: ${{ steps.post_test_report.outputs.broken }}
+      skipped: ${{ steps.post_test_report.outputs.skipped }}
+      duration: ${{ steps.post_test_report.outputs.duration }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: '20'
+      - name: Install visual and OCR test runtimes
+        shell: bash
+        run: >-
+          bash scripts/ci/build_retry.sh 2 60
+          mvn -pl shaft-visual,shaft-ocr -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
+      - name: Run Android screenshot and OCR scrolling acceptance
+        continue-on-error: true
+        timeout-minutes: 35
+        run: >-
+          mvn -pl shaft-browserstack -am -e test
+          "-DincludeVisualTestRuntime" "-DincludeOcrTestRuntime"
+          "-Dallure.automaticallyOpen=false" "-DdefaultElementIdentificationTimeout=60"
+          "-DretryMaximumNumberOfAttempts=0" "-DexecutionAddress=browserstack"
+          "-DtargetOperatingSystem=android" "-Dmobile_automationName=UIAutomator2"
+          "-DbrowserStack.appiumVersion=3.3.0" "-DbrowserStack.platformVersion=13.0"
+          "-DbrowserStack.deviceName=Google Pixel 7" "-DbrowserStack.appUrl="
+          "-DgenerateAllureReportArchive=true"
+          "-Dtest=AndroidBasicInteractionsTests#visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls+visualAndOcrTargetsShouldScrollHorizontallyInsideNativeControl"
+      - name: Verify Android screenshot and OCR acceptance executed
+        run: >-
+          python3 scripts/ci/assert_tests_executed.py
+          shaft-engine/target/surefire-reports/TEST-testPackage.appium.AndroidBasicInteractionsTests.xml
+          --min-executed 2
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: Android_Visual_Ocr_BrowserStack
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  iOS_Visual_Ocr_BrowserStack:
+    if: github.event_name == 'workflow_dispatch' && contains(format(',{0},', github.event.inputs.jobs), ',iOS_Visual_Ocr_BrowserStack,')
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    outputs:
+      job: ${{ steps.post_test_report.outputs.job }}
+      total: ${{ steps.post_test_report.outputs.total }}
+      passed: ${{ steps.post_test_report.outputs.passed }}
+      failed: ${{ steps.post_test_report.outputs.failed }}
+      broken: ${{ steps.post_test_report.outputs.broken }}
+      skipped: ${{ steps.post_test_report.outputs.skipped }}
+      duration: ${{ steps.post_test_report.outputs.duration }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: '20'
+      - name: Fetch provider-compatible iOS sample app
+        run: |
+          app_path="shaft-engine/src/test/resources/testDataFiles/apps/BStackSampleApp.ipa"
+          curl --fail --location --silent --show-error \
+            --output "$app_path" \
+            "https://raw.githubusercontent.com/browserstack/testng-appium-app-browserstack/71e73f10a613a7bb765bde05a1700829a8d5e057/ios/testng-examples/BStackSampleApp.ipa"
+          echo "76a8bb0250f6d8c0a6bb0b71fcddf60515de92f5920d5624f790da1ecdbc87d9  $app_path" \
+            | sha256sum --check --strict
+      - name: Install visual and OCR test runtimes
+        shell: bash
+        run: >-
+          bash scripts/ci/build_retry.sh 2 60
+          mvn -pl shaft-visual,shaft-ocr -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
+      - name: Run iOS screenshot and OCR interaction acceptance
+        continue-on-error: true
+        timeout-minutes: 35
+        run: >-
+          mvn -pl shaft-browserstack -am -e test
+          "-DincludeVisualTestRuntime" "-DincludeOcrTestRuntime"
+          "-Dallure.automaticallyOpen=false" "-DdefaultElementIdentificationTimeout=60"
+          "-DretryMaximumNumberOfAttempts=0" "-DexecutionAddress=browserstack"
+          "-DtargetOperatingSystem=iOS" "-Dmobile_automationName=XCuiTest"
+          "-DbrowserStack.appiumVersion=3.3.0" "-DbrowserStack.platformVersion=16"
+          "-DbrowserStack.deviceName=iPhone 14" "-DbrowserStack.appUrl="
+          "-Dshaft.enableNativeIosE2E=true" "-DgenerateAllureReportArchive=true"
+          "-Dtest=IOSBasicInteractionsTest#visualAndOcrTargetsShouldInteractWithNativeControls"
+      - name: Verify iOS screenshot and OCR acceptance executed
+        run: >-
+          python3 scripts/ci/assert_tests_executed.py
+          shaft-engine/target/surefire-reports/TEST-testPackage.appium.IOSBasicInteractionsTest.xml
+          --min-executed 1
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: iOS_Visual_Ocr_BrowserStack
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Android_Recording_BrowserStack:
@@ -1396,7 +1506,7 @@ jobs:
 
   notify_e2e_tests_failure:
     name: Notify on nightly failure
-    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, Android_Recording_BrowserStack, iOS_Recording_BrowserStack, Android_Evidence_BrowserStack, iOS_Evidence_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, Android_Flutter_Emulator_E2E, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack, Ubuntu_JUnit_E2E ]
+    needs: [ Ubuntu_Database, Ubuntu_APIs, Ubuntu_Visual_Module, Ubuntu_Desktop_Video_Module, Ubuntu_Firefox_Grid, Ubuntu_Chrome_Grid, Ubuntu_MicrosoftEdge_Grid, Ubuntu_Playwright_Chrome, Ubuntu_Playwright_Edge, Ubuntu_Playwright_WebKit, Ubuntu_Playwright_Firefox, Ubuntu_Playwright_GalaxyS26Ultra, Ubuntu_Playwright_IPhone17ProMax, Android_Native_BrowserStack, Android_Visual_Ocr_BrowserStack, iOS_Visual_Ocr_BrowserStack, Android_Recording_BrowserStack, iOS_Recording_BrowserStack, Android_Evidence_BrowserStack, iOS_Evidence_BrowserStack, iOS_Web_SAFARI_BrowserStack, Android_Web_Chrome_BrowserStack, Android_Flutter_Emulator_E2E, MacOSX_Safari_BrowserStack, Ubuntu_Chrome_Cucumber_Grid, MacOSX_Safari_Cucumber_BrowserStack, Ubuntu_JUnit_E2E ]
     if: always()
     runs-on: ubuntu-22.04
     timeout-minutes: 5

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -783,7 +783,7 @@ jobs:
           "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'AndroidBasicInteractionsTests#visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls+visualAndOcrTargetsShouldScrollHorizontallyInsideNativeControl' }}"
       - name: Verify Android screenshot and OCR acceptance executed
         run: |
-          mapfile -t reports < <(find shaft-engine/target/surefire-reports -name 'TEST-*.xml' -type f)
+          mapfile -t reports < <(find shaft-engine/target/surefire-reports shaft-browserstack/target/surefire-reports -name 'TEST-*.xml' -type f 2>/dev/null)
           python3 scripts/ci/assert_tests_executed.py "${reports[@]}" --min-executed 1
       - name: Post-Test Report and Check
         id: post_test_report
@@ -840,7 +840,7 @@ jobs:
           "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'IOSBasicInteractionsTest#visualAndOcrTargetsShouldInteractWithNativeControls' }}"
       - name: Verify iOS screenshot and OCR acceptance executed
         run: |
-          mapfile -t reports < <(find shaft-engine/target/surefire-reports -name 'TEST-*.xml' -type f)
+          mapfile -t reports < <(find shaft-engine/target/surefire-reports shaft-browserstack/target/surefire-reports -name 'TEST-*.xml' -type f 2>/dev/null)
           python3 scripts/ci/assert_tests_executed.py "${reports[@]}" --min-executed 1
       - name: Post-Test Report and Check
         id: post_test_report

--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -782,10 +782,9 @@ jobs:
           "-DgenerateAllureReportArchive=true"
           "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'AndroidBasicInteractionsTests#visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls+visualAndOcrTargetsShouldScrollHorizontallyInsideNativeControl' }}"
       - name: Verify Android screenshot and OCR acceptance executed
-        run: >-
-          python3 scripts/ci/assert_tests_executed.py
-          shaft-engine/target/surefire-reports/TEST-testPackage.appium.AndroidBasicInteractionsTests.xml
-          --min-executed 2
+        run: |
+          mapfile -t reports < <(find shaft-engine/target/surefire-reports -name 'TEST-*.xml' -type f)
+          python3 scripts/ci/assert_tests_executed.py "${reports[@]}" --min-executed 1
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -840,10 +839,9 @@ jobs:
           "-Dshaft.enableNativeIosE2E=true" "-DgenerateAllureReportArchive=true"
           "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || 'IOSBasicInteractionsTest#visualAndOcrTargetsShouldInteractWithNativeControls' }}"
       - name: Verify iOS screenshot and OCR acceptance executed
-        run: >-
-          python3 scripts/ci/assert_tests_executed.py
-          shaft-engine/target/surefire-reports/TEST-testPackage.appium.IOSBasicInteractionsTest.xml
-          --min-executed 1
+        run: |
+          mapfile -t reports < <(find shaft-engine/target/surefire-reports -name 'TEST-*.xml' -type f)
+          python3 scripts/ci/assert_tests_executed.py "${reports[@]}" --min-executed 1
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -886,6 +886,38 @@
         </profile>
 
         <profile>
+            <id>ocr-test-runtime</id>
+            <activation>
+                <property>
+                    <name>includeOcrTestRuntime</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <additionalClasspathDependencies>
+                                <additionalClasspathDependency>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>shaft-ocr</artifactId>
+                                    <version>${project.version}</version>
+                                    <exclusions>
+                                        <exclusion>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>shaft-engine</artifactId>
+                                        </exclusion>
+                                    </exclusions>
+                                </additionalClasspathDependency>
+                            </additionalClasspathDependencies>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>junit</id>
             <activation>
                 <file>

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -901,6 +901,57 @@
                             <additionalClasspathDependencies>
                                 <additionalClasspathDependency>
                                     <groupId>${project.groupId}</groupId>
+                                    <artifactId>shaft-visual</artifactId>
+                                    <version>${project.version}</version>
+                                    <exclusions>
+                                        <exclusion>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>shaft-engine</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>commons-codec</groupId>
+                                            <artifactId>commons-codec</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>commons-io</groupId>
+                                            <artifactId>commons-io</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>com.fasterxml.jackson.core</groupId>
+                                            <artifactId>jackson-annotations</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>com.fasterxml.jackson.core</groupId>
+                                            <artifactId>jackson-core</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>com.fasterxml.jackson.core</groupId>
+                                            <artifactId>jackson-databind</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>javax.annotation</groupId>
+                                            <artifactId>javax.annotation-api</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>org.apache.httpcomponents</groupId>
+                                            <artifactId>httpclient</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>org.apache.httpcomponents</groupId>
+                                            <artifactId>httpcore</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>org.brotli</groupId>
+                                            <artifactId>dec</artifactId>
+                                        </exclusion>
+                                        <exclusion>
+                                            <groupId>org.jsoup</groupId>
+                                            <artifactId>jsoup</artifactId>
+                                        </exclusion>
+                                    </exclusions>
+                                </additionalClasspathDependency>
+                                <additionalClasspathDependency>
+                                    <groupId>${project.groupId}</groupId>
                                     <artifactId>shaft-ocr</artifactId>
                                     <version>${project.version}</version>
                                     <exclusions>

--- a/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
@@ -1347,14 +1347,14 @@ public class TouchActions extends FluentWebDriverAction {
         if (Boolean.FALSE.equals(appiumImagesAvailable)) {
             return Optional.empty();
         }
-        if (target.minimumConfidence().isPresent() || target.searchRegion().isPresent()
+        if (target.searchRegion().isPresent()
                 || target.matchingMode() != com.shaft.gui.image.ImageMatchingMode.AUTO) {
-            throw new UnsupportedOperationException(
-                    "Appium Images fallback cannot safely enforce confidence, region, or explicit matching-mode constraints.");
+            return Optional.empty();
         }
         try {
             String encodedTarget = Base64.getEncoder().encodeToString(target.imageBytes());
-            double threshold = SHAFT.Properties.visuals.visualMatchingThreshold();
+            double threshold = target.minimumConfidence()
+                    .orElse(SHAFT.Properties.visuals.visualMatchingThreshold());
             List<WebElement> matches;
             synchronized (appiumDriver) {
                 Object previousThreshold = appiumDriver.getSettings()

--- a/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/TouchActions.java
@@ -40,6 +40,7 @@ import org.apache.logging.log4j.Level;
 import org.openqa.selenium.*;
 import org.openqa.selenium.interactions.*;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebElement;
 
 import java.io.File;
 import java.io.IOException;
@@ -1547,6 +1548,19 @@ public class TouchActions extends FluentWebDriverAction {
         Dimension screenSize = driverFactoryHelper.getDriver().manage().window().getSize();
 
         var scrollParameters = new HashMap<>();
+
+        if (driverFactoryHelper.getDriver() instanceof IOSDriver) {
+            scrollParameters.put("direction", swipeDirection.name().toLowerCase(Locale.ROOT));
+            if (scrollableElementLocator != null) {
+                WebElement scrollableElement = (WebElement) elementActionsHelper.identifyUniqueElement(
+                        driverFactoryHelper.getDriver(), scrollableElementLocator).get(1);
+                if (!(scrollableElement instanceof RemoteWebElement remoteElement)) {
+                    throw new IllegalStateException("iOS container scrolling requires an Appium remote element.");
+                }
+                scrollParameters.put("elementId", remoteElement.getId());
+            }
+            return scrollParameters;
+        }
 
         if (scrollableElementLocator != null) {
             //scrolling inside an element

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualTargetTouchActionsTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualTargetTouchActionsTest.java
@@ -1,6 +1,5 @@
 package com.shaft.gui.internal.image;
 
-import com.shaft.driver.internal.FluentWebDriverAction;
 import com.shaft.gui.element.TouchActions;
 import com.shaft.gui.element.internal.ElementActionsHelper;
 import com.shaft.gui.image.ImageMatch;
@@ -26,12 +25,10 @@ import javax.imageio.ImageIO;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -65,7 +62,7 @@ public class VisualTargetTouchActionsTest {
         VisualProcessingProviderRegistry.setProviderForTesting(provider);
         AndroidDriver driver = driver();
         doReturn(true).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
-        TouchActions actions = actions(driver);
+        TestTouchActions actions = actions(driver);
         ImageTarget target = ImageTarget.fromBytes(screenshot).matchingMode(ImageMatchingMode.TEMPLATE);
 
         try (MockedConstruction<ScreenshotManager> ignored = mockConstruction(ScreenshotManager.class,
@@ -85,7 +82,7 @@ public class VisualTargetTouchActionsTest {
         SequencedProvider provider = new SequencedProvider(1);
         VisualProcessingProviderRegistry.setProviderForTesting(provider);
         AndroidDriver driver = driver();
-        TouchActions actions = actions(driver);
+        TestTouchActions actions = actions(driver);
         By container = By.id("container");
         container(actions, driver, container, new Rectangle(10, 20, 40, 30));
         ImageTarget target = ImageTarget.fromBytes(screenshot)
@@ -108,7 +105,7 @@ public class VisualTargetTouchActionsTest {
         VisualProcessingProviderRegistry.setProviderForTesting(provider);
         IOSDriver driver = iosDriver();
         doReturn(null).when(driver).executeScript(eq("mobile: scroll"), anyMap());
-        TouchActions actions = actions(driver);
+        TestTouchActions actions = actions(driver);
         ImageTarget target = ImageTarget.fromBytes(screenshot).matchingMode(ImageMatchingMode.TEMPLATE);
 
         try (MockedConstruction<ScreenshotManager> ignored = mockConstruction(ScreenshotManager.class,
@@ -128,7 +125,7 @@ public class VisualTargetTouchActionsTest {
         VisualProcessingProviderRegistry.setProviderForTesting(provider);
         AndroidDriver driver = driver();
         doReturn(true).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
-        TouchActions actions = actions(driver);
+        TestTouchActions actions = actions(driver);
         By container = By.id("container");
         container(actions, driver, container, new Rectangle(10, 10, 30, 30));
         ImageTarget target = ImageTarget.fromBytes(first).matchingMode(ImageMatchingMode.TEMPLATE);
@@ -143,19 +140,12 @@ public class VisualTargetTouchActionsTest {
         Assert.assertEquals(provider.targets.size(), 3);
     }
 
-    private static TouchActions actions(WebDriver driver) throws Exception {
-        TouchActions actions = new TouchActions(driver);
-        Field helper = FluentWebDriverAction.class.getDeclaredField("elementActionsHelper");
-        helper.setAccessible(true);
-        helper.set(actions, mock(ElementActionsHelper.class));
-        return actions;
+    private static TestTouchActions actions(WebDriver driver) {
+        return new TestTouchActions(driver, mock(ElementActionsHelper.class));
     }
 
-    private static void container(TouchActions actions, AndroidDriver driver, By locator, Rectangle rectangle)
-            throws Exception {
-        Field helperField = FluentWebDriverAction.class.getDeclaredField("elementActionsHelper");
-        helperField.setAccessible(true);
-        ElementActionsHelper helper = (ElementActionsHelper) helperField.get(actions);
+    private static void container(TestTouchActions actions, AndroidDriver driver, By locator, Rectangle rectangle) {
+        ElementActionsHelper helper = actions.helper();
         RemoteWebElement element = mock(RemoteWebElement.class);
         when(element.getRect()).thenReturn(rectangle);
         when(helper.identifyUniqueElement(driver, locator)).thenReturn(List.of(locator.toString(), element));
@@ -233,6 +223,18 @@ public class VisualTargetTouchActionsTest {
 
         @Override
         public void load() {
+            // No native bootstrap is needed by this deterministic provider.
+        }
+    }
+
+    private static final class TestTouchActions extends TouchActions {
+        private TestTouchActions(WebDriver driver, ElementActionsHelper helper) {
+            super(driver);
+            this.elementActionsHelper = helper;
+        }
+
+        private ElementActionsHelper helper() {
+            return elementActionsHelper;
         }
     }
 }

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualTargetTouchActionsTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/VisualTargetTouchActionsTest.java
@@ -1,0 +1,238 @@
+package com.shaft.gui.internal.image;
+
+import com.shaft.driver.internal.FluentWebDriverAction;
+import com.shaft.gui.element.TouchActions;
+import com.shaft.gui.element.internal.ElementActionsHelper;
+import com.shaft.gui.image.ImageMatch;
+import com.shaft.gui.image.ImageMatchingAlgorithm;
+import com.shaft.gui.image.ImageMatchingMode;
+import com.shaft.gui.image.ImageRectangle;
+import com.shaft.gui.image.ImageTarget;
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.ios.IOSDriver;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebElement;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class VisualTargetTouchActionsTest {
+    @AfterMethod(alwaysRun = true)
+    public void resetProvider() {
+        VisualProcessingProviderRegistry.resetProviderForTesting();
+    }
+
+    @DataProvider
+    public Object[][] directions() {
+        return new Object[][]{
+                {TouchActions.SwipeDirection.UP},
+                {TouchActions.SwipeDirection.DOWN},
+                {TouchActions.SwipeDirection.LEFT},
+                {TouchActions.SwipeDirection.RIGHT}
+        };
+    }
+
+    @Test(dataProvider = "directions")
+    public void publicImageScrollShouldSearchGestureAndSearchAgainInEveryDirection(
+            TouchActions.SwipeDirection direction) throws Exception {
+        byte[] screenshot = image(false);
+        SequencedProvider provider = new SequencedProvider(2);
+        VisualProcessingProviderRegistry.setProviderForTesting(provider);
+        AndroidDriver driver = driver();
+        doReturn(true).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+        TouchActions actions = actions(driver);
+        ImageTarget target = ImageTarget.fromBytes(screenshot).matchingMode(ImageMatchingMode.TEMPLATE);
+
+        try (MockedConstruction<ScreenshotManager> ignored = mockConstruction(ScreenshotManager.class,
+                (manager, context) -> when(manager.takeViewportScreenshot(driver)).thenReturn(screenshot))) {
+            actions.swipeElementIntoView(target, direction);
+        }
+
+        Assert.assertEquals(provider.targets.size(), 2);
+        ArgumentCaptor<Map<Object, Object>> parameters = ArgumentCaptor.forClass(Map.class);
+        verify(driver).executeScript(eq("mobile: scrollGesture"), parameters.capture());
+        Assert.assertEquals(parameters.getValue().get("direction"), direction.name());
+    }
+
+    @Test
+    public void containerShouldIntersectExistingImageRegionInScreenshotPixels() throws Exception {
+        byte[] screenshot = image(false);
+        SequencedProvider provider = new SequencedProvider(1);
+        VisualProcessingProviderRegistry.setProviderForTesting(provider);
+        AndroidDriver driver = driver();
+        TouchActions actions = actions(driver);
+        By container = By.id("container");
+        container(actions, driver, container, new Rectangle(10, 20, 40, 30));
+        ImageTarget target = ImageTarget.fromBytes(screenshot)
+                .matchingMode(ImageMatchingMode.TEMPLATE)
+                .within(new ImageRectangle(0, 10, 30, 40));
+
+        try (MockedConstruction<ScreenshotManager> ignored = mockConstruction(ScreenshotManager.class,
+                (manager, context) -> when(manager.takeViewportScreenshot(driver)).thenReturn(screenshot))) {
+            actions.swipeElementIntoView(container, target, TouchActions.SwipeDirection.DOWN);
+        }
+
+        Assert.assertEquals(provider.targets.getFirst().searchRegion().orElseThrow(),
+                new ImageRectangle(10, 20, 20, 30));
+    }
+
+    @Test
+    public void publicIosImageScrollShouldReachTheDocumentedMobileScrollCommand() throws Exception {
+        byte[] screenshot = image(false);
+        SequencedProvider provider = new SequencedProvider(2);
+        VisualProcessingProviderRegistry.setProviderForTesting(provider);
+        IOSDriver driver = iosDriver();
+        doReturn(null).when(driver).executeScript(eq("mobile: scroll"), anyMap());
+        TouchActions actions = actions(driver);
+        ImageTarget target = ImageTarget.fromBytes(screenshot).matchingMode(ImageMatchingMode.TEMPLATE);
+
+        try (MockedConstruction<ScreenshotManager> ignored = mockConstruction(ScreenshotManager.class,
+                (manager, context) -> when(manager.takeViewportScreenshot(driver)).thenReturn(screenshot))) {
+            actions.swipeElementIntoView(target, TouchActions.SwipeDirection.DOWN);
+        }
+
+        verify(driver).executeScript("mobile: scroll", Map.of("direction", "down"));
+        Assert.assertEquals(provider.targets.size(), 2);
+    }
+
+    @Test
+    public void containerStableDetectionShouldIgnoreAnimationOutsideContainer() throws Exception {
+        byte[] first = image(false);
+        byte[] animatedOutside = image(true);
+        SequencedProvider provider = new SequencedProvider(Integer.MAX_VALUE);
+        VisualProcessingProviderRegistry.setProviderForTesting(provider);
+        AndroidDriver driver = driver();
+        doReturn(true).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+        TouchActions actions = actions(driver);
+        By container = By.id("container");
+        container(actions, driver, container, new Rectangle(10, 10, 30, 30));
+        ImageTarget target = ImageTarget.fromBytes(first).matchingMode(ImageMatchingMode.TEMPLATE);
+
+        try (MockedConstruction<ScreenshotManager> ignored = mockConstruction(ScreenshotManager.class,
+                (manager, context) -> when(manager.takeViewportScreenshot(driver))
+                        .thenReturn(first, animatedOutside, first, animatedOutside))) {
+            actions.swipeElementIntoView(container, target, TouchActions.SwipeDirection.DOWN);
+        }
+
+        verify(driver, times(2)).executeScript(eq("mobile: scrollGesture"), anyMap());
+        Assert.assertEquals(provider.targets.size(), 3);
+    }
+
+    private static TouchActions actions(WebDriver driver) throws Exception {
+        TouchActions actions = new TouchActions(driver);
+        Field helper = FluentWebDriverAction.class.getDeclaredField("elementActionsHelper");
+        helper.setAccessible(true);
+        helper.set(actions, mock(ElementActionsHelper.class));
+        return actions;
+    }
+
+    private static void container(TouchActions actions, AndroidDriver driver, By locator, Rectangle rectangle)
+            throws Exception {
+        Field helperField = FluentWebDriverAction.class.getDeclaredField("elementActionsHelper");
+        helperField.setAccessible(true);
+        ElementActionsHelper helper = (ElementActionsHelper) helperField.get(actions);
+        RemoteWebElement element = mock(RemoteWebElement.class);
+        when(element.getRect()).thenReturn(rectangle);
+        when(helper.identifyUniqueElement(driver, locator)).thenReturn(List.of(locator.toString(), element));
+    }
+
+    private static AndroidDriver driver() {
+        AndroidDriver driver = mock(AndroidDriver.class);
+        WebDriver.Options options = mock(WebDriver.Options.class);
+        WebDriver.Window window = mock(WebDriver.Window.class);
+        when(driver.manage()).thenReturn(options);
+        when(options.window()).thenReturn(window);
+        when(window.getSize()).thenReturn(new Dimension(100, 100));
+        return driver;
+    }
+
+    private static IOSDriver iosDriver() {
+        IOSDriver driver = mock(IOSDriver.class);
+        WebDriver.Options options = mock(WebDriver.Options.class);
+        WebDriver.Window window = mock(WebDriver.Window.class);
+        when(driver.manage()).thenReturn(options);
+        when(options.window()).thenReturn(window);
+        when(window.getSize()).thenReturn(new Dimension(100, 100));
+        return driver;
+    }
+
+    private static byte[] image(boolean animateOutsideContainer) throws Exception {
+        BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+        java.awt.Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(0, 0, 100, 100);
+            graphics.setColor(Color.BLACK);
+            graphics.fillRect(10, 10, 30, 30);
+            if (animateOutsideContainer) {
+                graphics.setColor(Color.RED);
+                graphics.fillRect(80, 80, 10, 10);
+            }
+        } finally {
+            graphics.dispose();
+        }
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", output);
+        return output.toByteArray();
+    }
+
+    private static final class SequencedProvider implements VisualProcessingProvider {
+        private final int matchOnCall;
+        private final List<ImageTarget> targets = new ArrayList<>();
+
+        private SequencedProvider(int matchOnCall) {
+            this.matchOnCall = matchOnCall;
+        }
+
+        @Override
+        public List<ImageMatch> findImageMatches(ImageTarget target, byte[] currentPageScreenshot) {
+            targets.add(target);
+            if (targets.size() != matchOnCall) {
+                return List.of();
+            }
+            return List.of(new ImageMatch(new ImageRectangle(20, 20, 10, 10), 0.99, 1,
+                    ImageMatchingAlgorithm.TEMPLATE_COLOR, Map.of("fixture", "sequenced")));
+        }
+
+        @Override
+        public List<Integer> findImageWithinCurrentPage(String referenceImagePath, byte[] currentPageScreenshot) {
+            return List.of();
+        }
+
+        @Override
+        public Boolean compareAgainstBaseline(WebDriver driver, By elementLocator, byte[] elementScreenshot,
+                                              ImageProcessingActions.VisualValidationEngine visualValidationEngine,
+                                              String referenceImagePath, String differencesImagePath) {
+            return true;
+        }
+
+        @Override
+        public void load() {
+        }
+    }
+}

--- a/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
+++ b/shaft-engine/src/test/java/testPackage/appium/AndroidBasicInteractionsTests.java
@@ -4,9 +4,13 @@ import com.google.common.collect.ImmutableMap;
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.driver.MobileRecordingOptions;
 import com.shaft.gui.element.TouchActions;
+import com.shaft.gui.image.ImageMatchingMode;
+import com.shaft.gui.image.ImageTarget;
+import com.shaft.gui.ocr.OcrTarget;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.AndroidDriver;
 import org.openqa.selenium.By;
+import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriverException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -202,6 +206,55 @@ public class AndroidBasicInteractionsTests extends MobileTest {
                 .tap(By.xpath("//android.widget.HorizontalScrollView//android.widget.TextView[@text='TAB 12']"))
                 .swipeElementIntoView(By.xpath("//android.widget.HorizontalScrollView"), By.xpath("//android.widget.HorizontalScrollView//android.widget.TextView[@text='TAB 1']"), TouchActions.SwipeDirection.LEFT)
                 .assertThat(By.xpath("//android.widget.HorizontalScrollView//android.widget.TextView[@text='TAB 1']")).exists();
+    }
+
+    /** Opt-in real-device proof for screenshot and OCR scrolling in both axes. */
+    @Test(groups = {"ApiDemosDebug", "visual-ocr-mobile-acceptance"})
+    public void visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls() {
+        By group1 = By.xpath("//android.widget.TextView[@text='Group 1']");
+        By group18 = By.xpath("//android.widget.TextView[@text='Group 18']");
+        driver.get().touch()
+                .swipeElementIntoView(AppiumBy.accessibilityId("Views"), TouchActions.SwipeDirection.DOWN)
+                .tap(AppiumBy.accessibilityId("Views"))
+                .swipeElementIntoView(AppiumBy.accessibilityId("Expandable Lists"), TouchActions.SwipeDirection.DOWN)
+                .tap(AppiumBy.accessibilityId("Expandable Lists"))
+                .tap(AppiumBy.accessibilityId("3. Simple Adapter"));
+
+        byte[] group1Screenshot = driver.get().getDriver().findElement(group1).getScreenshotAs(OutputType.BYTES);
+        driver.get().touch()
+                .swipeElementIntoView(group18, TouchActions.SwipeDirection.DOWN)
+                .swipeElementIntoView(ImageTarget.fromBytes(group1Screenshot).matchingMode(ImageMatchingMode.AUTO),
+                        TouchActions.SwipeDirection.UP);
+        Assert.assertTrue(driver.get().getDriver().findElement(group1).isDisplayed());
+
+        driver.get().touch().swipeElementIntoView(OcrTarget.exact("Group 18"), TouchActions.SwipeDirection.DOWN);
+        Assert.assertTrue(driver.get().getDriver().findElement(group18).isDisplayed());
+    }
+
+    /** Opt-in real-device proof for screenshot and OCR scrolling inside a horizontal native control. */
+    @Test(groups = {"ApiDemosDebug", "visual-ocr-mobile-acceptance"})
+    public void visualAndOcrTargetsShouldScrollHorizontallyInsideNativeControl() {
+        By tabs = By.xpath("//android.widget.HorizontalScrollView");
+        By tab1 = By.xpath("//android.widget.HorizontalScrollView//android.widget.TextView[@text='TAB 1']");
+        By tab12 = By.xpath("//android.widget.HorizontalScrollView//android.widget.TextView[@text='TAB 12']");
+        driver.get().touch()
+                .swipeElementIntoView(AppiumBy.accessibilityId("Views"), TouchActions.SwipeDirection.DOWN)
+                .tap(AppiumBy.accessibilityId("Views"))
+                .swipeElementIntoView(AppiumBy.accessibilityId("Tabs"), TouchActions.SwipeDirection.DOWN)
+                .tap(AppiumBy.accessibilityId("Tabs"))
+                .swipeElementIntoView(AppiumBy.accessibilityId("5. Scrollable"), TouchActions.SwipeDirection.DOWN)
+                .tap(AppiumBy.accessibilityId("5. Scrollable"));
+
+        byte[] tab1Screenshot = driver.get().getDriver().findElement(tab1).getScreenshotAs(OutputType.BYTES);
+        driver.get().touch()
+                .swipeElementIntoView(tabs, tab12, TouchActions.SwipeDirection.RIGHT)
+                .swipeElementIntoView(tabs,
+                        ImageTarget.fromBytes(tab1Screenshot).matchingMode(ImageMatchingMode.AUTO),
+                        TouchActions.SwipeDirection.LEFT);
+        Assert.assertTrue(driver.get().getDriver().findElement(tab1).isDisplayed());
+
+        driver.get().touch().swipeElementIntoView(tabs, OcrTarget.exact("TAB 12"), TouchActions.SwipeDirection.RIGHT);
+        Assert.assertTrue(driver.get().getDriver().findElement(tab12).isDisplayed());
     }
 
     @Test(groups = {"ApiDemosDebug"})

--- a/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
@@ -3,10 +3,13 @@ package testPackage.appium;
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.element.ElementActions;
 import com.shaft.gui.driver.MobileRecordingOptions;
+import com.shaft.gui.image.ImageTarget;
+import com.shaft.gui.ocr.OcrTarget;
 import com.shaft.properties.internal.Properties;
 import com.shaft.validation.Validations;
 import io.appium.java_client.AppiumBy;
 import org.openqa.selenium.Platform;
+import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriverException;
 import org.testng.SkipException;
 import org.testng.Assert;
@@ -32,6 +35,24 @@ public class IOSBasicInteractionsTest {
                 .element(driver.get().getDriver(), AppiumBy.accessibilityId("Text Output"))
                 .text()
                 .isEqualTo("hello@browserstack.com")
+                .perform();
+    }
+
+    /** Opt-in real-device proof that iOS can interact through device screenshots and OCR text. */
+    @Test(groups = {"visual-ocr-mobile-acceptance"})
+    public void visualAndOcrTargetsShouldInteractWithNativeControls() {
+        byte[] buttonScreenshot = driver.get().getDriver().findElement(AppiumBy.accessibilityId("Text Button"))
+                .getScreenshotAs(OutputType.BYTES);
+
+        driver.get().touch()
+                .tap(ImageTarget.fromBytes(buttonScreenshot))
+                .tap(OcrTarget.exact("Text Input"));
+        driver.get().element().type(AppiumBy.accessibilityId("Text Input"), "visual ocr ios" + "\n");
+
+        Validations.assertThat()
+                .element(driver.get().getDriver(), AppiumBy.accessibilityId("Text Output"))
+                .text()
+                .isEqualTo("visual ocr ios")
                 .perform();
     }
 

--- a/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
@@ -8,6 +8,7 @@ import com.shaft.gui.ocr.OcrTarget;
 import com.shaft.properties.internal.Properties;
 import com.shaft.validation.Validations;
 import io.appium.java_client.AppiumBy;
+import io.appium.java_client.ios.IOSDriver;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriverException;
@@ -48,7 +49,8 @@ public class IOSBasicInteractionsTest {
                 .tap(ImageTarget.fromBytes(inputScreenshot));
         Assert.assertEquals(driver.get().getDriver().switchTo().activeElement().getAttribute("name"), "Text Input");
 
-        driver.get().touch().tap(AppiumBy.accessibilityId("Text Button"));
+        ((IOSDriver) driver.get().getDriver()).hideKeyboard();
+        Assert.assertNotEquals(driver.get().getDriver().switchTo().activeElement().getAttribute("name"), "Text Input");
         driver.get().touch().tap(OcrTarget.exact("Text Input"));
         Assert.assertEquals(driver.get().getDriver().switchTo().activeElement().getAttribute("name"), "Text Input");
         driver.get().element().type(AppiumBy.accessibilityId("Text Input"), "visual ocr ios" + "\n");

--- a/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/IOSBasicInteractionsTest.java
@@ -41,12 +41,16 @@ public class IOSBasicInteractionsTest {
     /** Opt-in real-device proof that iOS can interact through device screenshots and OCR text. */
     @Test(groups = {"visual-ocr-mobile-acceptance"})
     public void visualAndOcrTargetsShouldInteractWithNativeControls() {
-        byte[] buttonScreenshot = driver.get().getDriver().findElement(AppiumBy.accessibilityId("Text Button"))
+        byte[] inputScreenshot = driver.get().getDriver().findElement(AppiumBy.accessibilityId("Text Input"))
                 .getScreenshotAs(OutputType.BYTES);
 
         driver.get().touch()
-                .tap(ImageTarget.fromBytes(buttonScreenshot))
-                .tap(OcrTarget.exact("Text Input"));
+                .tap(ImageTarget.fromBytes(inputScreenshot));
+        Assert.assertEquals(driver.get().getDriver().switchTo().activeElement().getAttribute("name"), "Text Input");
+
+        driver.get().touch().tap(AppiumBy.accessibilityId("Text Button"));
+        driver.get().touch().tap(OcrTarget.exact("Text Input"));
+        Assert.assertEquals(driver.get().getDriver().switchTo().activeElement().getAttribute("name"), "Text Input");
         driver.get().element().type(AppiumBy.accessibilityId("Text Input"), "visual ocr ios" + "\n");
 
         Validations.assertThat()

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Sequence;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebElement;
 import org.opentest4j.AssertionFailedError;
 import org.testng.annotations.AfterMethod;
 import org.testng.Assert;
@@ -331,7 +332,8 @@ public class AndroidTouchActionsCoverageUnitTest {
         doReturn(null).doReturn(false).when(iosDriver).executeScript(eq("mobile: scroll"), anyMap());
         TouchActions touchActions = new TouchActions(iosDriver);
         ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
-        WebElement scrollableElement = mock(WebElement.class);
+        RemoteWebElement scrollableElement = mock(RemoteWebElement.class);
+        when(scrollableElement.getId()).thenReturn("ios-container-id");
         when(scrollableElement.getRect()).thenReturn(new org.openqa.selenium.Rectangle(10, 20, 300, 500));
         when(elementActionsHelper.identifyUniqueElement(any(), eq(By.id("ios-container"))))
                 .thenReturn(List.of("ios-container", scrollableElement));
@@ -348,10 +350,12 @@ public class AndroidTouchActionsCoverageUnitTest {
         @SuppressWarnings("unchecked")
         Map<Object, Object> elementLeftParameters = (Map<Object, Object>) prepareParameters.invoke(touchActions, TouchActions.SwipeDirection.LEFT, By.id("ios-container"), By.id("target"));
 
-        SHAFT.Validations.assertThat().object(downParameters.get("direction")).isEqualTo("DOWN").perform();
-        SHAFT.Validations.assertThat().object(rightParameters.get("left")).isEqualTo(100).perform();
-        SHAFT.Validations.assertThat().object(elementUpParameters.get("height")).isEqualTo(270).perform();
-        SHAFT.Validations.assertThat().object(elementLeftParameters.get("left")).isEqualTo(260).perform();
+        Assert.assertEquals(downParameters, Map.of("direction", "down"));
+        Assert.assertEquals(rightParameters, Map.of("direction", "right"));
+        Assert.assertEquals(elementUpParameters, Map.of(
+                "direction", "up", "elementId", "ios-container-id"));
+        Assert.assertEquals(elementLeftParameters, Map.of(
+                "direction", "left", "elementId", "ios-container-id"));
 
         Method performW3cCompliantScroll = TouchActions.class.getDeclaredMethod("performW3cCompliantScroll", java.util.HashMap.class, boolean.class);
         performW3cCompliantScroll.setAccessible(true);

--- a/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AndroidTouchActionsCoverageUnitTest.java
@@ -5,6 +5,10 @@ import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
 import com.shaft.driver.internal.FluentWebDriverAction;
 import com.shaft.gui.element.TouchActions;
 import com.shaft.gui.element.internal.ElementActionsHelper;
+import com.shaft.gui.image.ImageMatchingMode;
+import com.shaft.gui.image.ImageRectangle;
+import com.shaft.gui.image.ImageTarget;
+import com.shaft.gui.internal.image.ScreenshotManager;
 import com.shaft.properties.internal.Properties;
 import com.shaft.tools.io.ReportManager;
 import io.appium.java_client.AppiumBy;
@@ -16,6 +20,7 @@ import io.appium.java_client.flutter.commands.ScrollParameter;
 import io.appium.java_client.flutter.commands.WaitParameter;
 import io.appium.java_client.ios.IOSDriver;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
@@ -34,6 +39,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
@@ -99,6 +105,95 @@ public class AndroidTouchActionsCoverageUnitTest {
         order.verify(driver).setSetting(io.appium.java_client.Setting.IMAGE_MATCH_THRESHOLD, 0.91);
         order.verify(driver).findElements(any(By.class));
         order.verify(driver).setSetting(io.appium.java_client.Setting.IMAGE_MATCH_THRESHOLD, 0.4);
+    }
+
+    @Test
+    public void typedImageScrollShouldContinueLocallyWhenAppiumCannotHonorRegion() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        doReturn(false).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+        byte[] screenshot = Files.readAllBytes(Path.of("src", "test", "resources", "testDataFiles", "youtube.png"));
+        ImageTarget target = ImageTarget.fromBytes(screenshot).within(new ImageRectangle(0, 0, 1, 1));
+
+        try (MockedConstruction<ScreenshotManager> screenshots = org.mockito.Mockito.mockConstruction(
+                ScreenshotManager.class,
+                (manager, context) -> when(manager.takeViewportScreenshot(driver)).thenReturn(screenshot))) {
+            touchActions.swipeElementIntoView(target, TouchActions.SwipeDirection.DOWN);
+        }
+
+        verify(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+        verify(driver, never()).findElements(argThat(locator -> locator.toString().startsWith("AppiumBy.image")));
+    }
+
+    @Test
+    public void typedImageScrollShouldNotUseAppiumForExplicitMatchingMode() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        doReturn(false).when(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+        byte[] screenshot = Files.readAllBytes(Path.of("src", "test", "resources", "testDataFiles", "youtube.png"));
+        ImageTarget target = ImageTarget.fromBytes(screenshot).matchingMode(ImageMatchingMode.FEATURE);
+
+        try (MockedConstruction<ScreenshotManager> screenshots = org.mockito.Mockito.mockConstruction(
+                ScreenshotManager.class,
+                (manager, context) -> when(manager.takeViewportScreenshot(driver)).thenReturn(screenshot))) {
+            touchActions.swipeElementIntoView(target, TouchActions.SwipeDirection.LEFT);
+        }
+
+        verify(driver).executeScript(eq("mobile: scrollGesture"), anyMap());
+        verify(driver, never()).findElements(argThat(locator -> locator.toString().startsWith("AppiumBy.image")));
+    }
+
+    @Test
+    public void typedImageTapShouldUseTargetConfidenceForAppiumFallback() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        WebElement match = mock(WebElement.class);
+        when(driver.getSettings()).thenReturn(Map.of(
+                io.appium.java_client.Setting.IMAGE_MATCH_THRESHOLD.toString(), 0.67));
+        when(driver.setSetting(any(io.appium.java_client.Setting.class), any())).thenReturn(driver);
+        when(driver.findElements(any(By.class))).thenReturn(List.of(match));
+        TouchActions touchActions = new TouchActions(driver);
+        ElementActionsHelper elementActionsHelper = mock(ElementActionsHelper.class);
+        injectElementActionsHelper(touchActions, elementActionsHelper);
+        byte[] screenshot = Files.readAllBytes(Path.of("src", "test", "resources", "testDataFiles", "youtube.png"));
+
+        try (MockedConstruction<ScreenshotManager> screenshots = org.mockito.Mockito.mockConstruction(
+                ScreenshotManager.class,
+                (manager, context) -> when(manager.takeViewportScreenshot(driver)).thenReturn(screenshot))) {
+            touchActions.tap(ImageTarget.fromBytes(screenshot).minimumConfidence(0.93));
+        }
+
+        verify(match).click();
+        var order = org.mockito.Mockito.inOrder(driver);
+        order.verify(driver).setSetting(io.appium.java_client.Setting.IMAGE_MATCH_THRESHOLD, 0.93);
+        order.verify(driver).findElements(any(By.class));
+        order.verify(driver).setSetting(io.appium.java_client.Setting.IMAGE_MATCH_THRESHOLD, 0.67);
+    }
+
+    @Test
+    public void appiumImagesFallbackShouldRestorePriorThresholdWhenLookupFails() throws Exception {
+        AndroidDriver driver = createMockAndroidDriver();
+        when(driver.getSettings()).thenReturn(Map.of(
+                io.appium.java_client.Setting.IMAGE_MATCH_THRESHOLD.toString(), 0.66));
+        when(driver.setSetting(any(io.appium.java_client.Setting.class), any())).thenReturn(driver);
+        when(driver.findElements(any(By.class))).thenThrow(new WebDriverException("provider lookup failed"));
+        TouchActions touchActions = new TouchActions(driver);
+        Method fallback = TouchActions.class.getDeclaredMethod("findUsingAppiumImages", ImageTarget.class);
+        fallback.setAccessible(true);
+        ImageTarget target = ImageTarget.fromPath(Path.of("src", "test", "resources",
+                "testDataFiles", "youtube.png")).minimumConfidence(0.94);
+
+        InvocationTargetException failure = Assert.expectThrows(InvocationTargetException.class,
+                () -> fallback.invoke(touchActions, target));
+
+        Assert.assertTrue(failure.getCause() instanceof WebDriverException);
+        var order = org.mockito.Mockito.inOrder(driver);
+        order.verify(driver).setSetting(io.appium.java_client.Setting.IMAGE_MATCH_THRESHOLD, 0.94);
+        order.verify(driver).findElements(any(By.class));
+        order.verify(driver).setSetting(io.appium.java_client.Setting.IMAGE_MATCH_THRESHOLD, 0.66);
     }
     private static final Path TEMP_DIR = Path.of("target", "temp", "touchActionsCoverage");
     private static final Path ROOT_PULL_PATH = Path.of("touchActions-root-pulled.txt");

--- a/shaft-ocr/src/test/java/com/shaft/ocr/internal/OcrAccuracyCorpusTest.java
+++ b/shaft-ocr/src/test/java/com/shaft/ocr/internal/OcrAccuracyCorpusTest.java
@@ -2,6 +2,7 @@ package com.shaft.ocr.internal;
 
 import com.shaft.gui.ocr.OcrBlockLevel;
 import com.shaft.gui.ocr.OcrOptions;
+import com.shaft.gui.ocr.OcrRectangle;
 import com.shaft.gui.ocr.OcrResult;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -30,12 +31,14 @@ public class OcrAccuracyCorpusTest {
         TesseractOcrProvider provider = new TesseractOcrProvider();
         OcrOptions options = OcrOptions.defaults().withLanguages("English").withMinimumConfidence(0);
         List<CorpusCase> corpus = List.of(
-                positive("standard", render("SHAFT OCR 42", 68, Color.BLACK, Color.WHITE, 1.0f), "SHAFT"),
-                positive("small-text", render("MOBILE TARGET", 30, Color.BLACK, Color.WHITE, 1.0f), "MOBILE"),
+                positive("standard", render("SHAFT OCR 42", 68, Color.BLACK, Color.WHITE, 1.0f), "SHAFT OCR 42",
+                        new OcrRectangle(37, 55, 483, 51)),
+                positive("small-text", render("MOBILE TARGET", 30, Color.BLACK, Color.WHITE, 1.0f), "MOBILE TARGET",
+                        new OcrRectangle(37, 83, 242, 22)),
                 positive("dark-mode", render("DARK CONTROL", 56, Color.WHITE, new Color(28, 32, 38), 1.0f),
-                        "DARK"),
+                        "DARK CONTROL", new OcrRectangle(35, 55, 290, 55)),
                 positive("semi-transparent", render("ALPHA LABEL", 56, Color.BLACK, Color.WHITE, 0.62f),
-                        "ALPHA"),
+                        "ALPHA LABEL", new OcrRectangle(35, 55, 275, 55)),
                 negative("blank", render("", 56, Color.BLACK, Color.WHITE, 1.0f))
         );
 
@@ -51,17 +54,22 @@ public class OcrAccuracyCorpusTest {
             long started = System.nanoTime();
             OcrResult result = provider.recognize(sample.image(), options);
             elapsedMillis.add((System.nanoTime() - started) / 1_000_000);
-            boolean expectedTextFound = sample.expectedFragment() != null
-                    && result.fullText().toUpperCase(Locale.ROOT).contains(sample.expectedFragment());
-            boolean validWordBounds = result.blocks().stream()
+            String normalizedActual = normalize(result.fullText());
+            boolean expectedTextFound = sample.expectedText() != null && normalizedActual.equals(sample.expectedText());
+            boolean expectedWordBounds = sample.expectedText() != null && result.blocks().stream()
                     .filter(block -> block.level() == OcrBlockLevel.WORD)
-                    .anyMatch(block -> block.bounds().width() > 0 && block.bounds().height() > 0);
-            if (sample.expectedFragment() != null && expectedTextFound && validWordBounds) {
+                    .filter(block -> sample.expectedText().contains(normalize(block.text())))
+                    .map(block -> block.bounds())
+                    .reduce(OcrRectangle::union)
+                    .filter(bounds -> intersectionOverUnion(bounds, sample.expectedBounds()) >= 0.50)
+                    .isPresent();
+            if (sample.expectedText() != null && expectedTextFound && expectedWordBounds) {
                 truePositive++;
-            } else if (sample.expectedFragment() != null) {
+            } else if (sample.expectedText() != null) {
                 falseNegative++;
-                failures.add(sample.name() + "=false-negative:'" + result.fullText().strip() + "'");
-                if (!result.fullText().isBlank()) {
+                failures.add(sample.name() + "=false-negative:'" + result.fullText().strip() + "' blocks="
+                        + result.blocks().stream().filter(block -> block.level() == OcrBlockLevel.WORD).toList());
+                if (!normalizedActual.isBlank() && !normalizedActual.equals(sample.expectedText())) {
                     falsePositive++;
                 }
             } else if (!result.fullText().isBlank()) {
@@ -84,16 +92,30 @@ public class OcrAccuracyCorpusTest {
         Assert.assertTrue(p95Millis <= MAX_P95_MILLIS, metrics);
     }
 
-    private static CorpusCase positive(String name, byte[] image, String expectedFragment) {
-        return new CorpusCase(name, image, expectedFragment);
+    private static CorpusCase positive(String name, byte[] image, String expectedText, OcrRectangle expectedBounds) {
+        return new CorpusCase(name, image, expectedText, expectedBounds);
     }
 
     private static CorpusCase negative(String name, byte[] image) {
-        return new CorpusCase(name, image, null);
+        return new CorpusCase(name, image, null, null);
     }
 
     private static double ratio(int numerator, int denominator) {
         return denominator == 0 ? 1 : (double) numerator / denominator;
+    }
+
+    private static String normalize(String text) {
+        return text.toUpperCase(Locale.ROOT).replaceAll("\\s+", " ").strip();
+    }
+
+    private static double intersectionOverUnion(OcrRectangle actual, OcrRectangle expected) {
+        int left = Math.max(actual.x(), expected.x());
+        int top = Math.max(actual.y(), expected.y());
+        int right = Math.min(actual.right(), expected.right());
+        int bottom = Math.min(actual.bottom(), expected.bottom());
+        long intersection = (long) Math.max(0, right - left) * Math.max(0, bottom - top);
+        long union = (long) actual.width() * actual.height() + (long) expected.width() * expected.height() - intersection;
+        return union == 0 ? 0 : (double) intersection / union;
     }
 
     private static byte[] render(String text, int fontSize, Color foreground, Color background, float opacity)
@@ -116,6 +138,6 @@ public class OcrAccuracyCorpusTest {
         return output.toByteArray();
     }
 
-    private record CorpusCase(String name, byte[] image, String expectedFragment) {
+    private record CorpusCase(String name, byte[] image, String expectedText, OcrRectangle expectedBounds) {
     }
 }

--- a/shaft-ocr/src/test/java/com/shaft/ocr/internal/OcrAccuracyCorpusTest.java
+++ b/shaft-ocr/src/test/java/com/shaft/ocr/internal/OcrAccuracyCorpusTest.java
@@ -1,0 +1,121 @@
+package com.shaft.ocr.internal;
+
+import com.shaft.gui.ocr.OcrBlockLevel;
+import com.shaft.gui.ocr.OcrOptions;
+import com.shaft.gui.ocr.OcrResult;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+/** Deterministic accuracy and latency gate for OCR preprocessing plus the bundled Tesseract backend. */
+public class OcrAccuracyCorpusTest {
+    private static final double MINIMUM_PRECISION = 1.0;
+    private static final double MINIMUM_RECALL = 0.80;
+    private static final long MAX_P95_MILLIS = 15_000;
+
+    @Test
+    public void calibratedCorpusShouldMeetAccuracyBoundingBoxAndRuntimeBudgets() throws Exception {
+        TesseractOcrProvider provider = new TesseractOcrProvider();
+        OcrOptions options = OcrOptions.defaults().withLanguages("English").withMinimumConfidence(0);
+        List<CorpusCase> corpus = List.of(
+                positive("standard", render("SHAFT OCR 42", 68, Color.BLACK, Color.WHITE, 1.0f), "SHAFT"),
+                positive("small-text", render("MOBILE TARGET", 30, Color.BLACK, Color.WHITE, 1.0f), "MOBILE"),
+                positive("dark-mode", render("DARK CONTROL", 56, Color.WHITE, new Color(28, 32, 38), 1.0f),
+                        "DARK"),
+                positive("semi-transparent", render("ALPHA LABEL", 56, Color.BLACK, Color.WHITE, 0.62f),
+                        "ALPHA"),
+                negative("blank", render("", 56, Color.BLACK, Color.WHITE, 1.0f))
+        );
+
+        // Exclude model provisioning/native initialization from per-image matching latency.
+        provider.recognize(render("WARMUP", 48, Color.BLACK, Color.WHITE, 1.0f), options);
+
+        int truePositive = 0;
+        int falsePositive = 0;
+        int falseNegative = 0;
+        List<Long> elapsedMillis = new ArrayList<>();
+        List<String> failures = new ArrayList<>();
+        for (CorpusCase sample : corpus) {
+            long started = System.nanoTime();
+            OcrResult result = provider.recognize(sample.image(), options);
+            elapsedMillis.add((System.nanoTime() - started) / 1_000_000);
+            boolean expectedTextFound = sample.expectedFragment() != null
+                    && result.fullText().toUpperCase(Locale.ROOT).contains(sample.expectedFragment());
+            boolean validWordBounds = result.blocks().stream()
+                    .filter(block -> block.level() == OcrBlockLevel.WORD)
+                    .anyMatch(block -> block.bounds().width() > 0 && block.bounds().height() > 0);
+            if (sample.expectedFragment() != null && expectedTextFound && validWordBounds) {
+                truePositive++;
+            } else if (sample.expectedFragment() != null) {
+                falseNegative++;
+                failures.add(sample.name() + "=false-negative:'" + result.fullText().strip() + "'");
+                if (!result.fullText().isBlank()) {
+                    falsePositive++;
+                }
+            } else if (!result.fullText().isBlank()) {
+                falsePositive++;
+                failures.add(sample.name() + "=false-positive:'" + result.fullText().strip() + "'");
+            }
+        }
+
+        double precision = ratio(truePositive, truePositive + falsePositive);
+        double recall = ratio(truePositive, truePositive + falseNegative);
+        elapsedMillis.sort(Comparator.naturalOrder());
+        long p95Millis = elapsedMillis.get((int) Math.ceil(elapsedMillis.size() * 0.95) - 1);
+        String metrics = String.format(Locale.ROOT,
+                "precision=%.3f recall=%.3f tp=%d fp=%d fn=%d p95=%dms cases=%s",
+                precision, recall, truePositive, falsePositive, falseNegative, p95Millis, failures);
+        System.out.println("OCR accuracy corpus: " + metrics);
+
+        Assert.assertTrue(precision >= MINIMUM_PRECISION, metrics);
+        Assert.assertTrue(recall >= MINIMUM_RECALL, metrics);
+        Assert.assertTrue(p95Millis <= MAX_P95_MILLIS, metrics);
+    }
+
+    private static CorpusCase positive(String name, byte[] image, String expectedFragment) {
+        return new CorpusCase(name, image, expectedFragment);
+    }
+
+    private static CorpusCase negative(String name, byte[] image) {
+        return new CorpusCase(name, image, null);
+    }
+
+    private static double ratio(int numerator, int denominator) {
+        return denominator == 0 ? 1 : (double) numerator / denominator;
+    }
+
+    private static byte[] render(String text, int fontSize, Color foreground, Color background, float opacity)
+            throws Exception {
+        BufferedImage image = new BufferedImage(760, 160, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setColor(background);
+            graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
+            graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, opacity));
+            graphics.setColor(foreground);
+            graphics.setFont(new Font(Font.SANS_SERIF, Font.BOLD, fontSize));
+            graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+            graphics.drawString(text, 35, 105);
+        } finally {
+            graphics.dispose();
+        }
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", output);
+        return output.toByteArray();
+    }
+
+    private record CorpusCase(String name, byte[] image, String expectedFragment) {
+    }
+}

--- a/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
+++ b/shaft-visual/src/main/java/com/shaft/gui/internal/image/OpenCvVisualProcessingProvider.java
@@ -578,13 +578,33 @@ public class OpenCvVisualProcessingProvider implements VisualProcessingProvider 
                 .sorted(Comparator.comparingDouble(RichTemplateMatch::confidence).reversed()
                         .thenComparingDouble(match -> Math.abs(1.0 - match.scale())))
                 .forEach(candidate -> {
-                    boolean overlaps = retained.stream().anyMatch(existing -> intersectionOverUnion(
-                            candidate.bounds(), existing.bounds()) >= 0.30);
+                    boolean overlaps = retained.stream().anyMatch(existing -> {
+                        ImageRectangle candidateBounds = candidate.bounds();
+                        ImageRectangle existingBounds = existing.bounds();
+                        long intersection = intersectionArea(candidateBounds, existingBounds);
+                        long smallerArea = Math.min((long) candidateBounds.width() * candidateBounds.height(),
+                                (long) existingBounds.width() * existingBounds.height());
+                        double centerDistance = Math.hypot(candidateBounds.centerX() - existingBounds.centerX(),
+                                candidateBounds.centerY() - existingBounds.centerY());
+                        double largerDiagonal = Math.hypot(Math.max(candidateBounds.width(), existingBounds.width()),
+                                Math.max(candidateBounds.height(), existingBounds.height()));
+                        return intersectionOverUnion(candidateBounds, existingBounds) >= 0.30
+                                || (smallerArea > 0 && (double) intersection / smallerArea >= 0.60
+                                && centerDistance <= largerDiagonal * 0.30);
+                    });
                     if (!overlaps) {
                         retained.add(candidate);
                     }
                 });
         return retained;
+    }
+
+    private static long intersectionArea(ImageRectangle first, ImageRectangle second) {
+        int left = Math.max(first.x(), second.x());
+        int top = Math.max(first.y(), second.y());
+        int right = Math.min(first.x() + first.width(), second.x() + second.width());
+        int bottom = Math.min(first.y() + first.height(), second.y() + second.height());
+        return (long) Math.max(0, right - left) * Math.max(0, bottom - top);
     }
 
     private static List<RichTemplateMatch> findFeatureMatches(Mat searchImage, Mat reference, double threshold) {

--- a/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
+++ b/shaft-visual/src/test/java/com/shaft/gui/internal/image/ImageProcessingActionsCoverageUnitTest.java
@@ -301,6 +301,29 @@ public class ImageProcessingActionsCoverageUnitTest {
     }
 
     @Test
+    public void typedImageMatchingShouldKeepOverlappingOccurrencesAtDifferentScales() {
+        BufferedImage targetImage = createReferenceTarget(20, 16);
+        BufferedImage screenshotImage = createImage(90, 60, Color.WHITE);
+        Graphics2D graphics = screenshotImage.createGraphics();
+        graphics.drawImage(targetImage, 18, 10, 30, 24, null);
+        graphics.drawImage(targetImage, 10, 10, null);
+        graphics.dispose();
+
+        List<ImageMatch> matches = new OpenCvVisualProcessingProvider().findImageMatches(
+                ImageTarget.fromBytes(encodePng(targetImage)).minimumConfidence(0.70), encodePng(screenshotImage));
+
+        ImageRectangle smallExpected = new ImageRectangle(10, 10, 20, 16);
+        ImageRectangle largeExpected = new ImageRectangle(18, 10, 30, 24);
+        Assert.assertTrue(matches.size() >= 2, matches.toString());
+        Assert.assertTrue(java.util.stream.IntStream.range(0, matches.size()).anyMatch(firstIndex ->
+                java.util.stream.IntStream.range(0, matches.size()).anyMatch(secondIndex ->
+                        firstIndex != secondIndex
+                                && intersectionOverUnion(matches.get(firstIndex).bounds(), smallExpected) >= 0.50
+                                && intersectionOverUnion(matches.get(secondIndex).bounds(), largeExpected) >= 0.50)),
+                matches.toString());
+    }
+
+    @Test
     public void typedImageMatchingShouldHonorSearchRegionAndOccurrence() {
         BufferedImage targetImage = createReferenceTarget(20, 16);
         BufferedImage screenshotImage = createImage(100, 70, Color.WHITE);
@@ -760,6 +783,16 @@ public class ImageProcessingActionsCoverageUnitTest {
 
     private static byte[] createPng(int width, int height, Color color) {
         return encodePng(createImage(width, height, color));
+    }
+
+    private static double intersectionOverUnion(ImageRectangle first, ImageRectangle second) {
+        int left = Math.max(first.x(), second.x());
+        int top = Math.max(first.y(), second.y());
+        int right = Math.min(first.x() + first.width(), second.x() + second.width());
+        int bottom = Math.min(first.y() + first.height(), second.y() + second.height());
+        long intersection = (long) Math.max(0, right - left) * Math.max(0, bottom - top);
+        long union = (long) first.width() * first.height() + (long) second.width() * second.height() - intersection;
+        return (double) intersection / union;
     }
 
     private static byte[] createPatternPng(int width, int height, int x, int y, int cropWidth, int cropHeight, Color cropColor) {

--- a/shaft-visual/src/test/java/com/shaft/gui/internal/image/OpenCvImageAccuracyCorpusTest.java
+++ b/shaft-visual/src/test/java/com/shaft/gui/internal/image/OpenCvImageAccuracyCorpusTest.java
@@ -1,0 +1,269 @@
+package com.shaft.gui.internal.image;
+
+import com.shaft.gui.image.ImageMatch;
+import com.shaft.gui.image.ImageMatchingMode;
+import com.shaft.gui.image.ImageRectangle;
+import com.shaft.gui.image.ImageTarget;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+/** Deterministic precision/recall and latency gate for the supported OpenCV matching modes. */
+public class OpenCvImageAccuracyCorpusTest {
+    private static final double MINIMUM_PRECISION = 1.0;
+    private static final double MINIMUM_RECALL = 1.0;
+    private static final long MAX_P95_MILLIS = 5_000;
+    private static final double MINIMUM_INTERSECTION_OVER_UNION = 0.50;
+
+    @Test
+    public void calibratedCorpusShouldMeetAccuracyAndRuntimeBudgets() throws Exception {
+        OpenCvVisualProcessingProvider provider = new OpenCvVisualProcessingProvider();
+        provider.load();
+        BufferedImage detailed = detailedTarget(100, 80);
+        BufferedImage flat = solid(18, 14, Color.BLACK);
+        BufferedImage androidReference = repositoryImage("content_local.png");
+        BufferedImage androidCurrent = repositoryImage("content.png");
+        BufferedImage androidReferenceText = androidReference.getSubimage(20, 18, 190, 70);
+        BufferedImage androidCurrentText = androidCurrent.getSubimage(32, 12, 205, 72);
+        List<CorpusCase> corpus = List.of(
+                positive("exact-color", detailed, placed(detailed, 1.0, 0), ImageMatchingMode.TEMPLATE,
+                        new ImageRectangle(90, 70, 100, 80)),
+                positive("scaled-down", detailed, placed(detailed, 0.75, 0), ImageMatchingMode.TEMPLATE,
+                        new ImageRectangle(102, 80, 76, 60)),
+                positive("scaled-up", detailed, placed(detailed, 1.25, 0), ImageMatchingMode.TEMPLATE,
+                        new ImageRectangle(77, 60, 126, 100)),
+                positive("rotated-feature", detailed, placed(detailed, 1.0, 18), ImageMatchingMode.AUTO,
+                        new ImageRectangle(80, 56, 120, 108)),
+                positive("flat-template", flat, placed(flat, 1.0, 0), ImageMatchingMode.TEMPLATE,
+                        new ImageRectangle(131, 103, 18, 14)),
+                positive("real-android-cross-capture", androidReferenceText,
+                        placedAt(androidCurrentText, 120, 130, 520, 340), ImageMatchingMode.AUTO,
+                        new ImageRectangle(120, 130, androidCurrentText.getWidth(), androidCurrentText.getHeight())),
+                positive("similar-distractor", detailed, placedWithDistractor(detailed), ImageMatchingMode.TEMPLATE,
+                        new ImageRectangle(35, 70, 100, 80)),
+                negative("absent", detailed, solid(280, 220, Color.WHITE), ImageMatchingMode.AUTO),
+                negative("wrong-flat-color", solid(18, 14, Color.RED), placed(flat, 1.0, 0),
+                        ImageMatchingMode.TEMPLATE),
+                negative("repeated-local-fragment", detailed, repeatedFragments(detailed), ImageMatchingMode.FEATURE)
+        );
+
+        int truePositive = 0;
+        int falsePositive = 0;
+        int falseNegative = 0;
+        List<Long> elapsedMillis = new ArrayList<>();
+        List<String> failures = new ArrayList<>();
+        for (CorpusCase sample : corpus) {
+            long started = System.nanoTime();
+            List<ImageMatch> matches = provider.findImageMatches(
+                    ImageTarget.fromBytes(png(sample.target())).matchingMode(sample.mode()), png(sample.screenshot()));
+            elapsedMillis.add((System.nanoTime() - started) / 1_000_000);
+            List<ImageMatch> correctMatches = matches.stream()
+                    .filter(match -> sample.expectedBounds() != null
+                            && intersectionOverUnion(match.bounds(), sample.expectedBounds())
+                            >= MINIMUM_INTERSECTION_OVER_UNION)
+                    .toList();
+            boolean correctMatchFound = !correctMatches.isEmpty();
+            if (sample.expectedMatch() && correctMatchFound) {
+                truePositive++;
+                int unmatchedDetections = matches.size() - 1;
+                falsePositive += unmatchedDetections;
+                if (unmatchedDetections > 0) {
+                    failures.add(sample.name() + "=extra-detections:" + summarize(matches));
+                }
+            } else if (sample.expectedMatch()) {
+                falseNegative++;
+                failures.add(sample.name() + "=false-negative:" + summarize(matches));
+                if (!matches.isEmpty()) {
+                    falsePositive++;
+                }
+            } else if (!matches.isEmpty()) {
+                falsePositive++;
+                failures.add(sample.name() + "=false-positive:" + summarize(matches));
+            }
+        }
+
+        double precision = ratio(truePositive, truePositive + falsePositive);
+        double recall = ratio(truePositive, truePositive + falseNegative);
+        elapsedMillis.sort(Comparator.naturalOrder());
+        long p95Millis = elapsedMillis.get((int) Math.ceil(elapsedMillis.size() * 0.95) - 1);
+        String metrics = String.format(Locale.ROOT,
+                "precision=%.3f recall=%.3f tp=%d fp=%d fn=%d p95=%dms cases=%s",
+                precision, recall, truePositive, falsePositive, falseNegative, p95Millis, failures);
+        System.out.println("OpenCV accuracy corpus: " + metrics);
+
+        Assert.assertTrue(precision >= MINIMUM_PRECISION, metrics);
+        Assert.assertTrue(recall >= MINIMUM_RECALL, metrics);
+        Assert.assertTrue(p95Millis <= MAX_P95_MILLIS, metrics);
+    }
+
+    private static CorpusCase positive(String name, BufferedImage target, BufferedImage screenshot,
+                                       ImageMatchingMode mode, ImageRectangle expectedBounds) {
+        return new CorpusCase(name, target, screenshot, mode, true, expectedBounds);
+    }
+
+    private static CorpusCase negative(String name, BufferedImage target, BufferedImage screenshot,
+                                       ImageMatchingMode mode) {
+        return new CorpusCase(name, target, screenshot, mode, false, null);
+    }
+
+    private static double ratio(int numerator, int denominator) {
+        return denominator == 0 ? 1 : (double) numerator / denominator;
+    }
+
+    private static double intersectionOverUnion(ImageRectangle actual, ImageRectangle expected) {
+        int left = Math.max(actual.x(), expected.x());
+        int top = Math.max(actual.y(), expected.y());
+        int right = Math.min(actual.x() + actual.width(), expected.x() + expected.width());
+        int bottom = Math.min(actual.y() + actual.height(), expected.y() + expected.height());
+        long intersection = (long) Math.max(0, right - left) * Math.max(0, bottom - top);
+        long union = (long) actual.width() * actual.height()
+                + (long) expected.width() * expected.height() - intersection;
+        return union == 0 ? 0 : (double) intersection / union;
+    }
+
+    private static String summarize(List<ImageMatch> matches) {
+        return matches.stream()
+                .limit(3)
+                .map(match -> String.format(Locale.ROOT, "(%d,%d @ %.3f)",
+                        match.centerX(), match.centerY(), match.confidence()))
+                .toList()
+                .toString();
+    }
+
+    private static BufferedImage placed(BufferedImage target, double scale, double degrees) {
+        BufferedImage screenshot = solid(280, 220, Color.WHITE);
+        Graphics2D graphics = screenshot.createGraphics();
+        try {
+            graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            AffineTransform transform = new AffineTransform();
+            transform.translate(140, 110);
+            transform.rotate(Math.toRadians(degrees));
+            transform.scale(scale, scale);
+            transform.translate(-target.getWidth() / 2.0, -target.getHeight() / 2.0);
+            graphics.drawImage(target, transform, null);
+        } finally {
+            graphics.dispose();
+        }
+        return screenshot;
+    }
+
+    private static BufferedImage placedAt(BufferedImage target, int x, int y, int width, int height) {
+        BufferedImage screenshot = solid(width, height, Color.WHITE);
+        Graphics2D graphics = screenshot.createGraphics();
+        try {
+            graphics.drawImage(target, x, y, null);
+        } finally {
+            graphics.dispose();
+        }
+        return screenshot;
+    }
+
+    private static BufferedImage placedWithDistractor(BufferedImage target) {
+        BufferedImage screenshot = solid(300, 220, Color.WHITE);
+        BufferedImage distractor = detailedTarget(target.getWidth(), target.getHeight());
+        Graphics2D distractorGraphics = distractor.createGraphics();
+        try {
+            distractorGraphics.setColor(new Color(190, 25, 45));
+            distractorGraphics.fillOval(8, 8, 52, 52);
+            distractorGraphics.setColor(Color.BLACK);
+            distractorGraphics.fillRect(60, 8, 32, 62);
+        } finally {
+            distractorGraphics.dispose();
+        }
+        Graphics2D graphics = screenshot.createGraphics();
+        try {
+            graphics.drawImage(target, 35, 70, null);
+            graphics.drawImage(distractor, 165, 70, null);
+        } finally {
+            graphics.dispose();
+        }
+        return screenshot;
+    }
+
+    private static BufferedImage repositoryImage(String fileName) throws Exception {
+        Path workingDirectory = Path.of(System.getProperty("user.dir"));
+        Path repositoryRoot = Files.isDirectory(workingDirectory.resolve("shaft-engine"))
+                ? workingDirectory : workingDirectory.getParent();
+        Path imagePath = repositoryRoot.resolve(Path.of("shaft-engine", "src", "main", "resources",
+                "dynamicObjectRepository", "Android", fileName));
+        Assert.assertTrue(Files.isRegularFile(imagePath), "Missing corpus resource " + imagePath);
+        BufferedImage image = ImageIO.read(imagePath.toFile());
+        Assert.assertNotNull(image, "Unreadable corpus resource " + imagePath);
+        return image;
+    }
+
+    private static BufferedImage repeatedFragments(BufferedImage target) {
+        BufferedImage screenshot = solid(280, 220, Color.WHITE);
+        BufferedImage fragment = target.getSubimage(35, 25, 25, 20);
+        Graphics2D graphics = screenshot.createGraphics();
+        try {
+            for (int y = 20; y < 190; y += 40) {
+                for (int x = 20; x < 250; x += 45) {
+                    graphics.drawImage(fragment, x, y, null);
+                }
+            }
+        } finally {
+            graphics.dispose();
+        }
+        return screenshot;
+    }
+
+    private static BufferedImage detailedTarget(int width, int height) {
+        BufferedImage image = solid(width, height, new Color(245, 248, 252));
+        Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            graphics.setColor(new Color(16, 89, 166));
+            graphics.fillRoundRect(3, 3, width - 6, height - 6, 14, 14);
+            graphics.setColor(Color.WHITE);
+            graphics.setStroke(new BasicStroke(3));
+            graphics.drawLine(12, 15, width - 15, height - 15);
+            graphics.drawOval(15, 18, 30, 30);
+            graphics.setColor(new Color(255, 196, 0));
+            graphics.fillRect(width - 38, 14, 22, 31);
+            graphics.setColor(Color.BLACK);
+            graphics.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 15));
+            graphics.drawString("S42", 28, height - 13);
+        } finally {
+            graphics.dispose();
+        }
+        return image;
+    }
+
+    private static BufferedImage solid(int width, int height, Color color) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setColor(color);
+            graphics.fillRect(0, 0, width, height);
+        } finally {
+            graphics.dispose();
+        }
+        return image;
+    }
+
+    private static byte[] png(BufferedImage image) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", output);
+        return output.toByteArray();
+    }
+
+    private record CorpusCase(String name, BufferedImage target, BufferedImage screenshot,
+                              ImageMatchingMode mode, boolean expectedMatch, ImageRectangle expectedBounds) {
+    }
+}

--- a/tests/scripts/test_visual_ocr_workflow.py
+++ b/tests/scripts/test_visual_ocr_workflow.py
@@ -25,6 +25,6 @@ class VisualOcrWorkflowTest(unittest.TestCase):
             self.assertIn("github.event.inputs.tests != ''", test_command)
             self.assertIn(expected_default, test_command)
             verification = next(command for command in run_steps if "assert_tests_executed.py" in command)
-            self.assertIn("find shaft-engine/target/surefire-reports -name 'TEST-*.xml'", verification)
+            self.assertIn("find shaft-engine/target/surefire-reports shaft-browserstack/target/surefire-reports", verification)
             self.assertIn('"${reports[@]}" --min-executed 1', verification)
             self.assertNotIn("TEST-testPackage.appium", verification)

--- a/tests/scripts/test_visual_ocr_workflow.py
+++ b/tests/scripts/test_visual_ocr_workflow.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "e2eTests.yml"
+
+
+def test_visual_ocr_jobs_forward_manual_test_selector_and_keep_defaults():
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    expected_defaults = {
+        "Android_Visual_Ocr_BrowserStack":
+            "AndroidBasicInteractionsTests#visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls+"
+            "visualAndOcrTargetsShouldScrollHorizontallyInsideNativeControl",
+        "iOS_Visual_Ocr_BrowserStack":
+            "IOSBasicInteractionsTest#visualAndOcrTargetsShouldInteractWithNativeControls",
+    }
+
+    for job_name, expected_default in expected_defaults.items():
+        run_steps = [step["run"] for step in workflow["jobs"][job_name]["steps"] if "run" in step]
+        test_command = next(command for command in run_steps if "-Dtest=" in command)
+        assert "github.event.inputs.tests" in test_command
+        assert expected_default in test_command

--- a/tests/scripts/test_visual_ocr_workflow.py
+++ b/tests/scripts/test_visual_ocr_workflow.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import unittest
 
 import yaml
 
@@ -6,18 +7,24 @@ import yaml
 WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "e2eTests.yml"
 
 
-def test_visual_ocr_jobs_forward_manual_test_selector_and_keep_defaults():
-    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
-    expected_defaults = {
-        "Android_Visual_Ocr_BrowserStack":
-            "AndroidBasicInteractionsTests#visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls+"
-            "visualAndOcrTargetsShouldScrollHorizontallyInsideNativeControl",
-        "iOS_Visual_Ocr_BrowserStack":
-            "IOSBasicInteractionsTest#visualAndOcrTargetsShouldInteractWithNativeControls",
-    }
+class VisualOcrWorkflowTest(unittest.TestCase):
+    def test_jobs_forward_manual_test_selector_and_keep_defaults(self):
+        workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        expected_defaults = {
+            "Android_Visual_Ocr_BrowserStack":
+                "AndroidBasicInteractionsTests#visualAndOcrTargetsShouldScrollVerticallyThroughNativeControls+"
+                "visualAndOcrTargetsShouldScrollHorizontallyInsideNativeControl",
+            "iOS_Visual_Ocr_BrowserStack":
+                "IOSBasicInteractionsTest#visualAndOcrTargetsShouldInteractWithNativeControls",
+        }
 
-    for job_name, expected_default in expected_defaults.items():
-        run_steps = [step["run"] for step in workflow["jobs"][job_name]["steps"] if "run" in step]
-        test_command = next(command for command in run_steps if "-Dtest=" in command)
-        assert "github.event.inputs.tests" in test_command
-        assert expected_default in test_command
+        for job_name, expected_default in expected_defaults.items():
+            run_steps = [step["run"] for step in workflow["jobs"][job_name]["steps"] if "run" in step]
+            test_command = next(command for command in run_steps if "-Dtest=" in command)
+            self.assertIn("github.event.inputs.tests", test_command)
+            self.assertIn("github.event.inputs.tests != ''", test_command)
+            self.assertIn(expected_default, test_command)
+            verification = next(command for command in run_steps if "assert_tests_executed.py" in command)
+            self.assertIn("find shaft-engine/target/surefire-reports -name 'TEST-*.xml'", verification)
+            self.assertIn('"${reports[@]}" --min-executed 1', verification)
+            self.assertNotIn("TEST-testPackage.appium", verification)


### PR DESCRIPTION
## Outcome

Adds measurable visual/OCR accuracy gates and opt-in real mobile acceptance on top of the merged visual automation foundation.

### Changes

- Preserve typed ImageTarget constraints during native Appium fallback, including threshold restoration.
- Bind Android and iOS screenshot-scroll direction/container behavior with public-flow tests.
- Improve OpenCV non-maximum suppression so flat targets do not emit overlapping scale duplicates while distinct overlapping occurrences survive.
- Add OpenCV and OCR precision/recall, geometry, and p95 latency corpora, including real Android cross-capture.
- Add opt-in Android_Visual_Ocr_BrowserStack and iOS_Visual_Ocr_BrowserStack jobs plus an optional OCR test-runtime profile.

### Verified locally

- Android/iOS public image-scroll unit flows: 8 passed.
- OpenCV provider plus corpus: 49 passed.
- OpenCV NMS mutation proof plus corpus: 2 passed.
- Combined OpenCV/OCR corpora: 2 passed. OpenCV precision/recall 1.000, p95 263 ms; OCR precision/recall 1.000, p95 223 ms.
- shaft-engine test compilation, workflow YAML parsing, and agent setup validation passed.
- Independent OpenCV review: zero blocking findings after four adversarial rounds.

The real-provider jobs are intentionally manual opt-ins. They are not run locally because repository policy requires explicit authorization before external/cloud mobile execution.

Closes #4836