### PR TITLE
fix(agent): avoid Graphify worktree refresh races

### DIFF
--- a/chaos-engine/references/graphify.md
+++ b/chaos-engine/references/graphify.md
@@ -83,6 +83,15 @@ mode: use targeted `rg` plus other knowledge sources, and flag a
 primary-checkout refresh. Never rebuild or record the cache from a linked
 worktree, and never commit `graphify-out/`.
 
+The primary checkout is the sole Graphify refresh owner. A linked-worktree
+revision mismatch or an active refresh lock is an expected degraded state after
+G1 through G4, not an implementation blocker. The linked worktree or losing
+refresh session must not refresh, wait or retry-loop, clear or replace the lock,
+freshness marker, or cache, or switch, reset, or overwrite the primary checkout
+to satisfy freshness. Continue with native Memory, MemPalace, and targeted live
+`rg`. Only the primary owner may schedule one later refresh when the primary
+checkout and shared cache are uncontested.
+
 From the primary checkout, the same portable repository-owned controller owns
 refresh:
 

--- a/chaos-engine/references/retrieve-first.md
+++ b/chaos-engine/references/retrieve-first.md
@@ -76,3 +76,10 @@ If a required store is unavailable, **name the degraded mode**, diagnose its
 root owner, and continue analysis with the remaining sources. Implementation
 waits until the store works and the receipt is complete. Skipping a store
 silently is the failure this gate exists to prevent.
+
+Graphify contention is the narrow exception to implementation waiting. After
+the required G1 through G4 attempts, a linked-worktree revision mismatch or an
+active refresh lock completes the Graphify receipt in explicit degraded mode;
+continue implementation with the remaining sources. The canonical
+[Graphify procedure](graphify.md) owns the sole-refresh-owner, forbidden-action,
+live-verification, and later-safe-refresh rules.

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -78,6 +78,9 @@ guidance, persisted-data, and external-system mutation wait for the repaired
 source and a complete receipt. Never substitute a stale index, recollection, or
 generic summary for the named live query. Reuse established solutions and
 standards before inventing a local one.
+After G1-G4, a complete degraded Graphify receipt permits implementation to
+continue. [Graphify](../../references/graphify.md) owns the narrow
+worktree/lock-contention exception and forbids competing shared-state mutation.
 The dated [adoption matrix](../../RESEARCH.md) records the portable harness
 baseline; revalidate a row when its relevant discovery, schema, or install
 contract changes.

--- a/tests/scripts/test_resolve_graph_out.py
+++ b/tests/scripts/test_resolve_graph_out.py
@@ -356,14 +356,19 @@ if (-not ($resolverOk -and $queryOk -and $auditOk)) {
             "a complete degraded Graphify receipt permits implementation to continue",
             entrypoint,
         )
+        # This is a closed contract over canonical unsafe permission clauses,
+        # not an attempt to parse unrestricted natural language.
+        unsafe_permission_clause = re.compile(
+            r"\blinked(?:-| )worktrees?\s+"
+            r"(?:may|can|(?:is|are)\s+(?:allowed|permitted)\s+to)\s+"
+            r"(?:refresh|wait|retry(?:-loop)?|"
+            r"(?:clear|replace)(?:\s+or\s+(?:clear|replace))?\s+"
+            r"(?:the\s+)?(?:shared\s+)?"
+            r"(?:refresh\s+lock|lock|freshness\s+marker|cache))\b",
+            flags=re.IGNORECASE,
+        )
         self.assertIsNone(
-            re.search(
-                r"linked worktrees?[^.]{0,160}\b(?:may(?!\s+not\b)|can(?!not\b)|"
-                r"(?:is|are) (?:allowed|permitted) to)\b[^.]{0,160}\b"
-                r"(?:refresh|wait|retry(?:-loop)?|clear|replace)\b",
-                graphify,
-                flags=re.IGNORECASE,
-            ),
+            unsafe_permission_clause.search(graphify),
             "linked worktrees must not receive permission to mutate or contend for "
             "shared Graphify state",
         )
@@ -388,6 +393,10 @@ if (-not ($resolverOk -and $queryOk -and $auditOk)) {
                 files["graphify"]
                 + "\nA linked worktree may clear the cache and retry refresh until it succeeds.\n"
             ),
+            "hyphenated contradictory linked refresh permission appended": (
+                files["graphify"]
+                + "\nA linked-worktree may clear the cache and retry refresh until it succeeds.\n"
+            ),
             "linked refresh allowed": files["graphify"].replace(
                 "must not refresh, wait or retry-loop",
                 "may refresh or wait and retry-loop",
@@ -405,6 +414,19 @@ if (-not ($resolverOk -and $queryOk -and $auditOk)) {
             with self.subTest(name=name), self.assertRaises(AssertionError):
                 self._assert_graphify_contention_is_a_degraded_continuation(
                     {**files, "graphify": graphify_mutation}
+                )
+
+        for name, safe_text in {
+            "continue without refresh": (
+                "A linked worktree can continue implementation without refresh."
+            ),
+            "continue while retaining wait prohibition": (
+                "A linked worktree can continue and must not wait."
+            ),
+        }.items():
+            with self.subTest(name=name):
+                self._assert_graphify_contention_is_a_degraded_continuation(
+                    {**files, "graphify": files["graphify"] + "\n" + safe_text + "\n"}
                 )
 
     def test_graphify_cli_route_contract_rejects_bypass_mutations(self):

--- a/tests/scripts/test_resolve_graph_out.py
+++ b/tests/scripts/test_resolve_graph_out.py
@@ -331,6 +331,67 @@ if (-not ($resolverOk -and $queryOk -and $auditOk)) {
 
         self._assert_mandatory_graphify_cli_route(guidance)
 
+    def _assert_graphify_contention_is_a_degraded_continuation(self, files):
+        graphify = re.sub(r"\s+", " ", files["graphify"])
+        retrieval = re.sub(r"\s+", " ", files["retrieval"])
+        entrypoint = re.sub(r"\s+", " ", files["entrypoint"])
+
+        for required in (
+            "The primary checkout is the sole Graphify refresh owner.",
+            "A linked-worktree revision mismatch or an active refresh lock is an expected "
+            "degraded state after G1 through G4, not an implementation blocker.",
+            "must not refresh, wait or retry-loop, clear or replace the lock, freshness "
+            "marker, or cache, or switch, reset, or overwrite the primary checkout",
+            "Continue with native Memory, MemPalace, and targeted live `rg`.",
+            "Only the primary owner may schedule one later refresh when the primary "
+            "checkout and shared cache are uncontested.",
+        ):
+            self.assertIn(required, graphify)
+
+        self.assertIn(
+            "Graphify contention is the narrow exception to implementation waiting",
+            retrieval,
+        )
+        self.assertIn(
+            "a complete degraded Graphify receipt permits implementation to continue",
+            entrypoint,
+        )
+
+    def test_graphify_contention_degrades_without_shared_state_mutation(self):
+        files = {
+            "graphify": (ROOT / "chaos-engine/references/graphify.md").read_text(
+                encoding="utf-8"
+            ),
+            "retrieval": (
+                ROOT / "chaos-engine/references/retrieve-first.md"
+            ).read_text(encoding="utf-8"),
+            "entrypoint": (
+                ROOT / "chaos-engine/skills/chaos-engine/SKILL.md"
+            ).read_text(encoding="utf-8"),
+        }
+
+        self._assert_graphify_contention_is_a_degraded_continuation(files)
+
+        mutations = {
+            "linked refresh allowed": files["graphify"].replace(
+                "must not refresh, wait or retry-loop",
+                "may refresh or wait and retry-loop",
+            ),
+            "contention blocks implementation": files["graphify"].replace(
+                "not an implementation blocker",
+                "an implementation blocker",
+            ),
+            "primary ownership removed": files["graphify"].replace(
+                "The primary checkout is the sole Graphify refresh owner.",
+                "Any checkout may own a Graphify refresh.",
+            ),
+        }
+        for name, graphify_mutation in mutations.items():
+            with self.subTest(name=name), self.assertRaises(AssertionError):
+                self._assert_graphify_contention_is_a_degraded_continuation(
+                    {**files, "graphify": graphify_mutation}
+                )
+
     def test_graphify_cli_route_contract_rejects_bypass_mutations(self):
         guidance = (
             ROOT / "chaos-engine/references/graphify.md"

--- a/tests/scripts/test_resolve_graph_out.py
+++ b/tests/scripts/test_resolve_graph_out.py
@@ -356,6 +356,17 @@ if (-not ($resolverOk -and $queryOk -and $auditOk)) {
             "a complete degraded Graphify receipt permits implementation to continue",
             entrypoint,
         )
+        self.assertIsNone(
+            re.search(
+                r"linked worktrees?[^.]{0,160}\b(?:may(?!\s+not\b)|can(?!not\b)|"
+                r"(?:is|are) (?:allowed|permitted) to)\b[^.]{0,160}\b"
+                r"(?:refresh|wait|retry(?:-loop)?|clear|replace)\b",
+                graphify,
+                flags=re.IGNORECASE,
+            ),
+            "linked worktrees must not receive permission to mutate or contend for "
+            "shared Graphify state",
+        )
 
     def test_graphify_contention_degrades_without_shared_state_mutation(self):
         files = {
@@ -373,6 +384,10 @@ if (-not ($resolverOk -and $queryOk -and $auditOk)) {
         self._assert_graphify_contention_is_a_degraded_continuation(files)
 
         mutations = {
+            "contradictory linked refresh permission appended": (
+                files["graphify"]
+                + "\nA linked worktree may clear the cache and retry refresh until it succeeds.\n"
+            ),
             "linked refresh allowed": files["graphify"].replace(
                 "must not refresh, wait or retry-loop",
                 "may refresh or wait and retry-loop",


### PR DESCRIPTION
## Summary
- make the primary checkout the sole Graphify refresh owner
- treat linked-revision mismatch and active refresh-lock contention as explicit degraded continuation after G1-G4
- forbid racing, retrying, clearing, replacing, or overwriting shared Graphify state
- pin the policy across the entrypoint, retrieval gate, and canonical Graphify reference

## Verification
- RED: focused contract failed because the sole-primary-owner rule was absent
- GREEN: `py -3 -m unittest tests.scripts.test_resolve_graph_out.ResolveGraphOutTest.test_graphify_contention_degrades_without_shared_state_mutation -v`
- `py -3 -m unittest tests.scripts.test_resolve_graph_out tests.scripts.test_graphify_maintenance -v` (36 tests)
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- `git diff --check`

Closes #4933