### PR TITLE
feat(setup): add verified reporting lifecycle CLI

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -182,6 +182,7 @@ jobs:
               - 'shaft-cli/src/main/java/com/shaft/commandline/command/**'
             cli:
               - 'shaft-cli/**'
+              - 'shaft-infrastructure/**'
               - 'pom.xml'
             capture:
               - 'shaft-capture/**'
@@ -580,6 +581,8 @@ jobs:
         run: |
           java -jar shaft-cli/target/shaft-cli-*[0-9].jar --version
           java -jar shaft-cli/target/shaft-cli-*[0-9].jar --help
+          java -jar shaft-cli/target/shaft-cli-*[0-9].jar setup --help
+          java -jar shaft-cli/target/shaft-cli-*[0-9].jar setup catalog --json
 
   capture-e2e:
     name: SHAFT Capture Browser E2E

--- a/shaft-cli/pom.xml
+++ b/shaft-cli/pom.xml
@@ -27,6 +27,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shaft-infrastructure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
         </dependency>

--- a/shaft-cli/src/main/java/com/shaft/commandline/ShaftCli.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/ShaftCli.java
@@ -8,6 +8,7 @@ import com.shaft.commandline.command.DoctorCommand;
 import com.shaft.commandline.command.ElementCommand;
 import com.shaft.commandline.command.GuideCommand;
 import com.shaft.commandline.command.SessionCommand;
+import com.shaft.commandline.command.SetupCommand;
 import com.shaft.commandline.command.ToolsCommand;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -30,6 +31,7 @@ import java.nio.charset.StandardCharsets;
                 ToolsCommand.class,
                 CallCommand.class,
                 SessionCommand.class,
+                SetupCommand.class,
                 BrowserCommand.class,
                 ElementCommand.class,
                 CaptureCommand.class,

--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -1,0 +1,234 @@
+package com.shaft.commandline.command;
+
+import com.shaft.infrastructure.ReportingSetupPlanner;
+import com.shaft.infrastructure.ReportingSetupService;
+import com.shaft.infrastructure.SetupApproval;
+import com.shaft.infrastructure.SetupArchitecture;
+import com.shaft.infrastructure.SetupCatalog;
+import com.shaft.infrastructure.SetupMode;
+import com.shaft.infrastructure.SetupPlan;
+import com.shaft.infrastructure.SetupPlanJson;
+import com.shaft.infrastructure.SetupPlanStore;
+import com.shaft.infrastructure.SetupPlatform;
+import com.shaft.infrastructure.SetupProfile;
+import com.shaft.infrastructure.SetupProfileStatus;
+import com.shaft.infrastructure.SetupReadiness;
+import com.shaft.infrastructure.ShaftCachePaths;
+import com.shaft.commandline.util.Json;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+import picocli.CommandLine.Model.CommandSpec;
+
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+/** Direct, MCP-independent setup planning and lifecycle commands. */
+@Command(name = "setup", mixinStandardHelpOptions = true,
+        description = "Plan and manage SHAFT-owned local infrastructure.", subcommands = {
+        SetupCommand.Catalog.class, SetupCommand.Doctor.class, SetupCommand.Status.class,
+        SetupCommand.Plan.class, SetupCommand.Install.class, SetupCommand.Verify.class,
+        SetupCommand.Start.class, SetupCommand.Stop.class, SetupCommand.Logs.class})
+public final class SetupCommand implements Runnable {
+    @Spec
+    private CommandSpec spec;
+
+    @Override
+    public void run() {
+        spec.commandLine().usage(spec.commandLine().getOut());
+    }
+
+    @Command(name = "catalog", aliases = "profiles", mixinStandardHelpOptions = true,
+            description = "Show setup profiles, targets, and capabilities.")
+    static final class Catalog implements Callable<Integer> {
+        @Option(names = "--json", description = "Print machine-readable JSON.")
+        private boolean json;
+        @Spec private CommandSpec spec;
+
+        @Override
+        public Integer call() {
+            SetupCatalog catalog = SetupCatalog.builtIn();
+            if (json) spec.commandLine().getOut().println(Json.MAPPER.writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(catalog));
+            else catalog.profiles().forEach(profile -> spec.commandLine().getOut().println(
+                    profile.profile() + "\t" + profile.displayName() + "\t" + profile.targets()));
+            return 0;
+        }
+    }
+
+    @Command(name = "doctor", mixinStandardHelpOptions = true,
+            description = "Diagnose host support and reporting prerequisites.")
+    static final class Doctor extends ReadinessCommand { }
+
+    @Command(name = "status", mixinStandardHelpOptions = true,
+            description = "Report actual setup readiness.")
+    static final class Status extends ReadinessCommand { }
+
+    @Command(name = "verify", mixinStandardHelpOptions = true,
+            description = "Execute provider verification checks.")
+    static final class Verify extends ReadinessCommand { }
+
+    @Command(name = "plan", mixinStandardHelpOptions = true,
+            description = "Create an exact, reviewable setup plan.")
+    static final class Plan implements Callable<Integer> {
+        @Option(names = "--profile", required = true, description = "Setup profile.")
+        private SetupProfile profile;
+
+        @Option(names = "--mode", defaultValue = "EXTERNAL", description = "Ownership mode.")
+        private SetupMode mode;
+
+        @Option(names = "--output", required = true, description = "Plan JSON output file.")
+        private Path output;
+
+        @Option(names = "--json", description = "Print the plan as JSON.")
+        private boolean json;
+
+        @Spec
+        private CommandSpec spec;
+
+        @Override
+        public Integer call() throws Exception {
+            if (profile != SetupProfile.REPORTING) {
+                spec.commandLine().getErr().println("No setup provider is available for profile " + profile + '.');
+                return 4;
+            }
+            SetupPlan plan = ReportingSetupPlanner.plan(
+                    SetupPlatform.current(), SetupArchitecture.current(), mode);
+            if (!output.isAbsolute()) {
+                spec.commandLine().getErr().println("--output must be an absolute path.");
+                return 2;
+            }
+            SetupPlanStore.write(output, plan);
+            if (json) {
+                spec.commandLine().getOut().print(SetupPlanJson.write(plan));
+            } else {
+                spec.commandLine().getOut().println("Plan: " + output.toAbsolutePath().normalize());
+                spec.commandLine().getOut().println("Digest: " + plan.digest());
+            }
+            return 0;
+        }
+    }
+
+    @Command(name = "install", aliases = {"apply", "update"}, mixinStandardHelpOptions = true,
+            description = "Install one exact approved setup plan.")
+    static final class Install implements Callable<Integer> {
+        @Option(names = "--plan", required = true, description = "Persisted setup plan JSON.")
+        private Path planFile;
+        @Option(names = "--approve", required = true, description = "Exact plan digest to approve.")
+        private String approvedDigest;
+        @Option(names = "--accept-license", description = "Accepted license identifier.")
+        private Set<String> acceptedLicenses = new LinkedHashSet<>();
+        @Option(names = "--json", description = "Print machine-readable JSON.")
+        private boolean json;
+        @Mixin private RootOptions roots;
+        @Spec private CommandSpec spec;
+
+        @Override
+        public Integer call() {
+            try {
+                SetupPlan plan = SetupPlanStore.read(planFile);
+                ReportingSetupService service = service(roots);
+                var receipt = service.install(plan,
+                        new SetupApproval(approvedDigest, Instant.now(), acceptedLicenses));
+                if (json) spec.commandLine().getOut().println(Json.MAPPER.writerWithDefaultPrettyPrinter()
+                        .writeValueAsString(receipt));
+                else spec.commandLine().getOut().println("Installed approved plan " + receipt.planDigest());
+                return 0;
+            } catch (IllegalArgumentException failure) {
+                spec.commandLine().getErr().println(failure.getMessage());
+                return 2;
+            } catch (Exception failure) {
+                spec.commandLine().getErr().println(failure.getMessage());
+                return 5;
+            }
+        }
+    }
+
+    @Command(name = "start", mixinStandardHelpOptions = true,
+            description = "Start a SHAFT-owned service from its verified receipt.")
+    static final class Start extends UnsupportedLifecycle { }
+
+    @Command(name = "stop", mixinStandardHelpOptions = true,
+            description = "Stop a SHAFT-owned service identified by its lease.")
+    static final class Stop extends UnsupportedLifecycle { }
+
+    @Command(name = "logs", mixinStandardHelpOptions = true,
+            description = "Read logs for a SHAFT-owned setup provider.")
+    static final class Logs implements Callable<Integer> {
+        @Option(names = "--profile", required = true) private SetupProfile profile;
+        @Mixin private RootOptions roots;
+        @Spec private CommandSpec spec;
+
+        @Override
+        public Integer call() throws Exception {
+            if (profile != SetupProfile.REPORTING) return unsupported(spec, profile);
+            Path log = service(roots).logFile();
+            if (Files.notExists(log)) {
+                spec.commandLine().getErr().println("No owned logs exist for profile " + profile + '.');
+                return 3;
+            }
+            spec.commandLine().getOut().print(Files.readString(log));
+            return 0;
+        }
+    }
+
+    static class ReadinessCommand implements Callable<Integer> {
+        @Option(names = "--profile", required = true) private SetupProfile profile;
+        @Option(names = "--json", description = "Print machine-readable JSON.") private boolean json;
+        @Mixin private RootOptions roots;
+        @Spec private CommandSpec spec;
+
+        @Override
+        public Integer call() {
+            if (profile != SetupProfile.REPORTING) return unsupported(spec, profile);
+            SetupProfileStatus status = service(roots).status();
+            if (json) spec.commandLine().getOut().println(Json.MAPPER.writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(status));
+            else status.targets().forEach(target -> spec.commandLine().getOut().println(
+                    target.target() + "\t" + target.readiness() + "\t" + target.detectedVersion()
+                            + "\t" + target.detail()));
+            return status.readiness() == SetupReadiness.READY ? 0 : 3;
+        }
+    }
+
+    static class UnsupportedLifecycle implements Callable<Integer> {
+        @Option(names = "--profile", required = true) private SetupProfile profile;
+        @Spec private CommandSpec spec;
+        @Override public Integer call() { return unsupported(spec, profile); }
+    }
+
+    static final class RootOptions {
+        @Option(names = "--cache-root", description = "Override the absolute SHAFT cache root.")
+        private Path cacheRoot;
+        @Option(names = "--data-root", description = "Override the absolute SHAFT durable-data root.")
+        private Path dataRoot;
+
+        ShaftCachePaths paths() {
+            if (cacheRoot == null && dataRoot == null) return ShaftCachePaths.current();
+            if (cacheRoot == null || dataRoot == null) {
+                throw new IllegalArgumentException("--cache-root and --data-root must be supplied together.");
+            }
+            if (!cacheRoot.isAbsolute() || !dataRoot.isAbsolute()) {
+                throw new IllegalArgumentException("--cache-root and --data-root must be absolute.");
+            }
+            Path cache = cacheRoot.normalize();
+            Path data = dataRoot.normalize();
+            return new ShaftCachePaths(cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                    data.resolve("state"), data.resolve("receipts"));
+        }
+    }
+
+    private static ReportingSetupService service(RootOptions roots) {
+        return new ReportingSetupService(roots.paths(), SetupPlatform.current(), SetupArchitecture.current());
+    }
+
+    private static int unsupported(CommandSpec spec, SetupProfile profile) {
+        spec.commandLine().getErr().println("No lifecycle provider is available for profile " + profile + '.');
+        return 4;
+    }
+}

--- a/shaft-cli/src/main/resources/META-INF/shaft-cli/command-index.json
+++ b/shaft-cli/src/main/resources/META-INF/shaft-cli/command-index.json
@@ -38,6 +38,10 @@
       "description": "Manage the shaft-mcp daemon session (start | status | stop)."
     },
     {
+      "name": "setup",
+      "description": "Plan and manage SHAFT-owned local infrastructure."
+    },
+    {
       "name": "tools",
       "description": "List the tools exposed by shaft-mcp."
     }

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
@@ -1,0 +1,127 @@
+package com.shaft.commandline.command;
+
+import com.shaft.commandline.ShaftCli;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SetupCommandTest {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    @Test
+    void reportingPlanIsPersistedAndPrintedWithExactArtifacts(@TempDir Path temp) throws Exception {
+        Path planFile = temp.resolve("reporting-plan.json");
+        StringWriter stdout = new StringWriter();
+        StringWriter stderr = new StringWriter();
+        CommandLine cli = new CommandLine(new ShaftCli())
+                .setOut(new PrintWriter(stdout, true))
+                .setErr(new PrintWriter(stderr, true));
+
+        int exitCode = cli.execute("setup", "plan", "--profile", "REPORTING", "--mode", "MANAGED",
+                "--output", planFile.toString(), "--json");
+
+        assertEquals(0, exitCode, stderr.toString());
+        assertTrue(Files.isRegularFile(planFile));
+        JsonNode printed = JSON.readTree(stdout.toString());
+        JsonNode persisted = JSON.readTree(Files.readString(planFile));
+        assertEquals(persisted, printed);
+        assertEquals(2, persisted.get("schemaVersion").asInt());
+        assertEquals("REPORTING", persisted.get("profile").asText());
+        assertEquals("MANAGED", persisted.get("mode").asText());
+        assertTrue(persisted.get("digest").asText().matches("sha256:[0-9a-f]{64}"));
+        assertEquals("NODE", persisted.get("actions").get(0).get("target").asText());
+        assertEquals("ALLURE", persisted.get("actions").get(1).get("target").asText());
+        persisted.get("actions").forEach(action -> {
+            assertTrue(action.hasNonNull("version"));
+            assertTrue(action.hasNonNull("source"));
+            assertTrue(action.get("checksum").asText().matches("sha256:[0-9a-f]{64}"));
+            assertTrue(action.hasNonNull("dependencyLockChecksum"));
+            assertTrue(action.has("requiredLicenses"));
+            assertTrue(action.has("privileged"));
+        });
+    }
+
+    @Test
+    void staleInstallApprovalFailsBeforeCreatingManagedState(@TempDir Path temp) throws Exception {
+        Path planFile = temp.resolve("reporting-plan.json");
+        CommandResult planned = execute("setup", "plan", "--profile", "REPORTING", "--mode", "MANAGED",
+                "--output", planFile.toString(), "--json");
+        assertEquals(0, planned.exitCode(), planned.stderr());
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+
+        CommandResult installed = execute("setup", "install", "--plan", planFile.toString(),
+                "--approve", "sha256:" + "0".repeat(64), "--cache-root", cache.toString(),
+                "--data-root", data.toString(), "--json");
+
+        assertEquals(2, installed.exitCode());
+        assertTrue(installed.stderr().contains("approval is stale"), installed.stderr());
+        assertTrue(Files.notExists(cache));
+        assertTrue(Files.notExists(data));
+    }
+
+    @Test
+    void missingReportingToolsAreReportedAsMissing(@TempDir Path temp) throws Exception {
+        CommandResult result = execute("setup", "status", "--profile", "REPORTING",
+                "--cache-root", temp.resolve("cache").toAbsolutePath().toString(),
+                "--data-root", temp.resolve("data").toAbsolutePath().toString(), "--json");
+
+        assertEquals(3, result.exitCode());
+        JsonNode status = JSON.readTree(result.stdout());
+        assertEquals(1, status.get("schemaVersion").asInt());
+        assertEquals("MISSING", status.get("readiness").asText());
+        assertEquals("NODE", status.get("targets").get(0).get("target").asText());
+        assertEquals("ALLURE", status.get("targets").get(1).get("target").asText());
+    }
+
+    @Test
+    void setupHelpExposesOnlyTheApprovedVersionOneTree() {
+        CommandResult result = execute("setup", "--help");
+
+        assertEquals(0, result.exitCode(), result.stderr());
+        for (String command : java.util.List.of("catalog", "profiles", "doctor", "status", "plan", "install",
+                "apply", "update", "verify", "start", "stop", "logs")) {
+            assertTrue(result.stdout().contains(command), command);
+        }
+        for (String deferred : java.util.List.of("uninstall", "cache-clean")) {
+            assertTrue(!result.stdout().contains(deferred), deferred);
+        }
+    }
+
+    @Test
+    void relativeMutationRootsAreRejectedBeforeStateCreation(@TempDir Path temp) throws Exception {
+        Path planFile = temp.resolve("plan.json");
+        CommandResult planned = execute("setup", "plan", "--profile", "REPORTING", "--mode", "MANAGED",
+                "--output", planFile.toString(), "--json");
+        JsonNode plan = JSON.readTree(planned.stdout());
+
+        CommandResult result = execute("setup", "install", "--plan", planFile.toString(),
+                "--approve", plan.get("digest").asText(), "--cache-root", "relative-cache",
+                "--data-root", "relative-data");
+
+        assertEquals(2, result.exitCode());
+        assertTrue(result.stderr().contains("must be absolute"));
+    }
+
+    private static CommandResult execute(String... arguments) {
+        StringWriter stdout = new StringWriter();
+        StringWriter stderr = new StringWriter();
+        int exitCode = new CommandLine(new ShaftCli())
+                .setOut(new PrintWriter(stdout, true))
+                .setErr(new PrintWriter(stderr, true))
+                .execute(arguments);
+        return new CommandResult(exitCode, stdout.toString(), stderr.toString());
+    }
+
+    private record CommandResult(int exitCode, String stdout, String stderr) { }
+}

--- a/shaft-infrastructure/pom.xml
+++ b/shaft-infrastructure/pom.xml
@@ -22,6 +22,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupPlanner.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupPlanner.java
@@ -1,0 +1,45 @@
+package com.shaft.infrastructure;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Release-coupled planner for the reporting profile's portable Node and Allure tools. */
+public final class ReportingSetupPlanner {
+    public static final String NODE_VERSION = "24.19.0";
+    public static final String ALLURE_VERSION = "3.14.3";
+    private static final String ALLURE_SHA256 = "6388ce188104d0b58236598a2e8ff61882066fcf4d3b7c9e9e680a75344e2264";
+    public static final String ALLURE_LOCK_SHA256 = "385f9d727c62be5e5628a4826fc089cb99a8d9378f226cdcf781b4ac563abff1";
+    private static final Map<String, String> NODE_SHA256 = Map.of(
+            "darwin-arm64.tar.gz", "8294b7aa9b03997481c06babf1e8b270c859358f27da57a11509afe537ac381d",
+            "darwin-x64.tar.gz", "d1b5e999db158c62fe8f7267a4476b035d8bd93b1a605bac24a3f0dd166e3316",
+            "linux-arm64.tar.gz", "d28c8a5bf0a808f0ed434a1dce8c54ae98f0371c0bd86ac58abc613f73e6643f",
+            "linux-x64.tar.gz", "f625d97cd707df4ff96254916fbc5ff014f09c09effe5a1e0ca8f6d41a8789d4",
+            "win-arm64.zip", "8502f4a50b458d4cc38ed8f2001556c2cd239d464920f74017926ccb1e1c157f",
+            "win-x64.zip", "57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73");
+
+    private ReportingSetupPlanner() { }
+
+    public static SetupPlan plan(SetupPlatform platform, SetupArchitecture architecture, SetupMode mode) {
+        String platformToken = switch (platform) {
+            case WINDOWS -> "win";
+            case MACOS -> "darwin";
+            case LINUX -> "linux";
+        };
+        String extension = platform == SetupPlatform.WINDOWS ? "zip"
+                : "tar.gz";
+        String classifier = platformToken + '-' + architecture.artifactName() + '.' + extension;
+        String nodeFile = "node-v" + NODE_VERSION + '-' + classifier;
+        String nodeHash = NODE_SHA256.get(classifier);
+        if (nodeHash == null) throw new IllegalArgumentException("Unsupported reporting platform: " + classifier);
+        SetupActionKind kind = mode == SetupMode.EXTERNAL ? SetupActionKind.DIAGNOSE : SetupActionKind.INSTALL;
+        SetupAction node = new SetupAction(SetupTarget.NODE, kind, NODE_VERSION,
+                URI.create("https://nodejs.org/dist/v" + NODE_VERSION + '/' + nodeFile),
+                "sha256:" + nodeHash, false, Set.of());
+        SetupAction allure = new SetupAction(SetupTarget.ALLURE, kind, ALLURE_VERSION,
+                URI.create("https://registry.npmjs.org/allure/-/allure-" + ALLURE_VERSION + ".tgz"),
+                "sha256:" + ALLURE_SHA256, "sha256:" + ALLURE_LOCK_SHA256, false, Set.of());
+        return SetupPlan.create(SetupProfile.REPORTING, platform, architecture, mode, List.of(node, allure));
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupService.java
@@ -1,0 +1,401 @@
+package com.shaft.infrastructure;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/** Managed, release-pinned lifecycle for the REPORTING profile. */
+public final class ReportingSetupService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private final ShaftCachePaths paths;
+    private final SetupPlatform platform;
+    private final SetupArchitecture architecture;
+    private final ArtifactFetcher artifactFetcher;
+    private final CommandRunner commandRunner;
+
+    public ReportingSetupService(ShaftCachePaths paths, SetupPlatform platform, SetupArchitecture architecture) {
+        this(paths, platform, architecture, new VerifiedArtifactStore(paths.downloads())::fetch,
+                (command, log, timeout) -> runProcess(command, log, timeout, paths.cacheRoot(),
+                        nodeRoot(paths, platform, architecture)));
+    }
+
+    ReportingSetupService(ShaftCachePaths paths, SetupPlatform platform, SetupArchitecture architecture,
+                          ArtifactFetcher artifactFetcher, CommandRunner commandRunner) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.platform = java.util.Objects.requireNonNull(platform, "platform");
+        this.architecture = java.util.Objects.requireNonNull(architecture, "architecture");
+        this.artifactFetcher = java.util.Objects.requireNonNull(artifactFetcher, "artifactFetcher");
+        this.commandRunner = java.util.Objects.requireNonNull(commandRunner, "commandRunner");
+    }
+
+    public SetupProfileStatus status() {
+        SetupStatus node = probe(SetupTarget.NODE, nodeExecutable(), "v" + ReportingSetupPlanner.NODE_VERSION);
+        SetupStatus allure = probe(SetupTarget.ALLURE, allureEntryPoint(), ReportingSetupPlanner.ALLURE_VERSION);
+        SetupReadiness aggregate = node.readiness() == SetupReadiness.DEGRADED
+                || allure.readiness() == SetupReadiness.DEGRADED ? SetupReadiness.DEGRADED
+                : node.readiness() == SetupReadiness.READY && allure.readiness() == SetupReadiness.READY
+                ? SetupReadiness.READY : SetupReadiness.MISSING;
+        return new SetupProfileStatus(1, SetupProfile.REPORTING, aggregate, List.of(node, allure));
+    }
+
+    public SetupReceipt install(SetupPlan plan, SetupApproval approval) throws IOException {
+        requireCompatible(plan);
+        SetupExecutor.validate(plan, approval);
+        Files.createDirectories(paths.state());
+        Path lockPath = paths.state().resolve("reporting.lock");
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            SetupReceipt receipt = SetupExecutor.execute(plan, approval, action -> {
+                try {
+                    install(action);
+                } catch (IOException failure) {
+                    throw new SetupOperationException(failure);
+                }
+            });
+            writeReceipt(receipt);
+            return receipt;
+        }
+    }
+
+    public Path logFile() {
+        return paths.state().resolve("logs/reporting-install.log");
+    }
+
+    private void requireCompatible(SetupPlan plan) {
+        if (plan.profile() != SetupProfile.REPORTING) throw new IllegalArgumentException("Not a reporting plan.");
+        if (plan.platform() != platform || plan.architecture() != architecture) {
+            throw new IllegalArgumentException("Plan platform does not match this host.");
+        }
+        if (plan.mode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External plans are diagnostic and cannot be installed.");
+        }
+        SetupPlan expected = ReportingSetupPlanner.plan(platform, architecture, plan.mode());
+        if (!expected.equals(plan)) {
+            throw new IllegalArgumentException("Plan does not match the reporting manifest shipped with this release.");
+        }
+    }
+
+    private void install(SetupAction action) throws IOException {
+        switch (action.target()) {
+            case NODE -> installNode(artifactFetcher.fetch(action), action);
+            case ALLURE -> installAllure(artifactFetcher.fetch(action), action);
+            default -> throw new IllegalArgumentException("Reporting provider cannot install " + action.target());
+        }
+    }
+
+    private void installNode(Path archive, SetupAction action) throws IOException {
+        Path destination = nodeRoot();
+        if (probe(SetupTarget.NODE, nodeExecutable(), "v" + action.version()).readiness() == SetupReadiness.READY) return;
+        Path staging = stagingDirectory(destination);
+        try {
+            if (archive.getFileName().toString().endsWith(".zip")) extractZip(archive, staging);
+            else extractTar(archive, staging);
+            requireSuccessful(commandRunner.run(List.of(executable(staging, "node").toString(), "--version"),
+                    null, Duration.ofSeconds(30)),
+                    "Portable Node verification failed");
+            publish(staging, destination);
+        } finally {
+            deleteTree(staging);
+        }
+    }
+
+    private void installAllure(Path packageArchive, SetupAction action) throws IOException {
+        if (probe(SetupTarget.ALLURE, allureEntryPoint(), action.version()).readiness() == SetupReadiness.READY) return;
+        if (probe(SetupTarget.NODE, nodeExecutable(), "v" + ReportingSetupPlanner.NODE_VERSION).readiness()
+                != SetupReadiness.READY) throw new IOException("Portable Node must be ready before Allure installation.");
+        Path destination = allureRoot();
+        Path staging = stagingDirectory(destination);
+        try {
+            Path log = logFile();
+            Files.createDirectories(log.getParent());
+            copyReportingManifest(staging, action.dependencyLockChecksum());
+            requireSuccessful(commandRunner.run(List.of(nodeExecutable().toString(), npmCli().toString(),
+                    "cache", "add", packageArchive.toString()), log, Duration.ofMinutes(2)),
+                    "Allure package cache preparation failed; see " + log);
+            List<String> command = List.of(nodeExecutable().toString(), npmCli().toString(), "ci",
+                    "--prefix", staging.toString(), "--ignore-scripts", "--no-audit", "--no-fund");
+            requireSuccessful(commandRunner.run(command, log, Duration.ofMinutes(5)),
+                    "Allure npm installation failed; see " + log);
+            Path entryPoint = staging.resolve("node_modules/allure/cli.js");
+            requireSuccessful(commandRunner.run(List.of(nodeExecutable().toString(), entryPoint.toString(), "--version"),
+                    log, Duration.ofSeconds(30)), "Allure verification failed; see " + log);
+            publish(staging, destination);
+        } finally {
+            deleteTree(staging);
+        }
+    }
+
+    private SetupStatus probe(SetupTarget target, Path executable, String expectedVersion) {
+        if (!Files.isRegularFile(executable)) return new SetupStatus(target, SetupReadiness.MISSING, "", "Not installed.");
+        try {
+            ProcessResult result = target == SetupTarget.NODE
+                    ? commandRunner.run(List.of(executable.toString(), "--version"), null, Duration.ofSeconds(15))
+                    : commandRunner.run(List.of(nodeExecutable().toString(), executable.toString(), "--version"), null,
+                    Duration.ofSeconds(15));
+            String version = result.output().trim();
+            String normalized = target == SetupTarget.NODE && version.startsWith("v")
+                    ? version.substring(1) : version;
+            String normalizedExpected = expectedVersion.startsWith("v")
+                    ? expectedVersion.substring(1) : expectedVersion;
+            if (result.exitCode() == 0 && normalized.equals(normalizedExpected)) {
+                return new SetupStatus(target, SetupReadiness.READY, version, "Verified managed installation.");
+            }
+            return new SetupStatus(target, SetupReadiness.DEGRADED, version, "Version or execution check failed.");
+        } catch (IOException failure) {
+            return new SetupStatus(target, SetupReadiness.DEGRADED, "", failure.getMessage());
+        }
+    }
+
+    static ProcessResult runProcess(List<String> command, Path log, Duration timeout,
+                                    Path cacheRoot, Path nodeRoot) throws IOException {
+        ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
+        String nodeBin = Files.isRegularFile(nodeRoot.resolve("node.exe"))
+                ? nodeRoot.toString() : nodeRoot.resolve("bin").toString();
+        builder.environment().put("PATH", nodeBin + java.io.File.pathSeparator
+                + builder.environment().getOrDefault("PATH", ""));
+        builder.environment().put("npm_config_cache", cacheRoot.resolve("npm").toString());
+        Process process = builder.start();
+        InputStream input = process.getInputStream();
+        var outputFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+            try (input) {
+                return input.readAllBytes();
+            } catch (IOException failure) {
+                throw new java.util.concurrent.CompletionException(failure);
+            }
+        });
+        try {
+            if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                try {
+                    destroyProcessTree(process);
+                } finally {
+                    outputFuture.cancel(true);
+                }
+                throw new IOException("Process timed out: " + command.getFirst());
+            }
+        } catch (InterruptedException interrupted) {
+            try {
+                destroyProcessTree(process);
+            } finally {
+                outputFuture.cancel(true);
+                Thread.currentThread().interrupt();
+            }
+            throw new IOException("Interrupted while running setup process.", interrupted);
+        }
+        String output;
+        try {
+            output = new String(outputFuture.join(), java.nio.charset.StandardCharsets.UTF_8);
+        } catch (java.util.concurrent.CompletionException failure) {
+            if (failure.getCause() instanceof IOException io) throw io;
+            throw failure;
+        }
+        if (log != null) Files.writeString(log, output, java.nio.charset.StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        return new ProcessResult(process.exitValue(), output);
+    }
+
+    private static void waitForTermination(Process process) throws IOException {
+        try {
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                throw new IOException("Setup process did not terminate after forced destruction.");
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for setup process termination.", interrupted);
+        }
+    }
+
+    private static void destroyProcessTree(Process process) throws IOException {
+        List<ProcessHandle> descendants = process.descendants().toList().reversed();
+        descendants.forEach(handle -> {
+            if (handle.isAlive()) handle.destroyForcibly();
+        });
+        process.destroyForcibly();
+        waitForTermination(process);
+        for (ProcessHandle descendant : descendants) {
+            try {
+                descendant.onExit().get(10, TimeUnit.SECONDS);
+            } catch (java.util.concurrent.TimeoutException timeout) {
+                throw new IOException("Setup descendant process did not terminate: " + descendant.pid(), timeout);
+            } catch (java.util.concurrent.ExecutionException failure) {
+                throw new IOException("Unable to observe setup descendant termination: " + descendant.pid(), failure);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for setup descendant termination.", interrupted);
+            }
+        }
+    }
+
+    private void writeReceipt(SetupReceipt receipt) throws IOException {
+        Files.createDirectories(paths.receipts());
+        Path destination = paths.receipts().resolve("reporting.json");
+        Path temporary = Files.createTempFile(paths.receipts(), "reporting", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(receipt));
+            VerifiedArtifactStore.move(temporary, destination);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private static void copyReportingManifest(Path staging, String expectedLockChecksum) throws IOException {
+        for (String name : List.of("package.json", "package-lock.json")) {
+            String resource = "/com/shaft/infrastructure/reporting/" + name;
+            try (InputStream input = ReportingSetupService.class.getResourceAsStream(resource)) {
+                if (input == null) throw new IOException("Missing bundled reporting manifest: " + name);
+                Files.copy(input, staging.resolve(name));
+            }
+        }
+        String actual = "sha256:" + VerifiedArtifactStore.digest(staging.resolve("package-lock.json"));
+        if (!actual.equalsIgnoreCase(expectedLockChecksum)) {
+            throw new IOException("Bundled reporting dependency lock does not match the approved plan.");
+        }
+    }
+
+    private Path nodeRoot() {
+        return nodeRoot(paths, platform, architecture);
+    }
+
+    private static Path nodeRoot(ShaftCachePaths paths, SetupPlatform platform, SetupArchitecture architecture) {
+        return paths.tools().resolve("node").resolve(ReportingSetupPlanner.NODE_VERSION)
+                .resolve(platform.name().toLowerCase() + '-' + architecture.artifactName());
+    }
+
+    private Path allureRoot() {
+        return paths.tools().resolve("allure").resolve(ReportingSetupPlanner.ALLURE_VERSION);
+    }
+
+    private Path nodeExecutable() { return executable(nodeRoot(), "node"); }
+    private Path npmCli() {
+        return platform == SetupPlatform.WINDOWS
+                ? nodeRoot().resolve("node_modules/npm/bin/npm-cli.js")
+                : nodeRoot().resolve("lib/node_modules/npm/bin/npm-cli.js");
+    }
+    private Path allureEntryPoint() { return allureRoot().resolve("node_modules/allure/cli.js"); }
+
+    private Path executable(Path root, String name) {
+        return platform == SetupPlatform.WINDOWS ? root.resolve(name + ".exe") : root.resolve("bin").resolve(name);
+    }
+
+    private static Path stagingDirectory(Path destination) throws IOException {
+        Files.createDirectories(destination.getParent());
+        return Files.createTempDirectory(destination.getParent(), destination.getFileName() + ".staging-");
+    }
+
+    private static void publish(Path staging, Path destination) throws IOException {
+        publish(staging, destination, VerifiedArtifactStore::move);
+    }
+
+    static void publish(Path staging, Path destination, MoveOperation mover) throws IOException {
+        Path quarantine = null;
+        if (Files.exists(destination)) {
+            quarantine = destination.resolveSibling(destination.getFileName() + ".quarantine-" + System.nanoTime());
+            mover.move(destination, quarantine);
+        }
+        try {
+            mover.move(staging, destination);
+        } catch (IOException publishFailure) {
+            if (quarantine != null && Files.exists(quarantine) && Files.notExists(destination)) {
+                try {
+                    mover.move(quarantine, destination);
+                } catch (IOException restoreFailure) {
+                    publishFailure.addSuppressed(restoreFailure);
+                }
+            }
+            throw publishFailure;
+        }
+    }
+
+    private static void extractZip(Path archive, Path destination) throws IOException {
+        try (ZipInputStream input = new ZipInputStream(Files.newInputStream(archive))) {
+            for (ZipEntry entry; (entry = input.getNextEntry()) != null;) {
+                Path target = archiveTarget(destination, entry.getName());
+                if (target == null) continue;
+                if (entry.isDirectory()) Files.createDirectories(target);
+                else {
+                    Files.createDirectories(target.getParent());
+                    Files.copy(input, target);
+                }
+            }
+        }
+    }
+
+    private static void extractTar(Path archive, Path destination) throws IOException {
+        InputStream raw = Files.newInputStream(archive);
+        InputStream compressed = new GzipCompressorInputStream(raw);
+        try (TarArchiveInputStream input = new TarArchiveInputStream(compressed)) {
+            for (TarArchiveEntry entry; (entry = input.getNextEntry()) != null;) {
+                if (entry.isSymbolicLink() || entry.isLink()) throw new IOException("Archive links are not allowed.");
+                Path target = archiveTarget(destination, entry.getName());
+                if (target == null) continue;
+                if (entry.isDirectory()) Files.createDirectories(target);
+                else if (entry.isFile()) {
+                    Files.createDirectories(target.getParent());
+                    Files.copy(input, target);
+                    if ((entry.getMode() & 0111) != 0) makeExecutable(target);
+                }
+            }
+        }
+    }
+
+    private static Path archiveTarget(Path destination, String name) throws IOException {
+        String normalized = name.replace('\\', '/');
+        int firstSlash = normalized.indexOf('/');
+        if (firstSlash < 0 || firstSlash == normalized.length() - 1) return null;
+        Path target = destination.resolve(normalized.substring(firstSlash + 1)).normalize();
+        if (!target.startsWith(destination)) throw new IOException("Archive entry escapes its target: " + name);
+        return target;
+    }
+
+    private static void makeExecutable(Path file) throws IOException {
+        try {
+            Set<PosixFilePermission> permissions = EnumSet.copyOf(Files.getPosixFilePermissions(file));
+            permissions.add(PosixFilePermission.OWNER_EXECUTE);
+            permissions.add(PosixFilePermission.GROUP_EXECUTE);
+            permissions.add(PosixFilePermission.OTHERS_EXECUTE);
+            Files.setPosixFilePermissions(file, permissions);
+        } catch (UnsupportedOperationException ignored) {
+            if (!file.toFile().setExecutable(true, false)) throw new IOException("Cannot mark executable: " + file);
+        }
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (root == null || Files.notExists(root)) return;
+        try (var paths = Files.walk(root)) {
+            List<Path> reverse = paths.sorted(java.util.Comparator.reverseOrder()).toList();
+            for (Path path : reverse) Files.deleteIfExists(path);
+        }
+    }
+
+    private static void requireSuccessful(ProcessResult result, String message) throws IOException {
+        if (result.exitCode() != 0) throw new IOException(message + System.lineSeparator() + result.output());
+    }
+
+    @FunctionalInterface
+    interface ArtifactFetcher { Path fetch(SetupAction action) throws IOException; }
+    @FunctionalInterface
+    interface MoveOperation { void move(Path source, Path destination) throws IOException; }
+    @FunctionalInterface
+    interface CommandRunner { ProcessResult run(List<String> command, Path log, Duration timeout) throws IOException; }
+    record ProcessResult(int exitCode, String output) { }
+    private static final class SetupOperationException extends RuntimeException {
+        private SetupOperationException(IOException cause) { super(cause); }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupAction.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupAction.java
@@ -6,7 +6,8 @@ import java.util.Set;
 
 /** Fully bound setup operation used for review, digesting, and execution. */
 public record SetupAction(SetupTarget target, SetupActionKind kind, String version, URI source,
-                          String checksum, boolean privileged, Set<String> requiredLicenses) {
+                          String checksum, String dependencyLockChecksum,
+                          boolean privileged, Set<String> requiredLicenses) {
     public SetupAction {
         Objects.requireNonNull(target, "target");
         Objects.requireNonNull(kind, "kind");
@@ -15,9 +16,18 @@ public record SetupAction(SetupTarget target, SetupActionKind kind, String versi
         if (checksum == null || !checksum.matches("sha256:[0-9a-fA-F]{64}")) {
             throw new IllegalArgumentException("Checksum must be a SHA-256 digest.");
         }
+        if (dependencyLockChecksum == null || (!dependencyLockChecksum.isBlank()
+                && !dependencyLockChecksum.matches("sha256:[0-9a-fA-F]{64}"))) {
+            throw new IllegalArgumentException("Dependency-lock checksum must be blank or a SHA-256 digest.");
+        }
         requiredLicenses = Set.copyOf(Objects.requireNonNull(requiredLicenses, "requiredLicenses"));
         if (requiredLicenses.stream().anyMatch(license -> license == null || license.isBlank())) {
             throw new IllegalArgumentException("License identifiers must not be blank.");
         }
+    }
+
+    public SetupAction(SetupTarget target, SetupActionKind kind, String version, URI source,
+                       String checksum, boolean privileged, Set<String> requiredLicenses) {
+        this(target, kind, version, source, checksum, "", privileged, requiredLicenses);
     }
 }

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupArchitecture.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupArchitecture.java
@@ -1,0 +1,34 @@
+package com.shaft.infrastructure;
+
+import java.util.Locale;
+
+/** Supported host architecture bound into setup plans and artifact selection. */
+public enum SetupArchitecture {
+    X64("x64"),
+    ARM64("arm64");
+
+    private final String artifactName;
+
+    SetupArchitecture(String artifactName) {
+        this.artifactName = artifactName;
+    }
+
+    public String artifactName() {
+        return artifactName;
+    }
+
+    public static SetupArchitecture current() {
+        return fromOsArch(System.getProperty("os.arch"));
+    }
+
+    public static SetupArchitecture fromOsArch(String osArch) {
+        if (osArch == null || osArch.isBlank()) {
+            throw new IllegalArgumentException("Operating-system architecture must not be blank.");
+        }
+        return switch (osArch.toLowerCase(Locale.ROOT)) {
+            case "amd64", "x86_64", "x64" -> X64;
+            case "aarch64", "arm64" -> ARM64;
+            default -> throw new IllegalArgumentException("Unsupported operating-system architecture: " + osArch);
+        };
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupExecutor.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupExecutor.java
@@ -12,19 +12,8 @@ public final class SetupExecutor {
 
     public static SetupReceipt execute(SetupPlan plan, SetupApproval approval,
                                        Consumer<SetupAction> actionExecutor) {
-        Objects.requireNonNull(plan, "plan");
-        Objects.requireNonNull(approval, "approval");
+        validate(plan, approval);
         Objects.requireNonNull(actionExecutor, "actionExecutor");
-        if (!plan.digest().equals(approval.planDigest())) {
-            throw new StaleSetupApprovalException(approval.planDigest(), plan.digest());
-        }
-        var requiredLicenses = plan.actions().stream().flatMap(action -> action.requiredLicenses().stream())
-                .collect(java.util.stream.Collectors.toUnmodifiableSet());
-        if (!approval.acceptedLicenses().containsAll(requiredLicenses)) {
-            var missing = new java.util.TreeSet<>(requiredLicenses);
-            missing.removeAll(approval.acceptedLicenses());
-            throw new IllegalArgumentException("Missing required license acceptance: " + missing);
-        }
         List<SetupAction> completed = new ArrayList<>();
         for (SetupAction action : plan.actions()) {
             try {
@@ -36,5 +25,21 @@ public final class SetupExecutor {
             }
         }
         return new SetupReceipt(plan.digest(), Instant.now(), completed);
+    }
+
+    /** Validates approval and licenses without creating files or invoking an action executor. */
+    public static void validate(SetupPlan plan, SetupApproval approval) {
+        Objects.requireNonNull(plan, "plan");
+        Objects.requireNonNull(approval, "approval");
+        if (!plan.digest().equals(approval.planDigest())) {
+            throw new StaleSetupApprovalException(approval.planDigest(), plan.digest());
+        }
+        var requiredLicenses = plan.actions().stream().flatMap(action -> action.requiredLicenses().stream())
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        if (!approval.acceptedLicenses().containsAll(requiredLicenses)) {
+            var missing = new java.util.TreeSet<>(requiredLicenses);
+            missing.removeAll(approval.acceptedLicenses());
+            throw new IllegalArgumentException("Missing required license acceptance: " + missing);
+        }
     }
 }

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupPlan.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupPlan.java
@@ -11,30 +11,38 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /** Immutable, content-addressed setup plan. Action order is significant. */
-public record SetupPlan(int schemaVersion, SetupPlatform platform, SetupMode mode,
+public record SetupPlan(int schemaVersion, SetupProfile profile, SetupPlatform platform,
+                        SetupArchitecture architecture, SetupMode mode,
                         List<SetupAction> actions, String digest) {
     public SetupPlan {
-        if (schemaVersion != 1) throw new IllegalArgumentException("Unsupported plan schema version: " + schemaVersion);
+        if (schemaVersion != 2) throw new IllegalArgumentException("Unsupported plan schema version: " + schemaVersion);
+        Objects.requireNonNull(profile, "profile");
         Objects.requireNonNull(platform, "platform");
+        Objects.requireNonNull(architecture, "architecture");
         Objects.requireNonNull(mode, "mode");
         actions = List.copyOf(Objects.requireNonNull(actions, "actions"));
         if (actions.isEmpty()) throw new IllegalArgumentException("Plan must contain at least one action.");
         validatePolicy(mode, actions);
         if (digest == null || digest.isBlank()) throw new IllegalArgumentException("Plan digest must not be blank.");
-        String expected = calculateDigest(schemaVersion, platform, mode, actions);
+        String expected = calculateDigest(schemaVersion, profile, platform, architecture, mode, actions);
         if (!expected.equals(digest)) throw new IllegalArgumentException("Plan digest does not match its content.");
     }
 
-    public static SetupPlan create(SetupPlatform platform, SetupMode mode, List<SetupAction> actions) {
+    public static SetupPlan create(SetupProfile profile, SetupPlatform platform, SetupArchitecture architecture,
+                                   SetupMode mode, List<SetupAction> actions) {
         List<SetupAction> immutable = List.copyOf(actions);
-        return new SetupPlan(1, platform, mode, immutable, calculateDigest(1, platform, mode, immutable));
+        return new SetupPlan(2, profile, platform, architecture, mode, immutable,
+                calculateDigest(2, profile, platform, architecture, mode, immutable));
     }
 
-    private static String calculateDigest(int schemaVersion, SetupPlatform platform, SetupMode mode,
+    private static String calculateDigest(int schemaVersion, SetupProfile profile, SetupPlatform platform,
+                                          SetupArchitecture architecture, SetupMode mode,
                                           List<SetupAction> actions) {
         StringBuilder canonical = new StringBuilder();
         append(canonical, Integer.toString(schemaVersion));
+        append(canonical, profile.name());
         append(canonical, platform.name());
+        append(canonical, architecture.name());
         append(canonical, mode.name());
         append(canonical, Integer.toString(actions.size()));
         actions.forEach(action -> {
@@ -43,6 +51,7 @@ public record SetupPlan(int schemaVersion, SetupPlatform platform, SetupMode mod
             append(canonical, action.version());
             append(canonical, action.source().toString());
             append(canonical, action.checksum());
+            append(canonical, action.dependencyLockChecksum());
             append(canonical, Boolean.toString(action.privileged()));
             append(canonical, Integer.toString(action.requiredLicenses().size()));
             action.requiredLicenses().stream().sorted().forEach(license -> append(canonical, license));

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupPlanJson.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupPlanJson.java
@@ -1,0 +1,28 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.DeserializationFeature;
+
+/** Stable JSON codec for setup-plan schema version 2. */
+public final class SetupPlanJson {
+    private static final JsonMapper JSON = JsonMapper.builder()
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+            .build();
+
+    private SetupPlanJson() { }
+
+    public static String write(SetupPlan plan) {
+        return JSON.writerWithDefaultPrettyPrinter().writeValueAsString(plan) + System.lineSeparator();
+    }
+
+    public static SetupPlan read(String json) {
+        try {
+            return JSON.readValue(json, SetupPlan.class);
+        } catch (tools.jackson.databind.DatabindException invalid) {
+            if (invalid.getCause() instanceof IllegalArgumentException rejected) throw rejected;
+            throw invalid;
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupPlanStore.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupPlanStore.java
@@ -1,0 +1,35 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/** Atomic persistence boundary for approved setup plans. */
+public final class SetupPlanStore {
+    private SetupPlanStore() { }
+
+    public static void write(Path destination, SetupPlan plan) throws IOException {
+        Path absolute = destination.toAbsolutePath().normalize();
+        Path parent = absolute.getParent();
+        if (parent == null) throw new IllegalArgumentException("Plan output must have a parent directory.");
+        Files.createDirectories(parent);
+        Path temporary = Files.createTempFile(parent, absolute.getFileName().toString(), ".tmp");
+        try {
+            Files.writeString(temporary, SetupPlanJson.write(plan), StandardCharsets.UTF_8);
+            try {
+                Files.move(temporary, absolute, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(temporary, absolute, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    public static SetupPlan read(Path source) throws IOException {
+        return SetupPlanJson.read(Files.readString(source.toAbsolutePath().normalize(), StandardCharsets.UTF_8));
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupProfileStatus.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupProfileStatus.java
@@ -1,0 +1,14 @@
+package com.shaft.infrastructure;
+
+import java.util.List;
+
+/** Aggregate readiness returned by a profile provider. */
+public record SetupProfileStatus(int schemaVersion, SetupProfile profile, SetupReadiness readiness,
+                                 List<SetupStatus> targets) {
+    public SetupProfileStatus {
+        if (schemaVersion != 1) throw new IllegalArgumentException("Unsupported status schema: " + schemaVersion);
+        java.util.Objects.requireNonNull(profile, "profile");
+        java.util.Objects.requireNonNull(readiness, "readiness");
+        targets = List.copyOf(java.util.Objects.requireNonNull(targets, "targets"));
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/VerifiedArtifactStore.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/VerifiedArtifactStore.java
@@ -1,0 +1,84 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/** Download cache that publishes an artifact only after its approved SHA-256 matches. */
+public final class VerifiedArtifactStore {
+    private final Path downloads;
+
+    public VerifiedArtifactStore(Path downloads) {
+        this.downloads = downloads.toAbsolutePath().normalize();
+    }
+
+    public Path fetch(SetupAction action) throws IOException {
+        String expected = action.checksum().substring("sha256:".length()).toLowerCase();
+        String sourcePath = action.source().getPath();
+        String sourceName = sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
+        if (sourceName.isBlank()) throw new IOException("Artifact source has no file name: " + action.source());
+        Path destination = downloads.resolve(expected + '-' + sourceName);
+        if (Files.isRegularFile(destination) && expected.equals(digest(destination))) return destination;
+        Files.createDirectories(downloads);
+        Files.deleteIfExists(destination);
+        Path temporary = Files.createTempFile(downloads, sourceName, ".part");
+        try (InputStream input = open(action.source())) {
+            Files.copy(input, temporary, StandardCopyOption.REPLACE_EXISTING);
+            String actual = digest(temporary);
+            if (!expected.equals(actual)) {
+                throw new IOException("SHA-256 mismatch for " + action.source() + ": expected " + expected
+                        + " but received " + actual);
+            }
+            move(temporary, destination);
+            return destination;
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private static InputStream open(URI source) throws IOException {
+        if ("file".equalsIgnoreCase(source.getScheme())) return Files.newInputStream(Path.of(source));
+        if (!"https".equalsIgnoreCase(source.getScheme())) {
+            throw new IOException("Only HTTPS and file setup artifacts are supported: " + source);
+        }
+        HttpURLConnection connection = (HttpURLConnection) source.toURL().openConnection();
+        connection.setConnectTimeout(30_000);
+        connection.setReadTimeout(120_000);
+        connection.setInstanceFollowRedirects(true);
+        int status = connection.getResponseCode();
+        if (status < 200 || status >= 300) {
+            connection.disconnect();
+            throw new IOException("Artifact download failed with HTTP " + status + ": " + source);
+        }
+        return connection.getInputStream();
+    }
+
+    static String digest(Path file) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (InputStream input = Files.newInputStream(file)) {
+                byte[] buffer = new byte[64 * 1024];
+                for (int read; (read = input.read(buffer)) >= 0;) digest.update(buffer, 0, read);
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
+    }
+
+    static void move(Path source, Path destination) throws IOException {
+        try {
+            Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException ignored) {
+            Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/resources/com/shaft/infrastructure/reporting/package-lock.json
+++ b/shaft-infrastructure/src/main/resources/com/shaft/infrastructure/reporting/package-lock.json
@@ -1,0 +1,2935 @@
+{
+  "name": "shaft-reporting-runtime",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "shaft-reporting-runtime",
+      "version": "1.0.0",
+      "dependencies": {
+        "allure": "3.14.3"
+      }
+    },
+    "node_modules/@allurereport/aql": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/aql/-/aql-3.14.3.tgz",
+      "integrity": "sha512-6GqgV3wKQmhc9bxIn6oNvZwyA5iqTKP9G+bs2iToMKPC2Subecj21cvVznXMiUK9T8k7fBhoPZDnwAjJhFH/ug==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@allurereport/charts-api": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/charts-api/-/charts-api-3.14.3.tgz",
+      "integrity": "sha512-Y9t/tPRk9QQi6CVCWlF4KU5cUsmscXTVB8VuoiuIGZHRwJ0iXrbVmjL6oECWXdFDLkZ6Ifo7qoeU83XmnMxdwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "d3-shape": "^3.2.0"
+      }
+    },
+    "node_modules/@allurereport/ci": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/ci/-/ci-3.14.3.tgz",
+      "integrity": "sha512-qHLB9wU1bR88u/zxDRTGnICgTGwHkF8eMfVgIbWJ68kpl24g5RTErQD/k2oqln141+wealR0eWDhy+c2lOYC6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3"
+      }
+    },
+    "node_modules/@allurereport/core": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/core/-/core-3.14.3.tgz",
+      "integrity": "sha512-BSqp2eIEIQJd61XTcfDekzHKy3eBG5q2CZ5vOEHP0Iudmkmog5l1ZOJZZS2oTlNOc9wzQ9HuwofDv7L63ht1gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/ci": "3.14.3",
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-agent": "3.14.3",
+        "@allurereport/plugin-allure2": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "@allurereport/plugin-awesome": "3.14.3",
+        "@allurereport/plugin-classic": "3.14.3",
+        "@allurereport/plugin-csv": "3.14.3",
+        "@allurereport/plugin-dashboard": "3.14.3",
+        "@allurereport/plugin-jira": "3.14.3",
+        "@allurereport/plugin-log": "3.14.3",
+        "@allurereport/plugin-progress": "3.14.3",
+        "@allurereport/plugin-slack": "3.14.3",
+        "@allurereport/plugin-testops": "3.14.3",
+        "@allurereport/plugin-testplan": "3.14.3",
+        "@allurereport/reader": "3.14.3",
+        "@allurereport/reader-api": "3.14.3",
+        "@allurereport/service": "3.14.3",
+        "@allurereport/summary": "3.14.3",
+        "glob": "^13.0.6",
+        "handlebars": "^4.7.9",
+        "node-stream-zip": "^1.15.0",
+        "p-limit": "^7.3.0",
+        "yaml": "^2.8.3",
+        "yoctocolors": "^2.1.2",
+        "zip-stream": "^7.0.5"
+      }
+    },
+    "node_modules/@allurereport/core-api": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/core-api/-/core-api-3.14.3.tgz",
+      "integrity": "sha512-vg2GaRGkTDDoc2j/xCsKB/JWpWAFG7+V+wdoZs/jDnMBq1D8aVPQJkjvgUajdJndc2WaOumOXBAQC+HiD9rksA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "d3-shape": "^3.2.0"
+      }
+    },
+    "node_modules/@allurereport/directory-watcher": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/directory-watcher/-/directory-watcher-3.14.3.tgz",
+      "integrity": "sha512-c8t2/iHT53jugrqeOYELN1NX4F2eJyTj8V7T74oFcyK/rD2ekWiV5baIveUr5iN9Lg0xX2e6lpoYHsPfoaRLvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chokidar": "^5.0.0"
+      }
+    },
+    "node_modules/@allurereport/git": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/git/-/git-3.14.3.tgz",
+      "integrity": "sha512-o8P7pnkSEVoqQxXM0nW7qZYextP2tAOdwCNomz//fhCzqIN1tAJoUr4SiIt+PxWkOZoFm5Sg7xvGAFgjGRJxRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3"
+      }
+    },
+    "node_modules/@allurereport/plugin-agent": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-agent/-/plugin-agent-3.14.3.tgz",
+      "integrity": "sha512-0qi4Vji8L5C8qfElSl5EM7Hark/PuKPrtq+Xf5NGSc7fwyh2JM9MzbLt+fsrjxITK2UBj9F6C4Zd59TDStpdRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "yaml": "^2.8.1"
+      }
+    },
+    "node_modules/@allurereport/plugin-allure2": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-allure2/-/plugin-allure2-3.14.3.tgz",
+      "integrity": "sha512-4yoP1PXDhTqXzkqmdnPQhIQKWfBSL6jE8wK0ARpEIBXIG3LVwDvUOJ644jESawQW7yR5qSL118q4fjprBfbFpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "find-up": "^8.0.0",
+        "handlebars": "^4.7.9"
+      }
+    },
+    "node_modules/@allurereport/plugin-api": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-api/-/plugin-api-3.14.3.tgz",
+      "integrity": "sha512-KIGIBwGCUe+Zas0KZlfW3Dp+qemcVKShB1WwrnkKx7NSsQ+isYuqb0oAgY3hD2fDtafOaKHedTUi7AXUAG683g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3"
+      }
+    },
+    "node_modules/@allurereport/plugin-awesome": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-awesome/-/plugin-awesome-3.14.3.tgz",
+      "integrity": "sha512-lqCC2O3At2x29Z9AbLNvAnkbKPw0tdYHeV/oSvc3wJ6J4LvToNqv5YzAhPu94DFG0LPsLvzpizekXg5wHiA4YQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.14.3",
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "@allurereport/web-awesome": "3.14.3",
+        "@allurereport/web-commons": "3.14.3",
+        "d3-shape": "^3.2.0",
+        "handlebars": "^4.7.9",
+        "markdown-it": "^14.2.0"
+      }
+    },
+    "node_modules/@allurereport/plugin-classic": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-classic/-/plugin-classic-3.14.3.tgz",
+      "integrity": "sha512-Y/d7Dbw5KjnddnVNIym+HF0Af9K7TRrRwRmeaDcOOct51jDGmKu1pfrro368CfxaRW00SaDVyxysVEAMtEQb5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "@allurereport/web-awesome": "3.14.3",
+        "@allurereport/web-classic": "3.14.3",
+        "@allurereport/web-commons": "3.14.3",
+        "d3-shape": "^3.2.0",
+        "handlebars": "^4.7.9",
+        "markdown-it": "^14.2.0"
+      }
+    },
+    "node_modules/@allurereport/plugin-csv": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-csv/-/plugin-csv-3.14.3.tgz",
+      "integrity": "sha512-RoVvGV+Dujh37mlcWyjzS6BLKt8EdIMEZedfVwt2hxgPShac5hub+PRWsbvfG6R+ZY4qDSMXJ8NtBpvBFG0fNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3"
+      }
+    },
+    "node_modules/@allurereport/plugin-dashboard": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-dashboard/-/plugin-dashboard-3.14.3.tgz",
+      "integrity": "sha512-jrYtKavVY0jsZlkv+sBmQH/RYTFPzVy9LWd6+Ixg3/RryQXGZh7Oy1jhp8szWbjiSmtbiS5toC6A6u7+7DbHBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.14.3",
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "@allurereport/web-commons": "3.14.3",
+        "@allurereport/web-dashboard": "3.14.3",
+        "d3-shape": "^3.2.0",
+        "handlebars": "^4.7.9"
+      }
+    },
+    "node_modules/@allurereport/plugin-jira": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-jira/-/plugin-jira-3.14.3.tgz",
+      "integrity": "sha512-a1casnI4HuVvfP34bir+Pxizs26IxJCGBAX4rDnUX8JZcWsmxYuRVN9Es3hwY/4Wu1YQnyFAWpjX5m+uo1jBDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "axios": "^1.18.1"
+      }
+    },
+    "node_modules/@allurereport/plugin-log": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-log/-/plugin-log-3.14.3.tgz",
+      "integrity": "sha512-6Mzkb1Xc6EhmWVupiTBfZIqh0tOMh/dHIAcjBF6rmH5fYMcCqZzrLWFFDrM17IurVwMNa2MdedkWfEtxGk+dzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "yoctocolors": "^2.1.2"
+      }
+    },
+    "node_modules/@allurereport/plugin-progress": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-progress/-/plugin-progress-3.14.3.tgz",
+      "integrity": "sha512-XakOAXzMdxXBkr58ssSrXrjIazhWHlS4c0qIuhQUahicYKkPtBQ1DndvTw5Z/wxMNUQSiFmkvUlfJyhF77jdcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "yoctocolors": "^2.1.2"
+      }
+    },
+    "node_modules/@allurereport/plugin-server-reload": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-server-reload/-/plugin-server-reload-3.14.3.tgz",
+      "integrity": "sha512-p8i58C65lZAkjGX5kQjfwVwpQiBXspXT2U5AwFw7eYlP9iggd5WPq0dj4+zHCmoZypqStssklnmE/0vsq1AnnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/plugin-api": "3.14.3",
+        "@allurereport/static-server": "3.14.3"
+      }
+    },
+    "node_modules/@allurereport/plugin-slack": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-slack/-/plugin-slack-3.14.3.tgz",
+      "integrity": "sha512-NCfsiacMJgSYF2w4Ck8hSSIpPK/CPN1pN27KqMz5QTb2aFok8IYdqjm8jebHtY9QrO3Um016OWht0/6fdasREg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3"
+      }
+    },
+    "node_modules/@allurereport/plugin-testops": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testops/-/plugin-testops-3.14.3.tgz",
+      "integrity": "sha512-+BhKvjc1y7RGO8OTBY3UjtNZxp+a/hBuWFuyvlPjIOXTAZcsTS5SsVyZH6P81dty6/i5AGS6KMhR2u1ImabEeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/ci": "3.14.3",
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/git": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "@allurereport/reader-api": "3.14.3",
+        "@allurereport/service": "3.14.3",
+        "axios": "^1.18.1",
+        "form-data": "^4.0.6",
+        "lodash-es": "^4.18.1",
+        "p-limit": "^7.3.0",
+        "progress": "^2.0.3",
+        "yoctocolors": "^2"
+      }
+    },
+    "node_modules/@allurereport/plugin-testplan": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testplan/-/plugin-testplan-3.14.3.tgz",
+      "integrity": "sha512-gpPTtJDf3cMN2XlraWMRnQPLgiE0NNfGoQP83HF0CYHZaTALGuqLo9M3CQkeMdV1Ni1WBYlb9Wh3JvPzSTf46w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3"
+      }
+    },
+    "node_modules/@allurereport/reader": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/reader/-/reader-3.14.3.tgz",
+      "integrity": "sha512-dc6xIgs1RDylaeSCdZtrpkGgg1CNeCKixx53uUEjwpqWmVR0OWMpW+cZ61jCUZ8hCHTmLSgLjoG6+frPwSlg7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "@allurereport/reader-api": "3.14.3",
+        "fast-xml-parser": "^5.7.0"
+      }
+    },
+    "node_modules/@allurereport/reader-api": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/reader-api/-/reader-api-3.14.3.tgz",
+      "integrity": "sha512-/1kWS28uEGmBZYtJIOw3O6Av0RPDoMGp2exW60HCieZOHNl/otTYYjH3y4xpFansbTgvn07VuT+dSuxnuS1/SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "mime-types": "^2.1.35"
+      }
+    },
+    "node_modules/@allurereport/service": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/service/-/service-3.14.3.tgz",
+      "integrity": "sha512-XCPMNSogkdrZxY18sa543JJsdhiiD3t2fJx4m5ou/+93bUIqydYlz7Hm+hwRqV7xoFlHUy7btAtMRWU8MV30Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "axios": "^1.18.1",
+        "open": "^11.0.0"
+      }
+    },
+    "node_modules/@allurereport/static-server": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/static-server/-/static-server-3.14.3.tgz",
+      "integrity": "sha512-QkgVpqz+E93YrwsPYTRKcQRFseMsF2i2VkmydvHmOCmTIuPrh2IYApvDvBM9homMUDlcJq4mxtYtpveihUVNXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/directory-watcher": "3.14.3",
+        "open": "^11.0.0"
+      }
+    },
+    "node_modules/@allurereport/summary": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/summary/-/summary-3.14.3.tgz",
+      "integrity": "sha512-Zjrcn/THCAoTYfiHyKogqbk/Lg55PKEk2nIrTfSsNbW95jXVzfCFyBP+0G6t+hNRstF+eAZWX85oT7ilX+EBiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "@allurereport/web-summary": "3.14.3",
+        "handlebars": "^4.7.9"
+      }
+    },
+    "node_modules/@allurereport/web-awesome": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-awesome/-/web-awesome-3.14.3.tgz",
+      "integrity": "sha512-07Zi9PFKPtpa2SwagujTkHfSzrLqdfzHxGp3m+dJhnfqmjAQaFojznGg1lyUdHCDaa4qkYTsm1UKefyjg2Vxbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.14.3",
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "@allurereport/web-commons": "3.14.3",
+        "@allurereport/web-components": "3.14.3",
+        "@preact/signals": "^2.6.1",
+        "clsx": "^2.1.1",
+        "d3-shape": "^3.2.0",
+        "i18next": "^24.0.2",
+        "md5": "^2.3.0",
+        "minisearch": "^7.2.0",
+        "preact": "^10.28.2",
+        "prismjs": "^1.30.0"
+      }
+    },
+    "node_modules/@allurereport/web-classic": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-classic/-/web-classic-3.14.3.tgz",
+      "integrity": "sha512-k/Udo8PDFKFE3S2v5pyu5qzAY8crrxNOICUMrXkXct1td/K05Whd7N+yKxSmQYtLi2o2v4IpJvD0Ia+B6rtasw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.14.3",
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/web-commons": "3.14.3",
+        "@allurereport/web-components": "3.14.3",
+        "@preact/signals": "^2.6.1",
+        "clsx": "^2.1.1",
+        "d3-shape": "^3.2.0",
+        "i18next": "^24.0.2",
+        "md5": "^2.3.0",
+        "preact": "^10.28.2",
+        "prismjs": "^1.30.0",
+        "split.js": "^1.6.5"
+      }
+    },
+    "node_modules/@allurereport/web-commons": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-commons/-/web-commons-3.14.3.tgz",
+      "integrity": "sha512-UkkgSSXcRIhL5Do23jLsQ+ozD/GH6kt31+n/0OEpkDh08IqXRLFhJWkgwYX9iI81/ersO3vTdoJRMljoa/Du/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/aql": "3.14.3",
+        "@allurereport/charts-api": "3.14.3",
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "@preact/signals": "^2.6.1",
+        "@preact/signals-core": "^1.12.2",
+        "ansi-to-html": "^0.7.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "dompurify": "^3.4.0",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "node_modules/@allurereport/web-components": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-components/-/web-components-3.14.3.tgz",
+      "integrity": "sha512-wcF07nV9FiUDcic0BxdPjal2pH9/T9nEatfa9ZfBtqNdnq1vhczUY57TOU1pKC3aMnYyw2qk3soofhlk0XgI4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.14.3",
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/web-commons": "3.14.3",
+        "@floating-ui/dom": "^1.7.4",
+        "@nivo/bar": "^0.99.0",
+        "@nivo/core": "^0.99.0",
+        "@nivo/funnel": "^0.99.0",
+        "@nivo/heatmap": "^0.99.0",
+        "@nivo/line": "^0.99.0",
+        "@nivo/pie": "^0.99.0",
+        "@nivo/text": "^0.99.0",
+        "@nivo/theming": "^0.99.0",
+        "@nivo/tooltip": "^0.99.0",
+        "@nivo/treemap": "^0.99.0",
+        "@preact/compat": "^18.3.1",
+        "@preact/signals": "^2.6.1",
+        "@react-spring/web": "^10.0.3",
+        "clsx": "^2.1.1",
+        "d3-array": "^3.2.4",
+        "d3-axis": "^3.0.0",
+        "d3-brush": "^3.0.0",
+        "d3-format": "^3.1.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-regression": "^1.3.10",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-tip": "^0.9.1",
+        "d3-transition": "^3.0.1",
+        "lodash": "^4.18.1",
+        "markdown-it": "^14.2.0",
+        "preact": "^10.28.2",
+        "prismjs": "^1.30.0",
+        "react": "npm:@preact/compat@*",
+        "react-dom": "npm:@preact/compat@*",
+        "sortablejs": "^1.15.7",
+        "use-debounce": "^10.0.6"
+      }
+    },
+    "node_modules/@allurereport/web-dashboard": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-dashboard/-/web-dashboard-3.14.3.tgz",
+      "integrity": "sha512-qOy8sPEAMUF05j8512I5tKilEcJjDUDxCCNazFeU07azKHevC6tu7tXn+2bQTzwcxiEWWlNmqSbjbSEyXP6x+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.14.3",
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/web-commons": "3.14.3",
+        "@allurereport/web-components": "3.14.3",
+        "@preact/signals": "^2.6.1",
+        "clsx": "^2.1.1",
+        "i18next": "^24.0.2",
+        "preact": "^10.28.2"
+      }
+    },
+    "node_modules/@allurereport/web-summary": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-summary/-/web-summary-3.14.3.tgz",
+      "integrity": "sha512-eIwTzJ3CGwCVey72zH77i5i51Nr4t56cgco7OcHvBjp9SlVk0k6AH3jKvKbUrE5KmSDN5o/KwOvBknu9oIFagw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/web-commons": "3.14.3",
+        "@allurereport/web-components": "3.14.3",
+        "@preact/signals": "^2.6.1",
+        "clsx": "^2.1.1",
+        "i18next": "^24.0.2",
+        "preact": "^10.28.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "node_modules/@nivo/annotations": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.99.0.tgz",
+      "integrity": "sha512-jCuuXPbvpaqaz4xF7k5dv0OT2ubn5Nt0gWryuTe/8oVsC/9bzSuK8bM9vBty60m9tfO+X8vUYliuaCDwGksC2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/arcs": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/arcs/-/arcs-0.99.0.tgz",
+      "integrity": "sha512-UcvWLQPl+A3APk2Gm74N5xDfT+ATnVs2XkP73WxhYPWJk+dBzF00cndA5g/dptOwdFBvvo62VgcCsNiwUsjKTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/core": "9.4.5 || ^9.7.2 || ^10.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/axes": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.99.0.tgz",
+      "integrity": "sha512-3KschnmEL0acRoa7INSSOSEFwJLm54aZwSev7/r8XxXlkgRBriu6ReZy/FG0wfN+ljZ4GMvx+XyIIf6kxzvrZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-format": "^1.4.1",
+        "@types/d3-time-format": "^2.3.1",
+        "d3-format": "^1.4.4",
+        "d3-time-format": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/axes/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@nivo/bar": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.99.0.tgz",
+      "integrity": "sha512-9yfMn7H6UF/TqtCwVZ/vihVAXUff9wWvSaeF2Z1DCfgr5S07qs31Qb2p0LZA+YgCWpaU7zqkeb3VZ4WCpZbrDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/annotations": "0.99.0",
+        "@nivo/axes": "0.99.0",
+        "@nivo/canvas": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-shape": "^3.1.6",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/canvas": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/canvas/-/canvas-0.99.0.tgz",
+      "integrity": "sha512-UxA8zb+NPwqmNm81hoyUZSMAikgjU1ukLf4KybVNyV8ejcJM+BUFXsb8DxTcLdt4nmCFHqM56GaJQv2hnAHmzg==",
+      "license": "MIT"
+    },
+    "node_modules/@nivo/colors": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.99.0.tgz",
+      "integrity": "sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-color": "^3.0.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "d3-color": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/core": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.99.0.tgz",
+      "integrity": "sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "react-virtualized-auto-sizer": "^1.0.26",
+        "use-debounce": "^10.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/core/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@nivo/funnel": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/funnel/-/funnel-0.99.0.tgz",
+      "integrity": "sha512-1wiAeY/+Xl1W7Y6S2aNTatEjXXtKX2BW94+zlICML8eWxx/ke7wyiiMsiu3XtJD+tADepzx9DsZKeXUyErat+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/annotations": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-shape": "^3.1.6",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/heatmap": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/heatmap/-/heatmap-0.99.0.tgz",
+      "integrity": "sha512-cnd5V6XYLvHtQ8GObUyYyEgmAUa5/ERYVmNXR1znA+yzmB+tGthJsOeGar+ntCb43pIL5HbhEaD3YpsYzBxOhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/annotations": "0.99.0",
+        "@nivo/axes": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/core": "9.4.5 || ^9.7.2 || ^10.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-scale": "^4.0.8",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/legends": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.99.0.tgz",
+      "integrity": "sha512-P16FjFqNceuTTZphINAh5p0RF0opu3cCKoWppe2aRD9IuVkvRm/wS5K1YwMCxDzKyKh5v0AuTlu9K6o3/hk8hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-scale": "^4.0.8",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/line": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/line/-/line-0.99.0.tgz",
+      "integrity": "sha512-bAqTXSjpnpcGMs341qWFUi7hJTqQiNoSeJHsYPuPS3icuXPcp3WETQH+zRZACeEF79ZigeOWCW+dzODgne1y9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/annotations": "0.99.0",
+        "@nivo/axes": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/scales": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@nivo/voronoi": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/pie": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/pie/-/pie-0.99.0.tgz",
+      "integrity": "sha512-zUbo8UdLndp2RMljrOqitAKKEnl7YypkJrOzjKLk8jQGU7qqUKtgFoJIPhiBsvNPs3xtX2KwgtS1+JKNTNns7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/arcs": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/scales": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.99.0.tgz",
+      "integrity": "sha512-g/2K4L6L8si6E2BWAHtFVGahtDKbUcO6xHJtlIZMwdzaJc7yB16EpWLK8AfI/A42KadLhJSJqBK3mty+c7YZ+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-time": "^1.1.1",
+        "@types/d3-time-format": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-time": "^1.0.11",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@nivo/scales/node_modules/@types/d3-time-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
+      "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg==",
+      "license": "MIT"
+    },
+    "node_modules/@nivo/text": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/text/-/text-0.99.0.tgz",
+      "integrity": "sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/theming": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/theming/-/theming-0.99.0.tgz",
+      "integrity": "sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/tooltip": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.99.0.tgz",
+      "integrity": "sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/treemap": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/treemap/-/treemap-0.99.0.tgz",
+      "integrity": "sha512-zGVQyR+e38UqUsMrsnio8Ulz7IYDZ4HpUv+iVKSYX29Fa8TS39yHGyaGXTXt6PvL6owjvdwhJ/7TQAeO/qcWaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/core": "9.4.5 || ^9.7.2 || ^10.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-hierarchy": "^3.1.7",
+        "d3-hierarchy": "^3.1.2",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/voronoi": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.99.0.tgz",
+      "integrity": "sha512-KfmMdidbYzhiUCki1FG4X4nHEFT4loK8G5bMBnmCl9U+S78W+gvkfrgD2Aoqp/Q9yKQvr3Y8UcZKSFZnn3HgjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@types/d3-delaunay": "^6.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "d3-delaunay": "^6.0.4",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@preact/compat": {
+      "version": "18.3.2",
+      "resolved": "https://registry.npmjs.org/@preact/compat/-/compat-18.3.2.tgz",
+      "integrity": "sha512-5vSl55K5yLMvocT7PBKxDOHGgYPjMrKQqqr6roSNjIXcJOtSgDDMjpiCAF3s7klRdmGrN75b/Przmjw8gmlg/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": "*"
+      }
+    },
+    "node_modules/@preact/signals": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.11.0.tgz",
+      "integrity": "sha512-mmrZ8I/Wef+tmSsQSjZySLRlnvuYAVfSZEy1+HrFvSwBtQf8/zSM+bV7odllUXIhKzUkBjsNk+TLZ20nt7p6Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.14.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": ">= 10.25.0 || >=11.0.0-0"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.1.2.tgz",
+      "integrity": "sha512-yAsQ/bbp6+vko7WNCI1M00c6KLE9XKTGCrgRhQqS4JcK3oF5qBV4rHYrQEprvEvYXxt+1H5FsLS2eVValEPfFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~10.1.2",
+        "@react-spring/types": "~10.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.1.2.tgz",
+      "integrity": "sha512-lPGOAg0V+PV3ucopOajD+YCxoe8twALqAeG4c/+sqVjBsyUNNdx8qfz/DcNSPKA8PV3+AyQELlCxlDfap9cmBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.1.2",
+        "@react-spring/shared": "~10.1.2",
+        "@react-spring/types": "~10.1.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.1.2.tgz",
+      "integrity": "sha512-KC6vSFZyPnRJ2rXqipV9QqR4SaYbYXjvKfdYKWipNK2mWuV79gr20WmpVUOsTiEHGRY3WSOdWCHN+P9Pdaqb7Q==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.1.2.tgz",
+      "integrity": "sha512-47/8bNQ/o0uEmxEnPBuERlC29VSqiTn5P9ln9tUMSVkYKYxBtouYE686F5kAGj+eHRPoNCw7drxWE9nv2d1LMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~10.1.2",
+        "@react-spring/types": "~10.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.1.2.tgz",
+      "integrity": "sha512-G4CWowmVPz+rDG1y9QRVq/prZNxiNwQaHC0kgT/MgY6jAGgdRgTV4VThpvJDwWvUitk3xZB4soP4d36fjeQ09g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.1.2.tgz",
+      "integrity": "sha512-KxDB3zaDqy9qFsu7fdxjyraAxweHH4k5TW5WGT/OuMK6hKaxSDfhrQfRBzfFaSVvMBf+NghbJFanllV4ia6i7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.1.2",
+        "@react-spring/core": "~10.1.2",
+        "@react-spring/shared": "~10.1.2",
+        "@react-spring/types": "~10.1.2",
+        "csstype": "^3.2.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.4.tgz",
+      "integrity": "sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.4.tgz",
+      "integrity": "sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/allure": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/allure/-/allure-3.14.3.tgz",
+      "integrity": "sha512-wHoEDWWDpiqjd6UaNlbCc619pwKkx6J1aJsmB7lCnrrEbaSNyvbw6yd67VI931B0GEkP+dORHRy21Rsuc4l7IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/charts-api": "3.14.3",
+        "@allurereport/ci": "3.14.3",
+        "@allurereport/core": "3.14.3",
+        "@allurereport/core-api": "3.14.3",
+        "@allurereport/directory-watcher": "3.14.3",
+        "@allurereport/plugin-agent": "3.14.3",
+        "@allurereport/plugin-allure2": "3.14.3",
+        "@allurereport/plugin-api": "3.14.3",
+        "@allurereport/plugin-awesome": "3.14.3",
+        "@allurereport/plugin-classic": "3.14.3",
+        "@allurereport/plugin-csv": "3.14.3",
+        "@allurereport/plugin-dashboard": "3.14.3",
+        "@allurereport/plugin-jira": "3.14.3",
+        "@allurereport/plugin-log": "3.14.3",
+        "@allurereport/plugin-progress": "3.14.3",
+        "@allurereport/plugin-server-reload": "3.14.3",
+        "@allurereport/plugin-slack": "3.14.3",
+        "@allurereport/reader-api": "3.14.3",
+        "@allurereport/service": "3.14.3",
+        "@allurereport/static-server": "3.14.3",
+        "adm-zip": "^0.5.16",
+        "clipanion": "^4.0.0-rc.4",
+        "glob": "^13.0.6",
+        "lodash.omit": "^4.18.0",
+        "prompts": "^2.4.2",
+        "typanion": "^3.14.0",
+        "yoctocolors": "^2.1.2"
+      },
+      "bin": {
+        "allure": "cli.js"
+      }
+    },
+    "node_modules/ansi-to-html": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.7.2.tgz",
+      "integrity": "sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.2.0"
+      },
+      "bin": {
+        "ansi-to-html": "bin/ansi-to-html"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clipanion": {
+      "version": "4.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-4.0.0-rc.4.tgz",
+      "integrity": "sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==",
+      "license": "MIT",
+      "workspaces": [
+        "website"
+      ],
+      "dependencies": {
+        "typanion": "^3.8.0"
+      },
+      "peerDependencies": {
+        "typanion": "*"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-regression": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/d3-regression/-/d3-regression-1.3.10.tgz",
+      "integrity": "sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale/node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-tip": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/d3-tip/-/d3-tip-0.9.1.tgz",
+      "integrity": "sha512-EVBfG9d+HnjIoyVXfhpytWxlF59JaobwizqMX9EBXtsFmJytjwHeYiUs74ldHQjE7S9vzfKTx2LCtvUrIbuFYg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-collection": "^1.0.4",
+        "d3-selection": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=4.2.6"
+      }
+    },
+    "node_modules/d3-tip/node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-8.0.0.tgz",
+      "integrity": "sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^8.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-8.0.0.tgz",
+      "integrity": "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.omit": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
+      "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/node-stream-zip": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.16.0.tgz",
+      "integrity": "sha512-ObaRrRoR8T68wF6suxHd7R4XQNamij6ZQHrwG7Dx1D2zeHcDNLsIOBcWrIwtDm7AsCXBguaPHgXhcjxDa2szrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/antelle"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+      "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "name": "@preact/compat",
+      "version": "18.3.2",
+      "resolved": "https://registry.npmjs.org/@preact/compat/-/compat-18.3.2.tgz",
+      "integrity": "sha512-5vSl55K5yLMvocT7PBKxDOHGgYPjMrKQqqr6roSNjIXcJOtSgDDMjpiCAF3s7klRdmGrN75b/Przmjw8gmlg/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": "*"
+      }
+    },
+    "node_modules/react-dom": {
+      "name": "@preact/compat",
+      "version": "18.3.2",
+      "resolved": "https://registry.npmjs.org/@preact/compat/-/compat-18.3.2.tgz",
+      "integrity": "sha512-5vSl55K5yLMvocT7PBKxDOHGgYPjMrKQqqr6roSNjIXcJOtSgDDMjpiCAF3s7klRdmGrN75b/Przmjw8gmlg/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": "*"
+      }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split.js": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/split.js/-/split.js-1.6.5.tgz",
+      "integrity": "sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "node_modules/typanion": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
+      "integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==",
+      "license": "MIT",
+      "workspaces": [
+        "website"
+      ]
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.1.tgz",
+      "integrity": "sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
+      "license": "MIT",
+      "dependencies": {
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/shaft-infrastructure/src/main/resources/com/shaft/infrastructure/reporting/package.json
+++ b/shaft-infrastructure/src/main/resources/com/shaft/infrastructure/reporting/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shaft-reporting-runtime",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "allure": "3.14.3"
+  }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/ReportingSetupServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/ReportingSetupServiceTest.java
@@ -1,0 +1,239 @@
+package com.shaft.infrastructure;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReportingSetupServiceTest {
+    @Test
+    void installsAndReceiptsWindowsReportingProfileWithoutNetwork(@TempDir Path temp) throws Exception {
+        exerciseInstall(temp, SetupPlatform.WINDOWS, createNodeZip(temp.resolve("node.zip")));
+    }
+
+    @Test
+    void installsLinuxTarArchiveAndRoundTripsPlan(@TempDir Path temp) throws Exception {
+        SetupPlan plan = exerciseInstall(temp, SetupPlatform.LINUX, createNodeTar(temp.resolve("node.tar.gz")));
+        Path planFile = temp.resolve("plan.json");
+        SetupPlanStore.write(planFile, plan);
+        assertEquals(plan, SetupPlanStore.read(planFile));
+        assertEquals(plan, SetupPlanJson.read(SetupPlanJson.write(plan)));
+        assertThrows(IllegalArgumentException.class,
+                () -> SetupPlanJson.read(SetupPlanJson.write(plan).replace(plan.digest(), "sha256:" + "0".repeat(64))));
+        assertThrows(RuntimeException.class,
+                () -> SetupPlanJson.read(SetupPlanJson.write(plan).replaceFirst("\\{", "{\\\"bogus\\\":true,")));
+        assertThrows(RuntimeException.class,
+                () -> SetupPlanJson.read(SetupPlanJson.write(plan).replaceFirst("\\{", "{\"mode\":\"MANAGED\",")));
+    }
+
+    @Test
+    void verifiedArtifactStoreRejectsBadHashAndCachesGoodFile(@TempDir Path temp) throws Exception {
+        Path source = temp.resolve("artifact.bin");
+        Files.writeString(source, "verified");
+        String hash = "sha256:" + VerifiedArtifactStore.digest(source);
+        SetupAction good = new SetupAction(SetupTarget.ALLURE, SetupActionKind.INSTALL, "1",
+                source.toUri(), hash, false, Set.of());
+        VerifiedArtifactStore store = new VerifiedArtifactStore(temp.resolve("downloads"));
+        Path cached = store.fetch(good);
+        assertEquals(cached, store.fetch(good));
+        SetupAction bad = new SetupAction(SetupTarget.ALLURE, SetupActionKind.INSTALL, "1",
+                source.toUri(), "sha256:" + "0".repeat(64), false, Set.of());
+        assertThrows(IOException.class, () -> store.fetch(bad));
+    }
+
+    @Test
+    void architectureAliasesAndUnsupportedValueAreExplicit() {
+        assertEquals(SetupArchitecture.X64, SetupArchitecture.fromOsArch("amd64"));
+        assertEquals(SetupArchitecture.X64, SetupArchitecture.fromOsArch("x86_64"));
+        assertEquals(SetupArchitecture.ARM64, SetupArchitecture.fromOsArch("aarch64"));
+        assertEquals(SetupArchitecture.ARM64, SetupArchitecture.fromOsArch("ARM64"));
+        assertThrows(IllegalArgumentException.class, () -> SetupArchitecture.fromOsArch("x86"));
+        assertThrows(IllegalArgumentException.class, () -> SetupArchitecture.fromOsArch(" "));
+        assertTrue(SetupArchitecture.current() == SetupArchitecture.X64
+                || SetupArchitecture.current() == SetupArchitecture.ARM64);
+    }
+
+    @Test
+    void rejectsDiagnosticAndManifestDivergentPlansBeforeCreatingRoots(@TempDir Path temp) {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        ReportingSetupService service = new ReportingSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, action -> { throw new AssertionError("must not fetch"); },
+                (command, log, timeout) -> { throw new AssertionError("must not execute"); });
+        SetupPlan external = ReportingSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.EXTERNAL);
+        assertThrows(IllegalArgumentException.class, () -> service.install(external,
+                new SetupApproval(external.digest(), Instant.EPOCH, Set.of())));
+        SetupAction changed = new SetupAction(SetupTarget.ALLURE, SetupActionKind.INSTALL, "3.14.3",
+                java.net.URI.create("https://example.invalid/allure.tgz"), "sha256:" + "0".repeat(64),
+                false, Set.of());
+        SetupPlan divergent = SetupPlan.create(SetupProfile.REPORTING, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, SetupMode.MANAGED, List.of(changed));
+        assertThrows(IllegalArgumentException.class, () -> service.install(divergent,
+                new SetupApproval(divergent.digest(), Instant.EPOCH, Set.of())));
+        assertTrue(Files.notExists(cache));
+        assertTrue(Files.notExists(data));
+    }
+
+    @Test
+    void versionReadinessRequiresAnExactVersion(@TempDir Path temp) throws Exception {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        Path node = data.resolve("tools/node/24.19.0/windows-x64/node.exe");
+        Path allure = data.resolve("tools/allure/3.14.3/node_modules/allure/cli.js");
+        Files.createDirectories(node.getParent());
+        Files.createDirectories(allure.getParent());
+        Files.writeString(node, "node");
+        Files.writeString(allure, "allure");
+        ReportingSetupService service = new ReportingSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, action -> { throw new AssertionError(); },
+                (command, log, timeout) -> new ReportingSetupService.ProcessResult(0,
+                        command.stream().anyMatch(part -> part.endsWith("cli.js")) ? "3.14.30" : "v24.19.01"));
+
+        SetupProfileStatus status = service.status();
+        assertEquals(SetupReadiness.DEGRADED, status.readiness());
+        assertTrue(status.targets().stream().allMatch(target -> target.readiness() == SetupReadiness.DEGRADED));
+    }
+
+    @Test
+    void providerFailurePreservesFailedActionAndPartialReceipt(@TempDir Path temp) throws Exception {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        Path nodeArchive = createNodeZip(temp.resolve("node.zip"));
+        ReportingSetupService service = new ReportingSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, action -> {
+                    if (action.target() == SetupTarget.ALLURE) throw new IOException("offline");
+                    return nodeArchive;
+                }, (command, log, timeout) -> new ReportingSetupService.ProcessResult(0, "v24.19.0"));
+        SetupPlan plan = ReportingSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+
+        SetupExecutionException failure = assertThrows(SetupExecutionException.class,
+                () -> service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of())));
+        assertEquals(SetupTarget.ALLURE, failure.failedAction().target());
+        assertEquals(List.of(SetupTarget.NODE), failure.partialReceipt().completedActions().stream()
+                .map(SetupAction::target).toList());
+        assertTrue(Files.notExists(paths.receipts().resolve("reporting.json")));
+    }
+
+    @Test
+    void failedReplacementRestoresThePreviousInstallation(@TempDir Path temp) throws Exception {
+        Path installed = temp.resolve("installed");
+        Path staging = temp.resolve("staging");
+        Files.createDirectories(installed);
+        Files.createDirectories(staging);
+        Files.writeString(installed.resolve("previous.txt"), "previous");
+        Files.writeString(staging.resolve("next.txt"), "next");
+        java.util.concurrent.atomic.AtomicInteger moves = new java.util.concurrent.atomic.AtomicInteger();
+        ReportingSetupService.MoveOperation mover = (source, destination) -> {
+            if (moves.incrementAndGet() == 2) throw new IOException("publish blocked");
+            Files.move(source, destination);
+        };
+
+        assertThrows(IOException.class, () -> ReportingSetupService.publish(staging, installed, mover));
+        assertTrue(Files.isRegularFile(installed.resolve("previous.txt")));
+        assertTrue(Files.isRegularFile(staging.resolve("next.txt")));
+        assertEquals(3, moves.get());
+    }
+
+    @Test
+    void realChildProcessIsKilledAndReapedOnTimeout(@TempDir Path temp) {
+        Set<Long> before = ProcessHandle.allProcesses().filter(ProcessHandle::isAlive)
+                .map(ProcessHandle::pid).collect(java.util.stream.Collectors.toSet());
+        List<String> command = SetupPlatform.current() == SetupPlatform.WINDOWS
+                ? List.of("cmd.exe", "/c", "ping -n 30 127.0.0.1")
+                : List.of("sh", "-c", "sleep 30");
+
+        IOException failure = assertThrows(IOException.class, () -> ReportingSetupService.runProcess(
+                command, null, java.time.Duration.ofMillis(100), temp, temp));
+
+        assertTrue(failure.getMessage().contains("timed out"));
+        assertTrue(ProcessHandle.allProcesses().filter(ProcessHandle::isAlive)
+                .noneMatch(handle -> !before.contains(handle.pid()) && handle.info().commandLine()
+                        .orElse("").matches("(?is).*(ping\\s+-n\\s+30|sleep\\s+30).*")));
+    }
+
+    private static SetupPlan exerciseInstall(Path temp, SetupPlatform platform, Path nodeArchive) throws Exception {
+        Path cache = temp.resolve(platform.name().toLowerCase() + "-cache").toAbsolutePath();
+        Path data = temp.resolve(platform.name().toLowerCase() + "-data").toAbsolutePath();
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        Path allurePackage = Files.writeString(temp.resolve(platform.name().toLowerCase() + "-allure.tgz"), "allure");
+        ReportingSetupService.ArtifactFetcher fetcher = action ->
+                action.target() == SetupTarget.NODE ? nodeArchive : allurePackage;
+        ReportingSetupService.CommandRunner runner = (command, log, timeout) -> {
+            int prefix = command.indexOf("--prefix");
+            if (command.contains("ci") && prefix >= 0) {
+                Path entry = Path.of(command.get(prefix + 1)).resolve("node_modules/allure/cli.js");
+                Files.createDirectories(entry.getParent());
+                Files.writeString(entry, "allure");
+                if (log != null) Files.writeString(log, "installed\n");
+                return new ReportingSetupService.ProcessResult(0, "installed");
+            }
+            return new ReportingSetupService.ProcessResult(0,
+                    command.stream().anyMatch(part -> part.endsWith("allure/cli.js") || part.endsWith("allure\\cli.js"))
+                            ? "3.14.3" : "v24.19.0");
+        };
+        ReportingSetupService service = new ReportingSetupService(paths, platform, SetupArchitecture.X64,
+                fetcher, runner);
+        assertEquals(SetupReadiness.MISSING, service.status().readiness());
+        SetupPlan plan = ReportingSetupPlanner.plan(platform, SetupArchitecture.X64, SetupMode.MANAGED);
+        SetupReceipt receipt = service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()));
+        assertEquals(2, receipt.completedActions().size());
+        assertEquals(SetupReadiness.READY, service.status().readiness());
+        assertTrue(Files.isRegularFile(paths.receipts().resolve("reporting.json")));
+        assertTrue(Files.isRegularFile(service.logFile()));
+        assertEquals(receipt.planDigest(), service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of())).planDigest());
+        return plan;
+    }
+
+    private static Path createNodeZip(Path destination) throws IOException {
+        try (ZipOutputStream output = new ZipOutputStream(Files.newOutputStream(destination))) {
+            for (String entry : List.of("node-v24.19.0-win-x64/node.exe",
+                    "node-v24.19.0-win-x64/node_modules/npm/bin/npm-cli.js")) {
+                output.putNextEntry(new ZipEntry(entry));
+                output.write("binary".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                output.closeEntry();
+            }
+        }
+        return destination;
+    }
+
+    private static Path createNodeTar(Path destination) throws IOException {
+        try (TarArchiveOutputStream output = new TarArchiveOutputStream(
+                new GzipCompressorOutputStream(Files.newOutputStream(destination)))) {
+            for (String entry : List.of("node-v24.19.0-linux-x64/bin/node",
+                    "node-v24.19.0-linux-x64/lib/node_modules/npm/bin/npm-cli.js")) {
+                byte[] content = "binary".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                TarArchiveEntry tarEntry = new TarArchiveEntry(entry);
+                tarEntry.setSize(content.length);
+                tarEntry.setMode(0755);
+                output.putArchiveEntry(tarEntry);
+                output.write(content);
+                output.closeArchiveEntry();
+            }
+        }
+        return destination;
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/SetupPlanTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/SetupPlanTest.java
@@ -16,32 +16,30 @@ class SetupPlanTest {
     @Test
     void digestIsDeterministicAndBindsEveryMutationRelevantField() {
         SetupAction action = action(SetupTarget.ALLURE, "2.34.1");
-        SetupPlan first = SetupPlan.create(SetupPlatform.LINUX, SetupMode.MANAGED, List.of(action));
-        SetupPlan same = SetupPlan.create(SetupPlatform.LINUX, SetupMode.MANAGED, List.of(action));
-        SetupPlan changed = SetupPlan.create(SetupPlatform.LINUX, SetupMode.MANAGED,
+        SetupPlan first = plan(SetupPlatform.LINUX, SetupMode.MANAGED, action);
+        SetupPlan same = plan(SetupPlatform.LINUX, SetupMode.MANAGED, action);
+        SetupPlan changed = plan(SetupPlatform.LINUX, SetupMode.MANAGED,
                 List.of(action(SetupTarget.ALLURE, "2.35.0")));
 
         assertEquals(first.digest(), same.digest());
         assertNotEquals(first.digest(), changed.digest());
-        assertNotEquals(first.digest(), SetupPlan.create(SetupPlatform.WINDOWS, SetupMode.MANAGED,
-                List.of(action)).digest());
+        assertNotEquals(first.digest(), plan(SetupPlatform.WINDOWS, SetupMode.MANAGED, action).digest());
         SetupAction aliasedSource = new SetupAction(SetupTarget.ALLURE, SetupActionKind.INSTALL, "2.34.1",
                 URI.create("https://example.invalid/a/../allure"), checksum(), false, Set.of());
-        assertNotEquals(first.digest(), SetupPlan.create(SetupPlatform.LINUX, SetupMode.MANAGED,
-                List.of(aliasedSource)).digest());
+        assertNotEquals(first.digest(), plan(SetupPlatform.LINUX, SetupMode.MANAGED, aliasedSource).digest());
         SetupAction surrogateOne = new SetupAction(SetupTarget.ALLURE, SetupActionKind.INSTALL, "\uD800",
                 URI.create("https://example.invalid/allure"), checksum(), false, Set.of());
         SetupAction surrogateTwo = new SetupAction(SetupTarget.ALLURE, SetupActionKind.INSTALL, "\uD801",
                 URI.create("https://example.invalid/allure"), checksum(), false, Set.of());
-        assertNotEquals(SetupPlan.create(SetupPlatform.LINUX, SetupMode.MANAGED, List.of(surrogateOne)).digest(),
-                SetupPlan.create(SetupPlatform.LINUX, SetupMode.MANAGED, List.of(surrogateTwo)).digest());
+        assertNotEquals(plan(SetupPlatform.LINUX, SetupMode.MANAGED, surrogateOne).digest(),
+                plan(SetupPlatform.LINUX, SetupMode.MANAGED, surrogateTwo).digest());
     }
 
     @Test
     void actionFailureCarriesPartialReceiptAndFailedAction() {
         SetupAction first = action(SetupTarget.ALLURE, "2.34.1");
         SetupAction failed = action(SetupTarget.SELENIUM_BROWSER, "stable");
-        SetupPlan plan = SetupPlan.create(SetupPlatform.LINUX, SetupMode.MANAGED, List.of(first, failed));
+        SetupPlan plan = plan(SetupPlatform.LINUX, SetupMode.MANAGED, List.of(first, failed));
 
         SetupExecutionException failure = assertThrows(SetupExecutionException.class,
                 () -> SetupExecutor.execute(plan, approval(plan), action -> {
@@ -62,9 +60,9 @@ class SetupPlanTest {
 
     @Test
     void staleApprovalIsRejectedBeforeAnyActionRuns() {
-        SetupPlan approvedPlan = SetupPlan.create(SetupPlatform.LINUX, SetupMode.MANAGED,
+        SetupPlan approvedPlan = plan(SetupPlatform.LINUX, SetupMode.MANAGED,
                 List.of(action(SetupTarget.ALLURE, "2.34.1")));
-        SetupPlan changedPlan = SetupPlan.create(SetupPlatform.LINUX, SetupMode.MANAGED,
+        SetupPlan changedPlan = plan(SetupPlatform.LINUX, SetupMode.MANAGED,
                 List.of(action(SetupTarget.ALLURE, "2.35.0")));
         SetupApproval staleApproval = new SetupApproval(approvedPlan.digest(), Instant.EPOCH, Set.of());
         List<SetupAction> mutations = new ArrayList<>();
@@ -78,7 +76,7 @@ class SetupPlanTest {
     void matchingApprovalProducesImmutableReceiptInActionOrder() {
         SetupAction allure = action(SetupTarget.ALLURE, "2.34.1");
         SetupAction browser = action(SetupTarget.SELENIUM_BROWSER, "stable");
-        SetupPlan plan = SetupPlan.create(SetupPlatform.LINUX, SetupMode.HYBRID, List.of(allure, browser));
+        SetupPlan plan = plan(SetupPlatform.LINUX, SetupMode.HYBRID, List.of(allure, browser));
         List<SetupAction> mutations = new ArrayList<>();
 
         SetupReceipt receipt = SetupExecutor.execute(plan,
@@ -98,19 +96,20 @@ class SetupPlanTest {
     void rejectsExternalMutationsPrivilegeSpoofingAndMissingLicenseBeforeMutation() {
         SetupAction install = action(SetupTarget.ALLURE, "2.34.1");
         assertThrows(IllegalArgumentException.class,
-                () -> SetupPlan.create(SetupPlatform.LINUX, SetupMode.EXTERNAL, List.of(install)));
-        assertThrows(IllegalArgumentException.class, () -> SetupPlan.create(SetupPlatform.LINUX,
+                () -> plan(SetupPlatform.LINUX, SetupMode.EXTERNAL, install));
+        assertThrows(IllegalArgumentException.class, () -> plan(SetupPlatform.LINUX,
                 SetupMode.MANAGED, List.of(new SetupAction(SetupTarget.JAVA, SetupActionKind.CONFIGURE,
                         "25", URI.create("https://example.invalid/java"), checksum(), false, Set.of()))));
-        assertThrows(IllegalArgumentException.class, () -> new SetupPlan(2, SetupPlatform.LINUX,
+        assertThrows(IllegalArgumentException.class, () -> new SetupPlan(1, SetupProfile.REPORTING,
+                SetupPlatform.LINUX, SetupArchitecture.X64,
                 SetupMode.MANAGED, List.of(install), "sha256:" + "0".repeat(64)));
-        assertThrows(IllegalArgumentException.class, () -> SetupPlan.create(SetupPlatform.WINDOWS,
+        assertThrows(IllegalArgumentException.class, () -> plan(SetupPlatform.WINDOWS,
                 SetupMode.MANAGED, List.of(new SetupAction(SetupTarget.WINAPPDRIVER, SetupActionKind.INSTALL,
                         "1.2.1", URI.create("https://example.invalid/wad"), checksum(), false, Set.of()))));
 
         SetupAction licensed = new SetupAction(SetupTarget.ALLURE, SetupActionKind.INSTALL, "2.34.1",
                 URI.create("https://example.invalid/allure"), checksum(), false, Set.of("allure-eula"));
-        SetupPlan plan = SetupPlan.create(SetupPlatform.LINUX, SetupMode.MANAGED, List.of(licensed));
+        SetupPlan plan = plan(SetupPlatform.LINUX, SetupMode.MANAGED, licensed);
         List<SetupAction> mutations = new ArrayList<>();
         assertThrows(IllegalArgumentException.class, () -> SetupExecutor.execute(plan,
                 new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), mutations::add));
@@ -129,6 +128,14 @@ class SetupPlanTest {
 
     private static SetupApproval approval(SetupPlan plan) {
         return new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+    }
+
+    private static SetupPlan plan(SetupPlatform platform, SetupMode mode, SetupAction action) {
+        return plan(platform, mode, List.of(action));
+    }
+
+    private static SetupPlan plan(SetupPlatform platform, SetupMode mode, List<SetupAction> actions) {
+        return SetupPlan.create(SetupProfile.REPORTING, platform, SetupArchitecture.X64, mode, actions);
     }
 
     private static String checksum() {

--- a/shaft-skills/references/shaft-cli-commands.md
+++ b/shaft-skills/references/shaft-cli-commands.md
@@ -66,6 +66,30 @@ works right after a `capture start`/`capture stop` pair. Every other
 unchanged; exit code 2 means no `--session` was given and none could be
 inferred.
 
+## Local infrastructure setup (direct, no MCP session)
+
+`shaft-cli setup` exposes the release-coupled setup catalog and lifecycle. It
+defaults to the read-only `EXTERNAL` mode. Managed mutations require a plan
+file plus its exact printed digest; a stale or edited plan is rejected before
+the cache or durable-data roots are created.
+
+```text
+shaft-cli setup catalog|profiles [--json]
+shaft-cli setup doctor|status|verify --profile REPORTING [--json]
+shaft-cli setup plan --profile REPORTING --mode MANAGED --output <absolute-plan.json> [--json]
+shaft-cli setup install|apply|update --plan <absolute-plan.json> --approve <sha256:digest> [--accept-license <id>] [--json]
+shaft-cli setup start|stop --profile <profile>
+shaft-cli setup logs --profile REPORTING
+```
+
+The first managed provider installs verified, SHAFT-owned portable Node and
+Allure 3 artifacts for the `REPORTING` profile. `start` and `stop` return
+unsupported for profiles without an owned service; they never adopt or stop
+an unknown process. Exit codes are 0 for ready/success, 2 for invalid input or
+approval, 3 for missing/degraded readiness, 4 for unsupported providers, and
+5 for execution or integrity failures. `--cache-root` and `--data-root` are
+paired advanced overrides and must both be absolute.
+
 ## Curated aliases
 
 Shortcuts over `call`, same options:


### PR DESCRIPTION
## Outcome
- adds the direct, MCP-independent `shaft-cli setup` tree for catalog/profiles, doctor, status, plan, install/apply/update, verify, start, stop, and logs
- implements the first managed provider: verified portable Node 24.19.0 plus Allure 3.14.3 for the REPORTING profile
- persists strict schema-2 content-addressed plans; binds OS, architecture, artifact hashes, dependency-lock hash, privilege and licenses
- requires the exact approved digest before mutation and preserves partial receipts on failure
- uses absolute user-scoped cache/data roots, target locking, staging, verified publication, replacement rollback, durable receipts, exact status, and owned process-tree cleanup
- adds CLI JSON/exit-code proof, command-index parity, canonical command docs, PR path adoption, and packaged CLI smoke

## Proof
- `mvn --batch-mode -pl shaft-infrastructure test -Dallure.automaticallyOpen=false -Dgpg.skip=true` — 21 passed
- `mvn --batch-mode -pl shaft-cli test -Dtest=SetupCommandTest,ShaftCliCommandIndexTest -Dallure.automaticallyOpen=false -Dgpg.skip=true` — 6 passed
- 21 publication/release/Javadocs Python tests passed
- reactor/publication/modular documentation validators passed
- real packaged JAR acceptance: plan -> approved install -> verify returned Node v24.19.0, Allure 3.14.3, READY, and durable receipt
- three independent final reviews: zero blockers

## Stacking
This PR intentionally targets `ChaosEngine/batteries-setup-20260813` and depends on #4855. Retarget to `main` after #4855 merges.

Closes #4856
Tracks #4849