### PR TITLE
fix(agent): stabilize native Maven MCP runtime

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -81,9 +81,11 @@ native JAR flow instead:
    `.codex/config.toml` with their resolved absolute paths. Upgrades repeat
    discovery, so another user's Java or data path is never inherited.
 5. Start a fresh client session and prove both the MCP initialize and tools/list
-   responses. The JAR launch includes `--spring.profiles.active=docker` only
-   because upstream uses that Spring profile to enable clean stdio; it does not
-   start or require Docker.
+   responses. The JAR launch includes
+   `--spring.profiles.active=docker,no-context7`: upstream's `docker` profile
+   enables clean stdio without starting or requiring Docker, while
+   `no-context7` keeps the receipt-pinned server's native tool surface independent
+   of a live downstream Context7 connection.
 
 If Java 25 or the verified JAR is absent, installation leaves this optional MCP
 server out of every host configuration. Maven CLI, repository files, Context7,

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -25,6 +25,7 @@ SCHEMA_VERSION = 1
 MAVEN_TOOLS_MCP_VERSION = "3.2.0"
 MAVEN_TOOLS_MCP_COMMIT = "4475ff6c61f23ea9a93cb6d5665a63235ef2ef36"
 MAVEN_TOOLS_MCP_RECEIPT = "install-receipt.json"
+MAVEN_TOOLS_MCP_PROFILE = "docker,no-context7"
 LEGACY_MAVEN_TOOLS_SERVER = {
     "command": "docker",
     "args": ["run", "-i", "--rm", "arvindand/maven-tools-mcp:3.2.0"],
@@ -87,11 +88,10 @@ def verified_maven_tools_jar(candidate: Path) -> Path | None:
 
 def discover_maven_tools_runtime() -> tuple[Path, Path] | None:
     configured_jar = os.environ.get("CHAOSENGINE_MAVEN_TOOLS_MCP_JAR")
-    data_root = Path(
-        os.environ.get("LOCALAPPDATA", "")
-        or os.environ.get("XDG_DATA_HOME", "")
-        or Path.home() / ".local/share"
+    configured_data_root = os.environ.get(
+        "LOCALAPPDATA" if os.name == "nt" else "XDG_DATA_HOME", ""
     )
+    data_root = Path(configured_data_root or Path.home() / ".local/share")
     jar_candidates = [
         Path(configured_jar).expanduser() if configured_jar else None,
         data_root
@@ -158,7 +158,11 @@ def owned_servers(
         java, jar = maven_runtime
         servers["maven-tools-mcp"] = {
             "command": str(java),
-            "args": ["-jar", str(jar), "--spring.profiles.active=docker"],
+            "args": [
+                "-jar",
+                str(jar),
+                f"--spring.profiles.active={MAVEN_TOOLS_MCP_PROFILE}",
+            ],
         }
     return servers
 
@@ -463,7 +467,7 @@ def codex_content(
             '[mcp_servers."maven-tools-mcp"]\n'
             f"command = {json.dumps(str(java))}\n"
             f'args = ["-jar", {json.dumps(str(jar))}, '
-            '"--spring.profiles.active=docker"]\n'
+            f'"--spring.profiles.active={MAVEN_TOOLS_MCP_PROFILE}"]\n'
             "# CHAOSENGINE:END\n",
         )
     if "# CHAOSENGINE:START" in existing or "# CHAOSENGINE:END" in existing:

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -127,7 +127,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
         self.assertEqual(str(java), maven["command"])
         self.assertEqual(
-            ["-jar", str(jar), "--spring.profiles.active=docker"],
+            ["-jar", str(jar), "--spring.profiles.active=docker,no-context7"],
             maven["args"],
         )
         self.assertNotEqual("docker", Path(str(maven["command"])).name.casefold())
@@ -144,7 +144,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
         self.assertEqual(str(java), claude["mcpServers"]["maven-tools-mcp"]["command"])
         self.assertIn(str(jar).replace("\\", "\\\\"), codex)
-        self.assertIn("--spring.profiles.active=docker", codex)
+        self.assertIn("--spring.profiles.active=docker,no-context7", codex)
 
     def test_native_maven_tools_runtime_discovers_user_paths(self):
         module = load(HOSTS, "chaos_engine_hosts_native_maven_discovery")
@@ -179,17 +179,62 @@ class ChaosEngineHostsTest(unittest.TestCase):
                     os.environ,
                     {
                         "LOCALAPPDATA": str(root / "data"),
+                        "XDG_DATA_HOME": str(root / "other-data"),
                         "CHAOSENGINE_JAVA": str(java),
                         "CHAOSENGINE_MAVEN_TOOLS_MCP_JAR": "",
                     },
                     clear=False,
-                ):
+                ), mock.patch.object(module.os, "name", "nt"):
                     self.assertEqual(
                         (java.resolve(), jar.resolve()),
                         module.discover_maven_tools_runtime(),
                     )
             finally:
                 globals_["java_major"] = prior
+
+    def test_posix_runtime_ignores_localappdata_when_xdg_is_set(self):
+        module = load(HOSTS, "chaos_engine_hosts_native_maven_posix_data_root")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            java = root / "jdk-25/bin/java"
+            jar = (
+                root
+                / "xdg-data/ChaosEngine/tools/maven-tools-mcp/3.2.0"
+                / "maven-tools-mcp-3.2.0.jar"
+            )
+            java.parent.mkdir(parents=True)
+            jar.parent.mkdir(parents=True)
+            java.write_bytes(b"java")
+            jar.write_bytes(b"jar")
+            jar.with_name("install-receipt.json").write_text(
+                json.dumps(
+                    {
+                        "version": "3.2.0",
+                        "commit": "4475ff6c61f23ea9a93cb6d5665a63235ef2ef36",
+                        "jar": jar.name,
+                        "sha256": hashlib.sha256(jar.read_bytes()).hexdigest(),
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "LOCALAPPDATA": str(root / "windows-data"),
+                    "XDG_DATA_HOME": str(root / "xdg-data"),
+                    "CHAOSENGINE_JAVA": str(java),
+                    "CHAOSENGINE_MAVEN_TOOLS_MCP_JAR": "",
+                    "JAVA_HOME": "",
+                },
+                clear=False,
+            ), mock.patch.object(module.os, "name", "posix"), mock.patch.object(
+                module, "Path", type(root)
+            ), mock.patch.object(module, "java_major", return_value=25):
+                self.assertEqual(
+                    (java.resolve(), jar.resolve()),
+                    module.discover_maven_tools_runtime(),
+                )
 
     def test_native_maven_tools_runtime_rejects_unreceipted_or_changed_jar(self):
         module = load(HOSTS, "chaos_engine_hosts_native_maven_receipt")


### PR DESCRIPTION
## Summary
- select the native Maven Tools data root by host OS so POSIX honors `XDG_DATA_HOME`
- activate upstream `docker,no-context7` profiles for deterministic native stdio tools
- document why neither profile starts nor requires Docker

## TDD
- RED: POSIX discovery returned `None` when conflicting `LOCALAPPDATA` shadowed a valid XDG installation
- RED: native JSON/TOML rendering emitted `docker` without `no-context7`
- GREEN: focused 3/3 tests
- GREEN: `py -3 -m unittest tests.scripts.test_chaos_engine_hosts tests.scripts.test_chaos_engine_installer tests.scripts.test_agent_harness_portability` (129 passed)
- GREEN: `py -3 scripts/ci/validate_agent_guidance.py`
- GREEN: `py -3 scripts/ci/validate_skills.py`
- GREEN: `git diff --check`

## Review
Two fresh independent adversarial passes found zero blocking findings. A third fresh reviewer was attempted by both the root session and a reviewer but the session agent-thread limit rejected creation; the PR remains subject to its normal independent GitHub and CI review gates.

Closes #4934
Closes #4935
Related to #4906