### PR TITLE
ci(actions): update repo-owned Node 24 actions

### DIFF
--- a/.github/actions/cache-maven-repo/action.yml
+++ b/.github/actions/cache-maven-repo/action.yml
@@ -22,7 +22,7 @@ runs:
   using: 'composite'
   steps:
     - name: Restore ~/.m2/repository
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2/repository
         key: shaft-m2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -613,7 +613,7 @@ jobs:
           distribution: "zulu"
           check-latest: true
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.5
       # pr-gate has no earlier install step for this module set, unlike the
@@ -787,7 +787,7 @@ jobs:
           distribution: 'zulu'
           check-latest: true
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.12
       - name: Run template-coupled shaft-mcp tests

--- a/.github/workflows/publishJavaDocs.yml
+++ b/.github/workflows/publishJavaDocs.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Cache Maven repository
         uses: ./.github/actions/cache-maven-repo
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.5
       # Captures the reactor version from the root pom.xml.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
           check-latest: true
 
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.5
 

--- a/.github/workflows/shaft-mcp.yml
+++ b/.github/workflows/shaft-mcp.yml
@@ -58,7 +58,7 @@ jobs:
           distribution: 'zulu'
           check-latest: true
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.12
       - name: Validate reactor versions


### PR DESCRIPTION
## Summary

- move the shared Maven cache composite action from `actions/cache@v4` to the supported Node 24 `@v5` runtime
- move all five remaining `stCarolas/setup-maven@v5` references to the released Node 24 `@v5.1` runtime
- preserve workflow triggers, permissions, runner labels, Maven versions, cache inputs, keys, restore prefixes, coverage, and step order

Related to #4929.

## Scope and blocker

This PR resolves every repository-controlled Node.js 20 action reference identified by #4929. It intentionally does not change the GitHub-managed `dynamic/dependency-graph/auto-submission` workflow. GitHub's Maven automatic-submission fork still declares Node 20; upstream issue https://github.com/advanced-security/maven-dependency-submission-action/issues/127 is open and PR https://github.com/advanced-security/maven-dependency-submission-action/pull/131 is open/blocked. Replacing or disabling the managed workflow would change dependency-graph ownership and coverage semantics. #4929 therefore remains open until GitHub/upstream deploys a supported runtime.

## RED / GREEN

RED on `origin/main`:

```text
{'actions/cache@v4': 1, 'stCarolas/setup-maven@v5': 5}
```

The exact-reference scan exited 1.

GREEN at `aeb16523ded2079ed106de4b5ab642fe3874aa78`:

- exact-reference scan: `actions/cache@v4 = 0`, bare `stCarolas/setup-maven@v5 = 0`
- PyYAML: 5 changed YAML documents parsed
- `git diff --check`: exit 0
- workflow timeout validator: pass
- `tests.scripts.test_validate_workflow_timeouts`: 13/13 pass
- SHAFT MCP configuration validator: pass
- `tests.scripts.test_validate_shaft_mcp_configuration`: 21/21 pass
- local gate dry-run selected the expected default reactor command because workflow/root infrastructure changed
- affected quality validator: 26/27 pass; sole repository-baseline failure is the three `trace-viewer-acceptance.yml` inventory/coverage errors already tracked by #4940, with no overlap in this diff

## Remote proof required

PR checks must resolve and execute `actions/cache@v5` and `stCarolas/setup-maven@v5.1`. The final annotation audit must show no repository-controlled Node.js 20 warnings; the managed automatic-submission warning remains the documented external blocker.
