### PR TITLE
feat(heal): bound managed local candidate reranking

### DIFF
--- a/shaft-heal/src/main/java/com/shaft/heal/internal/AiCandidateReranker.java
+++ b/shaft-heal/src/main/java/com/shaft/heal/internal/AiCandidateReranker.java
@@ -47,12 +47,13 @@ final class AiCandidateReranker {
         } catch (RuntimeException exception) {
             return fallback(candidates, "AI configuration is invalid.");
         }
-        ObjectNode responseSchema = responseSchema();
+        ObjectNode responseSchema = responseSchema(candidates);
         ObjectNode deterministicFallback = rankingPayload(candidates, false);
         AiRequest.Builder builder = AiRequest.builder("shaft-heal-candidate-rerank", responseSchema)
                 .text("""
                         Rerank only the supplied SHAFT Heal candidates. Never invent a candidate ID or locator.
-                        Scores must be between 0 and 1 and must be based only on the minimized evidence.
+                        Confidence must be between 0 and 1 and must be based only on the minimized evidence.
+                        Cite one or more feature names supplied for that candidate.
                         """)
                 .timeout(Duration.ofSeconds(Math.max(1, pilotConfiguration.timeout().toSeconds())))
                 .approvalPolicy(pilotConfiguration.approvalPolicy())
@@ -129,18 +130,33 @@ final class AiCandidateReranker {
     }
 
     private static Map<String, Double> parse(JsonNode payload, List<RankedCandidate> candidates) {
-        Set<String> allowed = candidates.stream()
-                .map(candidate -> candidate.report().candidateId())
-                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        Map<String, RankedCandidate> allowed = candidates.stream()
+                .collect(java.util.stream.Collectors.toUnmodifiableMap(
+                        candidate -> candidate.report().candidateId(),
+                        candidate -> candidate));
         Map<String, Double> scores = new HashMap<>();
         for (JsonNode item : payload.path("ranking")) {
             String candidateId = item.path("candidateId").asText();
-            double score = item.path("score").asDouble(Double.NaN);
-            if (!allowed.contains(candidateId)) {
+            double score = item.path("confidence").asDouble(Double.NaN);
+            RankedCandidate candidate = allowed.get(candidateId);
+            if (candidate == null) {
                 throw new IllegalArgumentException("Provider referenced an unknown candidate.");
             }
             if (!Double.isFinite(score) || score < 0 || score > 1) {
-                throw new IllegalArgumentException("Provider returned an invalid score.");
+                throw new IllegalArgumentException("Provider returned an invalid confidence.");
+            }
+            Set<String> citedFeatures = new HashSet<>();
+            for (JsonNode citedFeature : item.path("citedFeatures")) {
+                String feature = citedFeature.asText();
+                if (!allowedFeatures(candidate).contains(feature)) {
+                    throw new IllegalArgumentException("Provider cited an unknown feature.");
+                }
+                if (!citedFeatures.add(feature)) {
+                    throw new IllegalArgumentException("Provider cited a duplicate feature.");
+                }
+            }
+            if (citedFeatures.isEmpty()) {
+                throw new IllegalArgumentException("Provider returned no cited features.");
             }
             if (scores.put(candidateId, score) != null) {
                 throw new IllegalArgumentException("Provider returned a duplicate candidate.");
@@ -152,23 +168,54 @@ final class AiCandidateReranker {
         return Map.copyOf(scores);
     }
 
-    private static ObjectNode responseSchema() {
+    private static Set<String> allowedFeatures(RankedCandidate candidate) {
+        Set<String> features = new HashSet<>(candidate.report().score().evidenceScores().keySet());
+        features.add("deterministicScore");
+        features.add("unique");
+        features.add("visible");
+        features.add("interactable");
+        features.add("contextMatched");
+        if (candidate.report().score().visualScore() != null) {
+            features.add("visualScore");
+        }
+        return Set.copyOf(features);
+    }
+
+    private static ObjectNode responseSchema(List<RankedCandidate> candidates) {
         ObjectNode root = JSON.createObjectNode();
         root.put("type", "object");
         ObjectNode properties = root.putObject("properties");
         ObjectNode ranking = properties.putObject("ranking");
         ranking.put("type", "array");
+        ranking.put("minItems", 1);
+        ranking.put("maxItems", candidates.size());
         ObjectNode item = ranking.putObject("items");
         item.put("type", "object");
         ObjectNode itemProperties = item.putObject("properties");
-        itemProperties.putObject("candidateId").put("type", "string");
-        ObjectNode score = itemProperties.putObject("score");
+        ObjectNode candidateId = itemProperties.putObject("candidateId");
+        candidateId.put("type", "string");
+        ArrayNode candidateIds = candidateId.putArray("enum");
+        candidates.forEach(candidate -> candidateIds.add(candidate.report().candidateId()));
+        ObjectNode score = itemProperties.putObject("confidence");
         score.put("type", "number");
         score.put("minimum", 0);
         score.put("maximum", 1);
+        ObjectNode citedFeatures = itemProperties.putObject("citedFeatures");
+        citedFeatures.put("type", "array");
+        citedFeatures.put("minItems", 1);
+        citedFeatures.put("uniqueItems", true);
+        ObjectNode citedFeature = citedFeatures.putObject("items");
+        citedFeature.put("type", "string");
+        ArrayNode featureNames = citedFeature.putArray("enum");
+        candidates.stream()
+                .flatMap(candidate -> allowedFeatures(candidate).stream())
+                .distinct()
+                .sorted()
+                .forEach(featureNames::add);
         ArrayNode requiredItem = item.putArray("required");
         requiredItem.add("candidateId");
-        requiredItem.add("score");
+        requiredItem.add("confidence");
+        requiredItem.add("citedFeatures");
         item.put("additionalProperties", false);
         root.putArray("required").add("ranking");
         root.put("additionalProperties", false);
@@ -181,9 +228,10 @@ final class AiCandidateReranker {
         candidates.forEach(candidate -> {
             ObjectNode item = ranking.addObject();
             item.put("candidateId", candidate.report().candidateId());
-            item.put("score", providerScore && candidate.report().score().providerScore() != null
+            item.put("confidence", providerScore && candidate.report().score().providerScore() != null
                     ? candidate.report().score().providerScore()
                     : candidate.report().score().deterministicScore());
+            item.putArray("citedFeatures").add("deterministicScore");
         });
         return root;
     }

--- a/shaft-heal/src/test/java/com/shaft/heal/internal/AiCandidateRerankerTest.java
+++ b/shaft-heal/src/test/java/com/shaft/heal/internal/AiCandidateRerankerTest.java
@@ -41,6 +41,34 @@ public class AiCandidateRerankerTest {
     }
 
     @Test
+    public void uncitedProviderRankingReturnsExactDeterministicOrdering() {
+        SHAFT.Properties.pilot.set()
+                .enabled(true)
+                .provider("ollama")
+                .localConsent(true)
+                .allowedEvidenceCategories("DOM,TEXT")
+                .ollamaModel("test-model");
+        RankedCandidate first = candidate("candidate-2", 0.90);
+        RankedCandidate second = candidate("candidate-1", 0.80);
+        List<RankedCandidate> deterministicOrder = List.of(first, second);
+        var payload = JsonNodeFactory.instance.objectNode();
+        payload.putArray("ranking").addObject()
+                .put("candidateId", "candidate-2")
+                .put("score", 0.98);
+        AiExecutionService service = mock(AiExecutionService.class);
+        when(service.execute(any())).thenReturn(AiResponse.success(
+                "ollama", "test-model", payload, Duration.ofMillis(1), AiUsage.empty(),
+                JsonNodeFactory.instance.objectNode()));
+
+        AiCandidateReranker.RerankResult result = new AiCandidateReranker(configuration(), service)
+                .apply(deterministicOrder);
+
+        Assert.assertEquals(result.metadata().status(), "REJECTED");
+        Assert.assertSame(result.candidates(), deterministicOrder);
+        Assert.assertNull(result.candidates().getFirst().report().score().providerScore());
+    }
+
+    @Test
     public void inventedProviderCandidateShouldBeRejected() {
         SHAFT.Properties.pilot.set()
                 .enabled(true)
@@ -77,7 +105,8 @@ public class AiCandidateRerankerTest {
         var payload = JsonNodeFactory.instance.objectNode();
         payload.putArray("ranking").addObject()
                 .put("candidateId", "invented")
-                .put("score", 1.0);
+                .put("confidence", 1.0)
+                .putArray("citedFeatures").add("accessibility");
         AiExecutionService service = mock(AiExecutionService.class);
         when(service.execute(any())).thenReturn(AiResponse.success(
                 "ollama", "test-model", payload, Duration.ofMillis(1), AiUsage.empty(),
@@ -102,7 +131,7 @@ public class AiCandidateRerankerTest {
                       "model": "heal-test-model",
                       "message": {
                         "role": "assistant",
-                        "content": "{\\"ranking\\":[{\\"candidateId\\":\\"candidate-1\\",\\"score\\":0.98}]}"
+                        "content": "{\\"ranking\\":[{\\"candidateId\\":\\"candidate-1\\",\\"confidence\\":0.98,\\"citedFeatures\\":[\\"accessibility\\"]}]}"
                       },
                       "prompt_eval_count": 20,
                       "eval_count": 8
@@ -157,6 +186,21 @@ public class AiCandidateRerankerTest {
                 false,
                 true,
                 false);
+    }
+
+    private static RankedCandidate candidate(String candidateId, double deterministicScore) {
+        HealingCandidate report = new HealingCandidate(
+                candidateId,
+                By.id(candidateId).toString(),
+                DeterministicScorerTest.fingerprint(candidateId, "Username"),
+                new HealingScore(deterministicScore, null, null, deterministicScore,
+                        Map.of("accessibility", deterministicScore)),
+                List.of("accessibility=" + deterministicScore),
+                true,
+                true,
+                true,
+                true);
+        return new RankedCandidate(mock(WebElement.class), By.id(candidateId), report);
     }
 
     private static void respond(HttpExchange exchange, String body) throws IOException {


### PR DESCRIPTION
## Summary
- constrain managed local reranking to submitted candidate IDs
- require bounded confidence plus cited candidate features
- preserve the exact deterministic ordering when the provider response is invalid

## Validation
- `AiCandidateRerankerTest#uncitedProviderRankingReturnsExactDeterministicOrdering`
- `AiCandidateRerankerTest` (3 tests)

Related to #4862
Parent: #4851