### PR TITLE
fix(agents): bound disposable reviewer lifecycle

### DIFF
--- a/chaos-engine/references/delegation.md
+++ b/chaos-engine/references/delegation.md
@@ -40,16 +40,28 @@ consume a slot. Check real progress for any agent or
 command unexamined for about twenty minutes, and supply a decision, a solved
 subproblem, or a re-spec — never a heartbeat.
 
+Treat agent lifetime as part of the assignment. Close every no-longer-needed
+agent and its descendants before moving to the next phase. Never use
+`followup_task` to reactivate a completed or finished assignment; a new review
+round gets a new reviewer instance. Preserve the closed relationship as
+history instead of deleting it. A final answer with an unneeded live agent is
+incomplete.
+
 ## Independent adversarial review
 
 Every behavior-changing step ends with a review before the next step starts. The
 property that makes it work is independence, so it is not optional:
 
 - The reviewer is a **separate agent instance, never the author** of the work.
-- Obtain it by dispatching a **`reviewer` subagent**. That is the mechanism the
-  harness counts: the guard records the dispatch when it observes it, and R15
-  accepts that record in place of a review from another account. A review the
-  harness never saw satisfies nobody, however thorough it was.
+- Choose a disposable review mechanism. When the host provides reliable terminal
+  close, use a native reviewer subagent and close it after the verdict. Without
+  reliable terminal close, use an artifact-bounded ephemeral reviewer and pass
+  the exact revision or diff plus its directly required guidance as immutable
+  input. It must not depend on repository shell access to discover the artifact.
+  Such a review clears the automated review gate only when the active host
+  adapter records its successful receipt, bound to that artifact. Until an
+  adapter supports that receipt, obtain an independent pull-request review too;
+  prose claiming the one-shot review happened is not evidence.
 - The reviewer is prompted to **refute** the work — find where it is wrong,
   unverified, or over-claimed — not to approve it.
 - The reviewer is handed **the exact revision under review** and a way to read

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -994,6 +994,67 @@ class RouterTableTest(unittest.TestCase):
         self.assertEqual(offenders, [])
 
 
+class DelegateTerminalLifecycleTest(unittest.TestCase):
+    """A finished assignment must not leave a reusable agent running forever."""
+
+    @staticmethod
+    def _section(document: str, heading: str) -> str:
+        match = re.search(
+            rf"(?ms)^## {re.escape(heading)}\s*$\n(.*?)(?=^## |\Z)", document
+        )
+        if match is None:
+            return ""
+        return match.group(1).strip().lower()
+
+    @staticmethod
+    def _bullets(section: str) -> list[str]:
+        return [
+            re.sub(r"\s+", " ", match).strip().lower()
+            for match in re.findall(r"(?ms)^- (.*?)(?=^- |\Z)", section)
+        ]
+
+    def test_main_thread_duties_require_terminal_cleanup_without_reactivation(self):
+        document = DELEGATION.read_text(encoding="utf-8")
+        duties = re.sub(
+            r"\s+", " ", self._section(document, "Main-thread duties")
+        )
+        required_rules = (
+            "close every no-longer-needed agent and its descendants before moving to the next phase",
+            "never use `followup_task` to reactivate a completed or finished assignment",
+            "a new review round gets a new reviewer instance",
+            "preserve the closed relationship as history instead of deleting it",
+            "a final answer with an unneeded live agent is incomplete",
+        )
+        for rule in required_rules:
+            with self.subTest(rule=rule):
+                self.assertIn(rule, duties)
+
+    def test_review_policy_has_one_fail_closed_disposable_mechanism_rule(self):
+        document = DELEGATION.read_text(encoding="utf-8")
+        review = self._section(document, "Independent adversarial review")
+        candidate_rules = [
+            bullet for bullet in self._bullets(review)
+            if bullet.startswith("choose a disposable review mechanism")
+        ]
+        self.assertEqual(len(candidate_rules), 1)
+        rule = candidate_rules[0]
+        required_clauses = (
+            "when the host provides reliable terminal close, use a native reviewer subagent and close it after the verdict",
+            "without reliable terminal close, use an artifact-bounded ephemeral reviewer and pass the exact revision or diff",
+            "clears the automated review gate only when the active host adapter records its successful receipt, bound to that artifact",
+            "until an adapter supports that receipt, obtain an independent pull-request review too",
+        )
+        for clause in required_clauses:
+            with self.subTest(clause=clause):
+                self.assertIn(clause, rule)
+
+        self.assertNotIn(
+            "the host adapter records either dispatch",
+            review,
+            "guidance must not claim receipt support that the active adapter lacks",
+        )
+
+
 class ProgressiveDisclosureTest(unittest.TestCase):
     """Bodies and read chains stay inside documented host read limits."""
 


### PR DESCRIPTION
## Summary
- terminally close completed agents and their descendants
- prohibit reactivating completed assignments and require a fresh reviewer per round
- prefer artifact-bounded ephemeral reviewers when native terminal close is unavailable
- fail closed when the host cannot record an artifact-bound one-shot review receipt
- structurally pin the lifecycle policy to its canonical guidance sections

## Proof
- py -3 -m unittest tests.scripts.test_agent_router_contract.DelegateTerminalLifecycleTest
- py -3 scripts/ci/validate_agent_setup.py --skip-external
- git diff --check
- final artifact-bounded independent review: APPROVED, zero findings

Closes #4894