### PR TITLE
fix(ci): set explicit CodeQL build mode

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,6 +42,7 @@ jobs:
         uses: github/codeql-action/init@v4.37.6
         with:
           languages: ${{ matrix.language }}
+          build-mode: manual
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5.7.0

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -428,6 +428,22 @@ def validate_browser_matrix_scope_policy(root: Path = ROOT) -> list[str]:
     return errors
 
 
+def validate_codeql_build_mode(workflow: str) -> list[str]:
+    document = yaml.safe_load(workflow) or {}
+    steps = document.get("jobs", {}).get("codeql", {}).get("steps", [])
+    init = next(
+        (
+            step
+            for step in steps
+            if str(step.get("uses", "")).startswith("github/codeql-action/init@")
+        ),
+        {},
+    )
+    if init.get("with", {}).get("build-mode") != "manual":
+        return ["CodeQL initialization must use explicit manual build mode"]
+    return []
+
+
 def validate_quality_configuration(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
     root_pom = ET.parse(root / "pom.xml").getroot()
@@ -491,6 +507,7 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
     codecov_count = (workflow_text + action_text).count("codecov/codecov-action@")
 
     codeql = (root / ".github" / "workflows" / "security.yml").read_text(encoding="utf-8")
+    errors.extend(validate_codeql_build_mode(codeql))
     selector = (
         "-pl shaft-infrastructure,shaft-engine,shaft-pilot-core,shaft-capture,shaft-capture-proxy,shaft-doctor,"
         "shaft-ai,shaft-heal,shaft-browserstack,shaft-video,shaft-visual,shaft-ocr,shaft-sikulix,"

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -430,7 +430,18 @@ def validate_browser_matrix_scope_policy(root: Path = ROOT) -> list[str]:
 
 def validate_codeql_build_mode(workflow: str) -> list[str]:
     document = yaml.safe_load(workflow) or {}
-    steps = document.get("jobs", {}).get("codeql", {}).get("steps", [])
+    error = ["CodeQL initialization must use explicit manual build mode"]
+    if not isinstance(document, dict):
+        return error
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        return error
+    codeql = jobs.get("codeql")
+    if not isinstance(codeql, dict):
+        return error
+    steps = codeql.get("steps")
+    if not isinstance(steps, list) or any(not isinstance(step, dict) for step in steps):
+        return error
     init = next(
         (
             step
@@ -439,8 +450,9 @@ def validate_codeql_build_mode(workflow: str) -> list[str]:
         ),
         {},
     )
-    if init.get("with", {}).get("build-mode") != "manual":
-        return ["CodeQL initialization must use explicit manual build mode"]
+    inputs = init.get("with")
+    if not isinstance(inputs, dict) or inputs.get("build-mode") != "manual":
+        return error
     return []
 
 

--- a/tests/scripts/test_validate_quality_configuration.py
+++ b/tests/scripts/test_validate_quality_configuration.py
@@ -84,7 +84,7 @@ class ValidateQualityConfigurationTest(unittest.TestCase):
             encoding="utf-8"
         )
 
-        self.assertIn("          build-mode: manual", security_workflow)
+        self.assertEqual(validate_codeql_build_mode(security_workflow), [])
 
     def test_codeql_validator_rejects_missing_or_different_build_mode(self):
         workflow = (
@@ -100,6 +100,51 @@ class ValidateQualityConfigurationTest(unittest.TestCase):
         self.assertEqual(validate_codeql_build_mode(workflow), error)
         self.assertEqual(validate_codeql_build_mode(f"{workflow}          build-mode: none\n"), error)
         self.assertEqual(validate_codeql_build_mode(f"{workflow}          build-mode: manual\n"), [])
+
+    def test_codeql_validator_returns_error_for_malformed_workflow_shapes(self):
+        error = ["CodeQL initialization must use explicit manual build mode"]
+        malformed_workflows = {
+            "null jobs": "jobs:\n",
+            "scalar jobs": "jobs: codeql\n",
+            "null codeql job": "jobs:\n  codeql:\n",
+            "scalar codeql job": "jobs:\n  codeql: analyze\n",
+            "null steps": "jobs:\n  codeql:\n    steps:\n",
+            "scalar steps": "jobs:\n  codeql:\n    steps: init\n",
+            "scalar step": "jobs:\n  codeql:\n    steps:\n      - init\n",
+            "null with": (
+                "jobs:\n"
+                "  codeql:\n"
+                "    steps:\n"
+                "      - uses: github/codeql-action/init@v4\n"
+                "        with:\n"
+            ),
+            "scalar with": (
+                "jobs:\n"
+                "  codeql:\n"
+                "    steps:\n"
+                "      - uses: github/codeql-action/init@v4\n"
+                "        with: manual\n"
+            ),
+        }
+
+        for scenario, workflow in malformed_workflows.items():
+            with self.subTest(scenario=scenario):
+                self.assertEqual(validate_codeql_build_mode(workflow), error)
+
+    def test_codeql_validator_rejects_yaml_boolean_build_mode(self):
+        workflow = (
+            "jobs:\n"
+            "  codeql:\n"
+            "    steps:\n"
+            "      - uses: github/codeql-action/init@v4\n"
+            "        with:\n"
+            "          build-mode: yes\n"
+        )
+
+        self.assertEqual(
+            validate_codeql_build_mode(workflow),
+            ["CodeQL initialization must use explicit manual build mode"],
+        )
 
     def test_local_browser_matrix_excludes_pr_gate_owned_unit_tests(self):
         root = Path(__file__).resolve().parents[2]

--- a/tests/scripts/test_validate_quality_configuration.py
+++ b/tests/scripts/test_validate_quality_configuration.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from scripts.ci.validate_quality_configuration import (
     validate_browser_matrix_scope_policy,
+    validate_codeql_build_mode,
     validate_maven_jvm_configuration,
     validate_quality_configuration,
     validate_surefire_jacoco_arg_lines,
@@ -76,6 +77,29 @@ def missing_coverage_error(workflow: str, job: str) -> str:
 class ValidateQualityConfigurationTest(unittest.TestCase):
     def test_repository_configuration_is_valid(self):
         self.assertEqual(validate_quality_configuration(), [])
+
+    def test_codeql_uses_explicit_manual_build_mode(self):
+        root = Path(__file__).resolve().parents[2]
+        security_workflow = (root / ".github" / "workflows" / "security.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("          build-mode: manual", security_workflow)
+
+    def test_codeql_validator_rejects_missing_or_different_build_mode(self):
+        workflow = (
+            "jobs:\n"
+            "  codeql:\n"
+            "    steps:\n"
+            "      - uses: github/codeql-action/init@v4\n"
+            "        with:\n"
+            "          languages: java\n"
+        )
+
+        error = ["CodeQL initialization must use explicit manual build mode"]
+        self.assertEqual(validate_codeql_build_mode(workflow), error)
+        self.assertEqual(validate_codeql_build_mode(f"{workflow}          build-mode: none\n"), error)
+        self.assertEqual(validate_codeql_build_mode(f"{workflow}          build-mode: manual\n"), [])
 
     def test_local_browser_matrix_excludes_pr_gate_owned_unit_tests(self):
         root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary

- set the advanced Java CodeQL workflow to explicit `manual` build mode
- enforce that mode in the existing quality-configuration validator
- preserve the existing Maven reactor selector and CodeQL analysis coverage

Closes #4931

## Proof

- RED: `test_codeql_uses_explicit_manual_build_mode` failed because the input was absent
- GREEN: focused CodeQL configuration tests, 2/2 passed
- PyYAML parsed `security.yml` and resolved `build-mode: manual`
- exact CodeQL Maven reactor: 16/16 projects built successfully with tests skipped, matching the workflow
- exact `-pl ... -am` selector preserved
- full quality-validator test module: 24 passed; one unrelated base assertion remains red and is tracked by #4940

## Scope

No trigger, permission, action version, language matrix, Maven selector, or managed/default CodeQL setup changes. Graphify was stale in the linked worktree, so the receipt used explicit degraded mode and live-file verification.