### PR TITLE
fix(agent): normalize portable schema guide EOF

### DIFF
--- a/chaos-engine/assets/memory-v5/SCHEMAS.md
+++ b/chaos-engine/assets/memory-v5/SCHEMAS.md
@@ -9,4 +9,3 @@ The upstream package is MIT-licensed. Keep this directory synchronized with
 the pinned package: update the dependency and all five schemas in one change,
 then prove `memory status --json` and `memory check --json` in a fresh adopter
 project.
-


### PR DESCRIPTION
## Summary
- remove the extra blank line at EOF from the tracked Memory schema guide
- keep fresh adopter installs clean under `git diff --check`

## Verification
- `git diff --check`
- `py -3 -m unittest tests.scripts.test_chaos_engine_installer tests.scripts.test_chaos_engine_portable_core` (76 passed)
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`

Related to #4961
Related to #4964