### PR TITLE
fix(agent): actively verify project MCP servers

### DIFF
--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -170,6 +170,64 @@ def retrieval_runtime_healthy(project: Path) -> bool:
     return True
 
 
+def mcp_runtime_healthy(project: Path) -> bool:
+    request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "chaos-engine-doctor", "version": "1"},
+            },
+        }
+    ) + "\n"
+    tool = project / ".chaos-engine/tool.py"
+    environment = os.environ.copy()
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["MEMPALACE_EMBEDDING_MODEL"] = "minilm"
+    commands = (
+        [sys.executable, str(tool), "memory-mcp"],
+        [
+            sys.executable,
+            str(tool),
+            "mempalace-mcp",
+            "--palace",
+            ".chaos-engine-state/mempalace",
+        ],
+    )
+    for command in commands:
+        result = subprocess.run(  # nosec B603 - fixed owned launcher and arguments.
+            command,
+            cwd=project,
+            input=request,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=environment,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return False
+        try:
+            responses = [
+                json.loads(line)
+                for line in result.stdout.splitlines()
+                if line.strip().startswith("{")
+            ]
+        except json.JSONDecodeError:
+            return False
+        if not any(
+            isinstance(response, dict)
+            and response.get("id") == 1
+            and isinstance(response.get("result"), dict)
+            for response in responses
+        ):
+            return False
+    return True
+
+
 def client_command(
     executable: str,
     arguments: list[str],

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -1119,6 +1119,11 @@ def doctor_with_dependencies(
             components.get("retrieval-config"), dict
         ):
             components["retrieval-config"]["status"] = "recovery-required"
+    if not host_controller.mcp_runtime_healthy(project.resolve()):
+        result["status"] = "recovery-required"
+        components = result.get("components")
+        if isinstance(components, dict) and isinstance(components.get("mcps"), dict):
+            components["mcps"]["status"] = "recovery-required"
     if not verify_clients:
         return result
     clients = host_controller.detected_plugin_status(project.resolve())

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -593,6 +593,34 @@ class ChaosEngineHostsTest(unittest.TestCase):
             ):
                 self.assertFalse(module.retrieval_runtime_healthy(project))
 
+    def test_mcp_runtime_executes_both_initialize_handshakes(self):
+        module = load(HOSTS, "chaos_engine_mcp_runtime")
+        response = mock.Mock(
+            returncode=0,
+            stdout=json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}) + "\n",
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            project.joinpath(".chaos-engine").mkdir()
+            project.joinpath(".chaos-engine/tool.py").write_text("# owned\n")
+            with mock.patch.object(
+                module.subprocess,
+                "run",
+                side_effect=[response, response],
+            ) as run:
+                self.assertTrue(module.mcp_runtime_healthy(project))
+
+            self.assertEqual(2, run.call_count)
+            for call in run.call_args_list:
+                request = json.loads(call.kwargs["input"])
+                self.assertEqual("initialize", request["method"])
+                self.assertEqual(project, call.kwargs["cwd"])
+                self.assertEqual("1", call.kwargs["env"]["PYTHONDONTWRITEBYTECODE"])
+
+            invalid = mock.Mock(returncode=0, stdout="not-json\n")
+            with mock.patch.object(module.subprocess, "run", return_value=invalid):
+                self.assertFalse(module.mcp_runtime_healthy(project))
+
     def test_launcher_rendering_is_explicit_for_windows_and_posix(self):
         module = load(HOSTS, "chaos_engine_hosts")
 

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -149,6 +149,35 @@ class ChaosEngineInstallerTest(unittest.TestCase):
                 result["components"]["retrieval-config"]["status"],
             )
 
+    def test_doctor_rejects_an_mcp_runtime_that_cannot_initialize(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            MODULE.install_with_dependencies(
+                project,
+                SOURCE,
+                TEST_COMMIT,
+                provisioner=lambda *_args, **_kwargs: None,
+            )
+            controller = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            with mock.patch.object(
+                controller,
+                "retrieval_runtime_healthy",
+                return_value=True,
+            ), mock.patch.object(
+                controller,
+                "mcp_runtime_healthy",
+                return_value=False,
+            ), mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                return_value=controller,
+            ):
+                result = MODULE.doctor_with_dependencies(project, verify_clients=False)
+
+            self.assertEqual("recovery-required", result["status"])
+            self.assertEqual("recovery-required", result["components"]["mcps"]["status"])
+
     def test_default_distribution_installs_only_neutral_portable_payload(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "consumer"


### PR DESCRIPTION
## Outcome
- make doctor perform a bounded JSON-RPC initialize handshake against both project-local MCP servers
- verify Memory and isolated MemPalace server startup rather than accepting help output
- keep all probe state project-local and suppress runtime bytecode writes

## Real target evidence
Both configured servers completed initialize against iTestFlow-Agent before this change was encoded.

## Verification
- 112 focused hosts/installer tests passed
- py -3 scripts/ci/validate_agent_setup.py --skip-external

Part of #4961