### PR TITLE
Tolerate element timeouts that have no root cause

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
@@ -494,8 +494,11 @@ public class ElementActionsHelper {
             if (resolution != null) {
                 return recoveredElementInformation(driver, elementLocator, resolution);
             }
-            var causeMessage = timeoutException.getCause().getMessage();
-            causeMessage = !causeMessage.isBlank() && causeMessage.contains("\n") ? timeoutException.getMessage() + " || " + causeMessage.substring(0, causeMessage.indexOf("\n")) : timeoutException.getMessage();
+            var cause = timeoutException.getCause();
+            var causeMessage = cause == null ? null : cause.getMessage();
+            causeMessage = causeMessage != null && !causeMessage.isBlank() && causeMessage.contains("\n")
+                    ? timeoutException.getMessage() + " || " + causeMessage.substring(0, causeMessage.indexOf("\n"))
+                    : timeoutException.getMessage();
             ReportManager.logDiscrete(causeMessage);
             var elementInformation = new ArrayList<>();
             elementInformation.add(0);

--- a/shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementsHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/element/internal/ElementsHelperCoverageUnitTest.java
@@ -144,6 +144,20 @@ public class ElementsHelperCoverageUnitTest {
     }
 
     @Test
+    public void waitForElementPresenceShouldTolerateTimeoutWithoutCause() {
+        TimeoutException timeoutException = new TimeoutException("timed out");
+
+        try (MockedStatic<DriverFactoryHelper> ignoredDriverFactoryHelper = mockDesktopExecution();
+             MockedConstruction<SynchronizationManager> ignored = mockSynchronizationManagerThrowing(timeoutException)) {
+            List<Object> information = helper.waitForElementPresence(driver, locator, true);
+
+            Assert.assertEquals(information.get(0), 0);
+            Assert.assertNull(information.get(1));
+            Assert.assertSame(information.get(2), timeoutException);
+        }
+    }
+
+    @Test
     public void waitForElementPresenceShouldReturnInvalidSelectorPayload() {
         InvalidSelectorException invalidSelectorException = new InvalidSelectorException("bad css");
 


### PR DESCRIPTION
﻿## Summary
- Element identification logged timeoutException.getCause().getMessage() with no null check
- Selenium TimeoutException often has a null cause, so the real element-not-found path crashed with an NPE instead of returning the missing-element payload
- Guard the cause before reading its message; fall back to the timeout message

## Tests
- [x] ElementsHelperCoverageUnitTest (22/22), including waitForElementPresenceShouldTolerateTimeoutWithoutCause
[2026-08-15_22-54-01-135_AllureReport.html](https://github.com/user-attachments/files/31107527/2026-08-15_22-54-01-135_AllureReport.html)

