### PR TITLE
feat(ai): build managed local runtime foundation

### DIFF
--- a/shaft-ai/pom.xml
+++ b/shaft-ai/pom.xml
@@ -53,6 +53,19 @@
     </properties>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>../tools/local-ai-poc</directory>
+                <includes>
+                    <include>manifest.json</include>
+                </includes>
+                <targetPath>com/shaft/ai/local</targetPath>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/shaft-ai/pom.xml
+++ b/shaft-ai/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>shaft-doctor</artifactId>
             <version>${project.version}</version>

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiArtifacts.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiArtifacts.java
@@ -1,0 +1,584 @@
+package com.shaft.ai.local;
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.compress.archivers.zip.UnixStat;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.EnumSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.ExecutorService;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Stream;
+
+/** Deterministic artifact transfer and extraction boundaries for managed local inference. */
+final class ManagedLocalAiArtifacts {
+    private static final int BUFFER_SIZE = 64 * 1024;
+    private static final int MAXIMUM_MEMBERS = 10_000;
+    private static final long MAXIMUM_EXPANDED_BYTES = 4L * 1024 * 1024 * 1024;
+    private static final long MINIMUM_EXPANSION_ALLOWANCE = 1024 * 1024;
+    private static final long MAXIMUM_COMPRESSION_RATIO = 200;
+    private static final int MAXIMUM_REDIRECTS = 3;
+    private static final ExecutorService BODY_READERS = Executors.newVirtualThreadPerTaskExecutor();
+
+    private ManagedLocalAiArtifacts() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static void download(URI source, long expectedSize, String expectedSha256, Path target, Duration timeout,
+                         BooleanSupplier cancelled) throws IOException, InterruptedException {
+        requireReviewedArtifact(source, expectedSize, expectedSha256);
+        HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NEVER)
+                .connectTimeout(timeout).build();
+        download(source, expectedSize, expectedSha256, target, timeout, cancelled, (uri, requestTimeout) -> {
+            HttpRequest request = HttpRequest.newBuilder(uri).timeout(requestTimeout).GET().build();
+            HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            return new DownloadResponse(response.statusCode(), response.uri(), response.headers().map(),
+                    response.body());
+        });
+    }
+
+    static void download(ManagedLocalAiManifest.RuntimeAsset asset, Path target, Duration timeout,
+                         BooleanSupplier cancelled) throws IOException, InterruptedException {
+        download(asset.url(), asset.size(), asset.sha256(), target, timeout, cancelled);
+    }
+
+    static void download(ManagedLocalAiManifest.ModelManifest model, Path target, Duration timeout,
+                         BooleanSupplier cancelled) throws IOException, InterruptedException {
+        download(model.url(), model.size(), model.sha256(), target, timeout, cancelled);
+    }
+
+    static void download(URI source, long expectedSize, String expectedSha256, Path target, Duration timeout,
+                         BooleanSupplier cancelled, DownloadTransport transport)
+            throws IOException, InterruptedException {
+        validateSource(source);
+        if (timeout == null || timeout.isZero() || timeout.isNegative()) {
+            throw new IllegalArgumentException("Artifact timeout must be positive.");
+        }
+        URI current = source;
+        for (int redirects = 0; redirects <= MAXIMUM_REDIRECTS; redirects++) {
+            checkCancelled(cancelled);
+            DownloadResponse response = transport.get(current, timeout);
+            if (!current.equals(response.uri())) {
+                response.body().close();
+                throw new IllegalArgumentException("Artifact response URI does not match its request.");
+            }
+            if (response.statusCode() >= 300 && response.statusCode() < 400) {
+                String location = firstHeader(response.headers(), "location");
+                response.body().close();
+                if (redirects == MAXIMUM_REDIRECTS || location == null) {
+                    throw new IllegalArgumentException("Artifact redirect chain is invalid.");
+                }
+                URI next = current.resolve(location);
+                validateRedirect(source, next);
+                current = next;
+                continue;
+            }
+            if (response.statusCode() != 200) {
+                response.body().close();
+                throw new IOException("Artifact source returned HTTP " + response.statusCode() + ".");
+            }
+            String contentLength = firstHeader(response.headers(), "content-length");
+            if (contentLength != null) {
+                try {
+                    if (Long.parseLong(contentLength) != expectedSize) {
+                        response.body().close();
+                        throw new IllegalArgumentException("Artifact Content-Length does not match reviewed size.");
+                    }
+                } catch (NumberFormatException malformed) {
+                    response.body().close();
+                    throw new IllegalArgumentException("Artifact Content-Length is malformed.", malformed);
+                }
+            }
+            try {
+                download(new DeadlineInputStream(response.body(), timeout, cancelled), expectedSize, expectedSha256,
+                        target, cancelled);
+            } catch (BodyReadCancelled cancellation) {
+                throw new InterruptedException(cancellation.getMessage());
+            }
+            return;
+        }
+        throw new IllegalArgumentException("Artifact redirect chain is invalid.");
+    }
+
+    /**
+     * Streams one already-authorized response into a unique sibling stage and publishes only an exact match.
+     *
+     * @param input response body, closed by this method
+     * @param expectedSize exact reviewed byte count
+     * @param expectedSha256 exact reviewed lowercase digest
+     * @param target final contained cache path
+     * @param cancelled cooperative cancellation signal
+     * @throws IOException on filesystem or stream failure
+     * @throws InterruptedException when cancellation is observed
+     */
+    static void download(InputStream input, long expectedSize, String expectedSha256, Path target,
+                         BooleanSupplier cancelled) throws IOException, InterruptedException {
+        if (expectedSize <= 0 || expectedSha256 == null || !expectedSha256.matches("[0-9a-f]{64}")) {
+            throw new IllegalArgumentException("Expected artifact size and SHA-256 must be valid.");
+        }
+        Path absoluteTarget = target.toAbsolutePath().normalize();
+        Path parent = absoluteTarget.getParent();
+        if (parent == null) {
+            throw new IllegalArgumentException("Artifact target must have a parent directory.");
+        }
+        Files.createDirectories(parent);
+        if (Files.exists(absoluteTarget, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IllegalArgumentException("Artifact target must not already exist.");
+        }
+        Path stage = parent.resolve(absoluteTarget.getFileName() + ".part-" + UUID.randomUUID());
+        MessageDigest digest = sha256();
+        long received = 0;
+        try (InputStream source = input;
+             FileChannel output = FileChannel.open(stage, StandardOpenOption.CREATE_NEW,
+                     StandardOpenOption.WRITE)) {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int count;
+            while ((count = source.read(buffer)) != -1) {
+                checkCancelled(cancelled);
+                received = Math.addExact(received, count);
+                if (received > expectedSize) {
+                    throw new IllegalArgumentException("Artifact exceeds its reviewed byte count.");
+                }
+                digest.update(buffer, 0, count);
+                ByteBuffer bytes = ByteBuffer.wrap(buffer, 0, count);
+                while (bytes.hasRemaining()) {
+                    output.write(bytes);
+                }
+            }
+            checkCancelled(cancelled);
+            output.force(true);
+            if (received != expectedSize) {
+                throw new IllegalArgumentException("Artifact does not match its reviewed byte count.");
+            }
+            String actual = HexFormat.of().formatHex(digest.digest());
+            if (!MessageDigest.isEqual(actual.getBytes(java.nio.charset.StandardCharsets.US_ASCII),
+                    expectedSha256.getBytes(java.nio.charset.StandardCharsets.US_ASCII))) {
+                throw new IllegalArgumentException("Artifact SHA-256 does not match the reviewed digest.");
+            }
+            publishFileWithoutReplace(stage, absoluteTarget);
+        } catch (IOException | InterruptedException | RuntimeException primary) {
+            cleanupFile(stage, primary);
+            throw primary;
+        }
+        Files.deleteIfExists(stage);
+    }
+
+    /**
+     * Extracts a reviewed ZIP or tar.gz into a unique verified sibling stage.
+     *
+     * <p>This method deliberately does not publish an installation. The cache transaction owns the
+     * later no-replace publication and must accept only a returned stage carrying its ready marker.</p>
+     *
+     * @param archive verified archive
+     * @param destinationPrefix contained cache prefix used only to name the unique stage
+     * @param cancelled cooperative cancellation signal
+     * @throws IOException on archive or filesystem failure
+     * @throws InterruptedException when cancellation is observed
+     */
+    static Path extractToStage(Path archive, Path destinationPrefix, BooleanSupplier cancelled)
+            throws IOException, InterruptedException {
+        Path absoluteArchive = archive.toAbsolutePath().normalize();
+        if (!Files.isRegularFile(absoluteArchive, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IllegalArgumentException("Archive must be a verified regular file.");
+        }
+        Path absoluteDestination = destinationPrefix.toAbsolutePath().normalize();
+        Path parent = absoluteDestination.getParent();
+        if (parent == null) {
+            throw new IllegalArgumentException("Extraction destination prefix must have a parent.");
+        }
+        Files.createDirectories(parent);
+        Path stage = parent.resolve(absoluteDestination.getFileName() + ".extract-" + UUID.randomUUID());
+        Files.createDirectory(stage);
+        try {
+            List<Path> executables = extractInto(absoluteArchive, stage, cancelled);
+            markReviewedExecutables(executables);
+            checkCancelled(cancelled);
+            publishReadyMarker(stage);
+            return stage;
+        } catch (IOException | InterruptedException | RuntimeException primary) {
+            cleanupTree(stage, primary);
+            throw primary;
+        }
+    }
+
+    private static List<Path> extractInto(Path archive, Path stage, BooleanSupplier cancelled)
+            throws IOException, InterruptedException {
+        long archiveBytes = Files.size(archive);
+        long ratioLimit;
+        try {
+            ratioLimit = Math.addExact(Math.multiplyExact(archiveBytes, MAXIMUM_COMPRESSION_RATIO),
+                    MINIMUM_EXPANSION_ALLOWANCE);
+        } catch (ArithmeticException overflow) {
+            ratioLimit = MAXIMUM_EXPANDED_BYTES;
+        }
+        long byteLimit = Math.min(MAXIMUM_EXPANDED_BYTES, ratioLimit);
+        Set<String> memberPaths = new java.util.HashSet<>();
+        List<Path> executables = new ArrayList<>();
+        try (ArchiveInputStream<?> input = openArchive(archive)) {
+            int members = 0;
+            long expanded = 0;
+            ArchiveEntry entry;
+            while ((entry = input.getNextEntry()) != null) {
+                checkCancelled(cancelled);
+                if (++members > MAXIMUM_MEMBERS) {
+                    throw new IllegalArgumentException("Archive has too many members.");
+                }
+                validateEntry(entry);
+                Path target = contained(stage, entry.getName());
+                String portableIdentity = stage.relativize(target).toString().replace('\\', '/')
+                        .toLowerCase(Locale.ROOT);
+                if (!memberPaths.add(portableIdentity)) {
+                    throw new IllegalArgumentException("Archive contains a duplicate portable member path.");
+                }
+                if (entry.isDirectory()) {
+                    Files.createDirectories(target);
+                    continue;
+                }
+                long declared = entry.getSize();
+                if (declared != ArchiveEntry.SIZE_UNKNOWN && declared > byteLimit - expanded) {
+                    throw new IllegalArgumentException("Archive exceeds its expanded byte limit.");
+                }
+                Files.createDirectories(target.getParent());
+                if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+                    throw new IllegalArgumentException("Archive contains a duplicate member path.");
+                }
+                long written = copyBounded(input, target, byteLimit - expanded, cancelled);
+                if (declared != ArchiveEntry.SIZE_UNKNOWN && written != declared) {
+                    throw new IllegalArgumentException("Archive member size does not match its declaration.");
+                }
+                expanded = Math.addExact(expanded, written);
+                String basename = target.getFileName().toString();
+                if (basename.equals("llama-server") || basename.equals("llama-server.exe")) {
+                    executables.add(target);
+                }
+            }
+            if (members == 0) {
+                throw new IllegalArgumentException("Archive must contain at least one member.");
+            }
+        }
+        if (executables.size() != 1) {
+            throw new IllegalArgumentException("Archive must contain exactly one reviewed runtime executable.");
+        }
+        return List.copyOf(executables);
+    }
+
+    private static ArchiveInputStream<?> openArchive(Path archive) throws IOException {
+        String name = archive.getFileName().toString().toLowerCase(Locale.ROOT);
+        InputStream raw = new BufferedInputStream(Files.newInputStream(archive));
+        try {
+            if (name.endsWith(".zip")) {
+                return new ZipArchiveInputStream(raw);
+            }
+            if (name.endsWith(".tar.gz") || name.endsWith(".tgz")) {
+                return new TarArchiveInputStream(new GzipCompressorInputStream(raw));
+            }
+            throw new IllegalArgumentException("Only reviewed ZIP and tar.gz archives are supported.");
+        } catch (RuntimeException | IOException failure) {
+            raw.close();
+            throw failure;
+        }
+    }
+
+    private static void validateEntry(ArchiveEntry entry) {
+        String name = entry.getName();
+        if (name == null || name.isBlank() || name.indexOf('\0') >= 0) {
+            throw new IllegalArgumentException("Archive member name is invalid.");
+        }
+        if (entry instanceof ZipArchiveEntry zip) {
+            int type = zip.getUnixMode() & UnixStat.FILE_TYPE_FLAG;
+            if (zip.isUnixSymlink() || type != 0 && type != UnixStat.FILE_FLAG && type != UnixStat.DIR_FLAG) {
+                throw new IllegalArgumentException("Archive links and device members are not supported.");
+            }
+        }
+        if (entry instanceof TarArchiveEntry tar && (tar.isLink() || tar.isSymbolicLink()
+                || tar.isBlockDevice() || tar.isCharacterDevice() || tar.isFIFO())) {
+            throw new IllegalArgumentException("Archive links and device members are not supported.");
+        }
+    }
+
+    private static Path contained(Path root, String memberName) {
+        String normalizedSeparators = memberName.replace('\\', '/');
+        if (normalizedSeparators.startsWith("/") || normalizedSeparators.matches("^[A-Za-z]:.*")) {
+            throw new IllegalArgumentException("Archive member must use a relative path.");
+        }
+        Path target = root.resolve(normalizedSeparators).normalize();
+        if (!target.startsWith(root) || target.equals(root)) {
+            throw new IllegalArgumentException("Archive member escapes its extraction root.");
+        }
+        for (Path part : root.relativize(target)) {
+            String value = part.toString();
+            String stem = value.split("\\.", 2)[0].toUpperCase(Locale.ROOT);
+            if (value.isBlank() || value.endsWith(".") || value.endsWith(" ")
+                    || value.matches(".*[<>:\"|?*].*")
+                    || ManagedLocalAiManifest.WINDOWS_DEVICES.contains(stem)) {
+                throw new IllegalArgumentException("Archive member is not portable.");
+            }
+        }
+        return target;
+    }
+
+    private static long copyBounded(ArchiveInputStream<?> input, Path target, long remaining,
+                                    BooleanSupplier cancelled) throws IOException, InterruptedException {
+        long written = 0;
+        try (FileChannel output = FileChannel.open(target, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                checkCancelled(cancelled);
+                written = Math.addExact(written, count);
+                if (written > remaining) {
+                    throw new IllegalArgumentException("Archive exceeds its expanded byte limit.");
+                }
+                ByteBuffer bytes = ByteBuffer.wrap(buffer, 0, count);
+                while (bytes.hasRemaining()) {
+                    output.write(bytes);
+                }
+            }
+            output.force(true);
+        }
+        return written;
+    }
+
+    private static void publishFileWithoutReplace(Path source, Path target) throws IOException {
+        Files.createLink(target, source);
+        Files.delete(source);
+    }
+
+    private static void markReviewedExecutables(List<Path> executables) throws IOException {
+        Path executable = executables.getFirst();
+        if (Files.getFileStore(executable).supportsFileAttributeView("posix")) {
+            Files.setPosixFilePermissions(executable, EnumSet.of(PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
+                    PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
+                    PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE));
+        }
+    }
+
+    private static void publishReadyMarker(Path root) throws IOException {
+        Path marker = root.resolve(".shaft-ready");
+        try (FileChannel output = FileChannel.open(marker, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+            output.force(true);
+        }
+    }
+
+    private static void validateSource(URI source) {
+        if (source == null || !"https".equalsIgnoreCase(source.getScheme()) || source.getHost() == null
+                || source.getUserInfo() != null || source.getPort() != -1
+                || !Set.of("github.com", "huggingface.co").contains(source.getHost().toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException("Artifact source must use a reviewed canonical HTTPS host.");
+        }
+        String host = source.getHost().toLowerCase(Locale.ROOT);
+        String path = source.getPath();
+        boolean boundPath = "github.com".equals(host)
+                ? path.matches("/ggml-org/llama\\.cpp/releases/download/[A-Za-z0-9._+-]+/[A-Za-z0-9._+-]+")
+                : path.matches("/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/resolve/[0-9a-f]{40}/[A-Za-z0-9._+-]+");
+        if (!boundPath || source.getQuery() != null || source.getFragment() != null) {
+            throw new IllegalArgumentException("Artifact source path must bind a reviewed release or revision.");
+        }
+    }
+
+    private static void requireReviewedArtifact(URI source, long size, String sha256) {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        boolean runtime = manifest.runtime().assets().stream().anyMatch(asset -> asset.url().equals(source)
+                && asset.size() == size && asset.sha256().equals(sha256));
+        boolean model = manifest.models().stream().anyMatch(candidate -> candidate.url().equals(source)
+                && candidate.size() == size && candidate.sha256().equals(sha256));
+        if (!runtime && !model) {
+            throw new IllegalArgumentException("Artifact is not present in the reviewed managed local AI manifest.");
+        }
+    }
+
+    private static void validateRedirect(URI original, URI redirect) {
+        if (!"https".equalsIgnoreCase(redirect.getScheme()) || redirect.getHost() == null
+                || redirect.getUserInfo() != null || redirect.getPort() != -1 || redirect.getFragment() != null) {
+            throw new IllegalArgumentException("Artifact redirect must use canonical HTTPS.");
+        }
+        String originalHost = original.getHost().toLowerCase(Locale.ROOT);
+        String redirectHost = redirect.getHost().toLowerCase(Locale.ROOT);
+        boolean trusted = "github.com".equals(originalHost)
+                ? "release-assets.githubusercontent.com".equals(redirectHost)
+                : "huggingface.co".equals(originalHost)
+                && (redirectHost.endsWith(".cdn.hf.co") || "cdn-lfs.hf.co".equals(redirectHost)
+                || "cas-bridge.xethub.hf.co".equals(redirectHost));
+        if (!trusted) {
+            throw new IllegalArgumentException("Artifact redirect host is not trusted for its source.");
+        }
+    }
+
+    private static String firstHeader(Map<String, List<String>> headers, String name) {
+        return headers.entrySet().stream().filter(entry -> entry.getKey().equalsIgnoreCase(name))
+                .flatMap(entry -> entry.getValue().stream()).findFirst().orElse(null);
+    }
+
+    private static void checkCancelled(BooleanSupplier cancelled) throws InterruptedException {
+        if (Thread.currentThread().isInterrupted() || cancelled.getAsBoolean()) {
+            throw new InterruptedException("Managed local AI artifact operation was cancelled.");
+        }
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("JDK SHA-256 support is unavailable.", impossible);
+        }
+    }
+
+    private static void deleteCreatedTree(Path root) throws IOException {
+        if (!Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+            return;
+        }
+        List<IOException> failures = new ArrayList<>();
+        try (Stream<Path> paths = Files.walk(root)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException failure) {
+                    failures.add(failure);
+                }
+            });
+        }
+        if (!failures.isEmpty()) {
+            throw failures.getFirst();
+        }
+    }
+
+    private static void cleanupFile(Path stage, Throwable primary) {
+        try {
+            Files.deleteIfExists(stage);
+        } catch (IOException cleanup) {
+            primary.addSuppressed(cleanup);
+        }
+    }
+
+    private static void cleanupTree(Path stage, Throwable primary) {
+        try {
+            deleteCreatedTree(stage);
+        } catch (IOException cleanup) {
+            primary.addSuppressed(cleanup);
+        }
+    }
+
+    @FunctionalInterface
+    interface DownloadTransport {
+        DownloadResponse get(URI uri, Duration timeout) throws IOException, InterruptedException;
+    }
+
+    record DownloadResponse(int statusCode, URI uri, Map<String, List<String>> headers, InputStream body) {
+        DownloadResponse {
+            headers = Map.copyOf(headers);
+        }
+    }
+
+    private static final class DeadlineInputStream extends InputStream {
+        private final InputStream delegate;
+        private final long deadlineNanos;
+        private final BooleanSupplier cancelled;
+
+        private DeadlineInputStream(InputStream delegate, Duration timeout, BooleanSupplier cancelled) {
+            this.delegate = delegate;
+            this.deadlineNanos = System.nanoTime() + timeout.toNanos();
+            this.cancelled = cancelled;
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte[] single = new byte[1];
+            int count = read(single, 0, 1);
+            return count == -1 ? -1 : Byte.toUnsignedInt(single[0]);
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length) throws IOException {
+            Future<Integer> read = BODY_READERS.submit(() -> delegate.read(buffer, offset, length));
+            try {
+                while (true) {
+                    if (Thread.currentThread().isInterrupted() || cancelled.getAsBoolean()) {
+                        read.cancel(true);
+                        closeAsynchronously();
+                        throw new BodyReadCancelled("Artifact response-body read was cancelled.");
+                    }
+                    long remaining = deadlineNanos - System.nanoTime();
+                    if (remaining <= 0) {
+                        read.cancel(true);
+                        closeAsynchronously();
+                        throw new IOException("Artifact response body timed out.");
+                    }
+                    try {
+                        return read.get(Math.min(remaining, TimeUnit.MILLISECONDS.toNanos(100)),
+                                TimeUnit.NANOSECONDS);
+                    } catch (TimeoutException polling) {
+                        // Polling keeps cooperative cancellation observable while a native read is blocked.
+                    }
+                }
+            } catch (InterruptedException cancellation) {
+                Thread.currentThread().interrupt();
+                read.cancel(true);
+                closeAsynchronously();
+                throw new BodyReadCancelled("Artifact response-body read was interrupted.");
+            } catch (ExecutionException failure) {
+                Throwable cause = failure.getCause();
+                if (cause instanceof IOException ioFailure) {
+                    throw ioFailure;
+                }
+                throw new IOException("Artifact response-body read failed.", cause);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        private void closeAsynchronously() {
+            BODY_READERS.submit(() -> {
+                try {
+                    delegate.close();
+                } catch (IOException ignored) {
+                    // The timeout/cancellation failure remains primary.
+                }
+            });
+        }
+    }
+
+    private static final class BodyReadCancelled extends InterruptedIOException {
+        private BodyReadCancelled(String message) {
+            super(message);
+        }
+    }
+}

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiArtifacts.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiArtifacts.java
@@ -464,15 +464,41 @@ final class ManagedLocalAiArtifacts {
             return;
         }
         List<IOException> failures = new ArrayList<>();
-        try (Stream<Path> paths = Files.walk(root)) {
-            paths.sorted(Comparator.reverseOrder()).forEach(path -> {
-                try {
-                    Files.deleteIfExists(path);
-                } catch (IOException failure) {
+        Files.walkFileTree(root, new java.nio.file.SimpleFileVisitor<>() {
+            @Override
+            public java.nio.file.FileVisitResult preVisitDirectory(Path directory,
+                    java.nio.file.attribute.BasicFileAttributes attributes) {
+                if (!directory.equals(root) && (attributes.isSymbolicLink() || attributes.isOther())) {
+                    return java.nio.file.FileVisitResult.SKIP_SUBTREE;
+                }
+                return java.nio.file.FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public java.nio.file.FileVisitResult visitFile(Path file,
+                    java.nio.file.attribute.BasicFileAttributes attributes) throws IOException {
+                if (attributes.isSymbolicLink() || attributes.isOther()) {
+                    return java.nio.file.FileVisitResult.CONTINUE;
+                }
+                Files.deleteIfExists(file);
+                return java.nio.file.FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public java.nio.file.FileVisitResult postVisitDirectory(Path directory, IOException failure) {
+                if (failure != null) {
                     failures.add(failure);
                 }
-            });
-        }
+                try {
+                    Files.delete(directory);
+                } catch (java.nio.file.DirectoryNotEmptyException unknownContent) {
+                    // Concurrent unknown or reparse content is preserved.
+                } catch (IOException deleteFailure) {
+                    failures.add(deleteFailure);
+                }
+                return java.nio.file.FileVisitResult.CONTINUE;
+            }
+        });
         if (!failures.isEmpty()) {
             throw failures.getFirst();
         }

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiCache.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiCache.java
@@ -127,6 +127,23 @@ final class ManagedLocalAiCache {
         return installation;
     }
 
+    static Path verifyOwnedFile(Path cache, Path candidate) throws IOException {
+        Path root = cache.toAbsolutePath().normalize();
+        Path path = candidate.toAbsolutePath().normalize();
+        String relative = relative(root, path);
+        for (Installation installation : readOwnerManifest(root).values()) {
+            if (installation.files().stream().anyMatch(file -> file.path().equals(relative))
+                    && matches(root, installation, true)) {
+                return path;
+            }
+        }
+        throw new IllegalStateException("Managed local AI file is unowned or changed.");
+    }
+
+    static boolean ownsInstallation(Path cache, String id) throws IOException {
+        return readOwnerManifest(cache.toAbsolutePath().normalize()).containsKey(id);
+    }
+
     static CleanResult clean(Path cache) throws IOException {
         Path root = cache.toAbsolutePath().normalize();
         Map<String, Installation> owned = readOwnerManifest(root);

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiCache.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiCache.java
@@ -1,0 +1,655 @@
+package com.shaft.ai.local;
+
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/** Cross-process ownership and immutable-cache boundary for managed local inference. */
+final class ManagedLocalAiCache {
+    private static final String OWNER_MANIFEST = "owner-manifest.json";
+    private static final String LOCK = ".managed-local-ai.lock";
+    private static final String TRANSACTION = "transaction.json";
+    private static final Pattern ID = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._+-]{0,199}");
+    private static final ObjectMapper JSON = JsonMapper.builder()
+            .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION).build();
+
+    private ManagedLocalAiCache() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static <T> T withLock(Path cache, Duration timeout, CheckedSupplier<T> action) throws Exception {
+        if (timeout == null || timeout.isZero() || timeout.isNegative()) {
+            throw new IllegalArgumentException("Cache lock timeout must be positive.");
+        }
+        Path root = cache.toAbsolutePath().normalize();
+        Files.createDirectories(root);
+        Path lockPath = root.resolve(LOCK);
+        long deadline = System.nanoTime() + timeout.toNanos();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            while (true) {
+                FileLock lock = null;
+                try {
+                    lock = channel.tryLock();
+                } catch (OverlappingFileLockException busy) {
+                    // Another thread in this JVM holds the same process-wide lock.
+                }
+                if (lock != null) {
+                    try (FileLock acquired = lock) {
+                        recover(root);
+                        return action.get();
+                    }
+                }
+                if (System.nanoTime() >= deadline) {
+                    throw new IllegalStateException("Timed out waiting for the managed local AI cache lock.");
+                }
+                Thread.sleep(10);
+            }
+        }
+    }
+
+    static Installation adopt(Path cache, String id, Path stage) throws IOException {
+        validateId(id);
+        Path root = cache.toAbsolutePath().normalize();
+        Path stagingRoot = root.resolve("staging");
+        Path source = stage.toAbsolutePath().normalize();
+        if (!source.getParent().equals(stagingRoot)
+                || !source.getFileName().toString().contains(".extract-")
+                || !Files.isDirectory(source, LinkOption.NOFOLLOW_LINKS)
+                || !Files.isRegularFile(source.resolve(".shaft-ready"), LinkOption.NOFOLLOW_LINKS)) {
+            throw new IllegalArgumentException("Installation stage is not a verified cache-owned stage.");
+        }
+        validateTree(source);
+        Path installations = root.resolve("installations");
+        Files.createDirectories(installations);
+        Path destination = installations.resolve(id + "-" + UUID.randomUUID());
+        writeTransaction(root, new Transaction("ADOPT", id, relative(root, source), relative(root, destination),
+                List.of()));
+        try {
+            Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException unsupported) {
+            throw new IOException("Cache filesystem does not support atomic installation adoption.", unsupported);
+        }
+        Installation installation;
+        try {
+            installation = inventory(root, id, destination);
+            Map<String, Installation> owned = readOwnerManifest(root);
+            if (owned.containsKey(id)) {
+                throw new IllegalStateException("An installation with this identifier is already owned.");
+            }
+            owned.put(id, installation);
+            writeOwnerManifest(root, owned);
+            clearTransaction(root);
+        } catch (IOException | RuntimeException primary) {
+            rollbackAdopt(root, source, destination, primary);
+            throw primary;
+        }
+        return installation;
+    }
+
+    static Installation verify(Path cache, String id) throws IOException {
+        validateId(id);
+        Path root = cache.toAbsolutePath().normalize();
+        Installation installation = readOwnerManifest(root).get(id);
+        if (installation == null || !matches(root, installation, true)) {
+            throw new IllegalStateException("Managed local AI installation is unowned or changed.");
+        }
+        return installation;
+    }
+
+    static CleanResult clean(Path cache) throws IOException {
+        Path root = cache.toAbsolutePath().normalize();
+        Map<String, Installation> owned = readOwnerManifest(root);
+        int deleted = 0;
+        List<String> conflicts = new ArrayList<>();
+        Map<String, Installation> remaining = new LinkedHashMap<>(owned);
+        for (Installation installation : owned.values()) {
+            if (!matches(root, installation, true)) {
+                conflicts.add(installation.id());
+                continue;
+            }
+            Path trashRoot = root.resolve("trash");
+            Files.createDirectories(trashRoot);
+            Path trash = trashRoot.resolve(installation.id() + "-" + UUID.randomUUID());
+            writeTransaction(root, new Transaction("CLEAN", installation.id(),
+                    relative(root, installation.root()), relative(root, trash), installation.files()));
+            try {
+                Files.move(installation.root(), trash, StandardCopyOption.ATOMIC_MOVE);
+                remaining.remove(installation.id());
+                writeOwnerManifest(root, remaining);
+                deleted += installation.files().size();
+                deleteOwnedFromTrash(root, installation.root(), trash, installation.files());
+                clearTransaction(root);
+            } catch (IOException | RuntimeException primary) {
+                rollbackClean(root, installation.root(), trash, primary);
+                throw primary;
+            }
+        }
+        return new CleanResult(deleted, List.copyOf(conflicts));
+    }
+
+    static void recover(Path cache) throws IOException {
+        Path root = cache.toAbsolutePath().normalize();
+        Transaction transaction = readTransaction(root);
+        if (transaction == null) {
+            return;
+        }
+        Path source = contained(root, transaction.source());
+        Path target = contained(root, transaction.target());
+        Map<String, Installation> owned = readOwnerManifest(root);
+        if ("ADOPT".equals(transaction.operation())) {
+            requireTransactionPath(root, source, "staging", ".extract-");
+            requireTransactionPath(root, target, "installations", transaction.id() + "-");
+            Installation committed = owned.get(transaction.id());
+            if (committed == null && Files.exists(target, LinkOption.NOFOLLOW_LINKS)
+                    && !Files.exists(source, LinkOption.NOFOLLOW_LINKS)) {
+                Files.move(target, source, StandardCopyOption.ATOMIC_MOVE);
+            }
+        } else if ("CLEAN".equals(transaction.operation())) {
+            requireTransactionPath(root, source, "installations", transaction.id() + "-");
+            requireTransactionPath(root, target, "trash", transaction.id() + "-");
+            Installation installation = owned.get(transaction.id());
+            if (installation != null && !installation.root().equals(source)) {
+                throw new IllegalStateException("Cache transaction does not match owned installation.");
+            }
+            if (installation != null && Files.exists(source, LinkOption.NOFOLLOW_LINKS)
+                    && Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IllegalStateException("Cache recovery is conflicted; journal retained.");
+            }
+            if (installation != null && Files.exists(target, LinkOption.NOFOLLOW_LINKS)
+                    && !Files.exists(source, LinkOption.NOFOLLOW_LINKS)) {
+                Files.move(target, source, StandardCopyOption.ATOMIC_MOVE);
+            } else if (installation == null && Files.exists(target, LinkOption.NOFOLLOW_LINKS)
+                    && !Files.exists(source, LinkOption.NOFOLLOW_LINKS)) {
+                deleteOwnedFromTrash(root, source, target, transaction.files());
+            } else if (installation == null && Files.exists(source, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IllegalStateException("Cache recovery source is unowned; journal retained.");
+            }
+        } else {
+            throw new IllegalStateException("Cache transaction operation is invalid.");
+        }
+        clearTransaction(root);
+    }
+
+    private static void requireTransactionPath(Path cache, Path path, String parentName, String prefix) {
+        Path expectedParent = cache.resolve(parentName);
+        String name = path.getFileName().toString();
+        boolean expectedName = ".extract-".equals(prefix) ? name.contains(prefix) : name.startsWith(prefix);
+        if (!path.getParent().equals(expectedParent) || !expectedName) {
+            throw new IllegalStateException("Cache transaction path is not valid for its operation.");
+        }
+    }
+
+    private static Installation inventory(Path cache, String id, Path installationRoot) throws IOException {
+        List<OwnedFile> files = new ArrayList<>();
+        Files.walkFileTree(installationRoot, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path directory, BasicFileAttributes attributes) {
+                requireOrdinaryDirectory(attributes);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path path, BasicFileAttributes attributes) throws IOException {
+                requireOrdinaryFile(attributes);
+                files.add(new OwnedFile(relative(cache, path), Files.size(path), sha256(path)));
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        files.sort(Comparator.comparing(OwnedFile::path));
+        if (files.isEmpty()) {
+            throw new IllegalArgumentException("Installation stage contains no owned files.");
+        }
+        return new Installation(id, installationRoot, List.copyOf(files));
+    }
+
+    private static boolean matches(Path cache, Installation installation, boolean rejectUnknown) throws IOException {
+        Path root = installation.root().toAbsolutePath().normalize();
+        if (!root.startsWith(cache.resolve("installations"))) {
+            return false;
+        }
+        ensureNoLinks(cache, root);
+        if (!Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS)) {
+            return false;
+        }
+        Set<String> recorded = new HashSet<>();
+        Set<String> expectedPaths = new HashSet<>();
+        expectedPaths.add(relative(cache, root));
+        for (OwnedFile file : installation.files()) {
+            Path path = contained(cache, file.path());
+            ensureNoLinks(cache, path);
+            if (!path.startsWith(root) || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)
+                    || Files.size(path) != file.size() || !sha256(path).equals(file.sha256())) {
+                return false;
+            }
+            recorded.add(file.path());
+            Path current = path;
+            while (!current.equals(root)) {
+                expectedPaths.add(relative(cache, current));
+                current = current.getParent();
+            }
+        }
+        if (rejectUnknown) {
+            try (Stream<Path> paths = Files.walk(root)) {
+                Set<String> actual = paths.map(path -> relative(cache, path))
+                        .collect(java.util.stream.Collectors.toSet());
+                return actual.equals(expectedPaths);
+            }
+        }
+        return true;
+    }
+
+    private static Map<String, Installation> readOwnerManifest(Path cache) throws IOException {
+        Path manifest = cache.resolve(OWNER_MANIFEST);
+        Map<String, Installation> result = new LinkedHashMap<>();
+        Set<String> globalPaths = new HashSet<>();
+        Set<String> globalRoots = new HashSet<>();
+        if (!Files.exists(manifest, LinkOption.NOFOLLOW_LINKS)) {
+            return result;
+        }
+        if (!Files.isRegularFile(manifest, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IllegalStateException("Owner manifest is not a regular file.");
+        }
+        JsonNode root = JSON.readTree(Files.newInputStream(manifest));
+        if (root == null || !root.isObject() || root.path("schemaVersion").asInt(-1) != 1
+                || !root.path("installations").isArray() || root.size() != 2) {
+            throw new IllegalStateException("Owner manifest is invalid.");
+        }
+        for (JsonNode item : root.path("installations")) {
+            if (!item.isObject() || item.size() != 3 || !item.path("files").isArray()) {
+                throw new IllegalStateException("Owner manifest installation is invalid.");
+            }
+            String id = requiredText(item, "id");
+            validateId(id);
+            String rootPath = requiredText(item, "rootPath");
+            contained(cache, rootPath);
+            String portableRoot = rootPath.toLowerCase(java.util.Locale.ROOT);
+            if (!globalRoots.add(portableRoot) || globalRoots.stream().anyMatch(existing ->
+                    !existing.equals(portableRoot) && (existing.startsWith(portableRoot + "/")
+                            || portableRoot.startsWith(existing + "/")))) {
+                throw new IllegalStateException("Owner manifest contains overlapping installation roots.");
+            }
+            List<OwnedFile> files = new ArrayList<>();
+            Set<String> filePaths = new HashSet<>();
+            for (JsonNode file : item.path("files")) {
+                if (!file.isObject() || file.size() != 3 || !file.path("size").isIntegralNumber()) {
+                    throw new IllegalStateException("Owner manifest file entry is invalid.");
+                }
+                String path = requiredText(file, "path");
+                contained(cache, path);
+                if (!filePaths.add(path)) {
+                    throw new IllegalStateException("Owner manifest contains duplicate file paths.");
+                }
+                if (!path.startsWith(rootPath + "/")
+                        || !globalPaths.add(path.toLowerCase(java.util.Locale.ROOT))) {
+                    throw new IllegalStateException("Owner manifest contains overlapping owned file paths.");
+                }
+                long size = file.path("size").asLong(-1);
+                String digest = requiredText(file, "sha256");
+                if (size < 0 || !digest.matches("[0-9a-f]{64}")) {
+                    throw new IllegalStateException("Owner manifest file metadata is invalid.");
+                }
+                files.add(new OwnedFile(path, size, digest));
+            }
+            if (files.isEmpty() || result.putIfAbsent(id,
+                    new Installation(id, contained(cache, rootPath), List.copyOf(files))) != null) {
+                throw new IllegalStateException("Owner manifest contains an empty or duplicate installation.");
+            }
+        }
+        return result;
+    }
+
+    private static void writeOwnerManifest(Path cache, Map<String, Installation> installations) throws IOException {
+        Files.createDirectories(cache);
+        ObjectNode root = JSON.createObjectNode();
+        root.put("schemaVersion", 1);
+        ArrayNode values = root.putArray("installations");
+        installations.values().stream().sorted(Comparator.comparing(Installation::id)).forEach(installation -> {
+            ObjectNode item = values.addObject();
+            item.put("id", installation.id());
+            item.put("rootPath", relative(cache, installation.root()));
+            ArrayNode files = item.putArray("files");
+            installation.files().forEach(file -> {
+                ObjectNode entry = files.addObject();
+                entry.put("path", file.path());
+                entry.put("size", file.size());
+                entry.put("sha256", file.sha256());
+            });
+        });
+        Path stage = cache.resolve(OWNER_MANIFEST + ".stage-" + UUID.randomUUID());
+        try {
+            Files.write(stage, JSON.writeValueAsBytes(root), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+            try (FileChannel channel = FileChannel.open(stage, StandardOpenOption.WRITE)) {
+                channel.force(true);
+            }
+            Files.move(stage, cache.resolve(OWNER_MANIFEST), StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException unsupported) {
+            throw new IOException("Cache filesystem does not support atomic ownership publication.", unsupported);
+        } finally {
+            Files.deleteIfExists(stage);
+        }
+    }
+
+    private static void writeTransaction(Path cache, Transaction transaction) throws IOException {
+        ObjectNode value = JSON.createObjectNode();
+        value.put("schemaVersion", 1);
+        value.put("operation", transaction.operation());
+        value.put("id", transaction.id());
+        value.put("source", transaction.source());
+        value.put("target", transaction.target());
+        ArrayNode files = value.putArray("files");
+        transaction.files().forEach(file -> {
+            ObjectNode entry = files.addObject();
+            entry.put("path", file.path());
+            entry.put("size", file.size());
+            entry.put("sha256", file.sha256());
+        });
+        Path target = cache.resolve(TRANSACTION);
+        if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IllegalStateException("An unfinished cache transaction already exists.");
+        }
+        Path stage = cache.resolve(TRANSACTION + ".stage-" + UUID.randomUUID());
+        try {
+            Files.write(stage, JSON.writeValueAsBytes(value), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+            try (FileChannel channel = FileChannel.open(stage, StandardOpenOption.WRITE)) {
+                channel.force(true);
+            }
+            Files.createLink(target, stage);
+            Files.delete(stage);
+        } finally {
+            Files.deleteIfExists(stage);
+        }
+    }
+
+    private static Transaction readTransaction(Path cache) throws IOException {
+        Path path = cache.resolve(TRANSACTION);
+        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+            return null;
+        }
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IllegalStateException("Cache transaction journal is not a regular file.");
+        }
+        JsonNode value = JSON.readTree(Files.newInputStream(path));
+        if (value == null || !value.isObject() || value.size() != 6
+                || value.path("schemaVersion").asInt(-1) != 1 || !value.path("files").isArray()) {
+            throw new IllegalStateException("Cache transaction journal is invalid.");
+        }
+        String operation = requiredText(value, "operation");
+        String id = requiredText(value, "id");
+        validateId(id);
+        String source = requiredText(value, "source");
+        String target = requiredText(value, "target");
+        contained(cache, source);
+        contained(cache, target);
+        List<OwnedFile> files = new ArrayList<>();
+        for (JsonNode file : value.path("files")) {
+            if (!file.isObject() || file.size() != 3 || !file.path("size").isIntegralNumber()) {
+                throw new IllegalStateException("Cache transaction file entry is invalid.");
+            }
+            String filePath = requiredText(file, "path");
+            contained(cache, filePath);
+            long size = file.path("size").asLong(-1);
+            String digest = requiredText(file, "sha256");
+            if (size < 0 || !digest.matches("[0-9a-f]{64}")) {
+                throw new IllegalStateException("Cache transaction file metadata is invalid.");
+            }
+            files.add(new OwnedFile(filePath, size, digest));
+        }
+        if ("CLEAN".equals(operation) && files.isEmpty() || "ADOPT".equals(operation) && !files.isEmpty()) {
+            throw new IllegalStateException("Cache transaction file inventory is invalid.");
+        }
+        return new Transaction(operation, id, source, target, List.copyOf(files));
+    }
+
+    private static void clearTransaction(Path cache) throws IOException {
+        Files.deleteIfExists(cache.resolve(TRANSACTION));
+    }
+
+    private static void rollbackAdopt(Path cache, Path source, Path target, Throwable primary) {
+        try {
+            Installation committed = readOwnerManifest(cache).values().stream()
+                    .filter(value -> value.root().equals(target)).findFirst().orElse(null);
+            if (committed != null) {
+                return;
+            }
+            if (Files.exists(target, LinkOption.NOFOLLOW_LINKS) && !Files.exists(source, LinkOption.NOFOLLOW_LINKS)) {
+                Files.move(target, source, StandardCopyOption.ATOMIC_MOVE);
+            }
+            clearTransaction(cache);
+        } catch (IOException rollback) {
+            primary.addSuppressed(rollback);
+        }
+    }
+
+    private static void rollbackClean(Path cache, Path source, Path trash, Throwable primary) {
+        try {
+            if (Files.exists(trash, LinkOption.NOFOLLOW_LINKS)
+                    && !Files.exists(source, LinkOption.NOFOLLOW_LINKS)) {
+                Files.move(trash, source, StandardCopyOption.ATOMIC_MOVE);
+                clearTransaction(cache);
+            }
+        } catch (IOException | RuntimeException rollback) {
+            primary.addSuppressed(rollback);
+        }
+    }
+
+    private static void validateTree(Path root) throws IOException {
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path directory, BasicFileAttributes attributes) {
+                requireOrdinaryDirectory(attributes);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
+                requireOrdinaryFile(attributes);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static void ensureNoLinks(Path cache, Path target) throws IOException {
+        Path current = cache;
+        for (Path part : cache.relativize(target)) {
+            current = current.resolve(part);
+            BasicFileAttributes attributes = Files.readAttributes(current, BasicFileAttributes.class,
+                    LinkOption.NOFOLLOW_LINKS);
+            if (attributes.isSymbolicLink() || attributes.isOther()) {
+                throw new IllegalStateException("Owned path contains a link or reparse point.");
+            }
+        }
+    }
+
+    private static void requireOrdinaryDirectory(BasicFileAttributes attributes) {
+        if (!attributes.isDirectory() || attributes.isSymbolicLink() || attributes.isOther()) {
+            throw new IllegalArgumentException("Installation stage contains an unsupported directory type.");
+        }
+    }
+
+    private static void requireOrdinaryFile(BasicFileAttributes attributes) {
+        if (!attributes.isRegularFile() || attributes.isSymbolicLink() || attributes.isOther()) {
+            throw new IllegalArgumentException("Installation stage contains an unsupported file type.");
+        }
+    }
+
+    private static void removeOwnedEmptyDirectories(Path installationRoot, Path cache) throws IOException {
+        if (!installationRoot.startsWith(cache.resolve("installations"))) {
+            throw new IllegalStateException("Owned installation root escapes the cache.");
+        }
+        try (Stream<Path> paths = Files.walk(installationRoot)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                try {
+                    Files.delete(path);
+                } catch (java.nio.file.DirectoryNotEmptyException unknownContent) {
+                    // Unknown content is never removed.
+                }
+            }
+        }
+    }
+
+    private static void cleanupExactTree(Path root, Throwable primary) {
+        try {
+            deleteExactTree(root);
+        } catch (IOException cleanup) {
+            primary.addSuppressed(cleanup);
+        }
+    }
+
+    private static void deleteExactTree(Path root) throws IOException {
+        if (!Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(path);
+            }
+        }
+    }
+
+    private static void deleteOwnedFromTrash(Path cache, Path originalRoot, Path trash,
+                                             List<OwnedFile> files) throws IOException {
+        List<Path> directories = new ArrayList<>();
+        for (OwnedFile file : files) {
+            Path original = contained(cache, file.path());
+            Path suffix = originalRoot.relativize(original);
+            Path target = trash.resolve(suffix).normalize();
+            if (!target.startsWith(trash)) {
+                throw new IllegalStateException("Owned cleanup path escapes trash.");
+            }
+            if (!Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+                continue;
+            }
+            ensureNoLinks(cache, target);
+            if (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS)
+                    || Files.size(target) != file.size() || !sha256(target).equals(file.sha256())) {
+                throw new IllegalStateException("Owned file changed during cleanup; refusing deletion.");
+            }
+            Files.delete(target);
+            Path parent = target.getParent();
+            while (parent != null && parent.startsWith(trash)) {
+                directories.add(parent);
+                if (parent.equals(trash)) {
+                    break;
+                }
+                parent = parent.getParent();
+            }
+        }
+        directories.stream().distinct().sorted(Comparator.reverseOrder()).forEach(directory -> {
+            try {
+                Files.delete(directory);
+            } catch (java.nio.file.DirectoryNotEmptyException unknown) {
+                // Preserve concurrently introduced unknown content.
+            } catch (IOException failure) {
+                throw new java.io.UncheckedIOException(failure);
+            }
+        });
+        if (Files.exists(trash, LinkOption.NOFOLLOW_LINKS)) {
+            Files.move(trash, originalRoot, StandardCopyOption.ATOMIC_MOVE);
+        }
+    }
+
+    private static Path contained(Path cache, String relative) {
+        if (relative == null || relative.isBlank() || relative.contains("\\") || relative.contains(":")
+                || relative.startsWith("/") || relative.endsWith("/")
+                || Stream.of(relative.split("/", -1)).anyMatch(part -> part.isBlank() || ".".equals(part)
+                || "..".equals(part))) {
+            throw new IllegalStateException("Owned path is not a portable relative path.");
+        }
+        Path value = Path.of(relative);
+        if (value.isAbsolute()) {
+            throw new IllegalStateException("Owned path must be relative.");
+        }
+        Path target = cache.resolve(value).normalize();
+        if (!target.startsWith(cache) || target.equals(cache)) {
+            throw new IllegalStateException("Owned path escapes the cache.");
+        }
+        return target;
+    }
+
+    private static String relative(Path cache, Path path) {
+        Path normalized = path.toAbsolutePath().normalize();
+        if (!normalized.startsWith(cache)) {
+            throw new IllegalArgumentException("Path escapes managed local AI cache.");
+        }
+        return cache.relativize(normalized).toString().replace('\\', '/');
+    }
+
+    private static String requiredText(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || !value.isTextual() || value.asText().isBlank()) {
+            throw new IllegalStateException("Owner manifest field is invalid: " + field + ".");
+        }
+        return value.asText();
+    }
+
+    private static void validateId(String id) {
+        if (id == null || !ID.matcher(id).matches()) {
+            throw new IllegalArgumentException("Installation identifier is not portable.");
+        }
+    }
+
+    private static String sha256(Path path) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (var input = Files.newInputStream(path)) {
+                byte[] buffer = new byte[64 * 1024];
+                int count;
+                while ((count = input.read(buffer)) != -1) {
+                    digest.update(buffer, 0, count);
+                }
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("JDK SHA-256 support is unavailable.", impossible);
+        }
+    }
+
+    @FunctionalInterface
+    interface CheckedSupplier<T> {
+        T get() throws Exception;
+    }
+
+    record Installation(String id, Path root, List<OwnedFile> files) {
+    }
+
+    record OwnedFile(String path, long size, String sha256) {
+    }
+
+    record CleanResult(int deletedFiles, List<String> conflicts) {
+    }
+
+    record Transaction(String operation, String id, String source, String target, List<OwnedFile> files) {
+    }
+}

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiCache.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiCache.java
@@ -259,7 +259,6 @@ final class ManagedLocalAiCache {
         if (!Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS)) {
             return false;
         }
-        Set<String> recorded = new HashSet<>();
         Set<String> expectedPaths = new HashSet<>();
         expectedPaths.add(relative(cache, root));
         for (OwnedFile file : installation.files()) {
@@ -269,7 +268,6 @@ final class ManagedLocalAiCache {
                     || Files.size(path) != file.size() || !sha256(path).equals(file.sha256())) {
                 return false;
             }
-            recorded.add(file.path());
             Path current = path;
             while (!current.equals(root)) {
                 expectedPaths.add(relative(cache, current));

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiHardware.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiHardware.java
@@ -1,0 +1,380 @@
+package com.shaft.ai.local;
+
+import com.sun.management.OperatingSystemMXBean;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/** Read-only hardware profiling and deterministic model selection for managed local inference. */
+final class ManagedLocalAiHardware {
+    private static final long GIB = 1024L * 1024 * 1024;
+    private static final long MEMORY_RESERVE_BYTES = 2 * GIB;
+    private static final long DISK_RESERVE_BYTES = GIB;
+    private static final long MAXIMUM_RUNTIME_EXPANSION_BYTES = 4 * GIB;
+
+    private ManagedLocalAiHardware() {
+    }
+
+    static Profile profile(Path cache, HostAccess host) {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        String platform = platform(host.osName(), host.architecture());
+        boolean compatible = manifest.supportsRuntime(
+                host.osName(), host.architecture(), host.abi(), host.abiVersion());
+        long available = positiveOrZero(host.availableMemoryBytes());
+        int processors = Math.max(0, host.availableProcessors());
+        if ("linux".equals(normalizedOs(host.osName()))) {
+            available = Math.min(available, cgroupAvailableMemory(host).orElse(available));
+            processors = Math.min(processors, cgroupProcessors(host).orElse(processors));
+        }
+        long effectiveMemory = Math.max(0, available - MEMORY_RESERVE_BYTES);
+        Path ancestor = nearestExistingAncestor(cache.toAbsolutePath().normalize());
+        long disk = ancestor == null ? 0 : positiveOrZero(host.usableSpace(ancestor));
+        return new Profile(platform, compatible, effectiveMemory, processors, disk);
+    }
+
+    static Selection select(ManagedLocalAiManifest manifest, Profile profile, String requestedModelId) {
+        if (requestedModelId != null && manifest.models().stream()
+                .noneMatch(model -> model.id().equals(requestedModelId))) {
+            throw new IllegalArgumentException("Unknown managed local AI model: " + requestedModelId);
+        }
+        Map<String, ModelEvaluation> evaluations = new LinkedHashMap<>();
+        ManagedLocalAiManifest.ModelManifest selected = null;
+        for (ManagedLocalAiManifest.ModelManifest model : manifest.models()) {
+            List<String> reasons = new ArrayList<>();
+            boolean requested = requestedModelId != null && requestedModelId.equals(model.id());
+            if (!profile.runtimeCompatible()) {
+                reasons.add("UNSUPPORTED_RUNTIME");
+            }
+            if (profile.effectiveMemoryBytes() < gibibytes(model.minimumRamGb())) {
+                reasons.add("INSUFFICIENT_MEMORY");
+            }
+            if (profile.cpuCount() < model.minimumCpuCount()) {
+                reasons.add("INSUFFICIENT_CPU");
+            }
+            long requiredDisk = requiredDiskBytes(manifest, profile, model);
+            if (profile.freeDiskBytes() < requiredDisk) {
+                reasons.add("INSUFFICIENT_DISK");
+            }
+            if (requestedModelId == null && (!model.automatic() || !model.firstPartyQuantization())) {
+                reasons.add("MANUAL_ONLY");
+            }
+            boolean eligible = reasons.isEmpty();
+            evaluations.put(model.id(), new ModelEvaluation(eligible, List.copyOf(reasons), requiredDisk));
+            if (eligible && (requested || requestedModelId == null && better(model, selected))) {
+                selected = model;
+            }
+        }
+        return new Selection(selected == null ? null : selected.id(), Map.copyOf(evaluations));
+    }
+
+    static long requiredDiskBytes(ManagedLocalAiManifest manifest, Profile profile,
+                                  ManagedLocalAiManifest.ModelManifest model) {
+        long runtimeArchive = manifest.runtime().assets().stream()
+                .filter(asset -> asset.platform().equals(profile.platform()))
+                .mapToLong(ManagedLocalAiManifest.RuntimeAsset::size)
+                .findFirst().orElse(0);
+        long peak = saturatedAdd(runtimeArchive, MAXIMUM_RUNTIME_EXPANSION_BYTES);
+        peak = saturatedAdd(peak, saturatedMultiply(model.size(), 2));
+        peak = saturatedAdd(peak, DISK_RESERVE_BYTES);
+        long declared = gibibytes(model.minimumFreeDiskGb());
+        return Math.max(peak, declared);
+    }
+
+    private static boolean better(ManagedLocalAiManifest.ModelManifest candidate,
+                                  ManagedLocalAiManifest.ModelManifest current) {
+        if (current == null) {
+            return true;
+        }
+        int ram = Double.compare(candidate.minimumRamGb(), current.minimumRamGb());
+        if (ram != 0) {
+            return ram > 0;
+        }
+        int cpu = Integer.compare(candidate.minimumCpuCount(), current.minimumCpuCount());
+        return cpu > 0 || cpu == 0 && candidate.id().compareTo(current.id()) < 0;
+    }
+
+    private static Optional<Long> cgroupAvailableMemory(HostAccess host) {
+        for (String base : cgroupBases(host, "memory")) {
+            Optional<Long> maximum = positiveLong(read(host, base + "/memory.max"));
+            Optional<Long> current = nonNegativeLong(read(host, base + "/memory.current"));
+            if (maximum.isPresent() && current.isPresent()) {
+                return Optional.of(Math.max(0, maximum.get() - current.get()));
+            }
+            maximum = positiveLong(read(host, base + "/memory.limit_in_bytes"));
+            current = nonNegativeLong(read(host, base + "/memory.usage_in_bytes"));
+            if (maximum.isPresent() && current.isPresent() && maximum.get() < Long.MAX_VALUE / 2) {
+                return Optional.of(Math.max(0, maximum.get() - current.get()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Integer> cgroupProcessors(HostAccess host) {
+        int limit = Integer.MAX_VALUE;
+        boolean constrained = false;
+        for (String base : cgroupBases(host, "cpu")) {
+            String cpuMax = read(host, base + "/cpu.max");
+            if (cpuMax != null) {
+                String[] parts = cpuMax.trim().split("\\s+");
+                if (parts.length == 2 && !"max".equals(parts[0])) {
+                    Optional<Long> quota = positiveLong(parts[0]);
+                    Optional<Long> period = positiveLong(parts[1]);
+                    if (quota.isPresent() && period.isPresent()) {
+                        limit = Math.min(limit, Math.max(1, (int) (quota.get() / period.get())));
+                        constrained = true;
+                    }
+                }
+            }
+            Optional<Long> quota = positiveLong(read(host, base + "/cpu.cfs_quota_us"));
+            Optional<Long> period = positiveLong(read(host, base + "/cpu.cfs_period_us"));
+            if (quota.isPresent() && period.isPresent()) {
+                limit = Math.min(limit, Math.max(1, (int) (quota.get() / period.get())));
+                constrained = true;
+            }
+        }
+        for (String base : cgroupBases(host, "cpuset")) {
+            String cpus = read(host, base + "/cpuset.cpus.effective");
+            if (cpus == null) {
+                cpus = read(host, base + "/cpuset.cpus");
+            }
+            Optional<Integer> count = countCpuSet(cpus);
+            if (count.isPresent()) {
+                limit = Math.min(limit, count.get());
+                constrained = true;
+            }
+        }
+        return constrained ? Optional.of(limit) : Optional.empty();
+    }
+
+    private static List<String> cgroupBases(HostAccess host, String controller) {
+        List<String> bases = new ArrayList<>();
+        String membership = read(host, "/proc/self/cgroup");
+        String mountInfo = read(host, "/proc/self/mountinfo");
+        if (membership != null) {
+            for (String line : membership.lines().toList()) {
+                String[] fields = line.split(":", 3);
+                if (fields.length != 3 || !fields[2].startsWith("/")) {
+                    continue;
+                }
+                if (fields[0].equals("0") && fields[1].isEmpty()) {
+                    mountedCgroupBase(mountInfo, "cgroup2", controller, fields[2]).ifPresent(bases::add);
+                    bases.add("/sys/fs/cgroup" + fields[2]);
+                } else if (List.of(fields[1].split(",")).contains(controller)) {
+                    mountedCgroupBase(mountInfo, "cgroup", controller, fields[2]).ifPresent(bases::add);
+                }
+            }
+        }
+        bases.add("/sys/fs/cgroup");
+        bases.add("/sys/fs/cgroup/" + controller);
+        return bases.stream().distinct().toList();
+    }
+
+    private static Optional<String> mountedCgroupBase(String mountInfo, String fileSystem,
+                                                       String controller, String membership) {
+        if (mountInfo == null) {
+            return Optional.empty();
+        }
+        for (String line : mountInfo.lines().toList()) {
+            String[] fields = line.trim().split("\\s+");
+            int separator = List.of(fields).indexOf("-");
+            if (separator < 6 || separator + 3 >= fields.length || !fileSystem.equals(fields[separator + 1])) {
+                continue;
+            }
+            if ("cgroup".equals(fileSystem)) {
+                boolean mountedController = false;
+                for (int index = separator + 2; index < fields.length; index++) {
+                    if (List.of(fields[index].split(",")).contains(controller)) {
+                        mountedController = true;
+                        break;
+                    }
+                }
+                if (!mountedController) {
+                    continue;
+                }
+            }
+            String root = fields[3];
+            String mountPoint = fields[4];
+            if (root.contains("\\") || mountPoint.contains("\\") || !membership.startsWith("/")) {
+                continue;
+            }
+            if (!"/".equals(root) && !(membership.equals(root) || membership.startsWith(root + "/"))) {
+                continue;
+            }
+            String suffix = "/".equals(root) ? membership : membership.substring(root.length());
+            return Optional.of(mountPoint + suffix);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Integer> countCpuSet(String value) {
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        long total = 0;
+        try {
+            for (String segment : value.trim().split(",")) {
+                String[] range = segment.split("-", -1);
+                int first = Integer.parseInt(range[0]);
+                int last = range.length == 1 ? first : Integer.parseInt(range[1]);
+                if (range.length > 2 || first < 0 || last < first) {
+                    return Optional.empty();
+                }
+                total += (long) last - first + 1;
+                if (total > Integer.MAX_VALUE) {
+                    return Optional.empty();
+                }
+            }
+            return total > 0 ? Optional.of((int) total) : Optional.empty();
+        } catch (NumberFormatException malformed) {
+            return Optional.empty();
+        }
+    }
+
+    private static String read(HostAccess host, String path) {
+        try {
+            return host.read(path);
+        } catch (IOException unavailable) {
+            return null;
+        }
+    }
+
+    private static Optional<Long> positiveLong(String value) {
+        Optional<Long> parsed = nonNegativeLong(value);
+        return parsed.filter(number -> number > 0);
+    }
+
+    private static Optional<Long> nonNegativeLong(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        try {
+            long parsed = Long.parseLong(value.trim());
+            return parsed >= 0 ? Optional.of(parsed) : Optional.empty();
+        } catch (NumberFormatException malformed) {
+            return Optional.empty();
+        }
+    }
+
+    private static Path nearestExistingAncestor(Path path) {
+        Path candidate = path;
+        while (candidate != null && !Files.exists(candidate)) {
+            candidate = candidate.getParent();
+        }
+        return candidate;
+    }
+
+    private static String platform(String osName, String architecture) {
+        String os = normalizedOs(osName);
+        String arch = architecture.toLowerCase(Locale.ROOT);
+        String normalizedArch = arch.equals("amd64") || arch.equals("x86_64") || arch.equals("x64") ? "x86_64"
+                : arch.equals("aarch64") || arch.equals("arm64") ? "aarch64" : "unsupported";
+        return os.equals("unsupported") || normalizedArch.equals("unsupported")
+                ? "unsupported" : os + "-" + normalizedArch;
+    }
+
+    private static String normalizedOs(String osName) {
+        String os = osName.toLowerCase(Locale.ROOT);
+        if (os.contains("mac") || os.contains("darwin")) return "macos";
+        if (os.startsWith("windows")) return "windows";
+        if (os.contains("linux")) return "linux";
+        return "unsupported";
+    }
+
+    private static long gibibytes(double value) {
+        if (!Double.isFinite(value) || value <= 0 || value > Long.MAX_VALUE / (double) GIB) {
+            return Long.MAX_VALUE;
+        }
+        return (long) Math.ceil(value * GIB);
+    }
+
+    private static long positiveOrZero(long value) {
+        return Math.max(0, value);
+    }
+
+    private static long saturatedAdd(long left, long right) {
+        return left > Long.MAX_VALUE - right ? Long.MAX_VALUE : left + right;
+    }
+
+    private static long saturatedMultiply(long value, int multiplier) {
+        return value > Long.MAX_VALUE / multiplier ? Long.MAX_VALUE : value * multiplier;
+    }
+
+    record Profile(String platform, boolean runtimeCompatible, long effectiveMemoryBytes,
+                   int cpuCount, long freeDiskBytes) {
+        Profile {
+            if (platform == null || platform.isBlank() || effectiveMemoryBytes < 0
+                    || cpuCount < 0 || freeDiskBytes < 0) {
+                throw new IllegalArgumentException("Invalid managed local AI hardware profile.");
+            }
+        }
+    }
+
+    record ModelEvaluation(boolean eligible, List<String> reasons, long requiredDiskBytes) {
+    }
+
+    record Selection(String selectedModelId, Map<String, ModelEvaluation> models) {
+    }
+
+    interface HostAccess {
+        String osName();
+        String architecture();
+        String abi();
+        String abiVersion();
+        long availableMemoryBytes();
+        int availableProcessors();
+        long usableSpace(Path existingAncestor);
+        String read(String path) throws IOException;
+    }
+
+    static HostAccess systemHost() {
+        return new SystemHostAccess();
+    }
+
+    private static final class SystemHostAccess implements HostAccess {
+        public String osName() { return System.getProperty("os.name", ""); }
+        public String architecture() { return System.getProperty("os.arch", ""); }
+        public String abi() {
+            return switch (normalizedOs(osName())) {
+                case "windows" -> "windows-msvc";
+                case "macos" -> "macos-darwin";
+                case "linux" -> "linux-glibc";
+                default -> "unsupported";
+            };
+        }
+        public String abiVersion() {
+            if (!"linux".equals(normalizedOs(osName()))) return "";
+            try {
+                Process process = new ProcessBuilder("getconf", "GNU_LIBC_VERSION")
+                        .redirectErrorStream(true).start();
+                if (!process.waitFor(2, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    return "";
+                }
+                String output = new String(process.getInputStream().readNBytes(64)).trim();
+                String[] fields = output.split("\\s+");
+                return fields.length == 2 && fields[0].equalsIgnoreCase("glibc") ? fields[1] : "";
+            } catch (IOException failure) {
+                return "";
+            } catch (InterruptedException cancelled) {
+                Thread.currentThread().interrupt();
+                return "";
+            }
+        }
+        public long availableMemoryBytes() {
+            java.lang.management.OperatingSystemMXBean bean = ManagementFactory.getOperatingSystemMXBean();
+            return bean instanceof OperatingSystemMXBean extended ? extended.getFreeMemorySize() : 0;
+        }
+        public int availableProcessors() { return Runtime.getRuntime().availableProcessors(); }
+        public long usableSpace(Path existingAncestor) { return existingAncestor.toFile().getUsableSpace(); }
+        public String read(String path) throws IOException { return Files.readString(Path.of(path)); }
+    }
+}

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiManifest.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiManifest.java
@@ -30,7 +30,7 @@ final class ManagedLocalAiManifest {
     private static final Pattern SHA_256 = Pattern.compile("[0-9a-f]{64}");
     private static final Pattern PORTABLE_NAME = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._+-]{0,199}");
     private static final Set<String> LICENSES = Set.of("MIT", "Apache-2.0");
-    private static final Set<String> WINDOWS_DEVICES = Set.of("CON", "PRN", "AUX", "NUL",
+    static final Set<String> WINDOWS_DEVICES = Set.of("CON", "PRN", "AUX", "NUL",
             "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
             "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9");
 

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiManifest.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiManifest.java
@@ -1,0 +1,394 @@
+package com.shaft.ai.local;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.core.JacksonException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Immutable, validated artifact inventory for SHAFT-managed local inference.
+ *
+ * <p>The manifest is data, not authority: parsing succeeds only when every consumed field is
+ * structurally valid and bound to the reviewed upstream host, release, revision, and filename.</p>
+ */
+final class ManagedLocalAiManifest {
+    private static final ObjectMapper JSON = JsonMapper.builder()
+            .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+            .build();
+    private static final String RESOURCE = "/com/shaft/ai/local/manifest.json";
+    private static final Pattern SHA_256 = Pattern.compile("[0-9a-f]{64}");
+    private static final Pattern PORTABLE_NAME = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._+-]{0,199}");
+    private static final Set<String> LICENSES = Set.of("MIT", "Apache-2.0");
+    private static final Set<String> WINDOWS_DEVICES = Set.of("CON", "PRN", "AUX", "NUL",
+            "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+            "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9");
+
+    private final int schemaVersion;
+    private final RuntimeManifest runtime;
+    private final List<ModelManifest> models;
+
+    private ManagedLocalAiManifest(int schemaVersion, RuntimeManifest runtime, List<ModelManifest> models) {
+        this.schemaVersion = schemaVersion;
+        this.runtime = runtime;
+        this.models = List.copyOf(models);
+    }
+
+    static ManagedLocalAiManifest loadDefault() {
+        try (InputStream input = ManagedLocalAiManifest.class.getResourceAsStream(RESOURCE)) {
+            if (input == null) {
+                throw new IllegalStateException("Managed local AI manifest is not packaged.");
+            }
+            return parse(input);
+        } catch (IOException failure) {
+            throw new IllegalStateException("Managed local AI manifest cannot be read.", failure);
+        }
+    }
+
+    static ManagedLocalAiManifest parse(InputStream input) {
+        try {
+            JsonNode root = JSON.readTree(input);
+            requireObject(root, "manifest");
+            requireFields(root, "manifest", Set.of("schemaVersion", "runtime", "models"));
+            int schemaVersion = positiveInt(root.get("schemaVersion"), "schemaVersion");
+            if (schemaVersion != 1) {
+                throw invalid("schemaVersion must be 1");
+            }
+            RuntimeManifest runtime = parseRuntime(root.get("runtime"));
+            List<ModelManifest> models = parseModels(root.get("models"));
+            return new ManagedLocalAiManifest(schemaVersion, runtime, models);
+        } catch (JacksonException malformed) {
+            throw new IllegalArgumentException("Invalid managed local AI manifest: malformed JSON.", malformed);
+        }
+    }
+
+    int schemaVersion() {
+        return schemaVersion;
+    }
+
+    RuntimeManifest runtime() {
+        return runtime;
+    }
+
+    List<ModelManifest> models() {
+        return models;
+    }
+
+    RuntimeAsset selectRuntime(String osName, String architecture, String abi, String abiVersion) {
+        String platform = platform(osName, architecture);
+        return runtime.assets().stream()
+                .filter(asset -> asset.platform().equals(platform))
+                .filter(asset -> compatibleAbi(asset, abi, abiVersion))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No compatible managed local AI runtime is available."));
+    }
+
+    boolean supportsRuntime(String osName, String architecture, String abi, String abiVersion) {
+        try {
+            selectRuntime(osName, architecture, abi, abiVersion);
+            return true;
+        } catch (IllegalArgumentException unsupported) {
+            return false;
+        }
+    }
+
+    private static RuntimeManifest parseRuntime(JsonNode node) {
+        requireObject(node, "runtime");
+        requireFields(node, "runtime", Set.of("id", "version", "license", "releaseUrl", "assets"));
+        String id = text(node, "id");
+        String version = portableName(text(node, "version"), "runtime.version");
+        String license = license(text(node, "license"), "runtime.license");
+        URI release = https(node, "releaseUrl");
+        if (!"llama.cpp".equals(id) || !"github.com".equalsIgnoreCase(release.getHost())
+                || !release.getPath().equals("/ggml-org/llama.cpp/releases/tag/" + version)
+                || release.getQuery() != null || release.getFragment() != null) {
+            throw invalid("runtime release provenance is not trusted");
+        }
+        JsonNode assetsNode = node.get("assets");
+        requireNonEmptyArray(assetsNode, "runtime.assets");
+        List<RuntimeAsset> assets = new ArrayList<>();
+        Set<String> platforms = new HashSet<>();
+        for (JsonNode assetNode : assetsNode) {
+            requireObject(assetNode, "runtime asset");
+            Set<String> assetFields = new HashSet<>(Set.of("platform", "file", "url", "size", "sha256",
+                    "executable", "abi"));
+            if (assetNode.has("minimumAbiVersion")) {
+                assetFields.add("minimumAbiVersion");
+            }
+            requireFields(assetNode, "runtime asset", assetFields);
+            String platform = text(assetNode, "platform");
+            if (!Set.of("windows-x86_64", "windows-aarch64", "macos-x86_64", "macos-aarch64",
+                    "linux-x86_64", "linux-aarch64").contains(platform) || !platforms.add(platform)) {
+                throw invalid("runtime platform is unsupported or duplicated");
+            }
+            String file = portableName(text(assetNode, "file"), "runtime file");
+            URI url = https(assetNode, "url");
+            String expectedPath = "/ggml-org/llama.cpp/releases/download/" + version + "/" + file;
+            if (!"github.com".equalsIgnoreCase(url.getHost()) || !expectedPath.equals(url.getPath())
+                    || url.getQuery() != null || url.getFragment() != null) {
+                throw invalid("runtime asset provenance is not trusted");
+            }
+            long size = positiveLong(assetNode.get("size"), "runtime size");
+            String digest = digest(text(assetNode, "sha256"), "runtime sha256");
+            String executable = portableName(text(assetNode, "executable"), "runtime executable");
+            String abi = text(assetNode, "abi");
+            String minimumAbiVersion = optionalText(assetNode, "minimumAbiVersion");
+            validateAbi(platform, abi, minimumAbiVersion);
+            assets.add(new RuntimeAsset(platform, file, url, size, digest, executable, abi, minimumAbiVersion));
+        }
+        if (assets.size() != 6) {
+            throw invalid("runtime assets must cover exactly six desktop platforms");
+        }
+        return new RuntimeManifest(id, version, license, release, List.copyOf(assets));
+    }
+
+    private static List<ModelManifest> parseModels(JsonNode node) {
+        requireNonEmptyArray(node, "models");
+        List<ModelManifest> models = new ArrayList<>();
+        Set<String> identifiers = new HashSet<>();
+        for (JsonNode model : node) {
+            requireObject(model, "model");
+            requireFields(model, "model", Set.of("id", "displayName", "tier", "automatic",
+                    "firstPartyQuantization", "license", "source", "revision", "file", "url", "size",
+                    "sha256", "minimumRamGb", "minimumCpuCount", "minimumFreeDiskGb"));
+            String id = portableName(text(model, "id"), "model id");
+            if (!identifiers.add(id)) {
+                throw invalid("model id is duplicated");
+            }
+            String displayName = boundedText(model, "displayName", 200);
+            String tier = text(model, "tier");
+            if (!Set.of("lite", "balanced", "challenger").contains(tier)) {
+                throw invalid("model tier is unsupported");
+            }
+            boolean automatic = booleanValue(model, "automatic");
+            boolean firstParty = booleanValue(model, "firstPartyQuantization");
+            String license = license(text(model, "license"), "model license");
+            String source = source(text(model, "source"));
+            String revision = revision(text(model, "revision"));
+            String file = portableName(text(model, "file"), "model file");
+            URI url = https(model, "url");
+            String expectedPath = "/" + source + "/resolve/" + revision + "/" + file;
+            if (!"huggingface.co".equalsIgnoreCase(url.getHost()) || !expectedPath.equals(url.getPath())
+                    || url.getQuery() != null || url.getFragment() != null) {
+                throw invalid("model provenance is not trusted");
+            }
+            if (automatic && !firstParty) {
+                throw invalid("automatic models must use first-party quantization");
+            }
+            models.add(new ModelManifest(id, displayName, tier, automatic, firstParty, license, source, revision,
+                    file, url, positiveLong(model.get("size"), "model size"), digest(text(model, "sha256"),
+                    "model sha256"), positiveNumber(model.get("minimumRamGb"), "minimumRamGb"),
+                    positiveInt(model.get("minimumCpuCount"), "minimumCpuCount"),
+                    positiveNumber(model.get("minimumFreeDiskGb"), "minimumFreeDiskGb")));
+        }
+        return List.copyOf(models);
+    }
+
+    private static String platform(String osName, String architecture) {
+        String os = osName.toLowerCase(Locale.ROOT);
+        String normalizedOs = os.startsWith("windows") ? "windows"
+                : os.startsWith("mac") || os.startsWith("darwin") ? "macos"
+                : os.startsWith("linux") ? "linux" : "";
+        String arch = architecture.toLowerCase(Locale.ROOT);
+        String normalizedArch = switch (arch) {
+            case "amd64", "x86_64", "x64" -> "x86_64";
+            case "aarch64", "arm64" -> "aarch64";
+            default -> "";
+        };
+        if (normalizedOs.isEmpty() || normalizedArch.isEmpty()) {
+            throw invalid("host platform is unsupported");
+        }
+        return normalizedOs + "-" + normalizedArch;
+    }
+
+    private static boolean compatibleAbi(RuntimeAsset asset, String family, String version) {
+        String suppliedFamily = family == null ? "" : family;
+        String normalizedFamily = asset.platform().startsWith("linux-")
+                && Set.of("glibc", "gnu libc").contains(suppliedFamily.toLowerCase(Locale.ROOT))
+                ? "linux-glibc" : suppliedFamily;
+        if (!asset.abi().equalsIgnoreCase(normalizedFamily)) {
+            return false;
+        }
+        if (!asset.platform().startsWith("linux-")) {
+            return true;
+        }
+        int[] current = version(version);
+        int[] minimum = version(asset.minimumAbiVersion());
+        return current[0] > minimum[0] || current[0] == minimum[0] && current[1] >= minimum[1];
+    }
+
+    private static int[] version(String value) {
+        if (value == null || !value.matches("[0-9]+\\.[0-9]+(?:\\.[0-9]+)?")) {
+            throw invalid("ABI version is malformed");
+        }
+        String[] parts = value.split("\\.");
+        return new int[]{Integer.parseInt(parts[0]), Integer.parseInt(parts[1])};
+    }
+
+    private static void validateAbi(String platform, String abi, String minimumVersion) {
+        String expected = platform.startsWith("windows-") ? "windows-msvc"
+                : platform.startsWith("macos-") ? "macos-darwin" : "linux-glibc";
+        if (!expected.equals(abi)) {
+            throw invalid("runtime ABI does not match its platform");
+        }
+        if (platform.startsWith("linux-")) {
+            version(minimumVersion);
+        } else if (!minimumVersion.isEmpty()) {
+            throw invalid("minimum ABI version is only supported for Linux artifacts");
+        }
+    }
+
+    private static URI https(JsonNode node, String field) {
+        URI uri;
+        try {
+            uri = URI.create(text(node, field));
+        } catch (IllegalArgumentException malformed) {
+            throw invalid(field + " is not a valid URI");
+        }
+        if (!"https".equalsIgnoreCase(uri.getScheme()) || uri.getHost() == null || uri.getUserInfo() != null
+                || uri.getPort() != -1) {
+            throw invalid(field + " must be an authority-free HTTPS URI");
+        }
+        return uri;
+    }
+
+    private static String portableName(String value, String field) {
+        if (!PORTABLE_NAME.matcher(value).matches() || value.endsWith(".") || value.endsWith(" ")) {
+            throw invalid(field + " is not a portable basename");
+        }
+        String stem = value.split("\\.", 2)[0].toUpperCase(Locale.ROOT);
+        if (WINDOWS_DEVICES.contains(stem)) {
+            throw invalid(field + " is a reserved device name");
+        }
+        return value;
+    }
+
+    private static String source(String value) {
+        if (!value.matches("[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")) {
+            throw invalid("model source is malformed");
+        }
+        return value;
+    }
+
+    private static String revision(String value) {
+        if (!value.matches("[0-9a-f]{40}")) {
+            throw invalid("model revision must be a full commit digest");
+        }
+        return value;
+    }
+
+    private static String digest(String value, String field) {
+        if (!SHA_256.matcher(value).matches()) {
+            throw invalid(field + " must be a lowercase SHA-256 digest");
+        }
+        return value;
+    }
+
+    private static String license(String value, String field) {
+        if (!LICENSES.contains(value)) {
+            throw invalid(field + " is unsupported");
+        }
+        return value;
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode value = node == null ? null : node.get(field);
+        if (value == null || !value.isTextual() || value.asText().isBlank()) {
+            throw invalid(field + " must be a non-blank string");
+        }
+        return value.asText();
+    }
+
+    private static String optionalText(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull()) {
+            return "";
+        }
+        if (!value.isTextual()) {
+            throw invalid(field + " must be a string");
+        }
+        return value.asText();
+    }
+
+    private static String boundedText(JsonNode node, String field, int maximum) {
+        String value = text(node, field);
+        if (value.length() > maximum) {
+            throw invalid(field + " is too long");
+        }
+        return value;
+    }
+
+    private static boolean booleanValue(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || !value.isBoolean()) {
+            throw invalid(field + " must be a boolean");
+        }
+        return value.asBoolean();
+    }
+
+    private static int positiveInt(JsonNode node, String field) {
+        if (node == null || !node.isIntegralNumber() || !node.canConvertToInt() || node.asInt() <= 0) {
+            throw invalid(field + " must be a positive integer");
+        }
+        return node.asInt();
+    }
+
+    private static long positiveLong(JsonNode node, String field) {
+        if (node == null || !node.isIntegralNumber() || !node.canConvertToLong() || node.asLong() <= 0) {
+            throw invalid(field + " must be a positive integer");
+        }
+        return node.asLong();
+    }
+
+    private static double positiveNumber(JsonNode node, String field) {
+        if (node == null || !node.isNumber() || !Double.isFinite(node.asDouble()) || node.asDouble() <= 0) {
+            throw invalid(field + " must be a positive finite number");
+        }
+        return node.asDouble();
+    }
+
+    private static void requireObject(JsonNode node, String field) {
+        if (node == null || !node.isObject()) {
+            throw invalid(field + " must be an object");
+        }
+    }
+
+    private static void requireNonEmptyArray(JsonNode node, String field) {
+        if (node == null || !node.isArray() || node.isEmpty()) {
+            throw invalid(field + " must be a non-empty array");
+        }
+    }
+
+    private static void requireFields(JsonNode node, String field, Set<String> expected) {
+        if (!Set.copyOf(node.propertyNames()).equals(expected)) {
+            throw invalid(field + " contains missing or unknown fields");
+        }
+    }
+
+    private static IllegalArgumentException invalid(String reason) {
+        return new IllegalArgumentException("Invalid managed local AI manifest: " + reason + ".");
+    }
+
+    record RuntimeManifest(String id, String version, String license, URI releaseUrl, List<RuntimeAsset> assets) {
+    }
+
+    record RuntimeAsset(String platform, String file, URI url, long size, String sha256, String executable,
+                        String abi, String minimumAbiVersion) {
+    }
+
+    record ModelManifest(String id, String displayName, String tier, boolean automatic,
+                         boolean firstPartyQuantization, String license, String source, String revision,
+                         String file, URI url, long size, String sha256, double minimumRamGb,
+                         int minimumCpuCount, double minimumFreeDiskGb) {
+    }
+}

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcess.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcess.java
@@ -168,7 +168,10 @@ final class ManagedLocalAiProcess {
             }
             if (!parentExited) {
                 process.destroyForcibly();
-                process.waitFor(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS);
+                boolean forcedExit = process.waitFor(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS);
+                if (!forcedExit || process.isAlive()) {
+                    survivorFailure = new IllegalStateException("Managed local AI process did not terminate.");
+                }
             }
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcess.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcess.java
@@ -1,0 +1,412 @@
+package com.shaft.ai.local;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/** Bounded, authenticated loopback lifecycle for the SHAFT-owned llama.cpp process. */
+final class ManagedLocalAiProcess {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int MAX_LAUNCH_ATTEMPTS = 3;
+    private static final Set<String> ENVIRONMENT_ALLOWLIST = Set.of(
+            "PATH", "SYSTEMROOT", "WINDIR", "TEMP", "TMP", "TMPDIR", "COMSPEC", "PATHEXT",
+            "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH", "LANG", "LC_ALL",
+            "LC_CTYPE", "TZ", "HOME", "USERPROFILE");
+
+    private ManagedLocalAiProcess() {
+    }
+
+    static Map<String, String> runtimeEnvironment(Map<String, String> source) {
+        Objects.requireNonNull(source, "source");
+        Map<String, String> result = new LinkedHashMap<>();
+        source.forEach((key, value) -> {
+            if (key != null && value != null && ENVIRONMENT_ALLOWLIST.contains(key.toUpperCase(Locale.ROOT))) {
+                result.put(key, value);
+            }
+        });
+        return Map.copyOf(result);
+    }
+
+    static List<String> command(Path executable, Path model, int port, String alias, Path apiKeyFile, int threads) {
+        requireRegular(executable, "runtime executable");
+        requireRegular(model, "model");
+        requireRegular(apiKeyFile, "API key file");
+        if (port < 1 || port > 65_535 || alias == null || alias.isBlank()
+                || threads < 1) {
+            throw new IllegalArgumentException("Managed local AI launch parameters are invalid.");
+        }
+        return List.of(executable.toAbsolutePath().toString(), "--host", "127.0.0.1", "--port",
+                Integer.toString(port), "--model", model.toAbsolutePath().toString(), "--alias", alias,
+                "--api-key-file", apiKeyFile.toAbsolutePath().toString(), "--threads", Integer.toString(threads));
+    }
+
+    static Session launch(Path cache, Path executable, Path model, Path log, String alias, int threads, Duration timeout,
+                          PortSupplier ports, ProcessStarter starter, IdentityProbe identity) throws Exception {
+        Objects.requireNonNull(timeout, "timeout");
+        if (timeout.isNegative() || timeout.isZero()) {
+            throw new IllegalArgumentException("Launch timeout must be positive.");
+        }
+        Path verifiedExecutable = ManagedLocalAiCache.verifyOwnedFile(cache, executable);
+        Path verifiedModel = ManagedLocalAiCache.verifyOwnedFile(cache, model);
+        requireContainedLog(cache, log);
+        Files.createDirectories(log.toAbsolutePath().normalize().getParent());
+        requireContainedLog(cache, log);
+        reserveLog(log);
+        Exception lastFailure = null;
+        for (int attempt = 0; attempt < MAX_LAUNCH_ATTEMPTS; attempt++) {
+            String key = secret();
+            Path keyFile = createKeyFile(cache, key);
+            Process process = null;
+            try {
+                int port = ports.next();
+                process = starter.start(command(verifiedExecutable, verifiedModel, port, alias, keyFile, threads),
+                        runtimeEnvironment(System.getenv()), log);
+                identity.await(process, port, key, alias, timeout);
+                if (!process.isAlive()) {
+                    throw new IllegalStateException("Managed local AI process exited during identity verification.");
+                }
+                deleteKeyFile(keyFile, null);
+                return new Session(process, port, alias, key, timeout);
+            } catch (InterruptedException cancelled) {
+                Thread.currentThread().interrupt();
+                if (process != null) {
+                    terminate(process, Duration.ofSeconds(2), cancelled);
+                }
+                deleteKeyFile(keyFile, cancelled);
+                throw cancelled;
+            } catch (Exception failure) {
+                lastFailure = failure;
+                if (process != null) {
+                    terminate(process, Duration.ofSeconds(2), failure);
+                }
+                deleteKeyFile(keyFile, failure);
+            }
+        }
+        throw new IllegalStateException("Managed local AI process could not establish its authenticated identity.",
+                lastFailure);
+    }
+
+    static void requireIdentity(Process process, int port, String apiKey, String alias, Duration timeout,
+                                JsonRequester requester) throws Exception {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        Exception last = null;
+        do {
+            if (!process.isAlive()) {
+                throw new IllegalStateException("Managed local AI process exited before identity verification.");
+            }
+            try {
+                Map<String, Object> response = requester.get(
+                        URI.create("http://127.0.0.1:" + port + "/v1/models"), "Bearer " + apiKey);
+                Object data = response.get("data");
+                if (data instanceof List<?> models && models.size() == 1 && models.getFirst() instanceof Map<?, ?> model
+                        && alias.equals(model.get("id"))) {
+                    return;
+                }
+                last = new IllegalStateException("Authenticated runtime returned the wrong model identity.");
+            } catch (InterruptedException cancelled) {
+                Thread.currentThread().interrupt();
+                throw cancelled;
+            } catch (Exception failure) {
+                last = failure;
+            }
+            Thread.sleep(10);
+        } while (System.nanoTime() < deadline);
+        throw new IllegalStateException("Managed local AI authenticated identity was not established.", last);
+    }
+
+    static void terminate(Process process, Duration timeout, Throwable primary) {
+        if (process == null) {
+            return;
+        }
+        List<ProcessHandle> discovered = List.of();
+        try {
+            discovered = process.toHandle().descendants().toList();
+            discovered.forEach(ProcessHandle::destroy);
+        } catch (Exception cleanup) {
+            if (primary != null) {
+                primary.addSuppressed(cleanup);
+            }
+        }
+        List<ProcessHandle> descendants = discovered;
+        RuntimeException survivorFailure = null;
+        try {
+            process.destroy();
+            boolean parentExited = process.waitFor(Math.max(0, timeout.toMillis()), TimeUnit.MILLISECONDS);
+            descendants.stream().filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly);
+            long deadline = System.nanoTime() + timeout.toNanos();
+            while (descendants.stream().anyMatch(ProcessHandle::isAlive) && System.nanoTime() < deadline) {
+                Thread.sleep(10);
+            }
+            if (descendants.stream().anyMatch(ProcessHandle::isAlive)) {
+                survivorFailure = new IllegalStateException("Managed local AI descendant did not terminate.");
+            }
+            if (!parentExited) {
+                process.destroyForcibly();
+                process.waitFor(Math.max(1, timeout.toMillis()), TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            if (primary != null) {
+                primary.addSuppressed(interrupted);
+            }
+        } catch (Exception cleanup) {
+            if (primary != null) {
+                primary.addSuppressed(cleanup);
+            }
+        }
+        if (survivorFailure != null) {
+            if (primary != null) {
+                primary.addSuppressed(survivorFailure);
+            } else {
+                throw survivorFailure;
+            }
+        }
+    }
+
+    private static void requireRegular(Path path, String label) {
+        if (path == null || !Files.isRegularFile(path, java.nio.file.LinkOption.NOFOLLOW_LINKS)
+                || Files.isSymbolicLink(path)) {
+            throw new IllegalArgumentException("Managed local AI " + label + " is not a verified regular file.");
+        }
+    }
+
+    private static void requireContainedLog(Path cache, Path log) throws IOException {
+        Path cacheRoot = cache.toAbsolutePath().normalize();
+        Path value = log.toAbsolutePath().normalize();
+        Path parent = value.getParent();
+        Path logs = cacheRoot.resolve("staging/logs");
+        if (parent == null || !parent.equals(logs) || !value.startsWith(cacheRoot)) {
+            throw new IllegalArgumentException("Managed local AI log must be inside cache staging/logs.");
+        }
+        Path current = cacheRoot;
+        for (Path part : cacheRoot.relativize(parent)) {
+            current = current.resolve(part);
+            if (Files.exists(current, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
+                var attributes = Files.readAttributes(current, java.nio.file.attribute.BasicFileAttributes.class,
+                        java.nio.file.LinkOption.NOFOLLOW_LINKS);
+                if (attributes.isSymbolicLink() || attributes.isOther()) {
+                    throw new IllegalArgumentException("Managed local AI log path contains a link or reparse point.");
+                }
+            }
+        }
+        if (Files.exists(value, LinkOption.NOFOLLOW_LINKS)) {
+            var attributes = Files.readAttributes(value, java.nio.file.attribute.BasicFileAttributes.class,
+                    LinkOption.NOFOLLOW_LINKS);
+            if (!attributes.isRegularFile() || attributes.isSymbolicLink() || attributes.isOther()) {
+                throw new IllegalArgumentException("Managed local AI log leaf is not a regular file.");
+            }
+        }
+    }
+
+    private static void reserveLog(Path log) throws IOException {
+        try (var ignored = Files.newByteChannel(log, Set.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE,
+                LinkOption.NOFOLLOW_LINKS))) {
+            // The unique leaf is reserved before process launch.
+        }
+    }
+
+    private static Path createKeyFile(Path cache, String key) throws IOException {
+        Path directory = cache.toAbsolutePath().normalize().resolve("staging/secrets");
+        Files.createDirectories(directory);
+        requireOrdinaryDirectoryChain(cache.toAbsolutePath().normalize(), directory);
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            restrictWindowsOwner(directory);
+        }
+        Path file = directory.resolve("key-" + secret());
+        FileAttribute<?>[] attributes = Files.getFileStore(directory).supportsFileAttributeView("posix")
+                ? new FileAttribute<?>[]{PosixFilePermissions.asFileAttribute(
+                PosixFilePermissions.fromString("rw-------"))} : new FileAttribute<?>[0];
+        try (var channel = Files.newByteChannel(file,
+                Set.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS), attributes)) {
+            channel.write(StandardCharsets.UTF_8.encode(key));
+        }
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            restrictWindowsOwner(file);
+        }
+        return file;
+    }
+
+    private static void restrictWindowsOwner(Path path) throws IOException {
+        var view = Files.getFileAttributeView(path, java.nio.file.attribute.AclFileAttributeView.class,
+                LinkOption.NOFOLLOW_LINKS);
+        var owner = Files.getOwner(path, LinkOption.NOFOLLOW_LINKS);
+        view.setAcl(List.of(java.nio.file.attribute.AclEntry.newBuilder()
+                .setType(java.nio.file.attribute.AclEntryType.ALLOW).setPrincipal(owner)
+                .setPermissions(java.nio.file.attribute.AclEntryPermission.values()).build()));
+    }
+
+    private static void requireOrdinaryDirectoryChain(Path cache, Path directory) throws IOException {
+        Path current = cache;
+        for (Path part : cache.relativize(directory)) {
+            current = current.resolve(part);
+            var attributes = Files.readAttributes(current, java.nio.file.attribute.BasicFileAttributes.class,
+                    LinkOption.NOFOLLOW_LINKS);
+            if (!attributes.isDirectory() || attributes.isSymbolicLink() || attributes.isOther()) {
+                throw new IllegalArgumentException("Managed local AI secret path contains a link or reparse point.");
+            }
+        }
+    }
+
+    private static void deleteKeyFile(Path keyFile, Throwable primary) throws IOException {
+        try {
+            Files.deleteIfExists(keyFile);
+        } catch (IOException cleanup) {
+            if (primary != null) {
+                primary.addSuppressed(cleanup);
+                return;
+            }
+            throw cleanup;
+        }
+    }
+
+    private static String secret() {
+        byte[] bytes = new byte[32];
+        RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    static int availablePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0, 1, java.net.InetAddress.getLoopbackAddress())) {
+            return socket.getLocalPort();
+        }
+    }
+
+    static Process start(List<String> command, Map<String, String> environment, Path log) throws IOException {
+        ProcessBuilder builder = new ProcessBuilder(command);
+        builder.environment().clear();
+        builder.environment().putAll(environment);
+        builder.redirectErrorStream(true);
+        Process process = builder.start();
+        Thread.ofVirtual().name("shaft-local-ai-log").start(() -> {
+            try {
+                writeSanitizedLog(log.getParent().getParent().getParent(), process.getInputStream(), log,
+                        Set.of(), 1024 * 1024);
+            } catch (IOException ignored) {
+                // Lifecycle status owns launch failure; logging must never mask it.
+            }
+        });
+        return process;
+    }
+
+    static void writeSanitizedLog(Path cache, InputStream input, Path log, Set<String> secrets, long maximumBytes)
+            throws IOException {
+        if (maximumBytes < 1) {
+            throw new IllegalArgumentException("Log byte ceiling must be positive.");
+        }
+        requireContainedLog(cache, log);
+        Files.createDirectories(log.toAbsolutePath().normalize().getParent());
+        requireContainedLog(cache, log);
+        if (!Files.exists(log, LinkOption.NOFOLLOW_LINKS)) {
+            reserveLog(log);
+        }
+        byte[] raw = input.readNBytes((int) Math.min(Integer.MAX_VALUE, maximumBytes * 4 + 1));
+        String text = new String(raw, StandardCharsets.UTF_8)
+                .replaceAll("(?i)authorization\\s*:\\s*bearer\\s+\\S+", "Authorization: [REDACTED]")
+                .replaceAll("(?i)--api-key\\s+\\S+", "--api-key [REDACTED]");
+        for (String secret : secrets) {
+            if (secret != null && !secret.isEmpty()) {
+                text = text.replace(secret, "[REDACTED]");
+            }
+        }
+        byte[] sanitized = text.getBytes(StandardCharsets.UTF_8);
+        int length = (int) Math.min(maximumBytes, sanitized.length);
+        try (var output = Files.newByteChannel(log, Set.of(StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING, LinkOption.NOFOLLOW_LINKS))) {
+            output.write(java.nio.ByteBuffer.wrap(sanitized, 0, length));
+        }
+        input.transferTo(java.io.OutputStream.nullOutputStream());
+    }
+
+    static Map<String, Object> requestIdentity(URI uri, String bearer) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(2))
+                .header("Authorization", bearer).GET().build();
+        HttpResponse<InputStream> response = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build()
+                .send(request, HttpResponse.BodyHandlers.ofInputStream());
+        byte[] body = boundedRead(response.body(), 64 * 1024, Duration.ofSeconds(2));
+        if (response.statusCode() != 200 || body.length > 64 * 1024) {
+            throw new IOException("Managed local AI identity response was rejected.");
+        }
+        JsonNode root = JSON.readTree(body);
+        if (!root.isObject() || !root.path("data").isArray()) {
+            throw new IOException("Managed local AI identity response is malformed.");
+        }
+        List<Map<String, Object>> data = new ArrayList<>();
+        root.path("data").forEach(item -> {
+            if (item.isObject() && item.path("id").isTextual()) {
+                data.add(Map.of("id", item.path("id").textValue()));
+            }
+        });
+        return Map.of("data", data);
+    }
+
+    private static byte[] boundedRead(InputStream input, int maximumBytes, Duration timeout) throws Exception {
+        var executor = java.util.concurrent.Executors.newThreadPerTaskExecutor(
+                Thread.ofVirtual().name("shaft-local-ai-identity-reader").factory());
+        try {
+            var task = executor.submit(() -> input.readNBytes(maximumBytes + 1));
+            try {
+                return task.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (java.util.concurrent.TimeoutException timeoutFailure) {
+                task.cancel(true);
+                try {
+                    input.close();
+                } catch (IOException cleanup) {
+                    timeoutFailure.addSuppressed(cleanup);
+                }
+                throw new IOException("Managed local AI identity response body timed out.", timeoutFailure);
+            } catch (java.util.concurrent.ExecutionException failure) {
+                if (failure.getCause() instanceof Exception exception) {
+                    throw exception;
+                }
+                throw failure;
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    record Session(Process process, int port, String alias, String apiKey, Duration shutdownTimeout)
+            implements AutoCloseable {
+        @Override
+        public void close() {
+            terminate(process, shutdownTimeout, null);
+        }
+    }
+
+    @FunctionalInterface interface PortSupplier { int next() throws Exception; }
+    @FunctionalInterface interface ProcessStarter {
+        Process start(List<String> command, Map<String, String> environment, Path log) throws Exception;
+    }
+    @FunctionalInterface interface IdentityProbe {
+        void await(Process process, int port, String apiKey, String alias, Duration timeout) throws Exception;
+    }
+    @FunctionalInterface interface JsonRequester {
+        Map<String, Object> get(URI uri, String bearer) throws Exception;
+    }
+}

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiStatus.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiStatus.java
@@ -1,0 +1,52 @@
+package com.shaft.ai.local;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/** Read-only lifecycle state consumed by configuration and Doctor integrations. */
+public record ManagedLocalAiStatus(State state, String action) {
+    public enum State {
+        DISABLED,
+        UNSUPPORTED,
+        NOT_PROVISIONED,
+        READY,
+        CORRUPT
+    }
+
+    public static ManagedLocalAiStatus inspect(Path cache, boolean enabled, String osName, String architecture,
+                                               String abi, String abiVersion, String installationId) {
+        if (!enabled) {
+            return new ManagedLocalAiStatus(State.DISABLED, "Enable managed local AI to provision a local model.");
+        }
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        if (!manifest.supportsRuntime(osName, architecture, abi, abiVersion)) {
+            return new ManagedLocalAiStatus(State.UNSUPPORTED,
+                    "Use an external local provider or a supported desktop OS, architecture, and ABI.");
+        }
+        if (installationId == null || installationId.isBlank()) {
+            return new ManagedLocalAiStatus(State.NOT_PROVISIONED,
+                    "Provision the reviewed managed runtime and model explicitly.");
+        }
+        try {
+            ManagedLocalAiCache.verify(cache, installationId);
+            return new ManagedLocalAiStatus(State.READY, "No lifecycle action is required.");
+        } catch (IllegalStateException missingOrChanged) {
+            try {
+                if (!ManagedLocalAiCache.ownsInstallation(cache, installationId)) {
+                    return new ManagedLocalAiStatus(State.NOT_PROVISIONED,
+                            "Provision the reviewed managed runtime and model explicitly.");
+                }
+            } catch (IOException | IllegalStateException unreadable) {
+                return new ManagedLocalAiStatus(State.CORRUPT,
+                        "Inspect cache permissions and rebuild the managed installation.");
+            }
+            {
+                return new ManagedLocalAiStatus(State.CORRUPT,
+                        "Rebuild the changed managed installation; unknown files will be preserved.");
+            }
+        } catch (IOException unreadable) {
+            return new ManagedLocalAiStatus(State.CORRUPT,
+                    "Inspect cache permissions and rebuild the managed installation.");
+        }
+    }
+}

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiArtifactsTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiArtifactsTest.java
@@ -1,0 +1,252 @@
+package com.shaft.ai.local;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ManagedLocalAiArtifactsTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void publishesOnlyAnExactVerifiedDownload() throws Exception {
+        byte[] content = "verified-runtime".getBytes(StandardCharsets.UTF_8);
+        Path target = temp.resolve("downloads/runtime.zip");
+
+        ManagedLocalAiArtifacts.download(new ByteArrayInputStream(content), content.length, sha256(content),
+                target, () -> false);
+
+        assertArrayEquals(content, Files.readAllBytes(target));
+        assertFalse(Files.list(target.getParent()).anyMatch(path -> path.getFileName().toString().contains(".part-")));
+    }
+
+    @Test
+    void rejectsShortOversizedChangedAndCancelledDownloadsWithoutPublication() throws Exception {
+        byte[] content = "verified-runtime".getBytes(StandardCharsets.UTF_8);
+        Path target = temp.resolve("downloads/runtime.zip");
+
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiArtifacts.download(
+                new ByteArrayInputStream(content), content.length + 1, sha256(content), target, () -> false));
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiArtifacts.download(
+                new ByteArrayInputStream(content), content.length - 1, sha256(content), target, () -> false));
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiArtifacts.download(
+                new ByteArrayInputStream(content), content.length, "0".repeat(64), target, () -> false));
+        AtomicBoolean cancelled = new AtomicBoolean(true);
+        assertThrows(InterruptedException.class, () -> ManagedLocalAiArtifacts.download(
+                new ByteArrayInputStream(content), content.length, sha256(content), target, cancelled::get));
+
+        assertFalse(Files.exists(target));
+
+        Files.createDirectories(target.getParent());
+        Files.writeString(target, "existing");
+        assertThrows(IllegalArgumentException.class,
+                () -> ManagedLocalAiArtifacts.download(new ByteArrayInputStream(content), content.length,
+                        sha256(content), target, () -> false));
+        assertTrue(Files.readString(target).equals("existing"));
+    }
+
+    @Test
+    void followsOnlyBoundedReviewedHttpsRedirects() throws Exception {
+        byte[] content = "verified-runtime".getBytes(StandardCharsets.UTF_8);
+        URI source = URI.create("https://github.com/ggml-org/llama.cpp/releases/download/b1/runtime.zip");
+        URI storage = URI.create("https://release-assets.githubusercontent.com/signed-runtime");
+        AtomicInteger calls = new AtomicInteger();
+        ManagedLocalAiArtifacts.DownloadTransport transport = (uri, ignored) -> {
+            if (calls.getAndIncrement() == 0) {
+                return response(302, source, Map.of("location", List.of(storage.toString())), new byte[0]);
+            }
+            return response(200, storage, Map.of("content-length", List.of(String.valueOf(content.length))),
+                    content);
+        };
+
+        Path target = temp.resolve("https/runtime.zip");
+        ManagedLocalAiArtifacts.download(source, content.length, sha256(content), target, Duration.ofSeconds(5),
+                () -> false, transport);
+        assertArrayEquals(content, Files.readAllBytes(target));
+
+        ManagedLocalAiArtifacts.DownloadTransport foreign = (uri, ignored) -> response(302, source,
+                Map.of("location", List.of("https://attacker.invalid/runtime.zip")), new byte[0]);
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiArtifacts.download(source, content.length,
+                sha256(content), temp.resolve("foreign.zip"), Duration.ofSeconds(5), () -> false, foreign));
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiArtifacts.download(
+                URI.create("http://github.com/runtime.zip"), content.length, sha256(content),
+                temp.resolve("http.zip"), Duration.ofSeconds(5), () -> false, foreign));
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiArtifacts.download(
+                URI.create("https://github.com/other/project/releases/download/v1/runtime.zip"), content.length,
+                sha256(content), temp.resolve("same-host.zip"), Duration.ofSeconds(5), () -> false, foreign));
+
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiArtifacts.download(
+                URI.create("https://github.com/ggml-org/llama.cpp/releases/download/b999/runtime.zip"),
+                content.length, sha256(content), temp.resolve("unreviewed.zip"), Duration.ofSeconds(5),
+                () -> false));
+    }
+
+    @Test
+    void boundsAStalledResponseBody() throws Exception {
+        byte[] content = "verified-runtime".getBytes(StandardCharsets.UTF_8);
+        URI source = URI.create("https://github.com/ggml-org/llama.cpp/releases/download/b1/runtime.zip");
+        InputStream stalled = new InputStream() {
+            @Override
+            public int read() throws java.io.IOException {
+                try {
+                    Thread.sleep(60_000);
+                    return -1;
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw new java.io.InterruptedIOException("cancelled");
+                }
+            }
+        };
+        ManagedLocalAiArtifacts.DownloadTransport transport = (uri, ignored) ->
+                new ManagedLocalAiArtifacts.DownloadResponse(200, source, Map.of(), stalled);
+
+        long started = System.nanoTime();
+        assertThrows(java.io.IOException.class, () -> ManagedLocalAiArtifacts.download(source, content.length,
+                sha256(content), temp.resolve("stalled.zip"), Duration.ofMillis(100), () -> false, transport));
+        assertTrue(Duration.ofNanos(System.nanoTime() - started).compareTo(Duration.ofSeconds(2)) < 0);
+
+        AtomicBoolean cancelled = new AtomicBoolean();
+        Thread canceller = Thread.ofVirtual().start(() -> {
+            try {
+                Thread.sleep(100);
+                cancelled.set(true);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        started = System.nanoTime();
+        assertThrows(InterruptedException.class, () -> ManagedLocalAiArtifacts.download(source, content.length,
+                sha256(content), temp.resolve("cancelled-stall.zip"), Duration.ofSeconds(30), cancelled::get,
+                transport));
+        canceller.join();
+        assertTrue(Duration.ofNanos(System.nanoTime() - started).compareTo(Duration.ofSeconds(2)) < 0);
+    }
+
+    @Test
+    void extractsValidatedZipAndTarGzipIntoVerifiedUniqueStages() throws Exception {
+        Path zipTarget = temp.resolve("runtime-zip");
+        zipTarget = ManagedLocalAiArtifacts.extractToStage(write("runtime.zip", zip("bin/llama-server", "binary")),
+                zipTarget, () -> false);
+        assertTrue(Files.isRegularFile(zipTarget.resolve("bin/llama-server")));
+        assertTrue(Files.isRegularFile(zipTarget.resolve(".shaft-ready")));
+
+        Path tarTarget = temp.resolve("runtime-tar");
+        tarTarget = ManagedLocalAiArtifacts.extractToStage(
+                write("runtime.tar.gz", tarGzip("bin/llama-server", "binary")), tarTarget, () -> false);
+        assertTrue(Files.isRegularFile(tarTarget.resolve("bin/llama-server")));
+        if (Files.getFileStore(tarTarget).supportsFileAttributeView("posix")) {
+            assertTrue(Files.isExecutable(tarTarget.resolve("bin/llama-server")));
+        }
+    }
+
+    @Test
+    void rejectsTraversalLinksAndArchiveBombsWithoutPublishing() throws Exception {
+        Path traversal = write("traversal.zip", zip("../outside", "bad"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ManagedLocalAiArtifacts.extractToStage(traversal, temp.resolve("traversal"), () -> false));
+        assertFalse(Files.exists(temp.resolve("outside")));
+
+        byte[] linkTar = tarGzipLink("bin/llama-server", "../../outside");
+        assertThrows(IllegalArgumentException.class,
+                () -> ManagedLocalAiArtifacts.extractToStage(write("link.tar.gz", linkTar), temp.resolve("link"),
+                        () -> false));
+
+        byte[] bomb = zip("huge", "x".repeat(2_000_000));
+        assertThrows(IllegalArgumentException.class,
+                () -> ManagedLocalAiArtifacts.extractToStage(write("bomb.zip", bomb), temp.resolve("bomb"),
+                        () -> false));
+        assertFalse(Files.exists(temp.resolve("bomb")));
+
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiArtifacts.extractToStage(
+                write("collision.zip", zipEntries("bin/Server", "one", "BIN/server", "two")),
+                temp.resolve("collision"), () -> false));
+    }
+
+    private Path write(String name, byte[] value) throws Exception {
+        Path path = temp.resolve(name);
+        Files.write(path, value);
+        return path;
+    }
+
+    private static byte[] zip(String name, String content) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
+            zip.putNextEntry(new ZipEntry(name));
+            zip.write(content.getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
+        return bytes.toByteArray();
+    }
+
+    private static byte[] zipEntries(String firstName, String firstContent, String secondName,
+                                     String secondContent) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
+            for (String[] entry : List.of(new String[]{firstName, firstContent},
+                    new String[]{secondName, secondContent})) {
+                zip.putNextEntry(new ZipEntry(entry[0]));
+                zip.write(entry[1].getBytes(StandardCharsets.UTF_8));
+                zip.closeEntry();
+            }
+        }
+        return bytes.toByteArray();
+    }
+
+    private static byte[] tarGzip(String name, String content) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream tar = new TarArchiveOutputStream(new GZIPOutputStream(bytes))) {
+            byte[] value = content.getBytes(StandardCharsets.UTF_8);
+            TarArchiveEntry entry = new TarArchiveEntry(name);
+            entry.setSize(value.length);
+            tar.putArchiveEntry(entry);
+            tar.write(value);
+            tar.closeArchiveEntry();
+        }
+        return bytes.toByteArray();
+    }
+
+    private static byte[] tarGzipLink(String name, String target) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream tar = new TarArchiveOutputStream(new GZIPOutputStream(bytes))) {
+            TarArchiveEntry entry = new TarArchiveEntry(name, TarArchiveEntry.LF_SYMLINK);
+            entry.setLinkName(target);
+            tar.putArchiveEntry(entry);
+            tar.closeArchiveEntry();
+        }
+        return bytes.toByteArray();
+    }
+
+    private static String sha256(byte[] value) throws Exception {
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(value));
+    }
+
+    private static ManagedLocalAiArtifacts.DownloadResponse response(int status, URI uri,
+                                                                     Map<String, List<String>> headers,
+                                                                     byte[] body) {
+        return new ManagedLocalAiArtifacts.DownloadResponse(status, uri, headers, new ByteArrayInputStream(body));
+    }
+}

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiCacheTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiCacheTest.java
@@ -1,0 +1,302 @@
+package com.shaft.ai.local;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class ManagedLocalAiCacheTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void adoptsAndReusesOnlyAnImmutableOwnedInstallation() throws Exception {
+        Path cache = temp.resolve("cache");
+        Path stage = readyStage(cache, "runtime", "binary");
+
+        ManagedLocalAiCache.Installation installed = ManagedLocalAiCache.withLock(cache,
+                Duration.ofSeconds(1), () -> ManagedLocalAiCache.adopt(cache, "runtime-b10400-windows-x86_64", stage));
+
+        assertTrue(Files.isRegularFile(installed.root().resolve("bin/llama-server")));
+        assertEquals(installed, ManagedLocalAiCache.verify(cache, installed.id()));
+        assertTrue(Files.isRegularFile(cache.resolve("owner-manifest.json")));
+    }
+
+    @Test
+    void changedOrUnownedPathsAreNeverClaimedOrDeleted() throws Exception {
+        Path cache = temp.resolve("cache");
+        ManagedLocalAiCache.Installation installed = ManagedLocalAiCache.withLock(cache,
+                Duration.ofSeconds(1), () -> ManagedLocalAiCache.adopt(cache, "runtime-b10400-linux-x86_64",
+                        readyStage(cache, "runtime", "binary")));
+        Path changed = installed.root().resolve("bin/llama-server");
+        Files.writeString(changed, "changed", StandardCharsets.UTF_8);
+        Path unknown = installed.root().resolve("user-note.txt");
+        Files.writeString(unknown, "mine", StandardCharsets.UTF_8);
+
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiCache.verify(cache, installed.id()));
+        ManagedLocalAiCache.CleanResult result = ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(1),
+                () -> ManagedLocalAiCache.clean(cache));
+
+        assertTrue(Files.exists(changed));
+        assertTrue(Files.exists(unknown));
+        assertEquals(1, result.conflicts().size());
+        assertEquals(0, result.deletedFiles());
+
+        Path empty = installed.root().resolve("unknown-empty");
+        Files.createDirectory(empty);
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiCache.verify(cache, installed.id()));
+        ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(1), () -> ManagedLocalAiCache.clean(cache));
+        assertTrue(Files.isDirectory(empty));
+    }
+
+    @Test
+    void cleanDeletesOnlyExactOwnedFilesAndIsIdempotent() throws Exception {
+        Path cache = temp.resolve("cache");
+        ManagedLocalAiCache.Installation installed = ManagedLocalAiCache.withLock(cache,
+                Duration.ofSeconds(1), () -> ManagedLocalAiCache.adopt(cache, "model-qwen",
+                        readyStage(cache, "model", "weights")));
+        Path unrelated = cache.resolve("unowned.txt");
+        Files.writeString(unrelated, "mine");
+
+        ManagedLocalAiCache.CleanResult first = ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(1),
+                () -> ManagedLocalAiCache.clean(cache));
+        ManagedLocalAiCache.CleanResult second = ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(1),
+                () -> ManagedLocalAiCache.clean(cache));
+
+        assertTrue(first.deletedFiles() >= 2);
+        assertFalse(Files.exists(installed.root()));
+        assertTrue(Files.exists(unrelated));
+        assertEquals(0, second.deletedFiles());
+    }
+
+    @Test
+    void crossThreadContentionTimesOutWithoutMutation() throws Exception {
+        Path cache = temp.resolve("cache");
+        CountDownLatch locked = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var holder = executor.submit(() -> ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(2), () -> {
+                locked.countDown();
+                release.await();
+                return null;
+            }));
+            locked.await();
+
+            assertThrows(IllegalStateException.class, () -> ManagedLocalAiCache.withLock(cache,
+                    Duration.ofMillis(100), () -> ManagedLocalAiCache.adopt(cache, "must-not-install",
+                            readyStage(cache, "blocked", "bad"))));
+            release.countDown();
+            holder.get();
+        }
+        assertFalse(Files.exists(cache.resolve("installations")));
+    }
+
+    @Test
+    void rejectsTheStagingRootAndDuplicateOwnerPaths() throws Exception {
+        Path cache = temp.resolve("cache");
+        Path stage = readyStage(cache, "one", "binary");
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiCache.withLock(cache,
+                Duration.ofSeconds(1), () -> ManagedLocalAiCache.adopt(cache, "bad", cache.resolve("staging"))));
+        assertTrue(Files.exists(stage));
+
+        String duplicate = """
+                {"schemaVersion":1,"installations":[{"id":"duplicate","rootPath":"installations/x",
+                "files":[{"path":"installations/x/a","size":1,"sha256":"%s"},
+                {"path":"installations/x/a","size":1,"sha256":"%s"}]}]}
+                """.formatted("0".repeat(64), "0".repeat(64));
+        Files.createDirectories(cache);
+        Files.writeString(cache.resolve("owner-manifest.json"), duplicate);
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiCache.verify(cache, "duplicate"));
+
+        String overlapping = """
+                {"schemaVersion":1,"installations":[
+                {"id":"one","rootPath":"installations/x","files":[
+                {"path":"installations/x/a","size":1,"sha256":"%s"}]},
+                {"id":"two","rootPath":"installations/x","files":[
+                {"path":"installations/x/a","size":1,"sha256":"%s"}]}]}
+                """.formatted("0".repeat(64), "0".repeat(64));
+        Files.writeString(cache.resolve("owner-manifest.json"), overlapping);
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiCache.verify(cache, "one"));
+    }
+
+    @Test
+    void subprocessContentionTimesOutWithoutMutation() throws Exception {
+        Path cache = temp.resolve("process-cache");
+        Path ready = temp.resolve("process-ready");
+        Path release = temp.resolve("process-release");
+        String java = Path.of(System.getProperty("java.home"), "bin",
+                System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java").toString();
+        String classpath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+        Process process = new ProcessBuilder(java, "-cp", classpath, LockProbe.class.getName(),
+                cache.toString(), ready.toString(), release.toString())
+                .redirectErrorStream(true).redirectOutput(ProcessBuilder.Redirect.DISCARD).start();
+        try {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (!Files.exists(ready) && process.isAlive() && System.nanoTime() < deadline) {
+                Thread.sleep(20);
+            }
+            assertTrue(Files.exists(ready), "subprocess did not acquire the cache lock");
+            assertThrows(IllegalStateException.class, () -> ManagedLocalAiCache.withLock(cache,
+                    Duration.ofMillis(150), () -> null));
+            assertFalse(Files.exists(cache.resolve("installations")));
+        } finally {
+            Files.writeString(release, "release");
+            assertTrue(process.waitFor(10, TimeUnit.SECONDS));
+            if (process.isAlive()) {
+                process.destroyForcibly();
+            }
+        }
+        assertEquals(0, process.exitValue());
+    }
+
+    @Test
+    void windowsJunctionCannotEscapeCacheOwnership() throws Exception {
+        assumeTrue(System.getProperty("os.name").startsWith("Windows"));
+        Path cache = temp.resolve("junction-cache");
+        Path stage = readyStage(cache, "junction", "binary");
+        Path outside = temp.resolve("outside");
+        Files.createDirectories(outside);
+        Path victim = outside.resolve("victim.txt");
+        Files.writeString(victim, "user-owned");
+        Path junction = stage.resolve("linked");
+        Process creator = new ProcessBuilder("cmd.exe", "/d", "/c", "mklink", "/J",
+                junction.toString(), outside.toString())
+                .redirectErrorStream(true).redirectOutput(ProcessBuilder.Redirect.DISCARD).start();
+        assertTrue(creator.waitFor(10, TimeUnit.SECONDS));
+        assertEquals(0, creator.exitValue());
+
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiCache.withLock(cache,
+                Duration.ofSeconds(1), () -> ManagedLocalAiCache.adopt(cache, "junction", stage)));
+        assertTrue(Files.exists(victim));
+        ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(1), () -> ManagedLocalAiCache.clean(cache));
+        assertTrue(Files.exists(victim));
+    }
+
+    @Test
+    void recoversInterruptedAdoptAndCleanTransactions() throws Exception {
+        Path cache = temp.resolve("cache");
+        Path stage = readyStage(cache, "recover", "binary");
+        Path destination = cache.resolve("installations/recover-orphan");
+        Files.createDirectories(destination.getParent());
+        Files.move(stage, destination);
+        Files.writeString(cache.resolve("transaction.json"), """
+                {"schemaVersion":1,"operation":"ADOPT","id":"recover","source":"%s","target":"%s","files":[]}
+                """.formatted(relative(cache, stage), relative(cache, destination)));
+
+        ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(1), () -> {
+            ManagedLocalAiCache.recover(cache);
+            return null;
+        });
+        assertTrue(Files.isDirectory(stage));
+        assertFalse(Files.exists(destination));
+        assertFalse(Files.exists(cache.resolve("transaction.json")));
+
+        ManagedLocalAiCache.Installation installed = ManagedLocalAiCache.withLock(cache,
+                Duration.ofSeconds(1), () -> ManagedLocalAiCache.adopt(cache, "recover", stage));
+        Path trash = cache.resolve("trash/recover-interrupted");
+        Files.createDirectories(trash.getParent());
+        Files.move(installed.root(), trash);
+        String files = installed.files().stream().map(file ->
+                "{\"path\":\"%s\",\"size\":%d,\"sha256\":\"%s\"}".formatted(
+                        file.path(), file.size(), file.sha256())).collect(java.util.stream.Collectors.joining(","));
+        Files.writeString(cache.resolve("transaction.json"), """
+                {"schemaVersion":1,"operation":"CLEAN","id":"recover","source":"%s","target":"%s","files":[%s]}
+                """.formatted(relative(cache, installed.root()), relative(cache, trash), files));
+        ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(1), () -> {
+            ManagedLocalAiCache.recover(cache);
+            return null;
+        });
+        assertTrue(Files.isDirectory(installed.root()));
+        assertFalse(Files.exists(trash));
+    }
+
+    @Test
+    void forgedOrConflictedRecoveryNeverDeletesUnknownContentOrClearsEvidence() throws Exception {
+        Path cache = temp.resolve("cache");
+        Path victim = cache.resolve("user-data/keep.txt");
+        Files.createDirectories(victim.getParent());
+        Files.writeString(victim, "mine");
+        Files.writeString(cache.resolve("transaction.json"), """
+                {"schemaVersion":1,"operation":"CLEAN","id":"not-owned","source":"installations/not-owned-x",
+                "target":"user-data","files":[{"path":"installations/not-owned-x/a","size":1,"sha256":"%s"}]}
+                """.formatted("0".repeat(64)));
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiCache.recover(cache));
+        assertTrue(Files.exists(victim));
+        assertTrue(Files.exists(cache.resolve("transaction.json")));
+
+        Files.delete(cache.resolve("transaction.json"));
+        ManagedLocalAiCache.Installation installed = ManagedLocalAiCache.withLock(cache,
+                Duration.ofSeconds(1), () -> ManagedLocalAiCache.adopt(cache, "conflict",
+                        readyStage(cache, "conflict", "binary")));
+        Path trash = cache.resolve("trash/conflict-copy");
+        copyTree(installed.root(), trash);
+        String files = installed.files().stream().map(file ->
+                "{\"path\":\"%s\",\"size\":%d,\"sha256\":\"%s\"}".formatted(
+                        file.path(), file.size(), file.sha256())).collect(java.util.stream.Collectors.joining(","));
+        Files.writeString(cache.resolve("transaction.json"), """
+                {"schemaVersion":1,"operation":"CLEAN","id":"conflict","source":"%s",
+                "target":"%s","files":[%s]}
+                """.formatted(relative(cache, installed.root()), relative(cache, trash), files));
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiCache.recover(cache));
+        assertTrue(Files.exists(cache.resolve("transaction.json")));
+        assertTrue(Files.exists(installed.root()));
+        assertTrue(Files.exists(trash));
+    }
+
+    private static Path readyStage(Path cache, String prefix, String content) throws Exception {
+        Path stage = cache.resolve("staging").resolve(prefix + ".extract-test");
+        Files.createDirectories(stage.resolve("bin"));
+        Files.writeString(stage.resolve("bin/llama-server"), content);
+        Files.writeString(stage.resolve(".shaft-ready"), "");
+        return stage;
+    }
+
+    public static final class LockProbe {
+        private LockProbe() {
+        }
+
+        public static void main(String[] args) throws Exception {
+            Path cache = Path.of(args[0]);
+            Path ready = Path.of(args[1]);
+            Path release = Path.of(args[2]);
+            ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(10), () -> {
+                Files.writeString(ready, "ready");
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+                while (!Files.exists(release) && System.nanoTime() < deadline) {
+                    Thread.sleep(20);
+                }
+                return null;
+            });
+        }
+    }
+
+    private static String relative(Path cache, Path path) {
+        return cache.toAbsolutePath().normalize().relativize(path.toAbsolutePath().normalize())
+                .toString().replace('\\', '/');
+    }
+
+    private static void copyTree(Path source, Path target) throws Exception {
+        try (var paths = Files.walk(source)) {
+            for (Path path : paths.toList()) {
+                Path destination = target.resolve(source.relativize(path));
+                if (Files.isDirectory(path)) {
+                    Files.createDirectories(destination);
+                } else {
+                    Files.copy(path, destination);
+                }
+            }
+        }
+    }
+}

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiHardwareTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiHardwareTest.java
@@ -1,0 +1,153 @@
+package com.shaft.ai.local;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ManagedLocalAiHardwareTest {
+    private static final long GIB = 1024L * 1024 * 1024;
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void automaticSelectionUsesAvailableMemoryCpuAndExactPeakDisk() {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        ManagedLocalAiHardware.Profile balanced = new ManagedLocalAiHardware.Profile(
+                "windows-x86_64", true, 18 * GIB, 8, 20 * GIB);
+        ManagedLocalAiHardware.Selection selected = ManagedLocalAiHardware.select(manifest, balanced, null);
+        assertEquals("qwen3-4b-q4_k_m", selected.selectedModelId());
+
+        ManagedLocalAiManifest.ModelManifest lite = manifest.models().stream()
+                .filter(model -> model.id().equals("qwen3-1.7b-q8_0")).findFirst().orElseThrow();
+        long exactPeak = ManagedLocalAiHardware.requiredDiskBytes(manifest, balanced, lite);
+        ManagedLocalAiHardware.Selection boundary = ManagedLocalAiHardware.select(manifest,
+                new ManagedLocalAiHardware.Profile("windows-x86_64", true, 10 * GIB, 4, exactPeak), null);
+        assertEquals(lite.id(), boundary.selectedModelId());
+        ManagedLocalAiHardware.Selection oneByteShort = ManagedLocalAiHardware.select(manifest,
+                new ManagedLocalAiHardware.Profile("windows-x86_64", true, 10 * GIB, 4, exactPeak - 1), null);
+        assertEquals(null, oneByteShort.selectedModelId());
+        assertTrue(oneByteShort.models().get(lite.id()).reasons().contains("INSUFFICIENT_DISK"));
+
+        ManagedLocalAiHardware.Profile arm = new ManagedLocalAiHardware.Profile(
+                "linux-aarch64", true, 10 * GIB, 4, Long.MAX_VALUE);
+        long armPeak = ManagedLocalAiHardware.requiredDiskBytes(manifest, arm, lite);
+        long armArchive = manifest.runtime().assets().stream()
+                .filter(asset -> asset.platform().equals("linux-aarch64")).findFirst().orElseThrow().size();
+        assertEquals(armArchive, armPeak - lite.size() * 2 - 5 * GIB);
+        assertEquals(lite.id(), ManagedLocalAiHardware.select(manifest,
+                new ManagedLocalAiHardware.Profile("linux-aarch64", true, 10 * GIB, 4, armPeak), null)
+                .selectedModelId());
+        assertEquals(null, ManagedLocalAiHardware.select(manifest,
+                new ManagedLocalAiHardware.Profile("linux-aarch64", true, 10 * GIB, 4, armPeak - 1), null)
+                .selectedModelId());
+    }
+
+    @Test
+    void explicitOverrideUsesTheSameGatesAndThirdPartyNeverBecomesAutomatic() {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        ManagedLocalAiHardware.Profile constrained = new ManagedLocalAiHardware.Profile(
+                "linux-x86_64", true, 10 * GIB, 4, 20 * GIB);
+        ManagedLocalAiHardware.Selection unsafe = ManagedLocalAiHardware.select(
+                manifest, constrained, "qwen3-4b-q4_k_m");
+        assertEquals(null, unsafe.selectedModelId());
+        assertTrue(unsafe.models().get("qwen3-4b-q4_k_m").reasons().contains("INSUFFICIENT_MEMORY"));
+
+        ManagedLocalAiHardware.Selection automatic = ManagedLocalAiHardware.select(manifest,
+                new ManagedLocalAiHardware.Profile("linux-x86_64", true, 32 * GIB, 16, 30 * GIB), null);
+        assertEquals("qwen3-4b-q4_k_m", automatic.selectedModelId());
+        assertFalse(automatic.models().get("phi-4-mini-q4_k_m").eligible());
+    }
+
+    @Test
+    void linuxProfileHonorsV2AndV1MemoryCpuQuotaAndCpuset() throws Exception {
+        FakeHost v2 = new FakeHost("Linux", "amd64", "linux-glibc", "2.31",
+                32 * GIB, 16, 30 * GIB);
+        v2.files.put("/sys/fs/cgroup/memory.max", Long.toString(12 * GIB));
+        v2.files.put("/sys/fs/cgroup/memory.current", Long.toString(2 * GIB));
+        v2.files.put("/sys/fs/cgroup/cpu.max", "150000 100000");
+        v2.files.put("/sys/fs/cgroup/cpuset.cpus.effective", "2-3,7");
+        ManagedLocalAiHardware.Profile v2Profile = ManagedLocalAiHardware.profile(temp.resolve("absent"), v2);
+        assertEquals(8 * GIB, v2Profile.effectiveMemoryBytes());
+        assertEquals(1, v2Profile.cpuCount());
+
+        FakeHost v1 = new FakeHost("Linux", "aarch64", "linux-glibc", "2.31",
+                32 * GIB, 12, 30 * GIB);
+        v1.files.put("/proc/self/cgroup", "5:memory,cpu,cpuset:/workers/job-7\n");
+        v1.files.put("/proc/self/mountinfo",
+                "31 23 0:27 / /sys/fs/cgroup/combined rw,nosuid - cgroup cgroup rw,memory,cpu,cpuset\n");
+        v1.files.put("/sys/fs/cgroup/combined/workers/job-7/memory.limit_in_bytes", Long.toString(16 * GIB));
+        v1.files.put("/sys/fs/cgroup/combined/workers/job-7/memory.usage_in_bytes", Long.toString(4 * GIB));
+        v1.files.put("/sys/fs/cgroup/combined/workers/job-7/cpu.cfs_quota_us", "200000");
+        v1.files.put("/sys/fs/cgroup/combined/workers/job-7/cpu.cfs_period_us", "100000");
+        v1.files.put("/sys/fs/cgroup/combined/workers/job-7/cpuset.cpus", "0-7");
+        ManagedLocalAiHardware.Profile v1Profile = ManagedLocalAiHardware.profile(temp, v1);
+        assertEquals("linux-aarch64", v1Profile.platform());
+        assertEquals(10 * GIB, v1Profile.effectiveMemoryBytes());
+        assertEquals(2, v1Profile.cpuCount());
+    }
+
+    @Test
+    void unsupportedAndMalformedSignalsFailClosedWithoutCreatingCache() throws Exception {
+        String[][] supported = {
+                {"Windows 11", "amd64", "windows-msvc", "", "windows-x86_64"},
+                {"Windows 11", "arm64", "windows-msvc", "", "windows-aarch64"},
+                {"Mac OS X", "x64", "macos-darwin", "", "macos-x86_64"},
+                {"Darwin", "arm64", "macos-darwin", "", "macos-aarch64"},
+                {"Linux", "x86_64", "linux-glibc", "2.31", "linux-x86_64"},
+                {"Linux", "aarch64", "linux-glibc", "2.31", "linux-aarch64"}
+        };
+        for (String[] host : supported) {
+            FakeHost fake = new FakeHost(host[0], host[1], host[2], host[3], 32 * GIB, 8, 30 * GIB);
+            ManagedLocalAiHardware.Profile supportedProfile = ManagedLocalAiHardware.profile(temp, fake);
+            assertTrue(supportedProfile.runtimeCompatible());
+            assertEquals(host[4], supportedProfile.platform());
+        }
+
+        FakeHost unsupported = new FakeHost("Plan9", "mips", "unknown", "", 32 * GIB, 8, 30 * GIB);
+        Path cache = temp.resolve("never-created");
+        ManagedLocalAiHardware.Profile profile = ManagedLocalAiHardware.profile(cache, unsupported);
+        assertFalse(profile.runtimeCompatible());
+        assertFalse(java.nio.file.Files.exists(cache));
+        ManagedLocalAiHardware.Selection selection = ManagedLocalAiHardware.select(
+                ManagedLocalAiManifest.loadDefault(), profile, null);
+        assertEquals(null, selection.selectedModelId());
+        assertTrue(selection.models().values().stream()
+                .allMatch(model -> model.reasons().contains("UNSUPPORTED_RUNTIME")));
+    }
+
+    private static final class FakeHost implements ManagedLocalAiHardware.HostAccess {
+        private final String os;
+        private final String arch;
+        private final String abi;
+        private final String abiVersion;
+        private final long memory;
+        private final int processors;
+        private final long disk;
+        private final Map<String, String> files = new HashMap<>();
+
+        private FakeHost(String os, String arch, String abi, String abiVersion,
+                         long memory, int processors, long disk) {
+            this.os = os; this.arch = arch; this.abi = abi; this.abiVersion = abiVersion;
+            this.memory = memory; this.processors = processors; this.disk = disk;
+        }
+        public String osName() { return os; }
+        public String architecture() { return arch; }
+        public String abi() { return abi; }
+        public String abiVersion() { return abiVersion; }
+        public long availableMemoryBytes() { return memory; }
+        public int availableProcessors() { return processors; }
+        public long usableSpace(Path existingAncestor) { return disk; }
+        public String read(String path) throws java.io.IOException {
+            if (!files.containsKey(path)) throw new java.io.IOException("missing");
+            return files.get(path);
+        }
+    }
+}

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiManifestTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiManifestTest.java
@@ -1,0 +1,113 @@
+package com.shaft.ai.local;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ManagedLocalAiManifestTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Test
+    void packagesTheReviewedManifestWithTheProviderAdapter() {
+        assertNotNull(getClass().getResource("/com/shaft/ai/local/manifest.json"),
+                "The reviewed managed-local-AI manifest must be packaged with shaft-ai.");
+    }
+
+    @Test
+    void loadsTheReviewedRuntimeAndModelInventory() {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+
+        assertEquals(1, manifest.schemaVersion());
+        assertEquals("llama.cpp", manifest.runtime().id());
+        assertEquals("b10400", manifest.runtime().version());
+        assertEquals(6, manifest.runtime().assets().size());
+        assertEquals(4, manifest.models().size());
+    }
+
+    @Test
+    void selectsOnlyAnExactCompatiblePlatform() {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+
+        assertEquals("linux-x86_64", manifest.selectRuntime("Linux", "amd64", "glibc", "2.31").platform());
+        assertEquals("macos-aarch64",
+                manifest.selectRuntime("Mac OS X", "aarch64", "macos-darwin", "").platform());
+        assertTrue(manifest.supportsRuntime("Windows 11", "x86_64", "windows-msvc", ""));
+        assertFalse(manifest.supportsRuntime("Windows 11", "x86_64", "linux-glibc", "2.31"));
+        assertFalse(manifest.supportsRuntime("Mac OS X", "aarch64", "windows-msvc", ""));
+        assertFalse(manifest.supportsRuntime("Linux", "amd64", "musl", "1.2"));
+        assertFalse(manifest.supportsRuntime("Linux", "amd64", "glibc", "2.30"));
+        assertFalse(manifest.supportsRuntime("Plan 9", "amd64", "", ""));
+    }
+
+    @Test
+    void rejectsUntrustedOrAmbiguousManifestMutations() throws Exception {
+        List<Mutation> mutations = List.of(
+                new Mutation("path traversal", "/runtime/assets/0/file", "../runtime.zip"),
+                new Mutation("non-HTTPS runtime", "/runtime/assets/0/url", "http://github.com/ggml-org/llama.cpp/releases/download/b10400/llama-b10400-bin-win-cpu-x64.zip"),
+                new Mutation("wrong release host", "/runtime/assets/0/url", "https://attacker.invalid/ggml-org/llama.cpp/releases/download/b10400/llama-b10400-bin-win-cpu-x64.zip"),
+                new Mutation("noncanonical HTTPS port", "/runtime/assets/0/url", "https://github.com:444/ggml-org/llama.cpp/releases/download/b10400/llama-b10400-bin-win-cpu-x64.zip"),
+                new Mutation("invalid digest", "/runtime/assets/0/sha256", "abc"),
+                new Mutation("missing ABI", "/runtime/assets/0/abi", ""),
+                new Mutation("unsafe model id", "/models/0/id", "../../escape"),
+                new Mutation("untrusted model host", "/models/0/url", "https://attacker.invalid/Qwen/Qwen3-1.7B-GGUF/resolve/90862c4b9d2787eaed51d12237eafdfe7c5f6077/Qwen3-1.7B-Q8_0.gguf"),
+                new Mutation("boolean size", "/models/0/size", true)
+        );
+
+        for (Mutation mutation : mutations) {
+            JsonNode root = JSON.readTree(defaultBytes());
+            replace(root, mutation.pointer(), mutation.value());
+            IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                    () -> ManagedLocalAiManifest.parse(new ByteArrayInputStream(JSON.writeValueAsBytes(root))),
+                    mutation.name());
+            assertFalse(failure.getMessage().isBlank(), mutation.name());
+        }
+    }
+
+    @Test
+    void rejectsUnknownAndDuplicateKeys() throws Exception {
+        JsonNode unknown = JSON.readTree(defaultBytes());
+        ((tools.jackson.databind.node.ObjectNode) unknown).put("ignoredTrustOverride", true);
+        assertThrows(IllegalArgumentException.class,
+                () -> ManagedLocalAiManifest.parse(new ByteArrayInputStream(JSON.writeValueAsBytes(unknown))));
+
+        String duplicate = new String(defaultBytes(), StandardCharsets.UTF_8)
+                .replaceFirst("\\{", "{\\\"schemaVersion\\\":999,");
+        assertThrows(IllegalArgumentException.class,
+                () -> ManagedLocalAiManifest.parse(new ByteArrayInputStream(duplicate.getBytes(StandardCharsets.UTF_8))));
+    }
+
+    private byte[] defaultBytes() throws Exception {
+        try (var input = getClass().getResourceAsStream("/com/shaft/ai/local/manifest.json")) {
+            assertNotNull(input);
+            return input.readAllBytes();
+        }
+    }
+
+    private static void replace(JsonNode root, String pointer, Object value) {
+        int separator = pointer.lastIndexOf('/');
+        JsonNode parent = root.at(pointer.substring(0, separator));
+        String field = pointer.substring(separator + 1);
+        if (parent.isArray()) {
+            int index = Integer.parseInt(field);
+            if (value instanceof Boolean booleanValue) {
+                ((tools.jackson.databind.node.ArrayNode) parent).set(index,
+                        tools.jackson.databind.node.BooleanNode.valueOf(booleanValue));
+            }
+        } else {
+            ((tools.jackson.databind.node.ObjectNode) parent).put(field, String.valueOf(value));
+        }
+    }
+
+    private record Mutation(String name, String pointer, Object value) {
+    }
+}

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProcessTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProcessTest.java
@@ -154,7 +154,12 @@ class ManagedLocalAiProcessTest {
         @Override public java.io.OutputStream getOutputStream() { return new ByteArrayOutputStream(); }
         @Override public java.io.InputStream getInputStream() { return new ByteArrayInputStream(new byte[0]); }
         @Override public java.io.InputStream getErrorStream() { return new ByteArrayInputStream(new byte[0]); }
-        @Override public int waitFor() throws InterruptedException { while (exit == null) Thread.sleep(5); return exit; }
+        @Override public int waitFor() throws InterruptedException {
+            while (exit == null) {
+                Thread.sleep(5);
+            }
+            return exit;
+        }
         @Override public boolean waitFor(long timeout, java.util.concurrent.TimeUnit unit) { return exit != null; }
         @Override public int exitValue() { if (exit == null) throw new IllegalThreadStateException(); return exit; }
         @Override public void destroy() { destroyed = true; }

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProcessTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProcessTest.java
@@ -1,0 +1,180 @@
+package com.shaft.ai.local;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ManagedLocalAiProcessTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void commandIsLoopbackAuthenticatedAndEnvironmentIsAllowlistOnly() throws Exception {
+        Path executable = Files.writeString(temp.resolve("llama-server.exe"), "binary");
+        Path model = Files.writeString(temp.resolve("model.gguf"), "weights");
+        Path keyFile = Files.writeString(temp.resolve("api-key.txt"), "key-123");
+        Map<String, String> environment = ManagedLocalAiProcess.runtimeEnvironment(Map.of(
+                "Path", "bin", "SystemRoot", "windows", "TEMP", "tmp", "LD_LIBRARY_PATH", "loader",
+                "AWS_SECRET_ACCESS_KEY", "secret", "AZURE_CLIENT_SECRET", "secret", "DATABASE_URL", "secret"));
+        List<String> command = ManagedLocalAiProcess.command(executable, model, 19191, "alias-123", keyFile, 4);
+
+        assertEquals("bin", environment.get("Path"));
+        assertEquals("windows", environment.get("SystemRoot"));
+        assertEquals("loader", environment.get("LD_LIBRARY_PATH"));
+        assertFalse(environment.containsValue("secret"));
+        assertTrue(command.containsAll(List.of("--host", "127.0.0.1", "--port", "19191",
+                "--api-key-file", keyFile.toAbsolutePath().toString(), "--alias", "alias-123", "--threads", "4")));
+        assertFalse(command.contains("key-123"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ManagedLocalAiProcess.command(executable, model, 0, "alias", keyFile, 1));
+    }
+
+    @Test
+    void launchRetriesPortTheftAndRequiresAuthenticatedAliasIdentity() throws Exception {
+        AtomicInteger starts = new AtomicInteger();
+        FakeProcess stolen = new FakeProcess(1);
+        FakeProcess owned = new FakeProcess(null);
+        Path cache = temp.resolve("cache");
+        Path runtimeStage = readyStage(cache, "runtime", "server", "binary");
+        Path modelStage = readyStage(cache, "model", "model.gguf", "weights");
+        ManagedLocalAiCache.Installation runtime = ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(1),
+                () -> ManagedLocalAiCache.adopt(cache, "runtime", runtimeStage));
+        ManagedLocalAiCache.Installation modelInstall = ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(1),
+                () -> ManagedLocalAiCache.adopt(cache, "model", modelStage));
+        Path executable = runtime.root().resolve("server");
+        Path model = modelInstall.root().resolve("model.gguf");
+        Path logPath = cache.resolve("staging/logs/server.log");
+        ManagedLocalAiProcess.Session session = ManagedLocalAiProcess.launch(
+                cache, executable, model, logPath, "expected-alias",
+                2, Duration.ofSeconds(1), () -> starts.get() == 0 ? 18181 : 18182,
+                (command, environment, log) -> starts.getAndIncrement() == 0 ? stolen : owned,
+                (process, port, key, alias, timeout) -> {
+                    if (port == 18181) {
+                        throw new IllegalStateException("foreign loopback responder");
+                    }
+                    assertEquals("expected-alias", alias);
+                    assertFalse(key.isBlank());
+                });
+
+        assertEquals(2, starts.get());
+        assertEquals(18182, session.port());
+        assertEquals(owned, session.process());
+        assertTrue(stolen.destroyed);
+        session.close();
+        assertTrue(owned.destroyed);
+    }
+
+    @Test
+    void identityRejectsPublicHealthSpoofWrongBearerAndWrongAlias() throws Exception {
+        FakeProcess process = new FakeProcess(null);
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.requireIdentity(process, 1234,
+                "secret", "expected", Duration.ofMillis(50),
+                (uri, bearer) -> Map.of("data", List.of(Map.of("id", "foreign")))));
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.requireIdentity(process, 1234,
+                "secret", "expected", Duration.ofMillis(50),
+                (uri, bearer) -> { throw new SecurityException("wrong bearer"); }));
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.requireIdentity(process, 1234,
+                "secret", "expected", Duration.ofMillis(50),
+                (uri, bearer) -> Map.of("data", List.of(Map.of("id", "expected"), Map.of("id", "foreign")))));
+    }
+
+    @Test
+    void terminationIsBoundedKillsDescendantsAndDoesNotMaskPrimaryFailure() throws Exception {
+        FakeProcess process = new FakeProcess(null);
+        FakeHandle descendant = new FakeHandle();
+        process.descendant = descendant;
+        RuntimeException primary = new RuntimeException("inference failed");
+        ManagedLocalAiProcess.terminate(process, Duration.ZERO, primary);
+
+        assertTrue(process.destroyed);
+        assertTrue(process.forciblyDestroyed);
+        assertTrue(descendant.destroyed);
+        assertEquals(0, primary.getSuppressed().length);
+    }
+
+    @Test
+    void nativeLogIsBoundedAndRedactsAuthenticationMaterial() throws Exception {
+        String secret = "local-secret-value";
+        byte[] noisy = ("Authorization: Bearer " + secret + "\n--api-key " + secret + "\n"
+                + "x".repeat(2048)).getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        Path log = temp.resolve("staging/logs/sanitized.log");
+        ManagedLocalAiProcess.writeSanitizedLog(temp, new ByteArrayInputStream(noisy), log, Set.of(secret), 512);
+        String value = Files.readString(log);
+
+        assertFalse(value.contains(secret));
+        assertFalse(value.toLowerCase(java.util.Locale.ROOT).contains("bearer "));
+        assertTrue(Files.size(log) <= 512);
+    }
+
+    @Test
+    void logLeafLinkIsRejectedWithoutChangingExternalContent() throws Exception {
+        Path outside = Files.writeString(temp.resolve("outside.log"), "user-owned");
+        Path logs = temp.resolve("staging/logs");
+        Files.createDirectories(logs);
+        Path link = logs.resolve("server.log");
+        try {
+            Files.createSymbolicLink(link, outside);
+        } catch (UnsupportedOperationException | java.nio.file.FileSystemException unavailable) {
+            org.junit.jupiter.api.Assumptions.abort("symbolic links are unavailable");
+        }
+        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiProcess.writeSanitizedLog(temp,
+                new ByteArrayInputStream("runtime".getBytes()), link, Set.of(), 128));
+        assertEquals("user-owned", Files.readString(outside));
+    }
+
+    private static Path readyStage(Path cache, String prefix, String fileName, String content) throws Exception {
+        Path stage = cache.resolve("staging/" + prefix + ".extract-test");
+        Files.createDirectories(stage);
+        Files.writeString(stage.resolve(fileName), content);
+        Files.writeString(stage.resolve(".shaft-ready"), "");
+        return stage;
+    }
+
+    private static final class FakeProcess extends Process {
+        private Integer exit;
+        private boolean destroyed;
+        private boolean forciblyDestroyed;
+        private FakeHandle descendant;
+
+        private FakeProcess(Integer exit) { this.exit = exit; }
+        @Override public java.io.OutputStream getOutputStream() { return new ByteArrayOutputStream(); }
+        @Override public java.io.InputStream getInputStream() { return new ByteArrayInputStream(new byte[0]); }
+        @Override public java.io.InputStream getErrorStream() { return new ByteArrayInputStream(new byte[0]); }
+        @Override public int waitFor() throws InterruptedException { while (exit == null) Thread.sleep(5); return exit; }
+        @Override public boolean waitFor(long timeout, java.util.concurrent.TimeUnit unit) { return exit != null; }
+        @Override public int exitValue() { if (exit == null) throw new IllegalThreadStateException(); return exit; }
+        @Override public void destroy() { destroyed = true; }
+        @Override public Process destroyForcibly() { forciblyDestroyed = true; exit = -1; return this; }
+        @Override public boolean isAlive() { return exit == null; }
+        @Override public ProcessHandle toHandle() { return descendant == null ? super.toHandle() : descendant; }
+    }
+
+    private static final class FakeHandle implements ProcessHandle {
+        private boolean destroyed;
+        @Override public long pid() { return 42; }
+        @Override public java.util.Optional<ProcessHandle> parent() { return java.util.Optional.empty(); }
+        @Override public java.util.stream.Stream<ProcessHandle> children() { return java.util.stream.Stream.empty(); }
+        @Override public java.util.stream.Stream<ProcessHandle> descendants() { return java.util.stream.Stream.of(this); }
+        @Override public Info info() { throw new UnsupportedOperationException(); }
+        @Override public java.util.concurrent.CompletableFuture<ProcessHandle> onExit() { return new java.util.concurrent.CompletableFuture<>(); }
+        @Override public boolean supportsNormalTermination() { return true; }
+        @Override public boolean destroy() { destroyed = true; return true; }
+        @Override public boolean destroyForcibly() { destroyed = true; return true; }
+        @Override public boolean isAlive() { return !destroyed; }
+        @Override public int compareTo(ProcessHandle other) { return Long.compare(pid(), other.pid()); }
+    }
+}

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiStatusTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiStatusTest.java
@@ -1,0 +1,43 @@
+package com.shaft.ai.local;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ManagedLocalAiStatusTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void inspectionIsTypedActionableAndReadOnly() {
+        Path cache = temp.resolve("absent-cache");
+        assertEquals(ManagedLocalAiStatus.State.DISABLED,
+                ManagedLocalAiStatus.inspect(cache, false, "Windows 11", "amd64", "windows-msvc", "", null).state());
+        assertEquals(ManagedLocalAiStatus.State.UNSUPPORTED,
+                ManagedLocalAiStatus.inspect(cache, true, "Plan 9", "mips", "unknown", "", null).state());
+        ManagedLocalAiStatus missing = ManagedLocalAiStatus.inspect(cache, true, "Windows 11", "amd64",
+                "windows-msvc", "", "runtime-b10400-windows-x86_64");
+        assertEquals(ManagedLocalAiStatus.State.NOT_PROVISIONED, missing.state());
+        assertFalse(Files.exists(cache));
+    }
+
+    @Test
+    void anotherOwnedInstallationDoesNotMakeMissingSelectionCorrupt() throws Exception {
+        Path cache = temp.resolve("mixed-cache");
+        Path stage = cache.resolve("staging/runtime.extract-test");
+        Files.createDirectories(stage);
+        Files.writeString(stage.resolve("server"), "binary");
+        Files.writeString(stage.resolve(".shaft-ready"), "");
+        ManagedLocalAiCache.withLock(cache, java.time.Duration.ofSeconds(1),
+                () -> ManagedLocalAiCache.adopt(cache, "installed", stage));
+
+        ManagedLocalAiStatus status = ManagedLocalAiStatus.inspect(cache, true, "Windows 11", "amd64",
+                "windows-msvc", "", "missing");
+        assertEquals(ManagedLocalAiStatus.State.NOT_PROVISIONED, status.state());
+    }
+}

--- a/tests/scripts/test_local_ai_poc.py
+++ b/tests/scripts/test_local_ai_poc.py
@@ -777,8 +777,10 @@ class LifecycleTest(unittest.TestCase):
         self.assertEqual(29, labels.count(True))
 
     def test_transaction_rejects_unowned_targets_and_preserves_concurrent_unknown_files(self):
-        runtime = MODULE.select_runtime_asset(self.manifest, "windows-x86_64")
-        model = self.manifest["models"][0]
+        runtime = dict(MODULE.select_runtime_asset(self.manifest, "windows-x86_64"))
+        runtime.update(size=1, sha256=hashlib.sha256(b"r").hexdigest())
+        model = dict(self.manifest["models"][0])
+        model.update(size=1, sha256=hashlib.sha256(b"m").hexdigest())
         with tempfile.TemporaryDirectory() as temporary:
             cache = Path(temporary) / "cache"
             archive = MODULE.cache_path(cache, "downloads", runtime["file"])

--- a/tests/scripts/test_local_ai_poc.py
+++ b/tests/scripts/test_local_ai_poc.py
@@ -149,6 +149,15 @@ class ManifestAndSelectionTest(unittest.TestCase):
         bad_tier = json.loads(json.dumps(self.manifest))
         bad_tier["models"][0]["tier"] = 7
         mutations.append(bad_tier)
+        missing_abi = json.loads(json.dumps(self.manifest))
+        del missing_abi["runtime"]["assets"][0]["abi"]
+        mutations.append(missing_abi)
+        mismatched_abi = json.loads(json.dumps(self.manifest))
+        mismatched_abi["runtime"]["assets"][0]["abi"] = "linux-glibc"
+        mutations.append(mismatched_abi)
+        missing_minimum = json.loads(json.dumps(self.manifest))
+        del missing_minimum["runtime"]["assets"][4]["minimumAbiVersion"]
+        mutations.append(missing_minimum)
         for unsafe_name in ("CON", "model.", "NUL.gguf"):
             unsafe = json.loads(json.dumps(self.manifest))
             unsafe["models"][0]["file"] = unsafe_name
@@ -301,13 +310,23 @@ class ManifestAndSelectionTest(unittest.TestCase):
         self.assertEqual(6.0, mac["effectiveRamGb"])
 
     def test_linux_runtime_compatibility_and_inspect_no_mutation_are_proven(self):
-        self.assertTrue(MODULE.runtime_compatible("Linux", ("glibc", "2.31")))
-        self.assertFalse(MODULE.runtime_compatible("Linux", ("glibc", "2.30")))
+        self.assertTrue(
+            MODULE.runtime_compatible("Linux", ("glibc", "2.31"), self.manifest, "x86_64")
+        )
+        self.assertFalse(
+            MODULE.runtime_compatible("Linux", ("glibc", "2.30"), self.manifest, "x86_64")
+        )
         self.assertFalse(MODULE.runtime_compatible("Linux", ("glibc", "invalid")))
         self.assertFalse(MODULE.runtime_compatible("Linux", ("musl", "1.2")))
         self.assertFalse(MODULE.runtime_compatible("Linux", ("", "")))
         self.assertTrue(MODULE.runtime_compatible("Windows", ("", "")))
         self.assertTrue(MODULE.runtime_compatible("Darwin", ("", "")))
+
+        raised_minimum = json.loads(json.dumps(self.manifest))
+        raised_minimum["runtime"]["assets"][4]["minimumAbiVersion"] = "99.0"
+        self.assertFalse(
+            MODULE.runtime_compatible("Linux", ("glibc", "2.31"), raised_minimum, "x86_64")
+        )
 
         with tempfile.TemporaryDirectory() as temporary:
             cache = Path(temporary) / "missing" / "cache"

--- a/tools/local-ai-poc/local_ai_poc.py
+++ b/tools/local-ai-poc/local_ai_poc.py
@@ -48,7 +48,6 @@ SAFE_BASENAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*$")
 KNOWN_TIERS = {"lite", "balanced", "challenger"}
 KNOWN_LICENSES = {"MIT", "Apache-2.0"}
 MEMORY_RESERVE_GB = 2.0
-MINIMUM_GLIBC = (2, 31)
 WINDOWS_RESERVED_STEMS = {
     "CON", "PRN", "AUX", "NUL", "CLOCK$",
     *(f"COM{index}" for index in range(1, 10)),
@@ -153,7 +152,7 @@ def validate_manifest(manifest: dict[str, Any]) -> None:  # noqa: MC0001  # One 
     for index, raw_asset in enumerate(assets):
         if not isinstance(raw_asset, dict):
             raise ValueError(f"runtime asset {index} must be an object")
-        _require_keys(raw_asset, {"platform", "executable"}, f"runtime asset {index}")
+        _require_keys(raw_asset, {"platform", "executable", "abi"}, f"runtime asset {index}")
         _validate_artifact(raw_asset, f"runtime asset {index}")
         parsed_asset = urlparse(raw_asset["url"])
         if (
@@ -167,6 +166,21 @@ def validate_manifest(manifest: dict[str, Any]) -> None:  # noqa: MC0001  # One 
             raise ValueError(f"runtime asset {index} platform must be a string")
         if not _safe_basename(raw_asset["executable"]):
             raise ValueError(f"runtime asset {index} executable must be one safe basename")
+        expected_abi = (
+            "windows-msvc" if raw_asset["platform"].startswith("windows-")
+            else "macos-darwin" if raw_asset["platform"].startswith("macos-")
+            else "linux-glibc"
+        )
+        if raw_asset["abi"] != expected_abi:
+            raise ValueError(f"runtime asset {index} ABI must match its platform")
+        minimum_abi = raw_asset.get("minimumAbiVersion")
+        if raw_asset["platform"].startswith("linux-"):
+            if not isinstance(minimum_abi, str) or not re.fullmatch(
+                r"\d+\.\d+(?:\.\d+)?", minimum_abi
+            ):
+                raise ValueError(f"runtime asset {index} minimum ABI version is invalid")
+        elif minimum_abi is not None:
+            raise ValueError(f"runtime asset {index} must not declare a minimum ABI version")
         if f"/{runtime['version']}/" not in raw_asset["url"]:
             raise ValueError(f"runtime asset {index} URL must pin runtime version")
         platforms.append(raw_asset["platform"])
@@ -845,7 +859,12 @@ def memory_snapshot(
     }
 
 
-def runtime_compatible(system: str, libc: tuple[str, str] | None = None) -> bool:
+def runtime_compatible(
+    system: str,
+    libc: tuple[str, str] | None = None,
+    manifest: dict[str, Any] | None = None,
+    machine: str | None = None,
+) -> bool:
     """Fail closed when the published Ubuntu Linux baseline cannot be established."""
     if system in {"Windows", "Darwin"}:
         return True
@@ -855,7 +874,18 @@ def runtime_compatible(system: str, libc: tuple[str, str] | None = None) -> bool
     if name.lower() not in {"glibc", "gnu libc"}:
         return False
     match = re.fullmatch(r"(\d+)\.(\d+)(?:\.\d+)?", version)
-    return bool(match and (int(match.group(1)), int(match.group(2))) >= MINIMUM_GLIBC)
+    if not match:
+        return False
+    reviewed = manifest if manifest is not None else load_json(DEFAULT_MANIFEST)
+    validate_manifest(reviewed)
+    try:
+        asset = select_runtime_asset(reviewed, platform_key(system, machine or platform.machine()))
+    except ValueError:
+        return False
+    minimum = re.fullmatch(r"(\d+)\.(\d+)(?:\.\d+)?", asset["minimumAbiVersion"])
+    return bool(minimum and (int(match.group(1)), int(match.group(2))) >= (
+        int(minimum.group(1)), int(minimum.group(2))
+    ))
 
 
 def _nvidia_vram_gb() -> float:
@@ -876,7 +906,9 @@ def _nvidia_vram_gb() -> float:
         return 0.0
 
 
-def detect_hardware(cache: Path = DEFAULT_CACHE) -> dict[str, Any]:
+def detect_hardware(
+    cache: Path = DEFAULT_CACHE, manifest: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """Collect only deterministic local sizing signals used by the PoC selector."""
     system = platform.system()
     machine = platform.machine()
@@ -889,7 +921,7 @@ def detect_hardware(cache: Path = DEFAULT_CACHE) -> dict[str, Any]:
         "system": system,
         "release": platform.release(),
         "machine": machine,
-        "runtimeCompatible": runtime_compatible(system),
+        "runtimeCompatible": runtime_compatible(system, manifest=manifest, machine=machine),
         "cpuCount": (
             os.process_cpu_count() if hasattr(os, "process_cpu_count") else os.cpu_count()
         ) or 1,
@@ -904,7 +936,7 @@ def inspect(manifest_path: Path, corpus_path: Path, cache: Path) -> dict[str, An
     manifest = load_json(manifest_path)
     validate_manifest(manifest)
     corpus = load_corpus(corpus_path)
-    hardware = detect_hardware(cache)
+    hardware = detect_hardware(cache, manifest)
     runtime = select_runtime_asset(manifest, hardware["platform"])
     recommendation = recommend_model(manifest, hardware)
     return {
@@ -1047,7 +1079,7 @@ def provision(
     """Provision the exact runtime and model into one locked PoC-owned cache."""
     manifest = load_json(manifest_path)
     validate_manifest(manifest)
-    hardware = detect_hardware(cache)
+    hardware = detect_hardware(cache, manifest)
     model = resolve_model(manifest, hardware, requested_model)
     runtime = select_runtime_asset(manifest, hardware["platform"])
     with CacheLock(cache):

--- a/tools/local-ai-poc/manifest.json
+++ b/tools/local-ai-poc/manifest.json
@@ -12,6 +12,7 @@
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10400/llama-b10400-bin-win-cpu-x64.zip",
         "size": 18471221,
         "sha256": "905eb7adecddfef9c3f700dd086edced20a4751481f53e614d2eba11de2ad147",
+        "abi": "windows-msvc",
         "executable": "llama-server.exe"
       },
       {
@@ -20,6 +21,7 @@
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10400/llama-b10400-bin-win-cpu-arm64.zip",
         "size": 12305094,
         "sha256": "19714a9207381e18f464a926b77fa9680ec1ecca9a1d6ad8ccf1c90af965606e",
+        "abi": "windows-msvc",
         "executable": "llama-server.exe"
       },
       {
@@ -28,6 +30,7 @@
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10400/llama-b10400-bin-macos-x64.tar.gz",
         "size": 11365103,
         "sha256": "dccb8eb50c797e3338cc55cacf943a51853b4cce09f6aa1c1a8fdc3efea74725",
+        "abi": "macos-darwin",
         "executable": "llama-server"
       },
       {
@@ -36,6 +39,7 @@
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10400/llama-b10400-bin-macos-arm64.tar.gz",
         "size": 11083410,
         "sha256": "bb0172e886c7b6ece52edf04db03bc692ffc28e096728351c0343e4c75bb5374",
+        "abi": "macos-darwin",
         "executable": "llama-server"
       },
       {
@@ -44,6 +48,8 @@
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10400/llama-b10400-bin-ubuntu-x64.tar.gz",
         "size": 16609457,
         "sha256": "ce3aadaadcc443f46d0d9eaa5c688d4370e25b90bd7e6e903cabcaa72dd2a584",
+        "abi": "linux-glibc",
+        "minimumAbiVersion": "2.31",
         "executable": "llama-server"
       },
       {
@@ -52,6 +58,8 @@
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10400/llama-b10400-bin-ubuntu-arm64.tar.gz",
         "size": 13473976,
         "sha256": "737ff27872dcc3018c4ccd678de3550f6ccfbf416b855ee61b2ec012b4c20dca",
+        "abi": "linux-glibc",
+        "minimumAbiVersion": "2.31",
         "executable": "llama-server"
       }
     ]


### PR DESCRIPTION
## Outcome

Implements the deterministic production foundation for SHAFT-managed local AI in the optional `shaft-ai` module.

- packages and strictly validates the canonical reviewed llama.cpp/model manifest for six desktop platform selectors and ABI constraints;
- provides bounded, cancellable, provenance-bound downloads and safe bounded ZIP/tar extraction without normal-build network activity;
- owns immutable installations with cross-process locking, digest/type verification, transactional journals, interruption recovery, side-by-side adoption, and deletion of unchanged owned files only;
- rejects traversal, links, Windows junctions/reparse points, archive bombs, ambiguous ownership, and concurrent unknown content;
- launches only cache-owned runtime/model files on loopback with a private key file, exact authenticated alias identity, bounded fresh-port retries, allowlist-only environment, bounded descendant termination, and contained bounded redacted logs;
- exposes a typed, actionable, read-only lifecycle inspection surface for configuration and Doctor integration;
- keeps the Python research PoC bound to the same ABI manifest and deterministic disk fixture.

## Verification

- `mvn -pl shaft-ai -Dallure.automaticallyOpen=false -Dtelemetry.enabled=false test` — 101 tests, 0 failures/errors, 1 skipped
- managed-local foundation tests — 28/28 passed
- `py -3 -m unittest tests.scripts.test_local_ai_poc -v` — 29/29 passed
- `git diff --check` — passed (line-ending warning only)

## Review

Each behavior slice used RED/GREEN tests and an independent adversarial review. Review findings covering ABI drift, download/extraction bounds, cache data loss and recovery, Windows junctions, command-line credentials, identity spoofing, response/log bounds, secret-file permissions, descendant cleanup, and typed status handling were fixed and independently re-reviewed before push.

Closes #4858
Closes #4859
Related to #4851


### Hardware selection follow-up

Stacked PR #4880 merged into this implementation branch after independent approval. Focused hardware selection: 4/4; manifest plus selection: 9/9; affected shaft-ai package: BUILD SUCCESS.
