### PR TITLE
feat(chaos-engine): cut companion token tax and ship MIT notices

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -142,11 +142,15 @@ sends you there; the rest by
 - [repository Graphify procedure](../../chaos-engine/profiles/shaft/references/graphify.md)
 - [TDD](../../chaos-engine/references/tdd.md)
 - [TDD failure modes](../../chaos-engine/references/tdd-failure-modes.md)
+- [context economy](../../chaos-engine/references/context-economy.md)
+- [script first](../../chaos-engine/references/script-first.md)
+- [LICENSE](../../chaos-engine/LICENSE)
+- [third-party notices](../../chaos-engine/THIRD_PARTY_NOTICES.md)
 
 Caveman and Ponytail are pinned vendor companions, not restated in the
 entrypoint. The router loads [Caveman](../../chaos-engine/vendor/caveman/INVENTORY.md)
-and [Ponytail](../../chaos-engine/vendor/ponytail/INVENTORY.md) after triage for
-implementation and review. MIT notices stay at
+or [Ponytail](../../chaos-engine/vendor/ponytail/INVENTORY.md) only when the
+user invokes them or the next action needs that companion. MIT notices stay at
 [Caveman](../../chaos-engine/references/caveman.LICENSE),
 [Ponytail](../../chaos-engine/references/ponytail.LICENSE),
 [TDD](../../chaos-engine/references/test-driven-development.LICENSE).

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ shaft-skills/references/*.md text eol=lf
 scripts/mcp/*.py text eol=lf
 .memory/events.jsonl merge=union
 shaft-infrastructure/src/main/resources/com/shaft/infrastructure/reporting/package-lock.json text eol=lf
+chaos-engine/** text eol=lf

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -33,9 +33,11 @@ the project you want to manage:
 That agent instruction owns the complete flow: the bootstrap installs the
 neutral core, pinned local tools, Memory and isolated MemPalace MCP servers,
 Graphify CLI, skills, playbooks, five role adapters, ChaosEngine lifecycle
-hooks, the pinned Caveman and Ponytail companion skills and hooks, Codex and
-Claude plugin manifests/marketplaces for ChaosEngine plus those companions,
-retrieval configuration, and runtime ignore rules. When a detected client
+hooks, the pinned Caveman and Ponytail companion skills and hooks, the MIT license
+and third-party notices, Codex and Claude plugin manifests/marketplaces for
+ChaosEngine plus those companions, retrieval configuration, and runtime ignore
+rules. Companion skills install with the core; they load at runtime only when
+invoked or when they change the next action. When a detected client
 requires marketplace registration, the agent registers the project marketplace
 and installs `chaos-engine`, `caveman`, and `ponytail` at project local scope,
 then runs active `doctor` probes. Generated indexes, caches, receipts, and runtimes

--- a/chaos-engine/LICENSE
+++ b/chaos-engine/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ChaosEngine contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -134,6 +134,8 @@ default; repository-specific distributions require an explicit selection.
 | Path | Responsibility |
 | --- | --- |
 | [`skills/chaos-engine/SKILL.md`](skills/chaos-engine/SKILL.md) | Canonical router, lifecycle, safety rules, and completion contract |
+| [`LICENSE`](LICENSE) | MIT license for this portable tree |
+| [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) | Companion pins and reimplemented-pattern attribution |
 | [`references/`](references/) | Focused methods loaded only when their trigger fires |
 | [`profiles/`](profiles/) | Project-specific facts, routes, and permissions |
 | [`install.py`](install.py) | Verified install, status, rollback, and uninstall transactions |

--- a/chaos-engine/RESEARCH.md
+++ b/chaos-engine/RESEARCH.md
@@ -24,7 +24,7 @@ Primary source: [DeepSeek Harness architecture at commit
 
 | Capability | Decision | ChaosEngine ownership |
 | --- | --- | --- |
-| Capability ownership | Adopted | Keep service definition, provider, and consumer responsibilities explicit in validated component descriptors. |
+| Capability ownership | Adopted | Keep service definition, provider, and consumer responsibilities explicit in `distributions.json`, profile, and dependency component descriptors. |
 | Declarative composition | Adopted | Continue composing one canonical entrypoint with profiles and thin host adapters. |
 | Orthogonal outcomes | Adopted | Report task delivery, cleanup, and each knowledge-store outcome independently. |
 | Bounded asynchronous behavior | Adopted | Bound optional retrieval to one attempt and keep maintenance with its existing owner. |
@@ -36,6 +36,21 @@ replaceable plugin ecosystem with reversible effects and one event model, but
 importing it would create a second execution and persistence stack without a
 current consumer. ChaosEngine adopts the architectural invariants, not the
 preview runtime.
+
+## Token-first adoption — Accessed: 2026-08-17
+
+Primary sources checked live: [Agent Skills specification](https://agentskills.io/specification),
+[Anthropic context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents),
+and DeepSeek Harness [compaction](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/compaction.md)
+plus code mode. Companion bodies stay MIT-pinned and optional at runtime.
+
+| Pattern | Decision | ChaosEngine ownership |
+| --- | --- | --- |
+| Progressive disclosure | Adopted | Always-on router; references load when their decision is active. |
+| Just-in-time retrieval | Adopted | Query a store only when it can shorten the task; one bounded attempt. |
+| Tool-result prune and spill | Adopted as guidance | [context-economy](references/context-economy.md) |
+| Script over long tool chains | Adopted as guidance | [script-first](references/script-first.md) |
+| Auto-load companion bodies every mutation | Rejected | Caveman and Ponytail load on invoke or when they change the next action. |
 
 ## Architecture decision
 

--- a/chaos-engine/THIRD_PARTY_NOTICES.md
+++ b/chaos-engine/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,42 @@
+# Third-party notices
+
+This portable tree is MIT licensed. See [LICENSE](LICENSE). The notices below
+cover bundled companions and patterns reimplemented from published sources.
+No third-party runtime was copied into this tree.
+
+## Caveman
+
+- License: MIT
+- Copyright (c) 2026 Julius Brussee
+- Upstream: https://github.com/JuliusBrussee/caveman
+- Local pin: [vendor/caveman/PIN.json](vendor/caveman/PIN.json)
+- Local license: [vendor/caveman/LICENSE](vendor/caveman/LICENSE)
+
+Only the MIT skill and hook files listed in that pin are vendored. Upstream
+Engine-linked directories licensed under Business Source License 1.1 are not
+included here.
+
+## Ponytail
+
+- License: MIT
+- Copyright (c) 2026 DietrichGebert
+- Upstream: https://github.com/DietrichGebert/ponytail
+- Local pin: [vendor/ponytail/PIN.json](vendor/ponytail/PIN.json)
+- Local license: [vendor/ponytail/LICENSE](vendor/ponytail/LICENSE)
+
+Skill and hook bodies in that pin are verbatim upstream.
+
+## Test-driven development adaptation
+
+See [references/test-driven-development.LICENSE](references/test-driven-development.LICENSE).
+
+## DeepSeek Harness patterns
+
+- License: MIT
+- Copyright (c) 2026 DeepSeek
+- Upstream license: https://github.com/deepseek-ai/deepseek-harness/blob/master/LICENSE
+- Architecture reviewed at commit `47f943859bef60e4160492346772ded9b24f765a`
+
+Capability seams, orthogonal outcomes, tool-result pruning, spill, and code
+mode were reimplemented as portable guidance and installer contracts. The
+Node runtime, Cordis kernel, session log, agent loop, and UI were not copied.

--- a/chaos-engine/references/context-economy.md
+++ b/chaos-engine/references/context-economy.md
@@ -1,0 +1,46 @@
+# Context economy
+
+Load this when a task will make many tool calls, return large outputs, or run
+long enough that context rot becomes the next failure mode. Host compaction is
+the host's job. This page teaches the agent how to stay under it.
+
+Patterns here reimplement published progressive-disclosure, just-in-time
+retrieval, compaction, tool-result pruning, and spill ideas. Named sources
+and licenses live in [THIRD_PARTY_NOTICES](../THIRD_PARTY_NOTICES.md) and
+[RESEARCH](../RESEARCH.md).
+
+## Smallest high-signal set
+
+Every token competes for attention. Gather only the evidence that can change
+the next decision. Stop exploring when that decision is supported.
+
+- Bound every read (`offset`/`limit`, `head_limit`, ripgrep context).
+- After truncation, narrow once. Do not repeat the same broad query.
+- Do not reread an unchanged input.
+- Prefer a path plus a discriminating excerpt over a full dump.
+
+## Spill large tool output
+
+When a tool result is larger than the decision needs:
+
+1. Keep the head and tail that prove the outcome.
+2. Write or leave the full artifact on disk.
+3. Tell the next step the path and the one fact the result established.
+
+Do not paste multi-thousand-line logs, HAR files, or report HTML into the
+transcript unless the user asked for the raw body.
+
+## Distill, then continue
+
+- A subagent returns a distillate: what changed, what was proved, what remains.
+  It does not return its transcript.
+- Structured notes belong at session end or after repeated failure, through the
+  existing learning loop. They are not a running diary.
+- On failure, change the premise or the discriminating observation. Do not
+  repeat the same action with different wording.
+
+## What this page is not
+
+It is not a second agent loop, session log, or compaction engine. It does not
+authorize skipping safety warnings, irreversible-action confirmations, or an
+observed check.

--- a/chaos-engine/references/ethical-conduct.md
+++ b/chaos-engine/references/ethical-conduct.md
@@ -30,6 +30,12 @@ convenience, competitive pressure, or expected benefit does not erase a duty.
 | Reuse licensed work with required attribution | Confirm the terms, preserve notices and credit, and proceed within them. |
 | Exclude people by protected traits or optimize through avoidable harm | Refuse the exclusion and propose fair, relevant criteria. |
 | Implement an accessible accommodation | Proceed; equitable support is not improper preference. |
+| Use a dual-use capability to cause unauthorized harm | Refuse the harmful part and keep the legitimate engineering goal. |
+| Weaken a test, eval, or this contract to look green | Refuse and report the observed state. Efficiency is not a reason. |
+| Persist hidden adopter state or ship secrets into the learning queue | Refuse. The privacy gate stays closed; no covert monitoring. |
+| Adopt third-party work without the required notice | Refuse until attribution and license terms are preserved. |
+| Broaden cleanup or authority without consent | Refuse and stay inside the granted scope. |
+| Compress away negation, a safety warning, or an irreversible-action confirmation | Keep the warning in full; resume brevity after the clear part. |
 
 When duties conflict, do not hide the tradeoff. Prefer the option that respects
 rights and authorization, reduces foreseeable harm, preserves user trust and

--- a/chaos-engine/references/script-first.md
+++ b/chaos-engine/references/script-first.md
@@ -1,0 +1,40 @@
+# Script first
+
+Load this when an investigation would otherwise become a long chain of
+overlapping tool calls. Prefer one deterministic program or focused test over
+fifteen hops that restate the same question.
+
+This reimplements a published code-mode idea as portable guidance: write or
+run one program against the workspace instead of orchestrating each primitive
+by hand. No upstream runtime is required. Named sources and licenses live in
+[THIRD_PARTY_NOTICES](../THIRD_PARTY_NOTICES.md) and [RESEARCH](../RESEARCH.md).
+
+## When a script is the smaller move
+
+Use a script or focused test when you would otherwise:
+
+- call the same search or read with slightly different arguments;
+- parse a large log, report, or JSON document by hand;
+- apply the same mechanical edit in several files;
+- prove a behavior that a short executable already can fail.
+
+Mechanical one-file edits still inspect the target, apply the change, and
+report it. Do not invent a script for a single obvious line.
+
+## How to do it
+
+1. Name the question the program must answer or the transform it must apply.
+2. Write the smallest runnable probe or edit next to the work, or use an
+   existing test.
+3. Run it once. Read the result. Delete a throwaway probe when it has no
+   lasting value.
+4. If the script fails for setup or environment reasons, fix that first. A
+   broken harness is not evidence about the product.
+
+## Boundaries
+
+- Prefer the standard library and tools already in the project.
+- Do not add a dependency to avoid a few lines.
+- Do not replace an owned test with an untracked scratch file when the test
+  is the proof the task needs.
+- Token savings never drop negation, safety, or required attribution.

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Canonical provider-neutral skill router and working contract. Use at the start
   of every task, on every host, in every main thread and delegate, before
   discovery, planning, edits, or answering.
+license: MIT
 ---
 
 # ChaosEngine
@@ -48,13 +49,20 @@ Re-triage when a premise turns out false, the third fix for one symptom fails,
 the blast radius grows, or the user adds scope.
 
 Retrieval depth reads off the same answer. Load
-[retrieve-first](../../references/retrieve-first.md) before broad manual discovery on
-every row, and at completion to keep the stores from drifting.
+[retrieve-first](../../references/retrieve-first.md) before broad manual discovery
+when a store can shorten the task, and at completion to keep the stores from
+drifting. Bound tool reads and prefer one script over a long tool chain:
+[context economy](../../references/context-economy.md) and
+[script first](../../references/script-first.md).
 When this entrypoint was loaded through a role adapter, load
 [retrieve-first](../../references/retrieve-first.md) before task-specific discovery,
 including one-file reversible work.
 
 ## Implementation preflight
+
+Mechanical one-file reversible work still names the eight steps, then records
+store irrelevance without querying. Default and most-intelligent work query a
+store only when it can shorten the task.
 
 Before the first implementation mutation, do these in order for every task:
 
@@ -190,11 +198,14 @@ For the short decision procedure and boundary cases, load
 
 This file is the only router. It does not restate companion rules.
 
-After triage, implementation and review load both vendor skills before the
-first mutation. Mechanical one-file edits and consult-only answers skip them
-unless the user invoked `/caveman` or `/ponytail`. User `stop caveman`,
-`stop ponytail`, or `normal mode` still wins. Once loaded, each companion's
-own text applies.
+Load a vendor skill only when it changes the next action. Implementation and
+review do not auto-load both. Mechanical one-file edits and consult-only
+answers skip them unless the user invoked `/caveman` or `/ponytail`. User
+`stop caveman`, `stop ponytail`, or `normal mode` still wins. Once loaded,
+each companion's own text applies.
+
+- Caveman: `/caveman`, "talk like caveman", or an explicit token-efficiency request
+- Ponytail: `/ponytail`, or when implementing or designing code
 
 - [Caveman skill](../../vendor/caveman/skills/caveman/SKILL.md) — [inventory](../../vendor/caveman/INVENTORY.md)
 - [Ponytail skill](../../vendor/ponytail/skills/ponytail/SKILL.md) — [inventory](../../vendor/ponytail/INVENTORY.md)
@@ -215,7 +226,8 @@ push after they pass. Do not rerun an entire test suite merely because CI failed
 the CI matrix supplies the broader confirmation.
 
 Caveman, Ponytail, and TDD adaptations retain their MIT notices under
-`references/*.LICENSE`.
+`references/*.LICENSE`. The portable tree is MIT:
+[LICENSE](../../LICENSE) and [third-party notices](../../THIRD_PARTY_NOTICES.md).
 
 ## Route
 

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -46,6 +46,7 @@ ALLOWED_EXACT = {
     "chaos-engine/profiles/README.md",
     "chaos-engine/RESEARCH.md",
     "chaos-engine/INSTALL.md",
+    "chaos-engine/THIRD_PARTY_NOTICES.md",
 }
 ALLOWED_NESTED_READMES = {
     path for path in ALLOWED_EXACT

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -120,7 +120,7 @@ BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 # from the boundary was invisible. Equality makes shrinking the boundary a
 # deliberate two-line edit that shows up in review, which is the only place the
 # question "why is the harness smaller today" gets asked.
-EXPECTED_ELEMENT_COUNT = 239
+EXPECTED_ELEMENT_COUNT = 243
 
 ATX_HEADING = re.compile(r"(?m)^#{1,6}\s+(.+?)\s*$")
 

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -207,6 +207,12 @@ class EthicalConductContractTest(unittest.TestCase):
         ("Reuse licensed work with required attribution", "Confirm the terms, preserve notices and credit, and proceed within them."),
         ("Exclude people by protected traits or optimize through avoidable harm", "Refuse the exclusion and propose fair, relevant criteria."),
         ("Implement an accessible accommodation", "Proceed; equitable support is not improper preference."),
+        ("Use a dual-use capability to cause unauthorized harm", "Refuse the harmful part and keep the legitimate engineering goal."),
+        ("Weaken a test, eval, or this contract to look green", "Refuse and report the observed state. Efficiency is not a reason."),
+        ("Persist hidden adopter state or ship secrets into the learning queue", "Refuse. The privacy gate stays closed; no covert monitoring."),
+        ("Adopt third-party work without the required notice", "Refuse until attribution and license terms are preserved."),
+        ("Broaden cleanup or authority without consent", "Refuse and stay inside the granted scope."),
+        ("Compress away negation, a safety warning, or an irreversible-action confirmation", "Keep the warning in full; resume brevity after the clear part."),
     )
     REFERENCE_FINAL = (
         "When duties conflict, do not hide the tradeoff. Prefer the option that respects "

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -31,6 +31,17 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
         self.assertIn("only tests created or edited", guidance)
         self.assertIn("Do not rerun an entire test suite merely because CI failed", guidance)
         self.assertNotIn("shaft", guidance.casefold())
+        self.assertIn("license: MIT", guidance)
+        self.assertNotIn("load both vendor skills", guidance.casefold())
+        self.assertLessEqual(len(guidance.splitlines()), 500)
+        for relative in (
+            "references/context-economy.md",
+            "references/script-first.md",
+            "LICENSE",
+            "THIRD_PARTY_NOTICES.md",
+        ):
+            self.assertIn(relative, guidance.replace("\\", "/"))
+            self.assertTrue((CORE / relative).is_file(), relative)
 
     def test_portable_graphify_retrieval_is_read_only_and_ordered(self):
         guidance = (CORE / "references/graphify.md").read_text(encoding="utf-8")

--- a/tests/scripts/test_chaos_engine_research.py
+++ b/tests/scripts/test_chaos_engine_research.py
@@ -35,6 +35,14 @@ class ChaosEngineResearchTest(unittest.TestCase):
         ):
             self.assertIn(rejected, content.lower())
 
+    def test_token_first_adoption_is_dated_and_rejects_auto_loaded_companions(self):
+        content = MATRIX.read_text(encoding="utf-8")
+        self.assertIn("Accessed: 2026-08-17", content)
+        self.assertIn("context-economy", content)
+        self.assertIn("script-first", content)
+        self.assertIn("auto-load companion bodies every mutation", content.lower())
+        self.assertIn("rejected", content.lower())
+
     def test_top_ten_matrix_is_dated_primary_sourced_and_actionable(self):
         content = MATRIX.read_text(encoding="utf-8")
         self.assertIn("Accessed: 2026-08-12", content)

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -83,6 +83,7 @@ flowchart LR
         self.write("chaos-engine/profiles/README.md", "# Project profiles\n")
         self.write("chaos-engine/RESEARCH.md", "# Adoption matrix\n")
         self.write("chaos-engine/INSTALL.md", "# Install\n")
+        self.write("chaos-engine/THIRD_PARTY_NOTICES.md", "# Notices\n")
 
         self.assertEqual(validate_repository(self.root), [])
 


### PR DESCRIPTION
## Summary
- Fast-forwarded local main to origin, then made Caveman/Ponytail optional instead of auto-loaded on every mutation.
- Added on-demand `context-economy` and `script-first` references (DeepSeek/Anthropic patterns reimplemented, no runtime copied).
- Shipped portable MIT `LICENSE` and `THIRD_PARTY_NOTICES.md` with Caveman, Ponytail, TDD, and DeepSeek attribution.
- Strengthened ethical-conduct boundary cases without moving EC1-EC7 out of the always-on router (pinned contract).
- Forced `chaos-engine/**` to LF so vendor pin digests stay stable on Windows.

## Validation
- `py -3 -m unittest tests.scripts.test_chaos_engine_portable_core tests.scripts.test_chaos_engine_research tests.scripts.test_agent_harness_reachability tests.scripts.test_agent_router_contract tests.scripts.test_agent_harness_portability` (198 tests OK in the focused router/portability/reachability pass; portable-core and research also OK)
- `py -3 scripts/ci/validate_agent_guidance.py`
- `py -3 scripts/ci/validate_documentation_boundaries.py`
- Not run: full installer/hosts suite uninstall cases (pre-existing Windows host-receipt failures, unchanged hosts.py)

Do not merge unless asked.