### PR TITLE
feat(ai): add deterministic managed local hardware selection

### DIFF
--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiHardware.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiHardware.java
@@ -1,0 +1,380 @@
+package com.shaft.ai.local;
+
+import com.sun.management.OperatingSystemMXBean;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/** Read-only hardware profiling and deterministic model selection for managed local inference. */
+final class ManagedLocalAiHardware {
+    private static final long GIB = 1024L * 1024 * 1024;
+    private static final long MEMORY_RESERVE_BYTES = 2 * GIB;
+    private static final long DISK_RESERVE_BYTES = GIB;
+    private static final long MAXIMUM_RUNTIME_EXPANSION_BYTES = 4 * GIB;
+
+    private ManagedLocalAiHardware() {
+    }
+
+    static Profile profile(Path cache, HostAccess host) {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        String platform = platform(host.osName(), host.architecture());
+        boolean compatible = manifest.supportsRuntime(
+                host.osName(), host.architecture(), host.abi(), host.abiVersion());
+        long available = positiveOrZero(host.availableMemoryBytes());
+        int processors = Math.max(0, host.availableProcessors());
+        if ("linux".equals(normalizedOs(host.osName()))) {
+            available = Math.min(available, cgroupAvailableMemory(host).orElse(available));
+            processors = Math.min(processors, cgroupProcessors(host).orElse(processors));
+        }
+        long effectiveMemory = Math.max(0, available - MEMORY_RESERVE_BYTES);
+        Path ancestor = nearestExistingAncestor(cache.toAbsolutePath().normalize());
+        long disk = ancestor == null ? 0 : positiveOrZero(host.usableSpace(ancestor));
+        return new Profile(platform, compatible, effectiveMemory, processors, disk);
+    }
+
+    static Selection select(ManagedLocalAiManifest manifest, Profile profile, String requestedModelId) {
+        if (requestedModelId != null && manifest.models().stream()
+                .noneMatch(model -> model.id().equals(requestedModelId))) {
+            throw new IllegalArgumentException("Unknown managed local AI model: " + requestedModelId);
+        }
+        Map<String, ModelEvaluation> evaluations = new LinkedHashMap<>();
+        ManagedLocalAiManifest.ModelManifest selected = null;
+        for (ManagedLocalAiManifest.ModelManifest model : manifest.models()) {
+            List<String> reasons = new ArrayList<>();
+            boolean requested = requestedModelId != null && requestedModelId.equals(model.id());
+            if (!profile.runtimeCompatible()) {
+                reasons.add("UNSUPPORTED_RUNTIME");
+            }
+            if (profile.effectiveMemoryBytes() < gibibytes(model.minimumRamGb())) {
+                reasons.add("INSUFFICIENT_MEMORY");
+            }
+            if (profile.cpuCount() < model.minimumCpuCount()) {
+                reasons.add("INSUFFICIENT_CPU");
+            }
+            long requiredDisk = requiredDiskBytes(manifest, profile, model);
+            if (profile.freeDiskBytes() < requiredDisk) {
+                reasons.add("INSUFFICIENT_DISK");
+            }
+            if (requestedModelId == null && (!model.automatic() || !model.firstPartyQuantization())) {
+                reasons.add("MANUAL_ONLY");
+            }
+            boolean eligible = reasons.isEmpty();
+            evaluations.put(model.id(), new ModelEvaluation(eligible, List.copyOf(reasons), requiredDisk));
+            if (eligible && (requested || requestedModelId == null && better(model, selected))) {
+                selected = model;
+            }
+        }
+        return new Selection(selected == null ? null : selected.id(), Map.copyOf(evaluations));
+    }
+
+    static long requiredDiskBytes(ManagedLocalAiManifest manifest, Profile profile,
+                                  ManagedLocalAiManifest.ModelManifest model) {
+        long runtimeArchive = manifest.runtime().assets().stream()
+                .filter(asset -> asset.platform().equals(profile.platform()))
+                .mapToLong(ManagedLocalAiManifest.RuntimeAsset::size)
+                .findFirst().orElse(0);
+        long peak = saturatedAdd(runtimeArchive, MAXIMUM_RUNTIME_EXPANSION_BYTES);
+        peak = saturatedAdd(peak, saturatedMultiply(model.size(), 2));
+        peak = saturatedAdd(peak, DISK_RESERVE_BYTES);
+        long declared = gibibytes(model.minimumFreeDiskGb());
+        return Math.max(peak, declared);
+    }
+
+    private static boolean better(ManagedLocalAiManifest.ModelManifest candidate,
+                                  ManagedLocalAiManifest.ModelManifest current) {
+        if (current == null) {
+            return true;
+        }
+        int ram = Double.compare(candidate.minimumRamGb(), current.minimumRamGb());
+        if (ram != 0) {
+            return ram > 0;
+        }
+        int cpu = Integer.compare(candidate.minimumCpuCount(), current.minimumCpuCount());
+        return cpu > 0 || cpu == 0 && candidate.id().compareTo(current.id()) < 0;
+    }
+
+    private static Optional<Long> cgroupAvailableMemory(HostAccess host) {
+        for (String base : cgroupBases(host, "memory")) {
+            Optional<Long> maximum = positiveLong(read(host, base + "/memory.max"));
+            Optional<Long> current = nonNegativeLong(read(host, base + "/memory.current"));
+            if (maximum.isPresent() && current.isPresent()) {
+                return Optional.of(Math.max(0, maximum.get() - current.get()));
+            }
+            maximum = positiveLong(read(host, base + "/memory.limit_in_bytes"));
+            current = nonNegativeLong(read(host, base + "/memory.usage_in_bytes"));
+            if (maximum.isPresent() && current.isPresent() && maximum.get() < Long.MAX_VALUE / 2) {
+                return Optional.of(Math.max(0, maximum.get() - current.get()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Integer> cgroupProcessors(HostAccess host) {
+        int limit = Integer.MAX_VALUE;
+        boolean constrained = false;
+        for (String base : cgroupBases(host, "cpu")) {
+            String cpuMax = read(host, base + "/cpu.max");
+            if (cpuMax != null) {
+                String[] parts = cpuMax.trim().split("\\s+");
+                if (parts.length == 2 && !"max".equals(parts[0])) {
+                    Optional<Long> quota = positiveLong(parts[0]);
+                    Optional<Long> period = positiveLong(parts[1]);
+                    if (quota.isPresent() && period.isPresent()) {
+                        limit = Math.min(limit, Math.max(1, (int) (quota.get() / period.get())));
+                        constrained = true;
+                    }
+                }
+            }
+            Optional<Long> quota = positiveLong(read(host, base + "/cpu.cfs_quota_us"));
+            Optional<Long> period = positiveLong(read(host, base + "/cpu.cfs_period_us"));
+            if (quota.isPresent() && period.isPresent()) {
+                limit = Math.min(limit, Math.max(1, (int) (quota.get() / period.get())));
+                constrained = true;
+            }
+        }
+        for (String base : cgroupBases(host, "cpuset")) {
+            String cpus = read(host, base + "/cpuset.cpus.effective");
+            if (cpus == null) {
+                cpus = read(host, base + "/cpuset.cpus");
+            }
+            Optional<Integer> count = countCpuSet(cpus);
+            if (count.isPresent()) {
+                limit = Math.min(limit, count.get());
+                constrained = true;
+            }
+        }
+        return constrained ? Optional.of(limit) : Optional.empty();
+    }
+
+    private static List<String> cgroupBases(HostAccess host, String controller) {
+        List<String> bases = new ArrayList<>();
+        String membership = read(host, "/proc/self/cgroup");
+        String mountInfo = read(host, "/proc/self/mountinfo");
+        if (membership != null) {
+            for (String line : membership.lines().toList()) {
+                String[] fields = line.split(":", 3);
+                if (fields.length != 3 || !fields[2].startsWith("/")) {
+                    continue;
+                }
+                if (fields[0].equals("0") && fields[1].isEmpty()) {
+                    mountedCgroupBase(mountInfo, "cgroup2", controller, fields[2]).ifPresent(bases::add);
+                    bases.add("/sys/fs/cgroup" + fields[2]);
+                } else if (List.of(fields[1].split(",")).contains(controller)) {
+                    mountedCgroupBase(mountInfo, "cgroup", controller, fields[2]).ifPresent(bases::add);
+                }
+            }
+        }
+        bases.add("/sys/fs/cgroup");
+        bases.add("/sys/fs/cgroup/" + controller);
+        return bases.stream().distinct().toList();
+    }
+
+    private static Optional<String> mountedCgroupBase(String mountInfo, String fileSystem,
+                                                       String controller, String membership) {
+        if (mountInfo == null) {
+            return Optional.empty();
+        }
+        for (String line : mountInfo.lines().toList()) {
+            String[] fields = line.trim().split("\\s+");
+            int separator = List.of(fields).indexOf("-");
+            if (separator < 6 || separator + 3 >= fields.length || !fileSystem.equals(fields[separator + 1])) {
+                continue;
+            }
+            if ("cgroup".equals(fileSystem)) {
+                boolean mountedController = false;
+                for (int index = separator + 2; index < fields.length; index++) {
+                    if (List.of(fields[index].split(",")).contains(controller)) {
+                        mountedController = true;
+                        break;
+                    }
+                }
+                if (!mountedController) {
+                    continue;
+                }
+            }
+            String root = fields[3];
+            String mountPoint = fields[4];
+            if (root.contains("\\") || mountPoint.contains("\\") || !membership.startsWith("/")) {
+                continue;
+            }
+            if (!"/".equals(root) && !(membership.equals(root) || membership.startsWith(root + "/"))) {
+                continue;
+            }
+            String suffix = "/".equals(root) ? membership : membership.substring(root.length());
+            return Optional.of(mountPoint + suffix);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Integer> countCpuSet(String value) {
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        long total = 0;
+        try {
+            for (String segment : value.trim().split(",")) {
+                String[] range = segment.split("-", -1);
+                int first = Integer.parseInt(range[0]);
+                int last = range.length == 1 ? first : Integer.parseInt(range[1]);
+                if (range.length > 2 || first < 0 || last < first) {
+                    return Optional.empty();
+                }
+                total += (long) last - first + 1;
+                if (total > Integer.MAX_VALUE) {
+                    return Optional.empty();
+                }
+            }
+            return total > 0 ? Optional.of((int) total) : Optional.empty();
+        } catch (NumberFormatException malformed) {
+            return Optional.empty();
+        }
+    }
+
+    private static String read(HostAccess host, String path) {
+        try {
+            return host.read(path);
+        } catch (IOException unavailable) {
+            return null;
+        }
+    }
+
+    private static Optional<Long> positiveLong(String value) {
+        Optional<Long> parsed = nonNegativeLong(value);
+        return parsed.filter(number -> number > 0);
+    }
+
+    private static Optional<Long> nonNegativeLong(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        try {
+            long parsed = Long.parseLong(value.trim());
+            return parsed >= 0 ? Optional.of(parsed) : Optional.empty();
+        } catch (NumberFormatException malformed) {
+            return Optional.empty();
+        }
+    }
+
+    private static Path nearestExistingAncestor(Path path) {
+        Path candidate = path;
+        while (candidate != null && !Files.exists(candidate)) {
+            candidate = candidate.getParent();
+        }
+        return candidate;
+    }
+
+    private static String platform(String osName, String architecture) {
+        String os = normalizedOs(osName);
+        String arch = architecture.toLowerCase(Locale.ROOT);
+        String normalizedArch = arch.equals("amd64") || arch.equals("x86_64") || arch.equals("x64") ? "x86_64"
+                : arch.equals("aarch64") || arch.equals("arm64") ? "aarch64" : "unsupported";
+        return os.equals("unsupported") || normalizedArch.equals("unsupported")
+                ? "unsupported" : os + "-" + normalizedArch;
+    }
+
+    private static String normalizedOs(String osName) {
+        String os = osName.toLowerCase(Locale.ROOT);
+        if (os.contains("mac") || os.contains("darwin")) return "macos";
+        if (os.startsWith("windows")) return "windows";
+        if (os.contains("linux")) return "linux";
+        return "unsupported";
+    }
+
+    private static long gibibytes(double value) {
+        if (!Double.isFinite(value) || value <= 0 || value > Long.MAX_VALUE / (double) GIB) {
+            return Long.MAX_VALUE;
+        }
+        return (long) Math.ceil(value * GIB);
+    }
+
+    private static long positiveOrZero(long value) {
+        return Math.max(0, value);
+    }
+
+    private static long saturatedAdd(long left, long right) {
+        return left > Long.MAX_VALUE - right ? Long.MAX_VALUE : left + right;
+    }
+
+    private static long saturatedMultiply(long value, int multiplier) {
+        return value > Long.MAX_VALUE / multiplier ? Long.MAX_VALUE : value * multiplier;
+    }
+
+    record Profile(String platform, boolean runtimeCompatible, long effectiveMemoryBytes,
+                   int cpuCount, long freeDiskBytes) {
+        Profile {
+            if (platform == null || platform.isBlank() || effectiveMemoryBytes < 0
+                    || cpuCount < 0 || freeDiskBytes < 0) {
+                throw new IllegalArgumentException("Invalid managed local AI hardware profile.");
+            }
+        }
+    }
+
+    record ModelEvaluation(boolean eligible, List<String> reasons, long requiredDiskBytes) {
+    }
+
+    record Selection(String selectedModelId, Map<String, ModelEvaluation> models) {
+    }
+
+    interface HostAccess {
+        String osName();
+        String architecture();
+        String abi();
+        String abiVersion();
+        long availableMemoryBytes();
+        int availableProcessors();
+        long usableSpace(Path existingAncestor);
+        String read(String path) throws IOException;
+    }
+
+    static HostAccess systemHost() {
+        return new SystemHostAccess();
+    }
+
+    private static final class SystemHostAccess implements HostAccess {
+        public String osName() { return System.getProperty("os.name", ""); }
+        public String architecture() { return System.getProperty("os.arch", ""); }
+        public String abi() {
+            return switch (normalizedOs(osName())) {
+                case "windows" -> "windows-msvc";
+                case "macos" -> "macos-darwin";
+                case "linux" -> "linux-glibc";
+                default -> "unsupported";
+            };
+        }
+        public String abiVersion() {
+            if (!"linux".equals(normalizedOs(osName()))) return "";
+            try {
+                Process process = new ProcessBuilder("getconf", "GNU_LIBC_VERSION")
+                        .redirectErrorStream(true).start();
+                if (!process.waitFor(2, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    return "";
+                }
+                String output = new String(process.getInputStream().readNBytes(64)).trim();
+                String[] fields = output.split("\\s+");
+                return fields.length == 2 && fields[0].equalsIgnoreCase("glibc") ? fields[1] : "";
+            } catch (IOException failure) {
+                return "";
+            } catch (InterruptedException cancelled) {
+                Thread.currentThread().interrupt();
+                return "";
+            }
+        }
+        public long availableMemoryBytes() {
+            java.lang.management.OperatingSystemMXBean bean = ManagementFactory.getOperatingSystemMXBean();
+            return bean instanceof OperatingSystemMXBean extended ? extended.getFreeMemorySize() : 0;
+        }
+        public int availableProcessors() { return Runtime.getRuntime().availableProcessors(); }
+        public long usableSpace(Path existingAncestor) { return existingAncestor.toFile().getUsableSpace(); }
+        public String read(String path) throws IOException { return Files.readString(Path.of(path)); }
+    }
+}

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiHardwareTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiHardwareTest.java
@@ -1,0 +1,153 @@
+package com.shaft.ai.local;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ManagedLocalAiHardwareTest {
+    private static final long GIB = 1024L * 1024 * 1024;
+
+    @TempDir
+    Path temp;
+
+    @Test
+    void automaticSelectionUsesAvailableMemoryCpuAndExactPeakDisk() {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        ManagedLocalAiHardware.Profile balanced = new ManagedLocalAiHardware.Profile(
+                "windows-x86_64", true, 18 * GIB, 8, 20 * GIB);
+        ManagedLocalAiHardware.Selection selected = ManagedLocalAiHardware.select(manifest, balanced, null);
+        assertEquals("qwen3-4b-q4_k_m", selected.selectedModelId());
+
+        ManagedLocalAiManifest.ModelManifest lite = manifest.models().stream()
+                .filter(model -> model.id().equals("qwen3-1.7b-q8_0")).findFirst().orElseThrow();
+        long exactPeak = ManagedLocalAiHardware.requiredDiskBytes(manifest, balanced, lite);
+        ManagedLocalAiHardware.Selection boundary = ManagedLocalAiHardware.select(manifest,
+                new ManagedLocalAiHardware.Profile("windows-x86_64", true, 10 * GIB, 4, exactPeak), null);
+        assertEquals(lite.id(), boundary.selectedModelId());
+        ManagedLocalAiHardware.Selection oneByteShort = ManagedLocalAiHardware.select(manifest,
+                new ManagedLocalAiHardware.Profile("windows-x86_64", true, 10 * GIB, 4, exactPeak - 1), null);
+        assertEquals(null, oneByteShort.selectedModelId());
+        assertTrue(oneByteShort.models().get(lite.id()).reasons().contains("INSUFFICIENT_DISK"));
+
+        ManagedLocalAiHardware.Profile arm = new ManagedLocalAiHardware.Profile(
+                "linux-aarch64", true, 10 * GIB, 4, Long.MAX_VALUE);
+        long armPeak = ManagedLocalAiHardware.requiredDiskBytes(manifest, arm, lite);
+        long armArchive = manifest.runtime().assets().stream()
+                .filter(asset -> asset.platform().equals("linux-aarch64")).findFirst().orElseThrow().size();
+        assertEquals(armArchive, armPeak - lite.size() * 2 - 5 * GIB);
+        assertEquals(lite.id(), ManagedLocalAiHardware.select(manifest,
+                new ManagedLocalAiHardware.Profile("linux-aarch64", true, 10 * GIB, 4, armPeak), null)
+                .selectedModelId());
+        assertEquals(null, ManagedLocalAiHardware.select(manifest,
+                new ManagedLocalAiHardware.Profile("linux-aarch64", true, 10 * GIB, 4, armPeak - 1), null)
+                .selectedModelId());
+    }
+
+    @Test
+    void explicitOverrideUsesTheSameGatesAndThirdPartyNeverBecomesAutomatic() {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        ManagedLocalAiHardware.Profile constrained = new ManagedLocalAiHardware.Profile(
+                "linux-x86_64", true, 10 * GIB, 4, 20 * GIB);
+        ManagedLocalAiHardware.Selection unsafe = ManagedLocalAiHardware.select(
+                manifest, constrained, "qwen3-4b-q4_k_m");
+        assertEquals(null, unsafe.selectedModelId());
+        assertTrue(unsafe.models().get("qwen3-4b-q4_k_m").reasons().contains("INSUFFICIENT_MEMORY"));
+
+        ManagedLocalAiHardware.Selection automatic = ManagedLocalAiHardware.select(manifest,
+                new ManagedLocalAiHardware.Profile("linux-x86_64", true, 32 * GIB, 16, 30 * GIB), null);
+        assertEquals("qwen3-4b-q4_k_m", automatic.selectedModelId());
+        assertFalse(automatic.models().get("phi-4-mini-q4_k_m").eligible());
+    }
+
+    @Test
+    void linuxProfileHonorsV2AndV1MemoryCpuQuotaAndCpuset() throws Exception {
+        FakeHost v2 = new FakeHost("Linux", "amd64", "linux-glibc", "2.31",
+                32 * GIB, 16, 30 * GIB);
+        v2.files.put("/sys/fs/cgroup/memory.max", Long.toString(12 * GIB));
+        v2.files.put("/sys/fs/cgroup/memory.current", Long.toString(2 * GIB));
+        v2.files.put("/sys/fs/cgroup/cpu.max", "150000 100000");
+        v2.files.put("/sys/fs/cgroup/cpuset.cpus.effective", "2-3,7");
+        ManagedLocalAiHardware.Profile v2Profile = ManagedLocalAiHardware.profile(temp.resolve("absent"), v2);
+        assertEquals(8 * GIB, v2Profile.effectiveMemoryBytes());
+        assertEquals(1, v2Profile.cpuCount());
+
+        FakeHost v1 = new FakeHost("Linux", "aarch64", "linux-glibc", "2.31",
+                32 * GIB, 12, 30 * GIB);
+        v1.files.put("/proc/self/cgroup", "5:memory,cpu,cpuset:/workers/job-7\n");
+        v1.files.put("/proc/self/mountinfo",
+                "31 23 0:27 / /sys/fs/cgroup/combined rw,nosuid - cgroup cgroup rw,memory,cpu,cpuset\n");
+        v1.files.put("/sys/fs/cgroup/combined/workers/job-7/memory.limit_in_bytes", Long.toString(16 * GIB));
+        v1.files.put("/sys/fs/cgroup/combined/workers/job-7/memory.usage_in_bytes", Long.toString(4 * GIB));
+        v1.files.put("/sys/fs/cgroup/combined/workers/job-7/cpu.cfs_quota_us", "200000");
+        v1.files.put("/sys/fs/cgroup/combined/workers/job-7/cpu.cfs_period_us", "100000");
+        v1.files.put("/sys/fs/cgroup/combined/workers/job-7/cpuset.cpus", "0-7");
+        ManagedLocalAiHardware.Profile v1Profile = ManagedLocalAiHardware.profile(temp, v1);
+        assertEquals("linux-aarch64", v1Profile.platform());
+        assertEquals(10 * GIB, v1Profile.effectiveMemoryBytes());
+        assertEquals(2, v1Profile.cpuCount());
+    }
+
+    @Test
+    void unsupportedAndMalformedSignalsFailClosedWithoutCreatingCache() throws Exception {
+        String[][] supported = {
+                {"Windows 11", "amd64", "windows-msvc", "", "windows-x86_64"},
+                {"Windows 11", "arm64", "windows-msvc", "", "windows-aarch64"},
+                {"Mac OS X", "x64", "macos-darwin", "", "macos-x86_64"},
+                {"Darwin", "arm64", "macos-darwin", "", "macos-aarch64"},
+                {"Linux", "x86_64", "linux-glibc", "2.31", "linux-x86_64"},
+                {"Linux", "aarch64", "linux-glibc", "2.31", "linux-aarch64"}
+        };
+        for (String[] host : supported) {
+            FakeHost fake = new FakeHost(host[0], host[1], host[2], host[3], 32 * GIB, 8, 30 * GIB);
+            ManagedLocalAiHardware.Profile supportedProfile = ManagedLocalAiHardware.profile(temp, fake);
+            assertTrue(supportedProfile.runtimeCompatible());
+            assertEquals(host[4], supportedProfile.platform());
+        }
+
+        FakeHost unsupported = new FakeHost("Plan9", "mips", "unknown", "", 32 * GIB, 8, 30 * GIB);
+        Path cache = temp.resolve("never-created");
+        ManagedLocalAiHardware.Profile profile = ManagedLocalAiHardware.profile(cache, unsupported);
+        assertFalse(profile.runtimeCompatible());
+        assertFalse(java.nio.file.Files.exists(cache));
+        ManagedLocalAiHardware.Selection selection = ManagedLocalAiHardware.select(
+                ManagedLocalAiManifest.loadDefault(), profile, null);
+        assertEquals(null, selection.selectedModelId());
+        assertTrue(selection.models().values().stream()
+                .allMatch(model -> model.reasons().contains("UNSUPPORTED_RUNTIME")));
+    }
+
+    private static final class FakeHost implements ManagedLocalAiHardware.HostAccess {
+        private final String os;
+        private final String arch;
+        private final String abi;
+        private final String abiVersion;
+        private final long memory;
+        private final int processors;
+        private final long disk;
+        private final Map<String, String> files = new HashMap<>();
+
+        private FakeHost(String os, String arch, String abi, String abiVersion,
+                         long memory, int processors, long disk) {
+            this.os = os; this.arch = arch; this.abi = abi; this.abiVersion = abiVersion;
+            this.memory = memory; this.processors = processors; this.disk = disk;
+        }
+        public String osName() { return os; }
+        public String architecture() { return arch; }
+        public String abi() { return abi; }
+        public String abiVersion() { return abiVersion; }
+        public long availableMemoryBytes() { return memory; }
+        public int availableProcessors() { return processors; }
+        public long usableSpace(Path existingAncestor) { return disk; }
+        public String read(String path) throws java.io.IOException {
+            if (!files.containsKey(path)) throw new java.io.IOException("missing");
+            return files.get(path);
+        }
+    }
+}


### PR DESCRIPTION
## Outcome

Adds the production read-only hardware profiler and deterministic managed-model selector for SHAFT local AI.

## Scope

- Canonical Windows/macOS/Linux x86_64 and aarch64 runtime/ABI profiling.
- Available-memory selection with a 2 GiB host reserve and Linux cgroup v2/v1 memory refinements.
- Process-visible CPU selection with cgroup quota and cpuset constraints, including arbitrary combined v1 mounts.
- Exact peak disk accounting for the selected platform's pinned runtime archive, bounded expansion, model staging/final copy, and reserve.
- Deterministic automatic Qwen tier selection, explicit override gates, exact exclusion reasons, and manual-only challenger isolation.
- Read-only nearest-ancestor disk inspection; absent cache paths are never created.

## Verification

- First RED: `ManagedLocalAiHardwareTest` failed compilation because the production selector did not exist.
- Focused selector: 4 tests, 0 failures/errors/skips.
- Manifest + selector: 9 tests, 0 failures/errors/skips.
- Affected `shaft-ai` package: BUILD SUCCESS.
- Independent adversarial review: approved after ARM asset, cgroup-v1 mount, and Darwin normalization regressions were fixed.

## Dependency

Stacked on #4873; retarget to `main` after the foundation PR merges.

Closes #4859
Related to #4851