### PR TITLE
fix(agent): keep portable Python caches untracked

### DIFF
--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -1214,7 +1214,7 @@ def gitignore_content(before: bytes | None) -> bytes:
         "!.memory/schema/\n!.memory/schema/*.schema.json\n"
         "!.memory/memory/\n.memory/memory/*\n!.memory/memory/.gitkeep\n"
         "!.memory/relations/\n.memory/relations/*\n!.memory/relations/.gitkeep\n"
-        "!.chaos-engine/\n!.chaos-engine/**\n"
+        "!.chaos-engine/\n!.chaos-engine/**\n.chaos-engine/**/__pycache__/\n"
         "!.agents/\n!.agents/plugins/\n!.agents/plugins/marketplace.json\n"
         "!.agents/skills/\n!.agents/skills/README.md\n"
         "!.agents/skills/chaos-engine/\n!.agents/skills/chaos-engine/**\n"

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -501,6 +501,26 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
             self.assertEqual(1, result.returncode, result.stdout)
 
+    def test_gitignore_keeps_generated_python_bytecode_untracked(self):
+        module = load(HOSTS, "chaos_engine_gitignore_bytecode")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            project.joinpath(".gitignore").write_bytes(module.gitignore_content(None))
+            generated = ".chaos-engine/__pycache__/hosts.cpython-314.pyc"
+            path = project / generated
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"generated")
+            subprocess.run(["git", "init", "-q", str(project)], check=True)
+
+            result = subprocess.run(
+                ["git", "-C", str(project), "check-ignore", generated],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stdout)
+
     def test_invalid_retrieval_configs_fail_before_mutation(self):
         module = load(HOSTS, "chaos_engine_invalid_retrieval")
         for relative, content, message in (


### PR DESCRIPTION
## Summary
- keep generated Python bytecode under the tracked portable harness out of Git
- preserve canonical `.chaos-engine` source visibility with an ordered ignore
- cover the real `git check-ignore` adopter flow

## Verification
- `py -3 -m unittest tests.scripts.test_chaos_engine_hosts tests.scripts.test_chaos_engine_installer tests.scripts.test_chaos_engine_dependencies tests.scripts.test_chaos_engine_hook tests.scripts.test_chaos_engine_bootstrap` (154 passed)
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`

Related to #4961
Related to #4964