### PR TITLE
Bundle caveman skill + proxy in ChaosEngine

### DIFF
--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -612,6 +612,7 @@ def client_command(
     arguments: list[str],
     project: Path,
     runner=subprocess.run,
+    timeout: int = 30,
 ) -> subprocess.CompletedProcess[str]:
     result = runner(  # nosec B603 - executable is resolved by shutil.which.
         [executable, *arguments],
@@ -619,7 +620,7 @@ def client_command(
         capture_output=True,
         text=True,
         check=False,
-        timeout=30,
+        timeout=timeout,
     )
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip()
@@ -1004,13 +1005,29 @@ def install_caveman_proxy(
         ["install", "--global", CAVEMAN_CLI_SPEC, "--no-audit", "--no-fund"],
         project,
         runner=runner,
+        timeout=300,
     )
     caveman = which("caveman")
     if caveman is None:
         raise RuntimeError("Caveman CLI was not available after installation")
-    client_command(caveman, ["setup", "--install"], project, runner=runner)
-    client_command(caveman, ["enable", "--detected"], project, runner=runner)
-    return {"cli": CAVEMAN_CLI_SPEC, "runtime": "installed", "providers": "detected"}
+    client_command(
+        caveman,
+        ["setup", "--install"],
+        project,
+        runner=runner,
+        timeout=300,
+    )
+    supported = ("claude", "codex", "hermes", "gemini", "opencode", "aider")
+    detected = [name for name in supported if which(name) is not None]
+    if detected:
+        client_command(
+            caveman,
+            ["enable", "--detected"],
+            project,
+            runner=runner,
+            timeout=120,
+        )
+    return {"cli": CAVEMAN_CLI_SPEC, "runtime": "installed", "providers": detected}
 
 
 def activate_detected_plugins(

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -28,6 +28,10 @@ REMOVING_ANCHOR_PREFIX = ".chaos-engine-hosts.removing-"
 ANCHOR_TOKEN = re.compile(r"^[0-9a-f]{64}$")
 SCHEMA_VERSION = 1
 PLUGIN_NAME = "chaos-engine"
+CAVEMAN_PLUGIN_NAME = "caveman"
+CAVEMAN_PLUGIN_VERSION = "0.1.0"
+CAVEMAN_CLI_SPEC = "@caveman-ai/cli@1.2.0"
+CAVEMAN_UPSTREAM_COMMIT = "766dce6b1394ebb56a3090748d5a0240a5aefb36"
 MEMORY_SCHEMA_FILES = (
     "config.schema.json",
     "object.schema.json",
@@ -661,20 +665,50 @@ def activation_contract(project: Path) -> tuple[Path, str, str, str]:
     return root, marketplace_name, f"{PLUGIN_NAME}@{marketplace_name}", version
 
 
+def activation_plugins(project: Path, marketplace_name: str) -> dict[str, dict[str, object]]:
+    plugins: dict[str, dict[str, object]] = {}
+    for name in (PLUGIN_NAME, CAVEMAN_PLUGIN_NAME):
+        manifest_path = project / f"plugins/{name}/.codex-plugin/plugin.json"
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError(f"{name} plugin manifest is unavailable") from error
+        version = manifest.get("version") if isinstance(manifest, dict) else None
+        if (
+            not isinstance(version, str)
+            or re.fullmatch(r"\d+\.\d+\.\d+", version) is None
+            or manifest.get("name") != name
+        ):
+            raise ValueError(f"{name} plugin manifest is invalid")
+        plugins[name] = {
+            "id": f"{name}@{marketplace_name}",
+            "version": version,
+            "source": project / f"plugins/{name}",
+        }
+    return plugins
+
+
 def prepare_activation_bundle(project: Path) -> tuple[Path, str, str, str]:
     """Publish one path-unique generated marketplace without tracked machine paths."""
     project = project.resolve()
     root, marketplace_name, plugin_id, version = activation_contract(project)
-    source_plugin = project / "plugins/chaos-engine"
-    if not source_plugin.is_dir() or is_link_or_reparse(source_plugin):
-        raise ValueError("ChaosEngine plugin source is unavailable")
+    plugins = activation_plugins(project, marketplace_name)
+    for name, contract in plugins.items():
+        source_plugin = contract["source"]
+        if (
+            not isinstance(source_plugin, Path)
+            or not source_plugin.is_dir()
+            or is_link_or_reparse(source_plugin)
+        ):
+            raise ValueError(f"{name} plugin source is unavailable")
     state_root = root.parent
     state_root.mkdir(parents=True, exist_ok=True)
     building = state_root / f".{root.name}.building-{secrets.token_hex(8)}"
     backup = state_root / f".{root.name}.backup-{secrets.token_hex(8)}"
     building.mkdir()
     try:
-        shutil.copytree(source_plugin, building / "plugins/chaos-engine")
+        for name, contract in plugins.items():
+            shutil.copytree(contract["source"], building / f"plugins/{name}")
         codex_marketplace = {
             "name": marketplace_name,
             "interface": {"displayName": "ChaosEngine Project"},
@@ -684,7 +718,16 @@ def prepare_activation_bundle(project: Path) -> tuple[Path, str, str, str]:
                     "source": {"source": "local", "path": "./plugins/chaos-engine"},
                     "policy": {"installation": "INSTALLED_BY_DEFAULT", "authentication": "ON_INSTALL"},
                     "category": "Developer Tools",
-                }
+                },
+                {
+                    "name": CAVEMAN_PLUGIN_NAME,
+                    "source": {"source": "local", "path": "./plugins/caveman"},
+                    "policy": {
+                        "installation": "INSTALLED_BY_DEFAULT",
+                        "authentication": "ON_INSTALL",
+                    },
+                    "category": "Productivity",
+                },
             ],
         }
         claude_marketplace = {
@@ -697,7 +740,13 @@ def prepare_activation_bundle(project: Path) -> tuple[Path, str, str, str]:
                     "source": "./plugins/chaos-engine",
                     "description": "Neutral project-local agent harness.",
                     "version": version,
-                }
+                },
+                {
+                    "name": CAVEMAN_PLUGIN_NAME,
+                    "source": "./plugins/caveman",
+                    "description": "Ultra-compressed communication mode.",
+                    "version": CAVEMAN_PLUGIN_VERSION,
+                },
             ],
         }
         for relative, document in (
@@ -729,11 +778,12 @@ def detected_plugin_status(
     *,
     runner=subprocess.run,
     which=shutil.which,
-) -> dict[str, dict[str, str]]:
+) -> dict[str, dict[str, object]]:
     """Read back native plugin registration for every client installed on the host."""
     project = project.resolve()
     root, marketplace_name, plugin_id, version = activation_contract(project)
-    status: dict[str, dict[str, str]] = {}
+    plugins = activation_plugins(project, marketplace_name)
+    status: dict[str, dict[str, object]] = {}
     for client in ("codex", "claude"):
         executable = which(client)
         if executable is None:
@@ -757,21 +807,24 @@ def detected_plugin_status(
                 and same_path(item.get("root"), root)
                 for item in marketplaces
             )
-            plugin_present = any(
-                isinstance(item, dict)
-                and item.get("pluginId") == plugin_id
-                and item.get("installed") is True
-                and item.get("enabled") is True
-                and isinstance(item.get("source"), dict)
-                and same_path(item["source"].get("path"), root / "plugins/chaos-engine")
-                for item in records
-            )
-            plugin_ok = plugin_present and any(
-                isinstance(item, dict)
-                and item.get("pluginId") == plugin_id
-                and item.get("version") == version
-                for item in records
-            )
+            plugin_states = {}
+            for name, contract in plugins.items():
+                present = any(
+                    isinstance(item, dict)
+                    and item.get("pluginId") == contract["id"]
+                    and item.get("installed") is True
+                    and item.get("enabled") is True
+                    and isinstance(item.get("source"), dict)
+                    and same_path(item["source"].get("path"), root / f"plugins/{name}")
+                    for item in records
+                )
+                healthy = present and any(
+                    isinstance(item, dict)
+                    and item.get("pluginId") == contract["id"]
+                    and item.get("version") == contract["version"]
+                    for item in records
+                )
+                plugin_states[name] = "healthy" if healthy else ("stale" if present else "absent")
         else:
             marketplaces = client_json(
                 executable, ["plugin", "marketplace", "list", "--json"], project, runner=runner
@@ -786,25 +839,31 @@ def detected_plugin_status(
                 and same_path(item.get("path"), root)
                 for item in marketplaces
             )
-            plugin_present = any(
-                isinstance(item, dict)
-                and item.get("id") == plugin_id
-                and item.get("enabled") is True
-                and same_path(item.get("projectPath"), project)
-                for item in records
-            )
-            plugin_ok = plugin_present and any(
-                isinstance(item, dict)
-                and item.get("id") == plugin_id
-                and item.get("version") == version
-                and same_path(item.get("projectPath"), project)
-                and cached_plugin_matches(item.get("installPath"), root / "plugins/chaos-engine")
-                for item in records
-            )
+            plugin_states = {}
+            for name, contract in plugins.items():
+                present = any(
+                    isinstance(item, dict)
+                    and item.get("id") == contract["id"]
+                    and item.get("enabled") is True
+                    and same_path(item.get("projectPath"), project)
+                    for item in records
+                )
+                healthy = present and any(
+                    isinstance(item, dict)
+                    and item.get("id") == contract["id"]
+                    and item.get("version") == contract["version"]
+                    and same_path(item.get("projectPath"), project)
+                    and cached_plugin_matches(item.get("installPath"), root / f"plugins/{name}")
+                    for item in records
+                )
+                plugin_states[name] = "healthy" if healthy else ("stale" if present else "absent")
+        plugin_ok = all(item == "healthy" for item in plugin_states.values())
+        plugin_present = any(item != "absent" for item in plugin_states.values())
         status[client] = {
             "status": "healthy" if marketplace_ok and plugin_ok else "absent",
             "marketplace": "healthy" if marketplace_ok else "absent",
             "plugin": "healthy" if plugin_ok else ("stale" if plugin_present else "absent"),
+            "plugins": plugin_states,
         }
     return status
 
@@ -813,7 +872,12 @@ def cached_plugin_matches(installed_path: object, source: Path) -> bool:
     if not isinstance(installed_path, str):
         return False
     installed = Path(installed_path)
-    for relative in ("hooks/guard.py", "hooks/reflection.py", "skills/chaos-engine/SKILL.md"):
+    required = (
+        ("hooks/guard.py", "hooks/reflection.py", "skills/chaos-engine/SKILL.md")
+        if source.name == PLUGIN_NAME
+        else ("skills/caveman/SKILL.md", "LICENSE", "UPSTREAM.md")
+    )
+    for relative in required:
         cached = installed / relative
         expected = source / relative
         try:
@@ -855,6 +919,7 @@ def record_client_activation(project: Path, activation: dict[str, object]) -> No
         "ownedClients": activation["ownedClients"],
         "pluginVersion": activation["pluginVersion"],
         "claudeLocalBefore": activation["claudeLocalBefore"],
+        "cavemanProxy": activation.get("cavemanProxy"),
     }
     write_receipt(project, receipt, raw)
 
@@ -880,21 +945,23 @@ def remove_client_activation(
     runner=subprocess.run,
     which=shutil.which,
 ) -> None:
-    root, _, plugin_id, _ = activation_contract(project)
-    commands = activation_commands(root, plugin_id)
+    root, marketplace_name, _, _ = activation_contract(project)
+    plugins = activation_plugins(project, marketplace_name)
     for client in reversed(clients):
         executable = which(client)
         if executable is None:
             continue
         selected = lambda name, chosen=client, path=executable: path if name == chosen else None
         current = detected_plugin_status(project, runner=runner, which=selected).get(client, {})
-        if current.get("plugin") in {"healthy", "stale"}:
-            client_command(executable, commands[client]["remove"], project, runner=runner)
+        plugin_states = current.get("plugins", {})
+        for name in reversed(tuple(plugins)):
+            if isinstance(plugin_states, dict) and plugin_states.get(name) in {"healthy", "stale"}:
+                commands = activation_commands(root, str(plugins[name]["id"]))
+                client_command(executable, commands[client]["remove"], project, runner=runner)
         current = detected_plugin_status(project, runner=runner, which=selected).get(client, {})
         if current.get("marketplace") == "healthy":
-            client_command(
-                executable, commands[client]["removeMarketplace"], project, runner=runner
-            )
+            commands = activation_commands(root, str(plugins[PLUGIN_NAME]["id"]))
+            client_command(executable, commands[client]["removeMarketplace"], project, runner=runner)
 
 
 def restore_client_activation(
@@ -909,14 +976,41 @@ def restore_client_activation(
     clients = activation.get("ownedClients")
     if not isinstance(clients, list) or not all(item in {"codex", "claude"} for item in clients):
         raise ValueError("ChaosEngine client activation receipt is invalid")
-    root, _, plugin_id, _ = activation_contract(project)
-    commands = activation_commands(root, plugin_id)
+    root, marketplace_name, _, _ = activation_contract(project)
+    plugins = activation_plugins(project, marketplace_name)
     for client in clients:
         executable = which(client)
         if executable is None:
             continue
+        commands = activation_commands(root, str(plugins[PLUGIN_NAME]["id"]))
         client_command(executable, commands[client]["marketplace"], project, runner=runner)
-        client_command(executable, commands[client]["install"], project, runner=runner)
+        for contract in plugins.values():
+            plugin_commands = activation_commands(root, str(contract["id"]))
+            client_command(executable, plugin_commands[client]["install"], project, runner=runner)
+
+
+def install_caveman_proxy(
+    project: Path,
+    *,
+    runner=subprocess.run,
+    which=shutil.which,
+) -> dict[str, object]:
+    """Install Caveman's pinned signed runtime and enable every detected native provider."""
+    npm = which("npm")
+    if npm is None:
+        raise RuntimeError("Caveman proxy installation requires npm")
+    client_command(
+        npm,
+        ["install", "--global", CAVEMAN_CLI_SPEC, "--no-audit", "--no-fund"],
+        project,
+        runner=runner,
+    )
+    caveman = which("caveman")
+    if caveman is None:
+        raise RuntimeError("Caveman CLI was not available after installation")
+    client_command(caveman, ["setup", "--install"], project, runner=runner)
+    client_command(caveman, ["enable", "--detected"], project, runner=runner)
+    return {"cli": CAVEMAN_CLI_SPEC, "runtime": "installed", "providers": "detected"}
 
 
 def activate_detected_plugins(
@@ -951,7 +1045,8 @@ def activate_detected_plugins(
     root, marketplace_name, plugin_id, _ = prepare_activation_bundle(project)
     created_marketplaces: list[str] = []
     created_plugins: list[str] = []
-    commands = activation_commands(root, plugin_id)
+    plugins = activation_plugins(project, marketplace_name)
+    marketplace_commands = activation_commands(root, str(plugins[PLUGIN_NAME]["id"]))
     touched_clients: list[str] = []
     receipt: dict[str, object] = {
         "createdMarketplaces": created_marketplaces,
@@ -967,18 +1062,28 @@ def activate_detected_plugins(
             selected_client = lambda name, selected=client, path=executable: path if name == selected else None
             current = detected_plugin_status(project, runner=runner, which=selected_client)[client]
             if current["marketplace"] != "healthy":
-                client_command(executable, commands[client]["marketplace"], project, runner=runner)
+                client_command(
+                    executable,
+                    marketplace_commands[client]["marketplace"],
+                    project,
+                    runner=runner,
+                )
                 created_marketplaces.append(client)
             current = detected_plugin_status(project, runner=runner, which=selected_client)[client]
-            if current["plugin"] == "absent":
-                client_command(executable, commands[client]["install"], project, runner=runner)
-                created_plugins.append(client)
-            elif current["plugin"] == "stale":
-                client_command(executable, commands[client]["remove"], project, runner=runner)
-                client_command(executable, commands[client]["install"], project, runner=runner)
+            plugin_states = current.get("plugins", {})
+            for name, contract in plugins.items():
+                state = plugin_states.get(name) if isinstance(plugin_states, dict) else "absent"
+                commands = activation_commands(root, str(contract["id"]))
+                if state == "absent":
+                    client_command(executable, commands[client]["install"], project, runner=runner)
+                    created_plugins.append(f"{client}:{name}")
+                elif state == "stale":
+                    client_command(executable, commands[client]["remove"], project, runner=runner)
+                    client_command(executable, commands[client]["install"], project, runner=runner)
             verified = detected_plugin_status(project, runner=runner, which=selected_client)[client]
             if verified["status"] != "healthy":
                 raise RuntimeError(f"{client} plugin activation did not verify")
+        receipt["cavemanProxy"] = install_caveman_proxy(project, runner=runner, which=which)
         verified_clients = detected_plugin_status(project, runner=runner, which=which)
         receipt["ownedClients"] = touched_clients
         receipt["pluginVersion"] = activation_contract(project)[3]
@@ -1514,6 +1619,11 @@ def managed_paths() -> tuple[str, ...]:
         "plugins/chaos-engine/hooks/guard.py",
         "plugins/chaos-engine/hooks/reflection.py",
         "plugins/chaos-engine/skills/chaos-engine/SKILL.md",
+        "plugins/caveman/.codex-plugin/plugin.json",
+        "plugins/caveman/.claude-plugin/plugin.json",
+        "plugins/caveman/skills/caveman/SKILL.md",
+        "plugins/caveman/LICENSE",
+        "plugins/caveman/UPSTREAM.md",
         ".codex/hooks.json",
         ".claude/settings.json",
         ".claude/agents/chaos-engine-orchestrator.md",
@@ -1865,6 +1975,55 @@ def hook_content(before: bytes | None, rendered: bytes, label: str) -> bytes:
     return (json.dumps(existing, indent=2, sort_keys=True) + "\n").encode()
 
 
+def chaos_hook_command(command: object) -> bool:
+    if not isinstance(command, str):
+        return False
+    tokens = re.findall(r'"([^"]*)"|\'([^\']*)\'|(\S+)', command)
+    owned_suffixes = (
+        "scripts/agents/guard.py",
+        ".chaos-engine/hooks/guard.py",
+        "${CLAUDE_PLUGIN_ROOT}/hooks/guard.py",
+    )
+    for token_parts in tokens:
+        token = next((part for part in token_parts if part), "").replace("\\", "/")
+        token = token.rstrip(";,)")
+        if any(token == suffix or token.endswith(f"/{suffix}") for suffix in owned_suffixes):
+            return True
+    return False
+
+
+def without_chaos_hooks(before: bytes | None, label: str) -> bytes:
+    """Remove only owned command handlers while preserving foreign handlers and metadata."""
+    try:
+        existing = json.loads(before) if before is not None else {"hooks": {}}
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"invalid {label} hook configuration") from error
+    if not isinstance(existing, dict) or not isinstance(existing.get("hooks"), dict):
+        raise ValueError(f"invalid {label} hook configuration")
+    for event, groups in list(existing["hooks"].items()):
+        if not isinstance(groups, list):
+            raise ValueError(f"invalid {label} hook configuration")
+        retained_groups = []
+        for group in groups:
+            if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+                retained_groups.append(group)
+                continue
+            retained_hooks = [
+                hook
+                for hook in group["hooks"]
+                if not (isinstance(hook, dict) and chaos_hook_command(hook.get("command")))
+            ]
+            if retained_hooks:
+                retained_group = dict(group)
+                retained_group["hooks"] = retained_hooks
+                retained_groups.append(retained_group)
+        if retained_groups:
+            existing["hooks"][event] = retained_groups
+        else:
+            del existing["hooks"][event]
+    return (json.dumps(existing, indent=2, sort_keys=True) + "\n").encode()
+
+
 def gitignore_content(before: bytes | None) -> bytes:
     try:
         existing = before.decode("utf-8") if before is not None else ""
@@ -1892,6 +2051,7 @@ def gitignore_content(before: bytes | None) -> bytes:
         "!.github/\n!.github/copilot-instructions.md\n!.github/skills/\n"
         "!.github/skills/chaos-engine/\n!.github/skills/chaos-engine/**\n"
         "!plugins/\n!plugins/chaos-engine/\n!plugins/chaos-engine/**\n"
+        "!plugins/caveman/\n!plugins/caveman/**\n"
         "!.mcp.json\n!mempalace.yaml\n!AGENTS.md\n!CLAUDE.md\n!GEMINI.md\n!.gitattributes\n"
         ".chaos-engine-owned-directory\n"
         f"{GITIGNORE_END}\n"
@@ -1923,6 +2083,7 @@ def gitattributes_content(before: bytes | None) -> bytes:
         f"{repository_root_anchor}.mcp.json text eol=lf\n"
         f"{repository_root_anchor}.memory/** text eol=lf\n"
         f"{repository_root_anchor}plugins/chaos-engine/** text eol=lf\n"
+        f"{repository_root_anchor}plugins/caveman/** text eol=lf\n"
         f"{repository_root_anchor}AGENTS.md text eol=lf\n"
         f"{repository_root_anchor}CLAUDE.md text eol=lf\n"
         f"{repository_root_anchor}GEMINI.md text eol=lf\n"
@@ -1957,6 +2118,7 @@ def desired_content(
         "# Installed agent harness\n\n"
         "- `chaos-engine/`: canonical skill adapter.\n"
         "- `../../plugins/chaos-engine/`: installed plugin and lifecycle hook.\n"
+        "- `../../plugins/caveman/`: bundled Caveman response-compression skill.\n"
         "- `.chaos-engine/`: canonical skills, playbooks, tools, and policy.\n"
     ).encode()
     plugin_entry = {
@@ -1990,6 +2152,27 @@ def desired_content(
         raise ValueError("ChaosEngine plugin marketplace collision")
     if existing_plugin is None:
         marketplace["plugins"].append(plugin_entry)
+    caveman_entry = {
+        "name": CAVEMAN_PLUGIN_NAME,
+        "source": {"source": "local", "path": "./plugins/caveman"},
+        "policy": {
+            "installation": "INSTALLED_BY_DEFAULT",
+            "authentication": "ON_INSTALL",
+        },
+        "category": "Productivity",
+    }
+    existing_caveman = next(
+        (
+            item
+            for item in marketplace["plugins"]
+            if isinstance(item, dict) and item.get("name") == CAVEMAN_PLUGIN_NAME
+        ),
+        None,
+    )
+    if existing_caveman is not None and existing_caveman != caveman_entry:
+        raise ValueError("Caveman plugin marketplace collision")
+    if existing_caveman is None:
+        marketplace["plugins"].append(caveman_entry)
     after[".agents/plugins/marketplace.json"] = (
         json.dumps(marketplace, indent=2, sort_keys=True) + "\n"
     ).encode()
@@ -2030,6 +2213,24 @@ def desired_content(
         raise ValueError("ChaosEngine Claude marketplace collision")
     if existing_claude_plugin is None:
         claude_marketplace["plugins"].append(claude_plugin_entry)
+    caveman_claude_entry = {
+        "name": CAVEMAN_PLUGIN_NAME,
+        "source": "./plugins/caveman",
+        "description": "Ultra-compressed communication mode.",
+        "version": CAVEMAN_PLUGIN_VERSION,
+    }
+    existing_caveman = next(
+        (
+            item
+            for item in claude_marketplace["plugins"]
+            if isinstance(item, dict) and item.get("name") == CAVEMAN_PLUGIN_NAME
+        ),
+        None,
+    )
+    if existing_caveman is not None and existing_caveman != caveman_claude_entry:
+        raise ValueError("Caveman Claude plugin collision")
+    if existing_caveman is None:
+        claude_marketplace["plugins"].append(caveman_claude_entry)
     after[".claude-plugin/marketplace.json"] = (
         json.dumps(claude_marketplace, indent=2, sort_keys=True) + "\n"
     ).encode()
@@ -2045,7 +2246,7 @@ def desired_content(
             "longDescription": "A neutral project-local harness for research, planning, implementation, verification, and durable learning.",
             "developerName": "ChaosEngine contributors",
             "category": "Developer Tools",
-            "capabilities": ["Instructions", "Lifecycle hooks", "MCP servers"],
+            "capabilities": ["Instructions", "MCP servers"],
             "defaultPrompt": ["Use ChaosEngine for this task."],
         },
     }
@@ -2065,41 +2266,9 @@ def desired_content(
         )
         + "\n"
     ).encode()
-    command, prefix = interpreter()
-    hook_command = " ".join([command, *prefix, '"${CLAUDE_PLUGIN_ROOT}/hooks/guard.py"'])
-    lifecycle_events = {
-        "SessionStart": "startup|resume|clear|compact",
-        "UserPromptSubmit": None,
-        "PreToolUse": "Bash|PowerShell|shell_command|exec_command|functions[.]exec",
-        "PostToolUse": "Bash|PowerShell|shell_command|exec_command|functions[.]exec",
-        "PostToolUseFailure": "Bash|PowerShell|shell_command|exec_command|functions[.]exec",
-        "Stop": None,
-        "SubagentStop": None,
-    }
-    hooks: dict[str, list[dict[str, object]]] = {}
-    for event, matcher in lifecycle_events.items():
-        group: dict[str, object] = {
-            "hooks": [{"type": "command", "command": hook_command, "timeout": 5}]
-        }
-        if matcher is not None:
-            group["matcher"] = matcher
-        hooks[event] = [group]
-    rendered_plugin_hooks = (
-        json.dumps({"hooks": hooks}, indent=2, sort_keys=True) + "\n"
-    ).encode()
-    project_command = " ".join([command, *prefix, ".chaos-engine/hooks/guard.py"])
-    project_hooks = json.loads(rendered_plugin_hooks)
-    project_hooks["hooks"].pop("PostToolUseFailure", None)
-    for groups in project_hooks["hooks"].values():
-        for group in groups:
-            for hook in group["hooks"]:
-                hook["command"] = project_command
-    rendered_project_hooks = (json.dumps(project_hooks, indent=2, sort_keys=True) + "\n").encode()
-    after["plugins/chaos-engine/hooks/hooks.json"] = hook_content(
-        before["plugins/chaos-engine/hooks/hooks.json"], rendered_plugin_hooks, "plugin"
-    )
-    after[".codex/hooks.json"] = hook_content(
-        before[".codex/hooks.json"], rendered_project_hooks, "Codex"
+    after["plugins/chaos-engine/hooks/hooks.json"] = b'{\n  "hooks": {}\n}\n'
+    after[".codex/hooks.json"] = without_chaos_hooks(
+        before[".codex/hooks.json"], "Codex"
     )
     after["plugins/chaos-engine/hooks/guard.py"] = (
         Path(__file__).resolve().parent / "hooks/guard.py"
@@ -2110,8 +2279,9 @@ def desired_content(
     after["plugins/chaos-engine/skills/chaos-engine/SKILL.md"] = (
         "---\nname: chaos-engine\ndescription: Load the canonical installed ChaosEngine before every task.\n---\n\n"
         "From the active project root, load `.chaos-engine/skills/chaos-engine/SKILL.md` before every task.\n"
+        "Then load `plugins/caveman/skills/caveman/SKILL.md` as the bundled response-compression companion.\n"
     ).encode()
-    claude_settings = before[".claude/settings.json"]
+    claude_settings = without_chaos_hooks(before[".claude/settings.json"], "Claude")
     try:
         settings = json.loads(claude_settings) if claude_settings is not None else {}
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
@@ -2131,9 +2301,59 @@ def desired_content(
     if "chaos-engine-project" in marketplaces and marketplaces["chaos-engine-project"] != desired_marketplace:
         raise ValueError("ChaosEngine Claude marketplace collision")
     enabled[plugin_id] = True
+    enabled["caveman@chaos-engine-project"] = True
     marketplaces["chaos-engine-project"] = desired_marketplace
     after[".claude/settings.json"] = (
         json.dumps(settings, indent=2, sort_keys=True) + "\n"
+    ).encode()
+    caveman_manifest = {
+        "name": CAVEMAN_PLUGIN_NAME,
+        "version": CAVEMAN_PLUGIN_VERSION,
+        "description": "Ultra-compressed communication mode. Cut filler. Keep technical accuracy.",
+        "author": {
+            "name": "Julius Brussee",
+            "url": "https://github.com/JuliusBrussee",
+        },
+        "homepage": "https://github.com/JuliusBrussee/caveman",
+        "repository": "https://github.com/JuliusBrussee/caveman",
+        "license": "MIT",
+        "skills": "./skills/",
+        "interface": {
+            "displayName": "Caveman",
+            "shortDescription": "Talk like caveman. Cut filler. Keep technical accuracy.",
+            "longDescription": "Ultra-compressed communication mode for coding agents.",
+            "developerName": "Julius Brussee",
+            "category": "Productivity",
+            "capabilities": ["Write"],
+            "websiteURL": "https://github.com/JuliusBrussee/caveman",
+            "defaultPrompt": ["Use caveman mode. Cut filler. Keep technical accuracy."],
+        },
+    }
+    after["plugins/caveman/.codex-plugin/plugin.json"] = (
+        json.dumps(caveman_manifest, indent=2, sort_keys=True) + "\n"
+    ).encode()
+    after["plugins/caveman/.claude-plugin/plugin.json"] = (
+        json.dumps(
+            {
+                key: caveman_manifest[key]
+                for key in ("name", "version", "description", "author")
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+    caveman_vendor = Path(__file__).resolve().parent / "vendor/caveman"
+    after["plugins/caveman/skills/caveman/SKILL.md"] = (
+        caveman_vendor / "SKILL.md"
+    ).read_bytes()
+    after["plugins/caveman/LICENSE"] = (caveman_vendor / "LICENSE").read_bytes()
+    after["plugins/caveman/UPSTREAM.md"] = (
+        "# Caveman provenance\n\n"
+        "Bundled from `JuliusBrussee/caveman` under the MIT license.\n\n"
+        f"- Upstream commit: `{CAVEMAN_UPSTREAM_COMMIT}`\n"
+        f"- Skill version: `{CAVEMAN_PLUGIN_VERSION}`\n"
+        f"- Proxy package: `{CAVEMAN_CLI_SPEC}`\n"
     ).encode()
     roles = {
         "orchestrator": "Own planning, architecture, synthesis, and final verification.",

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -689,6 +689,32 @@ def activation_plugins(project: Path, marketplace_name: str) -> dict[str, dict[s
     return plugins
 
 
+def activation_plugins_from_root(root: Path, marketplace_name: str) -> dict[str, dict[str, object]]:
+    plugins: dict[str, dict[str, object]] = {}
+    source_root = root / "plugins"
+    for name in (PLUGIN_NAME, CAVEMAN_PLUGIN_NAME):
+        manifest_path = source_root / name / ".codex-plugin/plugin.json"
+        if not manifest_path.is_file():
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError(f"{name} plugin manifest is unavailable") from error
+        version = manifest.get("version") if isinstance(manifest, dict) else None
+        if (
+            not isinstance(version, str)
+            or re.fullmatch(r"\d+\.\d+\.\d+", version) is None
+            or manifest.get("name") != name
+        ):
+            raise ValueError(f"{name} plugin manifest is invalid")
+        plugins[name] = {
+            "id": f"{name}@{marketplace_name}",
+            "version": version,
+            "source": root / f"plugins/{name}",
+        }
+    return plugins
+
+
 def prepare_activation_bundle(project: Path) -> tuple[Path, str, str, str]:
     """Publish one path-unique generated marketplace without tracked machine paths."""
     project = project.resolve()
@@ -978,7 +1004,9 @@ def restore_client_activation(
     if not isinstance(clients, list) or not all(item in {"codex", "claude"} for item in clients):
         raise ValueError("ChaosEngine client activation receipt is invalid")
     root, marketplace_name, _, _ = activation_contract(project)
-    plugins = activation_plugins(project, marketplace_name)
+    plugins = activation_plugins_from_root(root, marketplace_name)
+    if PLUGIN_NAME not in plugins:
+        raise ValueError(f"{PLUGIN_NAME} plugin manifest is unavailable")
     for client in clients:
         executable = which(client)
         if executable is None:

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -191,6 +191,11 @@ For the short decision procedure and boundary cases, load
 When `plugins/caveman/skills/caveman/SKILL.md` exists, load that bundled skill as this
 section's response-compression companion. User requests for normal mode still win.
 
+Bundled Caveman artifacts:
+
+- [Bundled Caveman skill definition](../../vendor/caveman/SKILL.md)
+- [Bundled Caveman license](../../vendor/caveman/LICENSE)
+
 Default voice is terse and exact. Lead with outcome; remove filler,
 pleasantries, hedging, repetition, decorative formatting, and unrequested raw
 logs. Prefer short familiar words and fragments, but preserve user language,

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -186,7 +186,6 @@ safety boundaries.
 For the short decision procedure and boundary cases, load
 [ethical conduct](../../references/ethical-conduct.md).
 
-'
 ### Caveman
 
 If `plugins/caveman/skills/caveman/SKILL.md` exists, use it as this section's response-compression companion. User requests for normal mode still win.
@@ -194,8 +193,8 @@ If `plugins/caveman/skills/caveman/SKILL.md` exists, use it as this section's re
 - [Bundled Caveman skill definition](../../vendor/caveman/SKILL.md)
 - [Bundled Caveman license](../../vendor/caveman/LICENSE)
 
-### Ponytail
-'
+Preserve user language, negation, numbers, units, commands, and errors exactly. `/caveman lite|full|ultra` selects compression; `stop caveman` or `normal mode` disables it.
+
 ### Ponytail
 
 Default implementation rule is the first simple option that works after the

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -186,26 +186,16 @@ safety boundaries.
 For the short decision procedure and boundary cases, load
 [ethical conduct](../../references/ethical-conduct.md).
 
+'
 ### Caveman
 
-When `plugins/caveman/skills/caveman/SKILL.md` exists, load that bundled skill as this
-section's response-compression companion. User requests for normal mode still win.
-
-Bundled Caveman artifacts:
+If `plugins/caveman/skills/caveman/SKILL.md` exists, use it as this section's response-compression companion. User requests for normal mode still win.
 
 - [Bundled Caveman skill definition](../../vendor/caveman/SKILL.md)
 - [Bundled Caveman license](../../vendor/caveman/LICENSE)
 
-Default voice is terse and exact. Lead with outcome; remove filler,
-pleasantries, hedging, repetition, decorative formatting, and unrequested raw
-logs. Prefer short familiar words and fragments, but preserve user language,
-negation, numbers, units, technical names, commands, errors, code, commits, and
-PR prose exactly where precision requires them. Report measurable progress and results, not routine
-tool mechanics. Use normal grammar for security, irreversible actions, or
-multi-step instructions where compression could mislead. `/caveman
-lite|full|ultra` selects full sentences, concise fragments, or each fact once;
-`stop caveman` or `normal mode` disables it for the session.
-
+### Ponytail
+'
 ### Ponytail
 
 Default implementation rule is the first simple option that works after the
@@ -382,3 +372,5 @@ Gambaru.
 The portable distribution's [human overview](../../README.md) uses the
 deterministic light, dark, monochrome, lockup, and small-size identity masters
 documented in the [ChaosEngine identity guide](../../assets/brand/BRAND.md).
+
+

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -188,6 +188,9 @@ For the short decision procedure and boundary cases, load
 
 ### Caveman
 
+When `plugins/caveman/skills/caveman/SKILL.md` exists, load that bundled skill as this
+section's response-compression companion. User requests for normal mode still win.
+
 Default voice is terse and exact. Lead with outcome; remove filler,
 pleasantries, hedging, repetition, decorative formatting, and unrequested raw
 logs. Prefer short familiar words and fragments, but preserve user language,

--- a/chaos-engine/vendor/caveman/LICENSE
+++ b/chaos-engine/vendor/caveman/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Julius Brussee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/chaos-engine/vendor/caveman/SKILL.md
+++ b/chaos-engine/vendor/caveman/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Cut filler while keeping technical accuracy.
+  Use when the user asks for caveman mode, brevity, fewer tokens, or compressed output.
+---
+
+Respond tersely. Preserve all technical substance. Remove filler, pleasantries, repeated facts,
+unnecessary hedging, and decorative formatting. Keep code, commands, identifiers, errors, numbers,
+units, negation, safety warnings, and irreversible-action confirmations exact.
+
+Prefer short complete statements when fragments could change meaning. Never invent abbreviations.
+Never alter persisted code, comments, documentation, commits, issues, or pull request prose merely
+to sound compressed. User requests for normal mode or more detail override this skill.
+
+For tool use, act directly unless a progress update, safety warning, or clarification is needed.
+Final answers state outcome, validation, delivery state, and any material remaining risk once.

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -120,7 +120,7 @@ BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 # from the boundary was invisible. Equality makes shrinking the boundary a
 # deliberate two-line edit that shows up in review, which is the only place the
 # question "why is the harness smaller today" gets asked.
-EXPECTED_ELEMENT_COUNT = 218
+EXPECTED_ELEMENT_COUNT = 220
 
 ATX_HEADING = re.compile(r"(?m)^#{1,6}\s+(.+?)\s*$")
 

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -167,12 +167,62 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 {"claude", "codex", "hermes", "gemini", "opencode", "aider"},
                 set(receipt["cavemanProxy"]["providers"]),
             )
+            proxy_commands = [command for command, _ in calls if command and command[0] in {"npm", "caveman"}]
+            self.assertIn(
+                ["npm", "install", "--global", module.CAVEMAN_CLI_SPEC, "--no-audit", "--no-fund"],
+                proxy_commands,
+            )
+            self.assertIn(["caveman", "setup", "--install"], proxy_commands)
+            self.assertIn(["caveman", "enable", "--detected"], proxy_commands)
             self.assertTrue(all(item["status"] == "healthy" for item in status.values()))
             self.assertTrue(all(cwd == project for _, cwd in calls))
 
             module.uninstall(project, runner=runner, which=lambda name: name)
             self.assertFalse(any(state.values()))
             self.assertFalse(activation_root.exists())
+
+    def test_restore_client_activation_uses_snapshot_plugin_set(self):
+        module = load(HOSTS, "chaos_engine_restore_plugin_set")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            canonical = project / ".chaos-engine/skills/chaos-engine/SKILL.md"
+            canonical.parent.mkdir(parents=True)
+            canonical.write_text("# ChaosEngine\n", encoding="utf-8")
+            module.install(project, core_commit="1" * 40)
+            root, marketplace_name, _, _ = module.prepare_activation_bundle(project)
+            shutil.rmtree(root / "plugins/caveman")
+
+            activation = {
+                "marketplaceName": marketplace_name,
+                "ownedClients": ["codex"],
+                "pluginVersion": "1.0.0",
+                "claudeLocalBefore": None,
+            }
+            calls = []
+
+            def runner(command, **_options):
+                calls.append(command)
+                return mock.Mock(returncode=0, stdout=json.dumps({}), stderr="")
+
+            module.restore_client_activation(
+                project,
+                activation,
+                runner=runner,
+                which=lambda name: name if name == "codex" else None,
+            )
+
+            self.assertIn(
+                ["plugin", "marketplace", "add", str(root), "--json"],
+                [command for command in calls if command[0] == "codex"],
+            )
+            self.assertIn(
+                ["plugin", "add", f"{module.PLUGIN_NAME}@{marketplace_name}", "--json"],
+                [command for command in calls if command[0] == "codex" and command[1:3] == ["plugin", "add"]],
+            )
+            self.assertNotIn(
+                "caveman",
+                "".join(" ".join(command) for command in calls if command[0] == "codex"),
+            )
 
     def test_activation_marketplace_identity_is_collision_safe_across_projects(self):
         module = load(HOSTS, "chaos_engine_plugin_identity")

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -102,9 +102,9 @@ class ChaosEngineHostsTest(unittest.TestCase):
             activation_root, marketplace_name, plugin_id, version = module.activation_contract(project)
             state = {
                 "codex_marketplace": False,
-                "codex_plugin": False,
+                "codex_plugins": set(),
                 "claude_marketplace": False,
-                "claude_plugin": False,
+                "claude_plugins": set(),
             }
             calls = []
 
@@ -113,7 +113,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 client = Path(command[0]).stem
                 joined = " ".join(command[1:])
                 key = f"{client}_marketplace"
-                plugin_key = f"{client}_plugin"
+                plugin_key = f"{client}_plugins"
                 if "marketplace list" in joined:
                     if client == "codex":
                         value = {"marketplaces": [{"name": marketplace_name, "root": str(activation_root)}]} if state[key] else {"marketplaces": []}
@@ -126,16 +126,23 @@ class ChaosEngineHostsTest(unittest.TestCase):
                     state[key] = False
                     value = {}
                 elif "plugin list" in joined:
-                    if client == "codex":
-                        record = {"pluginId": plugin_id, "version": version, "installed": True, "enabled": True, "source": {"path": str(activation_root / "plugins/chaos-engine")}}
-                    else:
-                        record = {"id": plugin_id, "version": version, "enabled": True, "projectPath": str(project), "installPath": str(activation_root / "plugins/chaos-engine")}
-                    value = {"installed": [record] if state[plugin_key] else [], "available": []}
+                    records = []
+                    for name in state[plugin_key]:
+                        contract = module.activation_plugins(project, marketplace_name)[name]
+                        if client == "codex":
+                            records.append({"pluginId": contract["id"], "version": contract["version"], "installed": True, "enabled": True, "source": {"path": str(activation_root / f"plugins/{name}")}})
+                        else:
+                            records.append({"id": contract["id"], "version": contract["version"], "enabled": True, "projectPath": str(project), "installPath": str(activation_root / f"plugins/{name}")})
+                    value = {"installed": records, "available": []}
                 elif "plugin add" in joined or "plugin install" in joined:
-                    state[plugin_key] = True
+                    installed_id = next(item for item in command if "@" in item)
+                    state[plugin_key].add(installed_id.split("@", 1)[0])
                     value = {}
                 elif "plugin remove" in joined or "plugin uninstall" in joined:
-                    state[plugin_key] = False
+                    removed_id = next(item for item in command if "@" in item)
+                    state[plugin_key].discard(removed_id.split("@", 1)[0])
+                    value = {}
+                elif command[0] in {"npm", "caveman"}:
                     value = {}
                 else:
                     raise AssertionError(command)
@@ -152,7 +159,11 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 which=lambda name: name,
             )
 
-            self.assertEqual({"codex", "claude"}, set(receipt["createdPlugins"]))
+            self.assertEqual(
+                {"codex:chaos-engine", "codex:caveman", "claude:chaos-engine", "claude:caveman"},
+                set(receipt["createdPlugins"]),
+            )
+            self.assertEqual("detected", receipt["cavemanProxy"]["providers"])
             self.assertTrue(all(item["status"] == "healthy" for item in status.values()))
             self.assertTrue(all(cwd == project for _, cwd in calls))
 
@@ -355,6 +366,11 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 "plugins/chaos-engine/hooks/guard.py",
                 "plugins/chaos-engine/hooks/reflection.py",
                 "plugins/chaos-engine/skills/chaos-engine/SKILL.md",
+                "plugins/caveman/.codex-plugin/plugin.json",
+                "plugins/caveman/.claude-plugin/plugin.json",
+                "plugins/caveman/skills/caveman/SKILL.md",
+                "plugins/caveman/LICENSE",
+                "plugins/caveman/UPSTREAM.md",
                 ".codex/hooks.json",
                 ".claude/settings.json",
                 ".memory/config.json",
@@ -412,30 +428,12 @@ class ChaosEngineHostsTest(unittest.TestCase):
             self.assertIn("!.codex/**", ignores)
             self.assertIn(".claude/settings.local.json", ignores)
 
-            hook_events = set(
-                json.loads(project.joinpath(".codex/hooks.json").read_text())["hooks"]
-            )
-            self.assertEqual(
-                {
-                    "SessionStart",
-                    "UserPromptSubmit",
-                    "PreToolUse",
-                    "PostToolUse",
-                    "Stop",
-                    "SubagentStop",
-                },
-                hook_events,
-            )
             lifecycle = json.loads(project.joinpath(".codex/hooks.json").read_text())["hooks"]
-            for event in ("PreToolUse", "PostToolUse"):
-                matcher = lifecycle[event][0]["matcher"]
-                self.assertIn("exec_command", matcher)
-                self.assertIn("functions[.]exec", matcher)
+            self.assertEqual({}, lifecycle)
             plugin_lifecycle = json.loads(
                 project.joinpath("plugins/chaos-engine/hooks/hooks.json").read_text()
             )["hooks"]
-            self.assertIn("PostToolUseFailure", plugin_lifecycle)
-            self.assertNotIn("PostToolUseFailure", lifecycle)
+            self.assertEqual({}, plugin_lifecycle)
             installed_hook = project / "plugins/chaos-engine/hooks/guard.py"
             hook_environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}
             failure = {
@@ -482,7 +480,10 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
             module.install(project)
             merged = json.loads(marketplace_path.read_text())
-            self.assertEqual(["unrelated", "chaos-engine"], [item["name"] for item in merged["plugins"]])
+            self.assertEqual(
+                ["unrelated", "chaos-engine", "caveman"],
+                [item["name"] for item in merged["plugins"]],
+            )
             self.assertEqual("./plugins/chaos-engine", merged["plugins"][1]["source"]["path"])
             module.uninstall(project)
             self.assertEqual(original, json.loads(marketplace_path.read_text()))
@@ -542,9 +543,27 @@ class ChaosEngineHostsTest(unittest.TestCase):
             module.install(project)
             merged = json.loads(hook_path.read_text())
             self.assertEqual("user-hook", merged["hooks"]["SessionStart"][0]["hooks"][0]["command"])
-            self.assertGreater(len(merged["hooks"]["SessionStart"]), 1)
+            self.assertEqual(original, merged)
             module.uninstall(project)
             self.assertEqual(original, json.loads(hook_path.read_text()))
+
+    def test_hook_cleanup_removes_only_owned_handlers_from_mixed_group(self):
+        module = load(HOSTS, "chaos_engine_hook_cleanup")
+        source = {
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "python .chaos-engine/hooks/guard.py"},
+                        {"type": "command", "command": "python tools/my-guard.py"},
+                    ],
+                }],
+                "Custom": [{"hooks": [{"type": "command", "command": "python tools/scripts/agents/guard.py.backup"}]}],
+            }
+        }
+        cleaned = json.loads(module.without_chaos_hooks(json.dumps(source).encode(), "test"))
+        self.assertEqual("python tools/my-guard.py", cleaned["hooks"]["PreToolUse"][0]["hooks"][0]["command"])
+        self.assertIn("Custom", cleaned["hooks"])
 
     def test_unrelated_claude_marketplace_fails_closed_without_mutation(self):
         module = load(HOSTS, "chaos_engine_claude_marketplace_collision")

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -163,7 +163,10 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 {"codex:chaos-engine", "codex:caveman", "claude:chaos-engine", "claude:caveman"},
                 set(receipt["createdPlugins"]),
             )
-            self.assertEqual("detected", receipt["cavemanProxy"]["providers"])
+            self.assertEqual(
+                {"claude", "codex", "hermes", "gemini", "opencode", "aider"},
+                set(receipt["cavemanProxy"]["providers"]),
+            )
             self.assertTrue(all(item["status"] == "healthy" for item in status.values()))
             self.assertTrue(all(cwd == project for _, cwd in calls))
 


### PR DESCRIPTION
## Summary
- Bundles Caveman skill into ChaosEngine install and upgrades harness to install/configure Caveman proxy for detected native providers.
- Removes ChaosEngine lifecycle hook ownership and strips pre-existing ChaosEngine-owned hooks from `.codex/hooks.json` and `.claude/settings.json` during install.
- Fixes upgrade rollback restore so restored snapshots only reinstall plugins that exist in the restored activation root, avoiding legacy snapshot Caveman re-addition failures.
- Adds regression tests for proxy command execution and snapshot-only restore behavior.
- Restores the Caveman exact-meaning contract (negation, numbers, units, user language, commands, errors) after the skill-md byte-budget cut accidentally dropped it and introduced stray quotes that broke the ethical-conduct closed-surface check.

## Checks
- `python -m unittest tests.scripts.test_agent_router_contract` after the contract restore: **134 tests OK** (2.888s)
- `python scripts/ci/validate_agent_guidance.py`: **valid** (SKILL.md 19721/20000 bytes)

## Continuation
Head: e9b643ee8d6df40ad806cf3cb825ec62bcc7b8ba
State: ready for review, CI rerun in progress
Blockers: none
Next action: merge after required checks go green

Closes #5026