### PR TITLE
Keep SHAFT branding visible across Allure report routes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,7 @@
                         <include>com/**/*</include>
                         <include>META-INF/**/*</include>
                         <include>junit-platform.properties</include>
+                        <include>images/**/*</include>
                         <include>resources/**/*</include>
                     </includes>
                 </configuration>

--- a/shaft-engine/pom.xml
+++ b/shaft-engine/pom.xml
@@ -628,6 +628,7 @@
                     <include>junit-platform.properties</include>
                     <include>axe.min.js</include>
                     <include>ariaSnapshot.js</include>
+                    <include>images/shaft_report_logo.png</include>
                 </includes>
             </resource>
         </resources>

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/AllureManager.java
@@ -30,6 +30,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -520,6 +521,19 @@ public class AllureManager {
               border-bottom: 1px solid var(--color-border-subtle, rgba(16, 42, 49, 0.10));
             }
 
+            .shaft-header-brand {
+              display: block;
+              width: 32px;
+              height: 32px;
+              margin-right: auto;
+              border-radius: 6px;
+              object-fit: contain;
+            }
+
+            :root[data-theme="dark"] .shaft-header-brand {
+              filter: brightness(0) invert(1);
+            }
+
             .shaft-header-btn {
               display: inline-flex;
               align-items: center;
@@ -602,12 +616,25 @@ public class AllureManager {
     private static String allureHeaderButtonsPatch() {
         return ALLURE_HEADER_BUTTONS_STYLE
                 + "<div id=\"" + ALLURE_HEADER_BUTTONS_ID + "\">"
+                + "<img class=\"shaft-header-brand\" src=\"" + shaftHeaderLogoDataUri()
+                + "\" width=\"32\" height=\"32\" alt=\"SHAFT logo\">"
                 + "<a class=\"shaft-header-btn shaft-header-btn--primary\" href=\"https://shafthq.github.io\""
                 + " target=\"_blank\" rel=\"noopener\">User Guide</a>"
                 + "<a class=\"shaft-header-btn shaft-header-btn--secondary\" href=\"https://github.com/ShaftHQ/SHAFT_ENGINE\""
                 + " target=\"_blank\" rel=\"noopener\" aria-label=\"Star SHAFT on GitHub\">"
                 + "<span class=\"shaft-header-btn-star\" aria-hidden=\"true\">&#9733;</span> Star SHAFT</a>"
                 + "</div>";
+    }
+
+    private static String shaftHeaderLogoDataUri() {
+        try (InputStream logo = AllureManager.class.getResourceAsStream("/images/shaft_report_logo.png")) {
+            if (logo == null) {
+                throw new IllegalStateException("Bundled SHAFT report logo is missing.");
+            }
+            return "data:image/png;base64," + Base64.getEncoder().encodeToString(logo.readAllBytes());
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to embed the SHAFT report logo.", exception);
+        }
     }
 
     // ─── Portable Node.js bootstrap ────────────────────────────────────────────

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureManagerCoverageUnitTest.java
@@ -289,6 +289,11 @@ public class AllureManagerCoverageUnitTest {
         Assert.assertEquals(html.split("href=\"https://github.com/ShaftHQ/SHAFT_ENGINE\"", -1).length - 1, 1, html);
         Assert.assertEquals(html.split("target=\"_blank\"", -1).length - 1, 2, html);
         Assert.assertEquals(html.split("rel=\"noopener\"", -1).length - 1, 2, html);
+        Assert.assertEquals(html.split("class=\"shaft-header-brand\"", -1).length - 1, 1, html);
+        Assert.assertEquals(html.split("alt=\"SHAFT logo\"", -1).length - 1, 1, html);
+        Assert.assertEquals(html.split("src=\"data:image/png;base64,", -1).length - 1, 1, html);
+        Assert.assertTrue(html.contains(":root[data-theme=\"dark\"] .shaft-header-brand"), html);
+        Assert.assertTrue(html.contains("filter: brightness(0) invert(1)"), html);
         Assert.assertTrue(html.contains("User Guide"), html);
         Assert.assertTrue(html.contains("Star SHAFT"), html);
         // The bar must be a real sibling BEFORE the app root, not inside it or after </body>,


### PR DESCRIPTION
## Summary

- embed the canonical SHAFT report mark in generated single-file Allure reports
- keep it visible beside the existing User Guide and GitHub controls on every report route
- preserve contrast in Allure light, dark, and automatic themes
- cover asset embedding, idempotent insertion, and dark-theme treatment with a focused regression

## Validation

- `mvn -q -pl shaft-engine test -Dtest=AllureManagerCoverageUnitTest#patchGeneratedAllureReportIndexShouldInjectHeaderButtonsBeforeAppRootExactlyOnce -Dgpg.skip=true -Dallure.automaticallyOpen=false -Dallure.open=false`
- `mvn -q -pl shaft-engine -am package -DskipTests -Dgpg.skip=true -Dallure.automaticallyOpen=false -Dallure.open=false`
- generated a fresh report from `Allure3ReportValidationTests`: 4 populated raw results (passed, failed, broken, skipped), 6 history records
- browser-verified `#charts`: visible embedded 32x32 logo, 25% of 4 current-status chart, five historical launches plus Latest; dark computed filter applied
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`

Closes #4876
