### PR TITLE
feat(setup): converge managed lifecycle adapters

### DIFF
--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -207,7 +207,6 @@ public final class SetupCommand implements Runnable {
         public Integer call() {
             try {
                 SetupPlan plan = SetupPlanStore.read(planFile);
-                if (plan.profile() != SetupProfile.MOBILE_ANDROID) return unsupported(spec, plan.profile());
                 SetupSelection selection = selectionFromPlan(plan, languages, android);
                 SetupOptions options = policy.options(plan.profile(), plan.mode(), roots.paths(plan.profile()));
                 var environment = InfrastructureSetupService.builtIn().start(plan,
@@ -233,7 +232,13 @@ public final class SetupCommand implements Runnable {
     @Command(name = "stop", mixinStandardHelpOptions = true,
             description = "Stop a SHAFT-owned service identified by its lease.")
     static final class Stop implements Callable<Integer> {
-        @Option(names = "--profile", required = true) private SetupProfile profile;
+        @Option(names = "--plan") private Path planFile;
+        @Option(names = "--approve") private String approvedDigest;
+        @Option(names = "--accept-license") private Set<String> acceptedLicenses = new LinkedHashSet<>();
+        @Option(names = "--profile", description = "Deprecated profile-only compatibility input.")
+        private SetupProfile legacyProfile;
+        @Option(names = "--json") private boolean json;
+        @Option(names = "--language") private List<String> languages = new java.util.ArrayList<>();
         @Mixin private RootOptions roots;
         @Mixin private PolicyOptions policy;
         @Mixin private AndroidOptions android;
@@ -242,17 +247,25 @@ public final class SetupCommand implements Runnable {
         @Override
         public Integer call() {
             try {
-                if (profile != SetupProfile.MOBILE_ANDROID) return unsupported(spec, profile);
-                ShaftCachePaths paths = roots.paths(profile);
-                AndroidSetupRequest request = android.request(profile);
-                boolean stopped = AndroidRuntimeManager.stop(paths, SetupPlatform.current(),
-                        SetupArchitecture.current(), request,
-                        policy.options(profile, SetupMode.MANAGED, paths).shutdownTimeout());
+                if (planFile == null || approvedDigest == null || approvedDigest.isBlank()) {
+                    throw new IllegalArgumentException("setup stop requires --plan and --approve; profile-only stop "
+                            + "cannot satisfy exact approval.");
+                }
+                SetupPlan plan = SetupPlanStore.read(planFile);
+                SetupSelection selection = selectionFromPlan(plan, languages, android);
+                ShaftCachePaths paths = roots.paths(plan.profile());
+                SetupOptions options = policy.options(plan.profile(), plan.mode(), paths);
+                boolean stopped = InfrastructureSetupService.builtIn().stop(plan,
+                        new SetupApproval(approvedDigest, Instant.now(), acceptedLicenses), options, selection);
                 if (!stopped) {
-                    spec.commandLine().getErr().println("No live owned Android runtime exists.");
+                    spec.commandLine().getErr().println("No live owned service exists for profile "
+                            + plan.profile() + '.');
                     return 3;
                 }
-                spec.commandLine().getOut().println("Stopped the owned Android runtime.");
+                if (json) spec.commandLine().getOut().println(Json.MAPPER.writeValueAsString(
+                        java.util.Map.of("profile", plan.profile(), "stopped", true,
+                                "planDigest", plan.digest())));
+                else spec.commandLine().getOut().println("Stopped the owned service for profile " + plan.profile() + '.');
                 return 0;
             } catch (IllegalArgumentException failure) {
                 spec.commandLine().getErr().println(failure.getMessage());
@@ -269,19 +282,22 @@ public final class SetupCommand implements Runnable {
     static final class Logs implements Callable<Integer> {
         @Option(names = "--profile", required = true) private SetupProfile profile;
         @Mixin private RootOptions roots;
+        @Mixin private PolicyOptions policy;
         @Mixin private AndroidOptions android;
         @Spec private CommandSpec spec;
 
         @Override
         public Integer call() throws Exception {
+            if (!InfrastructureSetupService.builtIn().supports(profile)) return unsupported(spec, profile);
+            ShaftCachePaths paths = roots.paths(profile);
             String content;
-            if (profile == SetupProfile.REPORTING) {
-                Path log = service(roots).logFile();
-                content = Files.notExists(log) ? "" : Files.readString(log);
-            } else if (profile == SetupProfile.MOBILE_ANDROID) {
-                content = AndroidRuntimeManager.logs(roots.paths(), SetupPlatform.current(),
-                        SetupArchitecture.current(), android.request(profile));
-            } else return unsupported(spec, profile);
+            try {
+                content = InfrastructureSetupService.builtIn().logs(
+                        policy.options(profile, SetupMode.EXTERNAL, paths),
+                        selection(profile, List.of(), android.request(profile)));
+            } catch (UnsupportedOperationException unsupported) {
+                return unsupported(spec, profile);
+            }
             if (content.isEmpty()) {
                 spec.commandLine().getErr().println("No owned logs exist for profile " + profile + '.');
                 return 3;

--- a/shaft-cli/src/main/resources/tool-index-cache.json
+++ b/shaft-cli/src/main/resources/tool-index-cache.json
@@ -2974,14 +2974,14 @@
     {
       "name": "setup_logs",
       "service": "InfrastructureMcpService",
-      "description": "reports whether the selected setup profile exposes owned service logs",
+      "description": "reads bounded logs for a SHAFT-owned setup service without mutating the host",
       "params": [
         {
-          "name": "profile",
-          "type": "string",
+          "name": "request",
+          "type": "object",
           "required": true,
           "default": null,
-          "description": "setup profile"
+          "description": "setup profile, owned paths, policy, and components"
         }
       ],
       "mutation": false,
@@ -3020,14 +3020,35 @@
     {
       "name": "setup_start",
       "service": "InfrastructureMcpService",
-      "description": "reports whether the selected setup profile owns a startable managed service",
+      "description": "starts one managed service from an exact reviewed setup plan",
       "params": [
         {
-          "name": "profile",
+          "name": "acceptedLicenses",
+          "type": "array",
+          "required": false,
+          "default": null,
+          "description": "explicitly accepted license identifiers"
+        },
+        {
+          "name": "approvedDigest",
           "type": "string",
           "required": true,
           "default": null,
-          "description": "setup profile"
+          "description": "exact plan digest explicitly approved by the caller"
+        },
+        {
+          "name": "planJson",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "exact plan JSON returned by setup_plan"
+        },
+        {
+          "name": "request",
+          "type": "object",
+          "required": true,
+          "default": null,
+          "description": "the same paths and execution policy used to create the plan"
         }
       ],
       "mutation": true,
@@ -3066,14 +3087,35 @@
     {
       "name": "setup_stop",
       "service": "InfrastructureMcpService",
-      "description": "reports whether the selected setup profile owns a stoppable managed service lease",
+      "description": "stops one SHAFT-owned service using an exact reviewed setup plan",
       "params": [
         {
-          "name": "profile",
+          "name": "acceptedLicenses",
+          "type": "array",
+          "required": false,
+          "default": null,
+          "description": "explicitly accepted license identifiers"
+        },
+        {
+          "name": "approvedDigest",
           "type": "string",
           "required": true,
           "default": null,
-          "description": "setup profile"
+          "description": "exact plan digest explicitly approved by the caller"
+        },
+        {
+          "name": "planJson",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "exact plan JSON returned by setup_plan"
+        },
+        {
+          "name": "request",
+          "type": "object",
+          "required": true,
+          "default": null,
+          "description": "the same paths and execution policy used to create the plan"
         }
       ],
       "mutation": true,

--- a/shaft-cli/src/main/resources/tool-index-cache.json
+++ b/shaft-cli/src/main/resources/tool-index-cache.json
@@ -2974,12 +2974,19 @@
     {
       "name": "setup_logs",
       "service": "InfrastructureMcpService",
-      "description": "reads bounded logs for a SHAFT-owned setup service without mutating the host",
+      "description": "reads bounded logs for a SHAFT-owned setup service without mutating the host; profile-only calls remain supported as legacy capability queries",
       "params": [
+        {
+          "name": "profile",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "legacy setup profile capability query"
+        },
         {
           "name": "request",
           "type": "object",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "setup profile, owned paths, policy, and components"
         }
@@ -3020,7 +3027,7 @@
     {
       "name": "setup_start",
       "service": "InfrastructureMcpService",
-      "description": "starts one managed service from an exact reviewed setup plan",
+      "description": "starts one managed service from an exact reviewed setup plan; profile-only calls remain supported as legacy capability queries",
       "params": [
         {
           "name": "acceptedLicenses",
@@ -3032,21 +3039,28 @@
         {
           "name": "approvedDigest",
           "type": "string",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "exact plan digest explicitly approved by the caller"
         },
         {
           "name": "planJson",
           "type": "string",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "exact plan JSON returned by setup_plan"
         },
         {
+          "name": "profile",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "legacy setup profile capability query"
+        },
+        {
           "name": "request",
           "type": "object",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "the same paths and execution policy used to create the plan"
         }
@@ -3087,7 +3101,7 @@
     {
       "name": "setup_stop",
       "service": "InfrastructureMcpService",
-      "description": "stops one SHAFT-owned service using an exact reviewed setup plan",
+      "description": "stops one SHAFT-owned service using an exact reviewed setup plan; profile-only calls remain supported as legacy capability queries",
       "params": [
         {
           "name": "acceptedLicenses",
@@ -3099,21 +3113,28 @@
         {
           "name": "approvedDigest",
           "type": "string",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "exact plan digest explicitly approved by the caller"
         },
         {
           "name": "planJson",
           "type": "string",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "exact plan JSON returned by setup_plan"
         },
         {
+          "name": "profile",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "legacy setup profile capability query"
+        },
+        {
           "name": "request",
           "type": "object",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "the same paths and execution policy used to create the plan"
         }

--- a/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
+++ b/shaft-cli/src/test/java/com/shaft/commandline/command/SetupCommandTest.java
@@ -244,16 +244,28 @@ class SetupCommandTest {
     }
 
     @Test
-    void androidStopAndLogsReportMissingWithoutCreatingRuntimeState(@TempDir Path temp) {
+    void androidStopRequiresAnExactPlanAndLogsReportMissingWithoutCreatingRuntimeState(@TempDir Path temp)
+            throws Exception {
         Path cache = temp.resolve("cache").toAbsolutePath();
         Path data = temp.resolve("data").toAbsolutePath();
-        CommandResult stop = execute("setup", "stop", "--profile", "MOBILE_ANDROID",
+        Path planFile = temp.resolve("android-stop-plan.json");
+        CommandResult planned = execute("setup", "plan", "--profile", "MOBILE_ANDROID", "--mode", "MANAGED",
+                "--output", planFile.toString(), "--cache-root", cache.toString(), "--data-root", data.toString(),
+                "--json");
+        JsonNode plan = JSON.readTree(planned.stdout());
+        CommandResult stop = execute("setup", "stop", "--plan", planFile.toString(),
+                "--approve", plan.get("digest").asText(), "--accept-license", "android-sdk-license",
                 "--cache-root", cache.toString(), "--data-root", data.toString());
         CommandResult logs = execute("setup", "logs", "--profile", "MOBILE_ANDROID",
                 "--cache-root", cache.toString(), "--data-root", data.toString());
+        CommandResult unsafeCompatibility = execute("setup", "stop", "--profile", "MOBILE_ANDROID",
+                "--cache-root", cache.toString(), "--data-root", data.toString());
 
+        assertEquals(0, planned.exitCode(), planned.stderr());
         assertEquals(3, stop.exitCode(), stop.stderr());
         assertEquals(3, logs.exitCode(), logs.stderr());
+        assertEquals(2, unsafeCompatibility.exitCode(), unsafeCompatibility.stderr());
+        assertTrue(unsafeCompatibility.stderr().contains("--plan"), unsafeCompatibility.stderr());
         assertTrue(Files.notExists(cache));
         assertTrue(Files.notExists(data));
     }

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AndroidLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AndroidLifecycleService.java
@@ -82,6 +82,14 @@ final class AndroidLifecycleService {
     Path emulatorLog() { return layout.emulatorLog(); }
     Path appiumLog() { return layout.appiumLog(); }
 
+    String logs() throws IOException {
+        Optional<AndroidRuntimeLease> current = readLease();
+        if (current.isEmpty()) return "";
+        requireLeaseRequest(current.orElseThrow());
+        return section("emulator", OwnedLogReader.read("Android emulator", layout.emulatorLog()))
+                + section("appium", OwnedLogReader.read("Appium server", layout.appiumLog()));
+    }
+
     boolean stop(Duration timeout) throws IOException {
         Path lockPath = paths.state().resolve("mobile-android-runtime.lock").toAbsolutePath().normalize();
         VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
@@ -318,6 +326,11 @@ final class AndroidLifecycleService {
     }
 
     private Path leasePath() { return paths.state().resolve("mobile-android-runtime.json"); }
+
+    private static String section(String role, String content) {
+        if (content.isEmpty()) return "";
+        return "== " + role + " ==" + System.lineSeparator() + content + System.lineSeparator();
+    }
 
     private static IOException stopStarted(AndroidOwnedProcess appium, AndroidOwnedProcess emulator,
                                            Duration timeout) {

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AndroidRuntimeManager.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AndroidRuntimeManager.java
@@ -1,16 +1,10 @@
 package com.shaft.infrastructure;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
 import java.time.Duration;
 
 /** Explicit CLI/API access to lease-safe Android runtime stop and bounded logs. */
 public final class AndroidRuntimeManager {
-    private static final long MAX_LOG_BYTES = 2L * 1024 * 1024;
-
     private AndroidRuntimeManager() { }
 
     public static boolean stop(ShaftCachePaths paths, SetupPlatform platform, SetupArchitecture architecture,
@@ -20,8 +14,7 @@ public final class AndroidRuntimeManager {
 
     public static String logs(ShaftCachePaths paths, SetupPlatform platform, SetupArchitecture architecture,
                               AndroidSetupRequest request) throws IOException {
-        AndroidLifecycleService service = service(paths, platform, architecture, request);
-        return read("emulator", service.emulatorLog()) + read("appium", service.appiumLog());
+        return service(paths, platform, architecture, request).logs();
     }
 
     private static AndroidLifecycleService service(ShaftCachePaths paths, SetupPlatform platform,
@@ -32,12 +25,4 @@ public final class AndroidRuntimeManager {
                 new SystemAndroidRuntimeController(), new SystemAndroidRuntimeHealth(paths, platform, architecture));
     }
 
-    private static String read(String role, Path path) throws IOException {
-        VerifiedArtifactStore.requireUnlinkedAncestors(path);
-        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) return "";
-        long size = Files.size(path);
-        if (size > MAX_LOG_BYTES) throw new IOException(role + " log exceeds the 2 MiB safety limit: " + path);
-        return "== " + role + " ==" + System.lineSeparator()
-                + Files.readString(path, StandardCharsets.UTF_8) + System.lineSeparator();
-    }
 }

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AndroidSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AndroidSetupProvider.java
@@ -75,4 +75,18 @@ final class AndroidSetupProvider implements SetupProvider {
         return new ManagedEnvironment(profile(), receipt, inner.endpoint(), inner.connectionProperties(), inner::close);
     }
 
+    @Override
+    public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        return AndroidRuntimeManager.stop(options.paths(), plan.platform(), plan.architecture(),
+                AndroidSetupRequest.fromPlan(plan), options.shutdownTimeout());
+    }
+
+    @Override
+    public String logs(SetupOptions options, SetupSelection selection, SetupPlatform platform,
+                       SetupArchitecture architecture) throws IOException {
+        return AndroidRuntimeManager.logs(options.paths(), platform, architecture,
+                AndroidSetupRequest.fromSelection(selection));
+    }
+
 }

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
@@ -169,6 +169,31 @@ public final class InfrastructureSetupService {
         return start(plan, approval, options, Objects.requireNonNull(request, "request").toSelection());
     }
 
+    /** Stops the exact SHAFT-owned service represented by an approved plan. */
+    public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        return stop(plan, approval, options, SetupSelection.defaults());
+    }
+
+    /** Stops the exact selected SHAFT-owned service represented by an approved plan. */
+    public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions options,
+                        SetupSelection selection) throws IOException {
+        SetupProvider provider = authorize(plan, approval, options, selection, "stop a managed service");
+        return provider.stop(plan, approval, options);
+    }
+
+    /** Reads bounded logs for the default selection of one setup profile. */
+    public String logs(SetupOptions options) throws IOException {
+        return logs(options, SetupSelection.defaults());
+    }
+
+    /** Reads bounded logs owned by one exact provider selection without mutating the host. */
+    public String logs(SetupOptions options, SetupSelection selection) throws IOException {
+        SetupOptions value = Objects.requireNonNull(options, "options");
+        String logs = providers.require(value.profile()).logs(value,
+                Objects.requireNonNull(selection, "selection"), platform, architecture);
+        return Objects.requireNonNull(logs, "Setup provider returned null logs.");
+    }
+
     private SetupProvider authorize(SetupPlan plan, SetupApproval approval, SetupOptions options,
                                     SetupSelection selection, String operation) {
         Objects.requireNonNull(plan, "plan");

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/OwnedLogReader.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/OwnedLogReader.java
@@ -1,0 +1,50 @@
+package com.shaft.infrastructure;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Set;
+
+/** Bounded, no-follow reader for provider-owned UTF-8 log files. */
+final class OwnedLogReader {
+    static final long MAX_BYTES = 2L * 1024 * 1024;
+
+    private OwnedLogReader() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static String read(String label, Path path) throws IOException {
+        VerifiedArtifactStore.requireUnlinkedAncestors(path);
+        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) return "";
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException(label + " log is not an owned regular file: " + path);
+        }
+        Set<OpenOption> options = Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
+        try (SeekableByteChannel channel = Files.newByteChannel(path, options)) {
+            if (channel.size() > MAX_BYTES) throw tooLarge(label, path);
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            ByteBuffer buffer = ByteBuffer.allocate(8192);
+            while (channel.read(buffer) >= 0) {
+                buffer.flip();
+                if ((long) output.size() + buffer.remaining() > MAX_BYTES) throw tooLarge(label, path);
+                output.write(buffer.array(), buffer.position(), buffer.remaining());
+                buffer.clear();
+            }
+            return output.toString(StandardCharsets.UTF_8);
+        } catch (NoSuchFileException disappeared) {
+            return "";
+        }
+    }
+
+    private static IOException tooLarge(String label, Path path) {
+        return new IOException(label + " log exceeds the 2 MiB safety limit: " + path);
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportingSetupProvider.java
@@ -1,6 +1,7 @@
 package com.shaft.infrastructure;
 
 import java.io.IOException;
+import java.nio.file.Path;
 
 final class ReportingSetupProvider implements SetupProvider {
     @Override
@@ -24,6 +25,16 @@ final class ReportingSetupProvider implements SetupProvider {
         SetupReceipt receipt = service(options, plan.platform(), plan.architecture()).install(providerPlan,
                 new SetupApproval(providerPlan.digest(), approval.approvedAt(), approval.acceptedLicenses()));
         return new SetupReceipt(plan.digest(), receipt.completedAt(), receipt.completedActions());
+    }
+
+    @Override
+    public String logs(SetupOptions options, SetupSelection selection, SetupPlatform platform,
+                       SetupArchitecture architecture) throws IOException {
+        if (!selection.components().isEmpty()) {
+            throw new IllegalArgumentException("Profile REPORTING does not accept component selection.");
+        }
+        Path log = service(options, platform, architecture).logFile();
+        return OwnedLogReader.read("Reporting", log);
     }
 
     private static ReportingSetupService service(SetupOptions options, SetupPlatform platform,

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SetupProvider.java
@@ -48,4 +48,32 @@ public interface SetupProvider {
             throws IOException {
         throw new UnsupportedOperationException("Profile " + profile() + " does not own a startable service.");
     }
+
+    /**
+     * Stops the exact SHAFT-owned service represented by an approved plan.
+     *
+     * @param plan exact provider plan
+     * @param approval approval bound to {@code plan}
+     * @param options execution policy and owned roots
+     * @return {@code true} when an owned service was stopped
+     * @throws IOException when an owned service cannot be stopped safely
+     */
+    default boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        throw new UnsupportedOperationException("Profile " + profile() + " does not own a stoppable service.");
+    }
+
+    /**
+     * Reads bounded logs owned by this provider without mutating the host.
+     *
+     * @param options execution policy and owned roots
+     * @param selection exact profile selection
+     * @param platform selected host platform
+     * @param architecture selected host architecture
+     * @return log text, or an empty string when no owned logs exist
+     * @throws IOException when owned logs cannot be read safely
+     */
+    default String logs(SetupOptions options, SetupSelection selection, SetupPlatform platform,
+                        SetupArchitecture architecture) throws IOException {
+        throw new UnsupportedOperationException("Profile " + profile() + " does not expose owned logs.");
+    }
 }

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/InfrastructureSetupServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/InfrastructureSetupServiceTest.java
@@ -3,6 +3,7 @@ package com.shaft.infrastructure;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -382,6 +383,131 @@ class InfrastructureSetupServiceTest {
         assertThrows(IllegalStateException.class, () -> service.start(plan,
                 new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
         assertEquals(1, releases.get());
+    }
+
+    @Test
+    void approvedStopUsesTheProviderNeutralLifecycleContract(@TempDir Path temp) throws Exception {
+        AtomicInteger stops = new AtomicInteger();
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp))
+                .withMode(SetupMode.MANAGED);
+        SetupProvider provider = new FakeProvider() {
+            @Override
+            public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions ignored) {
+                stops.incrementAndGet();
+                return true;
+            }
+        };
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(provider)), SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupPlan plan = service.plan(options);
+
+        assertTrue(service.stop(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+        assertEquals(1, stops.get());
+    }
+
+    @Test
+    void staleStopApprovalReachesNoProviderMutation(@TempDir Path temp) {
+        AtomicInteger stops = new AtomicInteger();
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp))
+                .withMode(SetupMode.MANAGED);
+        SetupProvider provider = new FakeProvider() {
+            @Override
+            public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions ignored) {
+                stops.incrementAndGet();
+                return true;
+            }
+        };
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(provider)), SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupPlan plan = service.plan(options);
+
+        assertThrows(IllegalArgumentException.class, () -> service.stop(plan,
+                new SetupApproval("sha256:" + "0".repeat(64), Instant.EPOCH, Set.of()), options));
+        assertEquals(0, stops.get());
+    }
+
+    @Test
+    void logsUseTheProviderNeutralReadOnlyContract(@TempDir Path temp) throws Exception {
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp));
+        SetupProvider provider = new FakeProvider() {
+            @Override
+            public String logs(SetupOptions ignored, SetupSelection selection, SetupPlatform platform,
+                               SetupArchitecture architecture) {
+                return "owned log";
+            }
+        };
+        InfrastructureSetupService service = new InfrastructureSetupService(
+                new SetupProviderRegistry(List.of(provider)), SetupPlatform.LINUX, SetupArchitecture.X64);
+
+        assertEquals("owned log", service.logs(options, SetupSelection.defaults()));
+    }
+
+    @Test
+    void builtInReportingLogsUseTheProviderContractWithoutCreatingRoots(@TempDir Path temp) throws Exception {
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp));
+
+        assertEquals("", InfrastructureSetupService.builtIn(SetupPlatform.LINUX, SetupArchitecture.X64)
+                .logs(options));
+        assertFalse(java.nio.file.Files.exists(options.paths().cacheRoot()));
+        assertFalse(java.nio.file.Files.exists(options.paths().dataRoot()));
+    }
+
+    @Test
+    void builtInAndroidStopUsesTheProviderContract(@TempDir Path temp) throws Exception {
+        SetupOptions options = SetupOptions.defaults(SetupProfile.MOBILE_ANDROID, paths(temp))
+                .withMode(SetupMode.MANAGED);
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupPlan plan = service.plan(options, AndroidSetupRequest.defaults());
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH,
+                plan.actions().stream().flatMap(action -> action.requiredLicenses().stream())
+                        .collect(java.util.stream.Collectors.toSet()));
+
+        assertFalse(service.stop(plan, approval, options, AndroidSetupRequest.defaults().toSelection()));
+    }
+
+    @Test
+    void androidProviderRejectsStaleApprovalBeforeReadingTheLease(@TempDir Path temp) {
+        SetupOptions options = SetupOptions.defaults(SetupProfile.MOBILE_ANDROID, paths(temp))
+                .withMode(SetupMode.MANAGED);
+        SetupPlan plan = SetupPlan.bind(AndroidSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64,
+                SetupMode.MANAGED, AndroidSetupRequest.defaults()), options.policyDigest());
+
+        assertThrows(IllegalArgumentException.class, () -> new AndroidSetupProvider().stop(plan,
+                new SetupApproval("sha256:" + "0".repeat(64), Instant.EPOCH, Set.of()), options));
+        assertFalse(java.nio.file.Files.exists(options.paths().state()));
+    }
+
+    @Test
+    void androidLogsRequireAnOwnedLeaseEvenWhenOldLogFilesRemain(@TempDir Path temp) throws Exception {
+        SetupOptions options = SetupOptions.defaults(SetupProfile.MOBILE_ANDROID, paths(temp));
+        Path logs = options.paths().state().resolve("logs");
+        java.nio.file.Files.createDirectories(logs);
+        java.nio.file.Files.writeString(logs.resolve("android-emulator.log"), "old emulator log");
+        java.nio.file.Files.writeString(logs.resolve("appium-server.log"), "old appium log");
+
+        assertEquals("", InfrastructureSetupService.builtIn(SetupPlatform.LINUX, SetupArchitecture.X64)
+                .logs(options, AndroidSetupRequest.defaults().toSelection()));
+    }
+
+    @Test
+    void reportingLogsRejectFinalSymlinksAndOversizedFiles(@TempDir Path temp) throws Exception {
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORTING, paths(temp));
+        Path log = options.paths().state().resolve("logs/reporting-install.log");
+        java.nio.file.Files.createDirectories(log.getParent());
+        java.nio.file.Files.write(log, new byte[2 * 1024 * 1024 + 1]);
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+        assertThrows(IOException.class, () -> service.logs(options));
+
+        java.nio.file.Files.delete(log);
+        Path outside = java.nio.file.Files.writeString(temp.resolve("outside.log"), "outside");
+        try {
+            java.nio.file.Files.createSymbolicLink(log, outside);
+        } catch (UnsupportedOperationException | IOException unsupported) {
+            org.junit.jupiter.api.Assumptions.abort("Symbolic links unavailable: " + unsupported.getMessage());
+        }
+        assertThrows(IOException.class, () -> service.logs(options));
     }
 
     private static ShaftCachePaths paths(Path temp) {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/InfrastructureMcpService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/InfrastructureMcpService.java
@@ -1,6 +1,8 @@
 package com.shaft.mcp;
 
 import com.shaft.infrastructure.InfrastructureSetupService;
+import com.shaft.infrastructure.AndroidSetupRequest;
+import com.shaft.infrastructure.ManagedEnvironment;
 import com.shaft.infrastructure.SetupApproval;
 import com.shaft.infrastructure.SetupCatalog;
 import com.shaft.infrastructure.SetupOperation;
@@ -20,6 +22,7 @@ import java.time.Instant;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 
 /** MCP adapter over the provider-neutral setup coordinator. */
@@ -100,20 +103,82 @@ public final class InfrastructureMcpService {
     }
 
     @Tool(name = "setup_start",
-            description = "reports whether the selected setup profile owns a startable managed service")
-    public McpSetupLifecycleResult setupStart(@ToolParam(description = "setup profile") String profile) {
-        return unsupported(profile, "start");
+            description = "starts one managed service from an exact reviewed setup plan")
+    public McpSetupLifecycleResult setupStart(
+            @ToolParam(description = "exact plan JSON returned by setup_plan") String planJson,
+            @ToolParam(description = "exact plan digest explicitly approved by the caller") String approvedDigest,
+            @ToolParam(required = false, description = "explicitly accepted license identifiers")
+            List<String> acceptedLicenses,
+            @ToolParam(description = "the same paths and execution policy used to create the plan")
+            McpSetupRequest request) throws IOException {
+        SetupPlan plan = reviewedLifecyclePlan(planJson, request);
+        McpSetupRequest value = requireRequest(request);
+        try {
+            ManagedEnvironment environment = coordinator.start(plan, approval(approvedDigest, acceptedLicenses),
+                    value.options(), lifecycleSelection(plan, value));
+            return new McpSetupLifecycleResult(true, plan.profile().name(), "start",
+                    "Started the SHAFT-owned managed service.",
+                    environment.endpoint().map(Object::toString).orElse(""),
+                    environment.connectionProperties(), environment.receipt().planDigest(), "");
+        } catch (UnsupportedOperationException unsupported) {
+            return unsupported(plan.profile().name(), "start");
+        }
     }
 
     @Tool(name = "setup_stop",
-            description = "reports whether the selected setup profile owns a stoppable managed service lease")
-    public McpSetupLifecycleResult setupStop(@ToolParam(description = "setup profile") String profile) {
-        return unsupported(profile, "stop");
+            description = "stops one SHAFT-owned service using an exact reviewed setup plan")
+    public McpSetupLifecycleResult setupStop(
+            @ToolParam(description = "exact plan JSON returned by setup_plan") String planJson,
+            @ToolParam(description = "exact plan digest explicitly approved by the caller") String approvedDigest,
+            @ToolParam(required = false, description = "explicitly accepted license identifiers")
+            List<String> acceptedLicenses,
+            @ToolParam(description = "the same paths and execution policy used to create the plan")
+            McpSetupRequest request) throws IOException {
+        SetupPlan plan = reviewedLifecyclePlan(planJson, request);
+        McpSetupRequest value = requireRequest(request);
+        try {
+            boolean stopped = coordinator.stop(plan, approval(approvedDigest, acceptedLicenses),
+                    value.options(), lifecycleSelection(plan, value));
+            return new McpSetupLifecycleResult(true, plan.profile().name(), "stop",
+                    stopped ? "Stopped the SHAFT-owned managed service."
+                            : "No live SHAFT-owned managed service exists.",
+                    "", Map.of(), plan.digest(), "");
+        } catch (UnsupportedOperationException unsupported) {
+            return unsupported(plan.profile().name(), "stop");
+        }
     }
 
     @Tool(name = "setup_logs",
-            description = "reports whether the selected setup profile exposes owned service logs")
-    public McpSetupLifecycleResult setupLogs(@ToolParam(description = "setup profile") String profile) {
+            description = "reads bounded logs for a SHAFT-owned setup service without mutating the host")
+    public McpSetupLifecycleResult setupLogs(
+            @ToolParam(description = "setup profile, owned paths, policy, and components")
+            McpSetupRequest request) throws IOException {
+        McpSetupRequest value = requireRequest(request);
+        try {
+            String logs = coordinator.logs(value.options(), value.selection());
+            return new McpSetupLifecycleResult(true, value.setupProfile().name(), "logs",
+                    logs.isEmpty() ? "No owned logs exist." : "Read bounded SHAFT-owned logs.",
+                    "", Map.of(), "", logs);
+        } catch (UnsupportedOperationException unsupported) {
+            return unsupported(value.setupProfile().name(), "logs");
+        }
+    }
+
+    /** @deprecated Profile-only lifecycle calls cannot carry an exact reviewed plan and approval. */
+    @Deprecated(since = "10.3", forRemoval = false)
+    public McpSetupLifecycleResult setupStart(String profile) {
+        return unsupported(profile, "start");
+    }
+
+    /** @deprecated Profile-only lifecycle calls cannot carry an exact reviewed plan and approval. */
+    @Deprecated(since = "10.3", forRemoval = false)
+    public McpSetupLifecycleResult setupStop(String profile) {
+        return unsupported(profile, "stop");
+    }
+
+    /** @deprecated Profile-only lifecycle calls cannot identify provider-owned paths safely. */
+    @Deprecated(since = "10.3", forRemoval = false)
+    public McpSetupLifecycleResult setupLogs(String profile) {
         return unsupported(profile, "logs");
     }
 
@@ -127,6 +192,35 @@ public final class InfrastructureMcpService {
         } catch (RuntimeException invalid) {
             throw new IllegalArgumentException("planJson is not a valid strict setup plan.", invalid);
         }
+    }
+
+    private static SetupPlan reviewedLifecyclePlan(String planJson, McpSetupRequest request) {
+        if (planJson == null || planJson.isBlank()) throw new IllegalArgumentException("planJson must not be blank.");
+        SetupPlan plan = parsePlan(planJson);
+        McpSetupRequest value = requireRequest(request);
+        if (value.setupOperation() != SetupOperation.INSTALL || SetupOperation.fromPlan(plan) != SetupOperation.INSTALL) {
+            throw new IllegalArgumentException("Managed service lifecycle requires an INSTALL setup plan.");
+        }
+        if (plan.profile() != value.setupProfile()) {
+            throw new IllegalArgumentException("Setup plan profile does not match the request.");
+        }
+        return plan;
+    }
+
+    private static SetupApproval approval(String approvedDigest, List<String> acceptedLicenses) {
+        return new SetupApproval(approvedDigest, Instant.now(),
+                new LinkedHashSet<>(acceptedLicenses == null ? List.of() : acceptedLicenses));
+    }
+
+    private static SetupSelection lifecycleSelection(SetupPlan plan, McpSetupRequest request) {
+        if (plan.profile() == SetupProfile.MOBILE_ANDROID) {
+            SetupSelection selected = AndroidSetupRequest.fromPlan(plan).toSelection();
+            if (!request.components().isEmpty() && !selected.equals(request.selection())) {
+                throw new IllegalArgumentException("components do not match the reviewed Android plan.");
+            }
+            return selected;
+        }
+        return request.selection();
     }
 
     private static SetupSelection installSelection(SetupPlan plan, McpSetupRequest request) {

--- a/shaft-mcp/src/main/java/com/shaft/mcp/InfrastructureMcpService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/InfrastructureMcpService.java
@@ -103,19 +103,31 @@ public final class InfrastructureMcpService {
     }
 
     @Tool(name = "setup_start",
-            description = "starts one managed service from an exact reviewed setup plan")
+            description = "starts one managed service from an exact reviewed setup plan; profile-only calls remain "
+                    + "supported as legacy capability queries")
     public McpSetupLifecycleResult setupStart(
-            @ToolParam(description = "exact plan JSON returned by setup_plan") String planJson,
-            @ToolParam(description = "exact plan digest explicitly approved by the caller") String approvedDigest,
+            @ToolParam(required = false, description = "legacy setup profile capability query") String profile,
+            @ToolParam(required = false, description = "exact plan JSON returned by setup_plan") String planJson,
+            @ToolParam(required = false, description = "exact plan digest explicitly approved by the caller")
+            String approvedDigest,
             @ToolParam(required = false, description = "explicitly accepted license identifiers")
             List<String> acceptedLicenses,
-            @ToolParam(description = "the same paths and execution policy used to create the plan")
+            @ToolParam(required = false, description = "the same paths and execution policy used to create the plan")
             McpSetupRequest request) throws IOException {
+        if (planJson == null || planJson.isBlank()) return setupStart(profile);
+        requireMatchingOptionalProfile(profile, request);
+        return setupStart(planJson, approvedDigest, acceptedLicenses, request);
+    }
+
+    public McpSetupLifecycleResult setupStart(
+            String planJson, String approvedDigest, List<String> acceptedLicenses, McpSetupRequest request)
+            throws IOException {
         SetupPlan plan = reviewedLifecyclePlan(planJson, request);
         McpSetupRequest value = requireRequest(request);
         try {
             ManagedEnvironment environment = coordinator.start(plan, approval(approvedDigest, acceptedLicenses),
                     value.options(), lifecycleSelection(plan, value));
+            // The MCP operation establishes a persistent provider lease; setup_stop owns its explicit release.
             return new McpSetupLifecycleResult(true, plan.profile().name(), "start",
                     "Started the SHAFT-owned managed service.",
                     environment.endpoint().map(Object::toString).orElse(""),
@@ -126,14 +138,25 @@ public final class InfrastructureMcpService {
     }
 
     @Tool(name = "setup_stop",
-            description = "stops one SHAFT-owned service using an exact reviewed setup plan")
+            description = "stops one SHAFT-owned service using an exact reviewed setup plan; profile-only calls "
+                    + "remain supported as legacy capability queries")
     public McpSetupLifecycleResult setupStop(
-            @ToolParam(description = "exact plan JSON returned by setup_plan") String planJson,
-            @ToolParam(description = "exact plan digest explicitly approved by the caller") String approvedDigest,
+            @ToolParam(required = false, description = "legacy setup profile capability query") String profile,
+            @ToolParam(required = false, description = "exact plan JSON returned by setup_plan") String planJson,
+            @ToolParam(required = false, description = "exact plan digest explicitly approved by the caller")
+            String approvedDigest,
             @ToolParam(required = false, description = "explicitly accepted license identifiers")
             List<String> acceptedLicenses,
-            @ToolParam(description = "the same paths and execution policy used to create the plan")
+            @ToolParam(required = false, description = "the same paths and execution policy used to create the plan")
             McpSetupRequest request) throws IOException {
+        if (planJson == null || planJson.isBlank()) return setupStop(profile);
+        requireMatchingOptionalProfile(profile, request);
+        return setupStop(planJson, approvedDigest, acceptedLicenses, request);
+    }
+
+    public McpSetupLifecycleResult setupStop(
+            String planJson, String approvedDigest, List<String> acceptedLicenses, McpSetupRequest request)
+            throws IOException {
         SetupPlan plan = reviewedLifecyclePlan(planJson, request);
         McpSetupRequest value = requireRequest(request);
         try {
@@ -149,9 +172,18 @@ public final class InfrastructureMcpService {
     }
 
     @Tool(name = "setup_logs",
-            description = "reads bounded logs for a SHAFT-owned setup service without mutating the host")
+            description = "reads bounded logs for a SHAFT-owned setup service without mutating the host; "
+                    + "profile-only calls remain supported as legacy capability queries")
     public McpSetupLifecycleResult setupLogs(
-            @ToolParam(description = "setup profile, owned paths, policy, and components")
+            @ToolParam(required = false, description = "legacy setup profile capability query") String profile,
+            @ToolParam(required = false, description = "setup profile, owned paths, policy, and components")
+            McpSetupRequest request) throws IOException {
+        if (request == null) return setupLogs(profile);
+        requireMatchingOptionalProfile(profile, request);
+        return setupLogs(request);
+    }
+
+    public McpSetupLifecycleResult setupLogs(
             McpSetupRequest request) throws IOException {
         McpSetupRequest value = requireRequest(request);
         try {
@@ -184,6 +216,13 @@ public final class InfrastructureMcpService {
 
     private static McpSetupRequest requireRequest(McpSetupRequest request) {
         return Objects.requireNonNull(request, "request");
+    }
+
+    private static void requireMatchingOptionalProfile(String profile, McpSetupRequest request) {
+        if (profile == null || profile.isBlank()) return;
+        if (parseProfile(profile) != requireRequest(request).setupProfile()) {
+            throw new IllegalArgumentException("profile does not match the lifecycle request.");
+        }
     }
 
     private static SetupPlan parsePlan(String planJson) {
@@ -241,13 +280,16 @@ public final class InfrastructureMcpService {
 
     private static McpSetupLifecycleResult unsupported(String profile, String operation) {
         if (profile == null || profile.isBlank()) throw new IllegalArgumentException("profile must not be blank.");
-        SetupProfile parsed;
+        SetupProfile parsed = parseProfile(profile);
+        return new McpSetupLifecycleResult(false, parsed.name(), operation,
+                "Profile " + parsed + " does not currently own a " + operation + " lifecycle through MCP.");
+    }
+
+    private static SetupProfile parseProfile(String profile) {
         try {
-            parsed = SetupProfile.valueOf(profile.trim().toUpperCase(Locale.ROOT));
+            return SetupProfile.valueOf(profile.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException invalid) {
             throw new IllegalArgumentException("Unsupported setup profile: " + profile, invalid);
         }
-        return new McpSetupLifecycleResult(false, parsed.name(), operation,
-                "Profile " + parsed + " does not currently own a " + operation + " lifecycle through MCP.");
     }
 }

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpSetupLifecycleResult.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpSetupLifecycleResult.java
@@ -1,4 +1,19 @@
 package com.shaft.mcp;
 
-/** Explicit lifecycle capability result for profiles that do not yet own a service lease. */
-public record McpSetupLifecycleResult(boolean supported, String profile, String operation, String message) { }
+import java.util.Map;
+
+/** Structured result for provider-neutral setup service lifecycle operations. */
+public record McpSetupLifecycleResult(boolean supported, String profile, String operation, String message,
+                                      String endpoint, Map<String, String> connectionProperties,
+                                      String planDigest, String logs) {
+    public McpSetupLifecycleResult {
+        endpoint = endpoint == null ? "" : endpoint;
+        connectionProperties = connectionProperties == null ? Map.of() : Map.copyOf(connectionProperties);
+        planDigest = planDigest == null ? "" : planDigest;
+        logs = logs == null ? "" : logs;
+    }
+
+    public McpSetupLifecycleResult(boolean supported, String profile, String operation, String message) {
+        this(supported, profile, operation, message, "", Map.of(), "", "");
+    }
+}

--- a/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index-mechanical.json
+++ b/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index-mechanical.json
@@ -1653,12 +1653,12 @@
   }, {
     "name" : "setup_logs",
     "service" : "InfrastructureMcpService",
-    "description" : "reports whether the selected setup profile exposes owned service logs",
+    "description" : "reads bounded logs for a SHAFT-owned setup service without mutating the host",
     "params" : [ {
-      "name" : "profile",
-      "type" : "string",
+      "name" : "request",
+      "type" : "object",
       "required" : true,
-      "description" : "setup profile"
+      "description" : "setup profile, owned paths, policy, and components"
     } ]
   }, {
     "name" : "setup_plan",
@@ -1673,12 +1673,27 @@
   }, {
     "name" : "setup_start",
     "service" : "InfrastructureMcpService",
-    "description" : "reports whether the selected setup profile owns a startable managed service",
+    "description" : "starts one managed service from an exact reviewed setup plan",
     "params" : [ {
-      "name" : "profile",
+      "name" : "acceptedLicenses",
+      "type" : "array",
+      "required" : false,
+      "description" : "explicitly accepted license identifiers"
+    }, {
+      "name" : "approvedDigest",
       "type" : "string",
       "required" : true,
-      "description" : "setup profile"
+      "description" : "exact plan digest explicitly approved by the caller"
+    }, {
+      "name" : "planJson",
+      "type" : "string",
+      "required" : true,
+      "description" : "exact plan JSON returned by setup_plan"
+    }, {
+      "name" : "request",
+      "type" : "object",
+      "required" : true,
+      "description" : "the same paths and execution policy used to create the plan"
     } ]
   }, {
     "name" : "setup_status",
@@ -1693,12 +1708,27 @@
   }, {
     "name" : "setup_stop",
     "service" : "InfrastructureMcpService",
-    "description" : "reports whether the selected setup profile owns a stoppable managed service lease",
+    "description" : "stops one SHAFT-owned service using an exact reviewed setup plan",
     "params" : [ {
-      "name" : "profile",
+      "name" : "acceptedLicenses",
+      "type" : "array",
+      "required" : false,
+      "description" : "explicitly accepted license identifiers"
+    }, {
+      "name" : "approvedDigest",
       "type" : "string",
       "required" : true,
-      "description" : "setup profile"
+      "description" : "exact plan digest explicitly approved by the caller"
+    }, {
+      "name" : "planJson",
+      "type" : "string",
+      "required" : true,
+      "description" : "exact plan JSON returned by setup_plan"
+    }, {
+      "name" : "request",
+      "type" : "object",
+      "required" : true,
+      "description" : "the same paths and execution policy used to create the plan"
     } ]
   }, {
     "name" : "setup_verify",

--- a/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index-mechanical.json
+++ b/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index-mechanical.json
@@ -1653,11 +1653,16 @@
   }, {
     "name" : "setup_logs",
     "service" : "InfrastructureMcpService",
-    "description" : "reads bounded logs for a SHAFT-owned setup service without mutating the host",
+    "description" : "reads bounded logs for a SHAFT-owned setup service without mutating the host; profile-only calls remain supported as legacy capability queries",
     "params" : [ {
+      "name" : "profile",
+      "type" : "string",
+      "required" : false,
+      "description" : "legacy setup profile capability query"
+    }, {
       "name" : "request",
       "type" : "object",
-      "required" : true,
+      "required" : false,
       "description" : "setup profile, owned paths, policy, and components"
     } ]
   }, {
@@ -1673,7 +1678,7 @@
   }, {
     "name" : "setup_start",
     "service" : "InfrastructureMcpService",
-    "description" : "starts one managed service from an exact reviewed setup plan",
+    "description" : "starts one managed service from an exact reviewed setup plan; profile-only calls remain supported as legacy capability queries",
     "params" : [ {
       "name" : "acceptedLicenses",
       "type" : "array",
@@ -1682,17 +1687,22 @@
     }, {
       "name" : "approvedDigest",
       "type" : "string",
-      "required" : true,
+      "required" : false,
       "description" : "exact plan digest explicitly approved by the caller"
     }, {
       "name" : "planJson",
       "type" : "string",
-      "required" : true,
+      "required" : false,
       "description" : "exact plan JSON returned by setup_plan"
+    }, {
+      "name" : "profile",
+      "type" : "string",
+      "required" : false,
+      "description" : "legacy setup profile capability query"
     }, {
       "name" : "request",
       "type" : "object",
-      "required" : true,
+      "required" : false,
       "description" : "the same paths and execution policy used to create the plan"
     } ]
   }, {
@@ -1708,7 +1718,7 @@
   }, {
     "name" : "setup_stop",
     "service" : "InfrastructureMcpService",
-    "description" : "stops one SHAFT-owned service using an exact reviewed setup plan",
+    "description" : "stops one SHAFT-owned service using an exact reviewed setup plan; profile-only calls remain supported as legacy capability queries",
     "params" : [ {
       "name" : "acceptedLicenses",
       "type" : "array",
@@ -1717,17 +1727,22 @@
     }, {
       "name" : "approvedDigest",
       "type" : "string",
-      "required" : true,
+      "required" : false,
       "description" : "exact plan digest explicitly approved by the caller"
     }, {
       "name" : "planJson",
       "type" : "string",
-      "required" : true,
+      "required" : false,
       "description" : "exact plan JSON returned by setup_plan"
+    }, {
+      "name" : "profile",
+      "type" : "string",
+      "required" : false,
+      "description" : "legacy setup profile capability query"
     }, {
       "name" : "request",
       "type" : "object",
-      "required" : true,
+      "required" : false,
       "description" : "the same paths and execution policy used to create the plan"
     } ]
   }, {

--- a/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index.json
+++ b/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index.json
@@ -2974,14 +2974,14 @@
     {
       "name": "setup_logs",
       "service": "InfrastructureMcpService",
-      "description": "reports whether the selected setup profile exposes owned service logs",
+      "description": "reads bounded logs for a SHAFT-owned setup service without mutating the host",
       "params": [
         {
-          "name": "profile",
-          "type": "string",
+          "name": "request",
+          "type": "object",
           "required": true,
           "default": null,
-          "description": "setup profile"
+          "description": "setup profile, owned paths, policy, and components"
         }
       ],
       "mutation": false,
@@ -3020,14 +3020,35 @@
     {
       "name": "setup_start",
       "service": "InfrastructureMcpService",
-      "description": "reports whether the selected setup profile owns a startable managed service",
+      "description": "starts one managed service from an exact reviewed setup plan",
       "params": [
         {
-          "name": "profile",
+          "name": "acceptedLicenses",
+          "type": "array",
+          "required": false,
+          "default": null,
+          "description": "explicitly accepted license identifiers"
+        },
+        {
+          "name": "approvedDigest",
           "type": "string",
           "required": true,
           "default": null,
-          "description": "setup profile"
+          "description": "exact plan digest explicitly approved by the caller"
+        },
+        {
+          "name": "planJson",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "exact plan JSON returned by setup_plan"
+        },
+        {
+          "name": "request",
+          "type": "object",
+          "required": true,
+          "default": null,
+          "description": "the same paths and execution policy used to create the plan"
         }
       ],
       "mutation": true,
@@ -3066,14 +3087,35 @@
     {
       "name": "setup_stop",
       "service": "InfrastructureMcpService",
-      "description": "reports whether the selected setup profile owns a stoppable managed service lease",
+      "description": "stops one SHAFT-owned service using an exact reviewed setup plan",
       "params": [
         {
-          "name": "profile",
+          "name": "acceptedLicenses",
+          "type": "array",
+          "required": false,
+          "default": null,
+          "description": "explicitly accepted license identifiers"
+        },
+        {
+          "name": "approvedDigest",
           "type": "string",
           "required": true,
           "default": null,
-          "description": "setup profile"
+          "description": "exact plan digest explicitly approved by the caller"
+        },
+        {
+          "name": "planJson",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "exact plan JSON returned by setup_plan"
+        },
+        {
+          "name": "request",
+          "type": "object",
+          "required": true,
+          "default": null,
+          "description": "the same paths and execution policy used to create the plan"
         }
       ],
       "mutation": true,

--- a/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index.json
+++ b/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index.json
@@ -2974,12 +2974,19 @@
     {
       "name": "setup_logs",
       "service": "InfrastructureMcpService",
-      "description": "reads bounded logs for a SHAFT-owned setup service without mutating the host",
+      "description": "reads bounded logs for a SHAFT-owned setup service without mutating the host; profile-only calls remain supported as legacy capability queries",
       "params": [
+        {
+          "name": "profile",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "legacy setup profile capability query"
+        },
         {
           "name": "request",
           "type": "object",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "setup profile, owned paths, policy, and components"
         }
@@ -3020,7 +3027,7 @@
     {
       "name": "setup_start",
       "service": "InfrastructureMcpService",
-      "description": "starts one managed service from an exact reviewed setup plan",
+      "description": "starts one managed service from an exact reviewed setup plan; profile-only calls remain supported as legacy capability queries",
       "params": [
         {
           "name": "acceptedLicenses",
@@ -3032,21 +3039,28 @@
         {
           "name": "approvedDigest",
           "type": "string",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "exact plan digest explicitly approved by the caller"
         },
         {
           "name": "planJson",
           "type": "string",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "exact plan JSON returned by setup_plan"
         },
         {
+          "name": "profile",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "legacy setup profile capability query"
+        },
+        {
           "name": "request",
           "type": "object",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "the same paths and execution policy used to create the plan"
         }
@@ -3087,7 +3101,7 @@
     {
       "name": "setup_stop",
       "service": "InfrastructureMcpService",
-      "description": "stops one SHAFT-owned service using an exact reviewed setup plan",
+      "description": "stops one SHAFT-owned service using an exact reviewed setup plan; profile-only calls remain supported as legacy capability queries",
       "params": [
         {
           "name": "acceptedLicenses",
@@ -3099,21 +3113,28 @@
         {
           "name": "approvedDigest",
           "type": "string",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "exact plan digest explicitly approved by the caller"
         },
         {
           "name": "planJson",
           "type": "string",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "exact plan JSON returned by setup_plan"
         },
         {
+          "name": "profile",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "legacy setup profile capability query"
+        },
+        {
           "name": "request",
           "type": "object",
-          "required": true,
+          "required": false,
           "default": null,
           "description": "the same paths and execution policy used to create the plan"
         }

--- a/shaft-mcp/src/test/java/com/shaft/mcp/InfrastructureMcpServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/InfrastructureMcpServiceTest.java
@@ -1,6 +1,7 @@
 package com.shaft.mcp;
 
 import com.shaft.infrastructure.InfrastructureSetupService;
+import com.shaft.infrastructure.ManagedEnvironment;
 import com.shaft.infrastructure.SetupAction;
 import com.shaft.infrastructure.SetupActionKind;
 import com.shaft.infrastructure.SetupApproval;
@@ -23,6 +24,8 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -100,7 +103,36 @@ class InfrastructureMcpServiceTest {
     }
 
     @Test
-    void lifecycleToolsAreExplicitlyUnsupportedWithoutAnOwnedService() {
+    void lifecycleToolsDelegateExactPlansAndOwnedLogsToTheCoordinator() throws Exception {
+        InfrastructureSetupService coordinator = mock(InfrastructureSetupService.class);
+        SetupPlan plan = plan(SetupProfile.REPORTING);
+        SetupReceipt receipt = new SetupReceipt(plan.digest(), Instant.EPOCH, plan.actions());
+        ManagedEnvironment environment = new ManagedEnvironment(plan.profile(), receipt,
+                Optional.of(URI.create("http://127.0.0.1:4723/")), Map.of("appium", "ready"), () -> { });
+        when(coordinator.start(any(), any(), any(), any(SetupSelection.class))).thenReturn(environment);
+        when(coordinator.stop(any(), any(), any(), any(SetupSelection.class))).thenReturn(true);
+        when(coordinator.logs(any(), any(SetupSelection.class))).thenReturn("owned logs");
+        InfrastructureMcpService service = new InfrastructureMcpService(coordinator);
+        McpSetupRequest request = request("REPORTING", "MANAGED", List.of());
+        String json = com.shaft.infrastructure.SetupPlanJson.write(plan);
+
+        McpSetupLifecycleResult started = service.setupStart(json, plan.digest(), List.of(), request);
+        McpSetupLifecycleResult stopped = service.setupStop(json, plan.digest(), List.of(), request);
+        McpSetupLifecycleResult logs = service.setupLogs(request);
+
+        assertTrue(started.supported());
+        assertEquals("http://127.0.0.1:4723/", started.endpoint());
+        assertEquals(plan.digest(), started.planDigest());
+        assertTrue(stopped.supported());
+        assertEquals("owned logs", logs.logs());
+        verify(coordinator).start(any(), any(), any(), any(SetupSelection.class));
+        verify(coordinator).stop(any(), any(), any(), any(SetupSelection.class));
+        verify(coordinator).logs(any(), any(SetupSelection.class));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void legacyProfileOnlyLifecycleOverloadsRemainExplicitlyUnsupported() {
         InfrastructureMcpService service = new InfrastructureMcpService(mock(InfrastructureSetupService.class));
 
         assertFalse(service.setupStart("REPORTING").supported());

--- a/shaft-mcp/src/test/java/com/shaft/mcp/InfrastructureMcpServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/InfrastructureMcpServiceTest.java
@@ -37,6 +37,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class InfrastructureMcpServiceTest {
@@ -116,9 +117,9 @@ class InfrastructureMcpServiceTest {
         McpSetupRequest request = request("REPORTING", "MANAGED", List.of());
         String json = com.shaft.infrastructure.SetupPlanJson.write(plan);
 
-        McpSetupLifecycleResult started = service.setupStart(json, plan.digest(), List.of(), request);
-        McpSetupLifecycleResult stopped = service.setupStop(json, plan.digest(), List.of(), request);
-        McpSetupLifecycleResult logs = service.setupLogs(request);
+        McpSetupLifecycleResult started = service.setupStart(null, json, plan.digest(), List.of(), request);
+        McpSetupLifecycleResult stopped = service.setupStop(null, json, plan.digest(), List.of(), request);
+        McpSetupLifecycleResult logs = service.setupLogs(null, request);
 
         assertTrue(started.supported());
         assertEquals("http://127.0.0.1:4723/", started.endpoint());
@@ -132,12 +133,17 @@ class InfrastructureMcpServiceTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    void legacyProfileOnlyLifecycleOverloadsRemainExplicitlyUnsupported() {
-        InfrastructureMcpService service = new InfrastructureMcpService(mock(InfrastructureSetupService.class));
+    void legacyProfileOnlyLifecycleOverloadsRemainExplicitlyUnsupported() throws Exception {
+        InfrastructureSetupService coordinator = mock(InfrastructureSetupService.class);
+        InfrastructureMcpService service = new InfrastructureMcpService(coordinator);
 
         assertFalse(service.setupStart("REPORTING").supported());
         assertFalse(service.setupStop("REPORTING").supported());
         assertFalse(service.setupLogs("REPORTING").supported());
+        assertFalse(service.setupStart("REPORTING", null, null, null, null).supported());
+        assertFalse(service.setupStop("REPORTING", null, null, null, null).supported());
+        assertFalse(service.setupLogs("REPORTING", null).supported());
+        verifyNoInteractions(coordinator);
     }
 
     @Test

--- a/shaft-skills/references/shaft-mcp-tools.md
+++ b/shaft-skills/references/shaft-mcp-tools.md
@@ -107,9 +107,9 @@ Agents should use these exact tool names instead of guessing or listing tools at
 - `setup_verify` — verifies exact setup readiness without mutating the host
 - `setup_plan` — creates an exact reviewable setup plan and approval digest without mutating the host
 - `setup_install` — installs one reviewed setup plan after exact digest and license approval
-- `setup_start` — reports whether the selected setup profile owns a startable managed service
-- `setup_stop` — reports whether the selected setup profile owns a stoppable managed service lease
-- `setup_logs` — reports whether the selected setup profile exposes owned service logs
+- `setup_start` — starts one managed service from an exact reviewed setup plan
+- `setup_stop` — stops one SHAFT-owned service using an exact reviewed setup plan
+- `setup_logs` — reads bounded logs for a SHAFT-owned setup service without mutating the host
 
 ## Mobile (MobileService)
 

--- a/shaft-skills/references/shaft-mcp-tools.md
+++ b/shaft-skills/references/shaft-mcp-tools.md
@@ -107,9 +107,9 @@ Agents should use these exact tool names instead of guessing or listing tools at
 - `setup_verify` — verifies exact setup readiness without mutating the host
 - `setup_plan` — creates an exact reviewable setup plan and approval digest without mutating the host
 - `setup_install` — installs one reviewed setup plan after exact digest and license approval
-- `setup_start` — starts one managed service from an exact reviewed setup plan
-- `setup_stop` — stops one SHAFT-owned service using an exact reviewed setup plan
-- `setup_logs` — reads bounded logs for a SHAFT-owned setup service without mutating the host
+- `setup_start` — starts one managed service from an exact reviewed setup plan; profile-only calls remain supported as legacy capability queries
+- `setup_stop` — stops one SHAFT-owned service using an exact reviewed setup plan; profile-only calls remain supported as legacy capability queries
+- `setup_logs` — reads bounded logs for a SHAFT-owned setup service without mutating the host; profile-only calls remain supported as legacy capability queries
 
 ## Mobile (MobileService)
 


### PR DESCRIPTION
## Summary
- add provider-neutral approved `stop` and read-only `logs` lifecycle contracts
- route CLI and MCP lifecycle operations through `InfrastructureSetupService`
- enforce lease-bound, no-follow, 2 MiB-bounded owned log reads
- preserve deprecated profile-only MCP Java overloads while upgrading MCP tool schemas

## Verification
- `mvn --batch-mode -pl shaft-cli,shaft-mcp -am "-Dtest=InfrastructureSetupServiceTest,AndroidLifecycleServiceTest,SetupCommandTest,InfrastructureMcpServiceTest,ToolIndexMechanicalDumpTest" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dspring.ai.mcp.server.enabled=false" "-DheadlessExecution=true" "-Dallure.automaticallyOpen=false" "-Dgpg.skip" test`
- `mvn --batch-mode -pl shaft-cli,shaft-mcp -am "-DskipTests" "-DheadlessExecution=true" "-Dallure.automaticallyOpen=false" "-Dgpg.skip" package`
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- `py -3 scripts/ci/validate_shaft_mcp_configuration.py`
- `py -3 scripts/mcp/generate_tool_index.py --check`

Tracker: #4849
Closes #4967