### PR TITLE
docs: correct local AI cgroup fallback note

### DIFF
--- a/tools/local-ai-poc/local_ai_poc.py
+++ b/tools/local-ai-poc/local_ai_poc.py
@@ -832,7 +832,7 @@ def memory_snapshot(
                     total = min(total, limit)
                     available = min(available, max(0, limit - current))
             except (OSError, KeyError, ValueError):
-                # Windows exposes no stable NVIDIA memory value when this diagnostic is unavailable.
+                # Missing/invalid cgroup-v1 metrics leave /proc/meminfo as the conservative source.
                 pass
     else:
         raise ValueError(f"Unsupported memory platform: {system}")


### PR DESCRIPTION
Corrects one misleading comment found in the final independent review of #4868. The exception is the Linux cgroup-v1 fallback, not Windows GPU detection. No executable behavior changes.

Verification: `py -3 -m unittest tests.scripts.test_local_ai_poc.ManifestAndSelectionTest.test_memory_detection_honors_available_memory_cgroup_limit_and_os_reserve -v` passed; `git diff --check` passed.

Related to #4852