### PR TITLE
fix(agent): isolate runtime bytecode caches

### DIFF
--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -187,6 +187,7 @@ def tool_environment(runtime: Path) -> dict[str, str]:
         "UV_TOOL_DIR": str(runtime / "uv-tools"),
         "UV_TOOL_BIN_DIR": str(runtime / "bin"),
         "NPM_CONFIG_PREFIX": str(runtime / "npm"),
+        "PYTHONDONTWRITEBYTECODE": "1",
     }
 
 
@@ -278,7 +279,11 @@ def execute_plan(
         "checkedAt": (now or datetime.now(timezone.utc)).isoformat(),
         "specificationSha256": specification_digest(specification),
         "environment": {
-            key: Path(value).relative_to(runtime).as_posix()
+            key: (
+                value
+                if key == "PYTHONDONTWRITEBYTECODE"
+                else Path(value).relative_to(runtime).as_posix()
+            )
             for key, value in environment.items()
         },
         "installed": completed,

--- a/chaos-engine/tool.py
+++ b/chaos-engine/tool.py
@@ -41,7 +41,12 @@ def main() -> int:
         return 2
     try:
         command = resolve_command(Path(__file__).resolve().parent, sys.argv[1])
-        return subprocess.call([str(command), *sys.argv[2:]])  # nosec B603
+        environment = os.environ.copy()
+        environment["PYTHONDONTWRITEBYTECODE"] = "1"
+        return subprocess.call(  # nosec B603
+            [str(command), *sys.argv[2:]],
+            env=environment,
+        )
     except (OSError, ValueError) as error:
         print(str(error), file=sys.stderr)
         return 1

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -69,6 +69,7 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
         self.assertEqual(str(runtime / "uv-tools"), environment["UV_TOOL_DIR"])
         self.assertEqual(str(runtime / "bin"), environment["UV_TOOL_BIN_DIR"])
         self.assertEqual(str(runtime / "npm"), environment["NPM_CONFIG_PREFIX"])
+        self.assertEqual("1", environment["PYTHONDONTWRITEBYTECODE"])
         for commands in plan.values():
             for command in commands:
                 self.assertNotIn("--global", command)

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -1290,6 +1290,23 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
             self.assertEqual(second / ".chaos-engine-runtime/bin" / command.name, resolved)
 
+    def test_tool_launcher_suppresses_runtime_bytecode_caches(self):
+        module = load(TOOL, "chaos_engine_tool_environment")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            core = project / ".chaos-engine"
+            runtime = project / ".chaos-engine-runtime/bin"
+            core.mkdir()
+            runtime.mkdir(parents=True)
+            command = runtime / ("mempalace.exe" if os.name == "nt" else "mempalace")
+            command.write_text("tool\n", encoding="utf-8")
+            with mock.patch.object(module.sys, "argv", ["tool.py", "mempalace", "status"]):
+                with mock.patch.object(module, "resolve_command", return_value=command):
+                    with mock.patch.object(module.subprocess, "call", return_value=0) as call:
+                        self.assertEqual(0, module.main())
+
+            self.assertEqual("1", call.call_args.kwargs["env"]["PYTHONDONTWRITEBYTECODE"])
+
     def test_host_tests_are_reached_by_pull_request_gate(self):
         budget = json.loads(
             (ROOT / "scripts/ci/agent_guidance_budget.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Outcome
- prevent supported Python tool and MCP launches from writing bytecode into the receipt-owned runtime
- record the non-writing environment flag in the dependency receipt
- cover both provisioning probes and the relocatable project launcher

## Reproduction
A real MemPalace status call previously created an unowned module cache and made uninstall fail with dependency runtime ownership drift.

## Verification
- py -3 -m unittest tests.scripts.test_chaos_engine_dependencies tests.scripts.test_chaos_engine_hosts
- py -3 scripts/ci/validate_agent_setup.py --skip-external

Part of #4961