### PR TITLE
refactor(ai): simplify managed-local lifecycle internals

### DIFF
--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcess.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcess.java
@@ -137,6 +137,12 @@ final class ManagedLocalAiProcess {
     }
 
     private static Session launchLocked(LaunchRequest request, LaunchHooks hooks, long deadline) throws Exception {
+        validateLaunchOwnership();
+        LaunchPlan plan = prepareLaunch(request);
+        return retryLaunch(plan, hooks, deadline);
+    }
+
+    private static void validateLaunchOwnership() {
         Session failedLaunch = FAILED_LAUNCH.get();
         if (failedLaunch != null && failedLaunch.hasSurvivors()) {
             throw new IllegalStateException("A prior managed local AI launch still owns a surviving process tree.");
@@ -147,14 +153,20 @@ final class ManagedLocalAiProcess {
             throw new IllegalStateException("A managed local AI process tree is already active.");
         }
         ACTIVE_LAUNCH.compareAndSet(activeLaunch, null);
+    }
+
+    private static LaunchPlan prepareLaunch(LaunchRequest request) throws Exception {
         RuntimeFiles files = request.files();
-        RuntimeSpec runtime = request.runtime();
         Path verifiedExecutable = ManagedLocalAiCache.verifyOwnedFile(files.cache(), files.executable());
         Path verifiedModel = ManagedLocalAiCache.verifyOwnedFile(files.cache(), files.model());
         requireContainedLog(files.cache(), files.log());
         Files.createDirectories(files.log().toAbsolutePath().normalize().getParent());
         requireContainedLog(files.cache(), files.log());
         reserveLog(files.log());
+        return new LaunchPlan(request, verifiedExecutable, verifiedModel);
+    }
+
+    private static Session retryLaunch(LaunchPlan plan, LaunchHooks hooks, long deadline) throws Exception {
         Exception lastFailure = null;
         for (int attempt = 0; attempt < MAX_LAUNCH_ATTEMPTS; attempt++) {
             try {
@@ -163,89 +175,128 @@ final class ManagedLocalAiProcess {
                 lastFailure = expired;
                 break;
             }
-            String key = secret();
-            Path keyFile = createKeyFile(files.cache(), key);
-            Process process = null;
-            Session candidate = null;
-            LaunchReservation reservation = new LaunchReservation(Thread.currentThread());
             try {
-                remaining(deadline);
-                if (!PENDING_LAUNCH.compareAndSet(null, reservation)) {
-                    throw new IllegalStateException("Managed local AI process start is already pending.");
+                return launchAttempt(plan, hooks, deadline);
+            } catch (AttemptFailure failed) {
+                lastFailure = failed.failure();
+                if (failed.resourceFailure() != null) {
+                    throw failed.resourceFailure();
                 }
-                if (request.cancelled().getAsBoolean() || reservation.cancelled()) {
-                    throw new IllegalStateException("Managed local AI launch was cancelled before process start.");
-                }
-                process = hooks.starter().start(
-                        command(verifiedExecutable, verifiedModel, 0, runtime.alias(), keyFile, runtime.threads()),
-                        runtimeEnvironment(System.getenv()), files.log());
-                synchronized (reservation) {
-                    reservation.bind(process);
-                    candidate = new Session(process, 0, runtime.alias(), key, request.timeout(), verifiedExecutable,
-                            verifiedModel, runtime.threads(), hooks.rssSampler());
-                    if (!ACTIVE_LAUNCH.compareAndSet(null, candidate)) {
-                        throw new IllegalStateException("Managed local AI process ownership is already registered.");
-                    }
-                }
-                candidate.awaitFirstResourceSample(remaining(deadline));
-                if (request.cancelled().getAsBoolean() || reservation.cancelled()) {
-                    throw new IllegalStateException("Managed local AI launch was cancelled during process start.");
-                }
-                reservation.resolve();
-                PENDING_LAUNCH.compareAndSet(reservation, null);
-                StartupObservation startup = awaitStartup(process, remaining(deadline));
-                candidate.bindLogCapture(captureLog(
-                        files.cache(), process.getInputStream(), files.log(), startup.captured(), key));
-                if (startup.port() == null) {
-                    throw new IOException("Managed local AI did not report its child-owned loopback endpoint.");
-                }
-                int port = startup.port();
-                candidate.bindPort(port);
-                hooks.identity().await(process, port, key, runtime.alias(), remaining(deadline));
-                candidate.requireResourceWithinLimit();
-                if (!process.isAlive()) {
-                    throw new IllegalStateException("Managed local AI process exited during identity verification.");
-                }
-                deleteKeyFile(keyFile, null);
-                return candidate;
-            } catch (InterruptedException cancelled) {
-                if (candidate != null) {
-                    candidate.close(cleanupTimeout(deadline), cancelled);
-                    retainFailedLaunch(candidate);
-                } else if (process != null) {
-                    terminate(process, cleanupTimeout(deadline), cancelled);
-                }
-                deleteKeyFile(keyFile, cancelled);
-                Thread.currentThread().interrupt();
-                throw cancelled;
-            } catch (Exception failure) {
-                lastFailure = failure;
-                boolean survivors = false;
-                IllegalStateException resourceFailure = null;
-                if (candidate != null) {
-                    candidate.close(cleanupTimeout(deadline), failure);
-                    resourceFailure = candidate.resourceFailure();
-                    survivors = candidate.hasSurvivors();
-                    if (survivors) {
-                        retainFailedLaunch(candidate);
-                    }
-                } else if (process != null) {
-                    terminate(process, cleanupTimeout(deadline), failure);
-                }
-                deleteKeyFile(keyFile, failure);
-                if (resourceFailure != null) {
-                    throw resourceFailure;
-                }
-                if (survivors) {
+                if (failed.survivors()) {
                     break;
                 }
-            } finally {
-                reservation.resolve();
-                PENDING_LAUNCH.compareAndSet(reservation, null);
             }
         }
         throw new IllegalStateException("Managed local AI process could not establish its authenticated identity.",
                 lastFailure);
+    }
+
+    private static Session launchAttempt(LaunchPlan plan, LaunchHooks hooks, long deadline) throws Exception {
+        AttemptState state = new AttemptState(plan.request().files().cache());
+        try {
+            publishPendingLaunch(plan.request(), state, deadline);
+            startCandidate(plan, hooks, state);
+            awaitCandidate(plan, hooks, state, deadline);
+            deleteKeyFile(state.keyFile, null);
+            return state.candidate;
+        } catch (InterruptedException cancelled) {
+            cleanupInterruptedAttempt(state, deadline, cancelled);
+            throw cancelled;
+        } catch (Exception failure) {
+            throw cleanupFailedAttempt(state, deadline, failure);
+        } finally {
+            state.reservation.resolve();
+            PENDING_LAUNCH.compareAndSet(state.reservation, null);
+        }
+    }
+
+    private static void publishPendingLaunch(LaunchRequest request, AttemptState state, long deadline)
+            throws Exception {
+        remaining(deadline);
+        if (!PENDING_LAUNCH.compareAndSet(null, state.reservation)) {
+            throw new IllegalStateException("Managed local AI process start is already pending.");
+        }
+        requireNotCancelled(request, state.reservation, "before process start");
+    }
+
+    private static void startCandidate(LaunchPlan plan, LaunchHooks hooks, AttemptState state) throws Exception {
+        LaunchRequest request = plan.request();
+        RuntimeSpec runtime = request.runtime();
+        RuntimeFiles files = request.files();
+        state.process = hooks.starter().start(
+                command(plan.executable(), plan.model(), 0, runtime.alias(), state.keyFile, runtime.threads()),
+                runtimeEnvironment(System.getenv()), files.log());
+        synchronized (state.reservation) {
+            state.reservation.bind(state.process);
+            state.candidate = new Session(state.process, 0, runtime.alias(), state.key, request.timeout(),
+                    plan.executable(), plan.model(), runtime.threads(), hooks.rssSampler());
+            if (!ACTIVE_LAUNCH.compareAndSet(null, state.candidate)) {
+                throw new IllegalStateException("Managed local AI process ownership is already registered.");
+            }
+        }
+    }
+
+    private static void awaitCandidate(LaunchPlan plan, LaunchHooks hooks, AttemptState state, long deadline)
+            throws Exception {
+        LaunchRequest request = plan.request();
+        state.candidate.awaitFirstResourceSample(remaining(deadline));
+        requireNotCancelled(request, state.reservation, "during process start");
+        state.reservation.resolve();
+        PENDING_LAUNCH.compareAndSet(state.reservation, null);
+        StartupObservation startup = awaitStartup(state.process, remaining(deadline));
+        state.candidate.bindLogCapture(captureLog(request.files().cache(), state.process.getInputStream(),
+                request.files().log(), startup.captured(), state.key));
+        int port = requireStartupPort(startup);
+        state.candidate.bindPort(port);
+        hooks.identity().await(state.process, port, state.key, request.runtime().alias(), remaining(deadline));
+        state.candidate.requireResourceWithinLimit();
+        if (!state.process.isAlive()) {
+            throw new IllegalStateException("Managed local AI process exited during identity verification.");
+        }
+    }
+
+    private static void requireNotCancelled(LaunchRequest request, LaunchReservation reservation, String phase) {
+        if (request.cancelled().getAsBoolean() || reservation.cancelled()) {
+            throw new IllegalStateException("Managed local AI launch was cancelled " + phase + '.');
+        }
+    }
+
+    private static int requireStartupPort(StartupObservation startup) throws IOException {
+        if (startup.port() == null) {
+            throw new IOException("Managed local AI did not report its child-owned loopback endpoint.");
+        }
+        return startup.port();
+    }
+
+    private static void cleanupInterruptedAttempt(AttemptState state, long deadline,
+                                                  InterruptedException cancelled) throws IOException {
+        cleanupAttemptProcess(state, deadline, cancelled, true);
+        deleteKeyFile(state.keyFile, cancelled);
+        Thread.currentThread().interrupt();
+    }
+
+    private static AttemptFailure cleanupFailedAttempt(AttemptState state, long deadline, Exception failure)
+            throws IOException {
+        cleanupAttemptProcess(state, deadline, failure, false);
+        deleteKeyFile(state.keyFile, failure);
+        IllegalStateException resourceFailure = state.candidate == null ? null : state.candidate.resourceFailure();
+        boolean survivors = state.candidate != null && state.candidate.hasSurvivors();
+        if (survivors) {
+            retainFailedLaunch(state.candidate);
+        }
+        return new AttemptFailure(failure, resourceFailure, survivors);
+    }
+
+    private static void cleanupAttemptProcess(AttemptState state, long deadline, Throwable primary,
+                                              boolean retainInterruptedCandidate) {
+        if (state.candidate != null) {
+            state.candidate.close(cleanupTimeout(deadline), primary);
+            if (retainInterruptedCandidate) {
+                retainFailedLaunch(state.candidate);
+            }
+        } else if (state.process != null) {
+            terminate(state.process, cleanupTimeout(deadline), primary);
+        }
     }
 
     private static Duration cleanupTimeout(long deadline) {
@@ -1314,6 +1365,46 @@ final class ManagedLocalAiProcess {
         LaunchHooks {
             Objects.requireNonNull(starter, "starter");
             Objects.requireNonNull(identity, "identity");
+        }
+    }
+
+    private record LaunchPlan(LaunchRequest request, Path executable, Path model) {
+    }
+
+    private static final class AttemptState {
+        private final String key = secret();
+        private final Path keyFile;
+        private final LaunchReservation reservation = new LaunchReservation(Thread.currentThread());
+        private Process process;
+        private Session candidate;
+
+        private AttemptState(Path cache) throws IOException {
+            keyFile = createKeyFile(cache, key);
+        }
+    }
+
+    private static final class AttemptFailure extends Exception {
+        private final Exception failure;
+        private final IllegalStateException resourceFailure;
+        private final boolean survivors;
+
+        private AttemptFailure(Exception failure, IllegalStateException resourceFailure, boolean survivors) {
+            super(failure);
+            this.failure = failure;
+            this.resourceFailure = resourceFailure;
+            this.survivors = survivors;
+        }
+
+        private Exception failure() {
+            return failure;
+        }
+
+        private IllegalStateException resourceFailure() {
+            return resourceFailure;
+        }
+
+        private boolean survivors() {
+            return survivors;
         }
     }
 

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcess.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcess.java
@@ -94,51 +94,38 @@ final class ManagedLocalAiProcess {
                 "--api-key-file", apiKeyFile.toAbsolutePath().toString(), "--threads", Integer.toString(threads));
     }
 
-    static Session launch(Path cache, Path executable, Path model, Path log, String alias, int threads,
-                          Duration timeout, ProcessStarter starter,
-                          IdentityProbe identity) throws Exception {
-        return launch(cache, executable, model, log, alias, threads, timeout, () -> false, null, starter, identity);
+    static Session launch(LaunchRequest request, ProcessStarter starter, IdentityProbe identity) throws Exception {
+        return launch(request, new LaunchHooks(null, starter, identity));
     }
 
-    static Session launch(Path cache, Path executable, Path model, Path log, String alias, int threads,
-                          Duration timeout, java.util.function.BooleanSupplier cancelled,
-                          ProcessStarter starter, IdentityProbe identity) throws Exception {
-        return launch(cache, executable, model, log, alias, threads, timeout, cancelled, null, starter, identity);
+    static Session launch(LaunchRequest request, LaunchHooks hooks) throws Exception {
+        return launchWithOwnership(request, hooks);
     }
 
-    static Session launchManaged(Path cache, Path executable, Path model, Path log, String alias, int threads,
-                                 Duration timeout, java.util.function.BooleanSupplier cancelled,
+    static Session launchManaged(LaunchRequest request, ProcessStarter starter, IdentityProbe identity)
+            throws Exception {
+        return launch(request, new LaunchHooks(ManagedLocalAiProcessTreeRss::sample, starter, identity));
+    }
+
+    static Session launchManaged(LaunchRequest request, ProcessTreeRssSampler rssSampler,
                                  ProcessStarter starter, IdentityProbe identity) throws Exception {
-        return launch(cache, executable, model, log, alias, threads, timeout, cancelled,
-                ManagedLocalAiProcessTreeRss::sample, starter, identity);
+        return launch(request, new LaunchHooks(Objects.requireNonNull(rssSampler, "rssSampler"), starter, identity));
     }
 
-    static Session launchManaged(Path cache, Path executable, Path model, Path log, String alias, int threads,
-                                 Duration timeout, java.util.function.BooleanSupplier cancelled,
-                                 ProcessTreeRssSampler rssSampler,
-                                 ProcessStarter starter, IdentityProbe identity) throws Exception {
-        return launch(cache, executable, model, log, alias, threads, timeout, cancelled,
-                Objects.requireNonNull(rssSampler, "rssSampler"), starter, identity);
-    }
-
-    private static Session launch(Path cache, Path executable, Path model, Path log, String alias, int threads,
-                          Duration timeout, java.util.function.BooleanSupplier cancelled,
-                          ProcessTreeRssSampler rssSampler,
-                          ProcessStarter starter, IdentityProbe identity) throws Exception {
-        Objects.requireNonNull(timeout, "timeout");
-        Objects.requireNonNull(cancelled, "cancelled");
-        if (timeout.isNegative() || timeout.isZero()) {
+    private static Session launchWithOwnership(LaunchRequest request, LaunchHooks hooks) throws Exception {
+        Objects.requireNonNull(request, "request");
+        Objects.requireNonNull(hooks, "hooks");
+        if (request.timeout().isNegative() || request.timeout().isZero()) {
             throw new IllegalArgumentException("Launch timeout must be positive.");
         }
-        long deadline = System.nanoTime() + timeout.toNanos();
+        long deadline = System.nanoTime() + request.timeout().toNanos();
         boolean locked = false;
         try {
             locked = LAUNCH_LOCK.tryLock(remaining(deadline).toNanos(), TimeUnit.NANOSECONDS);
             if (!locked) {
                 throw new DeadlineExceededException();
             }
-            return launchLocked(cache, executable, model, log, alias, threads, timeout, deadline, cancelled,
-                    rssSampler, starter, identity);
+            return launchLocked(request, hooks, deadline);
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();
             throw interrupted;
@@ -149,11 +136,7 @@ final class ManagedLocalAiProcess {
         }
     }
 
-    private static Session launchLocked(Path cache, Path executable, Path model, Path log, String alias, int threads,
-                                        Duration timeout, long deadline, java.util.function.BooleanSupplier cancellation,
-                                        ProcessTreeRssSampler rssSampler,
-                                        ProcessStarter starter,
-                                        IdentityProbe identity) throws Exception {
+    private static Session launchLocked(LaunchRequest request, LaunchHooks hooks, long deadline) throws Exception {
         Session failedLaunch = FAILED_LAUNCH.get();
         if (failedLaunch != null && failedLaunch.hasSurvivors()) {
             throw new IllegalStateException("A prior managed local AI launch still owns a surviving process tree.");
@@ -164,12 +147,14 @@ final class ManagedLocalAiProcess {
             throw new IllegalStateException("A managed local AI process tree is already active.");
         }
         ACTIVE_LAUNCH.compareAndSet(activeLaunch, null);
-        Path verifiedExecutable = ManagedLocalAiCache.verifyOwnedFile(cache, executable);
-        Path verifiedModel = ManagedLocalAiCache.verifyOwnedFile(cache, model);
-        requireContainedLog(cache, log);
-        Files.createDirectories(log.toAbsolutePath().normalize().getParent());
-        requireContainedLog(cache, log);
-        reserveLog(log);
+        RuntimeFiles files = request.files();
+        RuntimeSpec runtime = request.runtime();
+        Path verifiedExecutable = ManagedLocalAiCache.verifyOwnedFile(files.cache(), files.executable());
+        Path verifiedModel = ManagedLocalAiCache.verifyOwnedFile(files.cache(), files.model());
+        requireContainedLog(files.cache(), files.log());
+        Files.createDirectories(files.log().toAbsolutePath().normalize().getParent());
+        requireContainedLog(files.cache(), files.log());
+        reserveLog(files.log());
         Exception lastFailure = null;
         for (int attempt = 0; attempt < MAX_LAUNCH_ATTEMPTS; attempt++) {
             try {
@@ -179,7 +164,7 @@ final class ManagedLocalAiProcess {
                 break;
             }
             String key = secret();
-            Path keyFile = createKeyFile(cache, key);
+            Path keyFile = createKeyFile(files.cache(), key);
             Process process = null;
             Session candidate = null;
             LaunchReservation reservation = new LaunchReservation(Thread.currentThread());
@@ -188,33 +173,35 @@ final class ManagedLocalAiProcess {
                 if (!PENDING_LAUNCH.compareAndSet(null, reservation)) {
                     throw new IllegalStateException("Managed local AI process start is already pending.");
                 }
-                if (cancellation.getAsBoolean() || reservation.cancelled()) {
+                if (request.cancelled().getAsBoolean() || reservation.cancelled()) {
                     throw new IllegalStateException("Managed local AI launch was cancelled before process start.");
                 }
-                process = starter.start(command(verifiedExecutable, verifiedModel, 0, alias, keyFile, threads),
-                        runtimeEnvironment(System.getenv()), log);
+                process = hooks.starter().start(
+                        command(verifiedExecutable, verifiedModel, 0, runtime.alias(), keyFile, runtime.threads()),
+                        runtimeEnvironment(System.getenv()), files.log());
                 synchronized (reservation) {
                     reservation.bind(process);
-                    candidate = new Session(process, 0, alias, key, timeout, verifiedExecutable, verifiedModel,
-                            threads, rssSampler);
+                    candidate = new Session(process, 0, runtime.alias(), key, request.timeout(), verifiedExecutable,
+                            verifiedModel, runtime.threads(), hooks.rssSampler());
                     if (!ACTIVE_LAUNCH.compareAndSet(null, candidate)) {
                         throw new IllegalStateException("Managed local AI process ownership is already registered.");
                     }
                 }
                 candidate.awaitFirstResourceSample(remaining(deadline));
-                if (cancellation.getAsBoolean() || reservation.cancelled()) {
+                if (request.cancelled().getAsBoolean() || reservation.cancelled()) {
                     throw new IllegalStateException("Managed local AI launch was cancelled during process start.");
                 }
                 reservation.resolve();
                 PENDING_LAUNCH.compareAndSet(reservation, null);
                 StartupObservation startup = awaitStartup(process, remaining(deadline));
-                candidate.bindLogCapture(captureLog(cache, process.getInputStream(), log, startup.captured(), key));
+                candidate.bindLogCapture(captureLog(
+                        files.cache(), process.getInputStream(), files.log(), startup.captured(), key));
                 if (startup.port() == null) {
                     throw new IOException("Managed local AI did not report its child-owned loopback endpoint.");
                 }
                 int port = startup.port();
                 candidate.bindPort(port);
-                identity.await(process, port, key, alias, remaining(deadline));
+                hooks.identity().await(process, port, key, runtime.alias(), remaining(deadline));
                 candidate.requireResourceWithinLimit();
                 if (!process.isAlive()) {
                     throw new IllegalStateException("Managed local AI process exited during identity verification.");
@@ -368,70 +355,95 @@ final class ManagedLocalAiProcess {
         }
         revokeSupervisorOwnership(process, primary);
         if (SUPERVISED_PROCESSES.contains(process)) {
-            try {
-                boolean exited = process.waitFor(timeout.toNanos(), TimeUnit.NANOSECONDS);
-                if (exited || !process.isAlive()) {
-                    SUPERVISED_PROCESSES.remove(process);
-                    return false;
-                }
-            } catch (InterruptedException interrupted) {
-                Thread.currentThread().interrupt();
-                if (primary != null) {
-                    primary.addSuppressed(interrupted);
-                }
-            }
-            return true;
+            return awaitSupervisorExit(process, timeout, primary);
         }
+        return terminateDirectly(process, timeout, primary, retainedDescendants);
+    }
+
+    private static boolean awaitSupervisorExit(Process process, Duration timeout, Throwable primary) {
+        try {
+            boolean exited = process.waitFor(timeout.toNanos(), TimeUnit.NANOSECONDS);
+            if (exited || !process.isAlive()) {
+                SUPERVISED_PROCESSES.remove(process);
+                return false;
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            suppress(primary, interrupted);
+        }
+        return true;
+    }
+
+    private static boolean terminateDirectly(Process process, Duration timeout, Throwable primary,
+                                             Set<ProcessHandle> retainedDescendants) {
+        Set<ProcessHandle> descendants = discoverDescendants(process, retainedDescendants, primary);
+        long deadline = System.nanoTime() + timeout.toNanos();
+        RuntimeException survivorFailure = null;
+        try {
+            survivorFailure = stopProcessTree(process, descendants, deadline);
+        } catch (InterruptedException interrupted) {
+            forceAfterInterruption(process, descendants, interrupted);
+            Thread.currentThread().interrupt();
+            suppress(primary, interrupted);
+        } catch (Exception cleanup) {
+            suppress(primary, cleanup);
+        }
+        boolean survivors = retainSurvivors(process, descendants, retainedDescendants);
+        reportSurvivorFailure(primary, survivorFailure);
+        return survivors;
+    }
+
+    private static Set<ProcessHandle> discoverDescendants(Process process, Set<ProcessHandle> retainedDescendants,
+                                                          Throwable primary) {
         Set<ProcessHandle> discovered = new java.util.LinkedHashSet<>(retainedDescendants);
         try {
             discovered.addAll(process.toHandle().descendants().toList());
             discovered.forEach(ProcessHandle::destroy);
         } catch (Exception cleanup) {
-            if (primary != null) {
-                primary.addSuppressed(cleanup);
-            }
+            suppress(primary, cleanup);
         }
-        Set<ProcessHandle> descendants = discovered;
-        RuntimeException survivorFailure = null;
-        long deadline = System.nanoTime() + timeout.toNanos();
+        return discovered;
+    }
+
+    private static RuntimeException stopProcessTree(Process process, Set<ProcessHandle> descendants, long deadline)
+            throws InterruptedException {
+        process.destroy();
+        boolean parentExited = process.waitFor(Math.max(0, deadline - System.nanoTime()), TimeUnit.NANOSECONDS);
+        descendants.stream().filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly);
+        while (descendants.stream().anyMatch(ProcessHandle::isAlive) && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        RuntimeException failure = descendants.stream().anyMatch(ProcessHandle::isAlive)
+                ? new IllegalStateException("Managed local AI descendant did not terminate.") : null;
+        if (parentExited) {
+            return failure;
+        }
+        process.destroyForcibly();
+        boolean forcedExit = process.waitFor(Math.max(0, deadline - System.nanoTime()), TimeUnit.NANOSECONDS);
+        return forcedExit && !process.isAlive()
+                ? failure : new IllegalStateException("Managed local AI process did not terminate.");
+    }
+
+    private static void forceAfterInterruption(Process process, Set<ProcessHandle> descendants,
+                                               InterruptedException interrupted) {
         try {
-            process.destroy();
-            boolean parentExited = process.waitFor(Math.max(0, deadline - System.nanoTime()), TimeUnit.NANOSECONDS);
             descendants.stream().filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly);
-            while (descendants.stream().anyMatch(ProcessHandle::isAlive) && System.nanoTime() < deadline) {
-                Thread.sleep(10);
-            }
-            if (descendants.stream().anyMatch(ProcessHandle::isAlive)) {
-                survivorFailure = new IllegalStateException("Managed local AI descendant did not terminate.");
-            }
-            if (!parentExited) {
+            if (process.isAlive()) {
                 process.destroyForcibly();
-                boolean forcedExit = process.waitFor(Math.max(0, deadline - System.nanoTime()), TimeUnit.NANOSECONDS);
-                if (!forcedExit || process.isAlive()) {
-                    survivorFailure = new IllegalStateException("Managed local AI process did not terminate.");
-                }
-            }
-        } catch (InterruptedException interrupted) {
-            try {
-                descendants.stream().filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly);
-                if (process.isAlive()) {
-                    process.destroyForcibly();
-                }
-            } catch (Exception cleanup) {
-                interrupted.addSuppressed(cleanup);
-            }
-            Thread.currentThread().interrupt();
-            if (primary != null) {
-                primary.addSuppressed(interrupted);
             }
         } catch (Exception cleanup) {
-            if (primary != null) {
-                primary.addSuppressed(cleanup);
-            }
+            interrupted.addSuppressed(cleanup);
         }
+    }
+
+    private static boolean retainSurvivors(Process process, Set<ProcessHandle> descendants,
+                                           Set<ProcessHandle> retainedDescendants) {
         retainedDescendants.clear();
         descendants.stream().filter(ProcessHandle::isAlive).forEach(retainedDescendants::add);
-        boolean survivors = process.isAlive() || !retainedDescendants.isEmpty();
+        return process.isAlive() || !retainedDescendants.isEmpty();
+    }
+
+    private static void reportSurvivorFailure(Throwable primary, RuntimeException survivorFailure) {
         if (survivorFailure != null) {
             if (primary != null) {
                 primary.addSuppressed(survivorFailure);
@@ -439,7 +451,12 @@ final class ManagedLocalAiProcess {
                 throw survivorFailure;
             }
         }
-        return survivors;
+    }
+
+    private static void suppress(Throwable primary, Throwable cleanup) {
+        if (primary != null) {
+            primary.addSuppressed(cleanup);
+        }
     }
 
     private static void revokeSupervisorOwnership(Process process, Throwable primary) {
@@ -1266,6 +1283,38 @@ final class ManagedLocalAiProcess {
 
     @FunctionalInterface interface ProcessTreeRssSampler {
         long sample(Process process, Set<ProcessHandle> retainedDescendants) throws Exception;
+    }
+
+    record RuntimeFiles(Path cache, Path executable, Path model, Path log) {
+        RuntimeFiles {
+            Objects.requireNonNull(cache, "cache");
+            Objects.requireNonNull(executable, "executable");
+            Objects.requireNonNull(model, "model");
+            Objects.requireNonNull(log, "log");
+        }
+    }
+
+    record RuntimeSpec(String alias, int threads) {
+        RuntimeSpec {
+            Objects.requireNonNull(alias, "alias");
+        }
+    }
+
+    record LaunchRequest(RuntimeFiles files, RuntimeSpec runtime, Duration timeout,
+                         java.util.function.BooleanSupplier cancelled) {
+        LaunchRequest {
+            Objects.requireNonNull(files, "files");
+            Objects.requireNonNull(runtime, "runtime");
+            Objects.requireNonNull(timeout, "timeout");
+            Objects.requireNonNull(cancelled, "cancelled");
+        }
+    }
+
+    record LaunchHooks(ProcessTreeRssSampler rssSampler, ProcessStarter starter, IdentityProbe identity) {
+        LaunchHooks {
+            Objects.requireNonNull(starter, "starter");
+            Objects.requireNonNull(identity, "identity");
+        }
     }
 
     private static final class LaunchReservation {

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcessSupervisor.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcessSupervisor.java
@@ -41,7 +41,11 @@ public final class ManagedLocalAiProcessSupervisor {
 
     private record ParentIdentity(long parentPid, Instant parentStartedAt) {
         private static ParentIdentity parse(String[] arguments) {
-            return new ParentIdentity(Long.parseLong(arguments[0]), Instant.parse(arguments[1]));
+            try {
+                return new ParentIdentity(Long.parseLong(arguments[0]), Instant.parse(arguments[1]));
+            } catch (NumberFormatException invalidPid) {
+                throw new IllegalArgumentException("Managed local AI parent PID is invalid.", invalidPid);
+            }
         }
     }
 

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcessSupervisor.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProcessSupervisor.java
@@ -22,29 +22,110 @@ public final class ManagedLocalAiProcessSupervisor {
         if (arguments.length < 4) {
             System.exit(2);
         }
-        long parentPid = Long.parseLong(arguments[0]);
-        Instant parentStartedAt = Instant.parse(arguments[1]);
-        ProcessHandle parent = ProcessHandle.of(parentPid)
+        ParentIdentity identity = ParentIdentity.parse(arguments);
+        ProcessHandle parent = findParent(identity.parentPid(), identity.parentStartedAt());
+        if (parent != null) {
+            Invocation invocation = Invocation.parse(arguments);
+            new Ownership(parent, invocation.workingDirectory(), invocation.command()).run();
+        }
+    }
+
+    private static ProcessHandle findParent(long parentPid, Instant parentStartedAt) {
+        return ProcessHandle.of(parentPid)
                 .filter(ProcessHandle::isAlive)
                 .filter(candidate -> candidate.info().startInstant()
                         .map(parentStartedAt::equals)
                         .orElse(false))
                 .orElse(null);
-        if (parent == null) {
-            return;
+    }
+
+    private record ParentIdentity(long parentPid, Instant parentStartedAt) {
+        private static ParentIdentity parse(String[] arguments) {
+            return new ParentIdentity(Long.parseLong(arguments[0]), Instant.parse(arguments[1]));
         }
-        Path workingDirectory = validatedWorkingDirectory(arguments[2], arguments[3]);
-        List<String> command = new ArrayList<>(List.of(arguments).subList(3, arguments.length));
-        Object gate = new Object();
-        AtomicBoolean parentExited = new AtomicBoolean();
-        AtomicBoolean launchResolved = new AtomicBoolean();
-        AtomicReference<Process> child = new AtomicReference<>();
-        Set<ProcessHandle> retainedDescendants = java.util.concurrent.ConcurrentHashMap.newKeySet();
-        Thread monitor = Thread.ofVirtual().name("shaft-local-ai-parent-monitor").start(() -> {
-            parent.onExit().join();
-            terminateOnOwnerLoss(gate, parentExited, child, retainedDescendants);
-        });
-        Thread control = Thread.ofVirtual().name("shaft-local-ai-control-monitor").start(() -> {
+    }
+
+    private record Invocation(Path workingDirectory, List<String> command) {
+        private static Invocation parse(String[] arguments) throws java.io.IOException {
+            Path workingDirectory = validatedWorkingDirectory(arguments[2], arguments[3]);
+            List<String> command = List.copyOf(new ArrayList<>(List.of(arguments).subList(3, arguments.length)));
+            return new Invocation(workingDirectory, command);
+        }
+    }
+
+    private static final class Ownership {
+        private final ProcessHandle parent;
+        private final Path workingDirectory;
+        private final List<String> command;
+        private final Object gate = new Object();
+        private final AtomicBoolean parentExited = new AtomicBoolean();
+        private final AtomicBoolean launchResolved = new AtomicBoolean();
+        private final AtomicReference<Process> child = new AtomicReference<>();
+        private final Set<ProcessHandle> retainedDescendants =
+                java.util.concurrent.ConcurrentHashMap.newKeySet();
+        private Thread parentMonitor;
+        private Thread controlMonitor;
+        private Thread treeMonitor;
+
+        private Ownership(ProcessHandle parent, Path workingDirectory, List<String> command) {
+            this.parent = parent;
+            this.workingDirectory = workingDirectory;
+            this.command = command;
+        }
+
+        private void run() throws Exception {
+            startMonitors();
+            if (!launch()) {
+                return;
+            }
+            awaitChild();
+        }
+
+        private void startMonitors() {
+            parentMonitor = Thread.ofVirtual().name("shaft-local-ai-parent-monitor").start(() -> {
+                parent.onExit().join();
+                ownerLost();
+            });
+            controlMonitor = Thread.ofVirtual().name("shaft-local-ai-control-monitor").start(() -> {
+                awaitControlPipeClosure();
+                ownerLost();
+            });
+            treeMonitor = Thread.ofVirtual().name("shaft-local-ai-tree-monitor").start(this::monitorTree);
+        }
+
+        private boolean launch() throws java.io.IOException {
+            synchronized (gate) {
+                if (parentExited.get() || !parent.isAlive()) {
+                    launchResolved.set(true);
+                    return false;
+                }
+                ProcessBuilder builder = new ProcessBuilder(command).directory(workingDirectory.toFile())
+                        .redirectErrorStream(true);
+                builder.environment().remove("CLASSPATH");
+                builder.inheritIO();
+                try {
+                    child.set(builder.start());
+                    return true;
+                } finally {
+                    launchResolved.set(true);
+                }
+            }
+        }
+
+        private void awaitChild() throws InterruptedException {
+            try {
+                child.get().waitFor();
+            } finally {
+                parentMonitor.interrupt();
+                controlMonitor.interrupt();
+                synchronized (gate) {
+                    terminate(child.get(), Duration.ofSeconds(2), retainedDescendants);
+                }
+                treeMonitor.interrupt();
+            }
+        }
+
+        private void awaitControlPipeClosure() {
             try {
                 while (System.in.read() != -1) {
                     // The private control pipe carries no data; EOF revokes launch ownership.
@@ -52,9 +133,9 @@ public final class ManagedLocalAiProcessSupervisor {
             } catch (java.io.IOException ignored) {
                 // A broken control pipe has the same meaning as EOF.
             }
-            terminateOnOwnerLoss(gate, parentExited, child, retainedDescendants);
-        });
-        Thread treeMonitor = Thread.ofVirtual().name("shaft-local-ai-tree-monitor").start(() -> {
+        }
+
+        private void monitorTree() {
             while (true) {
                 Process current = child.get();
                 if (current != null) {
@@ -65,38 +146,24 @@ public final class ManagedLocalAiProcessSupervisor {
                 } else if (launchResolved.get()) {
                     return;
                 }
-                try {
-                    Thread.sleep(1);
-                } catch (InterruptedException interrupted) {
-                    Thread.currentThread().interrupt();
+                if (!pauseTreeMonitor()) {
                     return;
                 }
             }
-        });
-        synchronized (gate) {
-            if (parentExited.get() || !parent.isAlive()) {
-                launchResolved.set(true);
-                return;
-            }
-            ProcessBuilder builder = new ProcessBuilder(command).directory(workingDirectory.toFile())
-                    .redirectErrorStream(true);
-            builder.environment().remove("CLASSPATH");
-            builder.inheritIO();
+        }
+
+        private boolean pauseTreeMonitor() {
             try {
-                child.set(builder.start());
-            } finally {
-                launchResolved.set(true);
+                Thread.sleep(1);
+                return true;
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                return false;
             }
         }
-        try {
-            child.get().waitFor();
-        } finally {
-            monitor.interrupt();
-            control.interrupt();
-            synchronized (gate) {
-                terminate(child.get(), Duration.ofSeconds(2), retainedDescendants);
-            }
-            treeMonitor.interrupt();
+
+        private void ownerLost() {
+            terminateOnOwnerLoss(gate, parentExited, child, retainedDescendants);
         }
     }
 

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProvider.java
@@ -142,81 +142,105 @@ public final class ManagedLocalAiProvider implements AiProvider {
             if (shuttingDown) {
                 return unavailable(request, "Managed local inference is shutting down.");
             }
-            long deadline = System.nanoTime() + request.timeout().toNanos();
-            ManagedLocalAiOperation provisioningOperation = null;
-            boolean locked = false;
+            ExecutionContext context = new ExecutionContext(request);
             try {
-                locked = executionLock.tryLock(ManagedLocalAiProcess.remaining(deadline).toNanos(),
-                        TimeUnit.NANOSECONDS);
-                if (!locked) {
+                if (!acquire(context)) {
                     return timedOut(request);
                 }
-                activeExecutionThread = Thread.currentThread();
-                if (shuttingDown) {
-                    return unavailable(request, "Managed local inference is shutting down.");
-                }
-                ManagedLocalAiSnapshot snapshot = service.inspect();
-                if (retireIfShuttingDown(deadline)) {
-                    return unavailable(request, "Managed local inference is shutting down.");
-                }
-                if (snapshot.state() == ManagedLocalAiSnapshot.State.NOT_PROVISIONED
-                        && snapshot.transparentProvisioning()) {
-                    provisioningOperation = service.provision(ignored -> { });
-                    activeProvisioning = provisioningOperation;
-                    snapshot = provisioningOperation.completion()
-                            .get(ManagedLocalAiProcess.remaining(deadline).toNanos(),
-                                    TimeUnit.NANOSECONDS);
-                    if (retireIfShuttingDown(deadline)) {
-                        return unavailable(request, "Managed local inference is shutting down.");
-                    }
-                }
-                if (snapshot.state() != ManagedLocalAiSnapshot.State.READY) {
-                    closeSession(deadline);
-                    return unavailable(request, snapshot.action());
-                }
-                ManagedLocalAiService.ReadyRuntime runtime = service.readyRuntime();
-                if (retireIfShuttingDown(deadline)) {
-                    return unavailable(request, "Managed local inference is shutting down.");
-                }
-                if (session == null || !session.process().isAlive()
-                        || !session.matches(runtime.executable(), runtime.model(), runtime.alias(), runtime.threads())) {
-                    closeSession(deadline);
-                    Duration launchTimeout = min(runtime.launchTimeout(), ManagedLocalAiProcess.remaining(deadline));
-                    session = runtimeClient.launch(runtime, launchTimeout, () -> shuttingDown);
-                    if (retireIfShuttingDown(deadline)) {
-                        return unavailable(request, "Managed local inference is shutting down.");
-                    }
-                }
-                AiResponse response = runtimeClient.infer(session, request, deadline);
-                if (!session.process().isAlive() || session.resourceFailure() != null) {
-                    closeSession(deadline);
-                }
-                return response;
-            } catch (java.util.concurrent.TimeoutException timeout) {
-                cancel(provisioningOperation);
-                closeSession(locked, deadline, timeout);
-                return timedOut(request);
-            } catch (ManagedLocalAiProcess.DeadlineExceededException timeout) {
-                cancel(provisioningOperation);
-                closeSession(locked, deadline, timeout);
+                return executeOwned(context);
+            } catch (java.util.concurrent.TimeoutException
+                     | ManagedLocalAiProcess.DeadlineExceededException timeout) {
+                cancel(context.provisioning);
+                closeSession(context.locked, context.deadline, timeout);
                 return timedOut(request);
             } catch (InterruptedException interrupted) {
-                cancel(provisioningOperation);
-                closeSession(locked, deadline, interrupted);
+                cancel(context.provisioning);
+                closeSession(context.locked, context.deadline, interrupted);
                 Thread.currentThread().interrupt();
                 return AiResponse.failure(AiResponseStatus.ERROR, "managed-local", "",
                         "Managed local inference was interrupted.", Duration.ZERO,
                         request.deterministicFallback());
             } catch (Exception failure) {
-                closeSession(locked, deadline, failure);
+                closeSession(context.locked, context.deadline, failure);
                 return unavailable(request, "Managed local inference is unavailable.");
             } finally {
-                if (locked) {
-                    activeProvisioning = null;
-                    activeExecutionThread = null;
-                    executionLock.unlock();
-                }
+                release(context);
             }
+        }
+
+        private boolean acquire(ExecutionContext context) throws InterruptedException {
+            context.locked = executionLock.tryLock(
+                    ManagedLocalAiProcess.remaining(context.deadline).toNanos(), TimeUnit.NANOSECONDS);
+            if (context.locked) {
+                activeExecutionThread = Thread.currentThread();
+            }
+            return context.locked;
+        }
+
+        private AiResponse executeOwned(ExecutionContext context) throws Exception {
+            if (shuttingDown) {
+                return unavailable(context.request, "Managed local inference is shutting down.");
+            }
+            ManagedLocalAiSnapshot snapshot = service.inspect();
+            if (retireIfShuttingDown(context.deadline)) {
+                return unavailable(context.request, "Managed local inference is shutting down.");
+            }
+            snapshot = provisionIfNeeded(context, snapshot);
+            if (retireIfShuttingDown(context.deadline)) {
+                return unavailable(context.request, "Managed local inference is shutting down.");
+            }
+            if (snapshot.state() != ManagedLocalAiSnapshot.State.READY) {
+                closeSession(context.deadline);
+                return unavailable(context.request, snapshot.action());
+            }
+            ManagedLocalAiService.ReadyRuntime runtime = service.readyRuntime();
+            if (retireIfShuttingDown(context.deadline)) {
+                return unavailable(context.request, "Managed local inference is shutting down.");
+            }
+            ensureSession(runtime, context.deadline);
+            if (retireIfShuttingDown(context.deadline)) {
+                return unavailable(context.request, "Managed local inference is shutting down.");
+            }
+            return infer(context);
+        }
+
+        private ManagedLocalAiSnapshot provisionIfNeeded(ExecutionContext context, ManagedLocalAiSnapshot snapshot)
+                throws Exception {
+            if (snapshot.state() != ManagedLocalAiSnapshot.State.NOT_PROVISIONED
+                    || !snapshot.transparentProvisioning()) {
+                return snapshot;
+            }
+            context.provisioning = service.provision(ignored -> { });
+            activeProvisioning = context.provisioning;
+            return context.provisioning.completion().get(
+                    ManagedLocalAiProcess.remaining(context.deadline).toNanos(), TimeUnit.NANOSECONDS);
+        }
+
+        private void ensureSession(ManagedLocalAiService.ReadyRuntime runtime, long deadline) throws Exception {
+            if (session != null && session.process().isAlive()
+                    && session.matches(runtime.executable(), runtime.model(), runtime.alias(), runtime.threads())) {
+                return;
+            }
+            closeSession(deadline);
+            Duration launchTimeout = min(runtime.launchTimeout(), ManagedLocalAiProcess.remaining(deadline));
+            session = runtimeClient.launch(runtime, launchTimeout, () -> shuttingDown);
+        }
+
+        private AiResponse infer(ExecutionContext context) throws Exception {
+            AiResponse response = runtimeClient.infer(session, context.request, context.deadline);
+            if (!session.process().isAlive() || session.resourceFailure() != null) {
+                closeSession(context.deadline);
+            }
+            return response;
+        }
+
+        private void release(ExecutionContext context) {
+            if (!context.locked) {
+                return;
+            }
+            activeProvisioning = null;
+            activeExecutionThread = null;
+            executionLock.unlock();
         }
 
         private static AiResponse timedOut(AiRequest request) {
@@ -317,6 +341,18 @@ public final class ManagedLocalAiProvider implements AiProvider {
                 if (locked) {
                     executionLock.unlock();
                 }
+            }
+        }
+
+        private static final class ExecutionContext {
+            private final AiRequest request;
+            private final long deadline;
+            private ManagedLocalAiOperation provisioning;
+            private boolean locked;
+
+            private ExecutionContext(AiRequest request) {
+                this.request = request;
+                this.deadline = System.nanoTime() + request.timeout().toNanos();
             }
         }
     }

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProvider.java
@@ -16,7 +16,30 @@ import java.util.concurrent.locks.ReentrantLock;
 
 /** SHAFT-owned provider entrypoint for managed local inference. */
 public final class ManagedLocalAiProvider implements AiProvider {
-    private final Lifecycle lifecycle;
+    private static final RuntimeClient PROCESS_CLIENT = new RuntimeClient() {
+        @Override
+        public ManagedLocalAiProcess.Session launch(ManagedLocalAiService.ReadyRuntime runtime, Duration timeout,
+                                                    BooleanSupplier shuttingDown) throws Exception {
+            return ManagedLocalAiProcess.launchManaged(runtime.cache(), runtime.executable(), runtime.model(),
+                    runtime.log(), runtime.alias(), runtime.threads(), timeout, shuttingDown,
+                    ManagedLocalAiProcess::start, (process, port, key, alias, identityTimeout) ->
+                            ManagedLocalAiProcess.requireIdentity(process, port, key, alias, identityTimeout,
+                                    ManagedLocalAiProcess::requestIdentity));
+        }
+
+        @Override
+        public AiResponse infer(ManagedLocalAiProcess.Session session, AiRequest request, long deadline)
+                throws Exception {
+            return ManagedLocalAiProcess.infer(session, request, ManagedLocalAiProcess::requestInference, deadline);
+        }
+    };
+    private static final ServiceLifecycle SERVICE_LIFECYCLE = new ServiceLifecycle(new ManagedLocalAiService());
+    static {
+        Runtime.getRuntime().addShutdownHook(Thread.ofPlatform().name("shaft-managed-local-ai-shutdown")
+                .unstarted(SERVICE_LIFECYCLE::shutdown));
+    }
+
+    final Lifecycle lifecycle;
 
     /** Creates the service-loadable managed provider. */
     public ManagedLocalAiProvider() {
@@ -75,43 +98,20 @@ public final class ManagedLocalAiProvider implements AiProvider {
         AiResponse infer(ManagedLocalAiProcess.Session session, AiRequest request, long deadline) throws Exception;
     }
 
-    private static final RuntimeClient PROCESS_CLIENT = new RuntimeClient() {
-        @Override
-        public ManagedLocalAiProcess.Session launch(ManagedLocalAiService.ReadyRuntime runtime, Duration timeout,
-                                                    BooleanSupplier shuttingDown) throws Exception {
-            return ManagedLocalAiProcess.launchManaged(runtime.cache(), runtime.executable(), runtime.model(),
-                    runtime.log(), runtime.alias(), runtime.threads(), timeout, shuttingDown,
-                    ManagedLocalAiProcess::start, (process, port, key, alias, identityTimeout) ->
-                            ManagedLocalAiProcess.requireIdentity(process, port, key, alias, identityTimeout,
-                                    ManagedLocalAiProcess::requestIdentity));
-        }
-
-        @Override
-        public AiResponse infer(ManagedLocalAiProcess.Session session, AiRequest request, long deadline)
-                throws Exception {
-            return ManagedLocalAiProcess.infer(session, request, ManagedLocalAiProcess::requestInference, deadline);
-        }
-    };
-    private static final ServiceLifecycle SERVICE_LIFECYCLE = new ServiceLifecycle(new ManagedLocalAiService());
-    static {
-        Runtime.getRuntime().addShutdownHook(Thread.ofPlatform().name("shaft-managed-local-ai-shutdown")
-                .unstarted(SERVICE_LIFECYCLE::closeSession));
-    }
-
-    private static final class ServiceLifecycle implements Lifecycle {
+    static final class ServiceLifecycle implements Lifecycle {
         private final ManagedLocalAiService service;
         private final RuntimeClient runtimeClient;
-        private final ReentrantLock executionLock = new ReentrantLock();
-        private volatile ManagedLocalAiProcess.Session session;
+        final ReentrantLock executionLock = new ReentrantLock();
+        volatile ManagedLocalAiProcess.Session session;
         private volatile ManagedLocalAiOperation activeProvisioning;
         private volatile Thread activeExecutionThread;
         private volatile boolean shuttingDown;
 
-        private ServiceLifecycle(ManagedLocalAiService service) {
+        ServiceLifecycle(ManagedLocalAiService service) {
             this(service, PROCESS_CLIENT);
         }
 
-        private ServiceLifecycle(ManagedLocalAiService service, RuntimeClient runtimeClient) {
+        ServiceLifecycle(ManagedLocalAiService service, RuntimeClient runtimeClient) {
             this.service = Objects.requireNonNull(service, "service");
             this.runtimeClient = Objects.requireNonNull(runtimeClient, "runtimeClient");
         }
@@ -284,7 +284,7 @@ public final class ManagedLocalAiProvider implements AiProvider {
             }
         }
 
-        private void closeSession() {
+        void shutdown() {
             shuttingDown = true;
             cancel(activeProvisioning);
             Thread executing = activeExecutionThread;

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiProvider.java
@@ -20,9 +20,12 @@ public final class ManagedLocalAiProvider implements AiProvider {
         @Override
         public ManagedLocalAiProcess.Session launch(ManagedLocalAiService.ReadyRuntime runtime, Duration timeout,
                                                     BooleanSupplier shuttingDown) throws Exception {
-            return ManagedLocalAiProcess.launchManaged(runtime.cache(), runtime.executable(), runtime.model(),
-                    runtime.log(), runtime.alias(), runtime.threads(), timeout, shuttingDown,
-                    ManagedLocalAiProcess::start, (process, port, key, alias, identityTimeout) ->
+            var files = new ManagedLocalAiProcess.RuntimeFiles(
+                    runtime.cache(), runtime.executable(), runtime.model(), runtime.log());
+            var spec = new ManagedLocalAiProcess.RuntimeSpec(runtime.alias(), runtime.threads());
+            var request = new ManagedLocalAiProcess.LaunchRequest(files, spec, timeout, shuttingDown);
+            return ManagedLocalAiProcess.launchManaged(request, ManagedLocalAiProcess::start,
+                    (process, port, key, alias, identityTimeout) ->
                             ManagedLocalAiProcess.requireIdentity(process, port, key, alias, identityTimeout,
                                     ManagedLocalAiProcess::requestIdentity));
         }
@@ -168,7 +171,8 @@ public final class ManagedLocalAiProvider implements AiProvider {
             }
         }
 
-        private boolean acquire(ExecutionContext context) throws InterruptedException {
+        private boolean acquire(ExecutionContext context)
+                throws InterruptedException, ManagedLocalAiProcess.DeadlineExceededException {
             context.locked = executionLock.tryLock(
                     ManagedLocalAiProcess.remaining(context.deadline).toNanos(), TimeUnit.NANOSECONDS);
             if (context.locked) {

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiService.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiService.java
@@ -2,22 +2,25 @@ package com.shaft.ai.local;
 
 import com.shaft.driver.SHAFT;
 
-import java.nio.file.Path;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Supplier;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
-import java.time.Duration;
-import java.util.UUID;
+import java.util.function.Supplier;
 
 /** Public batteries-included lifecycle boundary for SHAFT-managed local inference. */
 public final class ManagedLocalAiService {
@@ -62,72 +65,112 @@ public final class ManagedLocalAiService {
         ManagedLocalAiSnapshot initial = inspect(true, configured);
         ManagedLocalAiSnapshot reviewedInitial = inspect(false, configured);
         ManagedLocalAiOperation operation = new ManagedLocalAiOperation(initial);
-        Thread worker = Thread.ofVirtual().name("shaft-managed-local-ai-provision").start(() -> {
-            ProvisionResult provisioned = null;
-            try {
-                if (reviewedInitial.state() == ManagedLocalAiSnapshot.State.READY) {
-                    publish(operation, progress, reviewedInitial);
-                    ManagedLocalAiManifest manifest = Objects.requireNonNull(manifests.get(),
-                            "managed local AI manifest");
-                    if (!publishActivation(operation, reviewedInitial, configured, manifest)) {
-                        operation.cancelled();
-                    }
-                    return;
-                }
-                if (reviewedInitial.state() != ManagedLocalAiSnapshot.State.NOT_PROVISIONED) {
-                    throw new IllegalStateException("Managed local AI cannot be provisioned from state "
-                            + reviewedInitial.state() + ".");
-                }
-                if (!allowDownloads) {
-                    throw new IOException("Managed local AI is not ready and offline setup cannot download artifacts.");
-                }
-                ManagedLocalAiManifest manifest = Objects.requireNonNull(manifests.get(), "managed local AI manifest");
-                ManagedLocalAiHardware.Profile profile = ManagedLocalAiHardware.profile(
-                        reviewedInitial.cacheDirectory(), host);
-                String requested = AUTOMATIC_MODEL.equalsIgnoreCase(configured.model()) ? null : configured.model();
-                ManagedLocalAiHardware.Selection selection = ManagedLocalAiHardware.select(manifest, profile, requested);
-                ManagedLocalAiManifest.ModelManifest model = manifest.models().stream()
-                        .filter(candidate -> candidate.id().equals(selection.selectedModelId())).findFirst().orElseThrow();
-                provisioned = provisioning.provision(reviewedInitial.cacheDirectory(), manifest, profile,
-                        model, configured,
-                        host, operation::isCancelled, phase -> publish(operation, progress,
-                                withProgress(reviewedInitial, phase.phase(), phase.completedBytes(), phase.totalBytes())));
-                if (operation.isCancelled()) {
-                    throw new InterruptedException("Managed local AI provisioning was cancelled.");
-                }
-                ManagedLocalAiSnapshot ready = inspect(false, configured);
-                if (ready.state() != ManagedLocalAiSnapshot.State.READY) {
-                    throw new IllegalStateException("Managed local AI provisioning did not produce a ready cache.");
-                }
-                operation.publish(ready);
-                try {
-                    progress.accept(ready);
-                } catch (RuntimeException observerFailure) {
-                    // Lifecycle ownership and rollback must not depend on an observer callback.
-                }
-                if (!publishActivation(operation, ready, configured, manifest)) {
-                    rollbackCancellation(initial.cacheDirectory(), configured, provisioned.installationIds());
-                    operation.cancelled();
-                }
-            } catch (InterruptedException cancelled) {
-                if (provisioned != null) {
-                    rollbackCancellation(initial.cacheDirectory(), configured, provisioned.installationIds());
-                }
-                Thread.currentThread().interrupt();
-                operation.cancelled();
-            } catch (Exception failure) {
-                if (provisioned != null) {
-                    try {
-                        rollback(initial.cacheDirectory(), configured, provisioned.installationIds());
-                    } catch (Exception cleanup) {
-                        failure.addSuppressed(cleanup);
-                    }
-                }
-                operation.fail(failure);
-            }
-        });
+        ProvisionContext context = new ProvisionContext(
+                configured, initial, reviewedInitial, operation, progress, allowDownloads);
+        Thread worker = Thread.ofVirtual().name("shaft-managed-local-ai-provision")
+                .start(() -> runProvisioning(context));
         operation.attach(worker);
         return operation;
+    }
+
+    private void runProvisioning(ProvisionContext context) {
+        ProvisionResult provisioned = null;
+        try {
+            if (context.reviewed().state() == ManagedLocalAiSnapshot.State.READY) {
+                completeExisting(context);
+                return;
+            }
+            ProvisionPlan plan = planProvisioning(context);
+            provisioned = provision(context, plan);
+            requireActive(context);
+            publishProvisioned(context, plan.manifest(), provisioned);
+        } catch (InterruptedException cancelled) {
+            cancelProvisioning(context, provisioned);
+        } catch (Exception failure) {
+            failProvisioning(context, provisioned, failure);
+        }
+    }
+
+    private void completeExisting(ProvisionContext context) throws Exception {
+        publish(context.operation(), context.progress(), context.reviewed());
+        ManagedLocalAiManifest manifest = Objects.requireNonNull(manifests.get(), "managed local AI manifest");
+        if (!publishActivation(context.operation(), context.reviewed(), context.settings(), manifest)) {
+            context.operation().cancelled();
+        }
+    }
+
+    private ProvisionPlan planProvisioning(ProvisionContext context) throws IOException {
+        if (context.reviewed().state() != ManagedLocalAiSnapshot.State.NOT_PROVISIONED) {
+            throw new IllegalStateException("Managed local AI cannot be provisioned from state "
+                    + context.reviewed().state() + ".");
+        }
+        if (!context.allowDownloads()) {
+            throw new IOException("Managed local AI is not ready and offline setup cannot download artifacts.");
+        }
+        ManagedLocalAiManifest manifest = Objects.requireNonNull(manifests.get(), "managed local AI manifest");
+        ManagedLocalAiHardware.Profile profile = ManagedLocalAiHardware.profile(
+                context.reviewed().cacheDirectory(), host);
+        String requested = AUTOMATIC_MODEL.equalsIgnoreCase(context.settings().model())
+                ? null : context.settings().model();
+        ManagedLocalAiHardware.Selection selection = ManagedLocalAiHardware.select(manifest, profile, requested);
+        ManagedLocalAiManifest.ModelManifest model = manifest.models().stream()
+                .filter(candidate -> candidate.id().equals(selection.selectedModelId())).findFirst().orElseThrow();
+        return new ProvisionPlan(manifest, profile, model);
+    }
+
+    private ProvisionResult provision(ProvisionContext context, ProvisionPlan plan) throws Exception {
+        return provisioning.provision(context.reviewed().cacheDirectory(), plan.manifest(),
+                plan.profile(), plan.model(), context.settings(), host, context.operation()::isCancelled,
+                phase -> publish(context.operation(), context.progress(), withProgress(context.reviewed(),
+                        phase.phase(), phase.completedBytes(), phase.totalBytes())));
+    }
+
+    private static void requireActive(ProvisionContext context) throws InterruptedException {
+        if (context.operation().isCancelled()) {
+            throw new InterruptedException("Managed local AI provisioning was cancelled.");
+        }
+    }
+
+    private void publishProvisioned(ProvisionContext context, ManagedLocalAiManifest manifest,
+                                    ProvisionResult provisioned) throws Exception {
+        ManagedLocalAiSnapshot ready = inspect(false, context.settings());
+        if (ready.state() != ManagedLocalAiSnapshot.State.READY) {
+            throw new IllegalStateException("Managed local AI provisioning did not produce a ready cache.");
+        }
+        context.operation().publish(ready);
+        notifyProgress(context.progress(), ready);
+        if (!publishActivation(context.operation(), ready, context.settings(), manifest)) {
+            rollbackCancellation(context.initial().cacheDirectory(), context.settings(), provisioned.installationIds());
+            context.operation().cancelled();
+        }
+    }
+
+    private static void notifyProgress(Consumer<ManagedLocalAiSnapshot> progress, ManagedLocalAiSnapshot ready) {
+        try {
+            progress.accept(ready);
+        } catch (RuntimeException observerFailure) {
+            // Lifecycle ownership and rollback must not depend on an observer callback.
+        }
+    }
+
+    private static void cancelProvisioning(ProvisionContext context, ProvisionResult provisioned) {
+        if (provisioned != null) {
+            rollbackCancellation(
+                    context.initial().cacheDirectory(), context.settings(), provisioned.installationIds());
+        }
+        Thread.currentThread().interrupt();
+        context.operation().cancelled();
+    }
+
+    private static void failProvisioning(ProvisionContext context, ProvisionResult provisioned, Exception failure) {
+        if (provisioned != null) {
+            try {
+                rollback(context.initial().cacheDirectory(), context.settings(), provisioned.installationIds());
+            } catch (Exception cleanup) {
+                failure.addSuppressed(cleanup);
+            }
+        }
+        context.operation().fail(failure);
     }
 
     private static boolean publishActivation(ManagedLocalAiOperation operation, ManagedLocalAiSnapshot ready,
@@ -163,11 +206,10 @@ public final class ManagedLocalAiService {
         ManagedLocalAiManifest manifest = Objects.requireNonNull(manifests.get(), "managed local AI manifest");
         Path cache = resolveCache(configured.cacheDirectory());
         Duration lockTimeout = Duration.ofSeconds(configured.lockTimeoutSeconds());
-        Set<String> reviewed = new java.util.LinkedHashSet<>();
+        Set<String> reviewed = new LinkedHashSet<>();
         manifest.runtime().assets().forEach(asset -> reviewed.add(runtimeInstallationId(manifest, asset.platform())));
         manifest.models().forEach(model -> reviewed.add(modelInstallationId(model)));
-        java.util.concurrent.atomic.AtomicReference<ManagedLocalAiCache.CleanResult> result =
-                new java.util.concurrent.atomic.AtomicReference<>();
+        AtomicReference<ManagedLocalAiCache.CleanResult> result = new AtomicReference<>();
         ManagedLocalAiProcess.withLaunchExclusion(lockTimeout, () -> {
             ManagedLocalAiProcess.terminateRetainedLaunches();
             ManagedLocalAiCache.withLock(cache, lockTimeout, () -> {
@@ -198,24 +240,15 @@ public final class ManagedLocalAiService {
     private ManagedLocalAiSnapshot inspect(boolean effectiveActivation, Settings configured) {
         Path cache = resolveCache(configured.cacheDirectory());
         if (!configured.enabled()) {
-            return snapshot(ManagedLocalAiSnapshot.State.DISABLED,
-                    "Enable managed local AI to provision a local model.",
-                    new SnapshotContext(cache, configured, "", null, null, null, Map.of()));
+            return disabledSnapshot(cache, configured);
         }
 
         ManagedLocalAiManifest manifest = Objects.requireNonNull(manifests.get(), "managed local AI manifest");
         ManagedLocalAiHardware.Profile profile = ManagedLocalAiHardware.profile(cache, host);
         if (effectiveActivation) {
-            ManagedLocalAiActivationHistory.History history;
-            try {
-                history = ManagedLocalAiActivationHistory.readVerified(cache);
-            } catch (ManagedLocalAiActivationHistory.ActiveArtifactDrift changedActivation) {
-                history = null;
-            } catch (IOException failure) {
-                throw new IllegalStateException("Managed-local activation history cannot be read.", failure);
-            }
-            if (history != null) {
-                return activationSnapshot(cache, configured, history.active());
+            ManagedLocalAiSnapshot active = inspectActivation(cache, configured);
+            if (active != null) {
+                return active;
             }
         }
         if (!profile.runtimeCompatible()) {
@@ -223,7 +256,29 @@ public final class ManagedLocalAiService {
                     "Use an external local provider or a supported desktop OS, architecture, and ABI.",
                     new SnapshotContext(cache, configured, profile.platform(), profile, manifest, null, Map.of()));
         }
+        return inspectSelection(cache, configured, manifest, profile);
+    }
 
+    private static ManagedLocalAiSnapshot disabledSnapshot(Path cache, Settings configured) {
+        return snapshot(ManagedLocalAiSnapshot.State.DISABLED,
+                "Enable managed local AI to provision a local model.",
+                new SnapshotContext(cache, configured, "", null, null, null, Map.of()));
+    }
+
+    private ManagedLocalAiSnapshot inspectActivation(Path cache, Settings configured) {
+        try {
+            ManagedLocalAiActivationHistory.History history = ManagedLocalAiActivationHistory.readVerified(cache);
+            return history == null ? null : activationSnapshot(cache, configured, history.active());
+        } catch (ManagedLocalAiActivationHistory.ActiveArtifactDrift changedActivation) {
+            return null;
+        } catch (IOException failure) {
+            throw new IllegalStateException("Managed-local activation history cannot be read.", failure);
+        }
+    }
+
+    private static ManagedLocalAiSnapshot inspectSelection(Path cache, Settings configured,
+                                                           ManagedLocalAiManifest manifest,
+                                                           ManagedLocalAiHardware.Profile profile) {
         String requested = AUTOMATIC_MODEL.equalsIgnoreCase(configured.model()) ? null : configured.model();
         ManagedLocalAiHardware.Selection selection = ManagedLocalAiHardware.select(manifest, profile, requested);
         Map<String, ManagedLocalAiSnapshot.Model> models = modelInventory(manifest, selection);
@@ -239,6 +294,13 @@ public final class ManagedLocalAiService {
                 .filter(candidate -> candidate.platform().equals(profile.platform())).findFirst().orElseThrow();
         ManagedLocalAiSnapshot.CacheHealth runtimeStatus = inspectRuntime(cache, manifest, asset);
         ManagedLocalAiSnapshot.CacheHealth modelStatus = inspectModel(cache, model);
+        SelectionContext context = new SelectionContext(cache, configured, profile, manifest, model, models);
+        return cacheSnapshot(context, runtimeStatus, modelStatus);
+    }
+
+    private static ManagedLocalAiSnapshot cacheSnapshot(SelectionContext context,
+                                                        ManagedLocalAiSnapshot.CacheHealth runtimeStatus,
+                                                        ManagedLocalAiSnapshot.CacheHealth modelStatus) {
         ManagedLocalAiSnapshot.State state;
         String action;
         if (runtimeStatus == ManagedLocalAiSnapshot.CacheHealth.CORRUPT
@@ -254,7 +316,8 @@ public final class ManagedLocalAiService {
             action = "Provision the reviewed managed runtime and model.";
         }
         return snapshot(state, action,
-                new SnapshotContext(cache, configured, profile.platform(), profile, manifest, model, models),
+                new SnapshotContext(context.cache(), context.settings(), context.profile().platform(),
+                        context.profile(), context.manifest(), context.model(), context.models()),
                 runtimeStatus, modelStatus);
     }
 
@@ -399,8 +462,7 @@ public final class ManagedLocalAiService {
         Settings configured = Objects.requireNonNull(settings.get(), "managed local AI settings");
         Path cache = resolveCache(configured.cacheDirectory());
         Duration lockTimeout = Duration.ofSeconds(configured.lockTimeoutSeconds());
-        java.util.concurrent.atomic.AtomicReference<ManagedLocalAiSnapshot> result =
-                new java.util.concurrent.atomic.AtomicReference<>();
+        AtomicReference<ManagedLocalAiSnapshot> result = new AtomicReference<>();
         ManagedLocalAiProcess.withLaunchExclusion(lockTimeout, () -> {
             ManagedLocalAiCache.withLock(cache, lockTimeout, () -> {
                 ManagedLocalAiActivationHistory.rollbackLocked(cache, expected, () -> {
@@ -446,6 +508,11 @@ public final class ManagedLocalAiService {
                                    ManagedLocalAiHardware.Profile profile, ManagedLocalAiManifest manifest,
                                    ManagedLocalAiManifest.ModelManifest model,
                                    Map<String, ManagedLocalAiSnapshot.Model> models) {
+    }
+
+    private record SelectionContext(Path cache, Settings settings, ManagedLocalAiHardware.Profile profile,
+                                    ManagedLocalAiManifest manifest, ManagedLocalAiManifest.ModelManifest model,
+                                    Map<String, ManagedLocalAiSnapshot.Model> models) {
     }
 
     private record RuntimeDetails(String id, String version, String license, String file, String sha256,
@@ -589,7 +656,7 @@ public final class ManagedLocalAiService {
         }
     }
 
-    private static void rollback(Path cache, Settings settings, java.util.Set<String> installationIds)
+    private static void rollback(Path cache, Settings settings, Set<String> installationIds)
             throws Exception {
         if (!installationIds.isEmpty()) {
             boolean interrupted = Thread.interrupted();
@@ -605,12 +672,21 @@ public final class ManagedLocalAiService {
     }
 
     private static void rollbackCancellation(Path cache, Settings settings,
-                                             java.util.Set<String> installationIds) {
+                                             Set<String> installationIds) {
         try {
             rollback(cache, settings, installationIds);
         } catch (Exception cleanup) {
             // Cancellation stays primary; incomplete cleanup remains discoverable through cache status/recovery.
         }
+    }
+
+    private record ProvisionContext(Settings settings, ManagedLocalAiSnapshot initial,
+                                    ManagedLocalAiSnapshot reviewed, ManagedLocalAiOperation operation,
+                                    Consumer<ManagedLocalAiSnapshot> progress, boolean allowDownloads) {
+    }
+
+    private record ProvisionPlan(ManagedLocalAiManifest manifest, ManagedLocalAiHardware.Profile profile,
+                                 ManagedLocalAiManifest.ModelManifest model) {
     }
 
     record Settings(boolean enabled, boolean transparentProvisioning, String model, String cacheDirectory,
@@ -646,9 +722,9 @@ public final class ManagedLocalAiService {
     record Progress(ManagedLocalAiSnapshot.Phase phase, long completedBytes, long totalBytes) {
     }
 
-    record ProvisionResult(java.util.Set<String> installationIds) {
+    record ProvisionResult(Set<String> installationIds) {
         ProvisionResult {
-            installationIds = java.util.Set.copyOf(installationIds);
+            installationIds = Set.copyOf(installationIds);
         }
     }
 
@@ -728,7 +804,7 @@ public final class ManagedLocalAiService {
                 rollbackFailedProvision(context.cache(), runtimeId, installedRuntime, primary, interrupted);
                 throw primary;
             }
-            java.util.Set<String> installed = new java.util.LinkedHashSet<>();
+            Set<String> installed = new LinkedHashSet<>();
             if (installedRuntime) {
                 installed.add(runtimeId);
             }
@@ -768,7 +844,7 @@ public final class ManagedLocalAiService {
             Thread.interrupted();
             if (installedRuntime) {
                 try {
-                    ManagedLocalAiCache.clean(cache, java.util.Set.of(runtimeId));
+                    ManagedLocalAiCache.clean(cache, Set.of(runtimeId));
                 } catch (Exception rollback) {
                     primary.addSuppressed(rollback);
                 }
@@ -793,8 +869,8 @@ public final class ManagedLocalAiService {
             Files.createDirectories(staging);
             Path archive = staging.resolve(id + ".archive-" + UUID.randomUUID() + "-" + asset.file());
             Path stage = null;
-            List<Path> ownedFiles = new java.util.ArrayList<>();
-            List<Path> ownedDirectories = new java.util.ArrayList<>();
+            List<Path> ownedFiles = new ArrayList<>();
+            List<Path> ownedDirectories = new ArrayList<>();
             Throwable primary = null;
             try {
                 artifacts.download(asset, archive, Duration.ofSeconds(settings.downloadTimeoutSeconds()), cancelled);
@@ -825,7 +901,7 @@ public final class ManagedLocalAiService {
             Files.createDirectories(staging);
             Path stage = staging.resolve(id + ".extract-" + UUID.randomUUID());
             Files.createDirectory(stage);
-            List<Path> ownedFiles = new java.util.ArrayList<>();
+            List<Path> ownedFiles = new ArrayList<>();
             List<Path> ownedDirectories = List.of(stage);
             Throwable primary = null;
             try {

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiSetupProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiSetupProvider.java
@@ -22,6 +22,7 @@ import com.shaft.infrastructure.SetupSelection;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.Objects;
@@ -56,6 +57,21 @@ public final class ManagedLocalAiSetupProvider implements SetupProvider {
     @Override
     public SetupPlan plan(SetupOptions options, SetupSelection selection, SetupOperation operation,
                           SetupPlatform platform, SetupArchitecture architecture) {
+        validatePlanRequest(options, selection, operation);
+        if (operation == SetupOperation.ROLLBACK) {
+            return planRollback(options, platform, architecture);
+        }
+        ManagedLocalAiSnapshot snapshot = operation == SetupOperation.INSTALL
+                ? inspectReviewed(options) : inspect(options);
+        if (operation == SetupOperation.INSTALL && snapshot.selectedModelId() == null) {
+            throw new IllegalStateException("Managed local AI cannot select a reviewed model: " + snapshot.action());
+        }
+        return artifactPlan(options, operation, platform, architecture, snapshot,
+                ManagedLocalAiManifest.loadDefault());
+    }
+
+    private static void validatePlanRequest(SetupOptions options, SetupSelection selection,
+                                            SetupOperation operation) {
         Objects.requireNonNull(selection, "selection");
         Objects.requireNonNull(operation, "operation");
         if (!selection.components().isEmpty()) {
@@ -64,26 +80,25 @@ public final class ManagedLocalAiSetupProvider implements SetupProvider {
         if (operation != SetupOperation.INSTALL && options.effectiveMode() != SetupMode.MANAGED) {
             throw new IllegalArgumentException(operation + " requires MANAGED mode for profile LOCAL_AI.");
         }
-        if (operation == SetupOperation.ROLLBACK) {
-            Lifecycle lifecycle = lifecycles.create(options);
-            ManagedLocalAiSnapshot snapshot = lifecycle.inspect();
-            requireCacheRoot(options, snapshot);
-            try {
-                ManagedLocalAiActivationHistory.Activation candidate = lifecycle.rollbackCandidate();
-                if (candidate == null) {
-                    throw new IllegalStateException("No reviewed managed local AI rollback candidate is available.");
-                }
-                return rollbackPlan(options, platform, architecture, candidate);
-            } catch (IOException failure) {
-                throw new IllegalStateException("Managed local AI rollback candidate cannot be inspected.", failure);
+    }
+
+    private SetupPlan planRollback(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        Lifecycle lifecycle = lifecycles.create(options);
+        requireCacheRoot(options, lifecycle.inspect());
+        try {
+            ManagedLocalAiActivationHistory.Activation candidate = lifecycle.rollbackCandidate();
+            if (candidate == null) {
+                throw new IllegalStateException("No reviewed managed local AI rollback candidate is available.");
             }
+            return rollbackPlan(options, platform, architecture, candidate);
+        } catch (IOException failure) {
+            throw new IllegalStateException("Managed local AI rollback candidate cannot be inspected.", failure);
         }
-        ManagedLocalAiSnapshot snapshot = operation == SetupOperation.INSTALL
-                ? inspectReviewed(options) : inspect(options);
-        if (operation == SetupOperation.INSTALL && snapshot.selectedModelId() == null) {
-            throw new IllegalStateException("Managed local AI cannot select a reviewed model: " + snapshot.action());
-        }
-        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+    }
+
+    private static SetupPlan artifactPlan(SetupOptions options, SetupOperation operation,
+                                          SetupPlatform platform, SetupArchitecture architecture,
+                                          ManagedLocalAiSnapshot snapshot, ManagedLocalAiManifest manifest) {
         SetupActionKind kind = options.effectiveMode() == SetupMode.EXTERNAL
                 ? SetupActionKind.DIAGNOSE
                 : operation == SetupOperation.CLEAN ? SetupActionKind.CLEAN : SetupActionKind.INSTALL;
@@ -97,7 +112,7 @@ public final class ManagedLocalAiSetupProvider implements SetupProvider {
                 ? manifest.models()
                 : manifest.models().stream().filter(candidate -> candidate.id().equals(snapshot.selectedModelId()))
                 .toList();
-        java.util.ArrayList<SetupAction> actions = new java.util.ArrayList<>();
+        ArrayList<SetupAction> actions = new ArrayList<>();
         runtimes.forEach(runtime -> actions.add(new SetupAction(SetupTarget.MANAGED_LOCAL_AI_RUNTIME, kind,
                 manifest.runtime().version(), runtime.url(), "sha256:" + runtime.sha256(), runtime.size(), false,
                 runtimeLicenses)));
@@ -137,6 +152,17 @@ public final class ManagedLocalAiSetupProvider implements SetupProvider {
     @Override
     public SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options,
                                 Consumer<SetupProgress> progress) throws IOException {
+        validateInstallRequest(plan, approval, options, progress);
+        ReviewedInstall reviewed = reviewInstall(plan, options);
+        return switch (reviewed.operation()) {
+            case ROLLBACK -> installRollback(plan, reviewed);
+            case CLEAN -> installClean(plan, reviewed);
+            case INSTALL -> installProvision(plan, options, progress, reviewed);
+        };
+    }
+
+    private static void validateInstallRequest(SetupPlan plan, SetupApproval approval, SetupOptions options,
+                                               Consumer<SetupProgress> progress) {
         Objects.requireNonNull(options, "options");
         Objects.requireNonNull(progress, "progress");
         if (plan.profile() != SetupProfile.LOCAL_AI || options.profile() != SetupProfile.LOCAL_AI
@@ -147,6 +173,9 @@ public final class ManagedLocalAiSetupProvider implements SetupProvider {
             throw new IllegalArgumentException("External local AI setup is diagnostic-only.");
         }
         SetupExecutor.validate(plan, approval);
+    }
+
+    private ReviewedInstall reviewInstall(SetupPlan plan, SetupOptions options) throws IOException {
         SetupOperation operation = SetupOperation.fromPlan(plan);
         Lifecycle lifecycle = lifecycles.create(options);
         ManagedLocalAiSnapshot initial = operation == SetupOperation.INSTALL
@@ -167,48 +196,69 @@ public final class ManagedLocalAiSetupProvider implements SetupProvider {
         if (!expected.equals(plan)) {
             throw new IllegalArgumentException("Managed local AI plan does not match the reviewed manifest and operation.");
         }
-        if (operation == SetupOperation.ROLLBACK) {
-            ManagedLocalAiSnapshot rolledBack;
-            try {
-                rolledBack = lifecycle.rollback(rollbackCandidate);
-            } catch (InterruptedException cancelled) {
-                Thread.currentThread().interrupt();
-                throw new IOException("Managed local AI rollback was interrupted.", cancelled);
-            } catch (Exception failure) {
-                if (failure instanceof IOException io) throw io;
-                throw new IOException("Managed local AI rollback failed.", failure);
-            }
-            if (!matches(rolledBack, rollbackCandidate)) {
-                throw new IOException("Managed local AI rollback completed without the reviewed active pair.");
-            }
-            return new SetupReceipt(plan.digest(), Instant.now(), plan.actions());
+        return new ReviewedInstall(operation, lifecycle, initial, rollbackCandidate);
+    }
+
+    private static SetupReceipt installRollback(SetupPlan plan, ReviewedInstall reviewed) throws IOException {
+        ManagedLocalAiSnapshot rolledBack;
+        try {
+            rolledBack = reviewed.lifecycle().rollback(reviewed.rollbackCandidate());
+        } catch (IOException failure) {
+            throw failure;
+        } catch (InterruptedException cancelled) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Managed local AI rollback was interrupted.", cancelled);
+        } catch (Exception failure) {
+            throw new IOException("Managed local AI rollback failed.", failure);
         }
-        if (operation == SetupOperation.CLEAN) {
-            boolean cleaned;
-            try {
-                cleaned = lifecycle.clean();
-            } catch (InterruptedException cancelled) {
-                Thread.currentThread().interrupt();
-                throw new IOException("Managed local AI clean was interrupted.", cancelled);
-            } catch (Exception failure) {
-                if (failure instanceof IOException io) throw io;
-                throw new IOException("Managed local AI clean failed.", failure);
-            }
-            if (!cleaned) {
-                throw new IOException("Managed local AI clean preserved changed or unknown owned content; no receipt was created.");
-            }
-            return new SetupReceipt(plan.digest(), Instant.now(), plan.actions());
+        if (!matches(rolledBack, reviewed.rollbackCandidate())) {
+            throw new IOException("Managed local AI rollback completed without the reviewed active pair.");
         }
-        if (options.offline() && initial.state() != ManagedLocalAiSnapshot.State.READY) {
+        return receipt(plan);
+    }
+
+    private static SetupReceipt installClean(SetupPlan plan, ReviewedInstall reviewed) throws IOException {
+        boolean cleaned;
+        try {
+            cleaned = reviewed.lifecycle().clean();
+        } catch (IOException failure) {
+            throw failure;
+        } catch (InterruptedException cancelled) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Managed local AI clean was interrupted.", cancelled);
+        } catch (Exception failure) {
+            throw new IOException("Managed local AI clean failed.", failure);
+        }
+        if (!cleaned) {
+            throw new IOException(
+                    "Managed local AI clean preserved changed or unknown owned content; no receipt was created.");
+        }
+        return receipt(plan);
+    }
+
+    private static SetupReceipt installProvision(SetupPlan plan, SetupOptions options,
+                                                 Consumer<SetupProgress> progress, ReviewedInstall reviewed)
+            throws IOException {
+        if (options.offline() && reviewed.initial().state() != ManagedLocalAiSnapshot.State.READY) {
             throw new IOException("Managed local AI is not ready and offline setup cannot download artifacts.");
         }
-        ManagedLocalAiSnapshot ready = await(lifecycle.provision(snapshot -> progress.accept(SetupProgress.of(
+        ManagedLocalAiSnapshot ready = await(reviewed.lifecycle().provision(
+                snapshot -> progress.accept(SetupProgress.of(
                 SetupProfile.LOCAL_AI, snapshot.phase().name(), snapshot.completedBytes(),
                 snapshot.totalBytes())), !options.offline()), options);
         if (ready.state() != ManagedLocalAiSnapshot.State.READY) {
             throw new IOException("Managed local AI provisioning completed without a ready installation.");
         }
+        return receipt(plan);
+    }
+
+    private static SetupReceipt receipt(SetupPlan plan) {
         return new SetupReceipt(plan.digest(), Instant.now(), plan.actions());
+    }
+
+    private record ReviewedInstall(SetupOperation operation, Lifecycle lifecycle,
+                                   ManagedLocalAiSnapshot initial,
+                                   ManagedLocalAiActivationHistory.Activation rollbackCandidate) {
     }
 
     private ManagedLocalAiSnapshot inspect(SetupOptions options) {

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProcessTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProcessTest.java
@@ -211,9 +211,9 @@ class ManagedLocalAiProcessTest {
         java.util.concurrent.CountDownLatch sampled = new java.util.concurrent.CountDownLatch(1);
 
         IllegalStateException failure = assertThrows(IllegalStateException.class,
-                () -> ManagedLocalAiProcess.launchManaged(cache, runtime.root().resolve("server"),
+                () -> ManagedLocalAiProcess.launchManaged(launchRequest(cache, runtime.root().resolve("server"),
                         model.root().resolve("model.gguf"), cache.resolve("staging/logs/rss-startup.log"),
-                        "expected", 2, Duration.ofSeconds(1), () -> false,
+                        new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofSeconds(1)),
                         (ignoredProcess, ignoredDescendants) -> {
                             sampled.countDown();
                             throw new IOException("inventory unavailable");
@@ -243,9 +243,9 @@ class ManagedLocalAiProcessTest {
         var releaseSample = new java.util.concurrent.CountDownLatch(1);
         var launch = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
             try {
-                return ManagedLocalAiProcess.launchManaged(cache, runtime.root().resolve("server"),
+                return ManagedLocalAiProcess.launchManaged(launchRequest(cache, runtime.root().resolve("server"),
                         model.root().resolve("model.gguf"), cache.resolve("staging/logs/rss-first-sample.log"),
-                        "expected", 2, Duration.ofSeconds(2), () -> false,
+                        new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofSeconds(2)),
                         (ignoredProcess, ignoredDescendants) -> {
                             sampleEntered.countDown();
                             assertTrue(releaseSample.await(1, TimeUnit.SECONDS));
@@ -282,9 +282,10 @@ class ManagedLocalAiProcessTest {
 
         try {
             assertThrows(IllegalStateException.class,
-                    () -> unexpected.set(ManagedLocalAiProcess.launchManaged(cache, runtime.root().resolve("server"),
-                            model.root().resolve("model.gguf"), cache.resolve("staging/logs/rss-first-timeout.log"),
-                            "expected", 2, Duration.ofMillis(100), () -> false,
+                    () -> unexpected.set(ManagedLocalAiProcess.launchManaged(launchRequest(
+                            cache, runtime.root().resolve("server"), model.root().resolve("model.gguf"),
+                            cache.resolve("staging/logs/rss-first-timeout.log"),
+                            new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofMillis(100)),
                             (ignoredProcess, ignoredDescendants) -> {
                                 neverRelease.await();
                                 return 1;
@@ -334,9 +335,9 @@ class ManagedLocalAiProcessTest {
         var releaseFirst = new java.util.concurrent.CountDownLatch(1);
         var first = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
             try {
-                return ManagedLocalAiProcess.launch(cache, runtime.root().resolve("server"),
+                return ManagedLocalAiProcess.launch(launchRequest(cache, runtime.root().resolve("server"),
                         model.root().resolve("model.gguf"), cache.resolve("staging/logs/first-queued.log"),
-                        "expected", 2, Duration.ofSeconds(1),
+                        new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofSeconds(1)),
                         (command, environment, log) -> {
                             firstStarted.countDown();
                             releaseFirst.await();
@@ -351,9 +352,9 @@ class ManagedLocalAiProcessTest {
                 .execute(releaseFirst::countDown);
 
         assertThrows(ManagedLocalAiProcess.DeadlineExceededException.class,
-                () -> ManagedLocalAiProcess.launch(cache, runtime.root().resolve("server"),
+                () -> ManagedLocalAiProcess.launch(launchRequest(cache, runtime.root().resolve("server"),
                         model.root().resolve("model.gguf"), cache.resolve("staging/logs/second-queued.log"),
-                        "expected", 2, Duration.ofMillis(50),
+                        new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofMillis(50)),
                         (command, environment, log) -> new FakeProcess(null),
                         (process, port, key, alias, timeout) -> { }));
 
@@ -382,9 +383,9 @@ class ManagedLocalAiProcessTest {
         ManagedLocalAiProcess.Session session = null;
 
         try {
-            session = ManagedLocalAiProcess.launch(cache, runtime.root().resolve("server"),
+            session = ManagedLocalAiProcess.launch(launchRequest(cache, runtime.root().resolve("server"),
                     model.root().resolve("model.gguf"), cache.resolve("staging/logs/port-theft.log"),
-                    "expected-alias", 2, Duration.ofSeconds(3),
+                    new ManagedLocalAiProcess.RuntimeSpec("expected-alias", 2), Duration.ofSeconds(3)),
                     (command, environment, log) -> ManagedLocalAiProcess.start(
                             childRuntimeCommand("expected-alias"), environment, log),
                     (process, port, key, alias, timeout) -> ManagedLocalAiProcess.requireIdentity(
@@ -446,8 +447,9 @@ class ManagedLocalAiProcessTest {
         ManagedLocalAiProcess.Session session = null;
 
         try {
-            session = ManagedLocalAiProcess.launch(cache, runtime.root().resolve("server"),
-                    model.root().resolve("model.gguf"), log, "expected-alias", 2, Duration.ofSeconds(3),
+            session = ManagedLocalAiProcess.launch(launchRequest(cache, runtime.root().resolve("server"),
+                    model.root().resolve("model.gguf"), log,
+                    new ManagedLocalAiProcess.RuntimeSpec("expected-alias", 2), Duration.ofSeconds(3)),
                     (command, environment, ignored) -> ManagedLocalAiProcess.start(
                             childRuntimeCommand("expected-alias"), environment, log),
                     (process, port, key, alias, timeout) -> ManagedLocalAiProcess.requireIdentity(
@@ -477,9 +479,10 @@ class ManagedLocalAiProcessTest {
                 () -> ManagedLocalAiCache.adopt(cache, "model-clean-live",
                         readyStage(cache, "model-clean-live", "model.gguf", "weights")));
         FakeProcess process = new FakeProcess(null, "srv  llama_server: listening on http://127.0.0.1:19191\n");
-        ManagedLocalAiProcess.Session session = ManagedLocalAiProcess.launch(cache,
+        ManagedLocalAiProcess.Session session = ManagedLocalAiProcess.launch(launchRequest(cache,
                 runtime.root().resolve("server"), model.root().resolve("model.gguf"),
-                cache.resolve("staging/logs/clean-live.log"), "expected", 2, Duration.ofSeconds(1),
+                cache.resolve("staging/logs/clean-live.log"),
+                new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofSeconds(1)),
                 (command, environment, log) -> process,
                 (started, port, key, alias, timeout) -> { });
         ManagedLocalAiService service = new ManagedLocalAiService(
@@ -525,9 +528,10 @@ class ManagedLocalAiProcessTest {
         FakeProcess process = new FakeProcess(null, "srv  llama_server: listening on http://127.0.0.1:19191\n");
         var launch = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
             try {
-                return ManagedLocalAiProcess.launch(cache, runtime.root().resolve("server"),
+                return ManagedLocalAiProcess.launch(launchRequest(cache, runtime.root().resolve("server"),
                         model.root().resolve("model.gguf"), cache.resolve("staging/logs/clean-race.log"),
-                        "expected", 2, Duration.ofSeconds(3), (command, environment, log) -> {
+                        new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofSeconds(3)),
+                        (command, environment, log) -> {
                             startEntered.countDown();
                             releaseStart.await();
                             return process;
@@ -585,9 +589,10 @@ class ManagedLocalAiProcessTest {
                         readyStage(cache, "model-missing-port", "model.gguf", "weights")));
         AtomicBoolean identityCalled = new AtomicBoolean();
 
-        assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(cache,
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(launchRequest(cache,
                 runtime.root().resolve("server"), model.root().resolve("model.gguf"),
-                cache.resolve("staging/logs/missing-port.log"), "expected", 2, Duration.ofMillis(300),
+                cache.resolve("staging/logs/missing-port.log"),
+                new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofMillis(300)),
                 (command, environment, log) -> new FakeProcess(null),
                 (process, port, key, alias, timeout) -> {
                     identityCalled.set(true);
@@ -607,9 +612,10 @@ class ManagedLocalAiProcessTest {
                 () -> ManagedLocalAiCache.adopt(cache, "model-oversized-port",
                         readyStage(cache, "model-oversized-port", "model.gguf", "weights")));
 
-        IllegalStateException failure = assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(
-                cache, runtime.root().resolve("server"), model.root().resolve("model.gguf"),
-                cache.resolve("staging/logs/oversized-port.log"), "expected", 2, Duration.ofMillis(300),
+        IllegalStateException failure = assertThrows(IllegalStateException.class,
+                () -> ManagedLocalAiProcess.launch(launchRequest(cache, runtime.root().resolve("server"),
+                model.root().resolve("model.gguf"), cache.resolve("staging/logs/oversized-port.log"),
+                new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofMillis(300)),
                 (command, environment, log) -> new FakeProcess(null,
                         "srv  llama_server: listening on http://127.0.0.1:999999999999999999999999\n"),
                 (process, port, key, alias, timeout) -> { }));
@@ -628,9 +634,10 @@ class ManagedLocalAiProcessTest {
                         readyStage(cache, "model-negated-port", "model.gguf", "weights")));
         AtomicBoolean identityCalled = new AtomicBoolean();
 
-        assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(cache,
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(launchRequest(cache,
                 runtime.root().resolve("server"), model.root().resolve("model.gguf"),
-                cache.resolve("staging/logs/negated-port.log"), "expected", 2, Duration.ofMillis(300),
+                cache.resolve("staging/logs/negated-port.log"),
+                new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofMillis(300)),
                 (command, environment, log) -> new FakeProcess(null,
                         "server: not listening on http://127.0.0.1:19191\n"
                                 + "warning: foreign process: listening on http://127.0.0.1:19192\n"
@@ -652,9 +659,10 @@ class ManagedLocalAiProcessTest {
         ManagedLocalAiCache.Installation model = ManagedLocalAiCache.withLock(cache, Duration.ofSeconds(1),
                 () -> ManagedLocalAiCache.adopt(cache, "model-thread-identity",
                         readyStage(cache, "model-thread-identity", "model.gguf", "weights")));
-        ManagedLocalAiProcess.Session session = ManagedLocalAiProcess.launch(cache,
+        ManagedLocalAiProcess.Session session = ManagedLocalAiProcess.launch(launchRequest(cache,
                 runtime.root().resolve("server"), model.root().resolve("model.gguf"),
-                cache.resolve("staging/logs/thread-identity.log"), "expected", 2, Duration.ofSeconds(1),
+                cache.resolve("staging/logs/thread-identity.log"),
+                new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofSeconds(1)),
                 (command, environment, log) -> new FakeProcess(null,
                         "srv  llama_server: listening on http://127.0.0.1:19191\n"),
                 (process, port, key, alias, timeout) -> { });
@@ -684,9 +692,9 @@ class ManagedLocalAiProcessTest {
         FakeProcess process = new FakeProcess(null, "srv  llama_server: listening on http://127.0.0.1:19191\n");
         var launch = java.util.concurrent.CompletableFuture.runAsync(() -> {
             try {
-                ManagedLocalAiProcess.launch(cache, runtime.root().resolve("server"),
+                ManagedLocalAiProcess.launch(launchRequest(cache, runtime.root().resolve("server"),
                         model.root().resolve("model.gguf"), cache.resolve("staging/logs/start-publication.log"),
-                        "expected", 2, Duration.ofSeconds(3), cancelled::get,
+                        new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofSeconds(3), cancelled::get),
                         (command, environment, log) -> {
                             startEntered.countDown();
                             boolean released = false;
@@ -732,9 +740,9 @@ class ManagedLocalAiProcessTest {
         FakeProcess process = new FakeProcess(null, "srv  llama_server: listening on http://127.0.0.1:19191\n");
         var launch = java.util.concurrent.CompletableFuture.runAsync(() -> {
             try {
-                ManagedLocalAiProcess.launch(cache, runtime.root().resolve("server"),
+                ManagedLocalAiProcess.launch(launchRequest(cache, runtime.root().resolve("server"),
                         model.root().resolve("model.gguf"), cache.resolve("staging/logs/bounded-start.log"),
-                        "expected", 2, Duration.ofSeconds(5), cancelled::get,
+                        new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofSeconds(5), cancelled::get),
                         (command, environment, log) -> {
                             startEntered.countDown();
                             while (true) {
@@ -791,10 +799,11 @@ class ManagedLocalAiProcessTest {
         List<SurvivingTreeProcess> processes = new java.util.concurrent.CopyOnWriteArrayList<>();
 
         try {
-            assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(cache,
+            assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(launchRequest(cache,
                     runtime.root().resolve("server"), model.root().resolve("model.gguf"),
-                    cache.resolve("staging/logs/startup-survivor.log"), "expected", 2,
-                    Duration.ofMillis(300), (command, environment, log) -> {
+                    cache.resolve("staging/logs/startup-survivor.log"),
+                    new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofMillis(300)),
+                    (command, environment, log) -> {
                         starts.incrementAndGet();
                         SurvivingTreeProcess process = new SurvivingTreeProcess("x".repeat(4_097));
                         processes.add(process);
@@ -854,9 +863,9 @@ class ManagedLocalAiProcessTest {
         Path executable = runtime.root().resolve("server");
         Path model = modelInstall.root().resolve("model.gguf");
         Path logPath = cache.resolve("staging/logs/server.log");
-        ManagedLocalAiProcess.Session session = ManagedLocalAiProcess.launch(
-                cache, executable, model, logPath, "expected-alias",
-                2, Duration.ofSeconds(1),
+        ManagedLocalAiProcess.Session session = ManagedLocalAiProcess.launch(launchRequest(
+                cache, executable, model, logPath,
+                new ManagedLocalAiProcess.RuntimeSpec("expected-alias", 2), Duration.ofSeconds(1)),
                 (command, environment, log) -> starts.getAndIncrement() == 0 ? stolen : owned,
                 (process, port, key, alias, timeout) -> {
                     if (port == 18181) {
@@ -886,9 +895,10 @@ class ManagedLocalAiProcessTest {
                         readyStage(cache, "model-deadline", "model.gguf", "weights")));
         long started = System.nanoTime();
 
-        assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(cache,
+        assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(launchRequest(cache,
                 runtime.root().resolve("server"), model.root().resolve("model.gguf"),
-                cache.resolve("staging/logs/deadline.log"), "expected-alias", 2, Duration.ofMillis(100),
+                cache.resolve("staging/logs/deadline.log"),
+                new ManagedLocalAiProcess.RuntimeSpec("expected-alias", 2), Duration.ofMillis(100)),
                 (command, environment, log) -> {
                     starts.incrementAndGet();
                     return new FakeProcess(null, "srv  llama_server: listening on http://127.0.0.1:18181\n");
@@ -916,9 +926,10 @@ class ManagedLocalAiProcessTest {
                         readyStage(cache, "model-survivor", "model.gguf", "weights")));
 
         try {
-            assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(cache,
+            assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(launchRequest(cache,
                     runtime.root().resolve("server"), model.root().resolve("model.gguf"),
-                    cache.resolve("staging/logs/survivor.log"), "expected", 2, Duration.ofMillis(300),
+                    cache.resolve("staging/logs/survivor.log"),
+                    new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofMillis(300)),
                     (command, environment, log) -> {
                         starts.incrementAndGet();
                         SurvivingTreeProcess process = new SurvivingTreeProcess(
@@ -932,10 +943,10 @@ class ManagedLocalAiProcessTest {
                     "a new launch must not start while an earlier process tree still survives cleanup");
             assertTrue(waitForForceKillRetry(processes.getFirst().descendant, Duration.ofMillis(300)),
                     "failed-launch survivors must retain an active cleanup owner");
-            assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(cache,
+            assertThrows(IllegalStateException.class, () -> ManagedLocalAiProcess.launch(launchRequest(cache,
                     runtime.root().resolve("server"), model.root().resolve("model.gguf"),
-                    cache.resolve("staging/logs/blocked-by-survivor.log"), "expected", 2,
-                    Duration.ofMillis(100),
+                    cache.resolve("staging/logs/blocked-by-survivor.log"),
+                    new ManagedLocalAiProcess.RuntimeSpec("expected", 2), Duration.ofMillis(100)),
                     (command, environment, log) -> {
                         starts.incrementAndGet();
                         return new SurvivingTreeProcess();
@@ -1291,6 +1302,20 @@ class ManagedLocalAiProcessTest {
         Files.writeString(stage.resolve(fileName), content);
         Files.writeString(stage.resolve(".shaft-ready"), "");
         return stage;
+    }
+
+    private static ManagedLocalAiProcess.LaunchRequest launchRequest(
+            Path cache, Path executable, Path model, Path log,
+            ManagedLocalAiProcess.RuntimeSpec runtime, Duration timeout) {
+        return launchRequest(cache, executable, model, log, runtime, timeout, () -> false);
+    }
+
+    private static ManagedLocalAiProcess.LaunchRequest launchRequest(
+            Path cache, Path executable, Path model, Path log,
+            ManagedLocalAiProcess.RuntimeSpec runtime, Duration timeout,
+            java.util.function.BooleanSupplier cancelled) {
+        var files = new ManagedLocalAiProcess.RuntimeFiles(cache, executable, model, log);
+        return new ManagedLocalAiProcess.LaunchRequest(files, runtime, timeout, cancelled);
     }
 
     private Path sleepingProcessJar() throws Exception {

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProcessTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProcessTest.java
@@ -49,6 +49,16 @@ class ManagedLocalAiProcessTest {
     }
 
     @Test
+    void supervisorRejectsMalformedParentIdentityBeforeLaunching() {
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> ManagedLocalAiProcessSupervisor.main(new String[]{
+                        "not-a-pid", java.time.Instant.EPOCH.toString(), temp.toAbsolutePath().toString(),
+                        temp.resolve("must-not-start").toString()}));
+
+        assertTrue(failure.getMessage().contains("parent PID"));
+    }
+
+    @Test
     void supervisorTerminatesPublishedChildWhenItsParentExits() throws Exception {
         Path helper = sleepingProcessJar();
         Path parentMarker = temp.resolve("parent.pid");

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProviderTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProviderTest.java
@@ -578,7 +578,7 @@ class ManagedLocalAiProviderTest {
         AiResponse response = active.get(2, java.util.concurrent.TimeUnit.SECONDS);
 
         assertEquals(com.shaft.pilot.ai.AiResponseStatus.PROVIDER_UNAVAILABLE, response.status());
-        assertFalse(java.nio.file.Files.exists(cache.resolve("staging/logs")),
+        assertFalse(Files.exists(cache.resolve("staging/logs")),
                 "an execution released after shutdown must not begin a process launch");
     }
 
@@ -638,9 +638,9 @@ class ManagedLocalAiProviderTest {
 
     private Path readyStage(Path cache, String prefix, String fileName, String content) throws Exception {
         Path stage = cache.resolve("staging/" + prefix + ".extract-test");
-        java.nio.file.Files.createDirectories(stage);
-        java.nio.file.Files.writeString(stage.resolve(fileName), content);
-        java.nio.file.Files.writeString(stage.resolve(".shaft-ready"), "");
+        Files.createDirectories(stage);
+        Files.writeString(stage.resolve(fileName), content);
+        Files.writeString(stage.resolve(".shaft-ready"), "");
         return stage;
     }
 

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProviderTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiProviderTest.java
@@ -85,27 +85,18 @@ class ManagedLocalAiProviderTest {
     }
 
     @Test
-    void productionLifecycleIsExecutable() throws Exception {
-        Class<?> lifecycleType = java.util.Arrays.stream(ManagedLocalAiProvider.class.getDeclaredClasses())
-                .filter(type -> type.getSimpleName().equals("ServiceLifecycle"))
-                .findFirst().orElseThrow();
-        var constructor = lifecycleType.getDeclaredConstructor(ManagedLocalAiService.class);
-        constructor.setAccessible(true);
-        Object lifecycle = constructor.newInstance(new ManagedLocalAiService());
-        var executable = lifecycleType.getDeclaredMethod("executable");
-        executable.setAccessible(true);
+    void productionLifecycleIsExecutable() {
+        var lifecycle = new ManagedLocalAiProvider.ServiceLifecycle(new ManagedLocalAiService());
 
-        assertTrue((boolean) executable.invoke(lifecycle));
+        assertTrue(lifecycle.executable());
     }
 
     @Test
-    void serviceLoadedProvidersShareOneProcessLifecycleOwner() throws Exception {
+    void serviceLoadedProvidersShareOneProcessLifecycleOwner() {
         ManagedLocalAiProvider first = new ManagedLocalAiProvider();
         ManagedLocalAiProvider second = new ManagedLocalAiProvider();
-        var lifecycle = ManagedLocalAiProvider.class.getDeclaredField("lifecycle");
-        lifecycle.setAccessible(true);
 
-        assertSame(lifecycle.get(first), lifecycle.get(second));
+        assertSame(first.lifecycle, second.lifecycle);
     }
 
     @Test
@@ -133,14 +124,12 @@ class ManagedLocalAiProviderTest {
         ManagedLocalAiService service = new ManagedLocalAiService(
                 () -> new ManagedLocalAiService.Settings(true, true, "test-model", temp.toString()),
                 host(), () -> manifest, provisioning);
-        Object lifecycle = serviceLifecycle(service);
-        var execute = lifecycle.getClass().getDeclaredMethod("execute", AiRequest.class);
-        execute.setAccessible(true);
+        var lifecycle = serviceLifecycle(service);
         AiRequest request = AiRequest.builder("provision-timeout", JsonNodeFactory.instance.objectNode())
                 .timeout(Duration.ofMillis(50)).build();
 
         try {
-            AiResponse response = (AiResponse) execute.invoke(lifecycle, request);
+            AiResponse response = lifecycle.execute(request);
             assertTrue(started.await(1, java.util.concurrent.TimeUnit.SECONDS));
             assertEquals(com.shaft.pilot.ai.AiResponseStatus.TIMEOUT, response.status());
             assertTrue(waitUntil(cancellationObserved, Duration.ofSeconds(1)),
@@ -174,15 +163,13 @@ class ManagedLocalAiProviderTest {
                     }
                     throw new InterruptedException("provisioning stopped");
                 });
-        Object lifecycle = serviceLifecycle(service);
-        var execute = lifecycle.getClass().getDeclaredMethod("execute", AiRequest.class);
-        execute.setAccessible(true);
+        var lifecycle = serviceLifecycle(service);
         AiRequest request = AiRequest.builder("preflight-timeout", JsonNodeFactory.instance.objectNode())
                 .timeout(Duration.ofMillis(200)).build();
         long started = System.nanoTime();
 
         try {
-            AiResponse response = (AiResponse) execute.invoke(lifecycle, request);
+            AiResponse response = lifecycle.execute(request);
             assertEquals(com.shaft.pilot.ai.AiResponseStatus.TIMEOUT, response.status());
             assertTrue(Duration.ofNanos(System.nanoTime() - started).toMillis() < 450,
                     "expired synchronous preflight must not be followed by a stale full wait");
@@ -206,16 +193,14 @@ class ManagedLocalAiProviderTest {
                     }
                     throw new InterruptedException("provisioning stopped");
                 });
-        Object lifecycle = serviceLifecycle(service);
-        var execute = lifecycle.getClass().getDeclaredMethod("execute", AiRequest.class);
-        execute.setAccessible(true);
+        var lifecycle = serviceLifecycle(service);
         AiRequest longRequest = AiRequest.builder("long", JsonNodeFactory.instance.objectNode())
                 .timeout(Duration.ofSeconds(1)).build();
         AiRequest shortRequest = AiRequest.builder("short", JsonNodeFactory.instance.objectNode())
                 .timeout(Duration.ofMillis(50)).build();
-        var first = java.util.concurrent.CompletableFuture.supplyAsync(() -> invoke(execute, lifecycle, longRequest));
+        var first = java.util.concurrent.CompletableFuture.supplyAsync(() -> invoke(lifecycle, longRequest));
         assertTrue(provisioningStarted.await(1, java.util.concurrent.TimeUnit.SECONDS));
-        var second = java.util.concurrent.CompletableFuture.supplyAsync(() -> invoke(execute, lifecycle, shortRequest));
+        var second = java.util.concurrent.CompletableFuture.supplyAsync(() -> invoke(lifecycle, shortRequest));
 
         try {
             Thread.sleep(150);
@@ -232,18 +217,14 @@ class ManagedLocalAiProviderTest {
     void failureCleanupUsesCurrentRequestBudgetInsteadOfPriorSessionBudget() throws Exception {
         ManagedLocalAiService service = new ManagedLocalAiService(
                 () -> { throw new IllegalStateException("inspection failed"); }, host());
-        Object lifecycle = serviceLifecycle(service);
-        var session = lifecycle.getClass().getDeclaredField("session");
-        session.setAccessible(true);
-        session.set(lifecycle, new ManagedLocalAiProcess.Session(
-                new SlowProcess(), 18181, "prior", "key", Duration.ofMillis(300)));
-        var execute = lifecycle.getClass().getDeclaredMethod("execute", AiRequest.class);
-        execute.setAccessible(true);
+        var lifecycle = serviceLifecycle(service);
+        lifecycle.session = new ManagedLocalAiProcess.Session(
+                new SlowProcess(), 18181, "prior", "key", Duration.ofMillis(300));
         AiRequest request = AiRequest.builder("short-cleanup", JsonNodeFactory.instance.objectNode())
                 .timeout(Duration.ofMillis(50)).build();
         long started = System.nanoTime();
 
-        AiResponse response = (AiResponse) execute.invoke(lifecycle, request);
+        AiResponse response = lifecycle.execute(request);
 
         assertEquals(com.shaft.pilot.ai.AiResponseStatus.PROVIDER_UNAVAILABLE, response.status());
         assertTrue(Duration.ofNanos(System.nanoTime() - started).toMillis() < 180,
@@ -258,13 +239,11 @@ class ManagedLocalAiProviderTest {
                     inspections.incrementAndGet();
                     return new ManagedLocalAiService.Settings(false, false, "auto", temp.toString());
                 }, host());
-        Object lifecycle = serviceLifecycle(service);
+        var lifecycle = serviceLifecycle(service);
         CloseAwareProcess process = new CloseAwareProcess();
-        var session = lifecycle.getClass().getDeclaredField("session");
-        session.setAccessible(true);
-        session.set(lifecycle, new ManagedLocalAiProcess.Session(
-                process, 18181, "prior", "key", Duration.ofMillis(100)));
-        ManagedLocalAiProvider provider = new ManagedLocalAiProvider((ManagedLocalAiProvider.Lifecycle) lifecycle);
+        lifecycle.session = new ManagedLocalAiProcess.Session(
+                process, 18181, "prior", "key", Duration.ofMillis(100));
+        ManagedLocalAiProvider provider = new ManagedLocalAiProvider(lifecycle);
 
         AiProviderAvailability availability = provider.availability();
 
@@ -277,13 +256,11 @@ class ManagedLocalAiProviderTest {
     void availabilityInspectionFailureRetiresAnIdleSession() throws Exception {
         ManagedLocalAiService service = new ManagedLocalAiService(
                 () -> { throw new IllegalStateException("settings unavailable"); }, host());
-        Object lifecycle = serviceLifecycle(service);
+        var lifecycle = serviceLifecycle(service);
         CloseAwareProcess process = new CloseAwareProcess();
-        var session = lifecycle.getClass().getDeclaredField("session");
-        session.setAccessible(true);
-        session.set(lifecycle, new ManagedLocalAiProcess.Session(
-                process, 18181, "prior", "key", Duration.ofMillis(100)));
-        ManagedLocalAiProvider provider = new ManagedLocalAiProvider((ManagedLocalAiProvider.Lifecycle) lifecycle);
+        lifecycle.session = new ManagedLocalAiProcess.Session(
+                process, 18181, "prior", "key", Duration.ofMillis(100));
+        ManagedLocalAiProvider provider = new ManagedLocalAiProvider(lifecycle);
 
         AiProviderAvailability availability = provider.availability();
 
@@ -295,15 +272,11 @@ class ManagedLocalAiProviderTest {
     void anotherThreadsUnavailableConfigurationDoesNotKillAnActiveRequest() throws Exception {
         ManagedLocalAiService service = new ManagedLocalAiService(
                 () -> new ManagedLocalAiService.Settings(false, false, "auto", temp.toString()), host());
-        Object lifecycle = serviceLifecycle(service);
+        var lifecycle = serviceLifecycle(service);
         CloseAwareProcess process = new CloseAwareProcess();
-        var session = lifecycle.getClass().getDeclaredField("session");
-        session.setAccessible(true);
-        session.set(lifecycle, new ManagedLocalAiProcess.Session(
-                process, 18181, "prior", "key", Duration.ofMillis(100)));
-        var lockField = lifecycle.getClass().getDeclaredField("executionLock");
-        lockField.setAccessible(true);
-        var lock = (java.util.concurrent.locks.ReentrantLock) lockField.get(lifecycle);
+        lifecycle.session = new ManagedLocalAiProcess.Session(
+                process, 18181, "prior", "key", Duration.ofMillis(100));
+        var lock = lifecycle.executionLock;
         var lockHeld = new java.util.concurrent.CountDownLatch(1);
         var release = new java.util.concurrent.CountDownLatch(1);
         var active = java.util.concurrent.CompletableFuture.runAsync(() -> {
@@ -318,7 +291,7 @@ class ManagedLocalAiProviderTest {
             }
         });
         assertTrue(lockHeld.await(1, java.util.concurrent.TimeUnit.SECONDS));
-        ManagedLocalAiProvider provider = new ManagedLocalAiProvider((ManagedLocalAiProvider.Lifecycle) lifecycle);
+        ManagedLocalAiProvider provider = new ManagedLocalAiProvider(lifecycle);
 
         try {
             assertFalse(provider.availability().available());
@@ -351,13 +324,11 @@ class ManagedLocalAiProviderTest {
                                          ignoredHost, cancelled, progress) -> {
                     throw new AssertionError("ready cache must not provision");
                 });
-        Object lifecycle = serviceLifecycle(service);
+        var lifecycle = serviceLifecycle(service);
         CloseAwareProcess process = new CloseAwareProcess();
-        var session = lifecycle.getClass().getDeclaredField("session");
-        session.setAccessible(true);
-        session.set(lifecycle, new ManagedLocalAiProcess.Session(
-                process, 18181, "test-model", "key", Duration.ofMillis(100)));
-        ManagedLocalAiProvider provider = new ManagedLocalAiProvider((ManagedLocalAiProvider.Lifecycle) lifecycle);
+        lifecycle.session = new ManagedLocalAiProcess.Session(
+                process, 18181, "test-model", "key", Duration.ofMillis(100));
+        ManagedLocalAiProvider provider = new ManagedLocalAiProvider(lifecycle);
 
         provider.execute(AiRequest.builder("changed-runtime", JsonNodeFactory.instance.objectNode())
                 .timeout(Duration.ofSeconds(3)).build());
@@ -416,8 +387,7 @@ class ManagedLocalAiProviderTest {
                 return expected;
             }
         };
-        ManagedLocalAiProvider provider = new ManagedLocalAiProvider(
-                (ManagedLocalAiProvider.Lifecycle) serviceLifecycle(service, runtime));
+        ManagedLocalAiProvider provider = new ManagedLocalAiProvider(serviceLifecycle(service, runtime));
 
         AiResponse actual = provider.execute(request);
         ManagedLocalAiSnapshot after = service.inspect();
@@ -449,13 +419,11 @@ class ManagedLocalAiProviderTest {
                     while (!cancelled.getAsBoolean()) Thread.sleep(5);
                     throw new InterruptedException("cancelled");
                 });
-        Object lifecycle = serviceLifecycle(service);
+        var lifecycle = serviceLifecycle(service);
         AsyncForceProcess process = new AsyncForceProcess();
-        var session = lifecycle.getClass().getDeclaredField("session");
-        session.setAccessible(true);
-        session.set(lifecycle, new ManagedLocalAiProcess.Session(
-                process, 18181, "prior", "key", Duration.ofMillis(300)));
-        ManagedLocalAiProvider provider = new ManagedLocalAiProvider((ManagedLocalAiProvider.Lifecycle) lifecycle);
+        lifecycle.session = new ManagedLocalAiProcess.Session(
+                process, 18181, "prior", "key", Duration.ofMillis(300));
+        ManagedLocalAiProvider provider = new ManagedLocalAiProvider(lifecycle);
         AiRequest request = AiRequest.builder("expired-cleanup", JsonNodeFactory.instance.objectNode())
                 .timeout(Duration.ofMillis(30)).build();
 
@@ -463,7 +431,7 @@ class ManagedLocalAiProviderTest {
 
         assertEquals(com.shaft.pilot.ai.AiResponseStatus.TIMEOUT, response.status());
         assertTrue(process.forceKillRequested);
-        assertSame(process, ((ManagedLocalAiProcess.Session) session.get(lifecycle)).process(),
+        assertSame(process, lifecycle.session.process(),
                 "a still-live process must retain a lifecycle owner");
     }
 
@@ -479,22 +447,12 @@ class ManagedLocalAiProviderTest {
                     while (!release.get() && !cancelled.getAsBoolean()) Thread.sleep(5);
                     throw new InterruptedException("stopped");
                 });
-        Object lifecycle = serviceLifecycle(service);
-        var execute = lifecycle.getClass().getDeclaredMethod("execute", AiRequest.class);
-        execute.setAccessible(true);
-        var close = lifecycle.getClass().getDeclaredMethod("closeSession");
-        close.setAccessible(true);
-        var active = java.util.concurrent.CompletableFuture.supplyAsync(() -> invoke(execute, lifecycle,
+        var lifecycle = serviceLifecycle(service);
+        var active = java.util.concurrent.CompletableFuture.supplyAsync(() -> invoke(lifecycle,
                 AiRequest.builder("active", JsonNodeFactory.instance.objectNode())
                         .timeout(Duration.ofSeconds(1)).build()));
         assertTrue(provisioningStarted.await(1, java.util.concurrent.TimeUnit.SECONDS));
-        var shutdown = java.util.concurrent.CompletableFuture.runAsync(() -> {
-            try {
-                close.invoke(lifecycle);
-            } catch (ReflectiveOperationException failure) {
-                throw new java.util.concurrent.CompletionException(failure);
-            }
-        });
+        var shutdown = java.util.concurrent.CompletableFuture.runAsync(lifecycle::shutdown);
 
         try {
             Thread.sleep(200);
@@ -508,26 +466,14 @@ class ManagedLocalAiProviderTest {
 
     @Test
     void shutdownLockTimeoutStillForceKillsExistingSession() throws Exception {
-        Object lifecycle = serviceLifecycle(new ManagedLocalAiService(
+        var lifecycle = serviceLifecycle(new ManagedLocalAiService(
                 () -> { throw new IllegalStateException("unused"); }, host()));
         DelayedExitProcess process = new DelayedExitProcess();
-        var session = lifecycle.getClass().getDeclaredField("session");
-        session.setAccessible(true);
-        session.set(lifecycle, new ManagedLocalAiProcess.Session(
-                process, 18181, "prior", "key", Duration.ofMillis(300)));
-        var lockField = lifecycle.getClass().getDeclaredField("executionLock");
-        lockField.setAccessible(true);
-        var lock = (java.util.concurrent.locks.ReentrantLock) lockField.get(lifecycle);
-        var close = lifecycle.getClass().getDeclaredMethod("closeSession");
-        close.setAccessible(true);
+        lifecycle.session = new ManagedLocalAiProcess.Session(
+                process, 18181, "prior", "key", Duration.ofMillis(300));
+        var lock = lifecycle.executionLock;
         lock.lock();
-        var shutdown = java.util.concurrent.CompletableFuture.runAsync(() -> {
-            try {
-                close.invoke(lifecycle);
-            } catch (ReflectiveOperationException failure) {
-                throw new java.util.concurrent.CompletionException(failure);
-            }
-        });
+        var shutdown = java.util.concurrent.CompletableFuture.runAsync(lifecycle::shutdown);
 
         try {
             shutdown.get(3, java.util.concurrent.TimeUnit.SECONDS);
@@ -543,30 +489,18 @@ class ManagedLocalAiProviderTest {
 
     @Test
     void shutdownFallbackDoesNotWaitForConcurrentSessionCleanup() throws Exception {
-        Object lifecycle = serviceLifecycle(new ManagedLocalAiService(
+        var lifecycle = serviceLifecycle(new ManagedLocalAiService(
                 () -> { throw new IllegalStateException("unused"); }, host()));
         BlockingCloseProcess process = new BlockingCloseProcess();
         ManagedLocalAiProcess.Session owned = new ManagedLocalAiProcess.Session(
                 process, 18181, "prior", "key", Duration.ofSeconds(5));
-        var session = lifecycle.getClass().getDeclaredField("session");
-        session.setAccessible(true);
-        session.set(lifecycle, owned);
-        var lockField = lifecycle.getClass().getDeclaredField("executionLock");
-        lockField.setAccessible(true);
-        var lock = (java.util.concurrent.locks.ReentrantLock) lockField.get(lifecycle);
-        var close = lifecycle.getClass().getDeclaredMethod("closeSession");
-        close.setAccessible(true);
+        lifecycle.session = owned;
+        var lock = lifecycle.executionLock;
         var requestCleanup = java.util.concurrent.CompletableFuture.runAsync(() ->
                 owned.close(Duration.ofSeconds(5), new IllegalStateException("request cleanup")));
         assertTrue(process.destroyEntered.await(1, java.util.concurrent.TimeUnit.SECONDS));
         lock.lock();
-        var shutdown = java.util.concurrent.CompletableFuture.runAsync(() -> {
-            try {
-                close.invoke(lifecycle);
-            } catch (ReflectiveOperationException failure) {
-                throw new java.util.concurrent.CompletionException(failure);
-            }
-        });
+        var shutdown = java.util.concurrent.CompletableFuture.runAsync(lifecycle::shutdown);
 
         try {
             Thread.sleep(2_500);
@@ -589,11 +523,9 @@ class ManagedLocalAiProviderTest {
             inspections.incrementAndGet();
             return new ManagedLocalAiService.Settings(false, false, "auto", temp.toString());
         }, host());
-        Object lifecycle = serviceLifecycle(service);
-        var close = lifecycle.getClass().getDeclaredMethod("closeSession");
-        close.setAccessible(true);
-        close.invoke(lifecycle);
-        ManagedLocalAiProvider provider = new ManagedLocalAiProvider((ManagedLocalAiProvider.Lifecycle) lifecycle);
+        var lifecycle = serviceLifecycle(service);
+        lifecycle.shutdown();
+        ManagedLocalAiProvider provider = new ManagedLocalAiProvider(lifecycle);
 
         provider.execute(AiRequest.builder("after-shutdown", JsonNodeFactory.instance.objectNode()).build());
 
@@ -634,23 +566,13 @@ class ManagedLocalAiProviderTest {
                                      ignoredHost, cancelled, progress) -> {
             throw new AssertionError("ready cache must not provision");
         });
-        Object lifecycle = serviceLifecycle(service);
-        var execute = lifecycle.getClass().getDeclaredMethod("execute", AiRequest.class);
-        execute.setAccessible(true);
-        var close = lifecycle.getClass().getDeclaredMethod("closeSession");
-        close.setAccessible(true);
-        var active = java.util.concurrent.CompletableFuture.supplyAsync(() -> invoke(execute, lifecycle,
+        var lifecycle = serviceLifecycle(service);
+        var active = java.util.concurrent.CompletableFuture.supplyAsync(() -> invoke(lifecycle,
                 AiRequest.builder("shutdown-race", JsonNodeFactory.instance.objectNode())
                         .timeout(Duration.ofSeconds(10)).build()));
         assertTrue(inspectionStarted.await(1, java.util.concurrent.TimeUnit.SECONDS));
 
-        var shutdown = java.util.concurrent.CompletableFuture.runAsync(() -> {
-            try {
-                close.invoke(lifecycle);
-            } catch (ReflectiveOperationException failure) {
-                throw new java.util.concurrent.CompletionException(failure);
-            }
-        });
+        var shutdown = java.util.concurrent.CompletableFuture.runAsync(lifecycle::shutdown);
         shutdown.get(3, java.util.concurrent.TimeUnit.SECONDS);
         releaseInspection.countDown();
         AiResponse response = active.get(2, java.util.concurrent.TimeUnit.SECONDS);
@@ -664,48 +586,30 @@ class ManagedLocalAiProviderTest {
     void exitedParentWithLiveDescendantRetainsLifecycleOwnership() throws Exception {
         ManagedLocalAiService service = new ManagedLocalAiService(
                 () -> { throw new IllegalStateException("inspection failed"); }, host());
-        Object lifecycle = serviceLifecycle(service);
+        var lifecycle = serviceLifecycle(service);
         ParentExitProcess process = new ParentExitProcess();
-        var session = lifecycle.getClass().getDeclaredField("session");
-        session.setAccessible(true);
-        session.set(lifecycle, new ManagedLocalAiProcess.Session(
-                process, 18181, "prior", "key", Duration.ZERO));
+        lifecycle.session = new ManagedLocalAiProcess.Session(process, 18181, "prior", "key", Duration.ZERO);
         process.alive = false;
-        ManagedLocalAiProvider provider = new ManagedLocalAiProvider((ManagedLocalAiProvider.Lifecycle) lifecycle);
+        ManagedLocalAiProvider provider = new ManagedLocalAiProvider(lifecycle);
 
         provider.execute(AiRequest.builder("descendant-cleanup", JsonNodeFactory.instance.objectNode()).build());
 
         assertTrue(process.descendant.forceKillRequested);
-        assertTrue(session.get(lifecycle) != null,
+        assertTrue(lifecycle.session != null,
                 "a surviving descendant must keep the session under lifecycle ownership");
     }
 
-    private AiResponse invoke(java.lang.reflect.Method execute, Object lifecycle, AiRequest request) {
-        try {
-            return (AiResponse) execute.invoke(lifecycle, request);
-        } catch (ReflectiveOperationException failure) {
-            throw new java.util.concurrent.CompletionException(failure);
-        }
+    private AiResponse invoke(ManagedLocalAiProvider.ServiceLifecycle lifecycle, AiRequest request) {
+        return lifecycle.execute(request);
     }
 
-    private Object serviceLifecycle(ManagedLocalAiService service) throws Exception {
-        Class<?> lifecycleType = java.util.Arrays.stream(ManagedLocalAiProvider.class.getDeclaredClasses())
-                .filter(type -> type.getSimpleName().equals("ServiceLifecycle"))
-                .findFirst().orElseThrow();
-        var constructor = lifecycleType.getDeclaredConstructor(ManagedLocalAiService.class);
-        constructor.setAccessible(true);
-        return constructor.newInstance(service);
+    private ManagedLocalAiProvider.ServiceLifecycle serviceLifecycle(ManagedLocalAiService service) {
+        return new ManagedLocalAiProvider.ServiceLifecycle(service);
     }
 
-    private Object serviceLifecycle(ManagedLocalAiService service, ManagedLocalAiProvider.RuntimeClient runtime)
-            throws Exception {
-        Class<?> lifecycleType = java.util.Arrays.stream(ManagedLocalAiProvider.class.getDeclaredClasses())
-                .filter(type -> type.getSimpleName().equals("ServiceLifecycle"))
-                .findFirst().orElseThrow();
-        var constructor = lifecycleType.getDeclaredConstructor(
-                ManagedLocalAiService.class, ManagedLocalAiProvider.RuntimeClient.class);
-        constructor.setAccessible(true);
-        return constructor.newInstance(service, runtime);
+    private ManagedLocalAiProvider.ServiceLifecycle serviceLifecycle(ManagedLocalAiService service,
+                                                                      ManagedLocalAiProvider.RuntimeClient runtime) {
+        return new ManagedLocalAiProvider.ServiceLifecycle(service, runtime);
     }
 
     private boolean waitUntil(AtomicBoolean value, Duration timeout) throws InterruptedException {

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiSetupProviderTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiSetupProviderTest.java
@@ -316,7 +316,7 @@ class ManagedLocalAiSetupProviderTest {
     @Test
     void planAndStatusRejectACacheRootDifferentFromInference(@TempDir Path temp) {
         SetupOptions options = options(temp);
-        ManagedLocalAiSnapshot elsewhere = snapshot(options, ManagedLocalAiSnapshot.State.NOT_PROVISIONED,
+        ManagedLocalAiSnapshot elsewhere = snapshot(ManagedLocalAiSnapshot.State.NOT_PROVISIONED,
                 temp.resolve("other-managed-cache").toAbsolutePath());
         InfrastructureSetupService setup = setup(new FakeLifecycle(elsewhere));
 
@@ -466,11 +466,10 @@ class ManagedLocalAiSetupProviderTest {
     }
 
     private static ManagedLocalAiSnapshot snapshot(SetupOptions options, ManagedLocalAiSnapshot.State state) {
-        return snapshot(options, state, options.paths().cacheRoot());
+        return snapshot(state, options.paths().cacheRoot());
     }
 
-    private static ManagedLocalAiSnapshot snapshot(SetupOptions options, ManagedLocalAiSnapshot.State state,
-                                                   Path cache) {
+    private static ManagedLocalAiSnapshot snapshot(ManagedLocalAiSnapshot.State state, Path cache) {
         ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
         ManagedLocalAiManifest.RuntimeAsset runtime = manifest.runtime().assets().stream()
                 .filter(asset -> asset.platform().equals("windows-x86_64")).findFirst().orElseThrow();

--- a/shaft-mcp/src/main/java/com/shaft/mcp/McpSetupRequest.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/McpSetupRequest.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Locale;
 
 /** Machine-readable setup policy accepted by the MCP adapter. */
+// The canonical constructor mirrors the stable MCP wire schema; grouping these fields would break transport clients.
+@SuppressWarnings("PMD.ExcessiveParameterList")
 public record McpSetupRequest(String profile, String mode, String cacheRoot, String dataRoot,
                               Boolean offline, Boolean autoStart, Boolean preferSystemTools,
                               Boolean reuseOwnedProcesses, String startupTimeout, String shutdownTimeout,


### PR DESCRIPTION
## Summary

- replaces reflective provider tests with the production-used typed lifecycle collaborator
- decomposes provider execution, process launch/retry/termination, supervisor ownership, service provisioning/inspection, and setup operation dispatch
- preserves the MCP setup wire schema with one documented transport-boundary PMD suppression
- incorporates independent review feedback by validating malformed supervisor parent PIDs

## Validation

- affected reactor tests: 102 managed-local lifecycle tests and 15 MCP setup transport tests passed headlessly
- affected reactor package: all 10 modules through `shaft-mcp` packaged successfully with tests skipped after the focused run
- flags: `-Dallure.automaticallyOpen=false -Dtelemetry.enabled=false -DheadlessExecution=true`
- independent review: GitHub code-quality finding addressed; Codacy and CodeQL rerunning on the latest head

Closes #4953
Related to #4851