### PR TITLE
fix: inspect managed setup readiness from CLI

### DIFF
--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -285,8 +285,11 @@ public final class SetupCommand implements Runnable {
 
     static class ReadinessCommand implements Callable<Integer> {
         @Option(names = "--profile", required = true) private SetupProfile profile;
+        @Option(names = "--mode", defaultValue = "EXTERNAL", description = "Ownership mode.")
+        private SetupMode mode;
         @Option(names = "--json", description = "Print machine-readable JSON.") private boolean json;
         @Mixin private RootOptions roots;
+        @Mixin private PolicyOptions policy;
         @Mixin private AndroidOptions android;
         @Option(names = "--language", description = "OCR language code (repeatable).")
         private List<String> languages = new java.util.ArrayList<>();
@@ -299,8 +302,9 @@ public final class SetupCommand implements Runnable {
                 if (profile != SetupProfile.OCR && !languages.isEmpty()) {
                     throw new IllegalArgumentException("--language is supported only for profile OCR.");
                 }
+                ShaftCachePaths paths = roots.paths();
                 SetupReport status = InfrastructureSetupService.builtIn().status(
-                        SetupOptions.defaults(profile, roots.paths()),
+                        policy.options(profile, mode, paths),
                         selection(profile, languages, android.request(profile)));
                 if (json) spec.commandLine().getOut().println(Json.MAPPER.writerWithDefaultPrettyPrinter()
                         .writeValueAsString(status));

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
@@ -190,6 +190,27 @@ class SetupCommandTest {
     }
 
     @Test
+    void androidReadinessCommandsCanInspectManagedState(@TempDir Path temp) throws Exception {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+
+        for (String command : java.util.List.of("doctor", "status", "verify")) {
+            CommandResult result = execute("setup", command, "--profile", "MOBILE_ANDROID",
+                    "--mode", "MANAGED", "--cache-root", cache.toString(), "--data-root", data.toString(),
+                    "--json");
+
+            assertEquals(3, result.exitCode(), result.stderr());
+            JsonNode report = JSON.readTree(result.stdout());
+            assertEquals("MOBILE_ANDROID", report.get("profile").asText());
+            report.get("targets").forEach(target -> assertTrue(
+                    !target.get("detail").asText().contains("External mode is diagnostic-only"),
+                    command + " must inspect managed readiness instead of forcing EXTERNAL mode."));
+        }
+        assertTrue(Files.notExists(cache));
+        assertTrue(Files.notExists(data));
+    }
+
+    @Test
     void androidStopAndLogsReportMissingWithoutCreatingRuntimeState(@TempDir Path temp) {
         Path cache = temp.resolve("cache").toAbsolutePath();
         Path data = temp.resolve("data").toAbsolutePath();


### PR DESCRIPTION
## Summary
- let setup `doctor`, `status`, and `verify` accept an explicit ownership mode and the shared policy options
- preserve `EXTERNAL` as the non-mutating default
- prove managed Android readiness inspection remains read-only on missing state

## RED → GREEN
- RED: `SetupCommandTest.androidReadinessCommandsCanInspectManagedState` failed because `--mode MANAGED` was unknown
- GREEN: `SetupCommandTest` 16/16
- REFACTOR/check: affected nine-module CLI package succeeds

Follow-up found during the final #4898 companion-docs audit.