### PR TITLE
feat(doctor): harden managed local AI advisories

### DIFF
--- a/shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/provider/ProviderConformanceTest.java
@@ -507,7 +507,7 @@ class ProviderConformanceTest {
 
     private static String doctorPayload() throws JacksonException {
         return JSON.writeValueAsString(Map.of(
-                "schemaVersion", "1.0",
+                "schemaVersion", "2.0",
                 "observations", List.of(Map.of(
                         "statement", "The submitted exception reports a missing element.",
                         "evidenceIds", List.of("evidence-1"))),
@@ -518,8 +518,8 @@ class ProviderConformanceTest {
                         "evidenceIds", List.of("evidence-1"))),
                 "missingEvidence", List.of("Current DOM snapshot"),
                 "recommendedActions", List.of(Map.of(
-                        "title", "Inspect locator",
-                        "action", "Compare the locator with the current DOM.",
+                        "operation", "UPDATE_TEST_LOCATOR",
+                        "target", "TEST_LOCATOR",
                         "evidenceIds", List.of("evidence-1"))),
                 "limitations", List.of("Only submitted evidence was analyzed.")));
     }

--- a/shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java
@@ -139,6 +139,11 @@ public final class DoctorAiAnalysisService {
                         identity.identifier(), Duration.ZERO, AiUsage.empty(),
                         "Provider execution failed.", cacheWarning(ignoredCacheEntry));
             }
+            if (lastResponse == null) {
+                return fallback(AiResponseStatus.ERROR, identity.provider(), identity.model(),
+                        identity.identifier(), Duration.ZERO, AiUsage.empty(),
+                        "Provider did not return a result.", cacheWarning(ignoredCacheEntry));
+            }
             DoctorAdvisory terminal = terminalProviderFailure(lastResponse, context);
             if (terminal != null) {
                 return terminal;
@@ -160,11 +165,6 @@ public final class DoctorAiAnalysisService {
     }
 
     private static DoctorAdvisory terminalProviderFailure(AiResponse response, AnalysisContext context) {
-        if (response == null) {
-            return fallback(AiResponseStatus.ERROR, context.identity().provider(), context.identity().model(),
-                    context.identity().identifier(), Duration.ZERO, AiUsage.empty(),
-                    "Provider did not return a result.", cacheWarning(context.ignoredCacheEntry()));
-        }
         if (response.successful()) {
             return null;
         }

--- a/shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/ai/DoctorAiAnalysisService.java
@@ -47,7 +47,8 @@ import java.util.function.Supplier;
  * Builds minimized Doctor provider requests and validates separately rendered advisories.
  */
 public final class DoctorAiAnalysisService {
-    private static final String SCHEMA_RESOURCE = "/schema/shaft-doctor-advisory-1.0.schema.json";
+    private static final String SCHEMA_RESOURCE = "/schema/shaft-doctor-advisory-2.0.schema.json";
+    private static final int MAX_PROVIDER_ATTEMPTS = 2;
     private static final int MAX_TEXT_LENGTH = 2_000;
     private static final ObjectMapper JSON = JsonMapper.builder()
             .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
@@ -124,77 +125,84 @@ public final class DoctorAiAnalysisService {
             }
         }
 
-        AiRequest providerRequest = providerRequest(bundle, diagnosis, request, evidence, identity);
-        AiResponse response;
-        try {
-            response = executor.apply(providerRequest);
-        } catch (RuntimeException exception) {
-            return fallback(AiResponseStatus.ERROR, identity.provider(), identity.model(),
-                    identity.identifier(), Duration.ZERO, AiUsage.empty(),
-                    "Provider execution failed.", cacheWarning(ignoredCacheEntry));
+        AnalysisContext context = new AnalysisContext(
+                evidence, diagnosis, request, identity, cachePath, ignoredCacheEntry);
+        AiResponse lastResponse = null;
+        String validationReason = "Provider output failed Doctor advisory validation.";
+        for (int attempt = 1; attempt <= MAX_PROVIDER_ATTEMPTS; attempt++) {
+            AiRequest providerRequest = providerRequest(
+                    bundle, diagnosis, request, evidence, identity, attempt, attempt > 1);
+            try {
+                lastResponse = executor.apply(providerRequest);
+            } catch (RuntimeException exception) {
+                return fallback(AiResponseStatus.ERROR, identity.provider(), identity.model(),
+                        identity.identifier(), Duration.ZERO, AiUsage.empty(),
+                        "Provider execution failed.", cacheWarning(ignoredCacheEntry));
+            }
+            DoctorAdvisory terminal = terminalProviderFailure(lastResponse, context);
+            if (terminal != null) {
+                return terminal;
+            }
+            try {
+                return accept(lastResponse, context);
+            } catch (JacksonException | IllegalArgumentException invalid) {
+                validationReason = safeFallbackReason(invalid.getMessage());
+                if (attempt == MAX_PROVIDER_ATTEMPTS) {
+                    break;
+                }
+            }
         }
+        return fallback(AiResponseStatus.INVALID_RESPONSE, safe(lastResponse.provider()), safe(lastResponse.model()),
+                identity.identifier(), lastResponse.duration(), lastResponse.usage(),
+                "Provider output failed Doctor advisory validation: " + validationReason
+                        + " One corrective retry was exhausted.",
+                cacheWarning(ignoredCacheEntry));
+    }
+
+    private static DoctorAdvisory terminalProviderFailure(AiResponse response, AnalysisContext context) {
         if (response == null) {
-            return fallback(AiResponseStatus.ERROR, identity.provider(), identity.model(),
-                    identity.identifier(), Duration.ZERO, AiUsage.empty(),
-                    "Provider did not return a result.", cacheWarning(ignoredCacheEntry));
+            return fallback(AiResponseStatus.ERROR, context.identity().provider(), context.identity().model(),
+                    context.identity().identifier(), Duration.ZERO, AiUsage.empty(),
+                    "Provider did not return a result.", cacheWarning(context.ignoredCacheEntry()));
         }
-        if (!response.successful()) {
-            return fallback(response.status(), safe(response.provider()), safe(response.model()),
-                    identity.identifier(), response.duration(), response.usage(),
-                    safeFallbackReason(response.fallbackReason()),
-                    responseWarnings(response, ignoredCacheEntry));
+        if (response.successful()) {
+            return null;
         }
+        return fallback(response.status(), safe(response.provider()), safe(response.model()),
+                context.identity().identifier(), response.duration(), response.usage(),
+                safeFallbackReason(response.fallbackReason()),
+                responseWarnings(response, context.ignoredCacheEntry()));
+    }
 
-        try {
-            byte[] responseBytes = JSON.writeValueAsBytes(response.structuredPayload());
-            if (responseBytes.length > request.maxResponseBytes()) {
-                return fallback(AiResponseStatus.INVALID_RESPONSE, safe(response.provider()), safe(response.model()),
-                        identity.identifier(), response.duration(), response.usage(),
-                        "Provider output exceeded the Doctor response size limit.",
-                        cacheWarning(ignoredCacheEntry));
-            }
-            List<String> schemaErrors = JsonSchemaValidator.validate(RESPONSE_SCHEMA, response.structuredPayload());
-            if (!schemaErrors.isEmpty()) {
-                return fallback(AiResponseStatus.INVALID_RESPONSE, safe(response.provider()), safe(response.model()),
-                        identity.identifier(), response.duration(), response.usage(),
-                        "Provider output did not match the Doctor advisory schema.",
-                        cacheWarning(ignoredCacheEntry));
-            }
-
-            DoctorRedactor redactor = new DoctorRedactor();
-            JsonNode sanitized = redactor.redact(response.structuredPayload());
-            List<String> warnings = new ArrayList<>(responseWarnings(response, ignoredCacheEntry));
-            if (!sanitized.equals(response.structuredPayload())) {
-                warnings.add("Sensitive-looking provider text was redacted before advisory rendering.");
-            }
-            DoctorAdvisory.ProviderAnalysis analysis =
-                    parse(sanitized, evidence, diagnosis, warnings);
-            DoctorConfidenceScorer.ConfidenceResult confidenceResult = DoctorConfidenceScorer.score(analysis);
-            DoctorAdvisory advisory = new DoctorAdvisory(
-                    DoctorAdvisory.CURRENT_SCHEMA_VERSION,
-                    DoctorAdvisory.Status.SUCCESS,
-                    analysis,
-                    new DoctorAdvisory.Metadata(
-                            AiResponseStatus.SUCCESS,
-                            safe(response.provider()),
-                            safe(response.model()),
-                            identity.identifier(),
-                            millis(response.duration()),
-                            response.usage(),
-                            "",
-                            false,
-                            warnings),
-                    confidenceResult.score(),
-                    confidenceResult.rationale());
-            if (request.cacheEnabled() && cachePath != null) {
-                writeCache(cachePath, advisory);
-            }
-            return advisory;
-        } catch (JacksonException | IllegalArgumentException exception) {
-            return fallback(AiResponseStatus.INVALID_RESPONSE, safe(response.provider()), safe(response.model()),
-                    identity.identifier(), response.duration(), response.usage(),
-                    "Provider output failed Doctor advisory validation.", cacheWarning(ignoredCacheEntry));
+    private static DoctorAdvisory accept(AiResponse response, AnalysisContext context) throws JacksonException {
+        byte[] responseBytes = JSON.writeValueAsBytes(response.structuredPayload());
+        if (responseBytes.length > context.request().maxResponseBytes()) {
+            throw new IllegalArgumentException("Provider output exceeded the Doctor response size limit.");
         }
+        List<String> schemaErrors = JsonSchemaValidator.validate(RESPONSE_SCHEMA, response.structuredPayload());
+        if (!schemaErrors.isEmpty()) {
+            throw new IllegalArgumentException("Provider output did not match the Doctor advisory schema.");
+        }
+        DoctorRedactor redactor = new DoctorRedactor();
+        JsonNode sanitized = redactor.redact(response.structuredPayload());
+        List<String> warnings = new ArrayList<>(
+                responseWarnings(response, context.ignoredCacheEntry()));
+        if (!sanitized.equals(response.structuredPayload())) {
+            warnings.add("Sensitive-looking provider text was redacted before advisory rendering.");
+        }
+        DoctorAdvisory.ProviderAnalysis analysis =
+                parse(sanitized, context.evidence(), context.diagnosis(), warnings);
+        DoctorConfidenceScorer.ConfidenceResult confidenceResult = DoctorConfidenceScorer.score(analysis);
+        DoctorAdvisory advisory = new DoctorAdvisory(
+                DoctorAdvisory.CURRENT_SCHEMA_VERSION, DoctorAdvisory.Status.SUCCESS, analysis,
+                new DoctorAdvisory.Metadata(AiResponseStatus.SUCCESS, safe(response.provider()),
+                        safe(response.model()), context.identity().identifier(), millis(response.duration()),
+                        response.usage(), "", false, warnings),
+                confidenceResult.score(), confidenceResult.rationale());
+        if (context.request().cacheEnabled() && context.cachePath() != null) {
+            writeCache(context.cachePath(), advisory);
+        }
+        return advisory;
     }
 
     private static AiRequest providerRequest(
@@ -202,7 +210,9 @@ public final class DoctorAiAnalysisService {
             Diagnosis diagnosis,
             DoctorAiAnalysisRequest request,
             List<EvidenceReference> evidence,
-            ConfigurationIdentity identity) {
+            ConfigurationIdentity identity,
+            int attempt,
+            boolean corrective) {
         ObjectNode fallback = JSON.createObjectNode();
         fallback.put("schemaVersion", DoctorAdvisory.ProviderAnalysis.CURRENT_SCHEMA_VERSION);
         fallback.putArray("observations");
@@ -213,21 +223,26 @@ public final class DoctorAiAnalysisService {
 
         AiRequest.Builder builder = AiRequest.builder("shaft-doctor-advisory", RESPONSE_SCHEMA)
                 .requestId("doctor-advisory-" + shortValue(bundle.bundleId())
-                        + "-" + shortValue(identity.identifier()))
-                .text(prompt(diagnosis))
+                        + "-" + shortValue(identity.identifier()) + "-attempt-" + attempt)
+                .text(prompt(diagnosis, corrective))
                 .timeout(request.timeout())
                 .budget(request.budget())
                 .approvalPolicy(request.approvalPolicy())
+                .attemptNumber(attempt)
                 .deterministicFallback(fallback);
         evidence.forEach(builder::evidence);
         return builder.build();
     }
 
-    private static String prompt(Diagnosis diagnosis) {
-        return """
+    private static String prompt(Diagnosis diagnosis, boolean corrective) {
+        String correction = corrective
+                ? "Your previous response was invalid. Correct only the JSON contract; do not add evidence or prose actions.\n"
+                : "";
+        return correction + """
                 Analyze only the submitted redacted evidence and deterministic SHAFT Doctor diagnosis.
                 Return conclusions in the requested JSON schema. Do not include chain-of-thought, hidden reasoning,
                 credentials, patches, test-status changes, or evidence IDs that were not submitted.
+                Recommended actions must use only an allowlisted operation and its matching target.
                 The deterministic diagnosis remains authoritative; identify uncertainty and contradictions explicitly.
 
                 Deterministic diagnosis:
@@ -318,15 +333,12 @@ public final class DoctorAiAnalysisService {
         List<DoctorAdvisory.RecommendedAction> actions = new ArrayList<>();
         for (JsonNode item : payload.path("recommendedActions")) {
             List<String> evidenceIds = evidenceIds(item.path("evidenceIds"), allowedIds);
-            boolean cited = !evidenceIds.isEmpty();
-            if (!cited) {
-                warnings.add("Provider recommended action is uncited.");
-            }
+            DoctorAdvisory.RecommendedAction.ActionOperation operation =
+                    DoctorAdvisory.RecommendedAction.ActionOperation.valueOf(item.path("operation").asText());
+            DoctorAdvisory.RecommendedAction.ActionTarget target =
+                    DoctorAdvisory.RecommendedAction.ActionTarget.valueOf(item.path("target").asText());
             actions.add(new DoctorAdvisory.RecommendedAction(
-                    safeText(item.path("title").asText(), "action title"),
-                    safeText(item.path("action").asText(), "action"),
-                    evidenceIds,
-                    cited));
+                    operation, target, evidenceIds, true));
         }
 
         return new DoctorAdvisory.ProviderAnalysis(
@@ -464,6 +476,9 @@ public final class DoctorAiAnalysisService {
         advisory.analysis().recommendedActions().forEach(value -> {
             safeText(value.title(), "cached action title");
             safeText(value.action(), "cached action");
+            if (!value.structured()) {
+                throw new IllegalArgumentException("Cached advisory contains a prose-only action.");
+            }
             validateCachedIds(value.evidenceIds(), allowedIds);
         });
         advisory.analysis().missingEvidence().forEach(value -> safeText(value, "cached missing evidence"));
@@ -666,5 +681,10 @@ public final class DoctorAiAnalysisService {
     }
 
     private record ConfigurationIdentity(String provider, String model, String identifier) {
+    }
+
+    private record AnalysisContext(List<EvidenceReference> evidence, Diagnosis diagnosis,
+                                   DoctorAiAnalysisRequest request, ConfigurationIdentity identity,
+                                   Path cachePath, boolean ignoredCacheEntry) {
     }
 }

--- a/shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAdvisory.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAdvisory.java
@@ -152,6 +152,7 @@ public record DoctorAdvisory(
         }
 
         /** Allowlisted operations with their only valid target and SHAFT-owned display text. */
+        @SuppressWarnings("PMD.SingularField") // Enum constants retain their immutable action definition.
         public enum ActionOperation {
             COLLECT_EVIDENCE(ActionTarget.DOM_SNAPSHOT, "Collect current DOM evidence",
                     "Capture a current DOM snapshot and rerun deterministic Doctor analysis."),
@@ -164,7 +165,7 @@ public record DoctorAdvisory(
             REVIEW_TEST_DATA(ActionTarget.TEST_DATA, "Review test data",
                     "Compare the failing test data with the deterministic evidence and product state."),
             RETRY_INFRASTRUCTURE_CHECK(ActionTarget.INFRASTRUCTURE_STATUS, "Recheck infrastructure",
-                    "Recheck the reported infrastructure dependency before rerunning the test." );
+                    "Recheck the reported infrastructure dependency before rerunning the test.");
 
             private final ActionTarget target;
             private final String title;
@@ -174,6 +175,18 @@ public record DoctorAdvisory(
                 this.target = target;
                 this.title = title;
                 this.displayText = displayText;
+            }
+
+            private ActionTarget allowedTarget() {
+                return target;
+            }
+
+            private String actionTitle() {
+                return title;
+            }
+
+            private String actionDisplayText() {
+                return displayText;
             }
         }
 
@@ -188,11 +201,11 @@ public record DoctorAdvisory(
                 throw new IllegalArgumentException("Advisory operation and target must be supplied together.");
             }
             if (operation != null) {
-                if (operation.target != target) {
+                if (operation.allowedTarget() != target) {
                     throw new IllegalArgumentException("Advisory operation and target pair is not allowlisted.");
                 }
-                title = operation.title;
-                action = operation.displayText;
+                title = operation.actionTitle();
+                action = operation.actionDisplayText();
             }
         }
 
@@ -208,8 +221,8 @@ public record DoctorAdvisory(
          */
         public RecommendedAction(ActionOperation operation, ActionTarget target,
                                  List<String> evidenceIds, boolean cited) {
-            this(operation == null ? "Invalid action" : operation.title,
-                    operation == null ? "Invalid action" : operation.displayText,
+            this(operation == null ? "Invalid action" : operation.actionTitle(),
+                    operation == null ? "Invalid action" : operation.actionDisplayText(),
                     evidenceIds, cited, operation, target);
         }
 

--- a/shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAdvisory.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/model/DoctorAdvisory.java
@@ -56,7 +56,7 @@ public record DoctorAdvisory(
         /**
          * Current provider analysis schema version.
          */
-        public static final String CURRENT_SCHEMA_VERSION = "1.0";
+        public static final String CURRENT_SCHEMA_VERSION = "2.0";
 
         /**
          * Creates immutable provider analysis.
@@ -138,7 +138,45 @@ public record DoctorAdvisory(
             String title,
             String action,
             List<String> evidenceIds,
-            boolean cited) {
+            boolean cited,
+            ActionOperation operation,
+            ActionTarget target) {
+        /** Allowlisted advisory action targets. */
+        public enum ActionTarget {
+            DOM_SNAPSHOT,
+            RUNTIME_CONFIGURATION,
+            TEST_LOCATOR,
+            WAIT_CONDITION,
+            TEST_DATA,
+            INFRASTRUCTURE_STATUS
+        }
+
+        /** Allowlisted operations with their only valid target and SHAFT-owned display text. */
+        public enum ActionOperation {
+            COLLECT_EVIDENCE(ActionTarget.DOM_SNAPSHOT, "Collect current DOM evidence",
+                    "Capture a current DOM snapshot and rerun deterministic Doctor analysis."),
+            REVIEW_CONFIGURATION(ActionTarget.RUNTIME_CONFIGURATION, "Review runtime configuration",
+                    "Compare the effective runtime configuration with the reviewed project settings."),
+            UPDATE_TEST_LOCATOR(ActionTarget.TEST_LOCATOR, "Review the test locator",
+                    "Compare the typed test locator with the current application DOM."),
+            ADD_EXPLICIT_WAIT(ActionTarget.WAIT_CONDITION, "Review the wait condition",
+                    "Add or adjust an explicit condition only after confirming the observed timing boundary."),
+            REVIEW_TEST_DATA(ActionTarget.TEST_DATA, "Review test data",
+                    "Compare the failing test data with the deterministic evidence and product state."),
+            RETRY_INFRASTRUCTURE_CHECK(ActionTarget.INFRASTRUCTURE_STATUS, "Recheck infrastructure",
+                    "Recheck the reported infrastructure dependency before rerunning the test." );
+
+            private final ActionTarget target;
+            private final String title;
+            private final String displayText;
+
+            ActionOperation(ActionTarget target, String title, String displayText) {
+                this.target = target;
+                this.title = title;
+                this.displayText = displayText;
+            }
+        }
+
         /**
          * Creates an immutable recommended action.
          */
@@ -146,6 +184,38 @@ public record DoctorAdvisory(
             title = DoctorModelSupport.requireText(title, "Advisory action title");
             action = DoctorModelSupport.requireText(action, "Advisory action");
             evidenceIds = DoctorModelSupport.list(evidenceIds);
+            if ((operation == null) != (target == null)) {
+                throw new IllegalArgumentException("Advisory operation and target must be supplied together.");
+            }
+            if (operation != null) {
+                if (operation.target != target) {
+                    throw new IllegalArgumentException("Advisory operation and target pair is not allowlisted.");
+                }
+                title = operation.title;
+                action = operation.displayText;
+            }
+        }
+
+        /**
+         * Retains source compatibility for callers that construct display-only legacy actions.
+         */
+        public RecommendedAction(String title, String action, List<String> evidenceIds, boolean cited) {
+            this(title, action, evidenceIds, cited, null, null);
+        }
+
+        /**
+         * Creates an allowlisted action whose display text is owned by SHAFT.
+         */
+        public RecommendedAction(ActionOperation operation, ActionTarget target,
+                                 List<String> evidenceIds, boolean cited) {
+            this(operation == null ? "Invalid action" : operation.title,
+                    operation == null ? "Invalid action" : operation.displayText,
+                    evidenceIds, cited, operation, target);
+        }
+
+        /** Returns whether this action came from the structured allowlist. */
+        public boolean structured() {
+            return operation != null;
         }
     }
 

--- a/shaft-doctor/src/main/java/com/shaft/doctor/report/DoctorReportWriter.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/report/DoctorReportWriter.java
@@ -245,6 +245,8 @@ public final class DoctorReportWriter {
             for (DoctorAdvisory.RecommendedAction action : advisory.analysis().recommendedActions()) {
                 report.append("1. **").append(markdown(action.title())).append("**: ")
                         .append(markdown(action.action()))
+                        .append(" (`").append(action.operation()).append("` → `")
+                        .append(action.target()).append("`)")
                         .append(" Evidence: ").append(references(action.evidenceIds()))
                         .append(action.cited() ? "" : " (uncited)")
                         .append("\n");

--- a/shaft-doctor/src/main/resources/schema/shaft-doctor-advisory-2.0.schema.json
+++ b/shaft-doctor/src/main/resources/schema/shaft-doctor-advisory-2.0.schema.json
@@ -1,0 +1,103 @@
+{
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "observations",
+    "hypotheses",
+    "missingEvidence",
+    "recommendedActions",
+    "limitations"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "enum": ["2.0"]
+    },
+    "observations": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "type": "object",
+        "required": ["statement", "evidenceIds"],
+        "properties": {
+          "statement": {"type": "string", "minLength": 1, "maxLength": 2000},
+          "evidenceIds": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 12,
+            "items": {"type": "string", "minLength": 1}
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "hypotheses": {
+      "type": "array",
+      "maxItems": 12,
+      "items": {
+        "type": "object",
+        "required": ["causeCategory", "statement", "confidence", "evidenceIds"],
+        "properties": {
+          "causeCategory": {
+            "type": "string",
+            "enum": [
+              "PRODUCT", "TEST", "LOCATOR", "DATA", "TIMING_SYNCHRONIZATION",
+              "ENVIRONMENT_CONFIGURATION", "INFRASTRUCTURE", "UNKNOWN"
+            ]
+          },
+          "statement": {"type": "string", "minLength": 1, "maxLength": 2000},
+          "confidence": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW", "UNKNOWN"]},
+          "evidenceIds": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 12,
+            "items": {"type": "string", "minLength": 1}
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "missingEvidence": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {"type": "string", "minLength": 1, "maxLength": 2000}
+    },
+    "recommendedActions": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {
+        "type": "object",
+        "required": ["operation", "target", "evidenceIds"],
+        "properties": {
+          "operation": {
+            "type": "string",
+            "enum": [
+              "COLLECT_EVIDENCE", "REVIEW_CONFIGURATION", "UPDATE_TEST_LOCATOR",
+              "ADD_EXPLICIT_WAIT", "REVIEW_TEST_DATA", "RETRY_INFRASTRUCTURE_CHECK"
+            ]
+          },
+          "target": {
+            "type": "string",
+            "enum": [
+              "DOM_SNAPSHOT", "RUNTIME_CONFIGURATION", "TEST_LOCATOR",
+              "WAIT_CONDITION", "TEST_DATA", "INFRASTRUCTURE_STATUS"
+            ]
+          },
+          "evidenceIds": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 12,
+            "items": {"type": "string", "minLength": 1}
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "maxItems": 20,
+      "items": {"type": "string", "minLength": 1, "maxLength": 2000}
+    }
+  },
+  "additionalProperties": false
+}

--- a/shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/DoctorAnalyzerTest.java
@@ -300,7 +300,7 @@ class DoctorAnalyzerTest {
         DoctorAiAnalysisService service = new DoctorAiAnalysisService(request -> {
             String evidenceId = request.evidence().getFirst().id();
             var payload = MAPPER.createObjectNode();
-            payload.put("schemaVersion", "1.0");
+            payload.put("schemaVersion", "2.0");
             payload.putArray("observations").addObject()
                     .put("statement", "Authorization: Bearer advisory-report-secret\n## Fake Diagnosis")
                     .putArray("evidenceIds").add(evidenceId);
@@ -311,8 +311,8 @@ class DoctorAnalyzerTest {
                     .putArray("evidenceIds").add(evidenceId);
             payload.putArray("missingEvidence").add("Current DOM snapshot");
             payload.putArray("recommendedActions").addObject()
-                    .put("title", "Inspect locator")
-                    .put("action", "Compare the locator with the current DOM.")
+                    .put("operation", "UPDATE_TEST_LOCATOR")
+                    .put("target", "TEST_LOCATOR")
                     .putArray("evidenceIds").add(evidenceId);
             payload.putArray("limitations").add("Only submitted evidence was analyzed.");
             return AiResponse.success("mock", "mock-model", payload, java.time.Duration.ofMillis(2),
@@ -343,6 +343,8 @@ class DoctorAnalyzerTest {
         assertTrue(json.contains("\"advisory\""));
         assertTrue(markdown.contains("## Diagnosis"));
         assertTrue(markdown.contains("## AI Advisory"));
+        assertTrue(markdown.contains("UPDATE_TEST_LOCATOR"));
+        assertTrue(markdown.contains("TEST_LOCATOR"));
         assertTrue(markdown.contains("deterministic diagnosis above remains authoritative"));
         assertFalse(json.contains("advisory-report-secret"));
         assertFalse(markdown.contains("advisory-report-secret"));

--- a/shaft-doctor/src/test/java/com/shaft/doctor/ai/DoctorAiAnalysisServiceTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/ai/DoctorAiAnalysisServiceTest.java
@@ -78,6 +78,11 @@ class DoctorAiAnalysisServiceTest {
         assertTrue(advisory.analysis().observations().getFirst().statement().contains("[REDACTED]"));
         assertTrue(advisory.metadata().warnings().stream()
                 .anyMatch(value -> value.contains("redacted")));
+        DoctorAdvisory.RecommendedAction action = advisory.analysis().recommendedActions().getFirst();
+        assertTrue(action.structured());
+        assertEquals(DoctorAdvisory.RecommendedAction.ActionOperation.UPDATE_TEST_LOCATOR, action.operation());
+        assertEquals(DoctorAdvisory.RecommendedAction.ActionTarget.TEST_LOCATOR, action.target());
+        assertEquals("Review the test locator", action.title());
     }
 
     @Test
@@ -111,11 +116,71 @@ class DoctorAiAnalysisServiceTest {
     }
 
     @Test
-    void contradictoryAndUncitedClaimsAreMarkedWithoutChangingBaseline(@TempDir Path temp) throws Exception {
+    void proseOnlyRecommendedActionIsRejected(@TempDir Path temp) throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        DoctorAiAnalysisService service = service(request -> {
+            calls.incrementAndGet();
+            ObjectNode proseOnly = (ObjectNode) fixtureUnchecked("high-quality.json").deepCopy();
+            proseOnly.put("schemaVersion", "1.0");
+            ObjectNode action = (ObjectNode) proseOnly.withArray("recommendedActions").get(0);
+            action.remove("operation");
+            action.remove("target");
+            action.put("title", "Inspect the locator");
+            action.put("action", "Rewrite files based on generated prose.");
+            return success(request, proseOnly);
+        });
+
+        DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
+                DoctorAiAnalysisRequest.defaults(APPROVED), temp);
+
+        assertEquals(DoctorAdvisory.Status.FALLBACK, advisory.status());
+        assertEquals(AiResponseStatus.INVALID_RESPONSE, advisory.metadata().providerStatus());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void oneCorrectiveRetryCanRecoverAValidStructuredAction(@TempDir Path temp) throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        AtomicReference<AiRequest> correction = new AtomicReference<>();
+        DoctorAiAnalysisService service = service(request -> {
+            int attempt = calls.incrementAndGet();
+            if (attempt == 1) {
+                return success(request, JSON.createObjectNode().put("schemaVersion", "2.0"));
+            }
+            correction.set(request);
+            return success(request, fixtureUnchecked("high-quality.json"));
+        });
+
+        DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
+                DoctorAiAnalysisRequest.defaults(APPROVED), temp);
+
+        assertEquals(DoctorAdvisory.Status.SUCCESS, advisory.status(), advisory.metadata().fallbackReason());
+        assertEquals(2, calls.get());
+        assertEquals(2, correction.get().attemptNumber());
+        assertTrue(correction.get().text().contains("previous response was invalid"));
+    }
+
+    @Test
+    void mismatchedOperationAndTargetAreRejected(@TempDir Path temp) throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        ObjectNode payload = (ObjectNode) fixture("high-quality.json").deepCopy();
+        ((ObjectNode) payload.withArray("recommendedActions").get(0))
+                .put("target", "RUNTIME_CONFIGURATION");
+        DoctorAiAnalysisService service = service(request -> {
+            calls.incrementAndGet();
+            return success(request, payload);
+        });
+
+        DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
+                DoctorAiAnalysisRequest.defaults(APPROVED), temp);
+
+        assertEquals(DoctorAdvisory.Status.FALLBACK, advisory.status());
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void contradictoryCitedClaimsAreMarkedWithoutChangingBaseline(@TempDir Path temp) throws Exception {
         ObjectNode payload = (ObjectNode) fixture("contradictory.json").deepCopy();
-        payload.withArray("observations").addObject()
-                .put("statement", "The test may also have stale data.")
-                .putArray("evidenceIds");
         DoctorAiAnalysisService service = service(request -> success(request, payload));
 
         DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
@@ -123,12 +188,26 @@ class DoctorAiAnalysisServiceTest {
 
         assertEquals(DoctorAdvisory.Status.SUCCESS, advisory.status());
         assertTrue(advisory.analysis().hypotheses().getFirst().contradictsDeterministic());
-        assertFalse(advisory.analysis().observations().getLast().cited());
         assertTrue(advisory.metadata().warnings().stream()
                 .anyMatch(value -> value.contains("contradicts")));
-        assertTrue(advisory.metadata().warnings().stream()
-                .anyMatch(value -> value.contains("uncited")));
         assertEquals(CauseCategory.LOCATOR, diagnosis().primaryCause());
+    }
+
+    @Test
+    void uncitedFactualClaimIsRejectedAfterOneCorrection(@TempDir Path temp) throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        ObjectNode payload = (ObjectNode) fixture("high-quality.json").deepCopy();
+        ((ObjectNode) payload.withArray("observations").get(0)).putArray("evidenceIds");
+        DoctorAiAnalysisService service = service(request -> {
+            calls.incrementAndGet();
+            return success(request, payload);
+        });
+
+        DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
+                DoctorAiAnalysisRequest.defaults(APPROVED), temp);
+
+        assertEquals(DoctorAdvisory.Status.FALLBACK, advisory.status());
+        assertEquals(2, calls.get());
     }
 
     @ParameterizedTest
@@ -372,7 +451,7 @@ class DoctorAiAnalysisServiceTest {
     }
 
     @Test
-    void uncitedProposedFixScoresInLowBand(@TempDir Path temp) throws Exception {
+    void uncitedProposedFixIsRejected(@TempDir Path temp) throws Exception {
         ObjectNode payload = (ObjectNode) fixture("high-quality.json").deepCopy();
         // Modify all actions to have no evidence references, simulating uncited recommendations.
         payload.withArray("recommendedActions").forEach(action -> {
@@ -383,11 +462,8 @@ class DoctorAiAnalysisServiceTest {
         DoctorAdvisory advisory = service.analyze(bundle(), diagnosis(),
                 DoctorAiAnalysisRequest.defaults(APPROVED), temp);
 
-        assertEquals(DoctorAdvisory.Status.SUCCESS, advisory.status());
-        assertTrue(advisory.confidence() < 40,
-                "Uncited proposed fix should score <40 (Low band), got: " + advisory.confidence());
-        assertTrue(advisory.confidenceRationale().contains("action") || advisory.confidenceRationale().contains("uncited"),
-                "Rationale should explain low citation: " + advisory.confidenceRationale());
+        assertEquals(DoctorAdvisory.Status.FALLBACK, advisory.status());
+        assertEquals(AiResponseStatus.INVALID_RESPONSE, advisory.metadata().providerStatus());
     }
 
     @Test

--- a/shaft-doctor/src/test/resources/fixtures/ai/contradictory.json
+++ b/shaft-doctor/src/test/resources/fixtures/ai/contradictory.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0",
+  "schemaVersion": "2.0",
   "observations": [
     {
       "statement": "The submitted evidence reports a locator exception.",

--- a/shaft-doctor/src/test/resources/fixtures/ai/hallucinated-evidence.json
+++ b/shaft-doctor/src/test/resources/fixtures/ai/hallucinated-evidence.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0",
+  "schemaVersion": "2.0",
   "observations": [
     {
       "statement": "An unsubmitted network trace shows a connection failure.",

--- a/shaft-doctor/src/test/resources/fixtures/ai/high-quality.json
+++ b/shaft-doctor/src/test/resources/fixtures/ai/high-quality.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.0",
+  "schemaVersion": "2.0",
   "observations": [
     {
       "statement": "The failure contains a locator-not-found exception.",
@@ -23,8 +23,8 @@
   ],
   "recommendedActions": [
     {
-      "title": "Inspect the locator",
-      "action": "Compare the locator with the current application DOM before changing synchronization.",
+      "operation": "UPDATE_TEST_LOCATOR",
+      "target": "TEST_LOCATOR",
       "evidenceIds": [
         "evidence-1"
       ]

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiExecutionService.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiExecutionService.java
@@ -248,7 +248,7 @@ public final class AiExecutionService {
                 request.deterministicFallback());
         try {
             auditSink.record(new AiAuditEvent(Instant.now(), request.requestId(), request.purpose(), provider,
-                    normalized.model(), redactionSummary, duration, normalized.status()));
+                    normalized.model(), redactionSummary, duration, normalized.status(), request.attemptNumber()));
             return normalized;
         } catch (RuntimeException auditFailure) {
             java.util.ArrayList<String> warnings = new java.util.ArrayList<>(normalized.warnings());

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiRequest.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiRequest.java
@@ -26,6 +26,7 @@ import java.util.UUID;
  * @param timeout request timeout
  * @param budget request budget
  * @param approvalPolicy explicit processing and evidence approval
+ * @param attemptNumber caller-owned semantic attempt number for safe audit correlation
  * @param deterministicFallback caller-owned deterministic result
  */
 public record AiRequest(
@@ -39,6 +40,7 @@ public record AiRequest(
         Duration timeout,
         AiBudget budget,
         ApprovalPolicy approvalPolicy,
+        int attemptNumber,
         JsonNode deterministicFallback) {
     public static final String CURRENT_SCHEMA_VERSION = "1.0";
 
@@ -64,9 +66,21 @@ public record AiRequest(
         }
         budget = budget == null ? new AiBudget(0, 0, BigDecimal.ZERO) : budget;
         approvalPolicy = approvalPolicy == null ? ApprovalPolicy.denyAll() : approvalPolicy;
+        if (attemptNumber < 1) {
+            throw new IllegalArgumentException("AI request attempt number must be positive.");
+        }
         deterministicFallback = deterministicFallback == null
                 ? NullNode.getInstance()
                 : deterministicFallback.deepCopy();
+    }
+
+    /** Retains source compatibility for single-attempt callers. */
+    public AiRequest(String requestId, String purpose, String schemaVersion, String text,
+                     List<EvidenceReference> evidence, List<AiImage> images, JsonNode desiredResponseSchema,
+                     Duration timeout, AiBudget budget, ApprovalPolicy approvalPolicy,
+                     JsonNode deterministicFallback) {
+        this(requestId, purpose, schemaVersion, text, evidence, images, desiredResponseSchema,
+                timeout, budget, approvalPolicy, 1, deterministicFallback);
     }
 
     /**
@@ -104,7 +118,7 @@ public record AiRequest(
      */
     public AiRequest withSanitizedContent(String sanitizedText, List<EvidenceReference> sanitizedEvidence) {
         return new AiRequest(requestId, purpose, schemaVersion, sanitizedText, sanitizedEvidence, images,
-                desiredResponseSchema, timeout, budget, approvalPolicy, deterministicFallback);
+                desiredResponseSchema, timeout, budget, approvalPolicy, attemptNumber, deterministicFallback);
     }
 
     /**
@@ -115,7 +129,8 @@ public record AiRequest(
      */
     public AiRequest withTimeout(Duration effectiveTimeout) {
         return new AiRequest(requestId, purpose, schemaVersion, text, evidence, images,
-                desiredResponseSchema, effectiveTimeout, budget, approvalPolicy, deterministicFallback);
+                desiredResponseSchema, effectiveTimeout, budget, approvalPolicy, attemptNumber,
+                deterministicFallback);
     }
 
     /**
@@ -131,6 +146,7 @@ public record AiRequest(
         private Duration timeout = Duration.ofSeconds(30);
         private AiBudget budget = new AiBudget(0, 0, BigDecimal.ZERO);
         private ApprovalPolicy approvalPolicy = ApprovalPolicy.denyAll();
+        private int attemptNumber = 1;
         private JsonNode deterministicFallback = NullNode.getInstance();
 
         private Builder(String purpose, JsonNode responseSchema) {
@@ -215,6 +231,12 @@ public record AiRequest(
             return this;
         }
 
+        /** Sets the caller-owned semantic attempt number recorded in safe audit metadata. */
+        public Builder attemptNumber(int value) {
+            attemptNumber = value;
+            return this;
+        }
+
         /**
          * Sets the deterministic result returned on failure.
          *
@@ -233,7 +255,7 @@ public record AiRequest(
          */
         public AiRequest build() {
             return new AiRequest(requestId, purpose, CURRENT_SCHEMA_VERSION, text, evidence, images,
-                    responseSchema, timeout, budget, approvalPolicy, deterministicFallback);
+                    responseSchema, timeout, budget, approvalPolicy, attemptNumber, deterministicFallback);
         }
     }
 }

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiRequest.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/ai/AiRequest.java
@@ -75,6 +75,7 @@ public record AiRequest(
     }
 
     /** Retains source compatibility for single-attempt callers. */
+    @SuppressWarnings("PMD.ExcessiveParameterList") // Mirrors the pre-existing public record constructor.
     public AiRequest(String requestId, String purpose, String schemaVersion, String text,
                      List<EvidenceReference> evidence, List<AiImage> images, JsonNode desiredResponseSchema,
                      Duration timeout, AiBudget budget, ApprovalPolicy approvalPolicy,

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditEvent.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/audit/AiAuditEvent.java
@@ -16,6 +16,7 @@ import java.time.Instant;
  * @param redactionSummary safe redaction counts
  * @param duration elapsed duration
  * @param status normalized outcome
+ * @param attemptNumber caller-owned semantic attempt number
  */
 public record AiAuditEvent(
         Instant timestamp,
@@ -25,7 +26,8 @@ public record AiAuditEvent(
         String model,
         String redactionSummary,
         Duration duration,
-        AiResponseStatus status) {
+        AiResponseStatus status,
+        int attemptNumber) {
     /**
      * Normalizes user-controlled metadata before it reaches logs.
      */
@@ -35,6 +37,15 @@ public record AiAuditEvent(
         provider = safe(provider, 64);
         model = safe(model, 128);
         redactionSummary = safe(redactionSummary, 256);
+        if (attemptNumber < 1) {
+            throw new IllegalArgumentException("AI audit attempt number must be positive.");
+        }
+    }
+
+    /** Retains source compatibility for single-attempt audit producers. */
+    public AiAuditEvent(Instant timestamp, String requestId, String purpose, String provider, String model,
+                        String redactionSummary, Duration duration, AiResponseStatus status) {
+        this(timestamp, requestId, purpose, provider, model, redactionSummary, duration, status, 1);
     }
 
     private static String safe(String value, int limit) {

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiExecutionServiceTest.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/ai/AiExecutionServiceTest.java
@@ -2,6 +2,7 @@ package com.shaft.pilot.ai;
 
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import com.shaft.pilot.audit.AiAuditEvent;
 import com.shaft.pilot.config.PilotConfiguration;
 import org.junit.jupiter.api.Test;
 
@@ -248,6 +249,37 @@ class AiExecutionServiceTest {
 
             assertEquals(AiResponseStatus.SUCCESS, response.status());
             assertTrue(response.warnings().contains("Safe AI audit metadata could not be recorded."));
+        } finally {
+            registry.clearForCurrentThread();
+        }
+    }
+
+    @Test
+    void semanticAttemptNumberIsRecordedWithoutPromptOrEvidence() {
+        StubProvider provider = new StubProvider(ProcessingLocation.REMOTE);
+        AiProviderRegistry registry = new AiProviderRegistry();
+        AtomicReference<AiAuditEvent> captured = new AtomicReference<>();
+        registry.registerForCurrentThread(provider);
+        try {
+            AiExecutionService service = new AiExecutionService(registry,
+                    () -> PilotTestConfiguration.enabled("stub", ProcessingLocation.REMOTE), captured::set);
+            AiRequest request = request(approved(ProcessingLocation.REMOTE));
+            AiRequest corrective = AiRequest.builder(request.purpose(), request.desiredResponseSchema())
+                    .requestId("doctor-attempt-2")
+                    .text(request.text())
+                    .attemptNumber(2)
+                    .budget(request.budget())
+                    .approvalPolicy(request.approvalPolicy())
+                    .deterministicFallback(request.deterministicFallback())
+                    .timeout(request.timeout())
+                    .build();
+
+            AiResponse response = service.execute(corrective);
+
+            assertEquals(AiResponseStatus.SUCCESS, response.status());
+            assertEquals(2, captured.get().attemptNumber());
+            assertFalse(captured.get().toString().contains("top-secret"));
+            assertEquals("test-model", captured.get().model());
         } finally {
             registry.clearForCurrentThread();
         }


### PR DESCRIPTION
## Summary
- add Doctor advisory schema v2 with cited factual claims and allowlisted operation/target actions
- derive recommended-action display text inside SHAFT and reject prose-only, uncited, unknown, or mismatched actions
- permit exactly one corrective schema request and record each semantic attempt in privacy-safe Pilot audit metadata
- keep deterministic Doctor diagnosis and pass/fail authoritative; render accepted provider content only in a separate labeled advisory
- update the six-provider conformance matrix and companion docs

## Proof
- RED: `DoctorAiAnalysisServiceTest#proseOnlyRecommendedActionIsRejected` returned `SUCCESS` before the change and now returns bounded `FALLBACK`
- focused: 13 `AiExecutionServiceTest`, 22 `DoctorAiAnalysisServiceTest`, 23 `DoctorAnalyzerTest`, and 65 `ProviderConformanceTest` cases pass (one provider skip)
- complete affected suites: 46 Pilot, 161 Doctor, and 208 provider tests pass (one intentional skip)
- MCP integration: 22 `DoctorServiceTest` and 5 `McpDoctorRemediationServiceTest` cases pass
- affected reactor package: `mvn -T1 -pl shaft-mcp -am -DskipTests ... package` passes all 10 modules
- remote: PR Gate Summary, every affected module job, CodeQL, and Codacy pass; Codacy reports 0 findings

## Benchmark gate
The pinned #4852 corpus result remains 100% schema/citation validity but 0% primary-category agreement and 0% useful safe-recommendation coverage, with 6.843s warm P95. It does not meet #4861 quality gates, so managed-local Doctor advisories remain explicit/manual and cannot alter deterministic results or auto-run remediation.

Companion docs: ShaftHQ/shafthq.github.io#980

Closes #4861
Related to #4851