### PR TITLE
docs(agent): gate planning on a fresh primary base

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -132,6 +132,7 @@ sends you there; the rest by
 - [roles](../../chaos-engine/references/roles.md)
 - [heuristics](../../chaos-engine/references/heuristics.md)
 - [orchestrator bootstrap](../../chaos-engine/references/orchestrator-bootstrap.md)
+- [task isolation](../../chaos-engine/references/task-isolation.md)
 - [verification-gap lens](../../chaos-engine/references/verification-gap-lens.md)
 - [cleanup scopes](../../chaos-engine/references/cleanup-scopes.md)
 - [work GitHub playbook](../../chaos-engine/references/work-github-playbook.md)

--- a/chaos-engine/references/task-isolation.md
+++ b/chaos-engine/references/task-isolation.md
@@ -1,0 +1,24 @@
+# Task isolation
+
+For a new task, never treat the process working directory as planning authority
+merely because the session started there. Before task-specific planning or
+discovery, locate the verified primary checkout and require clean, unlocked,
+exclusive state; fetch and prune the configured upstream, verify its configured
+default branch, then fast-forward the local default branch to the immutable
+upstream tip. Stop on dirty, concurrently owned, locked, divergent, unfetched,
+or unverifiable state.
+
+Refresh and validate native Memory, MemPalace, and Graphify from that exact
+revision in the primary checkout. Only after this gate, freeze the base commit,
+create a dedicated `ChaosEngine/*` branch and linked worktree rooted at it, and
+perform planning, discovery, and implementation there.
+
+An explicit continuation of a named local or remote task branch is the sole
+fresh-default exception. Fetch when a remote exists, verify the named branch
+and its intended base, preserve its work, and isolate the continuation in a
+dedicated worktree; never silently restart it from the default branch.
+
+Resolve repository identity, upstream, default branch, primary-checkout path,
+and store commands from the selected profile, adapters, configuration, or
+integration playbooks. Never encode one repository or machine as portable
+policy.

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -140,9 +140,9 @@ Canonical policy stays repository-, machine-, user-, agent-, and
 provider-agnostic. Concrete identities and locations belong in selected
 profiles, adapters, configuration, or integration playbooks.
 
-Before edits, fetch and prune, verify the configured upstream, and isolate the
-task from that base. Stop if fetch or base verification fails. Apply the
-[cleanup scopes](../../references/cleanup-scopes.md) exactly.
+Follow [task isolation](../../references/task-isolation.md) before task-specific
+planning or discovery. Its fresh-primary gate and continuation exception are
+mandatory. Apply the [cleanup scopes](../../references/cleanup-scopes.md) exactly.
 
 ### Task scope (default)
 

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -120,7 +120,7 @@ BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 # from the boundary was invisible. Equality makes shrinking the boundary a
 # deliberate two-line edit that shows up in review, which is the only place the
 # question "why is the harness smaller today" gets asked.
-EXPECTED_ELEMENT_COUNT = 202
+EXPECTED_ELEMENT_COUNT = 203
 
 ATX_HEADING = re.compile(r"(?m)^#{1,6}\s+(.+?)\s*$")
 

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -11,6 +11,7 @@ ROOT = Path(__file__).resolve().parents[2]
 CORE = ROOT / "chaos-engine"
 CANONICAL_SKILL = CORE / "skills/chaos-engine/SKILL.md"
 CLEANUP_SCOPES = CORE / "references/cleanup-scopes.md"
+TASK_ISOLATION = CORE / "references/task-isolation.md"
 REPOSITORY_ADAPTER = ROOT / ".agents/skills/chaos-engine/SKILL.md"
 COMPATIBILITY_ALIAS = ROOT / ".agents/skills/act-as-mohab/SKILL.md"
 SHAFT_PROFILE = CORE / "profiles/shaft/profile.json"
@@ -333,6 +334,7 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
                 )
 
         assert_cleanup_contract(cleanup_scopes)
+
         weakening_mutations = (
             cleanup_scopes.replace(
                 "even if the task touches it.",
@@ -367,6 +369,42 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
         for label, pattern in forbidden.items():
             with self.subTest(forbidden=label):
                 self.assertIsNone(pattern.search(task_isolation_router + cleanup_scopes))
+
+    def test_task_isolation_gates_planning_on_a_refreshed_primary_checkout(self):
+        canonical = CANONICAL_SKILL.read_text(encoding="utf-8")
+        task_isolation_router = canonical.split("## Task isolation", 1)[1].split(
+            "## Operating contract", 1
+        )[0]
+        self.assertIn("../../references/task-isolation.md", task_isolation_router)
+        task_isolation = TASK_ISOLATION.read_text(encoding="utf-8")
+        normalized = " ".join(task_isolation.split())
+
+        required = (
+            "Before task-specific planning or discovery",
+            "verified primary checkout",
+            "clean, unlocked, exclusive state",
+            "fetch and prune the configured upstream",
+            "local default branch",
+            "immutable upstream tip",
+            "Refresh and validate native Memory, MemPalace, and Graphify from that exact revision",
+            "Only after this gate",
+            "dedicated `ChaosEngine/*` branch and linked worktree",
+            "perform planning, discovery, and implementation there",
+            "explicit continuation",
+            "local or remote task branch",
+            "never silently restart it from the default branch",
+            "process working directory",
+        )
+        for phrase in required:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, normalized)
+
+        self.assertRegex(
+            normalized,
+            r"fetch and prune the configured upstream.*"
+            r"Refresh and validate native Memory, MemPalace, and Graphify.*"
+            r"Only after this gate",
+        )
 
     def test_posix_absolute_path_guard_is_non_vacuous(self):
         self.assertRegex("cache at /opt/private/agent-cache", POSIX_ABSOLUTE_PATH)


### PR DESCRIPTION
## Summary
- require every new task to establish a clean, fetched primary-default-branch base before planning or discovery
- refresh native Memory, MemPalace, and Graphify at that exact revision before creating the task branch/worktree
- preserve an explicit named-branch continuation exception
- enforce the portable contract with a focused regression while keeping the canonical entrypoint within its byte budget

## RED/GREEN
- RED: focused portable-core test failed with 12 assertions against the old "before edits" contract
- GREEN: `py -3 -m unittest tests.scripts.test_chaos_engine_portable_core` (11 tests)
- GREEN: `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- GREEN: `git diff --check`

Closes #4969