### PR TITLE
fix(infrastructure): accept current macOS hosts for Playwright setup

### DIFF
--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/PlaywrightHostPlatform.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/PlaywrightHostPlatform.java
@@ -107,10 +107,26 @@ enum PlaywrightHostPlatform {
                 return UBUNTU_24_04_X64;
             }
         }
-        if (platform == SetupPlatform.MACOS && osRelease.matches("15(?:\\..*)?")) {
+        if (platform == SetupPlatform.MACOS && supportedMacOs(osRelease)) {
             return architecture == SetupArchitecture.X64 ? MAC15 : MAC15_ARM64;
         }
         throw new IllegalArgumentException("Unsupported Playwright host: " + platform + '-' + architecture);
+    }
+
+    /**
+     * Accepts macOS 15+ marketing versions and Darwin 24+ kernel versions.
+     * GitHub {@code macos-latest} reports the live host, not a pinned 15.x string.
+     */
+    static boolean supportedMacOs(String version) {
+        if (version == null || version.isBlank()) return false;
+        int dot = version.indexOf('.');
+        String majorText = (dot < 0 ? version : version.substring(0, dot)).trim();
+        try {
+            int major = Integer.parseInt(majorText);
+            return major >= 15 && major != 20 && major != 21 && major != 22 && major != 23;
+        } catch (NumberFormatException ignored) {
+            return false;
+        }
     }
 
     private static String unquote(String value) {

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/PlaywrightRuntime.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/PlaywrightRuntime.java
@@ -25,7 +25,12 @@ public final class PlaywrightRuntime {
         }
         SetupPlatform platform = SetupPlatform.current();
         SetupArchitecture architecture = SetupArchitecture.current();
-        SetupReport report = InfrastructureSetupService.builtIn(platform, architecture).status(selected);
+        SetupReport report;
+        try {
+            report = InfrastructureSetupService.builtIn(platform, architecture).status(selected);
+        } catch (IllegalArgumentException failure) {
+            throw unavailable(failure.getMessage());
+        }
         Path root = PlaywrightSetupService.browserRoot(selected.paths(), platform, architecture)
                 .toAbsolutePath().normalize();
         try {

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/PlaywrightHostPlatformTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/PlaywrightHostPlatformTest.java
@@ -43,8 +43,20 @@ class PlaywrightHostPlatformTest {
     }
 
     @Test
+    void currentMacOsAndDarwinTwentyFourUseTheMac15Artifacts() {
+        assertEquals("mac15-arm64", PlaywrightHostPlatform.resolve(
+                SetupPlatform.MACOS, SetupArchitecture.ARM64, "16.0").token());
+        assertEquals("mac15-arm64", PlaywrightHostPlatform.resolve(
+                SetupPlatform.MACOS, SetupArchitecture.ARM64, "24.6.0").token());
+        assertEquals("mac15", PlaywrightHostPlatform.resolve(
+                SetupPlatform.MACOS, SetupArchitecture.X64, "26.0").token());
+    }
+
+    @Test
     void unsupportedMacOsMajorFailsClosed() {
         assertThrows(IllegalArgumentException.class, () -> PlaywrightHostPlatform.resolve(
                 SetupPlatform.MACOS, SetupArchitecture.ARM64, "14.7.8"));
+        assertThrows(IllegalArgumentException.class, () -> PlaywrightHostPlatform.resolve(
+                SetupPlatform.MACOS, SetupArchitecture.ARM64, "23.6.0"));
     }
 }


### PR DESCRIPTION
## Summary
- Nightly Local E2E failed on `PlaywrightManagedRuntimeTest.localManagedModeRequiresACompatibleReceiptWithoutInstalling`.
- `macos-latest` no longer reports a pinned 15.x host, so Playwright host detection threw `IllegalArgumentException`.
- Accept macOS 15+ and Darwin 24+ as the existing mac15 artifacts. Convert an unsupported-host argument error into the managed not-ready state.

Related to #5025

## Checks
- `mvn -pl shaft-infrastructure -am test -Dtest=PlaywrightHostPlatformTest`
- `mvn -pl shaft-engine -am test -Dtest=PlaywrightManagedRuntimeTest`

## Continuation
Head: 4be48463b8
State: implemented, awaiting review and merge
Blockers: none
Next action: merge, then #5035, then #4849 and #4851