### PR TITLE
Refresh README for developer trust and adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,92 +2,98 @@
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="shaft-engine/src/main/resources/images/shaft_white.png">
-  <img src="shaft-engine/src/main/resources/images/shaft_standard.png" alt="SHAFT logo" width="180">
+  <img src="shaft-engine/src/main/resources/images/shaft_standard.png" alt="SHAFT S logo" width="260">
 </picture>
 
 # SHAFT
 
-**Write clearer Java tests. Run them anywhere. Keep the evidence.**
+**Reliable Java test automation, from first intent to production-grade evidence.**
 
-One automation framework for Web, Mobile, API, CLI, and Database testing—
-with synchronized actions, readable assertions, rich reports, and optional
-agent-assisted workflows.
+One strong, maintainable framework for Web, Mobile, API, CLI, Database, and
+native testing—with synchronized actions, configuration-first execution,
+readable assertions, and unified reports.
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.shafthq/shaft-engine?style=for-the-badge&logo=apachemaven)](https://central.sonatype.com/artifact/io.github.shafthq/shaft-engine)
 [![Build](https://img.shields.io/github/actions/workflow/status/ShaftHQ/SHAFT_ENGINE/pr-gate.yml?branch=main&style=for-the-badge&label=build)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/pr-gate.yml)
 [![Stars](https://img.shields.io/github/stars/ShaftHQ/SHAFT_ENGINE?style=for-the-badge&logo=github)](https://github.com/ShaftHQ/SHAFT_ENGINE)
-[![Docs](https://img.shields.io/badge/user_guide-live-006ec0?style=for-the-badge)](https://shafthq.github.io/docs/start/overview)
+[![User guide](https://img.shields.io/badge/user_guide-live-006ec0?style=for-the-badge)](https://shafthq.github.io/)
 
-**[Try SHAFT](https://shafthq.github.io/project-generator)** ·
-**[Read the guide](https://shafthq.github.io/docs/start/overview)** ·
-**[Star the repo ⭐](https://github.com/ShaftHQ/SHAFT_ENGINE)**
+**[Generate your first project](https://shafthq.github.io/)** ·
+**[Explore the user guide](https://shafthq.github.io/)** ·
+**[Star SHAFT on GitHub ⭐](https://github.com/ShaftHQ/SHAFT_ENGINE)**
 
 </div>
 
 SHAFT removes the repeated plumbing around drivers, waits, assertions,
-configuration, test data, screenshots, logs, and Allure evidence. Start with
-the lean `shaft-engine` artifact, then add Capture, Doctor, Heal, MCP, visual,
-video, cloud, or desktop-image modules only when a project needs them.
+configuration, test data, screenshots, logs, and Allure evidence. Its modular
+Maven reactor keeps the core lean and lets teams add advanced tooling only when
+they need it.
 
-## Get useful evidence in one run
+## From zero to useful evidence
 
-1. [Generate a ready-to-run Maven project](https://shafthq.github.io/project-generator).
+1. [Open the SHAFT landing page](https://shafthq.github.io/) and generate a
+   ready-to-run Maven project.
 2. Extract it and run:
 
    ```shell
    mvn test
    ```
 
-3. Confirm the sample passes, then inspect the screenshots, logs, and Allure
-   results under the generated project output.
+3. Inspect the sample result, screenshots, logs, and Allure evidence.
 
-The [quick-start guide](https://shafthq.github.io/docs/start/quick-start) covers
-new projects, safe upgrades, manual setup, and CI handoff.
+The generated project uses the canonical Maven coordinate
+**io.github.shafthq:shaft-engine** and gives you a repeatable baseline
+for local runs and CI.
 
-## One readable API, broad coverage
+## One orchestration layer, every execution surface
 
-| Need | SHAFT gives you |
+Test intent and configuration enter SHAFT's orchestration layer, fan out across
+the required execution surfaces, and return through one unified evidence flow.
+
+```mermaid
+flowchart LR
+    accTitle: SHAFT execution and evidence workflow
+    accDescr: Test intent and configuration enter SHAFT orchestration, run across Web, Mobile, API, and Native execution surfaces, and produce unified evidence.
+    I[Test intent] --> S[SHAFT orchestration]
+    C[Configuration] --> S
+    S --> W[Web]
+    S --> M[Mobile]
+    S --> A[API]
+    S --> N[Native, CLI, and Database]
+    W --> E[Unified evidence]
+    M --> E
+    A --> E
+    N --> E
+```
+
+| Engineering need | What SHAFT provides |
 |---|---|
-| Web and mobile UI | Managed Selenium/Appium drivers, synchronized actions, locator builders, screenshots, and accessibility evidence. |
-| API and services | REST and GraphQL requests, responses, assertions, and reporting in the same test flow. |
-| System workflows | Database and CLI actions for end-to-end checks beyond the browser. |
-| Trustworthy results | Hard and soft assertions, structured logs, attachments, failure evidence, and Allure reports. |
-| Scale and portability | Configuration-first local, Grid, BrowserStack, LambdaTest, TestNG, JUnit, and Cucumber execution. |
-| Optional intelligence | Capture, Doctor, deterministic Heal, MCP/CLI tools, provider adapters, and an IntelliJ IDEA plugin. |
+| Stable UI automation | Managed Selenium and Appium drivers, synchronized actions, locator builders, screenshots, and accessibility evidence. |
+| End-to-end coverage | REST, GraphQL, Database, CLI, and native desktop actions in the same test flow. |
+| Trustworthy verdicts | Hard and soft assertions, structured logs, attachments, failure context, and Allure reports. |
+| Scalable execution | Configuration-first local, Grid, BrowserStack, LambdaTest, TestNG, JUnit, and Cucumber runs. |
+| Maintainable architecture | A focused engine, BOM-aligned optional modules, public extension points, and reusable test assets. |
+| Assisted workflows | Capture, Doctor, deterministic Heal, MCP/CLI tools, provider adapters, and an IntelliJ IDEA plugin. |
 
-SHAFT is a Java 25 Maven reactor. Consumers can use the BOM to keep optional
-modules aligned; the [module guide](https://shafthq.github.io/docs/features/modules)
-maps every published artifact to its intended capability.
+## Built for long-lived automation suites
 
-## Documentation that stays current
+- **Strong defaults, explicit control.** Sensible behavior gets teams moving;
+  configuration keeps environments and CI reproducible.
+- **Modular by design.** Start with `shaft-engine`, then adopt visual, video,
+  cloud, native, or agentic modules without rebuilding the test architecture.
+- **Evidence is part of execution.** Logs, screenshots, attachments, and
+  reports share one lifecycle instead of becoming after-the-fact glue.
+- **Open and inspectable.** SHAFT is MIT licensed, built in public, and guarded
+  by its [pull-request gate](.github/workflows/pr-gate.yml),
+  [security policy](SECURITY.md), and published
+  [release history](https://github.com/ShaftHQ/SHAFT_ENGINE/releases).
 
-- Start: [overview](https://shafthq.github.io/docs/start/overview),
-  [quick start](https://shafthq.github.io/docs/start/quick-start),
-  [installation](https://shafthq.github.io/docs/start/installation), and
-  [upgrade](https://shafthq.github.io/docs/start/upgrade).
-- Test: [web](https://shafthq.github.io/docs/testing/web),
-  [mobile](https://shafthq.github.io/docs/testing/mobile), and
-  [API](https://shafthq.github.io/docs/testing/api).
-- Work with agents: [skills](https://shafthq.github.io/docs/agentic/skills),
-  [IntelliJ IDEA](https://shafthq.github.io/docs/agentic/intellij),
-  [MCP](https://shafthq.github.io/docs/agentic/mcp),
-  [Doctor](https://shafthq.github.io/docs/agentic/doctor), and
-  [Heal](https://shafthq.github.io/docs/agentic/heal).
-- Explore: [features and modules](https://shafthq.github.io/docs/features/modules),
-  [reporting](https://shafthq.github.io/docs/features/reporting), and
-  [release notes](https://github.com/ShaftHQ/SHAFT_ENGINE/releases).
-
-## Agent skills, without the guesswork
+## Agent-ready, source-grounded
 
 SHAFT ships 30 first-party skills for planning, authoring, running, diagnosing,
 and reporting tests. Start with `$shaft-developer`; it routes the immediate job
-to one focused specialist. The
-[agent-skills guide](https://shafthq.github.io/docs/agentic/skills) owns the
-supported install routes, client-native directories, upgrade behavior, and
-verification steps.
-
-Exact MCP names and CLI syntax are generated from source in
-[`shaft-mcp-tools.md`](shaft-skills/references/shaft-mcp-tools.md) and
+to one focused specialist. Exact MCP names and CLI syntax are generated from
+source in [`shaft-mcp-tools.md`](shaft-skills/references/shaft-mcp-tools.md) and
 [`shaft-cli-commands.md`](shaft-skills/references/shaft-cli-commands.md).
 
 ## Join the project
@@ -97,18 +103,15 @@ Exact MCP names and CLI syntax are generated from source in
   [Code of Conduct](CODE_OF_CONDUCT.md).
 - Found a vulnerability? Follow [SECURITY.md](SECURITY.md) and report it
   privately.
-- Like the direction? [Star SHAFT](https://github.com/ShaftHQ/SHAFT_ENGINE)
-  so more automation engineers can discover it.
-
-## Support that keeps SHAFT moving
+- Does SHAFT help your team? [Star the repository](https://github.com/ShaftHQ/SHAFT_ENGINE)
+  so more automation engineers can find it.
 
 BrowserStack, LambdaTest, Applitools, and JetBrains have provided tooling or
-open-source program support. They are project supporters, not represented as
-financial sponsors or endorsements. See the
-[support and adoption notes](https://shafthq.github.io/docs/features/modules#partners).
+open-source program support. This is support for the project, not a claim of
+financial sponsorship, customer status, or endorsement.
 
-SHAFT is free and MIT licensed. If it saves your team time, you can fund
-ongoing maintenance, documentation, and public infrastructure through
+SHAFT is free and MIT licensed. You can support ongoing maintenance,
+documentation, and public infrastructure through
 [GitHub Sponsors](https://github.com/sponsors/MohabMohie).
 
 MIT licensed — see [LICENSE](LICENSE).

--- a/scripts/ci/readme_contract.py
+++ b/scripts/ci/readme_contract.py
@@ -1,10 +1,8 @@
-"""Shared trust checks for the repository landing README.
-
-This is intentionally a small parser for the constructs used by this README:
-inline links and linked images, reference definitions, HTTP(S) autolinks,
-HTML ``href``/``src``, backtick or tilde fences, inline backtick code, HTML
-comments, and Mermaid flowcharts. It does not claim full CommonMark support.
-"""
+"""Shared trust checks for the repository landing README."""
+# Intentionally a small parser for the constructs used by this README: inline
+# links and linked images, reference definitions, HTTP(S) autolinks, HTML
+# href/src, backtick or tilde fences, inline backtick code, HTML comments, and
+# Mermaid flowcharts. It does not claim full CommonMark support.
 
 from __future__ import annotations
 

--- a/scripts/ci/readme_contract.py
+++ b/scripts/ci/readme_contract.py
@@ -1,0 +1,258 @@
+"""Shared trust checks for the repository landing README.
+
+This is intentionally a small parser for the constructs used by this README:
+inline links and linked images, reference definitions, HTTP(S) autolinks,
+HTML ``href``/``src``, backtick or tilde fences, inline backtick code, HTML
+comments, and Mermaid flowcharts. It does not claim full CommonMark support.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlsplit
+
+USER_GUIDE_ROOT = "https://shafthq.github.io/"
+USER_GUIDE_HOST = "shafthq.github.io"
+BUILD_BADGE_SOURCE = (
+    "https://img.shields.io/github/actions/workflow/status/"
+    "ShaftHQ/SHAFT_ENGINE/pr-gate.yml"
+)
+BUILD_WORKFLOW_URL = (
+    "https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/pr-gate.yml"
+)
+
+_HTML_COMMENT = re.compile(r"<!--.*?-->", flags=re.DOTALL)
+_FENCE_OPEN = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})([^\r\n]*)$")
+_INLINE_CODE = re.compile(r"`+[^`\n]*`+")
+_MARKDOWN_DESTINATION = re.compile(r"\]\(\s*<?([^\s)>]+)>?")
+_REFERENCE_DESTINATION = re.compile(
+    r"^[ \t]{0,3}\[([^\]\n]+)\]:[ \t]*<?([^>\s]+)>?(?:[ \t]+.*)?$",
+    flags=re.MULTILINE,
+)
+_FULL_REFERENCE = re.compile(r"!?\[([^\]\n]+)\]\[([^\]\n]*)\]")
+_SHORTCUT_REFERENCE = re.compile(r"(?<!!)\[([^\]\n]+)\](?![\[(])")
+_AUTOLINK_DESTINATION = re.compile(r"<(https?://[^<>\s]+)>", flags=re.IGNORECASE)
+_HTML_ATTRIBUTE = re.compile(
+    r"\b(href|src|width)\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s\"'=<>`]+))",
+    flags=re.IGNORECASE,
+)
+_HTML_TAG = re.compile(r"<([A-Za-z][\w:-]*)\b([^>]*)>", flags=re.DOTALL)
+_IMG_TAG = re.compile(r"<img\b([^>]*)>", flags=re.DOTALL | re.IGNORECASE)
+_GENERATOR_LINK = re.compile(
+    r"\[Generate[^\]]*project\]\(https://shafthq\.github\.io/\)",
+    flags=re.IGNORECASE,
+)
+_BUILD_BADGE = re.compile(
+    r"\[!\[[^\]\n]*\]\("
+    + re.escape(BUILD_BADGE_SOURCE)
+    + r"(?:\?[^)\s]*)?\)\]\("
+    + re.escape(BUILD_WORKFLOW_URL)
+    + r"\)",
+    flags=re.IGNORECASE,
+)
+_MERMAID_NODE = re.compile(r"\b([A-Za-z][\w-]*)\s*\[([^\]]+)\]")
+_MERMAID_EDGE = re.compile(
+    r"\b([A-Za-z][\w-]*)(?:\[[^\]]+\])?\s*-->\s*([A-Za-z][\w-]*)"
+)
+
+
+def _without_comments(markup: str) -> str:
+    return _HTML_COMMENT.sub("", markup)
+
+
+def _scan_fences(markup: str) -> tuple[str, tuple[tuple[str, str], ...]]:
+    """Strip supported fences and return closed blocks as ``(info, body)``."""
+    outside: list[str] = []
+    blocks: list[tuple[str, str]] = []
+    marker = ""
+    info = ""
+    body: list[str] = []
+
+    for line in markup.splitlines(keepends=True):
+        content = line.rstrip("\r\n")
+        if not marker:
+            opening = _FENCE_OPEN.fullmatch(content)
+            if opening:
+                marker = opening.group(1)
+                info = opening.group(2).strip()
+                body = []
+                outside.append("\n" if line.endswith(("\n", "\r")) else "")
+            else:
+                outside.append(line)
+            continue
+
+        closing = re.fullmatch(
+            rf"[ \t]{{0,3}}{re.escape(marker[0])}{{{len(marker)},}}[ \t]*",
+            content,
+        )
+        if closing:
+            blocks.append((info, "".join(body)))
+            marker = ""
+            info = ""
+            body = []
+            outside.append("\n" if line.endswith(("\n", "\r")) else "")
+        else:
+            body.append(line)
+
+    return "".join(outside), tuple(blocks)
+
+
+def _link_scan_markup(markup: str) -> str:
+    without_comments = _without_comments(markup)
+    without_fences, _ = _scan_fences(without_comments)
+    return _INLINE_CODE.sub("", without_fences)
+
+
+def _visible_markup(markup: str) -> str:
+    without_comments = _without_comments(markup)
+    without_fences, _ = _scan_fences(without_comments)
+    return without_fences
+
+
+def _attributes(fragment: str) -> dict[str, str]:
+    attributes: dict[str, str] = {}
+    for match in _HTML_ATTRIBUTE.finditer(fragment):
+        value = next(group for group in match.groups()[1:] if group is not None)
+        attributes[match.group(1).lower()] = value
+    return attributes
+
+
+def _reference_destinations(markup: str) -> list[str]:
+    definitions = {
+        " ".join(match.group(1).split()).casefold(): match.group(2)
+        for match in _REFERENCE_DESTINATION.finditer(markup)
+    }
+    without_definitions = _REFERENCE_DESTINATION.sub("", markup)
+    used_labels = {
+        " ".join((label or text).split()).casefold()
+        for text, label in _FULL_REFERENCE.findall(without_definitions)
+    }
+    used_labels.update(
+        " ".join(label.split()).casefold()
+        for label in _SHORTCUT_REFERENCE.findall(without_definitions)
+    )
+    return [definitions[label] for label in used_labels if label in definitions]
+
+
+def destinations(markup: str) -> tuple[str, ...]:
+    """Return rendered destinations from the README's supported constructs."""
+    rendered = _link_scan_markup(markup)
+    markdown = [match.group(1) for match in _MARKDOWN_DESTINATION.finditer(rendered)]
+    references = _reference_destinations(rendered)
+    autolinks = [
+        match.group(1) for match in _AUTOLINK_DESTINATION.finditer(rendered)
+    ]
+    html = []
+    for tag in _HTML_TAG.finditer(rendered):
+        attributes = _attributes(tag.group(2))
+        html.extend(
+            attributes[name] for name in ("href", "src") if name in attributes
+        )
+    return tuple(markdown + references + autolinks + html)
+
+
+def _has_accessible_evidence_workflow(markup: str) -> bool:
+    uncommented = _without_comments(markup)
+    _, blocks = _scan_fences(uncommented)
+    for info, body in blocks:
+        if not info or info.split()[0].casefold() != "mermaid":
+            continue
+        live_lines = [
+            line for line in body.splitlines()
+            if not line.lstrip().startswith("%%")
+        ]
+        block = "\n".join(live_lines)
+        if re.search(r"^\s*accTitle:\s*\S", block, flags=re.MULTILINE) is None:
+            continue
+        if re.search(r"^\s*accDescr:\s*\S", block, flags=re.MULTILINE) is None:
+            continue
+
+        nodes = {
+            label.strip().lower(): identifier
+            for identifier, label in _MERMAID_NODE.findall(block)
+        }
+        required_labels = (
+            "test intent",
+            "configuration",
+            "shaft orchestration",
+            "web",
+            "mobile",
+            "api",
+            "native, cli, and database",
+            "unified evidence",
+        )
+        if any(label not in nodes for label in required_labels):
+            continue
+
+        edges = set(_MERMAID_EDGE.findall(block))
+        orchestration = nodes["shaft orchestration"]
+        evidence = nodes["unified evidence"]
+        required_edges = {
+            (nodes["test intent"], orchestration),
+            (nodes["configuration"], orchestration),
+            *(
+                (orchestration, nodes[label])
+                for label in required_labels[3:7]
+            ),
+            *(
+                (nodes[label], evidence)
+                for label in required_labels[3:7]
+            ),
+        }
+        if required_edges.issubset(edges):
+            return True
+    return False
+
+
+def validate_readme_contract(readme: str) -> list[str]:
+    """Validate the visible, developer-facing trust contract owned by README.md."""
+    errors: list[str] = []
+    link_scan = _link_scan_markup(readme)
+    visible = _visible_markup(readme)
+    readme_destinations = set(destinations(readme))
+
+    if USER_GUIDE_ROOT not in readme_destinations:
+        errors.append(f"README.md is missing the user-guide landing page: {USER_GUIDE_ROOT}")
+    if any(
+        (urlsplit(destination).hostname or "").lower() == USER_GUIDE_HOST
+        and destination != USER_GUIDE_ROOT
+        for destination in readme_destinations
+    ):
+        errors.append(
+            f"README.md user-guide links must target {USER_GUIDE_ROOT} exactly"
+        )
+
+    prominent_logo = False
+    for image in _IMG_TAG.finditer(link_scan):
+        attributes = _attributes(image.group(1))
+        if not attributes.get("src", "").endswith("shaft_standard.png"):
+            continue
+        try:
+            prominent_logo = int(attributes.get("width", "0")) >= 240
+        except ValueError:
+            prominent_logo = False
+        if prominent_logo:
+            break
+    if not prominent_logo:
+        errors.append("README.md must display the SHAFT S logo prominently")
+    if _GENERATOR_LINK.search(link_scan) is None:
+        errors.append("README.md is missing the generator-first journey")
+
+    prose = link_scan.lower()
+    prose_markers = (
+        "test intent and configuration",
+        "orchestration",
+        "execution surfaces",
+        "unified evidence",
+    )
+    if (
+        any(marker not in prose for marker in prose_markers)
+        or not _has_accessible_evidence_workflow(readme)
+    ):
+        errors.append("README.md is missing the accessible Mermaid evidence workflow")
+    if "io.github.shafthq:shaft-engine" not in visible:
+        errors.append("README.md is missing the canonical Maven coordinate")
+    if _BUILD_BADGE.search(link_scan) is None:
+        errors.append("README.md is missing the pr-gate.yml build badge")
+
+    return errors

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -8,12 +8,11 @@ import sys
 
 try:
     from scripts.ci.readme_contract import (
-        USER_GUIDE_ROOT,
         destinations,
         validate_readme_contract,
     )
 except ModuleNotFoundError:  # Direct script execution adds scripts/ci to sys.path.
-    from readme_contract import USER_GUIDE_ROOT, destinations, validate_readme_contract
+    from readme_contract import destinations, validate_readme_contract
 
 ROOT = Path(__file__).resolve().parents[2]
 RELEASES_URL = "https://github.com/ShaftHQ/SHAFT_ENGINE/releases"

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -4,13 +4,19 @@
 from fnmatch import fnmatch
 import os
 from pathlib import Path
-import re
 import sys
 
+try:
+    from scripts.ci.readme_contract import (
+        USER_GUIDE_ROOT,
+        destinations,
+        validate_readme_contract,
+    )
+except ModuleNotFoundError:  # Direct script execution adds scripts/ci to sys.path.
+    from readme_contract import USER_GUIDE_ROOT, destinations, validate_readme_contract
+
 ROOT = Path(__file__).resolve().parents[2]
-DOCS_BASE = "https://shafthq.github.io/docs/"
 RELEASES_URL = "https://github.com/ShaftHQ/SHAFT_ENGINE/releases"
-MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)\s]+)")
 
 ALLOWED_EXACT = {
     "README.md",
@@ -112,30 +118,16 @@ def validate_repository(root: Path = ROOT) -> list[str]:
                 errors.append(f"non-root README is prohibited: {path}")
 
     readme = (root / "README.md").read_text(encoding="utf-8")
-    readme_links = set(MARKDOWN_LINK.findall(readme))
+    readme_links = set(destinations(readme))
     if len(readme.splitlines()) > 160:
         errors.append("README.md exceeds the 160-line landing-page budget")
-    for route in (
-        "start/overview",
-        "start/quick-start",
-        "start/installation",
-        "start/upgrade",
-        "testing/web",
-        "testing/mobile",
-        "testing/api",
-        "agentic/mcp",
-        "agentic/skills",
-        "agentic/doctor",
-        "agentic/heal",
-    ):
-        if f"{DOCS_BASE}{route}" not in readme_links:
-            errors.append(f"README.md is missing canonical route: {route}")
+    errors.extend(validate_readme_contract(readme))
     if "https://github.com/sponsors/MohabMohie" not in readme_links:
         errors.append("README.md is missing the GitHub Sponsors call to action")
 
     catalog_path = root / "modular-era-feature-catalog.md"
     if catalog_path.is_file():
-        catalog_links = set(MARKDOWN_LINK.findall(catalog_path.read_text(encoding="utf-8")))
+        catalog_links = set(destinations(catalog_path.read_text(encoding="utf-8")))
         if RELEASES_URL not in catalog_links:
             errors.append(
                 "modular-era-feature-catalog.md is missing the canonical release-history link"

--- a/scripts/ci/validate_modular_documentation.py
+++ b/scripts/ci/validate_modular_documentation.py
@@ -7,6 +7,11 @@ import subprocess  # nosec B404 - runs read-only git check-ignore query.
 import sys
 import xml.etree.ElementTree as ET
 
+try:
+    from scripts.ci.readme_contract import validate_readme_contract
+except ModuleNotFoundError:  # Direct script execution adds scripts/ci to sys.path.
+    from readme_contract import validate_readme_contract
+
 ROOT = Path(__file__).resolve().parents[2]
 EXAMPLES = ROOT / "shaft-engine/src/main/resources/examples"
 MCP_FIXTURES = ROOT / "shaft-mcp/src/test/resources/fixtures/shaft-pilot/mcp"
@@ -153,16 +158,6 @@ def main() -> None:
         fail("Internal.shaftEngineVersion must match the reactor version")
 
     canonical_links = {
-        ROOT / "README.md": (
-            f"{DOCS_BASE}/start/installation",
-            f"{DOCS_BASE}/start/upgrade",
-            f"{DOCS_BASE}/agentic/mcp",
-            f"{DOCS_BASE}/agentic/doctor",
-            f"{DOCS_BASE}/agentic/heal",
-            f"{DOCS_BASE}/testing/web",
-            f"{DOCS_BASE}/testing/mobile",
-            f"{DOCS_BASE}/testing/api",
-        ),
         ROOT / ".github/RELEASE_BODY_TEMPLATE.md": (
             f"{DOCS_BASE}/start/upgrade",
             f"{DOCS_BASE}/agentic/pilot",
@@ -208,6 +203,9 @@ def main() -> None:
         fail("doctor-analyze-invocations.json must not request provider credentials")
 
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme_errors = validate_readme_contract(readme)
+    if readme_errors:
+        fail(readme_errors[0])
     if "maven-central/v/io.github.shafthq/SHAFT_ENGINE" in readme:
         fail("README Maven Central badge still targets the legacy coordinate")
 

--- a/scripts/mcp/install_shaft_mcp.py
+++ b/scripts/mcp/install_shaft_mcp.py
@@ -72,6 +72,7 @@ AGENT_VALIDATION_SCRIPT_FILES = (
     "scripts/ci/validate_agent_guidance.py",
     "scripts/ci/harness_reachability.py",
     "scripts/ci/validate_documentation_boundaries.py",
+    "scripts/ci/readme_contract.py",
     "scripts/ci/validate_skills.py",
     "scripts/ci/worktree_hygiene.py",
     "scripts/ci/agent_guidance_budget.json",

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -661,11 +661,11 @@ class InstallShaftMcpTest(unittest.TestCase):
         self.assertEqual(expected, listed)
         self.assertIn("./shaft-developer", listed)
 
-    def test_readme_routes_agent_setup_to_the_current_skills_guide(self):
+    def test_readme_routes_agent_setup_without_website_subpaths(self):
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
         self.assertIn("`$shaft-developer`", readme)
-        self.assertIn("https://shafthq.github.io/docs/agentic/skills", readme)
+        self.assertIn("https://shafthq.github.io/", readme)
         self.assertIn("shaft-skills/references/shaft-mcp-tools.md", readme)
         self.assertIn("shaft-skills/references/shaft-cli-commands.md", readme)
         self.assertNotIn("act-as-shaft-dev", readme)

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 
 from scripts.ci.validate_documentation_boundaries import (
-    DOCS_BASE,
+    USER_GUIDE_ROOT,
     validate_repository,
 )
 
@@ -12,24 +12,36 @@ class ValidateDocumentationBoundariesTest(unittest.TestCase):
     def setUp(self):
         self.temporary_directory = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary_directory.name)
-        routes = (
-            "start/overview",
-            "start/quick-start",
-            "start/installation",
-            "start/upgrade",
-            "testing/web",
-            "testing/mobile",
-            "testing/api",
-            "agentic/mcp",
-            "agentic/skills",
-            "agentic/doctor",
-            "agentic/heal",
-        )
-        links = [
-            *(f"[{route}]({DOCS_BASE}{route})" for route in routes),
-            "[Sponsor SHAFT](https://github.com/sponsors/MohabMohie)",
-        ]
-        self.write("README.md", "\n".join(links))
+        self.valid_readme = f'''<picture>
+  <img src="shaft-engine/src/main/resources/images/shaft_standard.png" alt="SHAFT S logo" width="260">
+</picture>
+
+[![Build](https://img.shields.io/github/actions/workflow/status/ShaftHQ/SHAFT_ENGINE/pr-gate.yml?branch=main&style=for-the-badge)](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/pr-gate.yml)
+[User guide]({USER_GUIDE_ROOT})
+[Generate your first project]({USER_GUIDE_ROOT})
+[Sponsor SHAFT](https://github.com/sponsors/MohabMohie)
+
+Canonical Maven coordinate: **io.github.shafthq:shaft-engine**
+
+Test intent and configuration enter SHAFT orchestration, fan out across execution surfaces, and return as unified evidence.
+
+```mermaid
+flowchart LR
+    accTitle: SHAFT execution and evidence workflow
+    accDescr: Test intent and configuration enter SHAFT orchestration, run across execution surfaces, and produce unified evidence.
+    I[Test intent] --> S[SHAFT orchestration]
+    C[Configuration] --> S
+    S --> W[Web]
+    S --> M[Mobile]
+    S --> A[API]
+    S --> N[Native, CLI, and Database]
+    W --> E[Unified evidence]
+    M --> E
+    A --> E
+    N --> E
+```
+'''
+        self.write("README.md", self.valid_readme)
         self.write(
             "modular-era-feature-catalog.md",
             "[Release history](https://github.com/ShaftHQ/SHAFT_ENGINE/releases)",
@@ -106,54 +118,300 @@ class ValidateDocumentationBoundariesTest(unittest.TestCase):
             validate_repository(self.root),
         )
 
-    def test_requires_growth_landing_routes_and_sponsor_cta(self):
-        legacy_routes = (
-            "start/overview",
-            "start/installation",
-            "start/upgrade",
-            "testing/web",
-            "testing/mobile",
-            "testing/api",
-            "agentic/mcp",
-            "agentic/doctor",
-            "agentic/heal",
-        )
-        self.write("README.md", "\n".join(f"{DOCS_BASE}{route}" for route in legacy_routes))
+    def test_requires_user_guide_landing_page_and_sponsor_cta(self):
+        self.write("README.md", "# SHAFT\n")
 
         errors = validate_repository(self.root)
 
-        self.assertIn("README.md is missing canonical route: start/quick-start", errors)
-        self.assertIn("README.md is missing canonical route: agentic/skills", errors)
+        self.assertIn(
+            f"README.md is missing the user-guide landing page: {USER_GUIDE_ROOT}",
+            errors,
+        )
         self.assertIn("README.md is missing the GitHub Sponsors call to action", errors)
 
-    def test_rejects_bare_route_and_sponsor_urls_that_are_not_links(self):
-        routes = (
-            "start/overview",
-            "start/quick-start",
-            "start/installation",
-            "start/upgrade",
-            "testing/web",
-            "testing/mobile",
-            "testing/api",
-            "agentic/mcp",
-            "agentic/skills",
-            "agentic/doctor",
-            "agentic/heal",
-        )
+    def test_rejects_user_guide_subpath_even_when_root_link_exists(self):
         self.write(
             "README.md",
             "\n".join(
-                [
-                    *(f"[{route}]({DOCS_BASE}{route})" for route in routes[:-1]),
-                    f"plain text: {DOCS_BASE}{routes[-1]}",
-                    "plain text: https://github.com/sponsors/MohabMohie",
-                ]
+                (
+                    "[User guide](https://shafthq.github.io/)",
+                    "[Deep guide link](https://shafthq.github.io/docs/start/overview)",
+                    "[Sponsor SHAFT](https://github.com/sponsors/MohabMohie)",
+                )
             ),
+        )
+
+        self.assertIn(
+            "README.md user-guide links must target https://shafthq.github.io/ exactly",
+            validate_repository(self.root),
+        )
+
+    def test_rejects_user_guide_subpath_as_linked_badge_destination(self):
+        self.write(
+            "README.md",
+            self.valid_readme
+            + "\n[![Guide](https://img.shields.io/badge/guide-live-blue)]"
+            "(https://shafthq.github.io/docs/start/overview)\n",
+        )
+
+        self.assertIn(
+            "README.md user-guide links must target https://shafthq.github.io/ exactly",
+            validate_repository(self.root),
+        )
+
+    def test_rejects_user_guide_subpath_in_html_destination(self):
+        self.write(
+            "README.md",
+            self.valid_readme
+            + '\n<a href="https://shafthq.github.io/docs/start/overview">Guide</a>\n',
+        )
+
+        self.assertIn(
+            "README.md user-guide links must target https://shafthq.github.io/ exactly",
+            validate_repository(self.root),
+        )
+
+    def test_rejects_user_guide_subpath_in_html_image_source(self):
+        self.write(
+            "README.md",
+            self.valid_readme
+            + '\n<img src="https://shafthq.github.io/docs/preview.png" alt="Preview">\n',
+        )
+
+        self.assertIn(
+            "README.md user-guide links must target https://shafthq.github.io/ exactly",
+            validate_repository(self.root),
+        )
+
+    def test_rejects_user_guide_subpath_in_unquoted_html_attributes(self):
+        for element in (
+            '<a href=https://shafthq.github.io/docs/example>Guide</a>',
+            '<img src=https://shafthq.github.io/docs/example.png alt="Example">',
+        ):
+            with self.subTest(element=element):
+                self.write("README.md", self.valid_readme + f"\n{element}\n")
+
+                self.assertIn(
+                    "README.md user-guide links must target https://shafthq.github.io/ exactly",
+                    validate_repository(self.root),
+                )
+
+    def test_rejects_user_guide_subpath_in_reference_definition(self):
+        self.write(
+            "README.md",
+            self.valid_readme
+            + "\n[Deep guide][deep-guide]\n"
+            "[deep-guide]: https://shafthq.github.io/docs/start/overview\n",
+        )
+
+        self.assertIn(
+            "README.md user-guide links must target https://shafthq.github.io/ exactly",
+            validate_repository(self.root),
+        )
+
+    def test_ignores_unused_user_guide_reference_definition(self):
+        self.write(
+            "README.md",
+            self.valid_readme
+            + "\n[unused-guide]: https://shafthq.github.io/docs/example\n",
+        )
+
+        self.assertEqual(validate_repository(self.root), [])
+
+    def test_rejects_user_guide_subpath_in_autolink(self):
+        self.write(
+            "README.md",
+            self.valid_readme + "\n<https://shafthq.github.io/docs/start/overview>\n",
+        )
+
+        self.assertIn(
+            "README.md user-guide links must target https://shafthq.github.io/ exactly",
+            validate_repository(self.root),
+        )
+
+    def test_ignores_destinations_inside_fenced_code(self):
+        self.write(
+            "README.md",
+            self.valid_readme
+            + "\n```markdown\n[Example](https://shafthq.github.io/docs/example)\n```\n",
+        )
+
+        self.assertEqual(validate_repository(self.root), [])
+
+    def test_ignores_fenced_destinations_when_closer_is_longer(self):
+        for fenced_example in (
+            "```markdown\n[Example](https://shafthq.github.io/docs/example)\n````",
+            "~~~markdown\n[Example](https://shafthq.github.io/docs/example)\n~~~~",
+        ):
+            with self.subTest(fence=fenced_example.splitlines()[0]):
+                self.write("README.md", self.valid_readme + f"\n{fenced_example}\n")
+
+                self.assertEqual(validate_repository(self.root), [])
+
+    def test_ignores_destinations_inside_inline_code(self):
+        self.write(
+            "README.md",
+            self.valid_readme
+            + "\nExample only: `[Guide](https://shafthq.github.io/docs/example)`\n",
+        )
+
+        self.assertEqual(validate_repository(self.root), [])
+
+    def test_ignores_destinations_inside_html_comments(self):
+        self.write(
+            "README.md",
+            self.valid_readme
+            + '\n<!-- <a href="https://shafthq.github.io/docs/example">old</a> -->\n',
+        )
+
+        self.assertEqual(validate_repository(self.root), [])
+
+    def test_commented_readme_cannot_satisfy_visible_contract(self):
+        self.write("README.md", f"<!--\n{self.valid_readme}\n-->\n")
+
+        errors = validate_repository(self.root)
+
+        self.assertIn("README.md must display the SHAFT S logo prominently", errors)
+        self.assertIn("README.md is missing the generator-first journey", errors)
+        self.assertIn("README.md is missing the canonical Maven coordinate", errors)
+        self.assertIn("README.md is missing the pr-gate.yml build badge", errors)
+
+    def test_commented_mermaid_edges_do_not_satisfy_workflow(self):
+        readme = self.valid_readme
+        for edge in (
+            "I[Test intent] --> S[SHAFT orchestration]",
+            "C[Configuration] --> S",
+            "S --> W[Web, Mobile, API, and Native]",
+            "W --> E[Unified evidence]",
+        ):
+            readme = readme.replace(edge, f"%% {edge}")
+        self.write("README.md", readme)
+
+        self.assertIn(
+            "README.md is missing the accessible Mermaid evidence workflow",
+            validate_repository(self.root),
+        )
+
+    def test_mermaid_directives_outside_block_do_not_satisfy_workflow(self):
+        self.write(
+            "README.md",
+            self.valid_readme.replace("    accDescr:", "    description:")
+            + "\naccDescr: unrelated prose\n",
+        )
+
+        self.assertIn(
+            "README.md is missing the accessible Mermaid evidence workflow",
+            validate_repository(self.root),
+        )
+
+    def test_requires_prominent_s_logo(self):
+        self.write("README.md", self.valid_readme.replace('width="260"', 'width="120"'))
+
+        self.assertIn(
+            "README.md must display the SHAFT S logo prominently",
+            validate_repository(self.root),
+        )
+
+    def test_requires_generator_first_journey(self):
+        self.write(
+            "README.md",
+            self.valid_readme.replace("Generate your first project", "Browse features"),
+        )
+
+        self.assertIn(
+            "README.md is missing the generator-first journey",
+            validate_repository(self.root),
+        )
+
+    def test_requires_accessible_mermaid_evidence_workflow(self):
+        self.write(
+            "README.md",
+            self.valid_readme.replace("accDescr:", "description:"),
+        )
+
+        self.assertIn(
+            "README.md is missing the accessible Mermaid evidence workflow",
+            validate_repository(self.root),
+        )
+
+    def test_requires_canonical_maven_coordinate(self):
+        self.write(
+            "README.md",
+            self.valid_readme.replace(
+                "io.github.shafthq:shaft-engine", "io.github.shafthq:SHAFT_ENGINE"
+            ),
+        )
+
+        self.assertIn(
+            "README.md is missing the canonical Maven coordinate",
+            validate_repository(self.root),
+        )
+
+    def test_inline_code_coordinate_counts_as_visible_content(self):
+        self.write(
+            "README.md",
+            self.valid_readme.replace(
+                "**io.github.shafthq:shaft-engine**",
+                "`io.github.shafthq:shaft-engine`",
+            ),
+        )
+
+        self.assertEqual(validate_repository(self.root), [])
+
+    def test_s_logo_attributes_are_order_independent(self):
+        self.write(
+            "README.md",
+            self.valid_readme.replace(
+                '<img src="shaft-engine/src/main/resources/images/shaft_standard.png" alt="SHAFT S logo" width="260">',
+                '<img width="260" alt="SHAFT S logo" src="shaft-engine/src/main/resources/images/shaft_standard.png">',
+            ),
+        )
+
+        self.assertEqual(validate_repository(self.root), [])
+
+    def test_requires_pr_gate_build_badge(self):
+        self.write(
+            "README.md",
+            self.valid_readme.replace("pr-gate.yml", "build.yml"),
+        )
+
+        self.assertIn(
+            "README.md is missing the pr-gate.yml build badge",
+            validate_repository(self.root),
+        )
+
+    def test_build_workflow_url_outside_badge_does_not_satisfy_badge_contract(self):
+        correct_workflow = (
+            "https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/pr-gate.yml"
+        )
+        self.write(
+            "README.md",
+            self.valid_readme.replace(
+                f"]({correct_workflow})",
+                "](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/workflows/build.yml)",
+                1,
+            )
+            + f"\n[Workflow]({correct_workflow})\n",
+        )
+
+        self.assertIn(
+            "README.md is missing the pr-gate.yml build badge",
+            validate_repository(self.root),
+        )
+
+    def test_rejects_bare_guide_and_sponsor_urls_that_are_not_links(self):
+        self.write(
+            "README.md",
+            f"plain text: {USER_GUIDE_ROOT}\n"
+            "plain text: https://github.com/sponsors/MohabMohie",
         )
 
         errors = validate_repository(self.root)
 
-        self.assertIn("README.md is missing canonical route: agentic/heal", errors)
+        self.assertIn(
+            f"README.md is missing the user-guide landing page: {USER_GUIDE_ROOT}",
+            errors,
+        )
         self.assertIn("README.md is missing the GitHub Sponsors call to action", errors)
 
     def test_requires_catalog_release_history_link(self):

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -2,10 +2,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.ci.validate_documentation_boundaries import (
-    USER_GUIDE_ROOT,
-    validate_repository,
-)
+from scripts.ci.readme_contract import USER_GUIDE_ROOT
+from scripts.ci.validate_documentation_boundaries import validate_repository
 
 
 class ValidateDocumentationBoundariesTest(unittest.TestCase):


### PR DESCRIPTION
## Outcome

- refreshes the root README around reliable, scalable, maintainable Java automation and a generator-first developer journey
- makes the SHAFT S identity prominent, adds an accessible Mermaid evidence workflow, and preserves canonical Maven, CI, security, contribution, release, community, and supporter paths
- routes every website destination to the user-guide landing page exactly and adds shared validator coverage for rendered Markdown/HTML destinations and visible trust markers

## Trust rationale

The structure follows the strongest recurring pattern in highly adopted open-source READMEs: establish identity and utility immediately, provide one runnable first action, show the technical system compactly, and make maintenance, security, community, and support evidence easy to inspect. The README stays concise while the user guide retains detailed product documentation; claims remain source-backed and supporter language avoids implying customer status or endorsement.

## Validation

- RED: focused destination, rendering, badge-binding, Mermaid, identity, generator, Maven-coordinate, and code/comment mutation tests failed for the intended missing behavior before implementation; receipts are recorded on #4844
- `py -3 -m unittest tests.scripts.test_validate_documentation_boundaries tests.scripts.test_validate_modular_documentation tests.scripts.test_install_shaft_mcp.InstallShaftMcpTest.test_readme_routes_agent_setup_without_website_subpaths` — 38 tests passed
- `py -3 scripts/ci/validate_documentation_boundaries.py` — passed; 533 tracked Markdown files
- `py -3 scripts/ci/validate_modular_documentation.py` — passed
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` — passed
- `git diff --check` — passed
- independent adversarial review — clean

Closes #4844
