### PR TITLE
fix(agent): contain MemPalace HNSW crash path (#4976)

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -73,6 +73,25 @@ convert them with an explicit uninstall followed by the portable bootstrap.
 The installer refuses an in-place legacy conversion and leaves the old tree
 unchanged.
 
+ChaosEngine-created MemPalace MCP servers use MemPalace's bundled
+`sqlite_exact` backend explicitly. It keeps the complete local MCP contract but
+has no native HNSW index, so separate agent sessions cannot enter Chroma's
+process-crash and derived-index-corruption path. An upgrade never converts or
+deletes existing generated memory state silently. After dependency provisioning,
+a fresh install creates only the empty SQLite-exact schema and default collection;
+it never files adopter content. Passive `status` and active `doctor` validate
+that state through read-only SQLite queries. A structurally valid legacy Chroma
+palace reports `migration-required` before any MCP launch; corrupt, unrecognized,
+or incomplete state reports `recovery-required`. ChaosEngine does not migrate,
+archive, rename, delete, or claim receipt ownership of palace state, so install
+rollback and uninstall deliberately leave initialized or user-generated state unchanged.
+Migration remains an explicit operator-owned MemPalace procedure and must use a
+verified backup plus the upstream workflow appropriate to that MemPalace
+version. `doctor` stays blocked until the operator supplies a fresh or valid
+SQLite-exact palace. This containment avoids the native HNSW path for generated
+clients; it does not repair the upstream Chroma/HNSW defect. Never remove a
+writer lock or rename an HNSW segment while a MemPalace process is live.
+
 The consumer folder may be a GitHub checkout, another Git checkout, or a
 non-Git directory. ChaosEngine installs project-locally and does not infer its
 upstream from the consumer repository.

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -299,11 +299,11 @@ def mempalace_runtime_status(project: Path) -> dict[str, str]:
     try:
         children = list(palace.iterdir())
     except OSError:
-        children = []
-        unreadable = True
-    else:
-        unreadable = False
-    if unreadable or any(is_link_or_reparse(child) for child in children):
+        return {
+            "status": "recovery-required",
+            "detail": "MemPalace state is unreadable or contains a link or reparse point",
+        }
+    if any(is_link_or_reparse(child) for child in children):
         return {
             "status": "recovery-required",
             "detail": "MemPalace state is unreadable or contains a link or reparse point",
@@ -370,6 +370,34 @@ def mempalace_runtime_status(project: Path) -> dict[str, str]:
             }
         return {"status": "healthy", "backend": "sqlite_exact"}
     return {"status": "initialization-required", "backend": "sqlite_exact"}
+
+
+def _cleanup_failed_mempalace_initialization(
+    *,
+    connection,
+    descriptor: int | None,
+    database: Path,
+    identity: tuple[int, int] | None,
+    palace: Path,
+    palace_created: bool,
+    state_root: Path,
+    state_root_created: bool,
+) -> None:
+    """Remove only state created by the failed initializer transaction."""
+    if connection is not None:
+        connection.close()
+    if descriptor is not None:
+        os.close(descriptor)
+    try:
+        current = os.stat(database, follow_symlinks=False)
+    except OSError:
+        current = None
+    if current is not None and identity == (current.st_dev, current.st_ino):
+        database.unlink()
+    if palace_created and palace.exists() and not any(palace.iterdir()):
+        palace.rmdir()
+    if state_root_created and state_root.exists() and not any(state_root.iterdir()):
+        state_root.rmdir()
 
 
 def initialize_mempalace_runtime(project: Path) -> None:
@@ -451,20 +479,16 @@ def initialize_mempalace_runtime(project: Path) -> None:
         if mempalace_runtime_status(project)["status"] != "healthy":
             raise ValueError("fresh SQLite-exact MemPalace state failed validation")
     except BaseException:
-        if connection is not None:
-            connection.close()
-        if descriptor is not None:
-            os.close(descriptor)
-        try:
-            current = os.stat(database, follow_symlinks=False)
-        except OSError:
-            current = None
-        if current is not None and identity == (current.st_dev, current.st_ino):
-            database.unlink()
-        if palace_created and palace.exists() and not any(palace.iterdir()):
-            palace.rmdir()
-        if state_root_created and state_root.exists() and not any(state_root.iterdir()):
-            state_root.rmdir()
+        _cleanup_failed_mempalace_initialization(
+            connection=connection,
+            descriptor=descriptor,
+            database=database,
+            identity=identity,
+            palace=palace,
+            palace_created=palace_created,
+            state_root=state_root,
+            state_root_created=state_root_created,
+        )
         raise
 
 

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -11,6 +11,7 @@ import os
 import re
 import secrets
 import shutil
+import sqlite3
 import stat
 import subprocess  # nosec B404 - probes a resolved local Java executable.
 import sys
@@ -31,6 +32,49 @@ MEMORY_SCHEMA_FILES = (
     "event.schema.json",
     "patch.schema.json",
 )
+SQLITE_EXACT_SCHEMA = {
+    "meta": {"key": ("TEXT", 0, 1), "value": ("TEXT", 1, 0)},
+    "collections": {
+        "id": ("INTEGER", 0, 1),
+        "name": ("TEXT", 1, 0),
+        "dimension": ("INTEGER", 0, 0),
+        "created_at": ("TEXT", 1, 0),
+    },
+    "documents": {
+        "collection_id": ("INTEGER", 1, 1),
+        "id": ("TEXT", 1, 2),
+        "document": ("TEXT", 1, 0),
+        "metadata_json": ("TEXT", 1, 0),
+        "embedding": ("BLOB", 1, 0),
+        "dim": ("INTEGER", 1, 0),
+        "created_at": ("TEXT", 1, 0),
+        "updated_at": ("TEXT", 1, 0),
+    },
+}
+SQLITE_EXACT_INDEXES = {
+    "collections": {(1, ("name",))},
+    "documents": {
+        (0, ("collection_id",)),
+        (1, ("collection_id", "id")),
+    },
+}
+CHROMA_SCHEMA = {
+    "collections": {
+        "id": ("TEXT", 0, 1), "name": ("TEXT", 1, 0),
+        "dimension": ("INTEGER", 0, 0), "database_id": ("TEXT", 1, 0),
+        "config_json_str": ("TEXT", 0, 0), "schema_str": ("TEXT", 0, 0),
+    },
+    "segments": {
+        "id": ("TEXT", 0, 1), "type": ("TEXT", 1, 0),
+        "scope": ("TEXT", 1, 0), "collection": ("TEXT", 1, 0),
+    },
+    "embeddings_queue": {
+        "seq_id": ("INTEGER", 0, 1), "created_at": ("TIMESTAMP", 1, 0),
+        "operation": ("INTEGER", 1, 0), "topic": ("TEXT", 1, 0),
+        "id": ("TEXT", 1, 0), "vector": ("BLOB", 0, 0),
+        "encoding": ("TEXT", 0, 0), "metadata": ("TEXT", 0, 0),
+    },
+}
 LEGACY_MANAGED_PATHS = (
     ".agents/skills/chaos-engine/SKILL.md",
     ".claude/skills/chaos-engine/SKILL.md",
@@ -170,8 +214,264 @@ def retrieval_runtime_healthy(project: Path) -> bool:
     return True
 
 
+def _sqlite_runtime_valid(
+    database: Path,
+    *,
+    required_schema: dict[str, dict[str, tuple[str, int, int]]] | None = None,
+    required_indexes: dict[str, set[tuple[int, tuple[str, ...]]]] | None = None,
+    collection: str | None = None,
+) -> bool:
+    wal = Path(f"{database}-wal")
+    shared_memory = Path(f"{database}-shm")
+    if not database.is_file() or any(
+        is_link_or_reparse(path) for path in (database, wal, shared_memory)
+    ):
+        return False
+    wal_exists = wal.exists()
+    shared_memory_exists = shared_memory.exists()
+    if wal_exists != shared_memory_exists or (
+        wal_exists and (not wal.is_file() or not shared_memory.is_file())
+    ):
+        return False
+    connection = None
+    try:
+        query = "mode=ro" if wal_exists else "mode=ro&immutable=1"
+        connection = sqlite3.connect(
+            f"{database.resolve().as_uri()}?{query}",
+            uri=True,
+        )
+        connection.execute("PRAGMA trusted_schema=OFF")
+        if connection.execute("PRAGMA quick_check(1)").fetchone() != ("ok",):
+            return False
+        if required_schema is not None and not all(
+            expected
+            == {
+                str(row[1]): (str(row[2]).upper(), int(row[3]), int(row[5]))
+                for row in connection.execute(f"PRAGMA table_info({table})")
+            }
+            for table, expected in required_schema.items()
+        ):
+            return False
+        if required_indexes is not None:
+            for table, expected in required_indexes.items():
+                actual = set()
+                for row in connection.execute(f"PRAGMA index_list({table})"):
+                    columns = tuple(
+                        str(column[2])
+                        for column in connection.execute(
+                            f"PRAGMA index_info({str(row[1])})"
+                        )
+                    )
+                    actual.add((int(row[2]), columns))
+                if not expected <= actual:
+                    return False
+        if collection is not None and connection.execute(
+            "SELECT 1 FROM collections WHERE name = ?",
+            (collection,),
+        ).fetchone() != (1,):
+            return False
+        return True
+    except (OSError, sqlite3.DatabaseError):
+        return False
+    finally:
+        if connection is not None:
+            connection.close()
+
+
+def mempalace_runtime_status(project: Path) -> dict[str, str]:
+    """Classify project-local MemPalace state without importing its native backend."""
+    palace = project / ".chaos-engine-state/mempalace"
+    if is_link_or_reparse(palace):
+        return {
+            "status": "recovery-required",
+            "detail": "MemPalace state is a link or reparse point",
+        }
+    if not palace.exists():
+        return {"status": "initialization-required", "backend": "sqlite_exact"}
+    if not palace.is_dir():
+        return {
+            "status": "recovery-required",
+            "detail": "MemPalace state path is not a directory",
+        }
+
+    chroma = palace / "chroma.sqlite3"
+    exact = palace / "sqlite_exact.sqlite3"
+    try:
+        children = list(palace.iterdir())
+    except OSError:
+        children = []
+        unreadable = True
+    else:
+        unreadable = False
+    if unreadable or any(is_link_or_reparse(child) for child in children):
+        return {
+            "status": "recovery-required",
+            "detail": "MemPalace state is unreadable or contains a link or reparse point",
+        }
+    if chroma.exists():
+        if not _sqlite_runtime_valid(
+            chroma,
+            required_schema=CHROMA_SCHEMA,
+        ):
+            return {
+                "status": "recovery-required",
+                "detail": "Legacy Chroma MemPalace state is unreadable or malformed",
+            }
+        chroma_names = {
+            chroma.name,
+            f"{chroma.name}-wal",
+            f"{chroma.name}-shm",
+        }
+        segment = re.compile(
+            r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        )
+        if any(
+            child.name not in chroma_names
+            and (not child.is_dir() or segment.fullmatch(child.name) is None)
+            for child in children
+        ):
+            return {
+                "status": "recovery-required",
+                "detail": "Legacy Chroma MemPalace state is mixed or unrecognized",
+            }
+        return {
+            "status": "migration-required",
+            "detail": (
+                "Legacy Chroma/HNSW MemPalace state requires migration; "
+                "ChaosEngine will not open its native index"
+            ),
+        }
+
+    wal = Path(f"{exact}-wal")
+    shared_memory = Path(f"{exact}-shm")
+    allowed_names = {path.name for path in (exact, wal, shared_memory)}
+    if any(child.name not in allowed_names for child in children):
+        return {
+            "status": "recovery-required",
+            "detail": "MemPalace state contains unrecognized recoverable data",
+        }
+    wal_exists = wal.exists()
+    shared_memory_exists = shared_memory.exists()
+    if not exact.exists() and (wal_exists or shared_memory_exists):
+        return {
+            "status": "recovery-required",
+            "detail": "SQLite-exact MemPalace WAL state has no database",
+        }
+    if exact.exists():
+        if not _sqlite_runtime_valid(
+            exact,
+            required_schema=SQLITE_EXACT_SCHEMA,
+            required_indexes=SQLITE_EXACT_INDEXES,
+            collection="mempalace_drawers",
+        ):
+            return {
+                "status": "recovery-required",
+                "detail": "SQLite-exact MemPalace state is unreadable or malformed",
+            }
+        return {"status": "healthy", "backend": "sqlite_exact"}
+    return {"status": "initialization-required", "backend": "sqlite_exact"}
+
+
+def initialize_mempalace_runtime(project: Path) -> None:
+    """Create only a fresh empty sqlite_exact collection; never migrate user state."""
+    project = project.resolve()
+    state_root = project / ".chaos-engine-state"
+    palace = state_root / "mempalace"
+    status = mempalace_runtime_status(project)["status"]
+    if status == "healthy":
+        return
+    if status != "initialization-required":
+        return
+
+    validate_path(project, palace)
+    state_root_created = not state_root.exists()
+    palace_created = not palace.exists()
+    state_root.mkdir(exist_ok=True)
+    validate_path(project, palace)
+    palace.mkdir(exist_ok=True)
+    validate_path(project, palace)
+    palace_stat = os.stat(palace, follow_symlinks=False)
+    if not stat.S_ISDIR(palace_stat.st_mode):
+        raise ValueError("ChaosEngine MemPalace state path is not a directory")
+    palace_identity = (palace_stat.st_dev, palace_stat.st_ino)
+    database = palace / "sqlite_exact.sqlite3"
+    descriptor = None
+    connection = None
+    identity: tuple[int, int] | None = None
+    try:
+        if any(palace.iterdir()):
+            raise ValueError("ChaosEngine will not initialize over existing MemPalace state")
+        validate_path(project, palace)
+        named_palace = os.stat(palace, follow_symlinks=False)
+        if palace_identity != (named_palace.st_dev, named_palace.st_ino):
+            raise ValueError("ChaosEngine MemPalace state path changed before initialization")
+        descriptor = os.open(
+            database,
+            os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
+            0o600,
+        )
+        opened = os.fstat(descriptor)
+        identity = (opened.st_dev, opened.st_ino)
+        named_palace = os.stat(palace, follow_symlinks=False)
+        if palace_identity != (named_palace.st_dev, named_palace.st_ino):
+            raise ValueError("ChaosEngine MemPalace state path changed during initialization")
+        os.close(descriptor)
+        descriptor = None
+        connection = sqlite3.connect(database)
+        connection.executescript(
+            """
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE collections (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                dimension INTEGER,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE documents (
+                collection_id INTEGER NOT NULL,
+                id TEXT NOT NULL,
+                document TEXT NOT NULL,
+                metadata_json TEXT NOT NULL,
+                embedding BLOB NOT NULL,
+                dim INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (collection_id, id),
+                FOREIGN KEY(collection_id) REFERENCES collections(id) ON DELETE CASCADE
+            );
+            CREATE INDEX idx_documents_collection ON documents(collection_id);
+            INSERT INTO collections(name, created_at)
+            VALUES ('mempalace_drawers', CURRENT_TIMESTAMP);
+            """
+        )
+        connection.commit()
+        connection.close()
+        connection = None
+        if mempalace_runtime_status(project)["status"] != "healthy":
+            raise ValueError("fresh SQLite-exact MemPalace state failed validation")
+    except BaseException:
+        if connection is not None:
+            connection.close()
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            current = os.stat(database, follow_symlinks=False)
+        except OSError:
+            current = None
+        if current is not None and identity == (current.st_dev, current.st_ino):
+            database.unlink()
+        if palace_created and palace.exists() and not any(palace.iterdir()):
+            palace.rmdir()
+        if state_root_created and state_root.exists() and not any(state_root.iterdir()):
+            state_root.rmdir()
+        raise
+
+
 def mcp_runtime_healthy(project: Path) -> bool:
-    request = json.dumps(
+    if mempalace_runtime_status(project)["status"] != "healthy":
+        return False
+    initialize = json.dumps(
         {
             "jsonrpc": "2.0",
             "id": 1,
@@ -183,6 +483,22 @@ def mcp_runtime_healthy(project: Path) -> bool:
             },
         }
     ) + "\n"
+    mempalace_probe = (
+        initialize
+        + json.dumps(
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "mempalace_status", "arguments": {}},
+            }
+        )
+        + "\n"
+    )
     tool = project / ".chaos-engine/tool.py"
     environment = os.environ.copy()
     environment["PYTHONDONTWRITEBYTECODE"] = "1"
@@ -195,13 +511,15 @@ def mcp_runtime_healthy(project: Path) -> bool:
             "mempalace-mcp",
             "--palace",
             ".chaos-engine-state/mempalace",
+            "--backend",
+            "sqlite_exact",
         ],
     )
-    for command in commands:
+    for index, command in enumerate(commands):
         result = subprocess.run(  # nosec B603 - fixed owned launcher and arguments.
             command,
             cwd=project,
-            input=request,
+            input=mempalace_probe if index == 1 else initialize,
             capture_output=True,
             text=True,
             check=False,
@@ -225,6 +543,36 @@ def mcp_runtime_healthy(project: Path) -> bool:
             for response in responses
         ):
             return False
+        if index == 1:
+            status_responses = [
+                response
+                for response in responses
+                if isinstance(response, dict) and response.get("id") == 2
+            ]
+            if len(status_responses) != 1:
+                return False
+            result_payload = status_responses[0].get("result")
+            content = result_payload.get("content") if isinstance(result_payload, dict) else None
+            if not isinstance(content, list):
+                return False
+            try:
+                status_payloads = [
+                    json.loads(item["text"])
+                    for item in content
+                    if isinstance(item, dict)
+                    and item.get("type") == "text"
+                    and isinstance(item.get("text"), str)
+                ]
+            except json.JSONDecodeError:
+                return False
+            if not any(
+                isinstance(payload, dict)
+                and payload.get("backend") == "sqlite_exact"
+                and isinstance(payload.get("total_drawers"), int)
+                and "error" not in payload
+                for payload in status_payloads
+            ):
+                return False
     return True
 
 
@@ -817,6 +1165,8 @@ def owned_servers(
                 "mempalace-mcp",
                 "--palace",
                 ".chaos-engine-state/mempalace",
+                "--backend",
+                "sqlite_exact",
             ],
             "cwd": ".",
             "env": {"MEMPALACE_EMBEDDING_MODEL": "minilm"},
@@ -1157,7 +1507,7 @@ def codex_content(
         f'args = [{prefix_text}".chaos-engine/tool.py", "memory-mcp"]\ncwd = ".."\n\n'
         f'[mcp_servers."chaosengine-mempalace"]\ncommand = "{command}"\n'
         f'args = [{prefix_text}".chaos-engine/tool.py", "mempalace-mcp", "--palace", '
-        '".chaos-engine-state/mempalace"]\ncwd = ".."\n'
+        '".chaos-engine-state/mempalace", "--backend", "sqlite_exact"]\ncwd = ".."\n'
         'env = { MEMPALACE_EMBEDDING_MODEL = "minilm" }\n# CHAOSENGINE:END\n'
     )
     if maven_runtime is not None:

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -959,17 +959,30 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
         host_receipt = project / host_controller.RECEIPT_NAME
         host_existed = host_receipt.exists() or is_link_or_reparse(host_receipt)
         host_created = False
+        runtime = project / ".chaos-engine-runtime"
+        runtime_existed = runtime.exists() or is_link_or_reparse(runtime)
+        controller = None
+        specification = None
         try:
             host_controller.install(project, core_commit=commit)
             host_created = not host_existed
             controller = load_dependency_controller(target)
+            specification = controller.load_specification(target / "dependencies.json")
             provision = provisioner or controller.repair
-            provision(
-                project / ".chaos-engine-runtime",
-                controller.load_specification(target / "dependencies.json"),
-            )
+            provision(runtime, specification)
+            host_controller.initialize_mempalace_runtime(project)
         except BaseException as error:
             compensation_errors: list[BaseException] = []
+            if (
+                not runtime_existed
+                and runtime.exists()
+                and controller is not None
+                and specification is not None
+            ):
+                try:
+                    controller.remove(runtime, specification)
+                except BaseException as cleanup_error:
+                    compensation_errors.append(cleanup_error)
             if host_snapshot is not None:
                 try:
                     host_controller.restore_snapshot(project, host_snapshot)
@@ -1038,6 +1051,9 @@ def attach_component_status(
         components[name] = {"status": "healthy" if healthy else "absent"}
     for name in ("tools", "memory", "mempalace", "graphify"):
         components[name] = {"status": dependency_health}
+    mempalace_state = host_controller.mempalace_runtime_status(project)
+    if mempalace_state.get("status") != "healthy":
+        components["mempalace"] = mempalace_state
     result["components"] = components
     if dependency_health != "healthy" or any(
         item["status"] != "healthy" for item in components.values()

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -7,6 +7,7 @@ import errno
 import hashlib
 import json
 import os
+import sqlite3
 import subprocess  # nosec B404 - fixed Git acceptance commands.
 import tempfile
 import unittest
@@ -26,6 +27,66 @@ def load(path: Path, name: str):
     module = importlib.util.module_from_spec(specification)
     specification.loader.exec_module(module)
     return module
+
+
+def create_sqlite_exact_state(path: Path) -> None:
+    database = sqlite3.connect(path)
+    try:
+        database.executescript(
+            """
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE collections (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                dimension INTEGER,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE documents (
+                collection_id INTEGER NOT NULL,
+                id TEXT NOT NULL,
+                document TEXT NOT NULL,
+                metadata_json TEXT NOT NULL,
+                embedding BLOB NOT NULL,
+                dim INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (collection_id, id),
+                FOREIGN KEY(collection_id) REFERENCES collections(id) ON DELETE CASCADE
+            );
+            CREATE INDEX idx_documents_collection ON documents(collection_id);
+            INSERT INTO collections(name, created_at)
+            VALUES ('mempalace_drawers', '2026-08-15T00:00:00Z');
+            """
+        )
+        database.commit()
+    finally:
+        database.close()
+
+
+def create_chroma_state(path: Path) -> None:
+    database = sqlite3.connect(path)
+    try:
+        database.executescript(
+            """
+            CREATE TABLE collections (
+                id TEXT PRIMARY KEY, name TEXT NOT NULL, dimension INTEGER,
+                database_id TEXT NOT NULL, config_json_str TEXT, schema_str TEXT
+            );
+            CREATE TABLE segments (
+                id TEXT PRIMARY KEY, type TEXT NOT NULL, scope TEXT NOT NULL,
+                collection TEXT NOT NULL
+            );
+            CREATE TABLE embeddings_queue (
+                seq_id INTEGER PRIMARY KEY, created_at TIMESTAMP NOT NULL,
+                operation INTEGER NOT NULL, topic TEXT NOT NULL, id TEXT NOT NULL,
+                vector BLOB, encoding TEXT, metadata TEXT
+            );
+            """
+        )
+        database.commit()
+    finally:
+        database.close()
 
 
 class ChaosEngineHostsTest(unittest.TestCase):
@@ -264,9 +325,15 @@ class ChaosEngineHostsTest(unittest.TestCase):
                     if os.name == "nt":
                         self.assertEqual("-3", server["args"][0])
                     self.assertIn(".chaos-engine/tool.py", server["args"])
+                mempalace = servers["chaosengine-mempalace"]
+                self.assertEqual(
+                    ["--backend", "sqlite_exact"],
+                    mempalace["args"][-2:],
+                )
             self.assertIn('[mcp_servers."chaosengine-memory"]', codex)
             self.assertIn('".chaos-engine/tool.py", "memory-mcp"]', codex)
             self.assertIn(".chaos-engine-state/mempalace", str(claude))
+            self.assertIn('"--backend", "sqlite_exact"', codex)
 
     def test_complete_host_harness_installs_inventory_roles_hooks_and_plugin(self):
         module = load(HOSTS, "chaos_engine_complete_hosts")
@@ -686,31 +753,350 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
     def test_mcp_runtime_executes_both_initialize_handshakes(self):
         module = load(HOSTS, "chaos_engine_mcp_runtime")
-        response = mock.Mock(
+        memory_response = mock.Mock(
             returncode=0,
             stdout=json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}) + "\n",
+        )
+        mempalace_response = mock.Mock(
+            returncode=0,
+            stdout="\n".join(
+                (
+                    json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}),
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 2,
+                            "result": {
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": json.dumps(
+                                            {
+                                                "total_drawers": 0,
+                                                "backend": "sqlite_exact",
+                                            }
+                                        ),
+                                    }
+                                ]
+                            },
+                        }
+                    ),
+                )
+            )
+            + "\n",
         )
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary)
             project.joinpath(".chaos-engine").mkdir()
             project.joinpath(".chaos-engine/tool.py").write_text("# owned\n")
+            module.initialize_mempalace_runtime(project)
             with mock.patch.object(
                 module.subprocess,
                 "run",
-                side_effect=[response, response],
+                side_effect=[memory_response, mempalace_response],
             ) as run:
                 self.assertTrue(module.mcp_runtime_healthy(project))
 
             self.assertEqual(2, run.call_count)
+            self.assertEqual(
+                ["--backend", "sqlite_exact"],
+                run.call_args_list[1].args[0][-2:],
+            )
             for call in run.call_args_list:
-                request = json.loads(call.kwargs["input"])
-                self.assertEqual("initialize", request["method"])
+                requests = [
+                    json.loads(line) for line in call.kwargs["input"].splitlines()
+                ]
+                self.assertEqual("initialize", requests[0]["method"])
                 self.assertEqual(project, call.kwargs["cwd"])
                 self.assertEqual("1", call.kwargs["env"]["PYTHONDONTWRITEBYTECODE"])
+            mempalace_requests = run.call_args_list[1].kwargs["input"].splitlines()
+            self.assertEqual(3, len(mempalace_requests))
+            self.assertEqual(
+                "mempalace_status",
+                json.loads(mempalace_requests[2])["params"]["name"],
+            )
+
+            backend_error = mock.Mock(
+                returncode=0,
+                stdout="\n".join(
+                    (
+                        json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}),
+                        json.dumps(
+                            {
+                                "jsonrpc": "2.0",
+                                "id": 2,
+                                "result": {
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": json.dumps(
+                                                {
+                                                    "error": "Backend open failed",
+                                                    "backend": "sqlite_exact",
+                                                }
+                                            ),
+                                        }
+                                    ]
+                                },
+                            }
+                        ),
+                    )
+                ),
+            )
+            with mock.patch.object(
+                module.subprocess,
+                "run",
+                side_effect=[memory_response, backend_error],
+            ):
+                self.assertFalse(module.mcp_runtime_healthy(project))
 
             invalid = mock.Mock(returncode=0, stdout="not-json\n")
             with mock.patch.object(module.subprocess, "run", return_value=invalid):
                 self.assertFalse(module.mcp_runtime_healthy(project))
+
+    def test_mempalace_runtime_state_is_fail_closed_before_native_launch(self):
+        module = load(HOSTS, "chaos_engine_mempalace_runtime_state")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            palace = project / ".chaos-engine-state/mempalace"
+
+            self.assertEqual(
+                "initialization-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+
+            palace.mkdir(parents=True)
+            exact = palace / "sqlite_exact.sqlite3"
+            wal = Path(f"{exact}-wal")
+            shared_memory = Path(f"{exact}-shm")
+            wal.write_bytes(b"orphan WAL")
+            shared_memory.write_bytes(b"orphan shared memory")
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+            wal.unlink()
+            shared_memory.unlink()
+
+            database = sqlite3.connect(exact)
+            database.execute("CREATE TABLE unrelated (secret TEXT)")
+            database.commit()
+            database.close()
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+            exact.unlink()
+
+            database = sqlite3.connect(exact)
+            database.executescript(
+                """
+                CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+                CREATE TABLE collections (
+                    id INTEGER PRIMARY KEY, name TEXT, dimension INTEGER,
+                    created_at TEXT
+                );
+                CREATE TABLE documents (
+                    collection_id INTEGER, id TEXT, document TEXT,
+                    metadata_json TEXT, embedding BLOB, dim INTEGER,
+                    created_at TEXT, updated_at TEXT,
+                    PRIMARY KEY (collection_id, id)
+                );
+                INSERT INTO collections(name, created_at)
+                VALUES ('mempalace_drawers', '2026-08-15T00:00:00Z');
+                """
+            )
+            database.commit()
+            database.close()
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+            exact.unlink()
+
+            create_sqlite_exact_state(exact)
+            self.assertFalse(wal.exists())
+            self.assertFalse(shared_memory.exists())
+            self.assertEqual(
+                "healthy",
+                module.mempalace_runtime_status(project)["status"],
+            )
+            self.assertFalse(wal.exists())
+            self.assertFalse(shared_memory.exists())
+
+            database = sqlite3.connect(exact)
+            database.execute("DROP INDEX idx_documents_collection")
+            database.commit()
+            database.close()
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+            exact.unlink()
+            create_sqlite_exact_state(exact)
+
+            wal.write_bytes(b"partial sidecar")
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+            self.assertFalse(shared_memory.exists())
+            wal.unlink()
+
+            writer = sqlite3.connect(exact)
+            try:
+                writer.execute("INSERT INTO meta(key, value) VALUES ('live-wal', '1')")
+                writer.commit()
+                self.assertTrue(wal.is_file())
+                self.assertTrue(shared_memory.is_file())
+                self.assertEqual(
+                    "healthy",
+                    module.mempalace_runtime_status(project)["status"],
+                )
+            finally:
+                writer.close()
+
+            exact.write_bytes(b"SQLite format 3\x00" + b"truncated")
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+
+            exact.unlink()
+            chroma = palace / "chroma.sqlite3"
+            chroma.write_bytes(b"SQLite format 3\x00")
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+            chroma.unlink()
+
+            create_chroma_state(chroma)
+            (palace / "00000000-0000-0000-0000-000000000001").mkdir()
+            state = module.mempalace_runtime_status(project)
+            self.assertEqual("migration-required", state["status"])
+            self.assertIn("Chroma", state["detail"])
+
+            with mock.patch.object(module.subprocess, "run") as run:
+                self.assertFalse(module.mcp_runtime_healthy(project))
+            run.assert_not_called()
+
+            unknown = palace / "unknown.sqlite3"
+            unknown.write_bytes(b"preserve")
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+            unknown.unlink()
+
+            create_sqlite_exact_state(exact)
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+
+    def test_mempalace_runtime_rejects_reparse_state_before_native_launch(self):
+        module = load(HOSTS, "chaos_engine_mempalace_reparse_state")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            palace = project / ".chaos-engine-state/mempalace"
+            palace.mkdir(parents=True)
+            exact = palace / "sqlite_exact.sqlite3"
+            exact.write_bytes(b"SQLite format 3\x00")
+
+            with mock.patch.object(
+                module,
+                "is_link_or_reparse",
+                side_effect=lambda path: path == exact,
+            ):
+                state = module.mempalace_runtime_status(project)
+
+            self.assertEqual("recovery-required", state["status"])
+            self.assertIn("link or reparse", state["detail"])
+
+    def test_mempalace_runtime_rejects_unrecognized_state_before_native_launch(self):
+        module = load(HOSTS, "chaos_engine_mempalace_unknown_state")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            palace = project / ".chaos-engine-state/mempalace"
+            palace.mkdir(parents=True)
+
+            for relative, content in (
+                ("legacy-segment-uuid", None),
+                ("chroma.sqlite3-wal", b"recoverable legacy WAL"),
+                ("unknown.sqlite3", b"recoverable unknown database"),
+            ):
+                path = palace / relative
+                if content is None:
+                    path.mkdir()
+                else:
+                    path.write_bytes(content)
+                try:
+                    state = module.mempalace_runtime_status(project)
+                    self.assertEqual("recovery-required", state["status"])
+                    self.assertIn("unrecognized", state["detail"])
+                    with mock.patch.object(module.subprocess, "run") as run:
+                        self.assertFalse(module.mcp_runtime_healthy(project))
+                    run.assert_not_called()
+                finally:
+                    if path.is_dir():
+                        path.rmdir()
+                    else:
+                        path.unlink()
+
+    def test_fresh_mempalace_state_initializes_once_without_claiming_user_data(self):
+        module = load(HOSTS, "chaos_engine_mempalace_initialize")
+        self.assertTrue(hasattr(module, "initialize_mempalace_runtime"))
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            self.assertEqual(
+                "initialization-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+
+            module.initialize_mempalace_runtime(project)
+            database = project / ".chaos-engine-state/mempalace/sqlite_exact.sqlite3"
+            self.assertTrue(database.is_file())
+            self.assertEqual(
+                "healthy",
+                module.mempalace_runtime_status(project)["status"],
+            )
+            before = database.read_bytes()
+            module.initialize_mempalace_runtime(project)
+            self.assertEqual(before, database.read_bytes())
+
+            database.unlink()
+            (database.parent / "user-owned.bin").write_bytes(b"preserve")
+            module.initialize_mempalace_runtime(project)
+            self.assertEqual(
+                b"preserve",
+                (database.parent / "user-owned.bin").read_bytes(),
+            )
+
+    def test_fresh_mempalace_initializer_revalidates_paths_after_creation(self):
+        module = load(HOSTS, "chaos_engine_mempalace_initialize_race")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            palace = project / ".chaos-engine-state/mempalace"
+            real_validate = module.validate_path
+            calls = 0
+
+            def reject_post_creation(root, path):
+                nonlocal calls
+                calls += 1
+                real_validate(root, path)
+                if calls == 2:
+                    raise ValueError("simulated link or reparse point swap")
+
+            with mock.patch.object(
+                module,
+                "validate_path",
+                side_effect=reject_post_creation,
+            ):
+                with self.assertRaisesRegex(ValueError, "link or reparse"):
+                    module.initialize_mempalace_runtime(project)
+
+            self.assertFalse((palace / "sqlite_exact.sqlite3").exists())
 
     def test_launcher_rendering_is_explicit_for_windows_and_posix(self):
         module = load(HOSTS, "chaos_engine_hosts")

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -856,6 +856,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
     def test_mempalace_runtime_state_is_fail_closed_before_native_launch(self):
         module = load(HOSTS, "chaos_engine_mempalace_runtime_state")
+        self.assertTrue(hasattr(module, "mempalace_runtime_status"))
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary)
             palace = project / ".chaos-engine-state/mempalace"
@@ -997,6 +998,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
     def test_mempalace_runtime_rejects_reparse_state_before_native_launch(self):
         module = load(HOSTS, "chaos_engine_mempalace_reparse_state")
+        self.assertTrue(hasattr(module, "mempalace_runtime_status"))
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary)
             palace = project / ".chaos-engine-state/mempalace"
@@ -1016,6 +1018,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
     def test_mempalace_runtime_rejects_unrecognized_state_before_native_launch(self):
         module = load(HOSTS, "chaos_engine_mempalace_unknown_state")
+        self.assertTrue(hasattr(module, "mempalace_runtime_status"))
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary)
             palace = project / ".chaos-engine-state/mempalace"
@@ -1075,6 +1078,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
     def test_fresh_mempalace_initializer_revalidates_paths_after_creation(self):
         module = load(HOSTS, "chaos_engine_mempalace_initialize_race")
+        self.assertTrue(hasattr(module, "initialize_mempalace_runtime"))
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary)
             palace = project / ".chaos-engine-state/mempalace"

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -126,20 +126,30 @@ class ChaosEngineInstallerTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "consumer"
             project.mkdir()
+            original_load = MODULE.load_installed_controller
+            controllers = []
 
-            MODULE.install_with_dependencies(
-                project,
-                SOURCE,
-                TEST_COMMIT,
-                provisioner=lambda *_args, **_kwargs: None,
-            )
+            def load_with_initializer(installed_root, name):
+                controller = original_load(installed_root, name)
+                if name == "hosts":
+                    controller.initialize_mempalace_runtime = mock.Mock()
+                    controllers.append(controller)
+                return controller
 
-            controller = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
-            self.assertTrue(hasattr(controller, "mempalace_runtime_status"))
-            self.assertEqual(
-                "healthy",
-                controller.mempalace_runtime_status(project)["status"],
-            )
+            with mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                side_effect=load_with_initializer,
+            ):
+                MODULE.install_with_dependencies(
+                    project,
+                    SOURCE,
+                    TEST_COMMIT,
+                    provisioner=lambda *_args, **_kwargs: None,
+                )
+
+            controller = controllers[-1]
+            controller.initialize_mempalace_runtime.assert_called_once_with(project)
             receipt = json.loads(
                 (project / controller.RECEIPT_NAME).read_text(encoding="utf-8")
             )
@@ -228,7 +238,7 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             self.assertEqual("recovery-required", result["status"])
             self.assertEqual("recovery-required", result["components"]["mcps"]["status"])
 
-    def test_doctor_reports_legacy_chroma_state_as_migration_required(self):
+    def test_status_maps_legacy_mempalace_classifier_without_launching(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "consumer"
             project.mkdir()
@@ -238,37 +248,32 @@ class ChaosEngineInstallerTest(unittest.TestCase):
                 TEST_COMMIT,
                 provisioner=lambda *_args, **_kwargs: None,
             )
+            palace = project / ".chaos-engine-state/mempalace"
+            palace.mkdir(parents=True, exist_ok=True)
+            create_chroma_state(palace / "chroma.sqlite3")
+            palace.joinpath("00000000-0000-0000-0000-000000000001").mkdir()
             controller = MODULE.load_installed_controller(
                 project / ".chaos-engine", "hosts"
             )
-            self.assertTrue(hasattr(controller, "mempalace_runtime_status"))
-            palace = project / ".chaos-engine-state/mempalace"
-            palace.joinpath("sqlite_exact.sqlite3").unlink()
-            create_chroma_state(palace / "chroma.sqlite3")
-            palace.joinpath("00000000-0000-0000-0000-000000000001").mkdir()
-            passive = MODULE.status_with_dependencies(project)
+            controller.mempalace_runtime_status = mock.Mock(
+                return_value={
+                    "status": "migration-required",
+                    "detail": "Legacy Chroma state requires migration",
+                }
+            )
+            with mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                return_value=controller,
+            ):
+                passive = MODULE.status_with_dependencies(project)
+
             self.assertEqual("recovery-required", passive["status"])
             self.assertEqual(
                 "migration-required",
                 passive["components"]["mempalace"]["status"],
             )
-            with mock.patch.object(
-                controller,
-                "retrieval_runtime_healthy",
-                return_value=True,
-            ), mock.patch.object(
-                MODULE,
-                "load_installed_controller",
-                return_value=controller,
-            ):
-                result = MODULE.doctor_with_dependencies(project, verify_clients=False)
-
-            self.assertEqual("recovery-required", result["status"])
-            self.assertEqual(
-                "migration-required",
-                result["components"]["mempalace"]["status"],
-            )
-            self.assertIn("Chroma", result["components"]["mempalace"]["detail"])
+            controller.mempalace_runtime_status.assert_called_once_with(project)
 
     def test_default_distribution_installs_only_neutral_portable_payload(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -242,19 +242,32 @@ class ChaosEngineInstallerTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "consumer"
             project.mkdir()
-            MODULE.install_with_dependencies(
-                project,
-                SOURCE,
-                TEST_COMMIT,
-                provisioner=lambda *_args, **_kwargs: None,
-            )
+            original_load = MODULE.load_installed_controller
+            controllers = []
+
+            def load_with_initializer(installed_root, name):
+                controller = original_load(installed_root, name)
+                if name == "hosts":
+                    controller.initialize_mempalace_runtime = mock.Mock()
+                    controllers.append(controller)
+                return controller
+
+            with mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                side_effect=load_with_initializer,
+            ):
+                MODULE.install_with_dependencies(
+                    project,
+                    SOURCE,
+                    TEST_COMMIT,
+                    provisioner=lambda *_args, **_kwargs: None,
+                )
             palace = project / ".chaos-engine-state/mempalace"
             palace.mkdir(parents=True, exist_ok=True)
             create_chroma_state(palace / "chroma.sqlite3")
             palace.joinpath("00000000-0000-0000-0000-000000000001").mkdir()
-            controller = MODULE.load_installed_controller(
-                project / ".chaos-engine", "hosts"
-            )
+            controller = controllers[-1]
             controller.mempalace_runtime_status = mock.Mock(
                 return_value={
                     "status": "migration-required",

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -6,6 +6,7 @@ import hashlib
 import importlib.util
 import json
 import shutil
+import sqlite3
 import subprocess  # nosec B404 - tests run the fixed local installer only.
 import sys
 import tempfile
@@ -67,6 +68,31 @@ def tree_digest(root: Path) -> dict[str, str]:
     }
 
 
+def create_chroma_state(path: Path) -> None:
+    database = sqlite3.connect(path)
+    try:
+        database.executescript(
+            """
+            CREATE TABLE collections (
+                id TEXT PRIMARY KEY, name TEXT NOT NULL, dimension INTEGER,
+                database_id TEXT NOT NULL, config_json_str TEXT, schema_str TEXT
+            );
+            CREATE TABLE segments (
+                id TEXT PRIMARY KEY, type TEXT NOT NULL, scope TEXT NOT NULL,
+                collection TEXT NOT NULL
+            );
+            CREATE TABLE embeddings_queue (
+                seq_id INTEGER PRIMARY KEY, created_at TIMESTAMP NOT NULL,
+                operation INTEGER NOT NULL, topic TEXT NOT NULL, id TEXT NOT NULL,
+                vector BLOB, encoding TEXT, metadata TEXT
+            );
+            """
+        )
+        database.commit()
+    finally:
+        database.close()
+
+
 class ChaosEngineInstallerTest(unittest.TestCase):
     def test_doctor_command_uses_the_full_status_contract(self):
         arguments = MODULE.parser().parse_args(["doctor", "--project", "."])
@@ -95,6 +121,29 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             ), mock.patch.object(MODULE, "load_dependency_controller", return_value=controller):
                 with self.assertRaisesRegex(RuntimeError, "active probe failed"):
                     MODULE.doctor_with_dependencies(project)
+
+    def test_install_initializes_fresh_mempalace_without_receipt_ownership(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+
+            MODULE.install_with_dependencies(
+                project,
+                SOURCE,
+                TEST_COMMIT,
+                provisioner=lambda *_args, **_kwargs: None,
+            )
+
+            controller = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            self.assertEqual(
+                "healthy",
+                controller.mempalace_runtime_status(project)["status"],
+            )
+            receipt = json.loads(
+                (project / controller.RECEIPT_NAME).read_text(encoding="utf-8")
+            )
+            owned = json.dumps({"before": receipt["before"], "after": receipt["after"]})
+            self.assertNotIn(".chaos-engine-state/mempalace", owned)
 
     def test_status_rejects_semantically_invalid_retrieval_configuration(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -177,6 +226,45 @@ class ChaosEngineInstallerTest(unittest.TestCase):
 
             self.assertEqual("recovery-required", result["status"])
             self.assertEqual("recovery-required", result["components"]["mcps"]["status"])
+
+    def test_doctor_reports_legacy_chroma_state_as_migration_required(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            MODULE.install_with_dependencies(
+                project,
+                SOURCE,
+                TEST_COMMIT,
+                provisioner=lambda *_args, **_kwargs: None,
+            )
+            palace = project / ".chaos-engine-state/mempalace"
+            palace.joinpath("sqlite_exact.sqlite3").unlink()
+            create_chroma_state(palace / "chroma.sqlite3")
+            palace.joinpath("00000000-0000-0000-0000-000000000001").mkdir()
+            passive = MODULE.status_with_dependencies(project)
+            self.assertEqual("recovery-required", passive["status"])
+            self.assertEqual(
+                "migration-required",
+                passive["components"]["mempalace"]["status"],
+            )
+            controller = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            with mock.patch.object(
+                controller,
+                "retrieval_runtime_healthy",
+                return_value=True,
+            ), mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                return_value=controller,
+            ):
+                result = MODULE.doctor_with_dependencies(project, verify_clients=False)
+
+            self.assertEqual("recovery-required", result["status"])
+            self.assertEqual(
+                "migration-required",
+                result["components"]["mempalace"]["status"],
+            )
+            self.assertIn("Chroma", result["components"]["mempalace"]["detail"])
 
     def test_default_distribution_installs_only_neutral_portable_payload(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -484,6 +572,83 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "offline"):
                 MODULE.install_with_dependencies(project, SOURCE, TEST_COMMIT, provisioner=fail)
             self.assertEqual(TEST_COMMIT, MODULE.status(project)["commit"])
+
+    def test_initializer_failure_removes_only_runtime_created_by_install(self):
+        dependency_module = load_module(SOURCE / "dependencies.py")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            original_load = MODULE.load_installed_controller
+
+            def provision(runtime, specification):
+                return dependency_module.repair(
+                    runtime,
+                    specification,
+                    runner=ChaosEngineDependenciesRunner(runtime),
+                )
+
+            def load_with_failure(installed_root, name):
+                controller = original_load(installed_root, name)
+                if name == "hosts":
+                    controller.initialize_mempalace_runtime = mock.Mock(
+                        side_effect=RuntimeError("initialization failed")
+                    )
+                return controller
+
+            with mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                side_effect=load_with_failure,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "initialization failed"):
+                    MODULE.install_with_dependencies(
+                        project,
+                        SOURCE,
+                        TEST_COMMIT,
+                        provisioner=provision,
+                    )
+
+            self.assertFalse((project / ".chaos-engine-runtime").exists())
+
+    def test_initializer_failure_preserves_preexisting_verified_runtime(self):
+        dependency_module = load_module(SOURCE / "dependencies.py")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            runtime = project / ".chaos-engine-runtime"
+            specification = dependency_module.load_specification(
+                SOURCE / "dependencies.json"
+            )
+            dependency_module.repair(
+                runtime,
+                specification,
+                runner=ChaosEngineDependenciesRunner(runtime),
+            )
+            before = tree_digest(runtime)
+            original_load = MODULE.load_installed_controller
+
+            def load_with_failure(installed_root, name):
+                controller = original_load(installed_root, name)
+                if name == "hosts":
+                    controller.initialize_mempalace_runtime = mock.Mock(
+                        side_effect=RuntimeError("initialization failed")
+                    )
+                return controller
+
+            with mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                side_effect=load_with_failure,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "initialization failed"):
+                    MODULE.install_with_dependencies(
+                        project,
+                        SOURCE,
+                        TEST_COMMIT,
+                        provisioner=lambda *_args: None,
+                    )
+
+            self.assertEqual(before, tree_digest(runtime))
 
     def test_failed_update_restores_the_previous_host_generation(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -135,6 +135,7 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             )
 
             controller = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            self.assertTrue(hasattr(controller, "mempalace_runtime_status"))
             self.assertEqual(
                 "healthy",
                 controller.mempalace_runtime_status(project)["status"],
@@ -237,6 +238,10 @@ class ChaosEngineInstallerTest(unittest.TestCase):
                 TEST_COMMIT,
                 provisioner=lambda *_args, **_kwargs: None,
             )
+            controller = MODULE.load_installed_controller(
+                project / ".chaos-engine", "hosts"
+            )
+            self.assertTrue(hasattr(controller, "mempalace_runtime_status"))
             palace = project / ".chaos-engine-state/mempalace"
             palace.joinpath("sqlite_exact.sqlite3").unlink()
             create_chroma_state(palace / "chroma.sqlite3")
@@ -247,7 +252,6 @@ class ChaosEngineInstallerTest(unittest.TestCase):
                 "migration-required",
                 passive["components"]["mempalace"]["status"],
             )
-            controller = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
             with mock.patch.object(
                 controller,
                 "retrieval_runtime_healthy",


### PR DESCRIPTION
## Summary
- Configure every generated MemPalace MCP sibling to select `sqlite_exact`, containing new ChaosEngine-managed sessions away from the HNSW/native crash path owned upstream by mempalace#1329.
- Validate project-local SQLite state through structured read-only queries, exact schema/index/collection contracts, fail-closed legacy/mixed/reparse classification, and a real non-mutating `mempalace_status` MCP call.
- Initialize only fresh empty project-local state, preserve legacy/recovery state, harden path identity races, and compensate only dependency runtimes created by a failed install.
- Keep rollback/uninstall ownership honest: project-local MemPalace data is never receipt-owned, migrated, renamed, or deleted.

Related to #4976. This is containment only; upstream mempalace#1329 remains the root-fix owner.

## Checks
- Full affected suite — PASS (125 tests; latest full run 74.395s)
- Latest isolated status fixture — PASS (1 test, 0.964s)
- `py -3 -B scripts/ci/validate_agent_setup.py --skip-external` — PASS
- `git diff --check` — PASS
- Independent read-only adversarial review — ZERO BLOCKERS across production and all RED-history fixture deltas
- Exact RED-before-GREEN validators — PASS for both hosts and installer pairs at the recorded head
- Pinned MemPalace 3.7.1 behavior probe — fresh sqlite_exact state reports `total_drawers=0`, `backend=sqlite_exact`

## Continuation
Head: 2b1033f8bbcabf94dc48532fe4a2b5635dddb084
State: Reviewed containment and isolated RED-history fixtures are committed and pushed. Installer tests isolate install.py contracts under the validator's single-production-file overlay; host tests separately prove classifier/initializer behavior. No live palace or recovery directory was mutated.
Blockers: Exact-head CI and Codacy reanalysis are pending; implementation and review are clear.
Next action: Integrate commits `840a73f800938e95efadcafc6322a444b458bd3e`, `70b4a51bedbc3a6f63a4217eb19721814a08dfb9`, `252ff434dc4f9fa697b89118116bf7ee659374e9`, and `2b1033f8bbcabf94dc48532fe4a2b5635dddb084` in order into draft #4992, then await its combined CI.

Checkpoint constraint: GitHub cannot create a pull request before the branch contains a diff. The first honest checkpoint therefore used commit → immediate push → immediate draft PR; no empty or scaffold commit was manufactured. Every later commit was immediately pushed and this snapshot updated.