### PR TITLE
fix(agent): bootstrap the Memory canonical store

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -48,14 +48,14 @@ py -3 -c "import pathlib,runpy,sys,tempfile,urllib.request; o='S'+'haftHQ'; r='S
 
 On macOS or Linux, replace `py -3` with `python3`. Inspect the
 bootstrap source in this upstream repository first when policy requires review
-before execution. The temporary bootstrap
-resolves the default branch to an immutable commit; `portable` is already the
-default and need not be supplied. Restart any client that was open during
+before execution. The temporary bootstrap resolves the default branch to an
+immutable commit and downloads only its validated `chaos-engine/` subtree;
+`portable` is already the default and need not be supplied. Restart any client that was open during
 installation so it loads its verified local plugin cache.
 
 Add `--branch branch` to override the repository's configured default branch. The
 bootstrap resolves that mutable branch through the GitHub API, downloads the
-exact commit archive, rejects unsafe archive entries, and records repository,
+exact commit's declared harness files, rejects unsafe tree entries, and records repository,
 immutable provenance digests and the commit in `.chaos-engine/manifest.json`.
 The public default is always the neutral `portable` distribution; a source
 repository's contributor profile requires an explicit non-default selection. Re-running the

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -68,8 +68,8 @@ guidance out of the always-loaded context until it is needed.
 
 Start with the full [installation and upgrade guide](INSTALL.md). The safest
 flow resolves a configured upstream branch to an immutable commit, downloads
-that exact archive, validates its paths, and installs ChaosEngine inside the
-target project.
+only that commit's validated `chaos-engine/` subtree, and installs ChaosEngine
+inside the target project.
 
 From the adopter project, run one copy/paste command. On Windows PowerShell:
 
@@ -148,6 +148,15 @@ policy into competing copies.
 It also creates trackable Memory and MemPalace configuration, provider-native
 role/plugin/hook adapters, and ignore rules that separate canonical harness
 files from generated runtimes, indexes, receipts, and Graphify output.
+Memory's canonical store is bootstrapped from the pinned v5
+[schema bundle](assets/memory-v5/SCHEMAS.md):
+[config](assets/memory-v5/config.schema.json),
+[object](assets/memory-v5/object.schema.json),
+[relation](assets/memory-v5/relation.schema.json),
+[event](assets/memory-v5/event.schema.json), and
+[patch](assets/memory-v5/patch.schema.json) schemas. The active doctor runs
+Memory status and validation inside the adopter project instead of treating a
+launchable CLI as proof of a usable store.
 
 ## Trust boundaries
 

--- a/chaos-engine/assets/memory-v5/SCHEMAS.md
+++ b/chaos-engine/assets/memory-v5/SCHEMAS.md
@@ -1,0 +1,12 @@
+# Memory v5 schemas
+
+These schemas are the canonical project-store schemas distributed by
+`@aictx/memory@0.2.1`, which ChaosEngine pins in `dependencies.json`. They are
+installed into adopter repositories because Memory validates canonical data
+against project-local, tracked schemas.
+
+The upstream package is MIT-licensed. Keep this directory synchronized with
+the pinned package: update the dependency and all five schemas in one change,
+then prove `memory status --json` and `memory check --json` in a fresh adopter
+project.
+

--- a/chaos-engine/assets/memory-v5/config.schema.json
+++ b/chaos-engine/assets/memory-v5/config.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aictx.dev/schemas/v5/config.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "project", "memory"],
+  "properties": {
+    "version": {
+      "enum": [5]
+    },
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^project\\.[a-z0-9][a-z0-9-]*$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "memory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["defaultTokenBudget", "autoIndex"],
+      "properties": {
+        "defaultTokenBudget": {
+          "type": "integer",
+          "minimum": 501,
+          "maximum": 50000
+        },
+        "autoIndex": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/chaos-engine/assets/memory-v5/event.schema.json
+++ b/chaos-engine/assets/memory-v5/event.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aictx.dev/schemas/v5/event.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event", "actor", "timestamp"],
+  "properties": {
+    "event": {
+      "enum": [
+        "memory.created",
+        "memory.updated",
+        "memory.marked_stale",
+        "memory.superseded",
+        "memory.deleted",
+        "relation.created",
+        "relation.updated",
+        "relation.deleted",
+        "index.rebuilt"
+      ]
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "relation_id": {
+      "type": "string",
+      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "actor": {
+      "enum": ["agent", "user", "cli", "mcp", "system"]
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+    },
+    "reason": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "event": {
+            "pattern": "^memory\\."
+          }
+        }
+      },
+      "then": {
+        "required": ["id"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "event": {
+            "pattern": "^relation\\."
+          }
+        }
+      },
+      "then": {
+        "required": ["relation_id"]
+      }
+    }
+  ]
+}

--- a/chaos-engine/assets/memory-v5/object.schema.json
+++ b/chaos-engine/assets/memory-v5/object.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aictx.dev/schemas/v5/object.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "status",
+    "title",
+    "body_path",
+    "content_hash",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "type": {
+      "enum": ["project", "feature", "decision", "gotcha", "question"]
+    },
+    "status": {
+      "enum": ["active", "stale", "superseded", "open", "closed"]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "body_path": {
+      "type": "string",
+      "pattern": "^memory\\/.+\\.md$"
+    },
+    "stage": {
+      "enum": ["idea", "building", "shipped", "paused", "dead"]
+    },
+    "anchors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$"
+      },
+      "uniqueItems": true
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "id"],
+        "properties": {
+          "kind": {
+            "enum": ["memory", "relation", "file", "commit", "task", "source"]
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "enum": ["agent", "user", "cli", "mcp", "system"]
+        },
+        "task": {
+          "type": "string"
+        },
+        "commit": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "origin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "locator"],
+      "properties": {
+        "kind": {
+          "enum": ["file", "url", "user", "external"]
+        },
+        "locator": {
+          "type": "string",
+          "minLength": 1
+        },
+        "captured_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "media_type": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "superseded_by": {
+      "type": ["string", "null"],
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "content_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "created_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+    },
+    "updated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "question"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "status": {
+            "enum": ["stale", "superseded", "open", "closed"]
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "status": {
+            "enum": ["active", "stale", "superseded"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "feature"
+          }
+        }
+      },
+      "then": {},
+      "else": {
+        "not": {
+          "required": ["stage"]
+        }
+      }
+    }
+  ]
+}

--- a/chaos-engine/assets/memory-v5/patch.schema.json
+++ b/chaos-engine/assets/memory-v5/patch.schema.json
@@ -1,0 +1,353 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aictx.dev/schemas/v5/patch.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["source", "changes"],
+  "properties": {
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "enum": ["agent", "user", "cli", "mcp", "system"]
+        },
+        "task": {
+          "type": "string"
+        },
+        "commit": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "changes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/createObject"
+          },
+          {
+            "$ref": "#/$defs/updateObject"
+          },
+          {
+            "$ref": "#/$defs/markStale"
+          },
+          {
+            "$ref": "#/$defs/supersedeObject"
+          },
+          {
+            "$ref": "#/$defs/deleteObject"
+          },
+          {
+            "$ref": "#/$defs/createRelation"
+          },
+          {
+            "$ref": "#/$defs/updateRelation"
+          },
+          {
+            "$ref": "#/$defs/deleteRelation"
+          }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "objectId": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "relationId": {
+      "type": "string",
+      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "stage": {
+      "enum": ["idea", "building", "shipped", "paused", "dead"]
+    },
+    "anchors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$"
+      },
+      "uniqueItems": true
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "enum": ["agent", "user", "cli", "mcp", "system"]
+        },
+        "task": {
+          "type": "string"
+        },
+        "commit": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "origin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "locator"],
+      "properties": {
+        "kind": {
+          "enum": ["file", "url", "user", "external"]
+        },
+        "locator": {
+          "type": "string",
+          "minLength": 1
+        },
+        "captured_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "media_type": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "id"],
+        "properties": {
+          "kind": {
+            "enum": ["memory", "relation", "file", "commit", "task", "source"]
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "createObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "type", "title", "body"],
+      "properties": {
+        "op": {
+          "const": "create_object"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "type": {
+          "enum": ["project", "feature", "decision", "gotcha", "question"]
+        },
+        "status": {
+          "enum": ["active", "stale", "superseded", "open", "closed"]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "body": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stage": {
+          "$ref": "#/$defs/stage"
+        },
+        "anchors": {
+          "$ref": "#/$defs/anchors"
+        },
+        "tags": {
+          "$ref": "#/$defs/tags"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "origin": {
+          "$ref": "#/$defs/origin"
+        }
+      }
+    },
+    "updateObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id"],
+      "properties": {
+        "op": {
+          "const": "update_object"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "status": {
+          "enum": ["active", "stale", "superseded", "open", "closed"]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "body": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stage": {
+          "$ref": "#/$defs/stage"
+        },
+        "anchors": {
+          "$ref": "#/$defs/anchors"
+        },
+        "tags": {
+          "$ref": "#/$defs/tags"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "origin": {
+          "$ref": "#/$defs/origin"
+        },
+        "superseded_by": {
+          "$ref": "#/$defs/objectId"
+        }
+      }
+    },
+    "markStale": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id", "reason"],
+      "properties": {
+        "op": {
+          "const": "mark_stale"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "supersedeObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id", "superseded_by", "reason"],
+      "properties": {
+        "op": {
+          "const": "supersede_object"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "superseded_by": {
+          "$ref": "#/$defs/objectId"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "deleteObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id"],
+      "properties": {
+        "op": {
+          "const": "delete_object"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        }
+      }
+    },
+    "createRelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "from", "predicate", "to"],
+      "properties": {
+        "op": {
+          "const": "create_relation"
+        },
+        "id": {
+          "$ref": "#/$defs/relationId"
+        },
+        "from": {
+          "$ref": "#/$defs/objectId"
+        },
+        "predicate": {
+          "enum": ["affects", "depends_on", "supersedes", "related_to"]
+        },
+        "to": {
+          "$ref": "#/$defs/objectId"
+        },
+        "status": {
+          "enum": ["active", "stale", "rejected"]
+        },
+        "confidence": {
+          "enum": ["low", "medium", "high"]
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        }
+      }
+    },
+    "updateRelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id"],
+      "properties": {
+        "op": {
+          "const": "update_relation"
+        },
+        "id": {
+          "$ref": "#/$defs/relationId"
+        },
+        "status": {
+          "enum": ["active", "stale", "rejected"]
+        },
+        "confidence": {
+          "enum": ["low", "medium", "high"]
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        }
+      }
+    },
+    "deleteRelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id"],
+      "properties": {
+        "op": {
+          "const": "delete_relation"
+        },
+        "id": {
+          "$ref": "#/$defs/relationId"
+        }
+      }
+    }
+  }
+}

--- a/chaos-engine/assets/memory-v5/relation.schema.json
+++ b/chaos-engine/assets/memory-v5/relation.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aictx.dev/schemas/v5/relation.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "from", "predicate", "to", "status", "created_at", "updated_at"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "from": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "predicate": {
+      "enum": ["affects", "depends_on", "supersedes", "related_to"]
+    },
+    "to": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "status": {
+      "enum": ["active", "stale", "rejected"]
+    },
+    "confidence": {
+      "enum": ["low", "medium", "high"]
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "id"],
+        "properties": {
+          "kind": {
+            "enum": ["memory", "relation", "file", "commit", "task", "source"]
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "content_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "created_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+    },
+    "updated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+    }
+  }
+}

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -13,6 +13,7 @@ import secrets
 import shutil
 import stat
 import subprocess  # nosec B404 - probes a resolved local Java executable.
+import sys
 from pathlib import Path
 
 
@@ -23,6 +24,13 @@ REMOVING_ANCHOR_PREFIX = ".chaos-engine-hosts.removing-"
 ANCHOR_TOKEN = re.compile(r"^[0-9a-f]{64}$")
 SCHEMA_VERSION = 1
 PLUGIN_NAME = "chaos-engine"
+MEMORY_SCHEMA_FILES = (
+    "config.schema.json",
+    "object.schema.json",
+    "relation.schema.json",
+    "event.schema.json",
+    "patch.schema.json",
+)
 LEGACY_MANAGED_PATHS = (
     ".agents/skills/chaos-engine/SKILL.md",
     ".claude/skills/chaos-engine/SKILL.md",
@@ -64,19 +72,49 @@ def validate_memory_config(content: bytes) -> None:
         raise ValueError("invalid Memory configuration") from error
     project_config = config.get("project") if isinstance(config, dict) else None
     memory_options = config.get("memory") if isinstance(config, dict) else None
-    git_options = config.get("git") if isinstance(config, dict) else None
     if (
         not isinstance(config, dict)
+        or set(config) != {"version", "project", "memory"}
         or config.get("version") != 5
         or not isinstance(project_config, dict)
+        or set(project_config) != {"id", "name"}
         or not isinstance(project_config.get("id"), str)
-        or not project_config["id"].strip()
+        or re.fullmatch(r"project\.[a-z0-9][a-z0-9-]*", project_config["id"]) is None
         or not isinstance(project_config.get("name"), str)
         or not project_config["name"].strip()
         or not isinstance(memory_options, dict)
-        or not isinstance(git_options, dict)
+        or set(memory_options) != {"autoIndex", "defaultTokenBudget"}
+        or not isinstance(memory_options.get("autoIndex"), bool)
+        or not isinstance(memory_options.get("defaultTokenBudget"), int)
+        or isinstance(memory_options.get("defaultTokenBudget"), bool)
+        or not 501 <= memory_options["defaultTokenBudget"] <= 50000
     ):
         raise ValueError("invalid Memory configuration")
+
+
+def memory_schema_assets() -> Path:
+    return Path(__file__).resolve().parent / "assets/memory-v5"
+
+
+def validate_memory_storage(project: Path) -> None:
+    schema_root = project / ".memory/schema"
+    for name in MEMORY_SCHEMA_FILES:
+        try:
+            schema = json.loads((schema_root / name).read_bytes())
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError("invalid Memory storage") from error
+        if not isinstance(schema, (dict, bool)):
+            raise ValueError("invalid Memory storage")
+    for relative in (".memory/memory", ".memory/relations"):
+        if not (project / relative).is_dir():
+            raise ValueError("invalid Memory storage")
+    try:
+        events = (project / ".memory/events.jsonl").read_text(encoding="utf-8")
+        for line in events.splitlines():
+            if line.strip() and not isinstance(json.loads(line), dict):
+                raise ValueError("invalid Memory storage")
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("invalid Memory storage") from error
 
 
 def validate_mempalace_config(content: bytes) -> None:
@@ -101,9 +139,34 @@ def validate_mempalace_config(content: bytes) -> None:
 def retrieval_configs_healthy(project: Path) -> bool:
     try:
         validate_memory_config((project / ".memory/config.json").read_bytes())
+        validate_memory_storage(project)
         validate_mempalace_config((project / "mempalace.yaml").read_bytes())
     except (OSError, ValueError):
         return False
+    return True
+
+
+def retrieval_runtime_healthy(project: Path) -> bool:
+    tool = project / ".chaos-engine/tool.py"
+    for arguments in (("status", "--json"), ("check", "--json")):
+        result = subprocess.run(  # nosec B603 - fixed owned launcher and arguments.
+            [sys.executable, str(tool), "memory", *arguments],
+            cwd=project,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return False
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(payload, dict) or payload.get("ok") is not True:
+            return False
+        if arguments[0] == "check" and payload.get("data", {}).get("valid") is not True:
+            return False
     return True
 
 
@@ -746,6 +809,14 @@ def managed_paths() -> tuple[str, ...]:
         ".gemini/settings.json",
         ".codex/config.toml",
         ".memory/config.json",
+        ".memory/schema/config.schema.json",
+        ".memory/schema/object.schema.json",
+        ".memory/schema/relation.schema.json",
+        ".memory/schema/event.schema.json",
+        ".memory/schema/patch.schema.json",
+        ".memory/events.jsonl",
+        ".memory/memory/.gitkeep",
+        ".memory/relations/.gitkeep",
         "mempalace.yaml",
         ".gitignore",
     )
@@ -1081,7 +1152,10 @@ def gitignore_content(before: bytes | None) -> bytes:
         ".chaos-engine-cross-rollback/\n.chaos-engine-uninstall-*\n"
         ".chaos-engine-hosts.json\n.chaos-engine-hosts.*\n"
         ".chaos-engine-directory-claim-*\ngraphify-out/\n"
-        ".memory/*\n!.memory/\n!.memory/config.json\n"
+        ".memory/*\n!.memory/\n!.memory/config.json\n!.memory/events.jsonl\n"
+        "!.memory/schema/\n!.memory/schema/*.schema.json\n"
+        "!.memory/memory/\n.memory/memory/*\n!.memory/memory/.gitkeep\n"
+        "!.memory/relations/\n.memory/relations/*\n!.memory/relations/.gitkeep\n"
         "!.chaos-engine/\n!.chaos-engine/**\n"
         "!.agents/\n!.agents/plugins/\n!.agents/plugins/marketplace.json\n"
         "!.agents/skills/\n!.agents/skills/README.md\n"
@@ -1327,9 +1401,7 @@ def desired_content(
             "memory": {
                 "autoIndex": True,
                 "defaultTokenBudget": 6000,
-                "saveContextPacks": False,
             },
-            "git": {"trackContextPacks": False},
         }
         after[".memory/config.json"] = (
             json.dumps(memory_config, indent=2, sort_keys=True) + "\n"
@@ -1337,6 +1409,36 @@ def desired_content(
     else:
         validate_memory_config(memory_before)
         after[".memory/config.json"] = memory_before
+    schema_assets = memory_schema_assets()
+    for name in MEMORY_SCHEMA_FILES:
+        relative = f".memory/schema/{name}"
+        existing = before[relative]
+        if existing is None:
+            after[relative] = (schema_assets / name).read_bytes()
+        else:
+            try:
+                schema = json.loads(existing)
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                raise ValueError("invalid Memory storage") from error
+            if not isinstance(schema, (dict, bool)):
+                raise ValueError("invalid Memory storage")
+            after[relative] = existing
+    events = before[".memory/events.jsonl"]
+    if events is None:
+        after[".memory/events.jsonl"] = b""
+    else:
+        try:
+            for line in events.decode("utf-8").splitlines():
+                if line.strip() and not isinstance(json.loads(line), dict):
+                    raise ValueError("invalid Memory storage")
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError("invalid Memory storage") from error
+        after[".memory/events.jsonl"] = events
+    for relative in (".memory/memory/.gitkeep", ".memory/relations/.gitkeep"):
+        existing = before[relative]
+        if existing not in (None, b""):
+            raise ValueError("invalid Memory storage")
+        after[relative] = b""
     mempalace_before = before["mempalace.yaml"]
     if mempalace_before is None:
         safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "-", project_name).strip("-") or "project"

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -1110,10 +1110,17 @@ def doctor_with_dependencies(
 ) -> dict[str, object]:
     """Verify installed files and actively execute every dependency entrypoint probe."""
     result = status_with_dependencies(project, active_probes=True)
-    if not verify_clients:
-        return result
     target = project.resolve() / INSTALL_DIRECTORY
     host_controller = load_installed_controller(target, "hosts")
+    if not host_controller.retrieval_runtime_healthy(project.resolve()):
+        result["status"] = "recovery-required"
+        components = result.get("components")
+        if isinstance(components, dict) and isinstance(
+            components.get("retrieval-config"), dict
+        ):
+            components["retrieval-config"]["status"] = "recovery-required"
+    if not verify_clients:
+        return result
     clients = host_controller.detected_plugin_status(project.resolve())
     result["clients"] = clients
     if any(item.get("status") != "healthy" for item in clients.values()):

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -120,7 +120,7 @@ BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 # from the boundary was invisible. Equality makes shrinking the boundary a
 # deliberate two-line edit that shows up in review, which is the only place the
 # question "why is the harness smaller today" gets asked.
-EXPECTED_ELEMENT_COUNT = 208
+EXPECTED_ELEMENT_COUNT = 214
 
 ATX_HEADING = re.compile(r"(?m)^#{1,6}\s+(.+?)\s*$")
 

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -289,6 +289,14 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 ".codex/hooks.json",
                 ".claude/settings.json",
                 ".memory/config.json",
+                ".memory/schema/config.schema.json",
+                ".memory/schema/object.schema.json",
+                ".memory/schema/relation.schema.json",
+                ".memory/schema/event.schema.json",
+                ".memory/schema/patch.schema.json",
+                ".memory/events.jsonl",
+                ".memory/memory/.gitkeep",
+                ".memory/relations/.gitkeep",
                 "mempalace.yaml",
                 ".gitignore",
             }
@@ -313,7 +321,9 @@ class ChaosEngineHostsTest(unittest.TestCase):
             )
             memory_config = json.loads(project.joinpath(".memory/config.json").read_text())
             self.assertEqual(5, memory_config["version"])
+            self.assertEqual({"version", "project", "memory"}, set(memory_config))
             self.assertEqual("consumer", memory_config["project"]["name"])
+            self.assertTrue(module.retrieval_configs_healthy(project))
             self.assertIn("wing: consumer", project.joinpath("mempalace.yaml").read_text())
             ignores = project.joinpath(".gitignore").read_text()
             self.assertIn(".chaos-engine-runtime/", ignores)
@@ -326,6 +336,8 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 ignores.index("!.codex/**"),
             )
             self.assertIn("!.memory/config.json", ignores)
+            self.assertIn("!.memory/schema/*.schema.json", ignores)
+            self.assertIn("!.memory/events.jsonl", ignores)
             self.assertIn("!.claude/**", ignores)
             self.assertIn("!.codex/**", ignores)
             self.assertIn(".claude/settings.local.json", ignores)
@@ -550,6 +562,36 @@ class ChaosEngineHostsTest(unittest.TestCase):
             memory = json.loads(project.joinpath(".memory/config.json").read_text())
             self.assertEqual("actual-project", memory["project"]["name"])
             self.assertIn("wing: actual-project", project.joinpath("mempalace.yaml").read_text())
+
+    def test_retrieval_runtime_executes_memory_status_and_check(self):
+        module = load(HOSTS, "chaos_engine_retrieval_runtime")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            project.joinpath(".chaos-engine").mkdir()
+            project.joinpath(".chaos-engine/tool.py").write_text("# owned\n")
+            responses = [
+                mock.Mock(returncode=0, stdout=json.dumps({"ok": True})),
+                mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps({"ok": True, "data": {"valid": True}}),
+                ),
+            ]
+            with mock.patch.object(module.subprocess, "run", side_effect=responses) as run:
+                self.assertTrue(module.retrieval_runtime_healthy(project))
+
+            self.assertEqual(2, run.call_count)
+            self.assertEqual(project, run.call_args_list[0].kwargs["cwd"])
+
+            invalid = mock.Mock(
+                returncode=0,
+                stdout=json.dumps({"ok": True, "data": {"valid": False}}),
+            )
+            with mock.patch.object(
+                module.subprocess,
+                "run",
+                side_effect=[responses[0], invalid],
+            ):
+                self.assertFalse(module.retrieval_runtime_healthy(project))
 
     def test_launcher_rendering_is_explicit_for_windows_and_posix(self):
         module = load(HOSTS, "chaos_engine_hosts")

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -121,6 +121,34 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             self.assertEqual("recovery-required", result["status"])
             self.assertEqual("absent", result["components"]["retrieval-config"]["status"])
 
+    def test_doctor_rejects_a_memory_runtime_that_cannot_use_its_store(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            MODULE.install_with_dependencies(
+                project,
+                SOURCE,
+                TEST_COMMIT,
+                provisioner=lambda *_args, **_kwargs: None,
+            )
+            controller = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            with mock.patch.object(
+                controller,
+                "retrieval_runtime_healthy",
+                return_value=False,
+            ), mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                return_value=controller,
+            ):
+                result = MODULE.doctor_with_dependencies(project, verify_clients=False)
+
+            self.assertEqual("recovery-required", result["status"])
+            self.assertEqual(
+                "recovery-required",
+                result["components"]["retrieval-config"]["status"],
+            )
+
     def test_default_distribution_installs_only_neutral_portable_payload(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "consumer"


### PR DESCRIPTION
## Outcome
- install the pinned Memory v5 schemas, canonical events log, and trackable canonical directories under the authenticated host receipt
- render config that matches the pinned package schema exactly
- make doctor execute Memory status and check inside the adopter project
- document subtree bootstrap and schema provenance accurately

## Runtime evidence
A clean disposable adopter generated by the host controller passed both:
- memory status --json
- memory check --json

## Verification
- 186 ChaosEngine tests passed
- py -3 scripts/ci/validate_agent_setup.py --skip-external
- portable owned-content scan found no forbidden product/profile tokens

Follow-up to #4964
Part of #4961