### PR TITLE
fix(agent): verify retrieval runtime contract

### DIFF
--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -38,6 +38,75 @@ LEGACY_MANAGED_PATHS = (
 )
 
 
+def project_identity_name(project: Path) -> str:
+    """Return the repository identity, independent of a checkout/worktree folder name."""
+    result = subprocess.run(  # nosec B603 B607 - fixed git query, no shell.
+        ["git", "-C", str(project), "config", "--get", "remote.origin.url"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
+    )
+    if result.returncode == 0:
+        remote = result.stdout.strip().rstrip("/\\")
+        candidate = re.split(r"[/\\:]", remote)[-1]
+        if candidate.casefold().endswith(".git"):
+            candidate = candidate[:-4]
+        if candidate:
+            return candidate
+    return project.name
+
+
+def validate_memory_config(content: bytes) -> None:
+    try:
+        config = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("invalid Memory configuration") from error
+    project_config = config.get("project") if isinstance(config, dict) else None
+    memory_options = config.get("memory") if isinstance(config, dict) else None
+    git_options = config.get("git") if isinstance(config, dict) else None
+    if (
+        not isinstance(config, dict)
+        or config.get("version") != 5
+        or not isinstance(project_config, dict)
+        or not isinstance(project_config.get("id"), str)
+        or not project_config["id"].strip()
+        or not isinstance(project_config.get("name"), str)
+        or not project_config["name"].strip()
+        or not isinstance(memory_options, dict)
+        or not isinstance(git_options, dict)
+    ):
+        raise ValueError("invalid Memory configuration")
+
+
+def validate_mempalace_config(content: bytes) -> None:
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError("invalid MemPalace configuration") from error
+    wing_matches = re.findall(r"(?m)^wing:\s*([A-Za-z0-9_.-]+)\s*$", text)
+    rooms = re.search(r"(?ms)^rooms:\s*\n(?P<body>.*?)(?=^exclude_patterns:\s*$)", text)
+    excludes = re.search(r"(?ms)^exclude_patterns:\s*\n(?P<body>.*)\Z", text)
+    if (
+        len(wing_matches) != 1
+        or rooms is None
+        or re.search(r"(?m)^\s{2}- name:\s*\S+\s*$", rooms.group("body")) is None
+        or re.search(r"(?m)^\s{4}description:\s*\S+.*$", rooms.group("body")) is None
+        or excludes is None
+        or re.search(r"(?m)^\s{2}-\s+\S+\s*$", excludes.group("body")) is None
+    ):
+        raise ValueError("invalid MemPalace configuration")
+
+
+def retrieval_configs_healthy(project: Path) -> bool:
+    try:
+        validate_memory_config((project / ".memory/config.json").read_bytes())
+        validate_mempalace_config((project / "mempalace.yaml").read_bytes())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
 def client_command(
     executable: str,
     arguments: list[str],
@@ -1253,7 +1322,7 @@ def desired_content(
     if memory_before is None:
         normalized_name = re.sub(r"[^a-z0-9]+", "-", project_name.casefold()).strip("-") or "project"
         memory_config = {
-            "version": 4,
+            "version": 5,
             "project": {"id": f"project.{normalized_name}", "name": project_name},
             "memory": {
                 "autoIndex": True,
@@ -1266,23 +1335,7 @@ def desired_content(
             json.dumps(memory_config, indent=2, sort_keys=True) + "\n"
         ).encode()
     else:
-        try:
-            memory_config = json.loads(memory_before)
-        except (UnicodeDecodeError, json.JSONDecodeError) as error:
-            raise ValueError("invalid Memory configuration") from error
-        project_config = memory_config.get("project") if isinstance(memory_config, dict) else None
-        memory_options = memory_config.get("memory") if isinstance(memory_config, dict) else None
-        git_options = memory_config.get("git") if isinstance(memory_config, dict) else None
-        if (
-            not isinstance(memory_config, dict)
-            or memory_config.get("version") != 4
-            or not isinstance(project_config, dict)
-            or not isinstance(project_config.get("id"), str)
-            or not isinstance(project_config.get("name"), str)
-            or not isinstance(memory_options, dict)
-            or not isinstance(git_options, dict)
-        ):
-            raise ValueError("invalid Memory configuration")
+        validate_memory_config(memory_before)
         after[".memory/config.json"] = memory_before
     mempalace_before = before["mempalace.yaml"]
     if mempalace_before is None:
@@ -1295,28 +1348,7 @@ def desired_content(
             "  - graphify-out/**\n  - .chaos-engine-runtime/**\n  - .chaos-engine-state/**\n"
         ).encode()
     else:
-        try:
-            mempalace_text = mempalace_before.decode("utf-8")
-        except UnicodeDecodeError as error:
-            raise ValueError("invalid MemPalace configuration") from error
-        wing_matches = re.findall(r"(?m)^wing:\s*([A-Za-z0-9_.-]+)\s*$", mempalace_text)
-        rooms = re.search(
-            r"(?ms)^rooms:\s*\n(?P<body>.*?)(?=^exclude_patterns:\s*$)",
-            mempalace_text,
-        )
-        excludes = re.search(
-            r"(?ms)^exclude_patterns:\s*\n(?P<body>.*)\Z",
-            mempalace_text,
-        )
-        if (
-            len(wing_matches) != 1
-            or rooms is None
-            or re.search(r"(?m)^\s{2}- name:\s*\S+\s*$", rooms.group("body")) is None
-            or re.search(r"(?m)^\s{4}description:\s*\S+.*$", rooms.group("body")) is None
-            or excludes is None
-            or re.search(r"(?m)^\s{2}-\s+\S+\s*$", excludes.group("body")) is None
-        ):
-            raise ValueError("invalid MemPalace configuration")
+        validate_mempalace_config(mempalace_before)
         after["mempalace.yaml"] = mempalace_before
     after[".gitignore"] = gitignore_content(before[".gitignore"])
     for relative in ("AGENTS.md", "CLAUDE.md", "GEMINI.md"):
@@ -1744,7 +1776,11 @@ def install(project: Path, core_commit: str | None = None) -> dict[str, object]:
         if receipt["phase"] == "installed":
             verify(project, receipt)
             version = plugin_cache_version(core_commit)
-            wanted = desired_content(before, project_name=project.name, plugin_version=version)
+            wanted = desired_content(
+                before,
+                project_name=project_identity_name(project),
+                plugin_version=version,
+            )
             if after == wanted and receipt.get("coreCommit") == core_commit:
                 return receipt
             next_receipt = dict(receipt)
@@ -1779,7 +1815,11 @@ def install(project: Path, core_commit: str | None = None) -> dict[str, object]:
 
     before = current_images(project)
     version = plugin_cache_version(core_commit)
-    after = desired_content(before, project_name=project.name, plugin_version=version)
+    after = desired_content(
+        before,
+        project_name=project_identity_name(project),
+        plugin_version=version,
+    )
     if existing_anchors and existing_anchors[0].name.startswith(REMOVING_ANCHOR_PREFIX):
         raise ValueError("ChaosEngine host removal recovery is required")
     anchor_path = host_anchor_path(project, create=True)

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -997,7 +997,11 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
 
 
 def attach_component_status(
-    result: dict[str, object], project: Path, target: Path, dependency_health: str
+    result: dict[str, object],
+    project: Path,
+    target: Path,
+    dependency_health: str,
+    host_controller: object,
 ) -> None:
     component_paths = {
         "core": [target / "skills/chaos-engine/SKILL.md"],
@@ -1029,6 +1033,8 @@ def attach_component_status(
     for name, paths in component_paths.items():
         expected_count = 10 if name == "roles" else len(paths)
         healthy = len(paths) == expected_count and all(path.is_file() for path in paths)
+        if name == "retrieval-config" and healthy:
+            healthy = bool(host_controller.retrieval_configs_healthy(project))
         components[name] = {"status": "healthy" if healthy else "absent"}
     for name in ("tools", "memory", "mempalace", "graphify"):
         components[name] = {"status": dependency_health}
@@ -1078,11 +1084,13 @@ def status_with_dependencies(project: Path, *, active_probes: bool = False) -> d
                 for path in (removing, backup, building)
             ):
                 result["dependencies"] = {"status": "recovery-required"}
-                attach_component_status(result, project, target, "recovery-required")
+                attach_component_status(
+                    result, project, target, "recovery-required", host_controller
+                )
                 return result
             if not runtime.exists():
                 result["dependencies"] = {"status": "absent"}
-                attach_component_status(result, project, target, "absent")
+                attach_component_status(result, project, target, "absent", host_controller)
                 return result
             controller = load_dependency_controller(target)
             dependency_check = controller.doctor if active_probes else controller.status
@@ -1091,7 +1099,9 @@ def status_with_dependencies(project: Path, *, active_probes: bool = False) -> d
                 specification=controller.load_specification(target / "dependencies.json"),
             )
             dependency_health = str(result["dependencies"].get("status"))  # type: ignore[union-attr]
-            attach_component_status(result, project, target, dependency_health)
+            attach_component_status(
+                result, project, target, dependency_health, host_controller
+            )
             return result
 
 

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -312,6 +312,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 ),
             )
             memory_config = json.loads(project.joinpath(".memory/config.json").read_text())
+            self.assertEqual(5, memory_config["version"])
             self.assertEqual("consumer", memory_config["project"]["name"])
             self.assertIn("wing: consumer", project.joinpath("mempalace.yaml").read_text())
             ignores = project.joinpath(".gitignore").read_text()
@@ -492,6 +493,18 @@ class ChaosEngineHostsTest(unittest.TestCase):
         module = load(HOSTS, "chaos_engine_invalid_retrieval")
         for relative, content, message in (
             (".memory/config.json", "{}", "Memory configuration"),
+            (
+                ".memory/config.json",
+                json.dumps(
+                    {
+                        "version": 4,
+                        "project": {"id": "project.consumer", "name": "consumer"},
+                        "memory": {},
+                        "git": {},
+                    }
+                ),
+                "Memory configuration",
+            ),
             ("mempalace.yaml", "arbitrary: value\n", "MemPalace configuration"),
             (
                 "mempalace.yaml",
@@ -510,6 +523,33 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     module.install(project)
                 self.assertFalse(project.joinpath(module.RECEIPT_NAME).exists())
+
+    def test_repository_remote_defines_identity_in_a_named_worktree(self):
+        module = load(HOSTS, "chaos_engine_repository_identity")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "feature-worktree"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q", str(project)], check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(project),
+                    "remote",
+                    "add",
+                    "origin",
+                    "ssh://git.example/team/actual-project.git",
+                ],
+                check=True,
+            )
+            project.joinpath(".chaos-engine/skills/chaos-engine").mkdir(parents=True)
+            project.joinpath(".chaos-engine/skills/chaos-engine/SKILL.md").write_text("# C\n")
+
+            module.install(project)
+
+            memory = json.loads(project.joinpath(".memory/config.json").read_text())
+            self.assertEqual("actual-project", memory["project"]["name"])
+            self.assertIn("wing: actual-project", project.joinpath("mempalace.yaml").read_text())
 
     def test_launcher_rendering_is_explicit_for_windows_and_posix(self):
         module = load(HOSTS, "chaos_engine_hosts")

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -96,6 +96,31 @@ class ChaosEngineInstallerTest(unittest.TestCase):
                 with self.assertRaisesRegex(RuntimeError, "active probe failed"):
                     MODULE.doctor_with_dependencies(project)
 
+    def test_status_rejects_semantically_invalid_retrieval_configuration(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            MODULE.install_with_dependencies(
+                project,
+                SOURCE,
+                TEST_COMMIT,
+                provisioner=lambda *_args, **_kwargs: None,
+            )
+            controller = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            with mock.patch.object(
+                controller,
+                "retrieval_configs_healthy",
+                return_value=False,
+            ), mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                return_value=controller,
+            ):
+                result = MODULE.status_with_dependencies(project)
+
+            self.assertEqual("recovery-required", result["status"])
+            self.assertEqual("absent", result["components"]["retrieval-config"]["status"])
+
     def test_default_distribution_installs_only_neutral_portable_payload(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "consumer"


### PR DESCRIPTION
## Outcome
- generate the schema version required by the pinned Memory runtime
- reject semantically invalid Memory and MemPalace configuration in both installation and status/doctor
- derive neutral retrieval identity from the repository remote instead of a temporary worktree folder

## Verification
- py -3 -m unittest tests.scripts.test_chaos_engine_hosts tests.scripts.test_chaos_engine_installer
- py -3 -m unittest tests.scripts.test_chaos_engine_bootstrap tests.scripts.test_chaos_engine_dependencies tests.scripts.test_chaos_engine_hook
- py -3 scripts/ci/validate_agent_setup.py --skip-external

Closes #4964
Part of #4961