### PR TITLE
test(infrastructure): stabilize mirror close assertion

### DIFF
--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/VerifiedArtifactMirrorTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/VerifiedArtifactMirrorTest.java
@@ -4,17 +4,23 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class VerifiedArtifactMirrorTest {
@@ -36,7 +42,11 @@ class VerifiedArtifactMirrorTest {
         }
 
         URI closedMirror = base.resolve("builds/firefox/1538/firefox-win64.zip");
-        assertThrows(java.net.ConnectException.class, () -> request(closedMirror, "GET"));
+        byte[] replacementBody = "replacement listener".getBytes(StandardCharsets.UTF_8);
+        Response reusedPort = requestAfterPortReuse(closedMirror, replacementBody);
+        assertEquals(200, reusedPort.status());
+        assertArrayEquals(replacementBody, reusedPort.body());
+        assertFalse(java.util.Arrays.equals(expected, reusedPort.body()));
     }
 
     @Test
@@ -82,6 +92,34 @@ class VerifiedArtifactMirrorTest {
                 : connection.getInputStream().readAllBytes();
         connection.disconnect();
         return new Response(status, body);
+    }
+
+    private static Response requestAfterPortReuse(URI uri, byte[] replacementBody) throws Exception {
+        try (ServerSocket replacement = new ServerSocket()) {
+            replacement.setReuseAddress(true);
+            replacement.bind(new InetSocketAddress(uri.getHost(), uri.getPort()));
+            ExecutorService responder = Executors.newSingleThreadExecutor();
+            Future<?> response = responder.submit(() -> {
+                try (Socket connection = replacement.accept()) {
+                    byte[] headers = ("HTTP/1.1 200 OK\r\nContent-Length: " + replacementBody.length
+                            + "\r\nConnection: close\r\n\r\n").getBytes(StandardCharsets.US_ASCII);
+                    connection.getOutputStream().write(headers);
+                    connection.getOutputStream().write(replacementBody);
+                    connection.getOutputStream().flush();
+                } catch (java.io.IOException failure) {
+                    throw new java.io.UncheckedIOException(failure);
+                }
+            });
+            try {
+                return request(uri, "GET");
+            } finally {
+                try {
+                    response.get(2, TimeUnit.SECONDS);
+                } finally {
+                    responder.shutdownNow();
+                }
+            }
+        }
     }
 
     private record Response(int status, byte[] body) { }


### PR DESCRIPTION
## Summary
- reproduce former ephemeral-port reuse with a real replacement loopback listener
- identify the replacement listener by an exact marker response instead of requiring `ConnectException`
- keep the closed mirror artifact-byte guarantee explicit without changing production code

## RED
`mvn -pl shaft-infrastructure "-Dtest=VerifiedArtifactMirrorTest#servesOnlyExactGetRequestsFromLoopbackAndStopsOnClose" "-Dallure.automaticallyOpen=false" test`

Failed as expected with 1 test, 1 failure: `Expected java.net.ConnectException to be thrown, but nothing was thrown.`

## Verification
- focused method: 1 passed
- five repeated focused executions: 5 passed
- full `shaft-infrastructure` suite: 139 tests, 0 failures, 0 errors, 2 skipped (verified from 21 Surefire XML reports)
- `mvn -pl shaft-infrastructure "-DskipTests" "-Dallure.automaticallyOpen=false" package`
- `git diff --check`

Closes #4925