### PR TITLE
fix(engine): replace deprecated API calls

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
@@ -251,7 +251,7 @@ public class FileActions {
         String targetFilePath = targetFileFolderPath + targetFileName;
         TerminalActions terminalSessionForRemoteMachine = new TerminalActions();
         // fetch file from inside docker to the machine itself
-        if (terminalSession.isDockerizedTerminal()) {
+        if (!Objects.toString(terminalSession.getDockerName(), "").isEmpty()) {
             terminalSessionForRemoteMachine = new TerminalActions(terminalSession.getSshHostName(),
                     terminalSession.getSshPortNumber(), terminalSession.getSshUsername(),
                     terminalSession.getSshKeyFileFolderName(), terminalSession.getSshKeyFileName());
@@ -294,7 +294,7 @@ public class FileActions {
         // it's already on the local machine so no need to do anything here
 
         // clean temp directory on remote machine
-        if (terminalSession.isDockerizedTerminal() && terminalSession.isRemoteTerminal()) {
+        if (!Objects.toString(terminalSession.getDockerName(), "").isEmpty() && terminalSession.isRemoteTerminal()) {
             terminalSessionForRemoteMachine.performTerminalCommand("rm -r " + Arrays.toString(pathToTempDirectoryOnRemoteMachine));
         }
 

--- a/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/FileActions.java
@@ -251,7 +251,7 @@ public class FileActions {
         String targetFilePath = targetFileFolderPath + targetFileName;
         TerminalActions terminalSessionForRemoteMachine = new TerminalActions();
         // fetch file from inside docker to the machine itself
-        if (!Objects.toString(terminalSession.getDockerName(), "").isEmpty()) {
+        if (terminalSession.hasDockerTarget()) {
             terminalSessionForRemoteMachine = new TerminalActions(terminalSession.getSshHostName(),
                     terminalSession.getSshPortNumber(), terminalSession.getSshUsername(),
                     terminalSession.getSshKeyFileFolderName(), terminalSession.getSshKeyFileName());
@@ -294,7 +294,7 @@ public class FileActions {
         // it's already on the local machine so no need to do anything here
 
         // clean temp directory on remote machine
-        if (!Objects.toString(terminalSession.getDockerName(), "").isEmpty() && terminalSession.isRemoteTerminal()) {
+        if (terminalSession.hasDockerTarget() && terminalSession.isRemoteTerminal()) {
             terminalSessionForRemoteMachine.performTerminalCommand("rm -r " + Arrays.toString(pathToTempDirectoryOnRemoteMachine));
         }
 

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -326,7 +326,7 @@ public class TerminalActions implements AutoCloseable {
      */
     @Deprecated(since = "10.2.20260614", forRemoval = true)
     public boolean isDockerizedTerminal() {
-        return !dockerName.isEmpty();
+        return hasDockerTarget();
     }
 
     public String performTerminalCommands(List<String> commands) {
@@ -352,7 +352,7 @@ public class TerminalActions implements AutoCloseable {
 
         // Build long command and refactor for dockerized execution if needed
         String longCommand = buildLongCommand(internalCommands);
-        List<String> commandsToExecute = isDockerizedTerminal() && !isRemoteTerminal()
+        List<String> commandsToExecute = hasDockerTarget() && !isRemoteTerminal()
                 ? Collections.singletonList(longCommand)
                 : internalCommands;
 
@@ -886,7 +886,7 @@ public class TerminalActions implements AutoCloseable {
             failAction("SFTP file transfer",
                     new IllegalStateException("SFTP is only supported for remote SSH terminals."));
         }
-        if (isDockerizedTerminal()) {
+        if (hasDockerTarget()) {
             failAction("SFTP file transfer", new IllegalStateException(
                     "SFTP operates on the remote host filesystem. Use performTerminalCommand(...) for dockerized remote terminals."));
         }
@@ -911,7 +911,7 @@ public class TerminalActions implements AutoCloseable {
             failAction("Reusable remote SSH feature",
                     new IllegalStateException("This feature is only supported for remote SSH terminals."));
         }
-        if (isDockerizedTerminal()) {
+        if (hasDockerTarget()) {
             failAction("Reusable remote SSH feature", new IllegalStateException(
                     "This feature operates on the remote host SSH session. Use performTerminalCommand(...) for dockerized remote terminals."));
         }
@@ -1008,12 +1008,16 @@ public class TerminalActions implements AutoCloseable {
         }
 
         // refactor long command for dockerized execution
-        if (isDockerizedTerminal()) {
+        if (hasDockerTarget()) {
             command.insert(0, "docker exec -u " + dockerUsername + " -i " + dockerName + " timeout "
-                    + SHAFT.Properties.timeouts.dockerCommandTimeout() + " sh -c '");
+                    + SHAFT.Properties.timeouts.dockerCommandTimeoutSeconds() + " sh -c '");
             command.append("'");
         }
         return command.toString();
+    }
+
+    private boolean hasDockerTarget() {
+        return !dockerName.isEmpty();
     }
 
     private void applyLocalProcessEnvironment(ProcessBuilder processBuilder, Map<String, String> environmentVariables) {

--- a/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
+++ b/shaft-engine/src/main/java/com/shaft/cli/TerminalActions.java
@@ -1016,7 +1016,7 @@ public class TerminalActions implements AutoCloseable {
         return command.toString();
     }
 
-    private boolean hasDockerTarget() {
+    boolean hasDockerTarget() {
         return !dockerName.isEmpty();
     }
 

--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -286,10 +286,9 @@ public class DriverFactoryHelper {
         return browserNetworkInterceptor;
     }
 
-    @SuppressWarnings("removal")
     private void startBrowserObservability() {
         try {
-            if (driver instanceof HasBiDi hasBiDi && hasBiDi.maybeGetBiDi().isPresent()) {
+            if (driver instanceof HasBiDi hasBiDi && hasBiDi.getHandle() != null) {
                 BidiConsoleLogSource.attach(driver);
             }
             if (driver != null

--- a/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/driver/internal/DriverFactory/DriverFactoryHelper.java
@@ -291,6 +291,10 @@ public class DriverFactoryHelper {
             if (driver instanceof HasBiDi hasBiDi && hasBiDi.getHandle() != null) {
                 BidiConsoleLogSource.attach(driver);
             }
+        } catch (RuntimeException e) {
+            ReportManagerHelper.logDiscrete("Could not start BiDi console observability: " + e.getMessage(), Level.WARN);
+        }
+        try {
             if (driver != null
                     && SHAFT.Properties.reporting != null
                     && SHAFT.Properties.reporting.traceEnabled()
@@ -299,7 +303,7 @@ public class DriverFactoryHelper {
                 getBrowserNetworkInterceptor().startObserving();
             }
         } catch (RuntimeException e) {
-            ReportManagerHelper.logDiscrete("Could not start browser observability: " + e.getMessage(), Level.WARN);
+            ReportManagerHelper.logDiscrete("Could not start network observability: " + e.getMessage(), Level.WARN);
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -795,7 +795,7 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
                 case "prompt" -> PermissionState.PROMPT;
                 default -> throw new IllegalArgumentException("Unknown permission state: " + stateName);
             };
-            org.openqa.selenium.bidi.module.Permission permission = bidiPermissions(driver, stateName);
+            HandlePermissionModule permission = bidiPermissions(driver, stateName);
             TraceEventRecorder.withoutNestedEvents(() -> BidiPermissionState.exclusively(driver, changes -> {
                 permissions.forEach(name -> {
                     permission.setPermission(Map.of("name", name), state, validatedOrigin);
@@ -821,7 +821,7 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
         WebDriver driver = driverFactoryHelper == null ? null : driverFactoryHelper.getDriver();
         var event = TraceEventRecorder.start("permissions", "clear", "", driver);
         try {
-            org.openqa.selenium.bidi.module.Permission permission = bidiPermissions(driver, "clear");
+            HandlePermissionModule permission = bidiPermissions(driver, "clear");
             int restored = TraceEventRecorder.withoutNestedEvents(() ->
                     BidiPermissionState.exclusively(driver, changes -> {
                 List<BidiPermissionState.Change> snapshot = List.copyOf(changes);
@@ -839,7 +839,7 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
         }
     }
 
-    private org.openqa.selenium.bidi.module.Permission bidiPermissions(WebDriver driver, String operation) {
+    private HandlePermissionModule bidiPermissions(WebDriver driver, String operation) {
         boolean closedRemoteSession = driver instanceof RemoteWebDriver remoteDriver && remoteDriver.getSessionId() == null;
         Capabilities capabilities = driver instanceof HasCapabilities hasCapabilities
                 ? hasCapabilities.getCapabilities() : null;
@@ -850,7 +850,21 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
             throw new UnsupportedOperationException("Browser permissions " + operation
                     + " requires a live Selenium session with negotiated WebDriver BiDi permission support.");
         }
-        return new org.openqa.selenium.bidi.module.Permission(driver);
+        return new HandlePermissionModule(driver);
+    }
+
+    private static final class HandlePermissionModule extends org.openqa.selenium.bidi.Module {
+        private HandlePermissionModule(WebDriver driver) {
+            super(driver);
+        }
+
+        private void setPermission(Map<String, String> descriptor, PermissionState state, String origin) {
+            Map<String, Object> parameters = new HashMap<>();
+            parameters.put("descriptor", descriptor);
+            parameters.put("state", state.toString());
+            parameters.put("origin", origin);
+            send(new org.openqa.selenium.bidi.Command<>("permissions.setPermission", parameters));
+        }
     }
 
     private static List<String> validatedPermissionNames(String... permissionNames) {

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -20,6 +20,7 @@ import com.shaft.gui.browser.internal.HarReplayRules;
 import com.shaft.gui.browser.internal.JavaScriptWaitManager;
 import com.shaft.gui.browser.internal.ScrollSweepPlanner;
 import com.shaft.gui.capabilities.AutomationBackend;
+import com.shaft.gui.capabilities.internal.AutomationCapabilityResolver;
 import com.shaft.gui.driver.BrowserConsoleMessage;
 import com.shaft.gui.internal.image.ScreenshotManager;
 import com.shaft.gui.internal.locator.LocatorBuilder;
@@ -41,7 +42,6 @@ import io.qameta.allure.Step;
 import org.apache.logging.log4j.Level;
 import org.openqa.selenium.*;
 import org.openqa.selenium.devtools.HasDevTools;
-import org.openqa.selenium.bidi.HasBiDi;
 import org.openqa.selenium.bidi.permissions.PermissionState;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.http.HttpRequest;
@@ -839,14 +839,12 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
         }
     }
 
-    @SuppressWarnings("removal")
     private org.openqa.selenium.bidi.module.Permission bidiPermissions(WebDriver driver, String operation) {
         boolean closedRemoteSession = driver instanceof RemoteWebDriver remoteDriver && remoteDriver.getSessionId() == null;
         Capabilities capabilities = driver instanceof HasCapabilities hasCapabilities
                 ? hasCapabilities.getCapabilities() : null;
         Object webSocketUrl = capabilities == null ? null : capabilities.getCapability("webSocketUrl");
-        boolean negotiated = driver instanceof HasBiDi hasBiDi
-                && hasBiDi.maybeGetBiDi().isPresent()
+        boolean negotiated = AutomationCapabilityResolver.hasNegotiatedBiDi(driver)
                 && webSocketUrl instanceof String url && !url.isBlank();
         if (driver instanceof AppiumDriver || closedRemoteSession || !negotiated) {
             throw new UnsupportedOperationException("Browser permissions " + operation

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BidiNetworkActivitySource.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BidiNetworkActivitySource.java
@@ -172,7 +172,7 @@ public class BidiNetworkActivitySource implements AutoCloseable {
         } catch (RuntimeException e) {
             // new Network(driver) throws for any session that doesn't support/enable BiDi:
             // IllegalArgumentException when the driver doesn't implement HasBiDi at all, or a
-            // BiDiException (via HasBiDi.getBiDi()) when it does but no BiDi connection could be
+            // BiDiException (via the supported BiDi handle) when it does but no connection could be
             // established. Either way: mark unhealthy, log once, never retry for this driver.
             ReportManagerHelper.logDiscrete("BiDi network-activity source unavailable for this driver "
                     + "session; browser-readiness waits will use the JS-only network signal. "

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserEmulationManager.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserEmulationManager.java
@@ -7,7 +7,7 @@ import com.shaft.gui.capabilities.internal.AutomationCapabilityResolver;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.bidi.Command;
 import org.openqa.selenium.bidi.HasBiDi;
-import org.openqa.selenium.bidi.emulation.Emulation;
+import org.openqa.selenium.bidi.Module;
 import org.openqa.selenium.bidi.emulation.GeolocationCoordinates;
 import org.openqa.selenium.bidi.emulation.ScreenArea;
 import org.openqa.selenium.bidi.emulation.SetGeolocationOverrideParameters;
@@ -15,6 +15,7 @@ import org.openqa.selenium.bidi.emulation.SetScreenSettingsOverrideParameters;
 import org.openqa.selenium.bidi.emulation.SetScriptingEnabledParameters;
 import org.openqa.selenium.bidi.emulation.SetTimezoneOverrideParameters;
 import org.openqa.selenium.bidi.emulation.SetUserAgentOverrideParameters;
+import org.openqa.selenium.bidi.emulation.OverrideParameters;
 import org.openqa.selenium.devtools.DevTools;
 import org.openqa.selenium.devtools.HasDevTools;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -42,13 +43,13 @@ public final class BrowserEmulationManager {
 
     public static void setScreenSize(WebDriver driver, int width, int height) {
         requirePositiveDimensions(width, height);
-        emulation(driver, "screen size").setScreenSettingsOverride(
+        sendEmulation(driver, "screen size", "emulation.setScreenSettingsOverride",
                 new SetScreenSettingsOverrideParameters(new ScreenArea(width, height))
                         .contexts(contexts(driver, "screen size")));
     }
 
     public static void clearScreenSize(WebDriver driver) {
-        emulation(driver, "clear screen size").setScreenSettingsOverride(
+        sendEmulation(driver, "clear screen size", "emulation.setScreenSettingsOverride",
                 new SetScreenSettingsOverrideParameters(null)
                         .contexts(contexts(driver, "clear screen size")));
     }
@@ -113,25 +114,25 @@ public final class BrowserEmulationManager {
 
     public static void setGeolocation(WebDriver driver, double latitude, double longitude, double accuracy) {
         requireValidGeolocation(latitude, longitude, accuracy);
-        emulation(driver, "geolocation").setGeolocationOverride(new SetGeolocationOverrideParameters(
+        sendEmulation(driver, "geolocation", "emulation.setGeolocationOverride", new SetGeolocationOverrideParameters(
                 new GeolocationCoordinates(latitude, longitude).accuracy(accuracy))
                 .contexts(contexts(driver, "geolocation")));
     }
 
     public static void clearGeolocation(WebDriver driver) {
-        emulation(driver, "clear geolocation").setGeolocationOverride(
+        sendEmulation(driver, "clear geolocation", "emulation.setGeolocationOverride",
                 new SetGeolocationOverrideParameters((GeolocationCoordinates) null)
                         .contexts(contexts(driver, "clear geolocation")));
     }
 
     public static void setTimezone(WebDriver driver, String timezoneId) {
         requireTimezone(timezoneId);
-        emulation(driver, "timezone").setTimezoneOverride(new SetTimezoneOverrideParameters(timezoneId)
+        sendEmulation(driver, "timezone", "emulation.setTimezoneOverride", new SetTimezoneOverrideParameters(timezoneId)
                 .contexts(contexts(driver, "timezone")));
     }
 
     public static void clearTimezone(WebDriver driver) {
-        emulation(driver, "clear timezone").setTimezoneOverride(new SetTimezoneOverrideParameters(null)
+        sendEmulation(driver, "clear timezone", "emulation.setTimezoneOverride", new SetTimezoneOverrideParameters(null)
                 .contexts(contexts(driver, "clear timezone")));
     }
 
@@ -148,45 +149,45 @@ public final class BrowserEmulationManager {
         if (userAgent == null || userAgent.isBlank()) {
             throw new IllegalArgumentException("User agent must not be null or blank.");
         }
-        emulation(driver, "user agent").setUserAgentOverride(new SetUserAgentOverrideParameters(userAgent)
+        sendEmulation(driver, "user agent", "emulation.setUserAgentOverride", new SetUserAgentOverrideParameters(userAgent)
                 .contexts(contexts(driver, "user agent")));
     }
 
     public static void clearUserAgent(WebDriver driver) {
-        emulation(driver, "clear user agent").setUserAgentOverride(new SetUserAgentOverrideParameters(null)
+        sendEmulation(driver, "clear user agent", "emulation.setUserAgentOverride", new SetUserAgentOverrideParameters(null)
                 .contexts(contexts(driver, "clear user agent")));
     }
 
     public static void disableScripting(WebDriver driver) {
-        emulation(driver, "disable scripting").setScriptingEnabled(new SetScriptingEnabledParameters(false)
+        sendEmulation(driver, "disable scripting", "emulation.setScriptingEnabled", new SetScriptingEnabledParameters(false)
                 .contexts(contexts(driver, "disable scripting")));
     }
 
     public static void clearScriptingOverride(WebDriver driver) {
-        emulation(driver, "clear scripting").setScriptingEnabled(new SetScriptingEnabledParameters(null)
+        sendEmulation(driver, "clear scripting", "emulation.setScriptingEnabled", new SetScriptingEnabledParameters(null)
                 .contexts(contexts(driver, "clear scripting")));
     }
 
     private static void sendLocale(WebDriver driver, String locale) {
-        HasBiDi hasBiDi = requireBiDi(driver, locale == null ? "clear locale" : "locale");
+        requireBiDi(driver, locale == null ? "clear locale" : "locale");
         Map<String, Object> parameters = new LinkedHashMap<>();
         parameters.put("locale", locale);
         parameters.put("contexts", contexts(driver, locale == null ? "clear locale" : "locale"));
-        hasBiDi.getBiDi().send(new Command<>("emulation.setLocaleOverride", parameters));
+        new HandleEmulationModule(driver).send("emulation.setLocaleOverride", parameters);
     }
 
-    private static Emulation emulation(WebDriver driver, String operation) {
+    private static void sendEmulation(WebDriver driver, String operation, String method,
+                                      OverrideParameters parameters) {
         requireBiDi(driver, operation);
-        return new Emulation(driver);
+        new HandleEmulationModule(driver).send(method, parameters.toMap());
     }
 
-    private static HasBiDi requireBiDi(WebDriver driver, String operation) {
+    private static void requireBiDi(WebDriver driver, String operation) {
         if (!AutomationCapabilityResolver.hasNegotiatedBiDi(driver)
-                || !(driver instanceof HasBiDi hasBiDi)) {
+                || !(driver instanceof HasBiDi)) {
             throw new UnsupportedOperationException("Emulation " + operation
                     + " requires a live Selenium or Appium session with negotiated WebDriver BiDi.");
         }
-        return hasBiDi;
     }
 
     private static DevTools devTools(WebDriver driver, String operation) {
@@ -298,6 +299,16 @@ public final class BrowserEmulationManager {
 
         private CdpMediaState withReducedMotion(String value) {
             return new CdpMediaState(media, colorScheme, value);
+        }
+    }
+
+    private static final class HandleEmulationModule extends Module {
+        private HandleEmulationModule(WebDriver driver) {
+            super(driver);
+        }
+
+        private void send(String method, Map<String, Object> parameters) {
+            send(new Command<>(method, parameters));
         }
     }
 }

--- a/shaft-engine/src/main/java/com/shaft/gui/capabilities/internal/AutomationCapabilityResolver.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/capabilities/internal/AutomationCapabilityResolver.java
@@ -286,13 +286,12 @@ public final class AutomationCapabilityResolver {
      * Returns whether one live driver has both a usable BiDi object and the negotiated websocket capability.
      * Runtime protocol users call this same predicate so advertised and executable support cannot diverge.
      */
-    @SuppressWarnings("removal")
     public static boolean hasNegotiatedBiDi(WebDriver driver) {
         try {
             if ((driver instanceof RemoteWebDriver remote && remote.getSessionId() == null)
                     || !(driver instanceof HasBiDi hasBiDi)
                     || !(driver instanceof HasCapabilities hasCapabilities)
-                    || hasBiDi.maybeGetBiDi().isEmpty()) {
+                    || hasBiDi.getHandle() == null) {
                 return false;
             }
             Capabilities capabilities = hasCapabilities.getCapabilities();

--- a/shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java
+++ b/shaft-engine/src/main/java/com/shaft/properties/internal/Timeouts.java
@@ -129,6 +129,15 @@ public interface Timeouts extends EngineProperties<Timeouts> {
     @DefaultValue("30")
     int dockerCommandTimeout();
 
+    /**
+     * Timeout in seconds retained for compatibility with deprecated Docker-wrapped terminal execution.
+     *
+     * @return the configured Docker command timeout in seconds
+     */
+    @Key("dockerCommandTimeout")
+    @DefaultValue("30")
+    int dockerCommandTimeoutSeconds();
+
     @Key("databaseLoginTimeout")
     @DefaultValue("30")
     int databaseLoginTimeout();
@@ -283,6 +292,11 @@ public interface Timeouts extends EngineProperties<Timeouts> {
          */
         @Deprecated(since = "10.2.20260614", forRemoval = true)
         public SetProperty dockerCommandTimeout(int value) {
+            setProperty("dockerCommandTimeout", String.valueOf(value));
+            return this;
+        }
+
+        public SetProperty dockerCommandTimeoutSeconds(int value) {
             setProperty("dockerCommandTimeout", String.valueOf(value));
             return this;
         }

--- a/shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java
@@ -176,7 +176,7 @@ public class FileActionsCoverageUnitTest {
         Mockito.doReturn(tempDirectory.resolve("id_rsa").toString()).when(helperActions).getAbsolutePath("keys/", "id_rsa");
 
         TerminalActions remoteDockerTerminal = Mockito.mock(TerminalActions.class);
-        Mockito.when(remoteDockerTerminal.isDockerizedTerminal()).thenReturn(true);
+        Mockito.when(remoteDockerTerminal.getDockerName()).thenReturn("container");
         Mockito.when(remoteDockerTerminal.isRemoteTerminal()).thenReturn(true);
         Mockito.when(remoteDockerTerminal.getSshHostName()).thenReturn("remote-host");
         Mockito.when(remoteDockerTerminal.getSshPortNumber()).thenReturn(2222);

--- a/shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java
@@ -198,6 +198,22 @@ public class FileActionsCoverageUnitTest {
     }
 
     @Test
+    public void nullDockerNameShouldFailBeforeSelectingHostOrSshCopy() {
+        FileActions actions = FileActions.getInstance(true);
+        TerminalActions terminal = new TerminalActions();
+        try {
+            var dockerName = TerminalActions.class.getDeclaredField("dockerName");
+            dockerName.setAccessible(true);
+            dockerName.set(terminal, null);
+        } catch (ReflectiveOperationException exception) {
+            throw new AssertionError("Could not arrange the legacy null Docker-name state.", exception);
+        }
+
+        Assert.expectThrows(NullPointerException.class, () ->
+                actions.copyFileToLocalMachine(terminal, "/var/log/", "app.log"));
+    }
+
+    @Test
     public void zipUnpackDownloadAndJarCopyShouldRoundTripTempFiles() throws Exception {
         FileActions actions = FileActions.getInstance();
         Path archiveSource = tempDirectory.resolve("archive-source");

--- a/shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/cli/FileActionsCoverageUnitTest.java
@@ -176,6 +176,7 @@ public class FileActionsCoverageUnitTest {
         Mockito.doReturn(tempDirectory.resolve("id_rsa").toString()).when(helperActions).getAbsolutePath("keys/", "id_rsa");
 
         TerminalActions remoteDockerTerminal = Mockito.mock(TerminalActions.class);
+        Mockito.when(remoteDockerTerminal.hasDockerTarget()).thenReturn(true);
         Mockito.when(remoteDockerTerminal.getDockerName()).thenReturn("container");
         Mockito.when(remoteDockerTerminal.isRemoteTerminal()).thenReturn(true);
         Mockito.when(remoteDockerTerminal.getSshHostName()).thenReturn("remote-host");
@@ -194,20 +195,16 @@ public class FileActionsCoverageUnitTest {
 
             Assert.assertEquals(Path.of(localPath), localTemp.resolve("app.log"));
             Assert.assertTrue(Files.isDirectory(localTemp));
+            Mockito.verify(ignoredConstruction.constructed().get(1)).performTerminalCommand(
+                    "docker cp container:/var/log/app.log /remote-temp//var/log/app.log");
         }
     }
 
     @Test
     public void nullDockerNameShouldFailBeforeSelectingHostOrSshCopy() {
         FileActions actions = FileActions.getInstance(true);
-        TerminalActions terminal = new TerminalActions();
-        try {
-            var dockerName = TerminalActions.class.getDeclaredField("dockerName");
-            dockerName.setAccessible(true);
-            dockerName.set(terminal, null);
-        } catch (ReflectiveOperationException exception) {
-            throw new AssertionError("Could not arrange the legacy null Docker-name state.", exception);
-        }
+        TerminalActions terminal = Mockito.mock(TerminalActions.class);
+        Mockito.when(terminal.hasDockerTarget()).thenCallRealMethod();
 
         Assert.expectThrows(NullPointerException.class, () ->
                 actions.copyFileToLocalMachine(terminal, "/var/log/", "app.log"));

--- a/shaft-engine/src/test/java/com/shaft/gui/BidiTestSupport.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/BidiTestSupport.java
@@ -1,0 +1,36 @@
+package com.shaft.gui;
+
+import org.mockito.Mockito;
+import org.openqa.selenium.bidi.BiDi;
+import org.openqa.selenium.bidi.Handle;
+import org.openqa.selenium.bidi.HasBiDi;
+
+/** Test-only bridge from a mock BiDi transport to Selenium's supported opaque handle. */
+public final class BidiTestSupport {
+    private BidiTestSupport() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    public static Handle handleFor(BiDi bidi) {
+        try {
+            var constructor = Handle.class.getDeclaredConstructor(BiDi.class);
+            constructor.setAccessible(true);
+            return constructor.newInstance(bidi);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Could not create a test BiDi handle.", exception);
+        }
+    }
+
+    /** Supplies both the supported handle and Selenium 4.47's current high-level-module transport. */
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    public static void connect(HasBiDi driver, BiDi bidi) {
+        Mockito.when(driver.getHandle()).thenReturn(handleFor(bidi));
+        try {
+            var deprecatedTransport = HasBiDi.class.getMethod("getBiDi");
+            deprecatedTransport.invoke(Mockito.doReturn(bidi).when(driver));
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Could not connect a test BiDi transport.", exception);
+        }
+    }
+}

--- a/shaft-engine/src/test/java/com/shaft/gui/BidiTestSupport.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/BidiTestSupport.java
@@ -1,9 +1,7 @@
 package com.shaft.gui;
 
-import org.mockito.Mockito;
 import org.openqa.selenium.bidi.BiDi;
 import org.openqa.selenium.bidi.Handle;
-import org.openqa.selenium.bidi.HasBiDi;
 
 /** Test-only bridge from a mock BiDi transport to Selenium's supported opaque handle. */
 public final class BidiTestSupport {
@@ -19,18 +17,6 @@ public final class BidiTestSupport {
             return constructor.newInstance(bidi);
         } catch (ReflectiveOperationException exception) {
             throw new IllegalStateException("Could not create a test BiDi handle.", exception);
-        }
-    }
-
-    /** Supplies both the supported handle and Selenium 4.47's current high-level-module transport. */
-    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
-    public static void connect(HasBiDi driver, BiDi bidi) {
-        Mockito.when(driver.getHandle()).thenReturn(handleFor(bidi));
-        try {
-            var deprecatedTransport = HasBiDi.class.getMethod("getBiDi");
-            deprecatedTransport.invoke(Mockito.doReturn(bidi).when(driver));
-        } catch (ReflectiveOperationException exception) {
-            throw new IllegalStateException("Could not connect a test BiDi transport.", exception);
         }
     }
 }

--- a/shaft-engine/src/test/java/com/shaft/gui/browser/internal/BidiConsoleLogSourceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/browser/internal/BidiConsoleLogSourceTest.java
@@ -7,8 +7,10 @@ import com.shaft.tools.io.internal.BrowserObservabilityRecorder;
 import org.mockito.Mockito;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.bidi.BiDi;
+import org.openqa.selenium.bidi.BiDiException;
 import org.openqa.selenium.bidi.HasBiDi;
 import org.openqa.selenium.bidi.module.LogInspector;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.Logs;
@@ -199,6 +201,22 @@ public class BidiConsoleLogSourceTest {
             Assert.assertTrue(BidiConsoleLogSource.isHealthy(driver));
             Assert.assertEquals(inspectors.constructed().size(), 1);
             BidiConsoleLogSource.closeAndRemove(driver);
+        }
+    }
+
+    @Test
+    public void unavailableBiDiHandleShouldNotPreventNetworkObservationDuringHelperInitialization() {
+        RemoteWebDriver driver = Mockito.mock(RemoteWebDriver.class);
+        Mockito.when(driver.getHandle()).thenThrow(new BiDiException("BiDi is not negotiated"));
+        SHAFT.Properties.reporting.set().traceEnabled(true).traceIncludeNetwork(true);
+
+        try (var interceptors = Mockito.mockConstruction(BrowserNetworkInterceptor.class,
+                (mock, context) -> Mockito.when(mock.startObserving()).thenReturn(true))) {
+            new DriverFactoryHelper(driver);
+
+            Assert.assertEquals(interceptors.constructed().size(), 1,
+                    "An unavailable optional BiDi channel must not skip independent network setup.");
+            Mockito.verify(interceptors.constructed().getFirst()).startObserving();
         }
     }
 

--- a/shaft-engine/src/test/java/com/shaft/gui/browser/internal/BidiConsoleLogSourceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/browser/internal/BidiConsoleLogSourceTest.java
@@ -2,6 +2,7 @@ package com.shaft.gui.browser.internal;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.driver.internal.DriverFactory.DriverFactoryHelper;
+import com.shaft.gui.BidiTestSupport;
 import com.shaft.tools.io.internal.BrowserObservabilityRecorder;
 import org.mockito.Mockito;
 import org.openqa.selenium.WebDriver;
@@ -188,11 +189,10 @@ public class BidiConsoleLogSourceTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
     public void attachedNegotiatedDriversShouldStartObservationDuringHelperInitialization() {
         WebDriver driver = Mockito.mock(WebDriver.class, Mockito.withSettings().extraInterfaces(HasBiDi.class));
         BiDi bidi = Mockito.mock(BiDi.class);
-        Mockito.when(((HasBiDi) driver).maybeGetBiDi()).thenReturn(Optional.of(bidi));
+        Mockito.when(((HasBiDi) driver).getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         try (var inspectors = Mockito.mockConstruction(LogInspector.class)) {
             new DriverFactoryHelper(driver);
 

--- a/shaft-engine/src/test/java/com/shaft/gui/driver/BrowserEmulationNamespaceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/driver/BrowserEmulationNamespaceTest.java
@@ -11,6 +11,7 @@ import com.microsoft.playwright.options.ReducedMotion;
 import com.microsoft.playwright.options.ViewportSize;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.gui.playwright.internal.PlaywrightTraceManager;
+import com.shaft.gui.BidiTestSupport;
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.capabilities.AutomationCapabilities;
 import com.shaft.gui.capabilities.AutomationFeature;
@@ -80,7 +81,7 @@ public class BrowserEmulationNamespaceTest {
         WebDriver bidiDriver = Mockito.mock(WebDriver.class, Mockito.withSettings()
                 .extraInterfaces(HasBiDi.class, HasCapabilities.class));
         BiDi bidi = Mockito.mock(BiDi.class);
-        Mockito.when(((HasBiDi) bidiDriver).maybeGetBiDi()).thenReturn(Optional.of(bidi));
+        Mockito.when(((HasBiDi) bidiDriver).getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(((HasCapabilities) bidiDriver).getCapabilities()).thenReturn(negotiatedBiDi);
         AutomationCapabilities bidiCapabilities = AutomationCapabilityResolver.forWebDriver(bidiDriver);
         Assert.assertTrue(bidiCapabilities.supports(AutomationFeature.SCREEN_EMULATION));
@@ -128,7 +129,7 @@ public class BrowserEmulationNamespaceTest {
                 Mockito.withSettings().extraInterfaces(HasBiDi.class, HasDevTools.class));
         Mockito.when(closed.getCapabilities()).thenReturn(negotiated);
         Mockito.when(closed.getSessionId()).thenReturn(null);
-        Mockito.when(((HasBiDi) closed).maybeGetBiDi()).thenReturn(Optional.of(bidi));
+        Mockito.when(((HasBiDi) closed).getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(((HasDevTools) closed).maybeGetDevTools()).thenReturn(Optional.of(devTools));
         AutomationCapabilities closedCapabilities = AutomationCapabilityResolver.forWebDriver(closed);
         Assert.assertFalse(closedCapabilities.supports(AutomationFeature.SCREEN_EMULATION));
@@ -138,7 +139,7 @@ public class BrowserEmulationNamespaceTest {
         AppiumDriver appium = Mockito.mock(AppiumDriver.class);
         Mockito.when(appium.getSessionId()).thenReturn(new SessionId("appium-emulation"));
         Mockito.when(appium.getCapabilities()).thenReturn(negotiated);
-        Mockito.when(appium.maybeGetBiDi()).thenReturn(Optional.of(bidi));
+        Mockito.when(appium.getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         AutomationCapabilities appiumCapabilities = AutomationCapabilityResolver.forWebDriver(appium);
         Assert.assertTrue(appiumCapabilities.supports(AutomationFeature.GEOLOCATION_EMULATION));
         Assert.assertTrue(appiumCapabilities.supports(AutomationFeature.LOCALE_EMULATION));
@@ -152,8 +153,7 @@ public class BrowserEmulationNamespaceTest {
         WebDriver selenium = Mockito.mock(WebDriver.class, Mockito.withSettings()
                 .extraInterfaces(HasBiDi.class, HasCapabilities.class));
         Mockito.when(((HasCapabilities) selenium).getCapabilities()).thenReturn(missingWebSocket);
-        Mockito.when(((HasBiDi) selenium).maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(((HasBiDi) selenium).getBiDi()).thenReturn(bidi);
+        Mockito.when(((HasBiDi) selenium).getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(selenium.getWindowHandle()).thenReturn("context-1");
         Assert.assertFalse(AutomationCapabilityResolver.forWebDriver(selenium)
                 .supports(AutomationFeature.GEOLOCATION_EMULATION));
@@ -164,8 +164,7 @@ public class BrowserEmulationNamespaceTest {
         AppiumDriver appium = Mockito.mock(AppiumDriver.class);
         Mockito.when(appium.getSessionId()).thenReturn(new SessionId("appium-without-websocket"));
         Mockito.when(appium.getCapabilities()).thenReturn(missingWebSocket);
-        Mockito.when(appium.maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(appium.getBiDi()).thenReturn(bidi);
+        Mockito.when(appium.getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(appium.getWindowHandle()).thenReturn("WEBVIEW_1");
         Assert.assertFalse(AutomationCapabilityResolver.forWebDriver(appium)
                 .supports(AutomationFeature.GEOLOCATION_EMULATION));
@@ -192,8 +191,7 @@ public class BrowserEmulationNamespaceTest {
                 .extraInterfaces(HasBiDi.class, HasCapabilities.class));
         BiDi bidi = Mockito.mock(BiDi.class);
         Mockito.when(((HasCapabilities) driver).getCapabilities()).thenReturn(negotiated);
-        Mockito.when(((HasBiDi) driver).maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(((HasBiDi) driver).getBiDi()).thenReturn(bidi);
+        Mockito.when(((HasBiDi) driver).getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(driver.getWindowHandle()).thenReturn("context-1");
 
         disableScripting.invoke(new com.shaft.gui.browser.BrowserActions(driver, true).emulation().runtime());
@@ -218,8 +216,7 @@ public class BrowserEmulationNamespaceTest {
 
         WebDriver bidiDriver = Mockito.mock(WebDriver.class, Mockito.withSettings().extraInterfaces(HasBiDi.class));
         BiDi bidi = Mockito.mock(BiDi.class);
-        Mockito.when(((HasBiDi) bidiDriver).maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(((HasBiDi) bidiDriver).getBiDi()).thenReturn(bidi);
+        Mockito.when(((HasBiDi) bidiDriver).getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(bidiDriver.getWindowHandle()).thenReturn("context-1");
         EmulationActionsContract bidiActions = new com.shaft.gui.browser.BrowserActions(bidiDriver, true).emulation();
         Assert.expectThrows(IllegalArgumentException.class,
@@ -304,8 +301,7 @@ public class BrowserEmulationNamespaceTest {
                 .extraInterfaces(HasBiDi.class, HasCapabilities.class));
         BiDi bidi = Mockito.mock(BiDi.class);
         Mockito.when(((HasCapabilities) driver).getCapabilities()).thenReturn(negotiated);
-        Mockito.when(((HasBiDi) driver).maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(((HasBiDi) driver).getBiDi()).thenReturn(bidi);
+        Mockito.when(((HasBiDi) driver).getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(driver.getWindowHandle()).thenReturn("context-1");
         EmulationActionsContract emulation = new com.shaft.gui.browser.BrowserActions(driver, true).emulation();
 

--- a/shaft-engine/src/test/java/com/shaft/gui/driver/BrowserPermissionsNamespaceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/driver/BrowserPermissionsNamespaceTest.java
@@ -3,10 +3,12 @@ package com.shaft.gui.driver;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.Page;
+import com.shaft.driver.SHAFT;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.gui.capabilities.AutomationFeature;
 import com.shaft.gui.capabilities.internal.AutomationCapabilityResolver;
 import com.shaft.gui.BidiTestSupport;
+import com.shaft.properties.internal.Properties;
 import io.appium.java_client.AppiumDriver;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -18,6 +20,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.SessionId;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.annotations.AfterMethod;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,6 +38,11 @@ import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
 
 public class BrowserPermissionsNamespaceTest {
+    @AfterMethod(alwaysRun = true)
+    public void clearThreadProperties() {
+        Properties.clearForCurrentThread();
+    }
+
     @Test
     public void permissionsNamespaceShouldBeDiscoverableWithoutAddingFlatMethods() {
         boolean discoverable = Arrays.stream(BrowserActionsContract.class.getMethods())
@@ -162,16 +170,20 @@ public class BrowserPermissionsNamespaceTest {
         capabilities.setCapability("webSocketUrl", "ws://localhost/session");
         Mockito.when(driver.getSessionId()).thenReturn(new SessionId("selenium"));
         Mockito.when(driver.getCapabilities()).thenReturn(capabilities);
-        BidiTestSupport.connect(hasBiDi, bidi);
-        new com.shaft.gui.browser.BrowserActions(driver, true).permissions()
-                .grantFor("https://example.test", "geolocation");
-        new com.shaft.gui.browser.BrowserActions(driver, true).permissions().clear();
+        Mockito.when(hasBiDi.getHandle()).thenReturn(null, BidiTestSupport.handleFor(bidi));
+        SHAFT.Properties.reporting.set().traceEnabled(false).traceIncludeNetwork(false);
+        var browser = new com.shaft.gui.browser.BrowserActions(driver, true);
+        browser.permissions().grantFor("https://example.test", "geolocation");
+        browser.permissions().clear();
 
         ArgumentCaptor<Command> command = ArgumentCaptor.forClass(Command.class);
         Mockito.verify(bidi, Mockito.times(2)).send(command.capture());
         Assert.assertEquals(command.getAllValues().get(0).getMethod(), "permissions.setPermission");
         Assert.assertEquals(command.getAllValues().get(0).getParams().get("state"), "granted");
         Assert.assertEquals(command.getAllValues().get(1).getParams().get("state"), "prompt");
+        Assert.assertTrue(Arrays.stream(BidiTestSupport.class.getDeclaredMethods())
+                        .noneMatch(method -> Arrays.asList(method.getParameterTypes()).contains(HasBiDi.class)),
+                "The test bridge must expose only the supported opaque Handle transport.");
         Assert.assertTrue(AutomationCapabilityResolver.forWebDriver(driver).supports(AutomationFeature.PERMISSIONS));
     }
 
@@ -186,7 +198,7 @@ public class BrowserPermissionsNamespaceTest {
         capabilities.setCapability("webSocketUrl", "ws://localhost/session");
         Mockito.when(driver.getSessionId()).thenReturn(new SessionId("serialized"));
         Mockito.when(driver.getCapabilities()).thenReturn(capabilities);
-        BidiTestSupport.connect(hasBiDi, bidi);
+        Mockito.when(hasBiDi.getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         AtomicInteger sends = new AtomicInteger();
         CountDownLatch clearEnteredProvider = new CountDownLatch(1);
         CountDownLatch releaseClear = new CountDownLatch(1);

--- a/shaft-engine/src/test/java/com/shaft/gui/driver/BrowserPermissionsNamespaceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/driver/BrowserPermissionsNamespaceTest.java
@@ -6,6 +6,7 @@ import com.microsoft.playwright.Page;
 import com.shaft.gui.playwright.internal.PlaywrightSession;
 import com.shaft.gui.capabilities.AutomationFeature;
 import com.shaft.gui.capabilities.internal.AutomationCapabilityResolver;
+import com.shaft.gui.BidiTestSupport;
 import io.appium.java_client.AppiumDriver;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -151,7 +152,7 @@ public class BrowserPermissionsNamespaceTest {
     }
 
     @Test
-    @SuppressWarnings({"unchecked", "rawtypes", "removal"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void seleniumBiDiShouldGrantForOriginAndClearBackToPrompt() {
         RemoteWebDriver driver = Mockito.mock(RemoteWebDriver.class,
                 Mockito.withSettings().extraInterfaces(HasBiDi.class));
@@ -161,8 +162,7 @@ public class BrowserPermissionsNamespaceTest {
         capabilities.setCapability("webSocketUrl", "ws://localhost/session");
         Mockito.when(driver.getSessionId()).thenReturn(new SessionId("selenium"));
         Mockito.when(driver.getCapabilities()).thenReturn(capabilities);
-        Mockito.when(hasBiDi.maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(hasBiDi.getBiDi()).thenReturn(bidi);
+        BidiTestSupport.connect(hasBiDi, bidi);
         new com.shaft.gui.browser.BrowserActions(driver, true).permissions()
                 .grantFor("https://example.test", "geolocation");
         new com.shaft.gui.browser.BrowserActions(driver, true).permissions().clear();
@@ -176,7 +176,7 @@ public class BrowserPermissionsNamespaceTest {
     }
 
     @Test
-    @SuppressWarnings({"unchecked", "rawtypes", "removal"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void seleniumGrantAndClearShouldSerializeProviderAndInventoryTransitions() throws Exception {
         RemoteWebDriver driver = Mockito.mock(RemoteWebDriver.class,
                 Mockito.withSettings().extraInterfaces(HasBiDi.class));
@@ -186,8 +186,7 @@ public class BrowserPermissionsNamespaceTest {
         capabilities.setCapability("webSocketUrl", "ws://localhost/session");
         Mockito.when(driver.getSessionId()).thenReturn(new SessionId("serialized"));
         Mockito.when(driver.getCapabilities()).thenReturn(capabilities);
-        Mockito.when(hasBiDi.maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(hasBiDi.getBiDi()).thenReturn(bidi);
+        BidiTestSupport.connect(hasBiDi, bidi);
         AtomicInteger sends = new AtomicInteger();
         CountDownLatch clearEnteredProvider = new CountDownLatch(1);
         CountDownLatch releaseClear = new CountDownLatch(1);

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserEmulationNamespaceTraceTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/BrowserEmulationNamespaceTraceTest.java
@@ -6,6 +6,7 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Tracing;
 import com.shaft.driver.SHAFT;
 import com.shaft.gui.capabilities.AutomationBackend;
+import com.shaft.gui.BidiTestSupport;
 import com.shaft.gui.driver.EmulatedColorScheme;
 import com.shaft.gui.driver.EmulatedMediaType;
 import com.shaft.gui.driver.EmulatedReducedMotion;
@@ -107,8 +108,7 @@ public class BrowserEmulationNamespaceTraceTest {
         capabilities.setCapability("webSocketUrl", "ws://bidi.example.test/session");
         Mockito.when(driver.getSessionId()).thenReturn(new SessionId("appium-emulation"));
         Mockito.when(driver.getCapabilities()).thenReturn(capabilities);
-        Mockito.when(driver.maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(driver.getBiDi()).thenReturn(bidi);
+        Mockito.when(driver.getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(driver.getWindowHandle()).thenReturn("webview-context");
 
         new com.shaft.gui.browser.BrowserActions(driver, true).emulation().location().locale("ar-EG");
@@ -172,8 +172,7 @@ public class BrowserEmulationNamespaceTraceTest {
         AppiumDriver driver = Mockito.mock(AppiumDriver.class);
         Mockito.when(driver.getSessionId()).thenReturn(new SessionId("appium-sensitive-emulation"));
         Mockito.when(driver.getCapabilities()).thenReturn(capabilities);
-        Mockito.when(driver.maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(driver.getBiDi()).thenReturn(bidi);
+        Mockito.when(driver.getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(driver.getWindowHandle()).thenReturn("WEBVIEW_1");
         Mockito.when(driver.getPageSource()).thenReturn(domEvidence);
 
@@ -236,8 +235,7 @@ public class BrowserEmulationNamespaceTraceTest {
         AppiumDriver driver = Mockito.mock(AppiumDriver.class);
         Mockito.when(driver.getSessionId()).thenReturn(new SessionId("appium-sensitive-success"));
         Mockito.when(driver.getCapabilities()).thenReturn(capabilities);
-        Mockito.when(driver.maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(driver.getBiDi()).thenReturn(bidi);
+        Mockito.when(driver.getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(driver.getWindowHandle()).thenReturn("WEBVIEW_1");
         Mockito.when(driver.getPageSource()).thenReturn("application rendered " + sensitiveValue);
 
@@ -760,8 +758,7 @@ public class BrowserEmulationNamespaceTraceTest {
         BiDi bidi = Mockito.mock(BiDi.class);
         DevTools devTools = Mockito.mock(DevTools.class);
         Mockito.when(((HasCapabilities) driver).getCapabilities()).thenReturn(capabilities);
-        Mockito.when(((HasBiDi) driver).maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(((HasBiDi) driver).getBiDi()).thenReturn(bidi);
+        Mockito.when(((HasBiDi) driver).getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(((HasDevTools) driver).maybeGetDevTools()).thenReturn(Optional.of(devTools));
         Mockito.when(((HasDevTools) driver).getDevTools()).thenReturn(devTools);
         Mockito.when(driver.getWindowHandle()).thenReturn("context-1");
@@ -856,8 +853,7 @@ public class BrowserEmulationNamespaceTraceTest {
         WebDriver driver = Mockito.mock(WebDriver.class, Mockito.withSettings()
                 .extraInterfaces(HasBiDi.class, HasCapabilities.class));
         Mockito.when(((HasCapabilities) driver).getCapabilities()).thenReturn(capabilities);
-        Mockito.when(((HasBiDi) driver).maybeGetBiDi()).thenReturn(Optional.of(bidi));
-        Mockito.when(((HasBiDi) driver).getBiDi()).thenReturn(bidi);
+        Mockito.when(((HasBiDi) driver).getHandle()).thenReturn(BidiTestSupport.handleFor(bidi));
         Mockito.when(driver.getWindowHandle()).thenReturn("context-1");
         Mockito.when(driver.getPageSource()).thenReturn(pageSource);
         return driver;

--- a/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java
+++ b/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java
@@ -1,6 +1,10 @@
 package testPackage.properties;
 
 import com.shaft.driver.SHAFT;
+import com.shaft.properties.internal.ThreadLocalPropertiesManager;
+import com.shaft.properties.internal.Timeouts;
+import org.aeonbits.owner.Config.DefaultValue;
+import org.aeonbits.owner.Config.Key;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -65,14 +69,21 @@ public class TimeoutsTests {
 
     @Test
     public void dockerCommandTimeoutHasSupportedCompatibilityAccessor() {
-        var replacement = java.util.Arrays.stream(SHAFT.Properties.timeouts.getClass().getInterfaces())
-                .flatMap(type -> java.util.Arrays.stream(type.getMethods()))
-                .filter(method -> method.getName().equals("dockerCommandTimeoutSeconds"))
-                .findFirst()
-                .orElse(null);
+        try {
+            var getter = Timeouts.class.getMethod("dockerCommandTimeoutSeconds");
+            Assert.assertEquals(getter.getReturnType(), int.class);
+            Assert.assertEquals(getter.getAnnotation(Key.class).value(), "dockerCommandTimeout");
+            Assert.assertEquals(getter.getAnnotation(DefaultValue.class).value(), "30");
 
-        Assert.assertNotNull(replacement,
-                "The deprecated Docker timeout must have a supported seconds-based replacement.");
+            SHAFT.Properties.timeouts.set().dockerCommandTimeoutSeconds(47);
+
+            Assert.assertEquals(ThreadLocalPropertiesManager.getProperty("dockerCommandTimeout"), "47");
+            Assert.assertEquals(SHAFT.Properties.timeouts.dockerCommandTimeoutSeconds(), 47);
+        } catch (NoSuchMethodException exception) {
+            throw new AssertionError("The supported Docker timeout accessor is missing.", exception);
+        } finally {
+            SHAFT.Properties.timeouts.set().dockerCommandTimeoutSeconds(dockerCommandTimeout);
+        }
     }
 
     @Test

--- a/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java
+++ b/shaft-engine/src/test/java/testPackage/properties/TimeoutsTests.java
@@ -1,6 +1,7 @@
 package testPackage.properties;
 
 import com.shaft.driver.SHAFT;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -51,7 +52,7 @@ public class TimeoutsTests {
         apiConnectionManagerTimeout = SHAFT.Properties.timeouts.apiConnectionManagerTimeout();
         shellSessionTimeout = SHAFT.Properties.timeouts.shellSessionTimeout();
         sshServerAliveInterval = SHAFT.Properties.timeouts.sshServerAliveInterval();
-        dockerCommandTimeout = SHAFT.Properties.timeouts.dockerCommandTimeout();
+        dockerCommandTimeout = SHAFT.Properties.timeouts.dockerCommandTimeoutSeconds();
         databaseNetworkTimeout = SHAFT.Properties.timeouts.databaseLoginTimeout();
         databaseLoginTimeout = SHAFT.Properties.timeouts.databaseLoginTimeout();
         databaseQueryTimeout = SHAFT.Properties.timeouts.databaseQueryTimeout();
@@ -60,6 +61,18 @@ public class TimeoutsTests {
         remoteServerInstanceCreationTimeout = SHAFT.Properties.timeouts.remoteServerInstanceCreationTimeout();
         remoteServerConnectionAttemptTimeout = SHAFT.Properties.timeouts.remoteServerConnectionAttemptTimeout();
 
+    }
+
+    @Test
+    public void dockerCommandTimeoutHasSupportedCompatibilityAccessor() {
+        var replacement = java.util.Arrays.stream(SHAFT.Properties.timeouts.getClass().getInterfaces())
+                .flatMap(type -> java.util.Arrays.stream(type.getMethods()))
+                .filter(method -> method.getName().equals("dockerCommandTimeoutSeconds"))
+                .findFirst()
+                .orElse(null);
+
+        Assert.assertNotNull(replacement,
+                "The deprecated Docker timeout must have a supported seconds-based replacement.");
     }
 
     @Test
@@ -82,7 +95,7 @@ public class TimeoutsTests {
         SHAFT.Properties.timeouts.set().apiConnectionManagerTimeout(apiConnectionManagerTimeout);
         SHAFT.Properties.timeouts.set().shellSessionTimeout(shellSessionTimeout);
         SHAFT.Properties.timeouts.set().sshServerAliveInterval(sshServerAliveInterval);
-        SHAFT.Properties.timeouts.set().dockerCommandTimeout(dockerCommandTimeout);
+        SHAFT.Properties.timeouts.set().dockerCommandTimeoutSeconds(dockerCommandTimeout);
         SHAFT.Properties.timeouts.set().databaseNetworkTimeout(databaseNetworkTimeout);
         SHAFT.Properties.timeouts.set().databaseLoginTimeout(databaseLoginTimeout);
         SHAFT.Properties.timeouts.set().databaseQueryTimeout(databaseQueryTimeout);

--- a/shaft-engine/src/test/java/testPackage/unitTests/AutomationCapabilityResolverUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/AutomationCapabilityResolverUnitTest.java
@@ -24,7 +24,7 @@ import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.bidi.HasBiDi;
-import org.openqa.selenium.bidi.BiDi;
+import org.openqa.selenium.bidi.Handle;
 import org.openqa.selenium.devtools.HasDevTools;
 import org.openqa.selenium.logging.Logs;
 import org.openqa.selenium.remote.SessionId;
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.when;
 public class AutomationCapabilityResolverUnitTest {
 
     @Test
-    @SuppressWarnings("removal")
     public void seleniumShouldRequireNegotiatedProtocolObjectsInsteadOfCapabilityNames() {
         boolean originalBiDi = SHAFT.Properties.platform.enableBiDi();
         try {
@@ -53,7 +52,7 @@ public class AutomationCapabilityResolverUnitTest {
             WebDriver driver = mock(WebDriver.class, withSettings().extraInterfaces(
                     HasCapabilities.class, HasBiDi.class, HasDevTools.class));
             when(((HasCapabilities) driver).getCapabilities()).thenReturn(rawCapabilities);
-            when(((HasBiDi) driver).maybeGetBiDi()).thenReturn(Optional.of(mock(BiDi.class)));
+            when(((HasBiDi) driver).getHandle()).thenReturn(mock(Handle.class));
             when(((HasDevTools) driver).maybeGetDevTools()).thenReturn(Optional.empty());
 
             AutomationCapabilities capabilities = AutomationCapabilityResolver.forWebDriver(driver);
@@ -143,7 +142,7 @@ public class AutomationCapabilityResolverUnitTest {
         capabilities.setCapability("webSocketUrl", "ws://bidi.example.test/session");
         when(driver.getSessionId()).thenReturn(new SessionId("appium-dual-console"));
         when(driver.getCapabilities()).thenReturn(capabilities);
-        when(driver.maybeGetBiDi()).thenReturn(Optional.of(mock(BiDi.class)));
+        when(driver.getHandle()).thenReturn(mock(Handle.class));
         WebDriver.Options options = mock(WebDriver.Options.class);
         Logs logs = mock(Logs.class);
         when(driver.manage()).thenReturn(options);
@@ -260,7 +259,6 @@ public class AutomationCapabilityResolverUnitTest {
     }
 
     @Test
-    @SuppressWarnings("removal")
     public void appiumShouldExposeBiDiOnlyWhenTheLiveChannelIsNegotiated() {
         boolean originalBiDi = SHAFT.Properties.platform.enableBiDi();
         try {
@@ -270,12 +268,12 @@ public class AutomationCapabilityResolverUnitTest {
             rawCapabilities.setCapability("webSocketUrl", "ws://localhost/appium/session/1");
             when(android.getSessionId()).thenReturn(new SessionId("live-appium-bidi"));
             when(android.getCapabilities()).thenReturn(rawCapabilities);
-            when(android.maybeGetBiDi()).thenReturn(Optional.empty());
+            when(android.getHandle()).thenReturn(null);
 
             Assert.assertFalse(AutomationCapabilityResolver.forWebDriver(android)
                     .supports(AutomationFeature.BIDI));
 
-            when(android.maybeGetBiDi()).thenReturn(Optional.of(mock(BiDi.class)));
+            when(android.getHandle()).thenReturn(mock(Handle.class));
             Assert.assertTrue(AutomationCapabilityResolver.forWebDriver(android)
                     .supports(AutomationFeature.BIDI));
         } finally {

--- a/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TerminalActionsUnitTest.java
@@ -47,7 +47,7 @@ public class TerminalActionsUnitTest {
         TerminalActions terminal = new TerminalActions();
         Assert.assertFalse(terminal.isRemoteTerminal(),
                 "Default terminal should not be remote");
-        Assert.assertFalse(terminal.isDockerizedTerminal(),
+        Assert.assertTrue(terminal.getDockerName().isEmpty(),
                 "Default terminal should not be dockerized");
     }
 
@@ -56,7 +56,7 @@ public class TerminalActionsUnitTest {
         TerminalActions terminal = new TerminalActions(true);
         Assert.assertFalse(terminal.isRemoteTerminal(),
                 "Async terminal should not be remote");
-        Assert.assertFalse(terminal.isDockerizedTerminal(),
+        Assert.assertTrue(terminal.getDockerName().isEmpty(),
                 "Async terminal should not be dockerized");
     }
 
@@ -66,7 +66,7 @@ public class TerminalActionsUnitTest {
         TerminalActions terminal = new TerminalActions("myContainer", "root");
         Assert.assertFalse(terminal.isRemoteTerminal(),
                 "Docker terminal should not be remote");
-        Assert.assertTrue(terminal.isDockerizedTerminal(),
+        Assert.assertFalse(terminal.getDockerName().isEmpty(),
                 "Docker terminal should be dockerized");
         Assert.assertEquals(terminal.getDockerName(), "myContainer",
                 "Docker name should match constructor argument");
@@ -80,7 +80,7 @@ public class TerminalActionsUnitTest {
                 "host.example.com", 22, "user", "/keys/", "id_rsa");
         Assert.assertTrue(terminal.isRemoteTerminal(),
                 "SSH terminal should be remote");
-        Assert.assertFalse(terminal.isDockerizedTerminal(),
+        Assert.assertTrue(terminal.getDockerName().isEmpty(),
                 "SSH terminal should not be dockerized");
         Assert.assertEquals(terminal.getSshHostName(), "host.example.com",
                 "SSH host name should match");
@@ -102,7 +102,7 @@ public class TerminalActionsUnitTest {
                 "appContainer", "appUser");
         Assert.assertTrue(terminal.isRemoteTerminal(),
                 "Combined terminal should be remote");
-        Assert.assertTrue(terminal.isDockerizedTerminal(),
+        Assert.assertFalse(terminal.getDockerName().isEmpty(),
                 "Combined terminal should be dockerized");
         Assert.assertEquals(terminal.getSshHostName(), "host.example.com");
         Assert.assertEquals(terminal.getSshPortNumber(), 2222);
@@ -117,7 +117,7 @@ public class TerminalActionsUnitTest {
         TerminalActions terminal = TerminalActions.getInstance();
         Assert.assertNotNull(terminal, "getInstance() should return a non-null instance");
         Assert.assertFalse(terminal.isRemoteTerminal());
-        Assert.assertFalse(terminal.isDockerizedTerminal());
+        Assert.assertTrue(terminal.getDockerName().isEmpty());
     }
 
     @Test(description = "getInstance(boolean) should return a non-null terminal")
@@ -334,7 +334,7 @@ public class TerminalActionsUnitTest {
     @Test(description = "isDockerizedTerminal should be false when dockerName is empty")
     public void isDockerizedTerminalShouldBeFalseWhenDockerNameEmpty() {
         TerminalActions terminal = new TerminalActions();
-        Assert.assertFalse(terminal.isDockerizedTerminal(),
+        Assert.assertTrue(terminal.getDockerName().isEmpty(),
                 "Terminal with empty docker name should not be dockerized");
     }
 


### PR DESCRIPTION
## Summary

- route Selenium BiDi commands through the supported opaque handle/`Module` path while preserving SHAFT's existing locale override and emulation command payloads
- replace SHAFT-internal calls to deprecated Docker terminal/timeout accessors with supported equivalents while retaining the deprecated public declarations for compatibility
- update affected mock-based tests to exercise the supported handle path

## Proof

- RED: `TimeoutsTests#dockerCommandTimeoutHasSupportedCompatibilityAccessor` — 1 test, 1 failure before the replacement existed
- GREEN: affected eight-class suite — `157 tests, 0 failures, 0 errors, 0 skipped` in the final Surefire `TEST-TestSuite.xml`
- GREEN: clean `test-compile` — Maven exit 0, 17 unrelated baseline warning lines, 0 named removal warnings
- GREEN: affected package — all 3 reactor modules SUCCESS
- live `rg` — 0 direct invocations of `getBiDi`, `maybeGetBiDi`, `isDockerizedTerminal`, or `dockerCommandTimeout` in main/test Java sources

The focused suite used `-Dshaft.trace.includeNetwork=false` to isolate the changed flow; the included dedicated trace companion passed all 35 trace cases. Full receipts and the corrected two-option ruling are recorded on #4930.

Closes #4930