### PR TITLE
feat(infrastructure): manage a pinned Lighthouse toolchain

### DIFF
--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -42,6 +42,7 @@ jobs:
       - Windows_Edge_Local
       - MacOSX_Safari_Local
       - Windows_Chrome_Local
+      - Windows_Managed_Lighthouse
       - Windows_SikuliX_Local
       - Windows_Appium_Desktop_Local
       - MacOSX_Chrome_Local
@@ -182,6 +183,74 @@ jobs:
         uses: ./.github/actions/post-test-report
         with:
           job-name: Windows_Chrome_Local
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Issue #4884: opt-in real acceptance for the release-pinned managed Node/Lighthouse
+  # toolchain. This stays manual because it downloads a full npm dependency tree and
+  # audits a live local Chrome session; PR/unit gates cover the deterministic seams.
+  Windows_Managed_Lighthouse:
+    if: github.event_name == 'workflow_dispatch' && (github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Windows_Managed_Lighthouse,'))
+    runs-on: windows-latest
+    timeout-minutes: 30
+    outputs:
+      job: ${{ steps.post_test_report.outputs.job }}
+      total: ${{ steps.post_test_report.outputs.total }}
+      passed: ${{ steps.post_test_report.outputs.passed }}
+      failed: ${{ steps.post_test_report.outputs.failed }}
+      broken: ${{ steps.post_test_report.outputs.broken }}
+      skipped: ${{ steps.post_test_report.outputs.skipped }}
+      duration: ${{ steps.post_test_report.outputs.duration }}
+    steps:
+      - name: Enable Windows long paths
+        run: git config --global core.longpaths true
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: '24'
+      - name: Package the setup CLI
+        run: mvn --batch-mode -pl shaft-cli -am package "-DskipTests" "-Dallure.automaticallyOpen=false" "-Dgpg.skip=true"
+      - name: Plan, approve, install, and verify managed Lighthouse
+        shell: pwsh
+        run: |
+          $cli = Get-ChildItem -Path shaft-cli/target -Filter 'shaft-cli-*.jar' |
+            Where-Object { $_.Name -match '^shaft-cli-[0-9][0-9.]*\.jar$' } |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $cli) { throw 'Packaged shaft-cli executable JAR was not found.' }
+          $cacheRoot = Join-Path $env:RUNNER_TEMP 'shaft-lighthouse-cache'
+          $dataRoot = Join-Path $cacheRoot 'data'
+          $plan = Join-Path $env:RUNNER_TEMP 'lighthouse-plan.json'
+          $planOutput = & java -jar $cli setup plan --profile LIGHTHOUSE --mode MANAGED --output $plan --cache-root $cacheRoot --data-root $dataRoot
+          if ($LASTEXITCODE -ne 0) { throw "Lighthouse planning failed: $planOutput" }
+          $digest = (($planOutput | Select-String '^Digest: ').Line -replace '^Digest:\s*', '')
+          if (-not $digest) { throw 'Lighthouse plan did not emit an approval digest.' }
+          & java -jar $cli setup install --plan $plan --approve $digest --cache-root $cacheRoot --data-root $dataRoot
+          if ($LASTEXITCODE -ne 0) { throw 'Managed Lighthouse installation failed.' }
+          & java -jar $cli setup verify --profile LIGHTHOUSE --cache-root $cacheRoot --data-root $dataRoot
+          if ($LASTEXITCODE -ne 0) { throw 'Managed Lighthouse verification failed.' }
+      - name: Run real local-Chrome Lighthouse report
+        continue-on-error: true
+        run: >-
+          mvn --batch-mode -pl shaft-engine -am test
+          "-Dtest=testPackage.ManagedLighthouseE2ETest"
+          "-DrunManagedLighthouseE2E=true"
+          "-Dinfrastructure.mode=MANAGED"
+          "-Dinfrastructure.profile=LIGHTHOUSE"
+          "-Dinfrastructure.cacheDirectory=${{ runner.temp }}\shaft-lighthouse-cache"
+          "-DlightHouseExecution=true"
+          "-DopenLighthouseReportWhileExecution=false"
+          "-DexecutionAddress=local"
+          "-DtargetBrowserName=chrome"
+          "-DheadlessExecution=true"
+          "-Dallure.automaticallyOpen=false"
+          "-Dgpg.skip=true"
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: Windows_Managed_Lighthouse
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Windows_SikuliX_Local:
@@ -433,7 +502,7 @@ jobs:
 
   notify_local_e2e_tests_failure:
     name: Notify on nightly failure
-    needs: [ Windows_Edge_Local, MacOSX_Safari_Local, Windows_Chrome_Local, Windows_SikuliX_Local, Windows_Appium_Desktop_Local, MacOSX_Chrome_Local, Windows_Edge_Cucumber_Local ]
+    needs: [ Windows_Edge_Local, MacOSX_Safari_Local, Windows_Chrome_Local, Windows_Managed_Lighthouse, Windows_SikuliX_Local, Windows_Appium_Desktop_Local, MacOSX_Chrome_Local, Windows_Edge_Cucumber_Local ]
     if: always()
     runs-on: ubuntu-22.04
     timeout-minutes: 5

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -248,7 +248,9 @@ jobs:
               - 'shaft-ocr/**'
               - 'shaft-cli/pom.xml'
               - '.github/workflows/e2eTests.yml'
+              - '.github/workflows/e2eLocalTests.yml'
               - 'tests/scripts/test_ocr_infrastructure_boundary.py'
+              - 'tests/scripts/test_lighthouse_infrastructure_boundary.py'
             infra:
               - '.github/workflows/pr-gate.yml'
               # Composite actions this gate's jobs call (issue #4440 added
@@ -851,7 +853,8 @@ jobs:
         run: >-
           python3 -m unittest
           tests.scripts.test_pilot_module_boundary
-          tests.scripts.test_ocr_infrastructure_boundary -v
+          tests.scripts.test_ocr_infrastructure_boundary
+          tests.scripts.test_lighthouse_infrastructure_boundary -v
 
   # Issue #4071: a TestNG suite XML file that no pom, workflow, or script
   # references is invisible -- unlike a failing test, nothing reports it, so

--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -104,7 +104,7 @@ public final class SetupCommand implements Runnable {
         @Override
         public Integer call() {
             try {
-                if (profile != SetupProfile.REPORTING && profile != SetupProfile.OCR) {
+                if (!InfrastructureSetupService.builtIn().supports(profile)) {
                     spec.commandLine().getErr().println("No setup provider is available for profile " + profile + '.');
                     return 4;
                 }
@@ -219,7 +219,7 @@ public final class SetupCommand implements Runnable {
         @Override
         public Integer call() {
             try {
-                if (profile != SetupProfile.REPORTING && profile != SetupProfile.OCR) return unsupported(spec, profile);
+                if (!InfrastructureSetupService.builtIn().supports(profile)) return unsupported(spec, profile);
                 if (profile != SetupProfile.OCR && !languages.isEmpty()) {
                     throw new IllegalArgumentException("--language is supported only for profile OCR.");
                 }

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
@@ -86,6 +86,23 @@ class SetupCommandTest {
     }
 
     @Test
+    void lighthouseProfileUsesTheRegisteredProvider(@TempDir Path temp) throws Exception {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        CommandResult status = execute("setup", "status", "--profile", "LIGHTHOUSE",
+                "--cache-root", cache.toString(), "--data-root", data.toString(), "--json");
+        Path planFile = temp.resolve("lighthouse-plan.json").toAbsolutePath();
+        CommandResult plan = execute("setup", "plan", "--profile", "LIGHTHOUSE", "--mode", "MANAGED",
+                "--output", planFile.toString(), "--cache-root", cache.toString(),
+                "--data-root", data.toString(), "--json");
+
+        assertEquals(3, status.exitCode(), status.stderr());
+        assertEquals("LIGHTHOUSE", JSON.readTree(status.stdout()).get("profile").asText());
+        assertEquals(0, plan.exitCode(), plan.stderr());
+        assertEquals("LIGHTHOUSE", JSON.readTree(plan.stdout()).get("profile").asText());
+    }
+
+    @Test
     void ocrProfileHasProviderBackedStatusAndPlan(@TempDir Path temp) throws Exception {
         Path cache = temp.resolve("cache").toAbsolutePath();
         Path data = temp.resolve("data").toAbsolutePath();

--- a/shaft-engine/src/main/java/com/shaft/performance/internal/LightHouseGenerateReport.java
+++ b/shaft-engine/src/main/java/com/shaft/performance/internal/LightHouseGenerateReport.java
@@ -1,18 +1,27 @@
 package com.shaft.performance.internal;
 
-import com.shaft.cli.FileActions;
-import com.shaft.cli.TerminalActions;
 import com.shaft.driver.SHAFT;
+import com.shaft.infrastructure.LighthouseRuntime;
+import com.shaft.infrastructure.SetupOptions;
 import com.shaft.tools.io.internal.ReportManagerHelper;
-import org.apache.commons.lang3.SystemUtils;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
+import java.awt.Desktop;
+import java.awt.GraphicsEnvironment;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Generates Google Lighthouse performance reports for web pages by
@@ -26,136 +35,158 @@ public class LightHouseGenerateReport {
     final WebDriver driver;
     int PortNum;
     String PageName;
+    private final RuntimeResolver runtimeResolver;
+    private final CommandRunner commandRunner;
+    private final Path reportDirectory;
 
     public LightHouseGenerateReport(WebDriver driver) {
+        this(driver, LighthouseRuntime::requireReady, LightHouseGenerateReport::runCommand,
+                Path.of("lighthouse-reports"));
+    }
+
+    LightHouseGenerateReport(WebDriver driver, RuntimeResolver runtimeResolver, CommandRunner commandRunner,
+                             Path reportDirectory) {
         this.driver = driver;
+        this.runtimeResolver = runtimeResolver;
+        this.commandRunner = commandRunner;
+        this.reportDirectory = reportDirectory.toAbsolutePath().normalize();
+    }
+
+    static List<String> command(com.shaft.infrastructure.LighthouseRuntime runtime, String url, int port,
+                                java.nio.file.Path output) {
+        var command = new ArrayList<>(runtime.commandPrefix());
+        command.add(url);
+        command.add("--port=" + port);
+        command.add("--preset=desktop");
+        command.add("--output=html");
+        command.add("--output-path=" + output.toAbsolutePath().normalize());
+        command.add("--only-categories=performance");
+        return List.copyOf(command);
     }
 
     public void generateLightHouseReport() {
+        if (!SHAFT.Properties.performance.isEnabled()) {
+            return;
+        }
         PortNum = SHAFT.Properties.performance.port();
         PageName = getPageName();
-
-        String commandToGenerateLightHouseReport;
-        if (SHAFT.Properties.performance.isEnabled()) {
-            createLighthouseReportFolderInProjectDirectory();
-            writeNodeScriptFileInProjectDirectory();
-
-            if (SystemUtils.IS_OS_WINDOWS) {
-                commandToGenerateLightHouseReport = ("cmd.exe /c node GenerateLHScript.js --url=\"" + driver.getCurrentUrl() + "\" --port=" + PortNum + " --reportName=" + PageName + " ");
-            } else {
-                commandToGenerateLightHouseReport = ("node GenerateLHScript.js --url=\"" + driver.getCurrentUrl() + "\" --port=" + PortNum + " --reportName=" + PageName + " ");
+        try {
+            SetupOptions options = SHAFT.Infrastructure.options().withProfile(com.shaft.infrastructure.SetupProfile.LIGHTHOUSE);
+            LighthouseRuntime runtime = runtimeResolver.resolve(options);
+            Files.createDirectories(reportDirectory);
+            Path report = reportDirectory.resolve(PageName + ".html");
+            if (Files.exists(report)) {
+                throw new IOException("Refusing to overwrite an existing Lighthouse report: " + report);
             }
-            commandToGenerateLightHouseReport = commandToGenerateLightHouseReport.replace("&", "N898");
-            //TerminalActions.getInstance(true, true).performTerminalCommand(commandToGenerateLightHouseReport);
-            (new TerminalActions()).performTerminalCommand(commandToGenerateLightHouseReport);
-            writeReportPathToFilesInProjectDirectory(PageName);
-            openLighthouseReportWhileExecution();
-            SHAFT.Report.report("Lighthouse Report Generated successfully");
-            SHAFT.Report.attach("LightHouse HTML", "Report", FileActions.getInstance(true).readFile("lighthouse-reports/" + PageName + ".html"));
+            int port = debuggerPort(driver, PortNum);
+            boolean completed = false;
+            try {
+                CommandResult result = commandRunner.run(command(runtime, driver.getCurrentUrl(), port, report),
+                        runtime.workingDirectory(), options.startupTimeout());
+                if (result.exitCode() != 0) {
+                    throw new IOException("Lighthouse exited with code " + result.exitCode() + ": " + result.output());
+                }
+                if (!Files.isRegularFile(report) || Files.size(report) == 0) {
+                    throw new IOException("Lighthouse completed without creating a non-empty report at " + report);
+                }
+                String html = Files.readString(report, StandardCharsets.UTF_8);
+                if (!html.toLowerCase(java.util.Locale.ROOT).contains("<html")) {
+                    throw new IOException("Lighthouse output is not an HTML document: " + report);
+                }
+                completed = true;
+                openReportWhenRequested(report);
+                SHAFT.Report.report("Lighthouse Report Generated successfully");
+                SHAFT.Report.attach("LightHouse HTML", "Report", html);
+            } finally {
+                if (!completed) Files.deleteIfExists(report);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to generate the Lighthouse report: " + e.getMessage(), e);
         }
+    }
+
+    static int debuggerPort(WebDriver driver, int fallback) {
+        if (driver instanceof RemoteWebDriver remote) {
+            Object chromeOptions = remote.getCapabilities().getCapability("goog:chromeOptions");
+            if (chromeOptions instanceof Map<?, ?> options) {
+                Object address = options.get("debuggerAddress");
+                if (address instanceof String value) {
+                    int separator = value.lastIndexOf(':');
+                    if (separator >= 0 && separator + 1 < value.length()) {
+                        try {
+                            return Integer.parseInt(value.substring(separator + 1));
+                        } catch (NumberFormatException ignored) {
+                            // Fall back to the explicitly configured Lighthouse port.
+                        }
+                    }
+                }
+            }
+        }
+        return fallback;
+    }
+
+    private static void openReportWhenRequested(Path report) throws IOException {
+        if (!SHAFT.Properties.reporting.openLighthouseReportWhileExecution()) {
+            return;
+        }
+        if (GraphicsEnvironment.isHeadless() || !Desktop.isDesktopSupported()) {
+            throw new IOException("Opening the Lighthouse report was requested, but this environment has no desktop handler.");
+        }
+        Desktop.getDesktop().browse(report.toUri());
+        SHAFT.Report.report("Lighthouse Report Opened in the default browser successfully");
+    }
+
+    private static CommandResult runCommand(List<String> command, Path workingDirectory, Duration timeout)
+            throws IOException {
+        com.shaft.infrastructure.ManagedProcessRunner.Result result =
+                com.shaft.infrastructure.ManagedProcessRunner.run(command, workingDirectory, timeout);
+        return new CommandResult(result.exitCode(), result.output());
+    }
+
+    @FunctionalInterface
+    interface RuntimeResolver {
+        LighthouseRuntime resolve(SetupOptions options) throws IOException;
+    }
+
+    @FunctionalInterface
+    interface CommandRunner {
+        CommandResult run(List<String> command, Path workingDirectory, Duration timeout) throws IOException;
+    }
+
+    record CommandResult(int exitCode, String output) {
     }
 
     public void createLighthouseReportFolderInProjectDirectory() {
-        FileActions.getInstance(true).createFolder("lighthouse-reports");
+        try {
+            Files.createDirectories(reportDirectory);
+        } catch (IOException failure) {
+            throw new IllegalStateException("Unable to create the Lighthouse report directory.", failure);
+        }
     }
 
+    /** @deprecated Reports are opened directly from the verified output path. */
+    @Deprecated(forRemoval = true)
     public void openLighthouseReportWhileExecution() {
-        String commandToOpenLighthouseReport;
-        if (SHAFT.Properties.reporting.openLighthouseReportWhileExecution()) {
-            if (SystemUtils.IS_OS_WINDOWS) {
-                commandToOpenLighthouseReport = ("cmd.exe /c node OpenLHReport.js");
-            } else {
-                commandToOpenLighthouseReport = ("node OpenLHReport.js");
-            }
-//                TerminalActions.getInstance(true, true).performTerminalCommand(commandToOpenLighthouseReport);
-            (new TerminalActions()).performTerminalCommand(commandToOpenLighthouseReport);
-            SHAFT.Report.report("Lighthouse Report Opened in new tab successfully");
+        if (!SHAFT.Properties.reporting.openLighthouseReportWhileExecution()) return;
+        String name = PageName == null ? getPageName() : PageName;
+        try {
+            openReportWhenRequested(reportDirectory.resolve(name + ".html"));
+        } catch (IOException failure) {
+            throw new IllegalStateException("Unable to open the Lighthouse report.", failure);
         }
     }
 
+    /** @deprecated Generated report-opener scripts were removed; use the report output path. */
+    @Deprecated(forRemoval = true)
     public void writeReportPathToFilesInProjectDirectory(String pageName) {
-        List<String> commandsToServeLHReport;
-        commandsToServeLHReport = List.of(
-                "import open from 'open';\n" +
-                        "import path from 'path';\n" +
-                        "const __dirname = path.resolve();\n" +
-                        "await open(__dirname +'/lighthouse-reports/" + pageName + ".html');\n");
-        FileActions.getInstance(true).writeToFile("", "OpenLHReport.js", commandsToServeLHReport);
+        throw new UnsupportedOperationException("Generated Lighthouse opener scripts are no longer supported.");
     }
 
+    /** @deprecated Generated executable scripts were removed; use managed Lighthouse setup. */
+    @Deprecated(forRemoval = true)
     public void writeNodeScriptFileInProjectDirectory() {
-        List<String> commandsToServeLHReport;
-        if (SystemUtils.IS_OS_WINDOWS) {
-            commandsToServeLHReport = List.of("""
-                    import puppeteer from 'puppeteer';
-                    import fs from 'fs';
-                    import lighthouse from 'lighthouse';
-                    import optimist from 'optimist';
-                    var argv =optimist.argv;
-                    import open from 'open';
-                    import path from 'path';
-                    const __dirname = path.resolve();
-                     import desktopConfig from 'lighthouse/core/config/desktop-config.js';
-                    // -------- Configs ----------
-                      var text = argv.url;
-                      var Url = text.replaceAll("N898", "&");
-                      var Port = argv.port;
-                      var LogLevel='info';
-                      var OutputType='html'; // html , json
-                      var ReportName=argv.reportName;
-                    //----------------------------
-                    (async() => {
-                      // Use Puppeteer to connect to the opened session by port
-                      const browserURL = 'http://127.0.0.1:'+Port;
-                      const browser = await puppeteer.connect({browserURL});
-                      // Lighthouse connect to the opened page and generate the report.
-                      const options = {logLevel:LogLevel ,output: OutputType, port:Port};
-                      const runnerResult = await lighthouse(Url,options,desktopConfig);
-                      // `Genrate the report output as HTML or JSON
-                      const reportHtml = runnerResult.report;
-                      // save the report in node.js path
-                      fs.writeFileSync(__dirname +'/lighthouse-reports/'+ReportName+'.'+OutputType, reportHtml);
-                      // Disconnect from the session
-                      await browser.disconnect();
-                    })();""");
-        } else {
-            commandsToServeLHReport = List.of("""
-                    import puppeteer from 'puppeteer';
-                    import fs from 'fs';
-                    import lighthouse from 'lighthouse';
-                    import optimist from 'optimist';
-                    var argv =optimist.argv;
-                    import open from 'open';
-                    import path from 'path';
-                    const __dirname = path.resolve();
-                    import desktopConfig from 'lighthouse/lighthouse-core/config/desktop-config.js';
-                    // -------- Configs ----------
-                       var text = argv.url;
-                       var Url = text.replaceAll( "N898 ",  "& ");
-                       //Url=Url.replace( "'&' ",  "& ");
-                       var Port = argv.port;
-                       var LogLevel='info';
-                       var OutputType='html'; argv.outputType; // html , json
-                       var ReportName=argv.reportName;
-                    //----------------------------
-                    (async() => {
-                       // Use Puppeteer to connect to the opened session by port
-                       const browserURL = 'http://127.0.0.1:'+Port;
-                       const browser = await puppeteer.connect({browserURL});
-                       // open new tab to Fix Lighthouse issue in MacOS as it run on same tab
-                       const newTab = browser.newPage(browserURL);
-                       //Lighthouse connect to the opened page and generate the report.
-                       const options = {logLevel:LogLevel ,output: OutputType, port:Port};
-                       const runnerResult = await lighthouse(Url,options,desktopConfig);
-                       // `Genrate the report output as HTML or JSON
-                       const reportHtml = runnerResult.report;
-                       // save the report in node.js path
-                       fs.writeFileSync(__dirname +'/lighthouse-reports/'+ReportName+'.'+OutputType, reportHtml);
-                       // Disconnect from the session
-                       await browser.disconnect();
-                     })();""");
-        }
-        FileActions.getInstance(true).writeToFile("", "GenerateLHScript.js", commandsToServeLHReport);
+        throw new UnsupportedOperationException("Generated Lighthouse scripts are no longer supported. "
+                + "Install the managed LIGHTHOUSE profile and call generateLightHouseReport().");
     }
 
     public String getPageName() {

--- a/shaft-engine/src/test/java/com/shaft/performance/internal/LightHouseGenerateReportCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/performance/internal/LightHouseGenerateReportCoverageUnitTest.java
@@ -1,33 +1,56 @@
 package com.shaft.performance.internal;
 
-import com.shaft.cli.FileActions;
-import com.shaft.cli.TerminalActions;
 import com.shaft.driver.SHAFT;
 import com.shaft.properties.internal.Properties;
-import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class LightHouseGenerateReportCoverageUnitTest {
-    private static final String AMPERSAND_PLACEHOLDER = "N898";
+
+    @Test
+    public void managedCommandKeepsTheUrlAsOneArgumentAndUsesNoGeneratedScript() {
+        var runtime = new com.shaft.infrastructure.LighthouseRuntime(
+                List.of("C:/shaft/node.exe", "C:/shaft/lighthouse/index.js"), Path.of("C:/shaft/cache"));
+        Path output = Path.of("C:/work/lighthouse reports/report.html");
+
+        List<String> command = LightHouseGenerateReport.command(runtime,
+                "https://example.com/search?q=shaft&lang=en", 9999, output);
+
+        Assert.assertEquals(command, List.of("C:/shaft/node.exe", "C:/shaft/lighthouse/index.js",
+                "https://example.com/search?q=shaft&lang=en", "--port=9999", "--preset=desktop",
+                "--output=html", "--output-path=" + output.toAbsolutePath().normalize(),
+                "--only-categories=performance"));
+        Assert.assertFalse(command.stream().anyMatch(value -> value.endsWith("GenerateLHScript.js")));
+    }
+
+    @Test
+    public void debuggerAddressCapabilityWinsOverTheConfiguredFallbackPort() {
+        RemoteWebDriver driver = mock(RemoteWebDriver.class);
+        Capabilities capabilities = mock(Capabilities.class);
+        when(driver.getCapabilities()).thenReturn(capabilities);
+        when(capabilities.getCapability("goog:chromeOptions"))
+                .thenReturn(Map.of("debuggerAddress", "127.0.0.1:9222"));
+
+        Assert.assertEquals(LightHouseGenerateReport.debuggerPort(driver, 8888), 9222);
+    }
 
     @AfterMethod(alwaysRun = true)
     public void tearDown() {
@@ -40,90 +63,106 @@ public class LightHouseGenerateReportCoverageUnitTest {
     public void generateLightHouseReportShouldSkipExecutionWhenFeatureIsDisabled() {
         WebDriver driver = mock(WebDriver.class);
         when(driver.getCurrentUrl()).thenReturn("https://example.com/home");
-        LightHouseGenerateReport reportGenerator = new LightHouseGenerateReport(driver);
+        LightHouseGenerateReport reportGenerator = new LightHouseGenerateReport(driver,
+                options -> { throw new AssertionError("Disabled Lighthouse must not resolve a runtime."); },
+                (command, directory, timeout) -> { throw new AssertionError("Disabled Lighthouse must not run."); },
+                Path.of("lighthouse-reports"));
 
         SHAFT.Properties.performance.set().isEnabled(false);
-
-        try (MockedStatic<FileActions> mockedFileActionsStatic = Mockito.mockStatic(FileActions.class);
-             MockedConstruction<TerminalActions> mockedTerminalActions = Mockito.mockConstruction(TerminalActions.class)) {
-            reportGenerator.generateLightHouseReport();
-
-            mockedFileActionsStatic.verifyNoInteractions();
-            Assert.assertTrue(mockedTerminalActions.constructed().isEmpty());
-        }
+        reportGenerator.generateLightHouseReport();
     }
 
     @Test
-    public void generateLightHouseReportShouldCreateArtifactsAndExecuteCommandsWhenEnabled() {
+    public void generateLightHouseReportUsesManagedRuntimeAndProducesTheReviewedReport() throws Exception {
         WebDriver driver = mock(WebDriver.class);
         when(driver.getCurrentUrl()).thenReturn("https://example.com/search?q=shaft&lang=en");
-        LightHouseGenerateReport reportGenerator = new LightHouseGenerateReport(driver);
-
+        Path reportDirectory = Files.createTempDirectory("shaft-lighthouse-test-");
+        var runtime = new com.shaft.infrastructure.LighthouseRuntime(
+                List.of("C:/shaft/node.exe", "C:/shaft/lighthouse/index.js"), reportDirectory);
+        AtomicReference<List<String>> invoked = new AtomicReference<>();
+        LightHouseGenerateReport reportGenerator = new LightHouseGenerateReport(driver, options -> runtime,
+                (command, workingDirectory, timeout) -> {
+                    invoked.set(command);
+                    Path output = Path.of(command.stream().filter(value -> value.startsWith("--output-path="))
+                            .findFirst().orElseThrow().substring("--output-path=".length()));
+                    Files.writeString(output, "<html>verified report</html>");
+                    return new LightHouseGenerateReport.CommandResult(0, "ok");
+                }, reportDirectory);
         SHAFT.Properties.performance.set().isEnabled(true);
         SHAFT.Properties.performance.set().port(9999);
-        SHAFT.Properties.reporting.set().openLighthouseReportWhileExecution(true);
+        SHAFT.Properties.reporting.set().openLighthouseReportWhileExecution(false);
 
-        try (MockedStatic<FileActions> mockedFileActionsStatic = Mockito.mockStatic(FileActions.class);
-             MockedConstruction<TerminalActions> mockedTerminalActions = Mockito.mockConstruction(TerminalActions.class,
-                     (mock, context) -> when(mock.performTerminalCommand(anyString())).thenReturn("ok"))) {
-            FileActions mockedFileActions = mock(FileActions.class);
-            when(mockedFileActions.readFile(anyString())).thenReturn("<html>report</html>");
-            mockedFileActionsStatic.when(() -> FileActions.getInstance(true)).thenReturn(mockedFileActions);
+        reportGenerator.generateLightHouseReport();
 
-            reportGenerator.generateLightHouseReport();
-
-            verify(mockedFileActions, times(1)).createFolder("lighthouse-reports");
-            verify(mockedFileActions, times(1)).writeToFile(Mockito.eq(""), Mockito.eq("GenerateLHScript.js"), any(List.class));
-            verify(mockedFileActions, times(1)).writeToFile(Mockito.eq(""), Mockito.eq("OpenLHReport.js"), any(List.class));
-            verify(mockedFileActions, times(1)).readFile(Mockito.argThat(path -> path.startsWith("lighthouse-reports/") && path.endsWith(".html")));
-
-            Assert.assertEquals(mockedTerminalActions.constructed().size(), 2);
-            verify(mockedTerminalActions.constructed().getFirst(), times(1))
-                    .performTerminalCommand(Mockito.argThat(command ->
-                            command.contains("node GenerateLHScript.js")
-                                    && command.contains("--port=9999")
-                                    && command.contains(AMPERSAND_PLACEHOLDER)));
-            verify(mockedTerminalActions.constructed().get(1), times(1))
-                    .performTerminalCommand(Mockito.argThat(command -> command.contains("node OpenLHReport.js")));
-        }
+        Assert.assertNotNull(invoked.get());
+        Assert.assertEquals(invoked.get().get(2), "https://example.com/search?q=shaft&lang=en");
+        Assert.assertTrue(invoked.get().contains("--port=9999"));
+        Assert.assertFalse(Files.exists(reportDirectory.resolve("GenerateLHScript.js")));
+        Assert.assertFalse(Files.exists(reportDirectory.resolve("OpenLHReport.js")));
+        Assert.assertEquals(Files.list(reportDirectory).filter(path -> path.toString().endsWith(".html")).count(), 1L);
     }
 
     @Test
-    public void helperMethodsShouldWriteExpectedScriptsAndGenerateReadablePageName() {
+    public void nonzeroExitAndMissingOutputFailInsteadOfReportingSuccess() throws Exception {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.getCurrentUrl()).thenReturn("https://example.com");
+        Path reportDirectory = Files.createTempDirectory("shaft-lighthouse-failure-");
+        var runtime = new com.shaft.infrastructure.LighthouseRuntime(List.of("node", "lighthouse"), reportDirectory);
+        SHAFT.Properties.performance.set().isEnabled(true);
+
+        var nonzero = new LightHouseGenerateReport(driver, options -> runtime,
+                (command, directory, timeout) -> new LightHouseGenerateReport.CommandResult(7, "boom"),
+                reportDirectory);
+        IllegalStateException exitFailure = Assert.expectThrows(IllegalStateException.class,
+                nonzero::generateLightHouseReport);
+        Assert.assertTrue(exitFailure.getMessage().contains("code 7"));
+
+        var missing = new LightHouseGenerateReport(driver, options -> runtime,
+                (command, directory, timeout) -> new LightHouseGenerateReport.CommandResult(0, "ok"),
+                reportDirectory);
+        IllegalStateException missingFailure = Assert.expectThrows(IllegalStateException.class,
+                missing::generateLightHouseReport);
+        Assert.assertTrue(missingFailure.getMessage().contains("without creating"));
+    }
+
+    @Test
+    public void preexistingReportIsNeverAcceptedAsFreshSuccess() throws Exception {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.getCurrentUrl()).thenReturn("https://example.com");
+        Path reportDirectory = Files.createTempDirectory("shaft-lighthouse-stale-");
+        Files.writeString(reportDirectory.resolve("fixed.html"), "<html>old</html>");
+        var runtime = new com.shaft.infrastructure.LighthouseRuntime(List.of("node", "lighthouse"), reportDirectory);
+        SHAFT.Properties.performance.set().isEnabled(true);
+        LightHouseGenerateReport generator = new LightHouseGenerateReport(driver, options -> runtime,
+                (command, directory, timeout) -> new LightHouseGenerateReport.CommandResult(0, "ok"),
+                reportDirectory) {
+            @Override public String getPageName() { return "fixed"; }
+        };
+
+        IllegalStateException failure = Assert.expectThrows(IllegalStateException.class,
+                generator::generateLightHouseReport);
+
+        Assert.assertTrue(failure.getMessage().contains("Refusing to overwrite"));
+        Assert.assertEquals(Files.readString(reportDirectory.resolve("fixed.html")), "<html>old</html>");
+    }
+
+    @Test
+    public void deprecatedScriptHelpersFailClosedAndPageNameRemainsReadable() throws Exception {
         WebDriver driver = mock(WebDriver.class);
         when(driver.getCurrentUrl()).thenReturn("https://example.com/path/sub-path");
-        LightHouseGenerateReport reportGenerator = new LightHouseGenerateReport(driver);
-        @SuppressWarnings("unchecked")
-        List<String>[] openScriptContent = new List[1];
-        @SuppressWarnings("unchecked")
-        List<String>[] generateScriptContent = new List[1];
+        Path reportDirectory = Files.createTempDirectory("shaft-lighthouse-helper-");
+        LightHouseGenerateReport reportGenerator = new LightHouseGenerateReport(driver,
+                options -> { throw new AssertionError(); }, (command, directory, timeout) -> { throw new AssertionError(); },
+                reportDirectory);
 
-        try (MockedStatic<FileActions> mockedFileActionsStatic = Mockito.mockStatic(FileActions.class)) {
-            FileActions mockedFileActions = mock(FileActions.class);
-            mockedFileActionsStatic.when(() -> FileActions.getInstance(true)).thenReturn(mockedFileActions);
-            doAnswer(invocation -> {
-                openScriptContent[0] = invocation.getArgument(2);
-                return null;
-            }).when(mockedFileActions).writeToFile(eq(""), eq("OpenLHReport.js"), Mockito.<List<String>>any());
-            doAnswer(invocation -> {
-                generateScriptContent[0] = invocation.getArgument(2);
-                return null;
-            }).when(mockedFileActions).writeToFile(eq(""), eq("GenerateLHScript.js"), Mockito.<List<String>>any());
-
-            reportGenerator.createLighthouseReportFolderInProjectDirectory();
-            reportGenerator.writeReportPathToFilesInProjectDirectory("custom-page");
-            reportGenerator.writeNodeScriptFileInProjectDirectory();
-            String pageName = reportGenerator.getPageName();
-
-            verify(mockedFileActions, times(1)).createFolder("lighthouse-reports");
-            verify(mockedFileActions, times(1)).writeToFile(eq(""), eq("OpenLHReport.js"), Mockito.<List<String>>any());
-            verify(mockedFileActions, times(1)).writeToFile(eq(""), eq("GenerateLHScript.js"), Mockito.<List<String>>any());
-            Assert.assertTrue(openScriptContent[0].get(0).contains("custom-page.html"));
-            Assert.assertTrue(generateScriptContent[0].get(0).contains("desktop-config.js"));
-
-            Assert.assertTrue(pageName.contains("--path-sub-path"));
-            Assert.assertTrue(pageName.startsWith(LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern("dd-MM-yyyy"))));
-        }
+        reportGenerator.createLighthouseReportFolderInProjectDirectory();
+        Assert.assertTrue(Files.isDirectory(reportDirectory));
+        Assert.expectThrows(UnsupportedOperationException.class,
+                () -> reportGenerator.writeReportPathToFilesInProjectDirectory("custom-page"));
+        Assert.expectThrows(UnsupportedOperationException.class, reportGenerator::writeNodeScriptFileInProjectDirectory);
+        String pageName = reportGenerator.getPageName();
+        Assert.assertTrue(pageName.contains("--path-sub-path"));
+        Assert.assertTrue(pageName.startsWith(LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern("dd-MM-yyyy"))));
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/ManagedLighthouseE2ETest.java
+++ b/shaft-engine/src/test/java/testPackage/ManagedLighthouseE2ETest.java
@@ -1,0 +1,43 @@
+package testPackage;
+
+import com.shaft.driver.SHAFT;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Opt-in real local-Chrome acceptance for the managed Lighthouse runtime. */
+public class ManagedLighthouseE2ETest {
+    @Test
+    public void managedLighthouseProducesANonemptyHtmlReport() throws Exception {
+        if (!Boolean.getBoolean("runManagedLighthouseE2E")) {
+            throw new SkipException("Set -DrunManagedLighthouseE2E=true to run managed Lighthouse acceptance.");
+        }
+        Path reportDirectory = Path.of("lighthouse-reports").toAbsolutePath().normalize();
+        Set<Path> before = reports(reportDirectory);
+        SHAFT.GUI.WebDriver driver = new SHAFT.GUI.WebDriver();
+        try {
+            driver.browser().navigateToURL("https://example.com/");
+            driver.browser().generateLightHouseReport();
+        } finally {
+            driver.quit();
+        }
+        Set<Path> created = reports(reportDirectory);
+        created.removeAll(before);
+        Assert.assertEquals(created.size(), 1, "Managed Lighthouse should create exactly one HTML report.");
+        String html = Files.readString(created.iterator().next()).toLowerCase(java.util.Locale.ROOT);
+        Assert.assertTrue(html.contains("<html"), "Managed Lighthouse output should be an HTML document.");
+    }
+
+    private static Set<Path> reports(Path directory) throws Exception {
+        if (!Files.isDirectory(directory)) return new java.util.HashSet<>();
+        try (var reports = Files.list(directory)) {
+            return reports.filter(path -> path.toString().endsWith(".html"))
+                    .collect(Collectors.toCollection(java.util.HashSet::new));
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
@@ -23,12 +23,22 @@ public final class InfrastructureSetupService {
 
     public static InfrastructureSetupService builtIn(SetupPlatform platform, SetupArchitecture architecture) {
         return new InfrastructureSetupService(new SetupProviderRegistry(List.of(
-                new ReportingSetupProvider(), new OcrSetupProvider())),
+                new ReportingSetupProvider(), new OcrSetupProvider(), new LighthouseSetupProvider())),
                 platform, architecture);
     }
 
     public SetupCatalog catalog() {
         return SetupCatalog.builtIn();
+    }
+
+    /**
+     * Returns whether this coordinator has an executable provider for the profile.
+     *
+     * @param profile profile to query
+     * @return {@code true} when an executable provider is registered
+     */
+    public boolean supports(SetupProfile profile) {
+        return providers.profiles().contains(Objects.requireNonNull(profile, "profile"));
     }
 
     public SetupPlan plan(SetupOptions options) {

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/LighthouseRuntime.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/LighthouseRuntime.java
@@ -1,0 +1,43 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/** Exact managed Node/Lighthouse command resolved from a verified SHAFT receipt. */
+public record LighthouseRuntime(List<String> commandPrefix, Path workingDirectory) {
+    public LighthouseRuntime {
+        commandPrefix = List.copyOf(java.util.Objects.requireNonNull(commandPrefix, "commandPrefix"));
+        if (commandPrefix.isEmpty() || commandPrefix.stream().anyMatch(value -> value == null || value.isBlank())) {
+            throw new IllegalArgumentException("Lighthouse command prefix must not be empty.");
+        }
+        workingDirectory = java.util.Objects.requireNonNull(workingDirectory, "workingDirectory")
+                .toAbsolutePath().normalize();
+    }
+
+    /**
+     * Resolves the release-pinned managed runtime without installing or changing the filesystem.
+     *
+     * @param options setup policy and owned paths
+     * @return exact managed Node/Lighthouse command
+     * @throws IOException when the approved managed runtime is not ready
+     */
+    public static LighthouseRuntime requireReady(SetupOptions options) throws IOException {
+        SetupOptions selected = java.util.Objects.requireNonNull(options, "options").withProfile(SetupProfile.LIGHTHOUSE);
+        SetupPlatform platform = SetupPlatform.current();
+        SetupArchitecture architecture = SetupArchitecture.current();
+        LighthouseSetupService service = LighthouseSetupProvider.service(selected, platform, architecture);
+        SetupProfileStatus status = service.status();
+        if (status.readiness() != SetupReadiness.READY) {
+            throw new IOException("Managed Lighthouse is not ready. Run `shaft-cli setup plan --profile LIGHTHOUSE "
+                    + "--mode MANAGED --output <absolute-plan.json>`, review its digest, then install it.");
+        }
+        Path nodeRoot = selected.paths().tools().resolve("node").resolve(ReportingSetupPlanner.NODE_VERSION)
+                .resolve(platform.name().toLowerCase() + '-' + architecture.artifactName());
+        Path node = platform == SetupPlatform.WINDOWS ? nodeRoot.resolve("node.exe") : nodeRoot.resolve("bin/node");
+        Path lighthouse = selected.paths().tools().resolve("lighthouse")
+                .resolve(LighthouseSetupPlanner.LIGHTHOUSE_VERSION)
+                .resolve("node_modules/lighthouse/cli/index.js");
+        return new LighthouseRuntime(List.of(node.toString(), lighthouse.toString()), lighthouse.getParent());
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/LighthouseSetupPlanner.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/LighthouseSetupPlanner.java
@@ -1,0 +1,33 @@
+package com.shaft.infrastructure;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+
+/** Release-coupled planner for the managed Lighthouse command-line runtime. */
+public final class LighthouseSetupPlanner {
+    public static final String LIGHTHOUSE_VERSION = "13.4.1";
+    public static final String LIGHTHOUSE_LOCK_SHA256 =
+            "5691359da63475578daef5b322a620311110ff6a09953cdb898bee314106c4dd";
+    private static final String LIGHTHOUSE_SHA256 =
+            "110759ba9e863c024e214e9b08ed2b0344d89b492286227235d4dfb990dc3e54";
+
+    private LighthouseSetupPlanner() { }
+
+    /**
+     * Creates the exact Lighthouse plan shipped with this release.
+     *
+     * @param platform target operating system
+     * @param architecture target CPU architecture
+     * @param mode requested ownership mode
+     * @return immutable release-pinned setup plan
+     */
+    public static SetupPlan plan(SetupPlatform platform, SetupArchitecture architecture, SetupMode mode) {
+        SetupAction node = ReportingSetupPlanner.plan(platform, architecture, mode).actions().getFirst();
+        SetupActionKind kind = mode == SetupMode.EXTERNAL ? SetupActionKind.DIAGNOSE : SetupActionKind.INSTALL;
+        SetupAction lighthouse = new SetupAction(SetupTarget.LIGHTHOUSE, kind, LIGHTHOUSE_VERSION,
+                URI.create("https://registry.npmjs.org/lighthouse/-/lighthouse-" + LIGHTHOUSE_VERSION + ".tgz"),
+                "sha256:" + LIGHTHOUSE_SHA256, "sha256:" + LIGHTHOUSE_LOCK_SHA256, false, Set.of());
+        return SetupPlan.create(SetupProfile.LIGHTHOUSE, platform, architecture, mode, List.of(node, lighthouse));
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/LighthouseSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/LighthouseSetupProvider.java
@@ -1,0 +1,47 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.util.List;
+
+final class LighthouseSetupProvider implements SetupProvider {
+    @Override
+    public SetupProfile profile() {
+        return SetupProfile.LIGHTHOUSE;
+    }
+
+    @Override
+    public SetupPlan plan(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return LighthouseSetupPlanner.plan(platform, architecture, options.effectiveMode());
+    }
+
+    @Override
+    public SetupReport status(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        if (options.effectiveMode() == SetupMode.EXTERNAL) {
+            String detail = "External mode is diagnostic-only and does not execute managed tools.";
+            return SetupReport.from(new SetupProfileStatus(1, SetupProfile.LIGHTHOUSE, SetupReadiness.MISSING,
+                    List.of(new SetupStatus(SetupTarget.NODE, SetupReadiness.MISSING, "", detail),
+                            new SetupStatus(SetupTarget.LIGHTHOUSE, SetupReadiness.MISSING, "", detail))));
+        }
+        return SetupReport.from(service(options, platform, architecture).status());
+    }
+
+    @Override
+    public SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupPlan providerPlan = LighthouseSetupPlanner.plan(plan.platform(), plan.architecture(), plan.mode());
+        SetupReceipt receipt = service(options, plan.platform(), plan.architecture()).install(providerPlan,
+                new SetupApproval(providerPlan.digest(), approval.approvedAt(), approval.acceptedLicenses()));
+        return new SetupReceipt(plan.digest(), receipt.completedAt(), receipt.completedActions());
+    }
+
+    static LighthouseSetupService service(SetupOptions options, SetupPlatform platform,
+                                          SetupArchitecture architecture) {
+        return new LighthouseSetupService(options.paths(), platform, architecture,
+                action -> new VerifiedArtifactStore(options.paths().downloads()).fetch(action, options.offline()),
+                (command, log, timeout) -> ReportingSetupService.runProcess(command, log, timeout,
+                        options.paths().cacheRoot(), options.paths().tools().resolve("node")
+                                .resolve(ReportingSetupPlanner.NODE_VERSION)
+                                .resolve(platform.name().toLowerCase() + '-' + architecture.artifactName())),
+                options.offline());
+    }
+
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/LighthouseSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/LighthouseSetupService.java
@@ -1,0 +1,337 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Managed, release-pinned installation and verification for Lighthouse. */
+final class LighthouseSetupService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+    private static final Pattern LOCK_INTEGRITY = Pattern.compile("\\\"integrity\\\"\\s*:\\s*\\\"sha512-([^\\\"]+)\\\"");
+    private final ShaftCachePaths paths;
+    private final SetupPlatform platform;
+    private final SetupArchitecture architecture;
+    private final ReportingSetupService.ArtifactFetcher fetcher;
+    private final ReportingSetupService.CommandRunner runner;
+    private final ReportingSetupService nodeService;
+    private final boolean offline;
+
+    LighthouseSetupService(ShaftCachePaths paths, SetupPlatform platform, SetupArchitecture architecture,
+                           ReportingSetupService.ArtifactFetcher fetcher,
+                           ReportingSetupService.CommandRunner runner, boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.platform = java.util.Objects.requireNonNull(platform, "platform");
+        this.architecture = java.util.Objects.requireNonNull(architecture, "architecture");
+        this.fetcher = java.util.Objects.requireNonNull(fetcher, "fetcher");
+        this.runner = java.util.Objects.requireNonNull(runner, "runner");
+        this.nodeService = new ReportingSetupService(paths, platform, architecture, fetcher, runner, offline);
+        this.offline = offline;
+    }
+
+    SetupProfileStatus status() {
+        SetupStatus node = nodeService.nodeStatus();
+        SetupStatus lighthouse = probeLighthouse();
+        SetupReadiness readiness = node.readiness() == SetupReadiness.DEGRADED
+                || lighthouse.readiness() == SetupReadiness.DEGRADED ? SetupReadiness.DEGRADED
+                : node.readiness() == SetupReadiness.READY && lighthouse.readiness() == SetupReadiness.READY
+                ? SetupReadiness.READY : SetupReadiness.MISSING;
+        return new SetupProfileStatus(1, SetupProfile.LIGHTHOUSE, readiness, List.of(node, lighthouse));
+    }
+
+    SetupReceipt install(SetupPlan plan, SetupApproval approval) throws IOException {
+        requireCompatible(plan);
+        SetupExecutor.validate(plan, approval);
+        preflightOfflineArtifacts(plan);
+        requireSafePaths();
+        Path lockPath = paths.state().resolve("lighthouse.lock").toAbsolutePath().normalize();
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        try {
+            jvmLock.lockInterruptibly();
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                SetupReceipt receipt = SetupExecutor.execute(plan, approval, action -> {
+                    try {
+                        if (action.target() == SetupTarget.NODE) nodeService.installNodeAction(action);
+                        else if (action.target() == SetupTarget.LIGHTHOUSE) installLighthouse(action);
+                        else throw new IllegalArgumentException("Lighthouse provider cannot install " + action.target());
+                    } catch (IOException failure) {
+                        throw new SetupOperationException(failure);
+                    }
+                });
+                writeReceipt(receipt);
+                return receipt;
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the Lighthouse setup lock.", interrupted);
+        } finally {
+            if (jvmLock.isHeldByCurrentThread()) jvmLock.unlock();
+        }
+    }
+
+    private void preflightOfflineArtifacts(SetupPlan plan) throws IOException {
+        if (!offline) return;
+        boolean nodeInstalled = structurallyInstalledNode();
+        boolean lighthouseInstalled = structurallyInstalledLighthouse();
+        for (SetupAction action : plan.actions()) {
+            boolean installed = action.target() == SetupTarget.NODE
+                    ? nodeInstalled
+                    : action.target() == SetupTarget.LIGHTHOUSE && lighthouseInstalled;
+            if (!installed) fetcher.fetch(action);
+        }
+        if (!lighthouseInstalled) requireCompleteOfflineNpmCache();
+    }
+
+    private boolean structurallyInstalledNode() throws IOException {
+        VerifiedArtifactStore.requireUnlinkedAncestors(nodeRoot());
+        return Files.isRegularFile(nodeExecutable(), LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private boolean structurallyInstalledLighthouse() throws IOException {
+        Path root = lighthouseRoot();
+        Path entry = lighthouseEntryPoint(root);
+        Path lock = root.resolve("package-lock.json");
+        Path receipt = paths.receipts().resolve("lighthouse.json");
+        for (Path path : List.of(root, entry, lock, receipt)) VerifiedArtifactStore.requireUnlinkedAncestors(path);
+        if (!Files.isRegularFile(entry, LinkOption.NOFOLLOW_LINKS)
+                || !Files.isRegularFile(lock, LinkOption.NOFOLLOW_LINKS)
+                || !Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)
+                || !VerifiedArtifactStore.digest(lock).equalsIgnoreCase(LighthouseSetupPlanner.LIGHTHOUSE_LOCK_SHA256)) {
+            return false;
+        }
+        SetupReceipt saved = JSON.readValue(receipt.toFile(), SetupReceipt.class);
+        return List.of(SetupMode.MANAGED, SetupMode.HYBRID).stream().anyMatch(mode -> {
+            SetupPlan expected = LighthouseSetupPlanner.plan(platform, architecture, mode);
+            return saved.planDigest().equals(expected.digest()) && saved.completedActions().equals(expected.actions());
+        });
+    }
+
+    private void requireCompleteOfflineNpmCache() throws IOException {
+        String lock;
+        try (InputStream input = LighthouseSetupService.class.getResourceAsStream(
+                "/com/shaft/infrastructure/lighthouse/package-lock.json")) {
+            if (input == null) throw new IOException("Missing bundled Lighthouse dependency lock.");
+            lock = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        Path contentRoot = paths.cacheRoot().resolve("npm/_cacache/content-v2/sha512");
+        VerifiedArtifactStore.requireUnlinkedAncestors(contentRoot);
+        var matcher = LOCK_INTEGRITY.matcher(lock);
+        int checked = 0;
+        while (matcher.find()) {
+            byte[] digest;
+            try {
+                digest = Base64.getDecoder().decode(matcher.group(1));
+            } catch (IllegalArgumentException malformed) {
+                throw new IOException("Bundled Lighthouse lock contains an invalid integrity value.", malformed);
+            }
+            String hex = HexFormat.of().formatHex(digest);
+            Path content = contentRoot.resolve(hex.substring(0, 2)).resolve(hex.substring(2, 4))
+                    .resolve(hex.substring(4));
+            VerifiedArtifactStore.requireUnlinkedAncestors(content);
+            if (!Files.isRegularFile(content, LinkOption.NOFOLLOW_LINKS)
+                    || !hex.equalsIgnoreCase(sha512(content))) {
+                throw new IOException("Lighthouse's transitive npm cache is incomplete for offline installation: "
+                        + content.getFileName());
+            }
+            checked++;
+        }
+        if (checked == 0) throw new IOException("Bundled Lighthouse lock contains no integrity-bound packages.");
+    }
+
+    private static String sha512(Path path) throws IOException {
+        try {
+            var digest = java.security.MessageDigest.getInstance("SHA-512");
+            try (InputStream input = Files.newInputStream(path)) {
+                byte[] buffer = new byte[64 * 1024];
+                for (int read; (read = input.read(buffer)) >= 0;) digest.update(buffer, 0, read);
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (java.security.NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException(impossible);
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan) {
+        if (plan.profile() != SetupProfile.LIGHTHOUSE) throw new IllegalArgumentException("Not a Lighthouse plan.");
+        if (plan.platform() != platform || plan.architecture() != architecture) {
+            throw new IllegalArgumentException("Plan platform does not match this host.");
+        }
+        if (plan.mode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External plans are diagnostic and cannot be installed.");
+        }
+        if (!LighthouseSetupPlanner.plan(platform, architecture, plan.mode()).equals(plan)) {
+            throw new IllegalArgumentException("Plan does not match the Lighthouse manifest shipped with this release.");
+        }
+    }
+
+    private void installLighthouse(SetupAction action) throws IOException {
+        if (probeLighthouse().readiness() == SetupReadiness.READY) return;
+        if (nodeService.nodeStatus().readiness() != SetupReadiness.READY) {
+            throw new IOException("Portable Node must be ready before Lighthouse installation.");
+        }
+        Path archive = fetcher.fetch(action);
+        Path destination = lighthouseRoot();
+        Files.createDirectories(destination.getParent());
+        Path staging = Files.createTempDirectory(destination.getParent(), "lighthouse.staging-");
+        try {
+            copyManifest(staging, action.dependencyLockChecksum());
+            Path log = logFile();
+            Files.createDirectories(log.getParent());
+            List<String> cache = new ArrayList<>(List.of(nodeExecutable().toString(), npmCli().toString(),
+                    "cache", "add", archive.toString()));
+            if (offline) cache.add("--offline");
+            requireSuccess(runner.run(cache, log, Duration.ofMinutes(2)), "Lighthouse cache preparation failed");
+            List<String> install = new ArrayList<>(List.of(nodeExecutable().toString(), npmCli().toString(), "ci",
+                    "--prefix", staging.toString(), "--ignore-scripts", "--no-audit", "--no-fund"));
+            if (offline) install.add("--offline");
+            requireSuccess(runner.run(install, log, Duration.ofMinutes(5)), "Lighthouse npm installation failed");
+            ReportingSetupService.ProcessResult verification = runner.run(List.of(nodeExecutable().toString(),
+                    lighthouseEntryPoint(staging).toString(), "--version"), log, Duration.ofSeconds(30));
+            requireSuccess(verification, "Lighthouse verification failed");
+            if (!LighthouseSetupPlanner.LIGHTHOUSE_VERSION.equals(verification.output().trim())) {
+                throw new IOException("Lighthouse verification returned unexpected version: "
+                        + verification.output().trim());
+            }
+            ReportingSetupService.publish(staging, destination, VerifiedArtifactStore::move);
+        } finally {
+            deleteTree(staging);
+        }
+    }
+
+    private SetupStatus probeLighthouse() {
+        Path entry = lighthouseEntryPoint(lighthouseRoot());
+        Path lock = lighthouseRoot().resolve("package-lock.json");
+        try {
+            VerifiedArtifactStore.requireUnlinkedAncestors(lighthouseRoot());
+            if (!Files.isRegularFile(entry, LinkOption.NOFOLLOW_LINKS)
+                    || !Files.isRegularFile(lock, LinkOption.NOFOLLOW_LINKS)) {
+                return new SetupStatus(SetupTarget.LIGHTHOUSE, SetupReadiness.MISSING, "", "Not installed.");
+            }
+            if (!VerifiedArtifactStore.digest(lock).equalsIgnoreCase(LighthouseSetupPlanner.LIGHTHOUSE_LOCK_SHA256)) {
+                return new SetupStatus(SetupTarget.LIGHTHOUSE, SetupReadiness.DEGRADED, "",
+                        "Managed dependency lock does not match this release.");
+            }
+            Path receiptPath = paths.receipts().resolve("lighthouse.json");
+            VerifiedArtifactStore.requireUnlinkedAncestors(receiptPath);
+            if (!Files.isRegularFile(receiptPath, LinkOption.NOFOLLOW_LINKS)) {
+                return new SetupStatus(SetupTarget.LIGHTHOUSE, SetupReadiness.DEGRADED, "",
+                        "Managed Lighthouse receipt is missing.");
+            }
+            SetupReceipt receipt = JSON.readValue(receiptPath.toFile(), SetupReceipt.class);
+            boolean matchesRelease = List.of(SetupMode.MANAGED, SetupMode.HYBRID).stream().anyMatch(mode -> {
+                SetupPlan expected = LighthouseSetupPlanner.plan(platform, architecture, mode);
+                return receipt.planDigest().equals(expected.digest())
+                        && receipt.completedActions().equals(expected.actions());
+            });
+            if (!matchesRelease) {
+                return new SetupStatus(SetupTarget.LIGHTHOUSE, SetupReadiness.DEGRADED, "",
+                        "Managed Lighthouse receipt does not match this release.");
+            }
+            ReportingSetupService.ProcessResult result = runner.run(List.of(nodeExecutable().toString(),
+                    entry.toString(), "--version"), null, Duration.ofSeconds(15));
+            String version = result.output().trim();
+            return result.exitCode() == 0 && version.equals(LighthouseSetupPlanner.LIGHTHOUSE_VERSION)
+                    ? new SetupStatus(SetupTarget.LIGHTHOUSE, SetupReadiness.READY, version,
+                    "Verified managed installation.")
+                    : new SetupStatus(SetupTarget.LIGHTHOUSE, SetupReadiness.DEGRADED, version,
+                    "Version or execution check failed.");
+        } catch (IOException failure) {
+            return new SetupStatus(SetupTarget.LIGHTHOUSE, SetupReadiness.DEGRADED, "", failure.getMessage());
+        }
+    }
+
+    private void copyManifest(Path staging, String expectedChecksum) throws IOException {
+        for (String name : List.of("package.json", "package-lock.json")) {
+            try (InputStream input = LighthouseSetupService.class.getResourceAsStream(
+                    "/com/shaft/infrastructure/lighthouse/" + name)) {
+                if (input == null) throw new IOException("Missing bundled Lighthouse manifest: " + name);
+                byte[] content = input.readAllBytes();
+                if (name.endsWith("lock.json")) content = new String(content, StandardCharsets.UTF_8)
+                        .replace("\r\n", "\n").replace('\r', '\n').getBytes(StandardCharsets.UTF_8);
+                Files.write(staging.resolve(name), content);
+            }
+        }
+        if (!("sha256:" + VerifiedArtifactStore.digest(staging.resolve("package-lock.json")))
+                .equalsIgnoreCase(expectedChecksum)) {
+            throw new IOException("Bundled Lighthouse dependency lock does not match the approved plan.");
+        }
+    }
+
+    private void requireSafePaths() throws IOException {
+        for (Path path : List.of(paths.cacheRoot(), paths.dataRoot(), paths.downloads(), paths.tools(),
+                paths.state(), paths.receipts(), nodeRoot(), nodeExecutable(), lighthouseRoot())) {
+            VerifiedArtifactStore.requireUnlinkedAncestors(path);
+        }
+    }
+
+    private void writeReceipt(SetupReceipt receipt) throws IOException {
+        VerifiedArtifactStore.requireUnlinkedAncestors(paths.receipts());
+        Files.createDirectories(paths.receipts());
+        Path temporary = Files.createTempFile(paths.receipts(), "lighthouse", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(receipt));
+            VerifiedArtifactStore.move(temporary, paths.receipts().resolve("lighthouse.json"));
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private Path lighthouseRoot() {
+        return paths.tools().resolve("lighthouse").resolve(LighthouseSetupPlanner.LIGHTHOUSE_VERSION);
+    }
+
+    private Path nodeRoot() {
+        return paths.tools().resolve("node").resolve(ReportingSetupPlanner.NODE_VERSION)
+                .resolve(platform.name().toLowerCase() + '-' + architecture.artifactName());
+    }
+
+    private Path nodeExecutable() {
+        return platform == SetupPlatform.WINDOWS ? nodeRoot().resolve("node.exe") : nodeRoot().resolve("bin/node");
+    }
+
+    private Path npmCli() {
+        return platform == SetupPlatform.WINDOWS ? nodeRoot().resolve("node_modules/npm/bin/npm-cli.js")
+                : nodeRoot().resolve("lib/node_modules/npm/bin/npm-cli.js");
+    }
+
+    private static Path lighthouseEntryPoint(Path root) {
+        return root.resolve("node_modules/lighthouse/cli/index.js");
+    }
+
+    private Path logFile() {
+        return paths.state().resolve("logs/lighthouse-install.log");
+    }
+
+    private static void requireSuccess(ReportingSetupService.ProcessResult result, String message) throws IOException {
+        if (result.exitCode() != 0) throw new IOException(message + System.lineSeparator() + result.output());
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (root == null || Files.notExists(root)) return;
+        try (var stream = Files.walk(root)) {
+            for (Path path : stream.sorted(java.util.Comparator.reverseOrder()).toList()) Files.deleteIfExists(path);
+        }
+    }
+
+    private static final class SetupOperationException extends RuntimeException {
+        private SetupOperationException(IOException cause) { super(cause); }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ManagedProcessRunner.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ManagedProcessRunner.java
@@ -1,0 +1,41 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+/** Bounded, argument-list child-process boundary shared by managed setup consumers. */
+public final class ManagedProcessRunner {
+    private ManagedProcessRunner() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Runs a child without a shell, bounds output/time, and reaps its owned process tree.
+     *
+     * @param command exact executable and argument list
+     * @param workingDirectory existing working directory for the child
+     * @param timeout total execution and output-drain timeout
+     * @return immutable exit code and bounded combined output
+     * @throws IOException when the child cannot start, exceeds a bound, or cannot be reaped
+     */
+    public static Result run(List<String> command, Path workingDirectory, Duration timeout) throws IOException {
+        Path directory = java.util.Objects.requireNonNull(workingDirectory, "workingDirectory")
+                .toAbsolutePath().normalize();
+        if (!java.nio.file.Files.isDirectory(directory)) {
+            throw new IOException("Managed process working directory does not exist: " + directory);
+        }
+        ReportingSetupService.ProcessResult result = ReportingSetupService.runProcess(
+                List.copyOf(command), null, timeout, directory, directory, directory);
+        return new Result(result.exitCode(), result.output());
+    }
+
+    /**
+     * Immutable exit code and bounded combined output.
+     *
+     * @param exitCode child exit code
+     * @param output bounded combined standard output and error
+     */
+    public record Result(int exitCode, String output) { }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupService.java
@@ -14,17 +14,22 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 /** Managed, release-pinned lifecycle for the REPORTING profile. */
 public final class ReportingSetupService {
     private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> NODE_LOCKS = new ConcurrentHashMap<>();
     private final ShaftCachePaths paths;
     private final SetupPlatform platform;
     private final SetupArchitecture architecture;
@@ -61,13 +66,48 @@ public final class ReportingSetupService {
     }
 
     public SetupProfileStatus status() {
-        SetupStatus node = probe(SetupTarget.NODE, nodeExecutable(), "v" + ReportingSetupPlanner.NODE_VERSION);
+        SetupStatus node = nodeStatus();
         SetupStatus allure = probe(SetupTarget.ALLURE, allureEntryPoint(), ReportingSetupPlanner.ALLURE_VERSION);
         SetupReadiness aggregate = node.readiness() == SetupReadiness.DEGRADED
                 || allure.readiness() == SetupReadiness.DEGRADED ? SetupReadiness.DEGRADED
                 : node.readiness() == SetupReadiness.READY && allure.readiness() == SetupReadiness.READY
                 ? SetupReadiness.READY : SetupReadiness.MISSING;
         return new SetupProfileStatus(1, SetupProfile.REPORTING, aggregate, List.of(node, allure));
+    }
+
+    SetupStatus nodeStatus() {
+        return probe(SetupTarget.NODE, nodeExecutable(), "v" + ReportingSetupPlanner.NODE_VERSION);
+    }
+
+    void installNodeAction(SetupAction action) throws IOException {
+        if (action.target() != SetupTarget.NODE) {
+            throw new IllegalArgumentException("Expected a portable Node action.");
+        }
+        VerifiedArtifactStore.requireUnlinkedAncestors(nodeRoot());
+        if (Files.isSymbolicLink(nodeExecutable())) {
+            throw new IOException("Managed portable Node executable must not be a symbolic link: " + nodeExecutable());
+        }
+        if (nodeStatus().readiness() == SetupReadiness.READY) return;
+        withNodeInstallLock(() -> installNode(artifactFetcher.fetch(action), action));
+    }
+
+    private void withNodeInstallLock(IoOperation operation) throws IOException {
+        Path lockPath = paths.state().resolve("node-install.lock").toAbsolutePath().normalize();
+        ReentrantLock jvmLock = NODE_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        try {
+            jvmLock.lockInterruptibly();
+            if (nodeStatus().readiness() == SetupReadiness.READY) return;
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                if (nodeStatus().readiness() != SetupReadiness.READY) operation.run();
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the portable Node setup lock.", interrupted);
+        } finally {
+            if (jvmLock.isHeldByCurrentThread()) jvmLock.unlock();
+        }
     }
 
     public SetupReceipt install(SetupPlan plan, SetupApproval approval) throws IOException {
@@ -109,7 +149,7 @@ public final class ReportingSetupService {
 
     private void install(SetupAction action) throws IOException {
         switch (action.target()) {
-            case NODE -> installNode(artifactFetcher.fetch(action), action);
+            case NODE -> installNodeAction(action);
             case ALLURE -> installAllure(artifactFetcher.fetch(action), action);
             default -> throw new IllegalArgumentException("Reporting provider cannot install " + action.target());
         }
@@ -122,9 +162,13 @@ public final class ReportingSetupService {
         try {
             if (archive.getFileName().toString().endsWith(".zip")) extractZip(archive, staging);
             else extractTar(archive, staging);
-            requireSuccessful(commandRunner.run(List.of(executable(staging, "node").toString(), "--version"),
-                    null, Duration.ofSeconds(30)),
-                    "Portable Node verification failed");
+            ProcessResult verification = commandRunner.run(List.of(executable(staging, "node").toString(),
+                    "--version"), null, Duration.ofSeconds(30));
+            requireSuccessful(verification, "Portable Node verification failed");
+            if (!("v" + action.version()).equals(verification.output().trim())) {
+                throw new IOException("Portable Node verification returned unexpected version: "
+                        + verification.output().trim());
+            }
             publish(staging, destination);
         } finally {
             deleteTree(staging);
@@ -161,8 +205,11 @@ public final class ReportingSetupService {
     }
 
     private SetupStatus probe(SetupTarget target, Path executable, String expectedVersion) {
-        if (!Files.isRegularFile(executable)) return new SetupStatus(target, SetupReadiness.MISSING, "", "Not installed.");
         try {
+            VerifiedArtifactStore.requireUnlinkedAncestors(executable);
+            if (!Files.isRegularFile(executable, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
+                return new SetupStatus(target, SetupReadiness.MISSING, "", "Not installed.");
+            }
             ProcessResult result = target == SetupTarget.NODE
                     ? commandRunner.run(List.of(executable.toString(), "--version"), null, Duration.ofSeconds(15))
                     : commandRunner.run(List.of(nodeExecutable().toString(), executable.toString(), "--version"), null,
@@ -183,29 +230,44 @@ public final class ReportingSetupService {
 
     static ProcessResult runProcess(List<String> command, Path log, Duration timeout,
                                     Path cacheRoot, Path nodeRoot) throws IOException {
+        return runProcess(command, log, timeout, cacheRoot, nodeRoot, null);
+    }
+
+    static ProcessResult runProcess(List<String> command, Path log, Duration timeout,
+                                    Path cacheRoot, Path nodeRoot, Path workingDirectory) throws IOException {
         ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
+        if (workingDirectory != null) builder.directory(workingDirectory.toFile());
         String nodeBin = Files.isRegularFile(nodeRoot.resolve("node.exe"))
                 ? nodeRoot.toString() : nodeRoot.resolve("bin").toString();
         builder.environment().put("PATH", nodeBin + java.io.File.pathSeparator
                 + builder.environment().getOrDefault("PATH", ""));
         builder.environment().put("npm_config_cache", cacheRoot.resolve("npm").toString());
         Process process = builder.start();
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
         InputStream input = process.getInputStream();
         var outputFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
             try (input) {
-                return input.readAllBytes();
+                return readBoundedOutput(input);
             } catch (IOException failure) {
                 throw new java.util.concurrent.CompletionException(failure);
             }
         });
+        Set<ObservedProcess> observedDescendants = ConcurrentHashMap.newKeySet();
         try {
-            if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
-                try {
-                    destroyProcessTree(process);
-                } finally {
-                    outputFuture.cancel(true);
+            boolean finished = false;
+            while (!finished) {
+                process.descendants().map(ObservedProcess::capture).forEach(observedDescendants::add);
+                long remaining = deadlineNanos - System.nanoTime();
+                if (remaining <= 0) {
+                    try {
+                        destroyProcessTree(process, observedDescendants);
+                    } finally {
+                        outputFuture.cancel(true);
+                    }
+                    throw new IOException("Process timed out: " + command.getFirst());
                 }
-                throw new IOException("Process timed out: " + command.getFirst());
+                finished = process.waitFor(Math.min(remaining, TimeUnit.MILLISECONDS.toNanos(2)),
+                        TimeUnit.NANOSECONDS);
             }
         } catch (InterruptedException interrupted) {
             try {
@@ -218,19 +280,63 @@ public final class ReportingSetupService {
         }
         String output;
         try {
-            output = new String(outputFuture.join(), java.nio.charset.StandardCharsets.UTF_8);
-        } catch (java.util.concurrent.CompletionException failure) {
-            if (failure.getCause() instanceof IOException io) throw io;
-            throw failure;
+            long remaining = deadlineNanos - System.nanoTime();
+            if (remaining <= 0) throw new java.util.concurrent.TimeoutException();
+            output = new String(outputFuture.get(remaining, TimeUnit.NANOSECONDS),
+                    java.nio.charset.StandardCharsets.UTF_8);
+        } catch (java.util.concurrent.TimeoutException timeoutFailure) {
+            try {
+                destroyProcessTree(process, observedDescendants);
+            } finally {
+                outputFuture.cancel(true);
+            }
+            throw new IOException("Process output did not close before the timeout: " + command.getFirst(),
+                    timeoutFailure);
+        } catch (InterruptedException interrupted) {
+            try {
+                destroyProcessTree(process, observedDescendants);
+            } finally {
+                outputFuture.cancel(true);
+                Thread.currentThread().interrupt();
+            }
+            throw new IOException("Interrupted while reading setup process output.", interrupted);
+        } catch (java.util.concurrent.ExecutionException failure) {
+            IOException outputFailure = failure.getCause() instanceof IOException io
+                    ? io : new IOException("Unable to read setup process output.", failure.getCause());
+            try {
+                destroyProcessTree(process, observedDescendants);
+            } catch (IOException cleanupFailure) {
+                outputFailure.addSuppressed(cleanupFailure);
+            } finally {
+                outputFuture.cancel(true);
+            }
+            throw outputFailure;
         }
+        destroyProcessTree(process, observedDescendants);
         if (log != null) Files.writeString(log, output, java.nio.charset.StandardCharsets.UTF_8,
                 StandardOpenOption.CREATE, StandardOpenOption.APPEND);
         return new ProcessResult(process.exitValue(), output);
     }
 
-    private static void waitForTermination(Process process) throws IOException {
+    private static byte[] readBoundedOutput(InputStream input) throws IOException {
+        int maximum = 1024 * 1024;
+        var output = new java.io.ByteArrayOutputStream(Math.min(maximum, 64 * 1024));
+        byte[] buffer = new byte[16 * 1024];
+        int total = 0;
+        for (int read; (read = input.read(buffer)) >= 0;) {
+            total += read;
+            if (total > maximum) {
+                throw new IOException("Setup process output exceeded the 1 MiB safety limit.");
+            }
+            output.write(buffer, 0, read);
+        }
+        return output.toByteArray();
+    }
+
+    private static void waitForTermination(Process process, long deadlineNanos) throws IOException {
         try {
-            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+            long remaining = deadlineNanos - System.nanoTime();
+            if (remaining <= 0 || !process.waitFor(remaining, TimeUnit.NANOSECONDS)) {
                 throw new IOException("Setup process did not terminate after forced destruction.");
             }
         } catch (InterruptedException interrupted) {
@@ -240,15 +346,25 @@ public final class ReportingSetupService {
     }
 
     private static void destroyProcessTree(Process process) throws IOException {
-        List<ProcessHandle> descendants = process.descendants().toList().reversed();
+        destroyProcessTree(process, Set.of());
+    }
+
+    private static void destroyProcessTree(Process process, Set<ObservedProcess> observed) throws IOException {
+        long deadlineNanos = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        var current = process.descendants().collect(java.util.stream.Collectors.toSet());
+        var known = new java.util.LinkedHashSet<>(current);
+        observed.stream().filter(ObservedProcess::stillMatches).map(ObservedProcess::handle).forEach(known::add);
+        List<ProcessHandle> descendants = known.stream().toList().reversed();
         descendants.forEach(handle -> {
             if (handle.isAlive()) handle.destroyForcibly();
         });
         process.destroyForcibly();
-        waitForTermination(process);
+        waitForTermination(process, deadlineNanos);
         for (ProcessHandle descendant : descendants) {
             try {
-                descendant.onExit().get(10, TimeUnit.SECONDS);
+                long remaining = deadlineNanos - System.nanoTime();
+                if (remaining <= 0) throw new java.util.concurrent.TimeoutException();
+                descendant.onExit().get(remaining, TimeUnit.NANOSECONDS);
             } catch (java.util.concurrent.TimeoutException timeout) {
                 throw new IOException("Setup descendant process did not terminate: " + descendant.pid(), timeout);
             } catch (java.util.concurrent.ExecutionException failure) {
@@ -257,6 +373,16 @@ public final class ReportingSetupService {
                 Thread.currentThread().interrupt();
                 throw new IOException("Interrupted while waiting for setup descendant termination.", interrupted);
             }
+        }
+    }
+
+    private record ObservedProcess(ProcessHandle handle, Optional<Instant> started) {
+        private static ObservedProcess capture(ProcessHandle handle) {
+            return new ObservedProcess(handle, handle.info().startInstant());
+        }
+
+        private boolean stillMatches() {
+            return handle.isAlive() && started.isPresent() && started.equals(handle.info().startInstant());
         }
     }
 
@@ -327,23 +453,8 @@ public final class ReportingSetupService {
     }
 
     static void publish(Path staging, Path destination, MoveOperation mover) throws IOException {
-        Path quarantine = null;
-        if (Files.exists(destination)) {
-            quarantine = destination.resolveSibling(destination.getFileName() + ".quarantine-" + System.nanoTime());
-            mover.move(destination, quarantine);
-        }
-        try {
-            mover.move(staging, destination);
-        } catch (IOException publishFailure) {
-            if (quarantine != null && Files.exists(quarantine) && Files.notExists(destination)) {
-                try {
-                    mover.move(quarantine, destination);
-                } catch (IOException restoreFailure) {
-                    publishFailure.addSuppressed(restoreFailure);
-                }
-            }
-            throw publishFailure;
-        }
+        Path quarantine = destination.resolveSibling(destination.getFileName() + ".quarantine");
+        VerifiedArtifactStore.replaceWithRollback(staging, destination, quarantine, mover::move);
     }
 
     private static void extractZip(Path archive, Path destination) throws IOException {
@@ -413,6 +524,8 @@ public final class ReportingSetupService {
 
     @FunctionalInterface
     interface ArtifactFetcher { Path fetch(SetupAction action) throws IOException; }
+    @FunctionalInterface
+    private interface IoOperation { void run() throws IOException; }
     @FunctionalInterface
     interface MoveOperation { void move(Path source, Path destination) throws IOException; }
     @FunctionalInterface

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupOptions.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupOptions.java
@@ -38,6 +38,17 @@ public record SetupOptions(SetupProfile profile, SetupMode mode, ShaftCachePaths
                 startupTimeout, shutdownTimeout, remoteEndpoint);
     }
 
+    /**
+     * Reuses the same execution policy and owned paths for another setup profile.
+     *
+     * @param value replacement profile
+     * @return a copy with the selected profile
+     */
+    public SetupOptions withProfile(SetupProfile value) {
+        return new SetupOptions(Objects.requireNonNull(value, "value"), mode, paths, offline, autoStart,
+                preferSystemTools, reuseOwnedProcesses, startupTimeout, shutdownTimeout, remoteEndpoint);
+    }
+
     public SetupOptions withOffline(boolean value) {
         return copy(mode, value, autoStart, preferSystemTools, reuseOwnedProcesses,
                 startupTimeout, shutdownTimeout, remoteEndpoint);

--- a/shaft-infrastructure/src/main/resources/com/shaft/infrastructure/lighthouse/package-lock.json
+++ b/shaft-infrastructure/src/main/resources/com/shaft/infrastructure/lighthouse/package-lock.json
@@ -1,0 +1,1396 @@
+{
+  "name": "shaft-lighthouse-runtime",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "shaft-lighthouse-runtime",
+      "version": "1.0.0",
+      "dependencies": {
+        "lighthouse": "13.4.1"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
+      "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.1",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@paulirish/trace_engine": {
+      "version": "0.0.65",
+      "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.65.tgz",
+      "integrity": "sha512-Qsm6F5C8xf6ZzQXbQc2+wcpe6sggfs/gvc/ytqSurdvYg3kyW0ECHCqE0CWBKZpqgjVfPNX9c7SCS3r2nEIRGg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "legacy-javascript": "latest",
+        "third-party-web": "latest"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.0.tgz",
+      "integrity": "sha512-LlBrE8oqGfU7b1Nk2d5Q1SbuPhZxTj0cJEMDPEws28OjNMELlflekmPPuf4FnK03x0ZRjKaYwJElUcKK4kyqJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.8.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/@puppeteer/browsers/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+      "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.70.0.tgz",
+      "integrity": "sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/node-core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "@sentry/server-utils": "10.70.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.70.0.tgz",
+      "integrity": "sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.70.0.tgz",
+      "integrity": "sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.70.0.tgz",
+      "integrity": "sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "meriyah": "^6.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chrome-launcher": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+      "integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/configstore": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+      "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "atomically": "^2.0.3",
+        "dot-prop": "^9.0.0",
+        "graceful-fs": "^4.2.11",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/csp_evaluator": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.8.tgz",
+      "integrity": "sha512-EwOnfYuNbTytvbMKsLixTrRgnjOa0WZCxGy8A9nnSYAicrdwn+T/epU/yjgymmOxlgKnvH+8wXt+7p/8ak5Feg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1663043",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1663043.tgz",
+      "integrity": "sha512-33aOY3ZnBP1dgZsshgaL+/XlsQleiFZgyUaDtdZkEa1nbZhVY1MoDeWjk+wxg25fU924l1ZJfoGNmjjeA/5s1w==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/http-link-header": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.4.tgz",
+      "integrity": "sha512-xT3GPW6/ZbGuw4UvwHqErSCEjNUlwbQJuZn9/q5U4WEKfp2kENVCAlousG1zLxHeaQ/ffOHUNpWamvkbBW0eNw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/image-ssim": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==",
+      "license": "MIT"
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-library-detector": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.7.0.tgz",
+      "integrity": "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/legacy-javascript": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
+      "integrity": "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lighthouse": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-13.4.1.tgz",
+      "integrity": "sha512-fDu8lt3QLK/lTqIxtp1HkzQNJ32rsFHhbadYOepcMZFLgA8oINhxutMbMv8XXnpTOvZ0TXCo4JCk1LDTWaRLnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@paulirish/trace_engine": "0.0.65",
+        "@sentry/node": "^10.0.0",
+        "axe-core": "^4.12.1",
+        "chrome-launcher": "^1.2.1",
+        "configstore": "^7.0.0",
+        "csp_evaluator": "1.1.8",
+        "devtools-protocol": "0.0.1663043",
+        "enquirer": "^2.3.6",
+        "http-link-header": "^1.1.1",
+        "intl-messageformat": "^10.5.3",
+        "jpeg-js": "^0.4.4",
+        "js-library-detector": "^6.7.0",
+        "lighthouse-logger": "^2.0.2",
+        "lighthouse-stack-packs": "1.12.3",
+        "lodash-es": "^4.17.21",
+        "lookup-closest-locale": "6.2.0",
+        "open": "^8.4.0",
+        "puppeteer-core": "^25.3.0",
+        "robots-parser": "^3.0.1",
+        "speedline-core": "^1.4.3",
+        "third-party-web": "^0.29.2",
+        "tldts-icann": "^7.4.9",
+        "web-features": "^3.34.0",
+        "ws": "^7.0.0",
+        "yargs": "^17.3.1",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "chrome-debug": "core/scripts/manual-chrome-launcher.js",
+        "lighthouse": "cli/index.js",
+        "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
+      },
+      "engines": {
+        "node": ">=22.19"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-stack-packs": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.3.tgz",
+      "integrity": "sha512-d8IsOpE83kbANgnM+Tp8+x6HcMpX9o2ITBiUERssgzAIFdZCQzs/f4k6D0DLQTE59enml9mbAOU52Wu35exWtg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lookup-closest-locale": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
+      "integrity": "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.6.0.tgz",
+      "integrity": "sha512-GJ67rjZdVQzZmD2Ab0cgttfQN9j387QYMv3t6MN3/4nmjursNt6M5Utj4/T/4y0AwNrSwJzjw6Q/zuWFEIizOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.2.0",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1653615",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
+      "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/robots-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/speedline-core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz",
+      "integrity": "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "image-ssim": "^0.2.0",
+        "jpeg-js": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "license": "MIT"
+    },
+    "node_modules/third-party-web": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.29.2.tgz",
+      "integrity": "sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==",
+      "license": "MIT"
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "license": "MIT"
+    },
+    "node_modules/tldts-icann": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.4.10.tgz",
+      "integrity": "sha512-JrzJnTNDURpnyPCf/b0bq/mAiQhPcNwkwpfO67M0nECzVzSIuCFN+EYjqnEjnmO60nPRabS3zIFChbwPp/Q+Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-features": {
+      "version": "3.34.3",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.34.3.tgz",
+      "integrity": "sha512-eXdaGO8JSiLLC5/tLOeDiH0EVIbuD8NExMDAziU0frr9JRdiEKqyOsTeEZDtmCXbazEI3mB+plYO4oMYOj1/Dg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/shaft-infrastructure/src/main/resources/com/shaft/infrastructure/lighthouse/package.json
+++ b/shaft-infrastructure/src/main/resources/com/shaft/infrastructure/lighthouse/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shaft-lighthouse-runtime",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "lighthouse": "13.4.1"
+  }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/InfrastructureSetupServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/InfrastructureSetupServiceTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -60,6 +62,57 @@ class InfrastructureSetupServiceTest {
         assertEquals(SetupReadiness.MISSING, report.readiness());
         assertEquals(List.of(SetupTarget.NODE, SetupTarget.ALLURE), report.targets().stream()
                 .map(SetupStatus::target).toList());
+    }
+
+    @Test
+    void builtInCoordinatorProvidesReadOnlyLighthouseStatusAndManagedPlan(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+
+        SetupReport report = service.status(SetupOptions.defaults(SetupProfile.LIGHTHOUSE, paths));
+        SetupPlan plan = service.plan(SetupOptions.defaults(SetupProfile.LIGHTHOUSE, paths)
+                .withMode(SetupMode.MANAGED));
+
+        assertEquals(SetupProfile.LIGHTHOUSE, report.profile());
+        assertEquals(SetupReadiness.MISSING, report.readiness());
+        assertEquals(List.of(SetupTarget.NODE, SetupTarget.LIGHTHOUSE), report.targets().stream()
+                .map(SetupStatus::target).toList());
+        assertEquals(SetupProfile.LIGHTHOUSE, plan.profile());
+        assertEquals(List.of(SetupTarget.NODE, SetupTarget.LIGHTHOUSE), plan.actions().stream()
+                .map(SetupAction::target).toList());
+        SetupAction lighthouse = plan.actions().get(1);
+        assertEquals(SetupActionKind.INSTALL, lighthouse.kind());
+        assertEquals("13.4.1", lighthouse.version());
+        assertEquals(URI.create("https://registry.npmjs.org/lighthouse/-/lighthouse-13.4.1.tgz"),
+                lighthouse.source());
+        assertEquals("sha256:110759ba9e863c024e214e9b08ed2b0344d89b492286227235d4dfb990dc3e54",
+                lighthouse.checksum());
+        assertEquals("sha256:5691359da63475578daef5b322a620311110ff6a09953cdb898bee314106c4dd",
+                lighthouse.dependencyLockChecksum());
+        assertTrue(lighthouse.requiredLicenses().isEmpty());
+        assertTrue(Files.notExists(paths.cacheRoot()));
+        assertTrue(Files.notExists(paths.dataRoot()));
+    }
+
+    @Test
+    void bundledLighthouseManifestMatchesTheApprovedLock() throws Exception {
+        byte[] packageJson;
+        byte[] lock;
+        try (var packageInput = InfrastructureSetupServiceTest.class.getResourceAsStream(
+                "/com/shaft/infrastructure/lighthouse/package.json");
+             var lockInput = InfrastructureSetupServiceTest.class.getResourceAsStream(
+                     "/com/shaft/infrastructure/lighthouse/package-lock.json")) {
+            packageJson = java.util.Objects.requireNonNull(packageInput).readAllBytes();
+            lock = java.util.Objects.requireNonNull(lockInput).readAllBytes();
+        }
+        String canonical = new String(lock, StandardCharsets.UTF_8).replace("\r\n", "\n").replace('\r', '\n');
+
+        assertTrue(new String(packageJson, StandardCharsets.UTF_8).contains("\"lighthouse\": \"13.4.1\""));
+        assertTrue(canonical.contains("\"lighthouse\": \"13.4.1\""));
+        var digest = java.security.MessageDigest.getInstance("SHA-256")
+                .digest(canonical.getBytes(StandardCharsets.UTF_8));
+        assertEquals(LighthouseSetupPlanner.LIGHTHOUSE_LOCK_SHA256, java.util.HexFormat.of().formatHex(digest));
     }
 
     @Test

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/LighthouseSetupProviderTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/LighthouseSetupProviderTest.java
@@ -1,0 +1,318 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LighthouseSetupProviderTest {
+    @Test
+    void externalStatusNeverExecutesInstalledManagedTools(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        Path node = paths.tools().resolve("node/24.19.0/windows-x64/node.exe");
+        Path lighthouse = paths.tools().resolve("lighthouse/13.4.1/node_modules/lighthouse/cli/index.js");
+        Files.createDirectories(node.getParent());
+        Files.createDirectories(lighthouse.getParent());
+        if (SetupPlatform.current() == SetupPlatform.WINDOWS) {
+            Files.copy(Path.of(System.getenv("SystemRoot"), "System32", "where.exe"), node);
+        } else {
+            Files.writeString(node, "#!/bin/sh\nexit 7\n");
+            assertTrue(node.toFile().setExecutable(true));
+        }
+        Files.writeString(lighthouse, "installed lighthouse");
+        LighthouseSetupProvider provider = new LighthouseSetupProvider();
+        SetupOptions options = SetupOptions.defaults(SetupProfile.LIGHTHOUSE, paths);
+
+        SetupReport report = provider.status(options, SetupPlatform.WINDOWS, SetupArchitecture.X64);
+
+        assertEquals(SetupReadiness.MISSING, report.readiness());
+        assertTrue(report.targets().stream().allMatch(target -> target.readiness() == SetupReadiness.MISSING));
+    }
+
+    @Test
+    void offlineCacheMissIsRejectedBeforeAnySetupMutation(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        LighthouseSetupService service = new LighthouseSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, action -> { throw new IOException("offline miss"); },
+                (command, log, timeout) -> { throw new AssertionError("No process may start."); }, true);
+        SetupPlan plan = LighthouseSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+
+        IOException failure = assertThrows(IOException.class, () -> service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of())));
+
+        assertTrue(failure.getMessage().contains("offline miss"));
+        assertFalse(Files.exists(paths.cacheRoot()));
+        assertFalse(Files.exists(paths.dataRoot()));
+        assertFalse(Files.exists(paths.downloads()));
+        assertFalse(Files.exists(paths.tools()));
+        assertFalse(Files.exists(paths.state()));
+        assertFalse(Files.exists(paths.receipts()));
+    }
+
+    @Test
+    void incompleteTransitiveOfflineCacheIsRejectedBeforeProcessesOrMutation(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        Path nodeArchive = ReportingSetupServiceTest.createNodeZip(temp.resolve("node.zip"));
+        Path lighthouseArchive = Files.writeString(temp.resolve("lighthouse.tgz"), "lighthouse");
+        LighthouseSetupService service = new LighthouseSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64,
+                action -> action.target() == SetupTarget.NODE ? nodeArchive : lighthouseArchive,
+                (command, log, timeout) -> { throw new AssertionError("No process may start before offline preflight."); },
+                true);
+        SetupPlan plan = LighthouseSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+
+        IOException failure = assertThrows(IOException.class, () -> service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of())));
+
+        assertTrue(failure.getMessage().contains("transitive npm cache is incomplete"));
+        assertFalse(Files.exists(paths.cacheRoot()));
+        assertFalse(Files.exists(paths.dataRoot()));
+        assertFalse(Files.exists(paths.tools()));
+        assertFalse(Files.exists(paths.state()));
+        assertFalse(Files.exists(paths.receipts()));
+    }
+
+    @Test
+    void installedNodeDoesNotExecuteBeforeOfflineTransitiveCachePreflight(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        Path node = paths.tools().resolve("node/24.19.0/windows-x64/node.exe");
+        Files.createDirectories(node.getParent());
+        Files.writeString(node, "structurally installed node");
+        Path lighthouseArchive = Files.writeString(temp.resolve("lighthouse.tgz"), "lighthouse");
+        LighthouseSetupService service = new LighthouseSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, action -> {
+                    if (action.target() == SetupTarget.NODE) throw new AssertionError("Installed Node must not refetch.");
+                    return lighthouseArchive;
+                }, (command, log, timeout) -> { throw new AssertionError("No executable probe before offline cache proof."); },
+                true);
+        SetupPlan plan = LighthouseSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+
+        IOException failure = assertThrows(IOException.class, () -> service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of())));
+
+        assertTrue(failure.getMessage().contains("transitive npm cache is incomplete"));
+        assertFalse(Files.exists(paths.state()));
+        assertFalse(Files.exists(paths.receipts()));
+    }
+
+    @Test
+    void installsAndExactlyVerifiesTheApprovedToolchain(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        Path nodeArchive = ReportingSetupServiceTest.createNodeZip(temp.resolve("node.zip"));
+        Path lighthouseArchive = Files.writeString(temp.resolve("lighthouse.tgz"), "lighthouse");
+        AtomicBoolean lighthouseHealthy = new AtomicBoolean(true);
+        LighthouseSetupService service = new LighthouseSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64,
+                action -> action.target() == SetupTarget.NODE ? nodeArchive : lighthouseArchive,
+                (command, log, timeout) -> {
+                    int prefix = command.indexOf("--prefix");
+                    if (command.contains("ci") && prefix >= 0) {
+                        Path entry = Path.of(command.get(prefix + 1))
+                                .resolve("node_modules/lighthouse/cli/index.js");
+                        Files.createDirectories(entry.getParent());
+                        Files.writeString(entry, "lighthouse");
+                    }
+                    return new ReportingSetupService.ProcessResult(0,
+                            command.stream().anyMatch(part -> part.endsWith("index.js"))
+                                    ? lighthouseHealthy.get() ? "13.4.1" : "13.4.0"
+                                    : "v24.19.0");
+                }, false);
+        SetupPlan plan = LighthouseSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+
+        SetupReceipt receipt = service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()));
+
+        assertEquals(plan.actions(), receipt.completedActions());
+        assertEquals(SetupReadiness.READY, service.status().readiness());
+        assertTrue(Files.isRegularFile(paths.receipts().resolve("lighthouse.json")));
+
+        lighthouseHealthy.set(false);
+        assertEquals(SetupReadiness.DEGRADED, service.status().readiness());
+    }
+
+    @Test
+    void failedLighthouseActionPreservesNodeAndRetryCompletes(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        Path nodeArchive = ReportingSetupServiceTest.createNodeZip(temp.resolve("node.zip"));
+        Path lighthouseArchive = Files.writeString(temp.resolve("lighthouse.tgz"), "lighthouse");
+        AtomicBoolean failInstall = new AtomicBoolean(true);
+        LighthouseSetupService service = new LighthouseSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64,
+                action -> action.target() == SetupTarget.NODE ? nodeArchive : lighthouseArchive,
+                (command, log, timeout) -> {
+                    int prefix = command.indexOf("--prefix");
+                    if (command.contains("ci") && failInstall.getAndSet(false)) {
+                        return new ReportingSetupService.ProcessResult(9, "npm failed");
+                    }
+                    if (command.contains("ci") && prefix >= 0) {
+                        Path entry = Path.of(command.get(prefix + 1))
+                                .resolve("node_modules/lighthouse/cli/index.js");
+                        Files.createDirectories(entry.getParent());
+                        Files.writeString(entry, "lighthouse");
+                    }
+                    return new ReportingSetupService.ProcessResult(0,
+                            command.stream().anyMatch(part -> part.endsWith("index.js")) ? "13.4.1" : "v24.19.0");
+                }, false);
+        SetupPlan plan = LighthouseSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+
+        SetupExecutionException failure = assertThrows(SetupExecutionException.class,
+                () -> service.install(plan, approval));
+
+        assertEquals(SetupTarget.LIGHTHOUSE, failure.failedAction().target());
+        assertEquals(List.of(plan.actions().getFirst()), failure.partialReceipt().completedActions());
+        assertFalse(Files.exists(paths.receipts().resolve("lighthouse.json")));
+
+        SetupReceipt receipt = service.install(plan, approval);
+        assertEquals(plan.actions(), receipt.completedActions());
+        assertEquals(SetupReadiness.READY, service.status().readiness());
+    }
+
+    @Test
+    void wrongVersionNeverPublishesOrReceiptsLighthouse(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        Path nodeArchive = ReportingSetupServiceTest.createNodeZip(temp.resolve("node.zip"));
+        Path lighthouseArchive = Files.writeString(temp.resolve("lighthouse.tgz"), "lighthouse");
+        LighthouseSetupService service = new LighthouseSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64,
+                action -> action.target() == SetupTarget.NODE ? nodeArchive : lighthouseArchive,
+                (command, log, timeout) -> {
+                    int prefix = command.indexOf("--prefix");
+                    if (command.contains("ci") && prefix >= 0) {
+                        Path entry = Path.of(command.get(prefix + 1)).resolve("node_modules/lighthouse/cli/index.js");
+                        Files.createDirectories(entry.getParent());
+                        Files.writeString(entry, "wrong lighthouse");
+                    }
+                    return new ReportingSetupService.ProcessResult(0,
+                            command.stream().anyMatch(part -> part.endsWith("index.js")) ? "13.4.0" : "v24.19.0");
+                }, false);
+        SetupPlan plan = LighthouseSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+
+        SetupExecutionException failure = assertThrows(SetupExecutionException.class, () -> service.install(plan,
+                new SetupApproval(plan.digest(), Instant.EPOCH, Set.of())));
+
+        assertEquals(SetupTarget.LIGHTHOUSE, failure.failedAction().target());
+        assertFalse(Files.exists(paths.tools().resolve("lighthouse/13.4.1")));
+        assertFalse(Files.exists(paths.receipts().resolve("lighthouse.json")));
+    }
+
+    @Test
+    void hybridInstallImmediatelyVerifiesReady(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        Path nodeArchive = ReportingSetupServiceTest.createNodeZip(temp.resolve("node.zip"));
+        Path lighthouseArchive = Files.writeString(temp.resolve("lighthouse.tgz"), "lighthouse");
+        LighthouseSetupService service = new LighthouseSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, action -> action.target() == SetupTarget.NODE ? nodeArchive : lighthouseArchive,
+                (command, log, timeout) -> {
+                    int prefix = command.indexOf("--prefix");
+                    if (command.contains("ci") && prefix >= 0) {
+                        Path entry = Path.of(command.get(prefix + 1)).resolve("node_modules/lighthouse/cli/index.js");
+                        Files.createDirectories(entry.getParent());
+                        Files.writeString(entry, "lighthouse");
+                    }
+                    return new ReportingSetupService.ProcessResult(0,
+                            command.stream().anyMatch(part -> part.endsWith("index.js")) ? "13.4.1" : "v24.19.0");
+                }, false);
+        SetupPlan plan = LighthouseSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64, SetupMode.HYBRID);
+
+        service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()));
+
+        assertEquals(SetupReadiness.READY, service.status().readiness());
+    }
+
+    @Test
+    void readyInstallIsReusableOfflineAfterDownloadCacheEviction(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        Path nodeArchive = ReportingSetupServiceTest.createNodeZip(temp.resolve("node.zip"));
+        Path lighthouseArchive = Files.writeString(temp.resolve("lighthouse.tgz"), "lighthouse");
+        ReportingSetupService.CommandRunner runner = (command, log, timeout) -> {
+            int prefix = command.indexOf("--prefix");
+            if (command.contains("ci") && prefix >= 0) {
+                Path entry = Path.of(command.get(prefix + 1)).resolve("node_modules/lighthouse/cli/index.js");
+                Files.createDirectories(entry.getParent());
+                Files.writeString(entry, "lighthouse");
+            }
+            return new ReportingSetupService.ProcessResult(0,
+                    command.stream().anyMatch(part -> part.endsWith("index.js")) ? "13.4.1" : "v24.19.0");
+        };
+        SetupPlan plan = LighthouseSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+        new LighthouseSetupService(paths, SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                action -> action.target() == SetupTarget.NODE ? nodeArchive : lighthouseArchive,
+                runner, false).install(plan, approval);
+
+        LighthouseSetupService offline = new LighthouseSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, action -> { throw new AssertionError("Ready tools must not refetch artifacts."); },
+                runner, true);
+
+        assertEquals(plan.actions(), offline.install(plan, approval).completedActions());
+        assertEquals(SetupReadiness.READY, offline.status().readiness());
+    }
+
+    @Test
+    void concurrentProviderInstancesConvergeWithoutOverlappingFileLocks(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        Path nodeArchive = ReportingSetupServiceTest.createNodeZip(temp.resolve("node.zip"));
+        Path lighthouseArchive = Files.writeString(temp.resolve("lighthouse.tgz"), "lighthouse");
+        ReportingSetupService.ArtifactFetcher fetcher = action ->
+                action.target() == SetupTarget.NODE ? nodeArchive : lighthouseArchive;
+        ReportingSetupService.CommandRunner runner = (command, log, timeout) -> {
+            int prefix = command.indexOf("--prefix");
+            if (command.contains("ci") && prefix >= 0) {
+                Path entry = Path.of(command.get(prefix + 1)).resolve("node_modules/lighthouse/cli/index.js");
+                Files.createDirectories(entry.getParent());
+                Files.writeString(entry, "lighthouse");
+            }
+            return new ReportingSetupService.ProcessResult(0,
+                    command.stream().anyMatch(part -> part.endsWith("index.js")) ? "13.4.1" : "v24.19.0");
+        };
+        LighthouseSetupService first = new LighthouseSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, fetcher, runner, false);
+        LighthouseSetupService second = new LighthouseSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, fetcher, runner, false);
+        SetupPlan plan = LighthouseSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+        CountDownLatch start = new CountDownLatch(1);
+        var executor = Executors.newFixedThreadPool(2);
+        try {
+            var one = executor.submit(() -> { start.await(); return first.install(plan, approval); });
+            var two = executor.submit(() -> { start.await(); return second.install(plan, approval); });
+            start.countDown();
+
+            assertEquals(plan.actions(), one.get(30, TimeUnit.SECONDS).completedActions());
+            assertEquals(plan.actions(), two.get(30, TimeUnit.SECONDS).completedActions());
+            assertEquals(SetupReadiness.READY, first.status().readiness());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static ShaftCachePaths paths(Path temp) {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        return new ShaftCachePaths(cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts"));
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/ReportingSetupServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/ReportingSetupServiceTest.java
@@ -197,6 +197,85 @@ class ReportingSetupServiceTest {
     }
 
     @Test
+    void portableNodeOwnerSerializesAcrossProviderInstances(@TempDir Path temp) throws Exception {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        Path nodeArchive = createNodeZip(temp.resolve("node.zip"));
+        java.util.concurrent.atomic.AtomicInteger fetches = new java.util.concurrent.atomic.AtomicInteger();
+        ReportingSetupService.ArtifactFetcher fetcher = action -> {
+            fetches.incrementAndGet();
+            return nodeArchive;
+        };
+        ReportingSetupService.CommandRunner runner = (command, log, timeout) ->
+                new ReportingSetupService.ProcessResult(0, "v24.19.0");
+        ReportingSetupService first = new ReportingSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, fetcher, runner, false);
+        ReportingSetupService second = new ReportingSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, fetcher, runner, false);
+        SetupAction node = ReportingSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED).actions().getFirst();
+        var start = new java.util.concurrent.CountDownLatch(1);
+        var pool = java.util.concurrent.Executors.newFixedThreadPool(2);
+        try {
+            var one = pool.submit(() -> { start.await(); first.installNodeAction(node); return null; });
+            var two = pool.submit(() -> { start.await(); second.installNodeAction(node); return null; });
+            start.countDown();
+            one.get(30, java.util.concurrent.TimeUnit.SECONDS);
+            two.get(30, java.util.concurrent.TimeUnit.SECONDS);
+        } finally {
+            pool.shutdownNow();
+        }
+        assertEquals(1, fetches.get());
+        assertEquals(SetupReadiness.READY, first.nodeStatus().readiness());
+    }
+
+    @Test
+    void wrongNodeVersionIsNeverPublished(@TempDir Path temp) throws Exception {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        Path archive = createNodeZip(temp.resolve("node.zip"));
+        ReportingSetupService service = new ReportingSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, action -> archive,
+                (command, log, timeout) -> new ReportingSetupService.ProcessResult(0, "v24.19.1"), false);
+        SetupAction node = ReportingSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED).actions().getFirst();
+
+        IOException failure = assertThrows(IOException.class, () -> service.installNodeAction(node));
+
+        assertTrue(failure.getMessage().contains("unexpected version"));
+        assertTrue(Files.notExists(paths.tools().resolve("node/24.19.0/windows-x64")));
+    }
+
+    @Test
+    void linkedNodeExecutableIsNeverAcceptedAsManaged(@TempDir Path temp) throws Exception {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        Path root = paths.tools().resolve("node/24.19.0/windows-x64");
+        Files.createDirectories(root);
+        Path external = Files.writeString(temp.resolve("external-node.exe"), "external");
+        try {
+            Files.createSymbolicLink(root.resolve("node.exe"), external);
+        } catch (UnsupportedOperationException | IOException unsupported) {
+            org.junit.jupiter.api.Assumptions.abort("Symbolic links unavailable: " + unsupported.getMessage());
+        }
+        ReportingSetupService service = new ReportingSetupService(paths, SetupPlatform.WINDOWS,
+                SetupArchitecture.X64, action -> { throw new AssertionError("Linked Node must not be reused."); },
+                (command, log, timeout) -> { throw new AssertionError("Linked Node must not execute."); }, false);
+
+        assertEquals(SetupReadiness.DEGRADED, service.nodeStatus().readiness());
+        assertThrows(IOException.class, () -> service.installNodeAction(
+                ReportingSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                        SetupMode.MANAGED).actions().getFirst()));
+        assertEquals("external", Files.readString(external));
+    }
+
+    @Test
     void realChildProcessIsKilledAndReapedOnTimeout(@TempDir Path temp) {
         Set<Long> before = ProcessHandle.allProcesses().filter(ProcessHandle::isAlive)
                 .map(ProcessHandle::pid).collect(java.util.stream.Collectors.toSet());
@@ -211,6 +290,63 @@ class ReportingSetupServiceTest {
         assertTrue(ProcessHandle.allProcesses().filter(ProcessHandle::isAlive)
                 .noneMatch(handle -> !before.contains(handle.pid()) && handle.info().commandLine()
                         .orElse("").matches("(?is).*(ping\\s+-n\\s+30|sleep\\s+30).*")));
+    }
+
+    @Test
+    void exitedParentCannotLeaveInheritedOutputAndDescendantAlive(@TempDir Path temp) throws Exception {
+        Path pidFile = temp.resolve("descendant.pid");
+        List<String> command = List.of(Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                "-Xmx32m", "-XX:+UseSerialGC", "-cp", System.getProperty("java.class.path"),
+                OutputHoldingParent.class.getName(),
+                pidFile.toString());
+        long started = System.nanoTime();
+
+        IOException failure = assertThrows(IOException.class, () -> ReportingSetupService.runProcess(
+                command, null, java.time.Duration.ofSeconds(2), temp, temp));
+
+        assertTrue(failure.getMessage().contains("output did not close"));
+        assertTrue(java.time.Duration.ofNanos(System.nanoTime() - started).compareTo(java.time.Duration.ofSeconds(8)) < 0);
+        long pid = Long.parseLong(Files.readString(pidFile));
+        assertTrue(ProcessHandle.of(pid).map(handle -> !handle.isAlive()).orElse(true));
+    }
+
+    public static final class OutputHoldingParent {
+        public static void main(String[] args) throws Exception {
+            List<String> child = SetupPlatform.current() == SetupPlatform.WINDOWS
+                    ? List.of("ping", "-n", "30", "127.0.0.1") : List.of("sleep", "30");
+            Process process = new ProcessBuilder(child).inheritIO().start();
+            Files.writeString(Path.of(args[0]), Long.toString(process.pid()));
+            Thread.sleep(250);
+        }
+    }
+
+    @Test
+    void successfulParentCannotLeaveDetachedDescendantAlive(@TempDir Path temp) throws Exception {
+        Path pidFile = temp.resolve("detached-descendant.pid");
+        List<String> command = List.of(Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                "-Xmx32m", "-XX:+UseSerialGC", "-cp", System.getProperty("java.class.path"),
+                DetachedChildParent.class.getName(),
+                pidFile.toString());
+
+        ReportingSetupService.ProcessResult result = ReportingSetupService.runProcess(
+                command, null, java.time.Duration.ofSeconds(5), temp, temp);
+
+        assertEquals(0, result.exitCode(), result.output());
+        long pid = Long.parseLong(Files.readString(pidFile));
+        assertTrue(ProcessHandle.of(pid).map(handle -> !handle.isAlive()).orElse(true));
+    }
+
+    public static final class DetachedChildParent {
+        public static void main(String[] args) throws Exception {
+            List<String> child = SetupPlatform.current() == SetupPlatform.WINDOWS
+                    ? List.of("ping", "-n", "30", "127.0.0.1") : List.of("sleep", "30");
+            Process process = new ProcessBuilder(child)
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start();
+            Files.writeString(Path.of(args[0]), Long.toString(process.pid()));
+            Thread.sleep(250);
+        }
     }
 
     private static SetupPlan exerciseInstall(Path temp, SetupPlatform platform, Path nodeArchive) throws Exception {
@@ -248,7 +384,7 @@ class ReportingSetupServiceTest {
         return plan;
     }
 
-    private static Path createNodeZip(Path destination) throws IOException {
+    static Path createNodeZip(Path destination) throws IOException {
         try (ZipOutputStream output = new ZipOutputStream(Files.newOutputStream(destination))) {
             for (String entry : List.of("node-v24.19.0-win-x64/node.exe",
                     "node-v24.19.0-win-x64/node_modules/npm/bin/npm-cli.js")) {

--- a/tests/scripts/test_lighthouse_infrastructure_boundary.py
+++ b/tests/scripts/test_lighthouse_infrastructure_boundary.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class LighthouseInfrastructureBoundaryTest(unittest.TestCase):
+    def test_shared_provider_and_cli_are_registered_without_engine_dependency(self):
+        infrastructure_pom = (ROOT / "shaft-infrastructure/pom.xml").read_text(encoding="utf-8")
+        registry = (ROOT / "shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java").read_text(encoding="utf-8")
+        cli = (ROOT / "shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java").read_text(encoding="utf-8")
+
+        self.assertNotIn("<artifactId>shaft-engine</artifactId>", infrastructure_pom)
+        self.assertIn("new LighthouseSetupProvider()", registry)
+        self.assertIn(".supports(profile)", cli)
+        self.assertNotIn("profile != SetupProfile.REPORTING && profile != SetupProfile.OCR", cli)
+
+    def test_release_assets_and_runtime_boundary_are_tracked(self):
+        self.assertTrue((ROOT / "shaft-infrastructure/src/main/resources/com/shaft/infrastructure/lighthouse/package.json").is_file())
+        self.assertTrue((ROOT / "shaft-infrastructure/src/main/resources/com/shaft/infrastructure/lighthouse/package-lock.json").is_file())
+        runtime = (ROOT / "shaft-engine/src/main/java/com/shaft/performance/internal/LightHouseGenerateReport.java").read_text(encoding="utf-8")
+        active = runtime.split("public void generateLightHouseReport()", 1)[1].split("static int debuggerPort", 1)[0]
+        self.assertIn("LighthouseRuntime", active)
+        self.assertIn("commandRunner.run", active)
+        self.assertNotIn("writeNodeScriptFileInProjectDirectory", active)
+        self.assertNotIn("performTerminalCommand", active)
+
+    def test_ci_runs_the_boundary_and_real_managed_lighthouse_flow(self):
+        pr_gate = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")
+        local_e2e = (ROOT / ".github/workflows/e2eLocalTests.yml").read_text(encoding="utf-8")
+
+        self.assertIn("tests.scripts.test_lighthouse_infrastructure_boundary", pr_gate)
+        self.assertIn("setup plan --profile LIGHTHOUSE", local_e2e)
+        self.assertIn("setup install", local_e2e)
+        self.assertIn("setup verify --profile LIGHTHOUSE", local_e2e)
+        self.assertIn("-DrunManagedLighthouseE2E=true", local_e2e)
+        self.assertIn("^shaft-cli-[0-9][0-9.]*\\.jar$", local_e2e)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a release-pinned managed Node 24.19.0 and Lighthouse 13.4.1 provider
- expose LIGHTHOUSE through shared Java and CLI setup surfaces
- replace generated JavaScript/global npm/shell execution with a verified managed runtime
- harden offline preflight, safe paths, locks, receipts, atomic publication, and bounded process-tree cleanup
- add packaged CLI and opt-in real local-Chrome acceptance coverage

## Proof
- `mvn -pl shaft-infrastructure test -Dtest=InfrastructureSetupServiceTest,LighthouseSetupProviderTest,ReportingSetupServiceTest,VerifiedArtifactStoreTest ...` — 42 passed
- affected combined reactor previously passed infrastructure + engine + CLI; final local rerun was prevented before compilation by exhausted host page file, so remote CI is the clean-run authority
- Lighthouse boundary tests: 3 passed
- workflow timeout, reactor version, publication, modular docs, and documentation boundary validators: passed
- packaged CLI plan/install/verify real acceptance: Node v24.19.0 and Lighthouse 13.4.1 READY
- independent correctness review: zero blockers after process-tree hardening

## Documentation
Companion draft PR: ShaftHQ/shafthq.github.io#972 (green; intentionally waits for this implementation).

Closes #4884
Related to #4849