### PR TITLE
feat(engine): expose setup through SHAFT.Infrastructure and properties

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ scripts/ci/*.sh text eol=lf
 shaft-skills/references/*.md text eol=lf
 scripts/mcp/*.py text eol=lf
 .memory/events.jsonl merge=union
+shaft-infrastructure/src/main/resources/com/shaft/infrastructure/reporting/package-lock.json text eol=lf

--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -2,6 +2,8 @@ package com.shaft.commandline.command;
 
 import com.shaft.infrastructure.ReportingSetupPlanner;
 import com.shaft.infrastructure.ReportingSetupService;
+import com.shaft.infrastructure.InfrastructureSetupService;
+import com.shaft.infrastructure.SetupOptions;
 import com.shaft.infrastructure.SetupApproval;
 import com.shaft.infrastructure.SetupArchitecture;
 import com.shaft.infrastructure.SetupCatalog;
@@ -13,6 +15,7 @@ import com.shaft.infrastructure.SetupPlatform;
 import com.shaft.infrastructure.SetupProfile;
 import com.shaft.infrastructure.SetupProfileStatus;
 import com.shaft.infrastructure.SetupReadiness;
+import com.shaft.infrastructure.SetupReport;
 import com.shaft.infrastructure.ShaftCachePaths;
 import com.shaft.commandline.util.Json;
 import picocli.CommandLine.Command;
@@ -88,6 +91,8 @@ public final class SetupCommand implements Runnable {
         @Option(names = "--json", description = "Print the plan as JSON.")
         private boolean json;
 
+        @Mixin private RootOptions roots;
+
         @Spec
         private CommandSpec spec;
 
@@ -97,8 +102,9 @@ public final class SetupCommand implements Runnable {
                 spec.commandLine().getErr().println("No setup provider is available for profile " + profile + '.');
                 return 4;
             }
-            SetupPlan plan = ReportingSetupPlanner.plan(
-                    SetupPlatform.current(), SetupArchitecture.current(), mode);
+            SetupOptions options = SetupOptions.defaults(profile, roots.paths()).withMode(mode);
+            SetupPlan plan = InfrastructureSetupService.builtIn(
+                    SetupPlatform.current(), SetupArchitecture.current()).plan(options);
             if (!output.isAbsolute()) {
                 spec.commandLine().getErr().println("--output must be an absolute path.");
                 return 2;
@@ -132,9 +138,9 @@ public final class SetupCommand implements Runnable {
         public Integer call() {
             try {
                 SetupPlan plan = SetupPlanStore.read(planFile);
-                ReportingSetupService service = service(roots);
-                var receipt = service.install(plan,
-                        new SetupApproval(approvedDigest, Instant.now(), acceptedLicenses));
+                SetupOptions options = SetupOptions.defaults(plan.profile(), roots.paths()).withMode(plan.mode());
+                var receipt = InfrastructureSetupService.builtIn().install(plan,
+                        new SetupApproval(approvedDigest, Instant.now(), acceptedLicenses), options);
                 if (json) spec.commandLine().getOut().println(Json.MAPPER.writerWithDefaultPrettyPrinter()
                         .writeValueAsString(receipt));
                 else spec.commandLine().getOut().println("Installed approved plan " + receipt.planDigest());
@@ -186,7 +192,8 @@ public final class SetupCommand implements Runnable {
         @Override
         public Integer call() {
             if (profile != SetupProfile.REPORTING) return unsupported(spec, profile);
-            SetupProfileStatus status = service(roots).status();
+            SetupReport status = InfrastructureSetupService.builtIn().status(
+                    SetupOptions.defaults(profile, roots.paths()));
             if (json) spec.commandLine().getOut().println(Json.MAPPER.writerWithDefaultPrettyPrinter()
                     .writeValueAsString(status));
             else status.targets().forEach(target -> spec.commandLine().getOut().println(

--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -92,31 +92,40 @@ public final class SetupCommand implements Runnable {
         private boolean json;
 
         @Mixin private RootOptions roots;
+        @Mixin private PolicyOptions policy;
 
         @Spec
         private CommandSpec spec;
 
         @Override
-        public Integer call() throws Exception {
-            if (profile != SetupProfile.REPORTING) {
-                spec.commandLine().getErr().println("No setup provider is available for profile " + profile + '.');
-                return 4;
-            }
-            SetupOptions options = SetupOptions.defaults(profile, roots.paths()).withMode(mode);
-            SetupPlan plan = InfrastructureSetupService.builtIn(
-                    SetupPlatform.current(), SetupArchitecture.current()).plan(options);
-            if (!output.isAbsolute()) {
-                spec.commandLine().getErr().println("--output must be an absolute path.");
+        public Integer call() {
+            try {
+                if (profile != SetupProfile.REPORTING) {
+                    spec.commandLine().getErr().println("No setup provider is available for profile " + profile + '.');
+                    return 4;
+                }
+                SetupOptions options = policy.options(profile, mode, roots.paths());
+                SetupPlan plan = InfrastructureSetupService.builtIn(
+                        SetupPlatform.current(), SetupArchitecture.current()).plan(options);
+                if (!output.isAbsolute()) {
+                    spec.commandLine().getErr().println("--output must be an absolute path.");
+                    return 2;
+                }
+                SetupPlanStore.write(output, plan);
+                if (json) {
+                    spec.commandLine().getOut().print(SetupPlanJson.write(plan));
+                } else {
+                    spec.commandLine().getOut().println("Plan: " + output.toAbsolutePath().normalize());
+                    spec.commandLine().getOut().println("Digest: " + plan.digest());
+                }
+                return 0;
+            } catch (IllegalArgumentException failure) {
+                spec.commandLine().getErr().println(failure.getMessage());
                 return 2;
+            } catch (Exception failure) {
+                spec.commandLine().getErr().println(failure.getMessage());
+                return 5;
             }
-            SetupPlanStore.write(output, plan);
-            if (json) {
-                spec.commandLine().getOut().print(SetupPlanJson.write(plan));
-            } else {
-                spec.commandLine().getOut().println("Plan: " + output.toAbsolutePath().normalize());
-                spec.commandLine().getOut().println("Digest: " + plan.digest());
-            }
-            return 0;
         }
     }
 
@@ -132,13 +141,14 @@ public final class SetupCommand implements Runnable {
         @Option(names = "--json", description = "Print machine-readable JSON.")
         private boolean json;
         @Mixin private RootOptions roots;
+        @Mixin private PolicyOptions policy;
         @Spec private CommandSpec spec;
 
         @Override
         public Integer call() {
             try {
                 SetupPlan plan = SetupPlanStore.read(planFile);
-                SetupOptions options = SetupOptions.defaults(plan.profile(), roots.paths()).withMode(plan.mode());
+                SetupOptions options = policy.options(plan.profile(), plan.mode(), roots.paths());
                 var receipt = InfrastructureSetupService.builtIn().install(plan,
                         new SetupApproval(approvedDigest, Instant.now(), acceptedLicenses), options);
                 if (json) spec.commandLine().getOut().println(Json.MAPPER.writerWithDefaultPrettyPrinter()
@@ -227,6 +237,35 @@ public final class SetupCommand implements Runnable {
             Path data = dataRoot.normalize();
             return new ShaftCachePaths(cache, data, cache.resolve("downloads"), data.resolve("tools"),
                     data.resolve("state"), data.resolve("receipts"));
+        }
+    }
+
+    static final class PolicyOptions {
+        @Option(names = "--offline", description = "Require verified cached artifacts and disable network access.")
+        private boolean offline;
+        @Option(names = "--auto-start", description = "Request managed service start after verification.")
+        private boolean autoStart;
+        @Option(names = "--prefer-system-tools", defaultValue = "true",
+                description = "Prefer compatible host tools (true or false).")
+        private boolean preferSystemTools;
+        @Option(names = "--reuse-owned-processes", defaultValue = "true",
+                description = "Reuse compatible SHAFT-owned services (true or false).")
+        private boolean reuseOwnedProcesses;
+        @Option(names = "--startup-timeout", defaultValue = "PT2M")
+        private String startupTimeout;
+        @Option(names = "--shutdown-timeout", defaultValue = "PT30S")
+        private String shutdownTimeout;
+
+        SetupOptions options(SetupProfile profile, SetupMode mode, ShaftCachePaths paths) {
+            try {
+                return SetupOptions.defaults(profile, paths).withMode(mode).withOffline(offline)
+                        .withAutoStart(autoStart).withPreferSystemTools(preferSystemTools)
+                        .withReuseOwnedProcesses(reuseOwnedProcesses)
+                        .withTimeouts(java.time.Duration.parse(startupTimeout),
+                                java.time.Duration.parse(shutdownTimeout));
+            } catch (RuntimeException invalid) {
+                throw new IllegalArgumentException("Setup timeouts must be positive ISO-8601 durations.", invalid);
+            }
         }
     }
 

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
@@ -11,7 +11,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -116,6 +115,18 @@ class SetupCommandTest {
     }
 
     @Test
+    void incompletePlanRootsReturnInvalidInputWithoutWritingPlan(@TempDir Path temp) {
+        Path planFile = temp.resolve("plan.json").toAbsolutePath();
+
+        CommandResult result = execute("setup", "plan", "--profile", "REPORTING", "--mode", "MANAGED",
+                "--output", planFile.toString(), "--cache-root", temp.resolve("cache").toAbsolutePath().toString());
+
+        assertEquals(2, result.exitCode());
+        assertTrue(result.stderr().contains("must be supplied together"), result.stderr());
+        assertTrue(Files.notExists(planFile));
+    }
+
+    @Test
     void foreignPlatformPlanIsRejectedBeforeStateCreation(@TempDir Path temp) throws Exception {
         Path cache = temp.resolve("cache").toAbsolutePath();
         Path data = temp.resolve("data").toAbsolutePath();
@@ -139,6 +150,28 @@ class SetupCommandTest {
         assertEquals(2, result.exitCode());
         assertTrue(Files.notExists(cache));
         assertTrue(Files.notExists(data));
+    }
+
+    @Test
+    void cliPlanBindsTheSameNonDefaultPolicyAsJavaApi(@TempDir Path temp) throws Exception {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        Path planFile = temp.resolve("policy-plan.json").toAbsolutePath();
+        CommandResult result = execute("setup", "plan", "--profile", "REPORTING", "--mode", "MANAGED",
+                "--output", planFile.toString(), "--cache-root", cache.toString(), "--data-root", data.toString(),
+                "--offline", "--auto-start", "--prefer-system-tools=false", "--reuse-owned-processes=false",
+                "--startup-timeout", "PT45S", "--shutdown-timeout", "PT10S", "--json");
+
+        assertEquals(0, result.exitCode(), result.stderr());
+        com.shaft.infrastructure.SetupPlan plan = com.shaft.infrastructure.SetupPlanStore.read(planFile);
+        com.shaft.infrastructure.ShaftCachePaths paths = new com.shaft.infrastructure.ShaftCachePaths(cache, data,
+                cache.resolve("downloads"), data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        com.shaft.infrastructure.SetupOptions expected = com.shaft.infrastructure.SetupOptions.defaults(
+                com.shaft.infrastructure.SetupProfile.REPORTING, paths)
+                .withMode(com.shaft.infrastructure.SetupMode.MANAGED).withOffline(true).withAutoStart(true)
+                .withPreferSystemTools(false).withReuseOwnedProcesses(false)
+                .withTimeouts(java.time.Duration.ofSeconds(45), java.time.Duration.ofSeconds(10));
+        assertEquals(expected.policyDigest(), plan.executionPolicyDigest());
     }
 
     private static CommandResult execute(String... arguments) {

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
@@ -11,6 +11,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,7 +36,8 @@ class SetupCommandTest {
         JsonNode printed = JSON.readTree(stdout.toString());
         JsonNode persisted = JSON.readTree(Files.readString(planFile));
         assertEquals(persisted, printed);
-        assertEquals(2, persisted.get("schemaVersion").asInt());
+        assertEquals(3, persisted.get("schemaVersion").asInt());
+        assertTrue(persisted.get("executionPolicyDigest").asText().matches("sha256:[0-9a-f]{64}"));
         assertEquals("REPORTING", persisted.get("profile").asText());
         assertEquals("MANAGED", persisted.get("mode").asText());
         assertTrue(persisted.get("digest").asText().matches("sha256:[0-9a-f]{64}"));
@@ -111,6 +113,32 @@ class SetupCommandTest {
 
         assertEquals(2, result.exitCode());
         assertTrue(result.stderr().contains("must be absolute"));
+    }
+
+    @Test
+    void foreignPlatformPlanIsRejectedBeforeStateCreation(@TempDir Path temp) throws Exception {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        com.shaft.infrastructure.ShaftCachePaths paths = new com.shaft.infrastructure.ShaftCachePaths(
+                cache, data, cache.resolve("downloads"), data.resolve("tools"), data.resolve("state"),
+                data.resolve("receipts"));
+        com.shaft.infrastructure.SetupPlatform current = com.shaft.infrastructure.SetupPlatform.current();
+        com.shaft.infrastructure.SetupPlatform foreign = current == com.shaft.infrastructure.SetupPlatform.LINUX
+                ? com.shaft.infrastructure.SetupPlatform.WINDOWS : com.shaft.infrastructure.SetupPlatform.LINUX;
+        com.shaft.infrastructure.SetupOptions options = com.shaft.infrastructure.SetupOptions.defaults(
+                com.shaft.infrastructure.SetupProfile.REPORTING, paths)
+                .withMode(com.shaft.infrastructure.SetupMode.MANAGED);
+        com.shaft.infrastructure.SetupPlan plan = com.shaft.infrastructure.InfrastructureSetupService.builtIn(
+                foreign, com.shaft.infrastructure.SetupArchitecture.current()).plan(options);
+        Path planFile = temp.resolve("foreign-plan.json");
+        com.shaft.infrastructure.SetupPlanStore.write(planFile, plan);
+
+        CommandResult result = execute("setup", "install", "--plan", planFile.toString(),
+                "--approve", plan.digest(), "--cache-root", cache.toString(), "--data-root", data.toString());
+
+        assertEquals(2, result.exitCode());
+        assertTrue(Files.notExists(cache));
+        assertTrue(Files.notExists(data));
     }
 
     private static CommandResult execute(String... arguments) {

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -36,6 +36,11 @@
     </scm>
 
     <dependencies>
+        <dependency>
+            <groupId>io.github.shafthq</groupId>
+            <artifactId>shaft-infrastructure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- TESTNG DEPENDENCIES -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/SHAFT.java
@@ -1760,6 +1760,117 @@ public class SHAFT {
     }
 
     /**
+     * Plans, diagnoses, verifies, and explicitly provisions SHAFT-owned local infrastructure.
+     * Read-only methods use {@link Properties#infrastructure}; mutation always requires an exact
+     * {@link com.shaft.infrastructure.SetupApproval} for the supplied plan.
+     */
+    public static final class Infrastructure {
+        private Infrastructure() { throw new IllegalStateException("Utility class"); }
+
+        public static com.shaft.infrastructure.SetupCatalog catalog() {
+            return service().catalog();
+        }
+
+        public static com.shaft.infrastructure.SetupReport doctor() { return doctor(options()); }
+        public static com.shaft.infrastructure.SetupReport doctor(com.shaft.infrastructure.SetupOptions options) {
+            return service().doctor(options);
+        }
+
+        public static com.shaft.infrastructure.SetupReport status() { return status(options()); }
+        public static com.shaft.infrastructure.SetupReport status(com.shaft.infrastructure.SetupOptions options) {
+            return service().status(options);
+        }
+
+        public static com.shaft.infrastructure.SetupPlan plan() { return plan(options()); }
+        public static com.shaft.infrastructure.SetupPlan plan(com.shaft.infrastructure.SetupOptions options) {
+            return service().plan(options);
+        }
+
+        public static com.shaft.infrastructure.SetupReport verify() { return verify(options()); }
+        public static com.shaft.infrastructure.SetupReport verify(com.shaft.infrastructure.SetupOptions options) {
+            return service().verify(options);
+        }
+
+        public static com.shaft.infrastructure.SetupReceipt install(
+                com.shaft.infrastructure.SetupPlan plan, com.shaft.infrastructure.SetupApproval approval)
+                throws java.io.IOException {
+            return install(plan, approval, options());
+        }
+
+        public static com.shaft.infrastructure.SetupReceipt install(
+                com.shaft.infrastructure.SetupPlan plan, com.shaft.infrastructure.SetupApproval approval,
+                com.shaft.infrastructure.SetupOptions options) throws java.io.IOException {
+            return service().install(plan, approval, options);
+        }
+
+        public static com.shaft.infrastructure.ManagedEnvironment start(
+                com.shaft.infrastructure.SetupPlan plan, com.shaft.infrastructure.SetupApproval approval)
+                throws java.io.IOException {
+            return start(plan, approval, options());
+        }
+
+        public static com.shaft.infrastructure.ManagedEnvironment start(
+                com.shaft.infrastructure.SetupPlan plan, com.shaft.infrastructure.SetupApproval approval,
+                com.shaft.infrastructure.SetupOptions options) throws java.io.IOException {
+            return service().start(plan, approval, options);
+        }
+
+        public static com.shaft.infrastructure.SetupOptions options() {
+            com.shaft.properties.internal.Infrastructure configured = Properties.infrastructure;
+            com.shaft.infrastructure.ShaftCachePaths paths = configured.cacheDirectory().isBlank()
+                    ? com.shaft.infrastructure.ShaftCachePaths.current()
+                    : cachePaths(java.nio.file.Path.of(configured.cacheDirectory()));
+            com.shaft.infrastructure.SetupOptions options = com.shaft.infrastructure.SetupOptions
+                    .defaults(configured.profile(), paths)
+                    .withMode(configured.mode()).withOffline(configured.offline())
+                    .withAutoStart(configured.autoStart())
+                    .withPreferSystemTools(configured.preferSystemTools())
+                    .withReuseOwnedProcesses(configured.reuseOwnedProcesses())
+                    .withTimeouts(duration("infrastructure.startupTimeout", configured.startupTimeout()),
+                            duration("infrastructure.shutdownTimeout", configured.shutdownTimeout()));
+            String executionAddress = Properties.platform.executionAddress();
+            if (usesExecutionEndpoint(configured.profile()) && executionAddress != null
+                    && !executionAddress.isBlank() && !executionAddress.equalsIgnoreCase("local")
+                    && !executionAddress.equalsIgnoreCase("dockerized")) {
+                String normalized = executionAddress.matches("(?i)^https?://.*")
+                        ? executionAddress : "http://" + executionAddress;
+                options = options.withRemoteEndpoint(java.net.URI.create(normalized));
+            }
+            return options;
+        }
+
+        private static boolean usesExecutionEndpoint(com.shaft.infrastructure.SetupProfile profile) {
+            return switch (profile) {
+                case WEB_LOCAL, SELENIUM_GRID, MOBILE_ANDROID, MOBILE_IOS, MOBILE_WINDOWS, HEALENIUM -> true;
+                default -> false;
+            };
+        }
+
+        private static java.time.Duration duration(String property, String value) {
+            try {
+                java.time.Duration duration = java.time.Duration.parse(value);
+                if (duration.isZero() || duration.isNegative()) throw new IllegalArgumentException();
+                return duration;
+            } catch (RuntimeException invalid) {
+                throw new IllegalArgumentException(property + " must be a positive ISO-8601 duration.", invalid);
+            }
+        }
+
+        private static com.shaft.infrastructure.ShaftCachePaths cachePaths(java.nio.file.Path configured) {
+            java.nio.file.Path cache = configured.normalize();
+            if (!cache.isAbsolute()) throw new IllegalArgumentException(
+                    "infrastructure.cacheDirectory must be absolute.");
+            java.nio.file.Path data = cache.resolve("data");
+            return new com.shaft.infrastructure.ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                    data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        }
+
+        private static com.shaft.infrastructure.InfrastructureSetupService service() {
+            return com.shaft.infrastructure.InfrastructureSetupService.builtIn();
+        }
+    }
+
+    /**
      * Utility class for emitting log messages and attaching artifacts to
      * the Allure execution report.
      *

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Infrastructure.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Infrastructure.java
@@ -1,0 +1,46 @@
+package com.shaft.properties.internal;
+
+import com.shaft.infrastructure.SetupMode;
+import com.shaft.infrastructure.SetupProfile;
+import org.aeonbits.owner.Config.Sources;
+import org.aeonbits.owner.ConfigFactory;
+
+/** Configuration for the shared batteries-included setup subsystem. */
+@Sources({"system:properties", "file:src/main/resources/properties/custom.properties",
+        "file:src/main/resources/properties/default/custom.properties", "classpath:custom.properties"})
+public interface Infrastructure extends EngineProperties<Infrastructure> {
+    @Key("infrastructure.mode") @DefaultValue("EXTERNAL") SetupMode mode();
+    @Key("infrastructure.profile") @DefaultValue("REPORTING") SetupProfile profile();
+    @Key("infrastructure.cacheDirectory") @DefaultValue("") String cacheDirectory();
+    @Key("infrastructure.offline") @DefaultValue("false") boolean offline();
+    @Key("infrastructure.autoStart") @DefaultValue("false") boolean autoStart();
+    @Key("infrastructure.preferSystemTools") @DefaultValue("true") boolean preferSystemTools();
+    @Key("infrastructure.reuseOwnedProcesses") @DefaultValue("true") boolean reuseOwnedProcesses();
+    @Key("infrastructure.startupTimeout") @DefaultValue("PT2M") String startupTimeout();
+    @Key("infrastructure.shutdownTimeout") @DefaultValue("PT30S") String shutdownTimeout();
+
+    @Override
+    default InfrastructurePropertyBuilder set() { return new InfrastructurePropertyBuilder(); }
+
+    /** Thread-local fluent overrides for setup policy. */
+    final class InfrastructurePropertyBuilder implements EngineProperties.SetProperty {
+        public InfrastructurePropertyBuilder mode(SetupMode value) { return set("infrastructure.mode", value.name()); }
+        public InfrastructurePropertyBuilder profile(SetupProfile value) { return set("infrastructure.profile", value.name()); }
+        public InfrastructurePropertyBuilder cacheDirectory(String value) { return set("infrastructure.cacheDirectory", value); }
+        public InfrastructurePropertyBuilder offline(boolean value) { return set("infrastructure.offline", value); }
+        public InfrastructurePropertyBuilder autoStart(boolean value) { return set("infrastructure.autoStart", value); }
+        public InfrastructurePropertyBuilder preferSystemTools(boolean value) { return set("infrastructure.preferSystemTools", value); }
+        public InfrastructurePropertyBuilder reuseOwnedProcesses(boolean value) { return set("infrastructure.reuseOwnedProcesses", value); }
+        public InfrastructurePropertyBuilder startupTimeout(String value) { return set("infrastructure.startupTimeout", value); }
+        public InfrastructurePropertyBuilder shutdownTimeout(String value) { return set("infrastructure.shutdownTimeout", value); }
+
+        private InfrastructurePropertyBuilder set(String key, Object value) {
+            if (value == null) throw new IllegalArgumentException(key + " must not be null.");
+            ThreadLocalPropertiesManager.setProperty(key, String.valueOf(value));
+            Properties.infrastructureOverride.set(ConfigFactory.create(Infrastructure.class,
+                    ThreadLocalPropertiesManager.getOverrides()));
+            EngineProperties.logPropertyUpdate(key, value);
+            return this;
+        }
+    }
+}

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Properties.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Properties.java
@@ -63,6 +63,7 @@ public class Properties {
     static Playwright basePlaywright;
     static Capture baseCapture;
     static Ocr baseOcr;
+    static Infrastructure baseInfrastructure;
 
     // -------------------------------------------------------------------------
     // Thread-local override configs – updated by set() calls on each thread.
@@ -89,6 +90,7 @@ public class Properties {
     static final ThreadLocal<Playwright> playwrightOverride = new ThreadLocal<>();
     static final ThreadLocal<Capture> captureOverride = new ThreadLocal<>();
     static final ThreadLocal<Ocr> ocrOverride = new ThreadLocal<>();
+    static final ThreadLocal<Infrastructure> infrastructureOverride = new ThreadLocal<>();
 
     // -------------------------------------------------------------------------
     // Public proxy fields – fully API-compatible with the previous static fields.
@@ -119,6 +121,8 @@ public class Properties {
     public static final Playwright playwright = createProxy(Playwright.class, playwrightOverride, () -> basePlaywright);
     public static final Capture capture = createProxy(Capture.class, captureOverride, () -> baseCapture);
     public static final Ocr ocr = createProxy(Ocr.class, ocrOverride, () -> baseOcr);
+    public static final Infrastructure infrastructure = createProxy(Infrastructure.class,
+            infrastructureOverride, () -> baseInfrastructure);
 
     // Read-only properties – not mutable after initialisation, no proxy needed.
     public static Internal internal;
@@ -251,6 +255,7 @@ public class Properties {
         playwrightOverride.remove();
         captureOverride.remove();
         ocrOverride.remove();
+        infrastructureOverride.remove();
         synchronized (Properties.class) {
             if (pristineBaseFlags != null) {
                 baseFlags = pristineBaseFlags;

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/PropertiesHelper.java
@@ -116,6 +116,7 @@ public class PropertiesHelper {
         Properties.basePlaywright = ConfigFactory.create(Playwright.class);
         Properties.baseCapture = ConfigFactory.create(Capture.class);
         Properties.baseOcr = ConfigFactory.create(Ocr.class);
+        Properties.baseInfrastructure = ConfigFactory.create(Infrastructure.class);
         Properties.initialized = true;
     }
 

--- a/shaft-engine/src/main/resources/properties/default/custom.properties
+++ b/shaft-engine/src/main/resources/properties/default/custom.properties
@@ -48,3 +48,14 @@ capture.api.storeSecretsLocally=false
 capture.api.maxTransactions=500
 capture.api.urlIncludeGlobs=
 capture.api.urlExcludeGlobs=
+
+# Optional batteries-included infrastructure (safe default: diagnose only)
+infrastructure.mode=EXTERNAL
+infrastructure.profile=REPORTING
+infrastructure.cacheDirectory=
+infrastructure.offline=false
+infrastructure.autoStart=false
+infrastructure.preferSystemTools=true
+infrastructure.reuseOwnedProcesses=true
+infrastructure.startupTimeout=PT2M
+infrastructure.shutdownTimeout=PT30S

--- a/shaft-engine/src/test/java/testPackage/properties/InfrastructurePropertiesTests.java
+++ b/shaft-engine/src/test/java/testPackage/properties/InfrastructurePropertiesTests.java
@@ -1,0 +1,133 @@
+package testPackage.properties;
+
+import com.shaft.driver.SHAFT;
+import com.shaft.infrastructure.SetupApproval;
+import com.shaft.infrastructure.SetupMode;
+import com.shaft.infrastructure.SetupPlan;
+import com.shaft.infrastructure.SetupProfile;
+import com.shaft.properties.internal.Properties;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.CountDownLatch;
+
+public class InfrastructurePropertiesTests {
+    @AfterMethod(alwaysRun = true)
+    public void cleanup() {
+        Properties.clearForCurrentThread();
+    }
+
+    @Test
+    public void defaultsRemainExternalAndNonMutating() throws Exception {
+        Path root = Files.createTempDirectory("shaft-infrastructure-default-").toAbsolutePath();
+        Files.delete(root);
+        SHAFT.Properties.infrastructure.set().cacheDirectory(root.toString());
+
+        Assert.assertEquals(SHAFT.Properties.infrastructure.mode(), SetupMode.EXTERNAL);
+        Assert.assertEquals(SHAFT.Properties.infrastructure.profile(), SetupProfile.REPORTING);
+        Assert.assertFalse(SHAFT.Properties.infrastructure.offline());
+        Assert.assertFalse(SHAFT.Properties.infrastructure.autoStart());
+        SetupPlan plan = SHAFT.Infrastructure.plan();
+        Assert.assertEquals(plan.mode(), SetupMode.EXTERNAL);
+        Assert.assertTrue(plan.actions().stream().allMatch(action -> action.kind().name().equals("DIAGNOSE")));
+        SHAFT.Infrastructure.status();
+        Assert.assertFalse(Files.exists(root));
+    }
+
+    @Test
+    public void settersBuildTypedManagedOptionsForCurrentThread() throws Exception {
+        Path root = Files.createTempDirectory("shaft-infrastructure-options-").toAbsolutePath();
+        SHAFT.Properties.infrastructure.set().mode(SetupMode.MANAGED).profile(SetupProfile.REPORTING)
+                .cacheDirectory(root.toString()).offline(true).autoStart(true)
+                .preferSystemTools(false).reuseOwnedProcesses(false)
+                .startupTimeout("PT45S").shutdownTimeout("PT10S");
+
+        var options = SHAFT.Infrastructure.options();
+        Assert.assertEquals(options.mode(), SetupMode.MANAGED);
+        Assert.assertTrue(options.offline());
+        Assert.assertTrue(options.autoStart());
+        Assert.assertFalse(options.preferSystemTools());
+        Assert.assertFalse(options.reuseOwnedProcesses());
+        Assert.assertEquals(options.startupTimeout().toSeconds(), 45);
+        Assert.assertEquals(options.shutdownTimeout().toSeconds(), 10);
+        Assert.assertEquals(options.paths().cacheRoot(), root);
+    }
+
+    @Test
+    public void staleApprovalAndRelativeCacheFailBeforeMutation() throws Exception {
+        Path root = Files.createTempDirectory("shaft-infrastructure-approval-").toAbsolutePath();
+        Files.delete(root);
+        SHAFT.Properties.infrastructure.set().mode(SetupMode.MANAGED).cacheDirectory(root.toString());
+        SetupPlan plan = SHAFT.Infrastructure.plan();
+
+        Assert.expectThrows(com.shaft.infrastructure.StaleSetupApprovalException.class,
+                () -> SHAFT.Infrastructure.install(plan, new SetupApproval(
+                        "sha256:" + "0".repeat(64), Instant.EPOCH, Set.of())));
+        Assert.assertFalse(Files.exists(root));
+
+        SHAFT.Properties.infrastructure.set().cacheDirectory("relative-cache");
+        Assert.expectThrows(IllegalArgumentException.class, SHAFT.Infrastructure::options);
+
+        SHAFT.Properties.infrastructure.set().cacheDirectory(root.toString()).startupTimeout("not-a-duration");
+        IllegalArgumentException malformed = Assert.expectThrows(IllegalArgumentException.class,
+                SHAFT.Infrastructure::options);
+        Assert.assertTrue(malformed.getMessage().contains("infrastructure.startupTimeout"));
+        SHAFT.Properties.infrastructure.set().startupTimeout("PT0S");
+        Assert.assertTrue(Assert.expectThrows(IllegalArgumentException.class, SHAFT.Infrastructure::options)
+                .getMessage().contains("infrastructure.startupTimeout"));
+    }
+
+    @Test
+    public void overridesAreThreadLocalAndClearRestoresDefaults() throws Exception {
+        AtomicReference<SetupMode> writerBeforeClear = new AtomicReference<>();
+        AtomicReference<SetupMode> writerAfterClear = new AtomicReference<>();
+        CountDownLatch overrideActive = new CountDownLatch(1);
+        CountDownLatch observerRead = new CountDownLatch(1);
+        Thread writer = new Thread(() -> {
+            SHAFT.Properties.infrastructure.set().mode(SetupMode.MANAGED);
+            writerBeforeClear.set(SHAFT.Properties.infrastructure.mode());
+            overrideActive.countDown();
+            try {
+                observerRead.await();
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(interrupted);
+            }
+            Properties.clearForCurrentThread();
+            writerAfterClear.set(SHAFT.Properties.infrastructure.mode());
+        });
+        writer.start();
+        overrideActive.await();
+        Assert.assertEquals(SHAFT.Properties.infrastructure.mode(), SetupMode.EXTERNAL);
+        observerRead.countDown();
+        writer.join();
+
+        Assert.assertEquals(writerBeforeClear.get(), SetupMode.MANAGED);
+        Assert.assertEquals(writerAfterClear.get(), SetupMode.EXTERNAL);
+        Assert.assertEquals(SHAFT.Properties.infrastructure.mode(), SetupMode.EXTERNAL);
+    }
+
+    @Test
+    public void explicitRemoteExecutionWinsForEndpointProfiles() throws Exception {
+        Path root = Files.createTempDirectory("shaft-infrastructure-remote-").toAbsolutePath();
+        SHAFT.Properties.infrastructure.set().mode(SetupMode.MANAGED).profile(SetupProfile.SELENIUM_GRID)
+                .cacheDirectory(root.toString());
+        SHAFT.Properties.platform.set().executionAddress("grid.example:4444");
+
+        var options = SHAFT.Infrastructure.options();
+        Assert.assertEquals(options.mode(), SetupMode.MANAGED);
+        Assert.assertEquals(options.effectiveMode(), SetupMode.EXTERNAL);
+        Assert.assertEquals(options.remoteEndpoint().orElseThrow().toString(), "http://grid.example:4444");
+
+        SHAFT.Properties.infrastructure.set().profile(SetupProfile.REPORTING);
+        var reporting = SHAFT.Infrastructure.options();
+        Assert.assertEquals(reporting.effectiveMode(), SetupMode.MANAGED);
+        Assert.assertTrue(reporting.remoteEndpoint().isEmpty());
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
@@ -1,0 +1,120 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/** Shared provider-neutral setup orchestration used by every public adapter. */
+public final class InfrastructureSetupService {
+    private final SetupProviderRegistry providers;
+    private final SetupPlatform platform;
+    private final SetupArchitecture architecture;
+
+    public InfrastructureSetupService(SetupProviderRegistry providers, SetupPlatform platform,
+                                      SetupArchitecture architecture) {
+        this.providers = Objects.requireNonNull(providers, "providers");
+        this.platform = Objects.requireNonNull(platform, "platform");
+        this.architecture = Objects.requireNonNull(architecture, "architecture");
+    }
+
+    public static InfrastructureSetupService builtIn() {
+        return builtIn(SetupPlatform.current(), SetupArchitecture.current());
+    }
+
+    public static InfrastructureSetupService builtIn(SetupPlatform platform, SetupArchitecture architecture) {
+        return new InfrastructureSetupService(new SetupProviderRegistry(List.of(new ReportingSetupProvider())),
+                platform, architecture);
+    }
+
+    public SetupCatalog catalog() {
+        return SetupCatalog.builtIn();
+    }
+
+    public SetupPlan plan(SetupOptions options) {
+        SetupOptions value = Objects.requireNonNull(options, "options");
+        SetupPlan plan = providers.require(value.profile()).plan(value, platform, architecture);
+        requirePlanIdentity(plan, value);
+        return SetupPlan.bind(plan, value.policyDigest());
+    }
+
+    public SetupReport doctor(SetupOptions options) {
+        return status(options);
+    }
+
+    public SetupReport status(SetupOptions options) {
+        SetupOptions value = Objects.requireNonNull(options, "options");
+        SetupReport report = providers.require(value.profile()).status(value, platform, architecture);
+        if (report.profile() != value.profile()) {
+            throw new IllegalStateException("Setup provider returned a report for " + report.profile()
+                    + " instead of " + value.profile() + '.');
+        }
+        return report;
+    }
+
+    public SetupReport verify(SetupOptions options) {
+        return status(options);
+    }
+
+    public SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupProvider provider = authorize(plan, approval, options, "mutate the host");
+        SetupReceipt receipt = provider.install(plan, approval, options);
+        requireReceiptIdentity(receipt, plan);
+        return receipt;
+    }
+
+    public ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options)
+            throws IOException {
+        SetupProvider provider = authorize(plan, approval, options, "start a managed service");
+        ManagedEnvironment environment = provider.start(plan, approval, options);
+        try {
+            if (environment.profile() != plan.profile()) {
+                throw new IllegalStateException("Setup provider returned a mismatched managed environment.");
+            }
+            requireReceiptIdentity(environment.receipt(), plan);
+        } catch (IllegalStateException mismatch) {
+            try {
+                environment.close();
+            } catch (RuntimeException cleanupFailure) {
+                mismatch.addSuppressed(cleanupFailure);
+            }
+            throw mismatch;
+        }
+        return environment;
+    }
+
+    private SetupProvider authorize(SetupPlan plan, SetupApproval approval, SetupOptions options, String operation) {
+        Objects.requireNonNull(plan, "plan");
+        Objects.requireNonNull(options, "options");
+        if (options.effectiveMode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External setup is diagnostic and cannot " + operation + '.');
+        }
+        SetupExecutor.validate(plan, Objects.requireNonNull(approval, "approval"));
+        if (plan.actions().stream().anyMatch(SetupAction::privileged)) {
+            throw new IllegalArgumentException("Privileged host prerequisites cannot be performed by the Java API.");
+        }
+        if (plan.profile() != options.profile() || plan.mode() != options.effectiveMode()) {
+            throw new IllegalArgumentException("Plan does not match the requested setup options.");
+        }
+        SetupProvider provider = providers.require(options.profile());
+        SetupPlan expected = provider.plan(options, platform, architecture);
+        requirePlanIdentity(expected, options);
+        if (!SetupPlan.bind(expected, options.policyDigest()).equals(plan)) {
+            throw new IllegalArgumentException("Plan does not match the provider manifest shipped with this release.");
+        }
+        return provider;
+    }
+
+    private void requirePlanIdentity(SetupPlan plan, SetupOptions options) {
+        if (plan.profile() != options.profile() || plan.platform() != platform
+                || plan.architecture() != architecture || plan.mode() != options.effectiveMode()) {
+            throw new IllegalStateException("Setup provider returned a plan with mismatched identity.");
+        }
+    }
+
+    private static void requireReceiptIdentity(SetupReceipt receipt, SetupPlan plan) {
+        Objects.requireNonNull(receipt, "receipt");
+        if (!receipt.planDigest().equals(plan.digest()) || !receipt.completedActions().equals(plan.actions())) {
+            throw new IllegalStateException("Setup provider returned a mismatched receipt.");
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ManagedEnvironment.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ManagedEnvironment.java
@@ -1,0 +1,40 @@
+package com.shaft.infrastructure;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** An owned, verified runtime plus its connection metadata and idempotent release action. */
+public final class ManagedEnvironment implements AutoCloseable {
+    private final SetupProfile profile;
+    private final SetupReceipt receipt;
+    private final Optional<URI> endpoint;
+    private final Map<String, String> connectionProperties;
+    private final Runnable release;
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    public ManagedEnvironment(SetupProfile profile, SetupReceipt receipt, Optional<URI> endpoint,
+                              Map<String, String> connectionProperties, Runnable release) {
+        this.profile = Objects.requireNonNull(profile, "profile");
+        this.receipt = Objects.requireNonNull(receipt, "receipt");
+        this.endpoint = Objects.requireNonNull(endpoint, "endpoint");
+        this.connectionProperties = Map.copyOf(Objects.requireNonNull(connectionProperties,
+                "connectionProperties"));
+        this.release = Objects.requireNonNull(release, "release");
+    }
+
+    public SetupProfile profile() { return profile; }
+    public SetupReceipt receipt() { return receipt; }
+    public Optional<URI> endpoint() { return endpoint; }
+    public Map<String, String> connectionProperties() { return connectionProperties; }
+    public boolean isClosed() { return closed.get(); }
+
+    @Override
+    public synchronized void close() {
+        if (closed.get()) return;
+        release.run();
+        closed.set(true);
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupProvider.java
@@ -1,0 +1,33 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+
+final class ReportingSetupProvider implements SetupProvider {
+    @Override
+    public SetupProfile profile() {
+        return SetupProfile.REPORTING;
+    }
+
+    @Override
+    public SetupPlan plan(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return ReportingSetupPlanner.plan(platform, architecture, options.effectiveMode());
+    }
+
+    @Override
+    public SetupReport status(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return SetupReport.from(service(options, platform, architecture).status());
+    }
+
+    @Override
+    public SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupPlan providerPlan = ReportingSetupPlanner.plan(plan.platform(), plan.architecture(), plan.mode());
+        SetupReceipt receipt = service(options, plan.platform(), plan.architecture()).install(providerPlan,
+                new SetupApproval(providerPlan.digest(), approval.approvedAt(), approval.acceptedLicenses()));
+        return new SetupReceipt(plan.digest(), receipt.completedAt(), receipt.completedActions());
+    }
+
+    private static ReportingSetupService service(SetupOptions options, SetupPlatform platform,
+                                                 SetupArchitecture architecture) {
+        return new ReportingSetupService(options.paths(), platform, architecture, options.offline());
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupService.java
@@ -30,20 +30,34 @@ public final class ReportingSetupService {
     private final SetupArchitecture architecture;
     private final ArtifactFetcher artifactFetcher;
     private final CommandRunner commandRunner;
+    private boolean offline;
 
     public ReportingSetupService(ShaftCachePaths paths, SetupPlatform platform, SetupArchitecture architecture) {
-        this(paths, platform, architecture, new VerifiedArtifactStore(paths.downloads())::fetch,
+        this(paths, platform, architecture, false);
+    }
+
+    public ReportingSetupService(ShaftCachePaths paths, SetupPlatform platform, SetupArchitecture architecture,
+                                 boolean offline) {
+        this(paths, platform, architecture,
+                action -> new VerifiedArtifactStore(paths.downloads()).fetch(action, offline),
                 (command, log, timeout) -> runProcess(command, log, timeout, paths.cacheRoot(),
                         nodeRoot(paths, platform, architecture)));
+        this.offline = offline;
     }
 
     ReportingSetupService(ShaftCachePaths paths, SetupPlatform platform, SetupArchitecture architecture,
                           ArtifactFetcher artifactFetcher, CommandRunner commandRunner) {
+        this(paths, platform, architecture, artifactFetcher, commandRunner, false);
+    }
+
+    ReportingSetupService(ShaftCachePaths paths, SetupPlatform platform, SetupArchitecture architecture,
+                          ArtifactFetcher artifactFetcher, CommandRunner commandRunner, boolean offline) {
         this.paths = java.util.Objects.requireNonNull(paths, "paths");
         this.platform = java.util.Objects.requireNonNull(platform, "platform");
         this.architecture = java.util.Objects.requireNonNull(architecture, "architecture");
         this.artifactFetcher = java.util.Objects.requireNonNull(artifactFetcher, "artifactFetcher");
         this.commandRunner = java.util.Objects.requireNonNull(commandRunner, "commandRunner");
+        this.offline = offline;
     }
 
     public SetupProfileStatus status() {
@@ -127,11 +141,14 @@ public final class ReportingSetupService {
             Path log = logFile();
             Files.createDirectories(log.getParent());
             copyReportingManifest(staging, action.dependencyLockChecksum());
-            requireSuccessful(commandRunner.run(List.of(nodeExecutable().toString(), npmCli().toString(),
-                    "cache", "add", packageArchive.toString()), log, Duration.ofMinutes(2)),
+            List<String> cacheCommand = new ArrayList<>(List.of(nodeExecutable().toString(), npmCli().toString(),
+                    "cache", "add", packageArchive.toString()));
+            if (offline) cacheCommand.add("--offline");
+            requireSuccessful(commandRunner.run(cacheCommand, log, Duration.ofMinutes(2)),
                     "Allure package cache preparation failed; see " + log);
-            List<String> command = List.of(nodeExecutable().toString(), npmCli().toString(), "ci",
-                    "--prefix", staging.toString(), "--ignore-scripts", "--no-audit", "--no-fund");
+            List<String> command = new ArrayList<>(List.of(nodeExecutable().toString(), npmCli().toString(), "ci",
+                    "--prefix", staging.toString(), "--ignore-scripts", "--no-audit", "--no-fund"));
+            if (offline) command.add("--offline");
             requireSuccessful(commandRunner.run(command, log, Duration.ofMinutes(5)),
                     "Allure npm installation failed; see " + log);
             Path entryPoint = staging.resolve("node_modules/allure/cli.js");
@@ -260,7 +277,13 @@ public final class ReportingSetupService {
             String resource = "/com/shaft/infrastructure/reporting/" + name;
             try (InputStream input = ReportingSetupService.class.getResourceAsStream(resource)) {
                 if (input == null) throw new IOException("Missing bundled reporting manifest: " + name);
-                Files.copy(input, staging.resolve(name));
+                byte[] content = input.readAllBytes();
+                if ("package-lock.json".equals(name)) {
+                    String canonical = new String(content, java.nio.charset.StandardCharsets.UTF_8)
+                            .replace("\r\n", "\n").replace('\r', '\n');
+                    content = canonical.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                }
+                Files.write(staging.resolve(name), content);
             }
         }
         String actual = "sha256:" + VerifiedArtifactStore.digest(staging.resolve("package-lock.json"));

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupOptions.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupOptions.java
@@ -1,0 +1,115 @@
+package com.shaft.infrastructure;
+
+import java.net.URI;
+import java.time.Duration;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Immutable caller policy for planning, verifying, installing, and starting setup profiles. */
+public record SetupOptions(SetupProfile profile, SetupMode mode, ShaftCachePaths paths,
+                           boolean offline, boolean autoStart, boolean preferSystemTools,
+                           boolean reuseOwnedProcesses, Duration startupTimeout,
+                           Duration shutdownTimeout, Optional<URI> remoteEndpoint) {
+    public SetupOptions {
+        Objects.requireNonNull(profile, "profile");
+        Objects.requireNonNull(mode, "mode");
+        Objects.requireNonNull(paths, "paths");
+        startupTimeout = positive(startupTimeout, "startupTimeout");
+        shutdownTimeout = positive(shutdownTimeout, "shutdownTimeout");
+        remoteEndpoint = Objects.requireNonNull(remoteEndpoint, "remoteEndpoint");
+        remoteEndpoint.ifPresent(SetupOptions::validateRemoteEndpoint);
+    }
+
+    public static SetupOptions defaults(SetupProfile profile, ShaftCachePaths paths) {
+        return new SetupOptions(profile, SetupMode.EXTERNAL, paths, false, false,
+                true, true, Duration.ofMinutes(2), Duration.ofSeconds(30), Optional.empty());
+    }
+
+    /** An explicit remote endpoint always keeps local setup non-mutating. */
+    public SetupMode effectiveMode() {
+        return remoteEndpoint.isPresent() ? SetupMode.EXTERNAL : mode;
+    }
+
+    public SetupOptions withMode(SetupMode value) {
+        return copy(value, offline, autoStart, preferSystemTools, reuseOwnedProcesses,
+                startupTimeout, shutdownTimeout, remoteEndpoint);
+    }
+
+    public SetupOptions withOffline(boolean value) {
+        return copy(mode, value, autoStart, preferSystemTools, reuseOwnedProcesses,
+                startupTimeout, shutdownTimeout, remoteEndpoint);
+    }
+
+    public SetupOptions withAutoStart(boolean value) {
+        return copy(mode, offline, value, preferSystemTools, reuseOwnedProcesses,
+                startupTimeout, shutdownTimeout, remoteEndpoint);
+    }
+
+    public SetupOptions withPreferSystemTools(boolean value) {
+        return copy(mode, offline, autoStart, value, reuseOwnedProcesses,
+                startupTimeout, shutdownTimeout, remoteEndpoint);
+    }
+
+    public SetupOptions withReuseOwnedProcesses(boolean value) {
+        return copy(mode, offline, autoStart, preferSystemTools, value,
+                startupTimeout, shutdownTimeout, remoteEndpoint);
+    }
+
+    public SetupOptions withTimeouts(Duration startup, Duration shutdown) {
+        return copy(mode, offline, autoStart, preferSystemTools, reuseOwnedProcesses,
+                startup, shutdown, remoteEndpoint);
+    }
+
+    public SetupOptions withRemoteEndpoint(URI endpoint) {
+        return copy(mode, offline, autoStart, preferSystemTools, reuseOwnedProcesses,
+                startupTimeout, shutdownTimeout, Optional.of(Objects.requireNonNull(endpoint, "endpoint")));
+    }
+
+    /** Content address of every option that can change setup execution or its destinations. */
+    public String policyDigest() {
+        String value = String.join("\u0000", profile.name(), mode.name(), effectiveMode().name(),
+                paths.cacheRoot().toString(), paths.dataRoot().toString(), paths.downloads().toString(),
+                paths.tools().toString(), paths.state().toString(), paths.receipts().toString(),
+                Boolean.toString(offline),
+                Boolean.toString(autoStart), Boolean.toString(preferSystemTools),
+                Boolean.toString(reuseOwnedProcesses), startupTimeout.toString(), shutdownTimeout.toString(),
+                remoteEndpoint.map(URI::toString).orElse(""));
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            for (int index = 0; index < value.length(); index++) {
+                char codeUnit = value.charAt(index);
+                digest.update((byte) (codeUnit >>> 8));
+                digest.update((byte) codeUnit);
+            }
+            return "sha256:" + HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
+    }
+
+    private SetupOptions copy(SetupMode nextMode, boolean nextOffline, boolean nextAutoStart,
+                              boolean nextPreferSystemTools, boolean nextReuseOwnedProcesses,
+                              Duration nextStartupTimeout, Duration nextShutdownTimeout,
+                              Optional<URI> nextRemoteEndpoint) {
+        return new SetupOptions(profile, nextMode, paths, nextOffline, nextAutoStart,
+                nextPreferSystemTools, nextReuseOwnedProcesses, nextStartupTimeout,
+                nextShutdownTimeout, nextRemoteEndpoint);
+    }
+
+    private static Duration positive(Duration value, String name) {
+        Objects.requireNonNull(value, name);
+        if (value.isZero() || value.isNegative()) throw new IllegalArgumentException(name + " must be positive.");
+        return value;
+    }
+
+    private static void validateRemoteEndpoint(URI endpoint) {
+        if (!endpoint.isAbsolute() || endpoint.getHost() == null
+                || !("http".equalsIgnoreCase(endpoint.getScheme())
+                || "https".equalsIgnoreCase(endpoint.getScheme()))) {
+            throw new IllegalArgumentException("remoteEndpoint must be an absolute HTTP(S) URI.");
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupPlan.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupPlan.java
@@ -13,18 +13,23 @@ import java.util.stream.Collectors;
 /** Immutable, content-addressed setup plan. Action order is significant. */
 public record SetupPlan(int schemaVersion, SetupProfile profile, SetupPlatform platform,
                         SetupArchitecture architecture, SetupMode mode,
-                        List<SetupAction> actions, String digest) {
+                        List<SetupAction> actions, String executionPolicyDigest, String digest) {
     public SetupPlan {
-        if (schemaVersion != 2) throw new IllegalArgumentException("Unsupported plan schema version: " + schemaVersion);
+        if (schemaVersion != 2 && schemaVersion != 3) {
+            throw new IllegalArgumentException("Unsupported plan schema version: " + schemaVersion);
+        }
         Objects.requireNonNull(profile, "profile");
         Objects.requireNonNull(platform, "platform");
         Objects.requireNonNull(architecture, "architecture");
         Objects.requireNonNull(mode, "mode");
         actions = List.copyOf(Objects.requireNonNull(actions, "actions"));
         if (actions.isEmpty()) throw new IllegalArgumentException("Plan must contain at least one action.");
+        if (schemaVersion == 2) executionPolicyDigest = "";
+        else requireSha256(executionPolicyDigest, "executionPolicyDigest");
         validatePolicy(mode, actions);
         if (digest == null || digest.isBlank()) throw new IllegalArgumentException("Plan digest must not be blank.");
-        String expected = calculateDigest(schemaVersion, profile, platform, architecture, mode, actions);
+        String expected = calculateDigest(schemaVersion, profile, platform, architecture, mode, actions,
+                executionPolicyDigest);
         if (!expected.equals(digest)) throw new IllegalArgumentException("Plan digest does not match its content.");
     }
 
@@ -32,18 +37,28 @@ public record SetupPlan(int schemaVersion, SetupProfile profile, SetupPlatform p
                                    SetupMode mode, List<SetupAction> actions) {
         List<SetupAction> immutable = List.copyOf(actions);
         return new SetupPlan(2, profile, platform, architecture, mode, immutable,
-                calculateDigest(2, profile, platform, architecture, mode, immutable));
+                "", calculateDigest(2, profile, platform, architecture, mode, immutable, ""));
+    }
+
+    /** Binds an existing release plan to caller execution policy and destination roots. */
+    public static SetupPlan bind(SetupPlan plan, String executionPolicyDigest) {
+        Objects.requireNonNull(plan, "plan");
+        requireSha256(executionPolicyDigest, "executionPolicyDigest");
+        return new SetupPlan(3, plan.profile(), plan.platform(), plan.architecture(), plan.mode(), plan.actions(),
+                executionPolicyDigest, calculateDigest(3, plan.profile(), plan.platform(), plan.architecture(),
+                plan.mode(), plan.actions(), executionPolicyDigest));
     }
 
     private static String calculateDigest(int schemaVersion, SetupProfile profile, SetupPlatform platform,
                                           SetupArchitecture architecture, SetupMode mode,
-                                          List<SetupAction> actions) {
+                                          List<SetupAction> actions, String executionPolicyDigest) {
         StringBuilder canonical = new StringBuilder();
         append(canonical, Integer.toString(schemaVersion));
         append(canonical, profile.name());
         append(canonical, platform.name());
         append(canonical, architecture.name());
         append(canonical, mode.name());
+        if (schemaVersion >= 3) append(canonical, executionPolicyDigest);
         append(canonical, Integer.toString(actions.size()));
         actions.forEach(action -> {
             append(canonical, action.target().name());
@@ -66,6 +81,12 @@ public record SetupPlan(int schemaVersion, SetupProfile profile, SetupPlatform p
             return "sha256:" + HexFormat.of().formatHex(digest.digest());
         } catch (NoSuchAlgorithmException impossible) {
             throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
+    }
+
+    private static void requireSha256(String value, String name) {
+        if (value == null || !value.matches("sha256:[0-9a-fA-F]{64}")) {
+            throw new IllegalArgumentException(name + " must be a SHA-256 digest.");
         }
     }
 

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupPlanJson.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupPlanJson.java
@@ -4,7 +4,7 @@ import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.core.StreamReadFeature;
 import tools.jackson.databind.DeserializationFeature;
 
-/** Stable JSON codec for setup-plan schema version 2. */
+/** Stable, strict JSON codec for setup-plan schemas 2 and 3. */
 public final class SetupPlanJson {
     private static final JsonMapper JSON = JsonMapper.builder()
             .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
@@ -14,11 +14,22 @@ public final class SetupPlanJson {
     private SetupPlanJson() { }
 
     public static String write(SetupPlan plan) {
-        return JSON.writerWithDefaultPrettyPrinter().writeValueAsString(plan) + System.lineSeparator();
+        tools.jackson.databind.node.ObjectNode tree = JSON.valueToTree(plan);
+        if (plan.schemaVersion() == 2) tree.remove("executionPolicyDigest");
+        return JSON.writerWithDefaultPrettyPrinter().writeValueAsString(tree) + System.lineSeparator();
     }
 
     public static SetupPlan read(String json) {
         try {
+            tools.jackson.databind.JsonNode tree = JSON.readTree(json);
+            int schema = tree.path("schemaVersion").asInt(-1);
+            boolean hasPolicy = tree.has("executionPolicyDigest");
+            if (schema == 2 && hasPolicy) {
+                throw new IllegalArgumentException("Schema 2 plans must not contain executionPolicyDigest.");
+            }
+            if (schema == 3 && !hasPolicy) {
+                throw new IllegalArgumentException("Schema 3 plans require executionPolicyDigest.");
+            }
             return JSON.readValue(json, SetupPlan.class);
         } catch (tools.jackson.databind.DatabindException invalid) {
             if (invalid.getCause() instanceof IllegalArgumentException rejected) throw rejected;

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupProvider.java
@@ -1,0 +1,19 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+
+/** Provider SPI used by Java, CLI, MCP, and IDE setup adapters. */
+public interface SetupProvider {
+    SetupProfile profile();
+
+    SetupPlan plan(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture);
+
+    SetupReport status(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture);
+
+    SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException;
+
+    default ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options)
+            throws IOException {
+        throw new UnsupportedOperationException("Profile " + profile() + " does not own a startable service.");
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupProviderRegistry.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupProviderRegistry.java
@@ -1,0 +1,34 @@
+package com.shaft.infrastructure;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable profile-to-provider registry with deterministic duplicate and missing-provider failures. */
+public final class SetupProviderRegistry {
+    private final Map<SetupProfile, SetupProvider> providers;
+
+    public SetupProviderRegistry(List<? extends SetupProvider> providers) {
+        Objects.requireNonNull(providers, "providers");
+        LinkedHashMap<SetupProfile, SetupProvider> indexed = new LinkedHashMap<>();
+        for (SetupProvider provider : providers) {
+            SetupProvider value = Objects.requireNonNull(provider, "provider");
+            SetupProvider previous = indexed.putIfAbsent(
+                    Objects.requireNonNull(value.profile(), "provider.profile"), value);
+            if (previous != null) throw new IllegalArgumentException("Duplicate setup provider: " + value.profile());
+        }
+        this.providers = Map.copyOf(indexed);
+    }
+
+    public SetupProvider require(SetupProfile profile) {
+        SetupProvider provider = providers.get(Objects.requireNonNull(profile, "profile"));
+        if (provider == null) throw new IllegalArgumentException("No setup provider is available for profile "
+                + profile + '.');
+        return provider;
+    }
+
+    public List<SetupProfile> profiles() {
+        return providers.keySet().stream().sorted().toList();
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupReport.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupReport.java
@@ -1,0 +1,24 @@
+package com.shaft.infrastructure;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Stable provider-neutral diagnosis and verification result. */
+public record SetupReport(int schemaVersion, SetupProfile profile, SetupReadiness readiness,
+                          List<SetupStatus> targets, List<String> diagnostics) {
+    public SetupReport {
+        if (schemaVersion != 1) throw new IllegalArgumentException("Unsupported report schema: " + schemaVersion);
+        Objects.requireNonNull(profile, "profile");
+        Objects.requireNonNull(readiness, "readiness");
+        targets = List.copyOf(Objects.requireNonNull(targets, "targets"));
+        diagnostics = List.copyOf(Objects.requireNonNull(diagnostics, "diagnostics"));
+        if (targets.stream().anyMatch(Objects::isNull) || diagnostics.stream().anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("Report entries must not be null.");
+        }
+    }
+
+    public static SetupReport from(SetupProfileStatus status) {
+        Objects.requireNonNull(status, "status");
+        return new SetupReport(1, status.profile(), status.readiness(), status.targets(), List.of());
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/VerifiedArtifactStore.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/VerifiedArtifactStore.java
@@ -21,12 +21,17 @@ public final class VerifiedArtifactStore {
     }
 
     public Path fetch(SetupAction action) throws IOException {
+        return fetch(action, false);
+    }
+
+    public Path fetch(SetupAction action, boolean offline) throws IOException {
         String expected = action.checksum().substring("sha256:".length()).toLowerCase();
         String sourcePath = action.source().getPath();
         String sourceName = sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
         if (sourceName.isBlank()) throw new IOException("Artifact source has no file name: " + action.source());
         Path destination = downloads.resolve(expected + '-' + sourceName);
         if (Files.isRegularFile(destination) && expected.equals(digest(destination))) return destination;
+        if (offline) throw new IOException("Artifact is not available in the verified offline cache: " + sourceName);
         Files.createDirectories(downloads);
         Files.deleteIfExists(destination);
         Path temporary = Files.createTempFile(downloads, sourceName, ".part");

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/InfrastructureSetupServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/InfrastructureSetupServiceTest.java
@@ -1,0 +1,291 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InfrastructureSetupServiceTest {
+    @Test
+    void optionsDefaultToExternalAndNonMutating(@TempDir Path temp) {
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp));
+
+        assertEquals(SetupMode.EXTERNAL, options.mode());
+        assertFalse(options.offline());
+        assertFalse(options.autoStart());
+        assertTrue(options.preferSystemTools());
+        assertTrue(options.reuseOwnedProcesses());
+        assertEquals(Duration.ofMinutes(2), options.startupTimeout());
+        assertEquals(Duration.ofSeconds(30), options.shutdownTimeout());
+        assertTrue(options.remoteEndpoint().isEmpty());
+    }
+
+    @Test
+    void registryRejectsDuplicateAndMissingProviders(@TempDir Path temp) {
+        SetupProvider provider = new FakeProvider();
+        assertThrows(IllegalArgumentException.class, () -> new SetupProviderRegistry(List.of(provider, provider)));
+
+        SetupProviderRegistry registry = new SetupProviderRegistry(List.of(provider));
+        assertEquals(provider, registry.require(SetupProfile.REPORTING));
+        assertThrows(IllegalArgumentException.class, () -> registry.require(SetupProfile.OCR));
+        assertEquals(List.of(SetupProfile.REPORTING), registry.profiles());
+    }
+
+    @Test
+    void coordinatorUsesReleasePlannerAndReportsProviderStatus(@TempDir Path temp) {
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp))
+                .withMode(SetupMode.MANAGED);
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.WINDOWS, SetupArchitecture.X64);
+
+        SetupPlan boundPlan = service.plan(options);
+        assertEquals(SetupPlan.bind(ReportingSetupPlanner.plan(SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, SetupMode.MANAGED), options.policyDigest()), service.plan(options));
+        assertThrows(IllegalArgumentException.class, () -> SetupPlanJson.read(
+                SetupPlanJson.write(boundPlan).replaceFirst(
+                        "(?m)^  \"executionPolicyDigest\".*(?:\\R|$)", "")));
+        SetupReport report = service.status(options);
+        assertEquals(SetupProfile.REPORTING, report.profile());
+        assertEquals(SetupReadiness.MISSING, report.readiness());
+        assertEquals(List.of(SetupTarget.NODE, SetupTarget.ALLURE), report.targets().stream()
+                .map(SetupStatus::target).toList());
+    }
+
+    @Test
+    void remoteEndpointForcesDiagnosticPlanAndBlocksMutationBeforeProvider(@TempDir Path temp) {
+        AtomicInteger mutations = new AtomicInteger();
+        FakeProvider provider = new FakeProvider(mutations);
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(provider)), SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp))
+                .withMode(SetupMode.MANAGED)
+                .withRemoteEndpoint(URI.create("http://127.0.0.1:4444"));
+
+        SetupPlan plan = service.plan(options);
+        int callsAfterPlanning = provider.planCalls.get();
+        assertEquals(SetupMode.EXTERNAL, plan.mode());
+        assertTrue(plan.actions().stream().allMatch(action -> action.kind() == SetupActionKind.DIAGNOSE));
+        assertThrows(IllegalArgumentException.class, () -> service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+        assertEquals(0, mutations.get());
+        assertEquals(callsAfterPlanning, provider.planCalls.get());
+    }
+
+    @Test
+    void staleApprovalAndMismatchedOptionsReachNoProviderMutation(@TempDir Path temp) {
+        AtomicInteger mutations = new AtomicInteger();
+        FakeProvider provider = new FakeProvider(mutations);
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(provider)), SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupOptions managed = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp))
+                .withMode(SetupMode.MANAGED);
+        SetupPlan plan = service.plan(managed);
+        int callsAfterPlanning = provider.planCalls.get();
+
+        assertThrows(StaleSetupApprovalException.class, () -> service.install(plan,
+                new SetupApproval("sha256:" + "0".repeat(64), Instant.EPOCH, Set.of()), managed));
+        assertThrows(IllegalArgumentException.class, () -> service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()),
+                managed.withMode(SetupMode.HYBRID)));
+        assertEquals(0, mutations.get());
+        assertEquals(callsAfterPlanning, provider.planCalls.get());
+    }
+
+    @Test
+    void approvalBindsDestinationRoots(@TempDir Path temp) {
+        AtomicInteger mutations = new AtomicInteger();
+        FakeProvider provider = new FakeProvider(mutations);
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(provider)), SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupOptions rootA = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp.resolve("a")))
+                .withMode(SetupMode.MANAGED);
+        SetupOptions rootB = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp.resolve("b")))
+                .withMode(SetupMode.MANAGED);
+        SetupPlan plan = service.plan(rootA);
+
+        assertThrows(IllegalArgumentException.class, () -> service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), rootB));
+        assertEquals(0, mutations.get());
+    }
+
+    @Test
+    void approvalBindsEveryWritableChildPath(@TempDir Path temp) {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        ShaftCachePaths pathsA = new ShaftCachePaths(cache, data, cache.resolve("downloads-a"),
+                data.resolve("tools-a"), data.resolve("state-a"), data.resolve("receipts-a"));
+        ShaftCachePaths pathsB = new ShaftCachePaths(cache, data, cache.resolve("downloads-b"),
+                data.resolve("tools-b"), data.resolve("state-b"), data.resolve("receipts-b"));
+        SetupOptions optionsA = SetupOptions.defaults(SetupProfile.REPORTING, pathsA).withMode(SetupMode.MANAGED);
+        SetupOptions optionsB = SetupOptions.defaults(SetupProfile.REPORTING, pathsB).withMode(SetupMode.MANAGED);
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(new FakeProvider())), SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupPlan plan = service.plan(optionsA);
+
+        assertFalse(optionsA.policyDigest().equals(optionsB.policyDigest()));
+        assertThrows(IllegalArgumentException.class, () -> service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), optionsB));
+    }
+
+    @Test
+    void privilegedActionsAreRejectedBeforeProviderCallbacks(@TempDir Path temp) {
+        AtomicInteger callbacks = new AtomicInteger();
+        SetupProvider provider = new FakeProvider(callbacks) {
+            @Override public SetupProfile profile() { return SetupProfile.MOBILE_WINDOWS; }
+            @Override
+            public SetupPlan plan(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+                callbacks.incrementAndGet();
+                throw new AssertionError("privileged denial must not call the provider");
+            }
+        };
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(provider)), SetupPlatform.WINDOWS, SetupArchitecture.X64);
+        SetupAction action = new SetupAction(SetupTarget.WINAPPDRIVER, SetupActionKind.INSTALL, "1.2.1",
+                URI.create("https://example.invalid/wad"), "sha256:" + "0".repeat(64), true, Set.of());
+        SetupPlan plan = SetupPlan.bind(SetupPlan.create(SetupProfile.MOBILE_WINDOWS, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, SetupMode.MANAGED, List.of(action)),
+                SetupOptions.defaults(SetupProfile.MOBILE_WINDOWS, paths(temp)).withMode(SetupMode.MANAGED)
+                        .policyDigest());
+        SetupOptions options = SetupOptions.defaults(SetupProfile.MOBILE_WINDOWS, paths(temp))
+                .withMode(SetupMode.MANAGED);
+
+        assertThrows(IllegalArgumentException.class, () -> service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+        assertEquals(0, callbacks.get());
+    }
+
+    @Test
+    void providerOutputIdentityIsChecked(@TempDir Path temp) {
+        SetupProvider provider = new FakeProvider() {
+            @Override
+            public SetupReport status(SetupOptions options, SetupPlatform platform,
+                                      SetupArchitecture architecture) {
+                return new SetupReport(1, SetupProfile.OCR, SetupReadiness.READY, List.of(), List.of());
+            }
+        };
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(provider)), SetupPlatform.LINUX, SetupArchitecture.X64);
+        assertThrows(IllegalStateException.class, () -> service.status(
+                SetupOptions.defaults(SetupProfile.REPORTING, paths(temp))));
+    }
+
+    @Test
+    void managedEnvironmentReleaseCanRetryAfterFailure() {
+        AtomicInteger releases = new AtomicInteger();
+        ManagedEnvironment environment = new ManagedEnvironment(SetupProfile.REPORTING,
+                new SetupReceipt("sha256:" + "0".repeat(64), Instant.EPOCH, List.of()),
+                java.util.Optional.empty(), java.util.Map.of(), () -> {
+                    if (releases.incrementAndGet() == 1) throw new IllegalStateException("busy");
+                });
+
+        assertThrows(IllegalStateException.class, environment::close);
+        assertFalse(environment.isClosed());
+        environment.close();
+        assertTrue(environment.isClosed());
+        environment.close();
+        assertEquals(2, releases.get());
+    }
+
+    @Test
+    void rejectedManagedEnvironmentIsReleasedAndCleanupFailureIsSuppressed(@TempDir Path temp) {
+        AtomicInteger releases = new AtomicInteger();
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp))
+                .withMode(SetupMode.MANAGED);
+        SetupProvider provider = new FakeProvider() {
+            @Override
+            public ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions ignored) {
+                return new ManagedEnvironment(SetupProfile.OCR,
+                        new SetupReceipt(plan.digest(), Instant.EPOCH, plan.actions()),
+                        java.util.Optional.empty(), java.util.Map.of(), () -> {
+                            releases.incrementAndGet();
+                            throw new IllegalStateException("cleanup failed");
+                        });
+            }
+        };
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(provider)), SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupPlan plan = service.plan(options);
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class, () -> service.start(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+        assertEquals(1, releases.get());
+        assertEquals(1, failure.getSuppressed().length);
+        assertEquals("cleanup failed", failure.getSuppressed()[0].getMessage());
+    }
+
+    @Test
+    void partialStartedReceiptIsRejectedAndReleased(@TempDir Path temp) {
+        AtomicInteger releases = new AtomicInteger();
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp))
+                .withMode(SetupMode.MANAGED);
+        SetupProvider provider = new FakeProvider() {
+            @Override
+            public ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions ignored) {
+                return new ManagedEnvironment(plan.profile(),
+                        new SetupReceipt(plan.digest(), Instant.EPOCH, List.of()),
+                        java.util.Optional.empty(), java.util.Map.of(), releases::incrementAndGet);
+            }
+        };
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(provider)), SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupPlan plan = service.plan(options);
+
+        assertThrows(IllegalStateException.class, () -> service.start(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+        assertEquals(1, releases.get());
+    }
+
+    private static ShaftCachePaths paths(Path temp) {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        return new ShaftCachePaths(cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts"));
+    }
+
+    private static class FakeProvider implements SetupProvider {
+        private final AtomicInteger mutations;
+        private final AtomicInteger planCalls = new AtomicInteger();
+
+        private FakeProvider() {
+            this(new AtomicInteger());
+        }
+
+        private FakeProvider(AtomicInteger mutations) {
+            this.mutations = mutations;
+        }
+
+        @Override
+        public SetupProfile profile() {
+            return SetupProfile.REPORTING;
+        }
+
+        @Override
+        public SetupPlan plan(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+            planCalls.incrementAndGet();
+            return ReportingSetupPlanner.plan(platform, architecture, options.effectiveMode());
+        }
+
+        @Override
+        public SetupReport status(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+            return new SetupReport(1, profile(), SetupReadiness.MISSING, List.of(),
+                    List.of("fake provider"));
+        }
+
+        @Override
+        public SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options) {
+            mutations.incrementAndGet();
+            return new SetupReceipt(plan.digest(), Instant.EPOCH, plan.actions());
+        }
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/ReportingSetupServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/ReportingSetupServiceTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -32,6 +33,11 @@ class ReportingSetupServiceTest {
         SetupPlanStore.write(planFile, plan);
         assertEquals(plan, SetupPlanStore.read(planFile));
         assertEquals(plan, SetupPlanJson.read(SetupPlanJson.write(plan)));
+        String legacyJson = SetupPlanJson.write(plan);
+        assertTrue(!legacyJson.contains("executionPolicyDigest"));
+        assertThrows(IllegalArgumentException.class, () -> SetupPlanJson.read(legacyJson.replaceFirst(
+                "\"schemaVersion\" : 2,", "\"schemaVersion\" : 2,\n  \"executionPolicyDigest\" : \"sha256:"
+                        + "0".repeat(64) + "\",")));
         assertThrows(IllegalArgumentException.class,
                 () -> SetupPlanJson.read(SetupPlanJson.write(plan).replace(plan.digest(), "sha256:" + "0".repeat(64))));
         assertThrows(RuntimeException.class,
@@ -53,6 +59,40 @@ class ReportingSetupServiceTest {
         SetupAction bad = new SetupAction(SetupTarget.ALLURE, SetupActionKind.INSTALL, "1",
                 source.toUri(), "sha256:" + "0".repeat(64), false, Set.of());
         assertThrows(IOException.class, () -> store.fetch(bad));
+        Path offlineRoot = temp.resolve("offline");
+        VerifiedArtifactStore offline = new VerifiedArtifactStore(offlineRoot);
+        assertThrows(IOException.class, () -> offline.fetch(good, true));
+        assertTrue(Files.notExists(offlineRoot));
+    }
+
+    @Test
+    void offlineInstallPassesFailClosedNpmFlags(@TempDir Path temp) throws Exception {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        Path nodeArchive = createNodeZip(temp.resolve("node.zip"));
+        Path allureArchive = Files.writeString(temp.resolve("allure.tgz"), "allure");
+        List<List<String>> commands = new ArrayList<>();
+        ReportingSetupService service = new ReportingSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, action -> action.target() == SetupTarget.NODE ? nodeArchive : allureArchive,
+                (command, log, timeout) -> {
+                    commands.add(List.copyOf(command));
+                    int prefix = command.indexOf("--prefix");
+                    if (command.contains("ci") && prefix >= 0) {
+                        Path entry = Path.of(command.get(prefix + 1)).resolve("node_modules/allure/cli.js");
+                        Files.createDirectories(entry.getParent());
+                        Files.writeString(entry, "allure");
+                    }
+                    return new ReportingSetupService.ProcessResult(0,
+                            command.stream().anyMatch(part -> part.endsWith("cli.js")) ? "3.14.3" : "v24.19.0");
+                }, true);
+        SetupPlan plan = ReportingSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+        service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()));
+
+        assertTrue(commands.stream().filter(command -> command.contains("cache") || command.contains("ci"))
+                .allMatch(command -> command.contains("--offline")));
     }
 
     @Test

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/SetupPlanTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/SetupPlanTest.java
@@ -102,7 +102,7 @@ class SetupPlanTest {
                         "25", URI.create("https://example.invalid/java"), checksum(), false, Set.of()))));
         assertThrows(IllegalArgumentException.class, () -> new SetupPlan(1, SetupProfile.REPORTING,
                 SetupPlatform.LINUX, SetupArchitecture.X64,
-                SetupMode.MANAGED, List.of(install), "sha256:" + "0".repeat(64)));
+                SetupMode.MANAGED, List.of(install), "", "sha256:" + "0".repeat(64)));
         assertThrows(IllegalArgumentException.class, () -> plan(SetupPlatform.WINDOWS,
                 SetupMode.MANAGED, List.of(new SetupAction(SetupTarget.WINAPPDRIVER, SetupActionKind.INSTALL,
                         "1.2.1", URI.create("https://example.invalid/wad"), checksum(), false, Set.of()))));

--- a/shaft-skills/references/shaft-cli-commands.md
+++ b/shaft-skills/references/shaft-cli-commands.md
@@ -76,8 +76,8 @@ the cache or durable-data roots are created.
 ```text
 shaft-cli setup catalog|profiles [--json]
 shaft-cli setup doctor|status|verify --profile REPORTING [--json]
-shaft-cli setup plan --profile REPORTING --mode MANAGED --output <absolute-plan.json> [--json]
-shaft-cli setup install|apply|update --plan <absolute-plan.json> --approve <sha256:digest> [--accept-license <id>] [--json]
+shaft-cli setup plan --profile REPORTING --mode MANAGED --output <absolute-plan.json> [policy options] [--json]
+shaft-cli setup install|apply|update --plan <absolute-plan.json> --approve <sha256:digest> [--accept-license <id>] [policy options] [--json]
 shaft-cli setup start|stop --profile <profile>
 shaft-cli setup logs --profile REPORTING
 ```
@@ -89,6 +89,18 @@ an unknown process. Exit codes are 0 for ready/success, 2 for invalid input or
 approval, 3 for missing/degraded readiness, 4 for unsupported providers, and
 5 for execution or integrity failures. `--cache-root` and `--data-root` are
 paired advanced overrides and must both be absolute.
+
+Plan and install must receive the same policy options because those values are
+bound into the approved digest: `--offline`, `--auto-start`,
+`--prefer-system-tools=true|false`, `--reuse-owned-processes=true|false`,
+`--startup-timeout <ISO-8601 duration>`, and
+`--shutdown-timeout <ISO-8601 duration>`.
+
+The equivalent Java surface is `SHAFT.Infrastructure`. Its no-argument
+read-only methods use `SHAFT.Properties.infrastructure`; `install` and `start`
+require the exact `SetupPlan` and `SetupApproval`. Defaults remain
+`EXTERNAL`, `offline=false`, and `autoStart=false`. An explicit remote
+execution address wins for web, Grid, and mobile endpoint profiles.
 
 ## Curated aliases
 


### PR DESCRIPTION
Closes #4872## Delivered- provider-neutral options, reports, registry, coordinator, and managed environment contract- schema-3 plans bind exact execution policy and every writable destination; strict schema-2 compatibility remains- shared CLI and Java planning/status/install paths with identical policy options- `SHAFT.Infrastructure` catalog/doctor/status/plan/verify/install/start facade- `SHAFT.Properties.infrastructure` defaults and thread-local fluent overrides- explicit remote precedence for endpoint profiles while reporting remains independently managed- external/non-mutating defaults, privilege denial, host identity, offline npm/cache, receipt identity, and cleanup safety- cross-platform stable bundled npm lock integrity## Verification- affected 9-module Maven reactor: green- infrastructure focused suites: 28 tests green; full module suite previously 34 green- engine facade/properties: 5 tests green- CLI/index: 8 tests green- reactor version, Maven publication, modular documentation, and documentation-boundary validators: green- quality validator only reports pre-existing visual-runtime workflow drift- three independent correctness/failure/blast-radius reviews: zero blockers## Companion- user-guide update will be linked in a separate shafthq.github.io PR as required by repository policy

Companion documentation: https://github.com/ShaftHQ/shafthq.github.io/pull/957
