### PR TITLE
feat(setup): own iOS and Windows Appium runtime lifecycle

### DIFF
--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -367,6 +367,11 @@ public final class SetupCommand implements Runnable {
         return switch (plan.profile()) {
             case OCR -> ocrSelection(plan, languages);
             case MOBILE_ANDROID -> android.selectionFromPlan(plan);
+            case MOBILE_IOS, MOBILE_WINDOWS -> {
+                android.rejectIfSupplied(plan.profile());
+                yield InfrastructureSetupService.builtIn(plan.platform(), plan.architecture())
+                        .selectionFromPlan(plan);
+            }
             default -> {
                 android.rejectIfSupplied(plan.profile());
                 yield SetupSelection.defaults();

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileDeviceController.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileDeviceController.java
@@ -1,0 +1,20 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+
+/** Host device boundary used by desktop-mobile runtime start/stop. */
+interface DesktopMobileDeviceController {
+    enum SimulatorState { BOOTED, SHUTDOWN, MISSING }
+
+    default SimulatorState simulatorState(String udid) throws IOException {
+        throw new UnsupportedOperationException("This host does not own iOS Simulator lifecycle.");
+    }
+
+    default void bootSimulator(String udid) throws IOException {
+        throw new UnsupportedOperationException("This host does not own iOS Simulator lifecycle.");
+    }
+
+    default void shutdownSimulator(String udid) throws IOException {
+        throw new UnsupportedOperationException("This host does not own iOS Simulator lifecycle.");
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileLifecycleFactory.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileLifecycleFactory.java
@@ -1,0 +1,8 @@
+package com.shaft.infrastructure;
+
+/** Testable construction boundary for iOS/Windows Appium runtime ownership. */
+@FunctionalInterface
+interface DesktopMobileLifecycleFactory {
+    DesktopMobileLifecycleService create(ShaftCachePaths paths, SetupPlan plan,
+                                         DesktopMobileToolchainOperations operations);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileLifecycleService.java
@@ -147,13 +147,19 @@ final class DesktopMobileLifecycleService {
                     endpoint.toString(), simulatorUdid, shaftBootedSimulator, ProcessIdentity.of(appium), 1);
             writeLease(lease);
             return environment(receipt, new ActiveRuntime(lease, appium), options);
-        } catch (IOException | RuntimeException failure) {
-            IOException cleanup = stopStarted(appium, shaftBootedLease(plan, shaftBootedSimulator),
-                    options.shutdownTimeout());
-            if (cleanup != null) failure.addSuppressed(cleanup);
-            if (failure instanceof IOException io) throw io;
+        } catch (IOException failure) {
+            suppressCleanupFailure(failure, appium, shaftBootedSimulator, plan, options.shutdownTimeout());
+            throw failure;
+        } catch (RuntimeException failure) {
+            suppressCleanupFailure(failure, appium, shaftBootedSimulator, plan, options.shutdownTimeout());
             throw failure;
         }
+    }
+
+    private void suppressCleanupFailure(Throwable failure, AndroidOwnedProcess appium,
+                                        boolean shaftBootedSimulator, SetupPlan plan, Duration timeout) {
+        IOException cleanup = stopStarted(appium, shaftBootedLease(plan, shaftBootedSimulator), timeout);
+        if (cleanup != null) failure.addSuppressed(cleanup);
     }
 
     private DesktopMobileRuntimeLease shaftBootedLease(SetupPlan plan, boolean shaftBootedSimulator) {

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileLifecycleService.java
@@ -1,0 +1,406 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Lease-safe lifecycle owner for one verified iOS or Windows Appium server. */
+final class DesktopMobileLifecycleService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private final ShaftCachePaths paths;
+    private final SetupPlan expectedPlan;
+    private final DesktopMobileToolchainOperations operations;
+    private final AndroidRuntimeController runtime;
+    private final DesktopMobileDeviceController devices;
+    private final DesktopMobileRuntimeHealth health;
+    private final DesktopMobileRuntimeLayout layout;
+    private final int appiumPort;
+    private final String simulatorUdid;
+
+    DesktopMobileLifecycleService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                                  DesktopMobileToolchainOperations operations, AndroidRuntimeController runtime,
+                                  DesktopMobileDeviceController devices, DesktopMobileRuntimeHealth health) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.expectedPlan = java.util.Objects.requireNonNull(expectedPlan, "expectedPlan");
+        this.operations = java.util.Objects.requireNonNull(operations, "operations");
+        this.runtime = java.util.Objects.requireNonNull(runtime, "runtime");
+        this.devices = java.util.Objects.requireNonNull(devices, "devices");
+        this.health = java.util.Objects.requireNonNull(health, "health");
+        requireDesktopProfile(expectedPlan.profile());
+        this.layout = DesktopMobileRuntimeLayout.resolve(paths, expectedPlan);
+        this.appiumPort = DesktopMobileSetupPlanner.requestedAppiumPort(expectedPlan);
+        this.simulatorUdid = expectedPlan.profile() == SetupProfile.MOBILE_IOS
+                ? DesktopMobileSetupPlanner.requestedSimulator(expectedPlan) : "";
+    }
+
+    ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        requireCompatible(plan, options);
+        SetupExecutor.validate(plan, approval);
+        SetupReceipt receipt = requireInstallReceipt(plan);
+        requireInstalled(plan);
+        requireExactIosSimulator();
+        Path lockPath = lockPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        try {
+            jvmLock.lockInterruptibly();
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                receipt = requireInstallReceipt(plan);
+                requireInstalled(plan);
+                Optional<ActiveRuntime> reusable = readReusable(plan, options);
+                if (reusable.isPresent()) return environment(receipt, reusable.orElseThrow(), options);
+                return startNew(plan, receipt, options);
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the desktop-mobile runtime lock.", interrupted);
+        } finally {
+            if (jvmLock.isHeldByCurrentThread()) jvmLock.unlock();
+        }
+    }
+
+    String logs() throws IOException {
+        Optional<DesktopMobileRuntimeLease> current = readLease();
+        if (current.isEmpty()) return "";
+        requireLeaseRequest(current.orElseThrow());
+        return OwnedLogReader.read("Appium server", layout.appiumLog());
+    }
+
+    boolean stop(Duration timeout) throws IOException {
+        Path lockPath = lockPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        if (Files.notExists(leasePath(), LinkOption.NOFOLLOW_LINKS)) return false;
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        jvmLock.lock();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Optional<DesktopMobileRuntimeLease> current = readLease();
+            if (current.isEmpty()) return false;
+            DesktopMobileRuntimeLease lease = current.orElseThrow();
+            requireLeaseRequest(lease);
+            Optional<AndroidOwnedProcess> appium = find(lease.appium());
+            if (appium.isEmpty()) {
+                if (lease.shaftBootedSimulator() && iosSimulatorStillOwned(lease)) {
+                    throw new IOException("Desktop-mobile runtime lease is partially alive; refusing to kill an "
+                            + "uncertain Simulator identity.");
+                }
+                Files.deleteIfExists(leasePath());
+                return false;
+            }
+            IOException cleanup = stopStarted(appium.orElseThrow(), lease, timeout);
+            if (cleanup != null) throw cleanup;
+            Files.deleteIfExists(leasePath());
+            return true;
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    private ManagedEnvironment startNew(SetupPlan plan, SetupReceipt receipt, SetupOptions options)
+            throws IOException {
+        requireAvailablePort(appiumPort, "Appium");
+        boolean shaftBootedSimulator = false;
+        AndroidOwnedProcess appium = null;
+        try {
+            if (plan.profile() == SetupProfile.MOBILE_IOS) {
+                DesktopMobileDeviceController.SimulatorState state = devices.simulatorState(simulatorUdid);
+                if (state == DesktopMobileDeviceController.SimulatorState.MISSING) {
+                    throw new IOException("Selected iOS Simulator is unavailable: " + simulatorUdid);
+                }
+                if (state == DesktopMobileDeviceController.SimulatorState.SHUTDOWN) {
+                    devices.bootSimulator(simulatorUdid);
+                    shaftBootedSimulator = true;
+                    health.awaitSimulator(simulatorUdid, options.startupTimeout());
+                }
+            }
+            URI endpoint = URI.create("http://127.0.0.1:" + appiumPort + '/');
+            appium = runtime.start("appium", List.of(layout.nodeExecutable().toString(),
+                    layout.appiumEntryPoint().toString(), "--address", "127.0.0.1", "--port",
+                    Integer.toString(appiumPort), "--base-path", "/"), layout.appiumHome(),
+                    Map.of("APPIUM_HOME", layout.appiumHome().toString()),
+                    Set.of("APPIUM_HOME", "REPO_OS_OVERRIDE"), layout.appiumLog());
+            health.awaitAppium(endpoint, options.startupTimeout());
+            DesktopMobileRuntimeLease lease = new DesktopMobileRuntimeLease(1, plan.digest(), plan.profile(),
+                    endpoint.toString(), simulatorUdid, shaftBootedSimulator, ProcessIdentity.of(appium), 1);
+            writeLease(lease);
+            return environment(receipt, new ActiveRuntime(lease, appium), options);
+        } catch (IOException | RuntimeException failure) {
+            IOException cleanup = stopStarted(appium, shaftBootedLease(plan, shaftBootedSimulator),
+                    options.shutdownTimeout());
+            if (cleanup != null) failure.addSuppressed(cleanup);
+            if (failure instanceof IOException io) throw io;
+            throw failure;
+        }
+    }
+
+    private DesktopMobileRuntimeLease shaftBootedLease(SetupPlan plan, boolean shaftBootedSimulator) {
+        return new DesktopMobileRuntimeLease(1, plan.digest(), plan.profile(),
+                "http://127.0.0.1:" + appiumPort + '/', simulatorUdid, shaftBootedSimulator, null, 1);
+    }
+
+    private ManagedEnvironment environment(SetupReceipt receipt, ActiveRuntime active, SetupOptions options) {
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("APPIUM_HOME", layout.appiumHome().toString());
+        properties.put("appium.endpoint", active.lease().endpoint());
+        if (!simulatorUdid.isEmpty()) properties.put("ios.simulator.udid", simulatorUdid);
+        return new ManagedEnvironment(expectedPlan.profile(), receipt,
+                Optional.of(URI.create(active.lease().endpoint())), Map.copyOf(properties), () -> {
+                    try {
+                        release(active, options.shutdownTimeout());
+                    } catch (IOException failure) {
+                        throw new IllegalStateException("Failed to release the owned desktop-mobile runtime.",
+                                failure);
+                    }
+                });
+    }
+
+    private Optional<ActiveRuntime> readReusable(SetupPlan plan, SetupOptions options) throws IOException {
+        Optional<DesktopMobileRuntimeLease> existing = readLease();
+        if (existing.isEmpty()) return Optional.empty();
+        DesktopMobileRuntimeLease lease = existing.orElseThrow();
+        if (!lease.planDigest().equals(plan.digest()) || !lease.endpoint().equals(endpoint())
+                || !lease.simulatorUdid().equals(simulatorUdid) || lease.profile() != plan.profile()) {
+            throw new IOException("An existing SHAFT desktop-mobile lease does not match the reviewed plan.");
+        }
+        Optional<AndroidOwnedProcess> appium = find(lease.appium());
+        if (appium.isEmpty()) {
+            if (lease.shaftBootedSimulator() && iosSimulatorStillOwned(lease)) {
+                throw new IOException("The SHAFT desktop-mobile runtime lease is stale or only partially alive; "
+                        + "manual recovery is required before starting another runtime.");
+            }
+            Files.deleteIfExists(leasePath());
+            return Optional.empty();
+        }
+        if (!options.reuseOwnedProcesses()) {
+            throw new IOException("A compatible SHAFT desktop-mobile runtime is already active and reuse is disabled.");
+        }
+        health.awaitAppium(URI.create(lease.endpoint()), options.startupTimeout());
+        if (plan.profile() == SetupProfile.MOBILE_IOS) {
+            health.awaitSimulator(simulatorUdid, options.startupTimeout());
+        }
+        DesktopMobileRuntimeLease incremented = lease.withRefCount(lease.refCount() + 1);
+        writeLease(incremented);
+        return Optional.of(new ActiveRuntime(incremented, appium.orElseThrow()));
+    }
+
+    private void requireLeaseRequest(DesktopMobileRuntimeLease lease) throws IOException {
+        if (lease.profile() != expectedPlan.profile() || !lease.endpoint().equals(endpoint())
+                || !lease.simulatorUdid().equals(simulatorUdid)) {
+            throw new IOException("Desktop-mobile runtime lease does not match the requested profile and endpoint.");
+        }
+    }
+
+    private void release(ActiveRuntime active, Duration timeout) throws IOException {
+        Path lockPath = lockPath();
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        jvmLock.lock();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Optional<DesktopMobileRuntimeLease> current = readLease();
+            if (current.isEmpty()) return;
+            DesktopMobileRuntimeLease lease = current.orElseThrow();
+            if (!lease.sameIdentity(active.lease())) {
+                throw new IOException("Desktop-mobile runtime lease changed; refusing to stop an unowned process.");
+            }
+            if (lease.refCount() > 1) {
+                writeLease(lease.withRefCount(lease.refCount() - 1));
+                return;
+            }
+            IOException cleanup = stopStarted(active.appium(), lease, timeout);
+            if (cleanup != null) throw cleanup;
+            Files.deleteIfExists(leasePath());
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan, SetupOptions options) {
+        java.util.Objects.requireNonNull(plan, "plan");
+        java.util.Objects.requireNonNull(options, "options");
+        if (plan.profile() != expectedPlan.profile() || options.profile() != expectedPlan.profile()) {
+            throw new IllegalArgumentException("Desktop-mobile lifecycle requires profile "
+                    + expectedPlan.profile() + '.');
+        }
+        if (plan.platform() != expectedPlan.platform() || plan.architecture() != expectedPlan.architecture()) {
+            throw new IllegalArgumentException("Desktop-mobile lifecycle plan does not match this host.");
+        }
+        if (plan.mode() == SetupMode.EXTERNAL || options.effectiveMode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External desktop-mobile setup cannot start local processes.");
+        }
+        if (!expectedPlan.equals(plan)) {
+            throw new IllegalArgumentException("Desktop-mobile lifecycle plan does not match the release manifest.");
+        }
+    }
+
+    private void requireExactIosSimulator() throws IOException {
+        if (expectedPlan.profile() == SetupProfile.MOBILE_IOS && "existing".equals(simulatorUdid)) {
+            throw new IOException("iOS runtime start requires an exact Simulator UDID.");
+        }
+    }
+
+    private SetupReceipt requireInstallReceipt(SetupPlan plan) throws IOException {
+        Path receiptPath = paths.receipts().resolve(receiptStem() + ".json");
+        VerifiedArtifactStore.requireUnlinkedAncestors(receiptPath);
+        if (!Files.isRegularFile(receiptPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("A complete compatible desktop-mobile install receipt is required before start.");
+        }
+        SetupReceipt receipt;
+        try {
+            receipt = JSON.readValue(receiptPath.toFile(), SetupReceipt.class);
+        } catch (RuntimeException invalid) {
+            throw new IOException("Desktop-mobile install receipt is invalid.", invalid);
+        }
+        if (!receipt.planDigest().equals(plan.digest()) || !receipt.completedActions().equals(plan.actions())) {
+            throw new IOException("Desktop-mobile install receipt does not match the reviewed plan.");
+        }
+        return receipt;
+    }
+
+    private void requireInstalled(SetupPlan plan) throws IOException {
+        for (SetupAction action : plan.actions()) {
+            SetupStatus status = operations.status(action);
+            if (status.readiness() != SetupReadiness.READY) {
+                throw new IOException(action.target() + " is not ready: " + status.detail());
+            }
+        }
+    }
+
+    private void requireAvailablePort(int port, String owner) throws IOException {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(false);
+            socket.bind(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), port));
+        } catch (IOException occupied) {
+            throw new IOException(owner + " loopback port " + port + " is already occupied.", occupied);
+        }
+    }
+
+    private Optional<AndroidOwnedProcess> find(ProcessIdentity identity) throws IOException {
+        if (identity == null) return Optional.empty();
+        return runtime.find(identity.pid(), Instant.ofEpochMilli(identity.startEpochMilli()),
+                identity.commandIdentity());
+    }
+
+    private Optional<DesktopMobileRuntimeLease> readLease() throws IOException {
+        Path path = leasePath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(path);
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) return Optional.empty();
+        try {
+            DesktopMobileRuntimeLease lease = JSON.readValue(path.toFile(), DesktopMobileRuntimeLease.class);
+            if (lease.schemaVersion() != 1 || lease.refCount() < 1) {
+                throw new IOException("Invalid desktop-mobile lease.");
+            }
+            return Optional.of(lease);
+        } catch (RuntimeException invalid) {
+            throw new IOException("Desktop-mobile runtime lease is invalid.", invalid);
+        }
+    }
+
+    private void writeLease(DesktopMobileRuntimeLease lease) throws IOException {
+        Files.createDirectories(paths.state());
+        Path temporary = Files.createTempFile(paths.state(), receiptStem() + "-runtime", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(lease));
+            VerifiedArtifactStore.move(temporary, leasePath());
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private IOException stopStarted(AndroidOwnedProcess appium, DesktopMobileRuntimeLease lease, Duration timeout) {
+        IOException failure = null;
+        Instant deadline = Instant.now().plus(timeout);
+        if (appium != null) {
+            try {
+                Duration remaining = Duration.between(Instant.now(), deadline);
+                appium.stop(remaining.isNegative() ? Duration.ZERO : remaining);
+            } catch (IOException cleanup) {
+                failure = cleanup;
+            }
+        }
+        if (lease != null && lease.shaftBootedSimulator()) {
+            try {
+                devices.shutdownSimulator(lease.simulatorUdid());
+            } catch (IOException cleanup) {
+                if (failure == null) failure = cleanup;
+                else failure.addSuppressed(cleanup);
+            }
+        }
+        return failure;
+    }
+
+    private boolean iosSimulatorStillOwned(DesktopMobileRuntimeLease lease) throws IOException {
+        return expectedPlan.profile() == SetupProfile.MOBILE_IOS
+                && devices.simulatorState(lease.simulatorUdid())
+                == DesktopMobileDeviceController.SimulatorState.BOOTED;
+    }
+
+    private Path lockPath() {
+        return paths.state().resolve(receiptStem() + "-runtime.lock").toAbsolutePath().normalize();
+    }
+
+    private Path leasePath() {
+        return paths.state().resolve(receiptStem() + "-runtime.json");
+    }
+
+    private String receiptStem() {
+        return expectedPlan.profile() == SetupProfile.MOBILE_IOS ? "mobile-ios" : "mobile-windows";
+    }
+
+    private String endpoint() {
+        return "http://127.0.0.1:" + appiumPort + '/';
+    }
+
+    private static void requireDesktopProfile(SetupProfile profile) {
+        if (profile != SetupProfile.MOBILE_IOS && profile != SetupProfile.MOBILE_WINDOWS) {
+            throw new IllegalArgumentException("Desktop-mobile lifecycle requires an iOS or Windows profile.");
+        }
+    }
+
+    private record ActiveRuntime(DesktopMobileRuntimeLease lease, AndroidOwnedProcess appium) { }
+
+    private record ProcessIdentity(long pid, long startEpochMilli, String commandIdentity) {
+        static ProcessIdentity of(AndroidOwnedProcess process) {
+            return new ProcessIdentity(process.pid(), process.startInstant().toEpochMilli(),
+                    process.commandIdentity());
+        }
+    }
+
+    private record DesktopMobileRuntimeLease(int schemaVersion, String planDigest, SetupProfile profile,
+                                             String endpoint, String simulatorUdid, boolean shaftBootedSimulator,
+                                             ProcessIdentity appium, int refCount) {
+        DesktopMobileRuntimeLease withRefCount(int value) {
+            return new DesktopMobileRuntimeLease(schemaVersion, planDigest, profile, endpoint, simulatorUdid,
+                    shaftBootedSimulator, appium, value);
+        }
+
+        boolean sameIdentity(DesktopMobileRuntimeLease other) {
+            return planDigest.equals(other.planDigest) && profile == other.profile
+                    && endpoint.equals(other.endpoint) && simulatorUdid.equalsIgnoreCase(other.simulatorUdid)
+                    && shaftBootedSimulator == other.shaftBootedSimulator
+                    && java.util.Objects.equals(appium, other.appium);
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileRuntimeHealth.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileRuntimeHealth.java
@@ -1,0 +1,13 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+
+interface DesktopMobileRuntimeHealth {
+    void awaitAppium(URI endpoint, Duration timeout) throws IOException;
+
+    default void awaitSimulator(String udid, Duration timeout) throws IOException {
+        throw new UnsupportedOperationException("This host does not own iOS Simulator readiness.");
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileRuntimeLayout.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileRuntimeLayout.java
@@ -1,0 +1,18 @@
+package com.shaft.infrastructure;
+
+import java.nio.file.Path;
+
+/** Exact SHAFT-owned paths used by the managed iOS/Windows Appium runtime. */
+record DesktopMobileRuntimeLayout(Path nodeExecutable, Path appiumEntryPoint, Path appiumHome, Path appiumLog) {
+    static DesktopMobileRuntimeLayout resolve(ShaftCachePaths paths, SetupPlan plan) {
+        String platformKey = plan.platform().name().toLowerCase() + '-' + plan.architecture().artifactName();
+        Path nodeRoot = paths.tools().resolve("node").resolve(ReportingSetupPlanner.NODE_VERSION)
+                .resolve(platformKey);
+        Path node = plan.platform() == SetupPlatform.WINDOWS ? nodeRoot.resolve("node.exe")
+                : nodeRoot.resolve("bin/node");
+        String profile = plan.profile() == SetupProfile.MOBILE_IOS ? "appium-ios" : "appium-windows";
+        Path appium = paths.tools().resolve(profile).resolve(AndroidSetupPlanner.APPIUM_VERSION);
+        return new DesktopMobileRuntimeLayout(node, appium.resolve("node_modules/appium/index.js"), appium,
+                paths.state().resolve("logs/" + profile + ".log"));
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileRuntimeManager.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileRuntimeManager.java
@@ -1,0 +1,29 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.time.Duration;
+
+/** Explicit CLI/API access to lease-safe iOS/Windows Appium stop and bounded logs. */
+public final class DesktopMobileRuntimeManager {
+    private DesktopMobileRuntimeManager() { }
+
+    public static boolean stop(ShaftCachePaths paths, SetupPlan plan, Duration timeout) throws IOException {
+        return service(paths, plan).stop(timeout);
+    }
+
+    public static String logs(ShaftCachePaths paths, SetupPlan plan) throws IOException {
+        return service(paths, plan).logs();
+    }
+
+    private static DesktopMobileLifecycleService service(ShaftCachePaths paths, SetupPlan plan) {
+        DesktopMobileToolchainOperations operations = new DefaultDesktopMobileToolchainOperations(paths, plan, true);
+        return systemLifecycle(paths, plan, operations);
+    }
+
+    static DesktopMobileLifecycleService systemLifecycle(ShaftCachePaths paths, SetupPlan plan,
+                                                         DesktopMobileToolchainOperations operations) {
+        DesktopMobileDeviceController devices = new SystemDesktopMobileDeviceController(plan, paths);
+        return new DesktopMobileLifecycleService(paths, plan, operations, new SystemAndroidRuntimeController(),
+                devices, new SystemDesktopMobileRuntimeHealth(paths, plan, devices));
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileSetupPlanner.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DesktopMobileSetupPlanner.java
@@ -84,6 +84,17 @@ final class DesktopMobileSetupPlanner {
                 "sha256:" + WINAPPDRIVER_SHA256, 3_932_160, false, Set.of())));
     }
 
+    static String requestedSimulator(SetupPlan plan) {
+        if (plan.profile() != SetupProfile.MOBILE_IOS) {
+            throw new IllegalArgumentException("Simulator identity is only defined for iOS plans.");
+        }
+        return selectedSimulator(selectionFromPlan(plan));
+    }
+
+    static int requestedAppiumPort(SetupPlan plan) {
+        return selectedPort(selectionFromPlan(plan));
+    }
+
     static SetupSelection selectionFromPlan(SetupPlan plan) {
         java.util.Objects.requireNonNull(plan, "plan");
         return switch (plan.profile()) {

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
@@ -49,6 +49,11 @@ public final class InfrastructureSetupService {
         return providers.profiles().contains(Objects.requireNonNull(profile, "profile"));
     }
 
+    /** Reconstructs the canonical selection embedded in an approved plan. */
+    public SetupSelection selectionFromPlan(SetupPlan plan) {
+        return providers.require(Objects.requireNonNull(plan, "plan").profile()).selectionFromPlan(plan);
+    }
+
     public SetupPlan plan(SetupOptions options) {
         return plan(options, SetupSelection.defaults());
     }

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/IosSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/IosSetupProvider.java
@@ -5,13 +5,20 @@ import java.io.IOException;
 /** Built-in provider for a pinned Appium XCUITest toolchain and an existing iOS Simulator. */
 final class IosSetupProvider implements SetupProvider {
     private final DesktopMobileOperationsFactory operationsFactory;
+    private final DesktopMobileLifecycleFactory lifecycleFactory;
 
     IosSetupProvider() {
-        this(DefaultDesktopMobileToolchainOperations::new);
+        this(DefaultDesktopMobileToolchainOperations::new, DesktopMobileRuntimeManager::systemLifecycle);
     }
 
     IosSetupProvider(DesktopMobileOperationsFactory operationsFactory) {
+        this(operationsFactory, DesktopMobileRuntimeManager::systemLifecycle);
+    }
+
+    IosSetupProvider(DesktopMobileOperationsFactory operationsFactory,
+                     DesktopMobileLifecycleFactory lifecycleFactory) {
         this.operationsFactory = java.util.Objects.requireNonNull(operationsFactory, "operationsFactory");
+        this.lifecycleFactory = java.util.Objects.requireNonNull(lifecycleFactory, "lifecycleFactory");
     }
 
     @Override public SetupProfile profile() { return SetupProfile.MOBILE_IOS; }
@@ -58,6 +65,38 @@ final class IosSetupProvider implements SetupProvider {
                 options.offline()).install(providerPlan,
                 new SetupApproval(providerPlan.digest(), approval.approvedAt(), approval.acceptedLicenses()));
         return new SetupReceipt(plan.digest(), receipt.completedAt(), receipt.completedActions());
+    }
+
+    @Override
+    public ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        DesktopMobileToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        ManagedEnvironment inner = lifecycleFactory.create(options.paths(), providerPlan, operations)
+                .start(providerPlan, new SetupApproval(providerPlan.digest(), approval.approvedAt(),
+                        approval.acceptedLicenses()), options);
+        SetupReceipt receipt = new SetupReceipt(plan.digest(), inner.receipt().completedAt(),
+                inner.receipt().completedActions());
+        return new ManagedEnvironment(profile(), receipt, inner.endpoint(), inner.connectionProperties(),
+                inner::close);
+    }
+
+    @Override
+    public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        DesktopMobileToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), providerPlan, operations).stop(options.shutdownTimeout());
+    }
+
+    @Override
+    public String logs(SetupOptions options, SetupSelection selection, SetupPlatform platform,
+                       SetupArchitecture architecture) throws IOException {
+        SetupPlan plan = plan(options, selection, platform, architecture);
+        DesktopMobileToolchainOperations operations = operationsFactory.create(options.paths(), plan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), plan, operations).logs();
     }
 
     private SetupPlan canonicalPlan(SetupPlan plan, SetupOptions options) {

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SystemDesktopMobileDeviceController.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SystemDesktopMobileDeviceController.java
@@ -1,0 +1,73 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+
+/** Command-backed iOS Simulator boot/shutdown used only when SHAFT starts an exact UDID. */
+final class SystemDesktopMobileDeviceController implements DesktopMobileDeviceController {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    private final SetupPlatform platform;
+    private final Path workingDirectory;
+    private final AndroidCommandRunner runner;
+
+    SystemDesktopMobileDeviceController(SetupPlan plan, ShaftCachePaths paths) {
+        this(plan.platform(), Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize(),
+                AndroidCommandRunner.system(paths, plan.platform(), plan.architecture()));
+    }
+
+    SystemDesktopMobileDeviceController(SetupPlatform platform, Path workingDirectory,
+                                        AndroidCommandRunner runner) {
+        this.platform = java.util.Objects.requireNonNull(platform, "platform");
+        this.workingDirectory = java.util.Objects.requireNonNull(workingDirectory, "workingDirectory");
+        this.runner = java.util.Objects.requireNonNull(runner, "runner");
+    }
+
+    @Override
+    public SimulatorState simulatorState(String udid) throws IOException {
+        if (platform != SetupPlatform.MACOS) {
+            throw new IOException("iOS Simulator lifecycle is available only on macOS.");
+        }
+        ReportingSetupService.ProcessResult result = run(java.util.List.of("xcrun", "simctl", "list", "devices",
+                "--json"));
+        if (result.exitCode() != 0) {
+            throw new IOException("xcrun simctl could not enumerate Simulator devices.");
+        }
+        JsonNode tree = JSON.readTree(result.output());
+        final SimulatorState[] found = {SimulatorState.MISSING};
+        tree.path("devices").forEach(runtime -> runtime.forEach(device -> {
+            if (udid.equalsIgnoreCase(device.path("udid").asText())) {
+                found[0] = "Booted".equalsIgnoreCase(device.path("state").asText())
+                        ? SimulatorState.BOOTED : SimulatorState.SHUTDOWN;
+            }
+        }));
+        return found[0];
+    }
+
+    @Override
+    public void bootSimulator(String udid) throws IOException {
+        requireSuccess(run(java.util.List.of("xcrun", "simctl", "boot", udid)),
+                "Failed to boot iOS Simulator " + udid);
+    }
+
+    @Override
+    public void shutdownSimulator(String udid) throws IOException {
+        requireSuccess(run(java.util.List.of("xcrun", "simctl", "shutdown", udid)),
+                "Failed to shut down SHAFT-booted iOS Simulator " + udid);
+    }
+
+    private ReportingSetupService.ProcessResult run(java.util.List<String> command) throws IOException {
+        return runner.run(command, workingDirectory, Map.of(), Set.of(), null, null, Duration.ofSeconds(30));
+    }
+
+    private static void requireSuccess(ReportingSetupService.ProcessResult result, String message)
+            throws IOException {
+        if (result.exitCode() != 0) throw new IOException(message + ": " + result.output());
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SystemDesktopMobileHostProbe.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SystemDesktopMobileHostProbe.java
@@ -82,10 +82,12 @@ final class SystemDesktopMobileHostProbe implements DesktopMobileHostProbe {
             if (available.isEmpty()) return missing(action, "No available iOS Simulator device exists.");
             return ready(action, available.getFirst(), "An existing iOS Simulator device is available.");
         }
-        if (!available.contains(requested)) {
+        String matched = available.stream().filter(candidate -> candidate.equalsIgnoreCase(requested)).findFirst()
+                .orElse(null);
+        if (matched == null) {
             return missing(action, "Selected iOS Simulator is unavailable: " + requested);
         }
-        return ready(action, requested, "Selected iOS Simulator is available.");
+        return ready(action, matched, "Selected iOS Simulator is available.");
     }
 
     private SetupStatus winAppDriverStatus(SetupAction action) throws IOException {

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SystemDesktopMobileRuntimeHealth.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SystemDesktopMobileRuntimeHealth.java
@@ -1,0 +1,49 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+
+final class SystemDesktopMobileRuntimeHealth implements DesktopMobileRuntimeHealth {
+    private final SystemAndroidRuntimeHealth appium;
+    private final DesktopMobileDeviceController devices;
+
+    SystemDesktopMobileRuntimeHealth(ShaftCachePaths paths, SetupPlan plan,
+                                     DesktopMobileDeviceController devices) {
+        this(new SystemAndroidRuntimeHealth(paths, plan.platform(), plan.architecture()), devices);
+    }
+
+    SystemDesktopMobileRuntimeHealth(SystemAndroidRuntimeHealth appium, DesktopMobileDeviceController devices) {
+        this.appium = java.util.Objects.requireNonNull(appium, "appium");
+        this.devices = java.util.Objects.requireNonNull(devices, "devices");
+    }
+
+    @Override
+    public void awaitAppium(URI endpoint, Duration timeout) throws IOException {
+        appium.awaitAppium(endpoint, timeout);
+    }
+
+    @Override
+    public void awaitSimulator(String udid, Duration timeout) throws IOException {
+        Instant deadline = Instant.now().plus(timeout);
+        IOException last = new IOException("iOS Simulator did not become ready.");
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                if (devices.simulatorState(udid) == DesktopMobileDeviceController.SimulatorState.BOOTED) return;
+                last = new IOException("iOS Simulator " + udid + " is not Booted.");
+            } catch (IOException notReady) {
+                last = notReady;
+            }
+            long remaining = Duration.between(Instant.now(), deadline).toMillis();
+            if (remaining <= 0) break;
+            try {
+                Thread.sleep(Math.min(200, remaining));
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for iOS Simulator readiness.", interrupted);
+            }
+        }
+        throw new IOException("iOS Simulator readiness timed out for " + udid + '.', last);
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/WindowsSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/WindowsSetupProvider.java
@@ -5,13 +5,20 @@ import java.io.IOException;
 /** Built-in provider for pinned Appium Windows support and an existing WinAppDriver host. */
 final class WindowsSetupProvider implements SetupProvider {
     private final DesktopMobileOperationsFactory operationsFactory;
+    private final DesktopMobileLifecycleFactory lifecycleFactory;
 
     WindowsSetupProvider() {
-        this(DefaultDesktopMobileToolchainOperations::new);
+        this(DefaultDesktopMobileToolchainOperations::new, DesktopMobileRuntimeManager::systemLifecycle);
     }
 
     WindowsSetupProvider(DesktopMobileOperationsFactory operationsFactory) {
+        this(operationsFactory, DesktopMobileRuntimeManager::systemLifecycle);
+    }
+
+    WindowsSetupProvider(DesktopMobileOperationsFactory operationsFactory,
+                         DesktopMobileLifecycleFactory lifecycleFactory) {
         this.operationsFactory = java.util.Objects.requireNonNull(operationsFactory, "operationsFactory");
+        this.lifecycleFactory = java.util.Objects.requireNonNull(lifecycleFactory, "lifecycleFactory");
     }
 
     @Override public SetupProfile profile() { return SetupProfile.MOBILE_WINDOWS; }
@@ -58,6 +65,38 @@ final class WindowsSetupProvider implements SetupProvider {
                 options.offline()).install(providerPlan,
                 new SetupApproval(providerPlan.digest(), approval.approvedAt(), approval.acceptedLicenses()));
         return new SetupReceipt(plan.digest(), receipt.completedAt(), receipt.completedActions());
+    }
+
+    @Override
+    public ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        DesktopMobileToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        ManagedEnvironment inner = lifecycleFactory.create(options.paths(), providerPlan, operations)
+                .start(providerPlan, new SetupApproval(providerPlan.digest(), approval.approvedAt(),
+                        approval.acceptedLicenses()), options);
+        SetupReceipt receipt = new SetupReceipt(plan.digest(), inner.receipt().completedAt(),
+                inner.receipt().completedActions());
+        return new ManagedEnvironment(profile(), receipt, inner.endpoint(), inner.connectionProperties(),
+                inner::close);
+    }
+
+    @Override
+    public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        DesktopMobileToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), providerPlan, operations).stop(options.shutdownTimeout());
+    }
+
+    @Override
+    public String logs(SetupOptions options, SetupSelection selection, SetupPlatform platform,
+                       SetupArchitecture architecture) throws IOException {
+        SetupPlan plan = plan(options, selection, platform, architecture);
+        DesktopMobileToolchainOperations operations = operationsFactory.create(options.paths(), plan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), plan, operations).logs();
     }
 
     private SetupPlan canonicalPlan(SetupPlan plan, SetupOptions options) {

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DesktopMobileHostProbeTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DesktopMobileHostProbeTest.java
@@ -34,6 +34,35 @@ class DesktopMobileHostProbeTest {
     }
 
     @Test
+    void iosProbeMatchesHostUdidRegardlessOfHexCase(@TempDir Path temp) {
+        AndroidCommandRunner runner = (command, workingDirectory, environment, removed, input, log, timeout) ->
+                result(0, "{\"devices\":{\"com.apple.CoreSimulator.SimRuntime.iOS-18-5\":["
+                        + "{\"udid\":\"00000000-0000-0000-0000-00000000000A\",\"name\":\"iPhone 16\","
+                        + "\"isAvailable\":true}]}}");
+        SystemDesktopMobileHostProbe probe = new SystemDesktopMobileHostProbe(SetupPlatform.MACOS, temp, runner);
+        SetupAction simulator = DesktopMobileSetupPlanner.ios(SetupPlatform.MACOS, SetupArchitecture.ARM64,
+                SetupMode.MANAGED, new SetupSelection(List.of("simulator_00000000_0000_0000_0000_00000000000a")))
+                .actions().getLast();
+
+        SetupStatus status = probe.status(simulator);
+
+        assertEquals(SetupReadiness.READY, status.readiness());
+        assertEquals("00000000-0000-0000-0000-00000000000A", status.detectedVersion());
+    }
+
+    @Test
+    void deviceControllerMatchesHostUdidRegardlessOfHexCase(@TempDir Path temp) throws Exception {
+        AndroidCommandRunner runner = (command, workingDirectory, environment, removed, input, log, timeout) ->
+                result(0, "{\"devices\":{\"r\":[{\"udid\":\"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE\","
+                        + "\"state\":\"Booted\"}]}}");
+        SystemDesktopMobileDeviceController devices = new SystemDesktopMobileDeviceController(
+                SetupPlatform.MACOS, temp, runner);
+
+        assertEquals(DesktopMobileDeviceController.SimulatorState.BOOTED,
+                devices.simulatorState("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+    }
+
+    @Test
     void iosProbeRejectsASelectedSimulatorThatIsNotAvailable(@TempDir Path temp) {
         AndroidCommandRunner runner = (command, workingDirectory, environment, removed, input, log, timeout) ->
                 result(0, "{\"devices\":{}}");

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DesktopMobileLifecycleServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DesktopMobileLifecycleServiceTest.java
@@ -1,0 +1,486 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DesktopMobileLifecycleServiceTest {
+    private static final String UDID = "00000000-0000-0000-0000-000000000001";
+
+    @Test
+    void missingReceiptStartsNoProcess(@TempDir Path temp) {
+        Fixture fixture = uninstalled(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, new RecordingHealth());
+
+        assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+        assertTrue(runtime.commands.isEmpty());
+        assertTrue(devices.events.isEmpty());
+    }
+
+    @Test
+    void existingSimulatorSelectionStartsNoProcess(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp, SetupSelection.defaults());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, new RecordingHealth());
+
+        IOException failure = assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+        assertTrue(failure.getMessage().contains("exact Simulator UDID"));
+        assertTrue(runtime.commands.isEmpty());
+        assertTrue(devices.events.isEmpty());
+    }
+
+    @Test
+    void occupiedAppiumPortStartsNoProcess(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, new RecordingHealth());
+
+        try (ServerSocket occupied = new ServerSocket()) {
+            occupied.bind(new InetSocketAddress("127.0.0.1", 4723));
+
+            IOException failure = assertThrows(IOException.class,
+                    () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+            assertTrue(failure.getMessage().contains("4723"));
+            assertTrue(runtime.commands.isEmpty());
+            assertTrue(devices.events.isEmpty());
+        }
+    }
+
+    @Test
+    void iosStartBootsShutdownSimulatorThenOnlyAppiumAndCloseStopsBoth(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        RecordingHealth health = new RecordingHealth();
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, health);
+
+        ManagedEnvironment environment = lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+
+        assertEquals(1, runtime.commands.size());
+        assertTrue(runtime.commands.getFirst().containsAll(List.of("--address", "127.0.0.1", "--port", "4723")));
+        assertFalse(runtime.commands.getFirst().contains("WinAppDriver"));
+        assertEquals(List.of("boot:" + UDID), devices.events);
+        assertEquals(List.of("simulator:" + UDID, "appium:http://127.0.0.1:4723/"), health.events);
+        assertEquals(URI.create("http://127.0.0.1:4723/"), environment.endpoint().orElseThrow());
+        assertEquals(UDID, environment.connectionProperties().get("ios.simulator.udid"));
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("mobile-ios-runtime.json")));
+
+        environment.close();
+
+        assertEquals(List.of("appium"), runtime.stopped);
+        assertEquals(List.of("boot:" + UDID, "shutdown:" + UDID), devices.events);
+        assertFalse(Files.exists(fixture.paths().state().resolve("mobile-ios-runtime.json")));
+    }
+
+    @Test
+    void alreadyBootedSimulatorIsPreservedOnClose(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.BOOTED);
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, new RecordingHealth());
+
+        ManagedEnvironment environment = lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+        environment.close();
+
+        assertEquals(List.of("appium"), runtime.stopped);
+        assertTrue(devices.events.isEmpty());
+        assertEquals(DesktopMobileDeviceController.SimulatorState.BOOTED, devices.state);
+    }
+
+    @Test
+    void windowsStartNeverTouchesWinAppDriver(@TempDir Path temp) throws Exception {
+        Fixture fixture = installedWindows(temp);
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.MISSING);
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, new RecordingHealth());
+
+        ManagedEnvironment environment = lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+
+        assertEquals(1, runtime.commands.size());
+        assertTrue(runtime.commands.getFirst().containsAll(List.of("--address", "127.0.0.1", "--port", "4723")));
+        assertTrue(devices.events.isEmpty());
+        assertFalse(environment.connectionProperties().containsKey("ios.simulator.udid"));
+
+        environment.close();
+
+        assertEquals(List.of("appium"), runtime.stopped);
+        assertTrue(devices.events.isEmpty());
+    }
+
+    @Test
+    void leaseRoundTripReusesAppiumAndStopsOnlyAfterFinalRelease(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        DesktopMobileLifecycleService first = lifecycle(fixture, runtime, devices, new RecordingHealth());
+        ManagedEnvironment firstEnv = first.start(fixture.plan(), fixture.approval(), fixture.options());
+        DesktopMobileLifecycleService second = lifecycle(fixture, runtime, devices, new RecordingHealth());
+
+        ManagedEnvironment secondEnv = second.start(fixture.plan(), fixture.approval(), fixture.options());
+
+        assertEquals(1, runtime.commands.size());
+        firstEnv.close();
+        assertTrue(runtime.stopped.isEmpty());
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("mobile-ios-runtime.json")));
+
+        secondEnv.close();
+
+        assertEquals(List.of("appium"), runtime.stopped);
+        assertEquals(List.of("boot:" + UDID, "shutdown:" + UDID), devices.events);
+        assertFalse(Files.exists(fixture.paths().state().resolve("mobile-ios-runtime.json")));
+    }
+
+    @Test
+    void fullyStaleLeaseIsReplacedButPartialIosLeaseIsRejectedWithoutShutdown(@TempDir Path temp)
+            throws Exception {
+        Fixture stale = installed(temp.resolve("stale"), iosSelection());
+        RecordingRuntime staleRuntime = new RecordingRuntime();
+        RecordingDevices staleDevices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        DesktopMobileLifecycleService staleLifecycle = lifecycle(stale, staleRuntime, staleDevices,
+                new RecordingHealth());
+        staleLifecycle.start(stale.plan(), stale.approval(), stale.options());
+        staleRuntime.setAllAlive(false);
+        staleDevices.state = DesktopMobileDeviceController.SimulatorState.SHUTDOWN;
+
+        ManagedEnvironment replacement = staleLifecycle.start(stale.plan(), stale.approval(), stale.options());
+        assertEquals(2, staleRuntime.commands.size());
+        replacement.close();
+
+        Fixture partial = installed(temp.resolve("partial"), iosSelection());
+        RecordingRuntime partialRuntime = new RecordingRuntime();
+        RecordingDevices partialDevices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        DesktopMobileLifecycleService partialLifecycle = lifecycle(partial, partialRuntime, partialDevices,
+                new RecordingHealth());
+        ManagedEnvironment started = partialLifecycle.start(partial.plan(), partial.approval(), partial.options());
+        partialRuntime.setAllAlive(false);
+        partialDevices.state = DesktopMobileDeviceController.SimulatorState.BOOTED;
+
+        IOException failure = assertThrows(IOException.class,
+                () -> partialLifecycle.start(partial.plan(), partial.approval(), partial.options()));
+
+        assertTrue(failure.getMessage().contains("partially alive"));
+        assertEquals(1, partialRuntime.commands.size());
+        assertFalse(partialDevices.events.contains("shutdown:" + UDID));
+        started.close();
+    }
+
+    @Test
+    void appiumReadinessFailureCleansStartedSimulatorAndRetainsLogs(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        RecordingHealth health = new RecordingHealth();
+        health.failAppium = true;
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, health);
+
+        IOException failure = assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+        assertTrue(failure.getMessage().contains("Appium readiness"));
+        assertEquals(List.of("appium"), runtime.stopped);
+        assertEquals(List.of("boot:" + UDID, "shutdown:" + UDID), devices.events);
+        assertFalse(Files.exists(fixture.paths().state().resolve("mobile-ios-runtime.json")));
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("logs/appium-ios.log")));
+    }
+
+    @Test
+    void simulatorReadinessFailureAfterBootShutsDownOnlyTheShaftBootedDevice(@TempDir Path temp)
+            throws Exception {
+        Fixture fixture = installed(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        RecordingHealth health = new RecordingHealth();
+        health.failSimulator = true;
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, health);
+
+        IOException failure = assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+        assertTrue(failure.getMessage().contains("Simulator readiness"));
+        assertTrue(runtime.commands.isEmpty());
+        assertEquals(List.of("boot:" + UDID, "shutdown:" + UDID), devices.events);
+        assertFalse(Files.exists(fixture.paths().state().resolve("mobile-ios-runtime.json")));
+    }
+
+    @Test
+    void explicitStopEndsOwnedAppiumAndShaftBootedSimulator(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, new RecordingHealth());
+        lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+
+        assertTrue(lifecycle.stop(Duration.ofSeconds(5)));
+
+        assertEquals(List.of("appium"), runtime.stopped);
+        assertEquals(List.of("boot:" + UDID, "shutdown:" + UDID), devices.events);
+        assertFalse(Files.exists(fixture.paths().state().resolve("mobile-ios-runtime.json")));
+        assertFalse(lifecycle.stop(Duration.ofSeconds(1)));
+    }
+
+    @Test
+    void unknownProcessLeaseIsClearedWithoutKillingAnything(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, new RecordingHealth());
+        ManagedEnvironment environment = lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+        runtime.setAllAlive(false);
+        devices.state = DesktopMobileDeviceController.SimulatorState.SHUTDOWN;
+        Files.writeString(fixture.paths().state().resolve("mobile-ios-runtime.json"),
+                Files.readString(fixture.paths().state().resolve("mobile-ios-runtime.json"))
+                        .replace("\"pid\" : 200", "\"pid\" : 99999"));
+
+        assertFalse(lifecycle.stop(Duration.ofSeconds(1)));
+
+        assertEquals(List.of(), runtime.stopped);
+        assertFalse(devices.events.contains("shutdown:" + UDID));
+        assertFalse(Files.exists(fixture.paths().state().resolve("mobile-ios-runtime.json")));
+        environment.close();
+    }
+
+    @Test
+    void commandIdentityDriftRefusesToReuseOrStopTheSurvivor(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        RecordingDevices devices = new RecordingDevices(DesktopMobileDeviceController.SimulatorState.SHUTDOWN);
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime, devices, new RecordingHealth());
+        ManagedEnvironment environment = lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+        runtime.processes.getFirst().identity = "foreign";
+
+        IOException reuse = assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+        IOException stop = assertThrows(IOException.class, () -> lifecycle.stop(Duration.ofSeconds(1)));
+
+        assertTrue(reuse.getMessage().contains("does not match"));
+        assertTrue(stop.getMessage().contains("does not match"));
+        assertEquals(List.of(), runtime.stopped);
+        assertFalse(devices.events.contains("shutdown:" + UDID));
+        runtime.processes.getFirst().identity = "appium";
+        environment.close();
+    }
+
+    @Test
+    void logsReadOwnedAppiumFileWithoutFollowingLinks(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp, iosSelection());
+        RecordingRuntime runtime = new RecordingRuntime();
+        DesktopMobileLifecycleService lifecycle = lifecycle(fixture, runtime,
+                new RecordingDevices(DesktopMobileDeviceController.SimulatorState.BOOTED), new RecordingHealth());
+        ManagedEnvironment environment = lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+
+        assertTrue(lifecycle.logs().contains("appium log"));
+
+        Path log = fixture.paths().state().resolve("logs/appium-ios.log");
+        Path linked = fixture.paths().state().resolve("logs/appium-ios.link");
+        try {
+            Files.deleteIfExists(log);
+            Files.writeString(linked, "secret");
+            Files.createSymbolicLink(log, linked);
+            assertThrows(IOException.class, lifecycle::logs);
+        } catch (UnsupportedOperationException | IOException unsupported) {
+            org.junit.jupiter.api.Assumptions.assumeTrue(Files.isSymbolicLink(log),
+                    "Symlink proof unavailable: " + unsupported.getMessage());
+        }
+
+        environment.close();
+        if (!Files.isSymbolicLink(log)) assertEquals("", lifecycle.logs());
+    }
+
+    private static DesktopMobileLifecycleService lifecycle(Fixture fixture, RecordingRuntime runtime,
+                                                           RecordingDevices devices, RecordingHealth health) {
+        return new DesktopMobileLifecycleService(fixture.paths(), fixture.plan(), fixture.operations(), runtime,
+                devices, health);
+    }
+
+    private static Fixture installed(Path temp, SetupSelection selection) throws Exception {
+        Fixture fixture = uninstalled(temp, selection);
+        new DesktopMobileSetupService(fixture.paths(), fixture.plan(), fixture.operations(), false)
+                .install(fixture.plan(), fixture.approval());
+        return fixture;
+    }
+
+    private static Fixture installedWindows(Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        SetupPlan plan = DesktopMobileSetupPlanner.windows(SetupPlatform.WINDOWS, SetupArchitecture.X64,
+                SetupMode.MANAGED, SetupSelection.defaults());
+        ReadyOperations operations = new ReadyOperations();
+        SetupOptions options = SetupOptions.defaults(SetupProfile.MOBILE_WINDOWS, paths)
+                .withMode(SetupMode.MANAGED).withTimeouts(Duration.ofSeconds(5), Duration.ofSeconds(5));
+        new DesktopMobileSetupService(paths, plan, operations, false).install(plan, approval(plan));
+        return new Fixture(paths, plan, approval(plan), options, operations);
+    }
+
+    private static Fixture uninstalled(Path temp, SetupSelection selection) {
+        ShaftCachePaths paths = paths(temp);
+        SetupPlan plan = DesktopMobileSetupPlanner.ios(SetupPlatform.MACOS, SetupArchitecture.ARM64,
+                SetupMode.MANAGED, selection);
+        ReadyOperations operations = new ReadyOperations();
+        SetupOptions options = SetupOptions.defaults(SetupProfile.MOBILE_IOS, paths)
+                .withMode(SetupMode.MANAGED).withTimeouts(Duration.ofSeconds(5), Duration.ofSeconds(5));
+        return new Fixture(paths, plan, approval(plan), options, operations);
+    }
+
+    private static SetupSelection iosSelection() {
+        return new SetupSelection(List.of("simulator_00000000_0000_0000_0000_000000000001"));
+    }
+
+    private static SetupApproval approval(SetupPlan plan) {
+        return new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+    }
+
+    private static ShaftCachePaths paths(Path temp) {
+        Path cache = temp.resolve("cache").toAbsolutePath();
+        Path data = temp.resolve("data").toAbsolutePath();
+        return new ShaftCachePaths(cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts"));
+    }
+
+    private record Fixture(ShaftCachePaths paths, SetupPlan plan, SetupApproval approval, SetupOptions options,
+                           ReadyOperations operations) { }
+
+    private static final class ReadyOperations implements DesktopMobileToolchainOperations {
+        @Override public void hostPreflight(List<SetupAction> actions) { }
+        @Override public void lockedPreflight(List<SetupAction> actions, boolean offline) { }
+        @Override public void install(SetupAction action) { }
+        @Override public SetupStatus status(SetupAction action) {
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(), "ready");
+        }
+    }
+
+    private static final class RecordingRuntime implements AndroidRuntimeController {
+        private final List<List<String>> commands = new ArrayList<>();
+        private final List<String> stopped = new ArrayList<>();
+        private final List<FakeProcess> processes = new ArrayList<>();
+        private long nextPid = 200;
+
+        @Override
+        public AndroidOwnedProcess start(String role, List<String> command, Path workingDirectory,
+                                         Map<String, String> environment, Set<String> removedEnvironment,
+                                         Path log) throws IOException {
+            commands.add(List.copyOf(command));
+            Files.createDirectories(log.getParent());
+            Files.writeString(log, role + " log");
+            FakeProcess process = new FakeProcess(role, nextPid++, stopped);
+            processes.add(process);
+            return process;
+        }
+
+        @Override
+        public Optional<AndroidOwnedProcess> find(long pid, Instant startInstant, String commandIdentity)
+                throws IOException {
+            for (FakeProcess process : processes) {
+                if (process.pid() != pid) continue;
+                if (!process.isAlive()) return Optional.empty();
+                if (!process.startInstant().equals(startInstant)
+                        || !process.commandIdentity().equals(commandIdentity)) {
+                    throw new IOException("Live process identity does not match the SHAFT runtime lease: " + pid);
+                }
+                return Optional.of(process);
+            }
+            return Optional.empty();
+        }
+
+        private void setAllAlive(boolean alive) {
+            processes.forEach(process -> process.alive = alive);
+        }
+    }
+
+    private static final class FakeProcess implements AndroidOwnedProcess {
+        private final String role;
+        private final long pid;
+        private final List<String> stopped;
+        private final Instant start = Instant.ofEpochSecond(200);
+        private String identity;
+        private boolean alive = true;
+
+        private FakeProcess(String role, long pid, List<String> stopped) {
+            this.role = role;
+            this.pid = pid;
+            this.stopped = stopped;
+            this.identity = role;
+        }
+
+        @Override public long pid() { return pid; }
+        @Override public Instant startInstant() { return start; }
+        @Override public String commandIdentity() { return identity; }
+        @Override public boolean isAlive() { return alive; }
+
+        @Override
+        public void stop(Duration timeout) {
+            if (alive) {
+                alive = false;
+                stopped.add(role);
+            }
+        }
+    }
+
+    private static final class RecordingDevices implements DesktopMobileDeviceController {
+        private final List<String> events = new ArrayList<>();
+        private SimulatorState state;
+
+        private RecordingDevices(SimulatorState state) {
+            this.state = state;
+        }
+
+        @Override
+        public SimulatorState simulatorState(String udid) {
+            return state;
+        }
+
+        @Override
+        public void bootSimulator(String udid) {
+            events.add("boot:" + udid);
+            state = SimulatorState.BOOTED;
+        }
+
+        @Override
+        public void shutdownSimulator(String udid) {
+            events.add("shutdown:" + udid);
+            state = SimulatorState.SHUTDOWN;
+        }
+    }
+
+    private static final class RecordingHealth implements DesktopMobileRuntimeHealth {
+        private final List<String> events = new ArrayList<>();
+        private boolean failAppium;
+        private boolean failSimulator;
+
+        @Override
+        public void awaitAppium(URI endpoint, Duration timeout) throws IOException {
+            events.add("appium:" + endpoint);
+            if (failAppium) throw new IOException("Appium readiness failed");
+        }
+
+        @Override
+        public void awaitSimulator(String udid, Duration timeout) throws IOException {
+            events.add("simulator:" + udid);
+            if (failSimulator) throw new IOException("Simulator readiness failed");
+        }
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DesktopMobileLifecycleServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DesktopMobileLifecycleServiceTest.java
@@ -365,9 +365,9 @@ class DesktopMobileLifecycleServiceTest {
                            ReadyOperations operations) { }
 
     private static final class ReadyOperations implements DesktopMobileToolchainOperations {
-        @Override public void hostPreflight(List<SetupAction> actions) { }
-        @Override public void lockedPreflight(List<SetupAction> actions, boolean offline) { }
-        @Override public void install(SetupAction action) { }
+        @Override public void hostPreflight(List<SetupAction> actions) { /* no host mutation in this fixture */ }
+        @Override public void lockedPreflight(List<SetupAction> actions, boolean offline) { /* no locked preflight */ }
+        @Override public void install(SetupAction action) { /* receipt-only fixture */ }
         @Override public SetupStatus status(SetupAction action) {
             return new SetupStatus(action.target(), SetupReadiness.READY, action.version(), "ready");
         }
@@ -394,16 +394,18 @@ class DesktopMobileLifecycleServiceTest {
         @Override
         public Optional<AndroidOwnedProcess> find(long pid, Instant startInstant, String commandIdentity)
                 throws IOException {
+            FakeProcess match = null;
             for (FakeProcess process : processes) {
-                if (process.pid() != pid) continue;
-                if (!process.isAlive()) return Optional.empty();
-                if (!process.startInstant().equals(startInstant)
-                        || !process.commandIdentity().equals(commandIdentity)) {
-                    throw new IOException("Live process identity does not match the SHAFT runtime lease: " + pid);
+                if (process.pid() == pid) {
+                    match = process;
+                    break;
                 }
-                return Optional.of(process);
             }
-            return Optional.empty();
+            if (match == null || !match.isAlive()) return Optional.empty();
+            if (!match.startInstant().equals(startInstant) || !match.commandIdentity().equals(commandIdentity)) {
+                throw new IOException("Live process identity does not match the SHAFT runtime lease: " + pid);
+            }
+            return Optional.of(match);
         }
 
         private void setAllAlive(boolean alive) {

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DesktopMobileSetupProviderTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DesktopMobileSetupProviderTest.java
@@ -121,6 +121,17 @@ class DesktopMobileSetupProviderTest {
                 () -> windows.plan(options, new SetupSelection(List.of("port_invalid"))));
     }
 
+    @Test
+    void coordinatorReconstructsExactIosSelectionFromAnApprovedPlan(@TempDir Path temp) {
+        InfrastructureSetupService ios = InfrastructureSetupService.builtIn(
+                SetupPlatform.MACOS, SetupArchitecture.ARM64);
+        SetupSelection selection = new SetupSelection(List.of(
+                "simulator_00000000_0000_0000_0000_000000000001", "port_4725"));
+        SetupPlan plan = ios.plan(managed(SetupProfile.MOBILE_IOS, temp.resolve("ios")), selection);
+
+        assertEquals(selection, ios.selectionFromPlan(plan));
+    }
+
     private static SetupOptions managed(SetupProfile profile, Path root) {
         Path cache = root.resolve("cache");
         Path data = root.resolve("data");


### PR DESCRIPTION
## Summary
- Own Appium start/stop/logs for `MOBILE_IOS` and `MOBILE_WINDOWS` from the verified receipt and exact approved plan.
- Start only Appium on the reviewed loopback port. Boot an exact iOS Simulator UDID only when it is shut down, and shut it down only when SHAFT booted it.
- Never launch, adopt, or kill WinAppDriver. Reject `udid=existing`, occupied ports, missing receipts, partial leases, and process-identity drift.
- Reconstruct exact iOS/Windows selections from approved plans in CLI start/stop/logs.

Closes #5024
Related to #4849

## Checks
- `mvn -pl shaft-infrastructure,shaft-cli -Dtest=DesktopMobileLifecycleServiceTest,DesktopMobileHostProbeTest,DesktopMobileSetupProviderTest,InfrastructureSetupServiceTest,SetupCommandTest -DfailIfNoTests=false -Dallure.automaticallyOpen=false test` (57 + 21 tests, OK)
- `mvn -pl shaft-infrastructure -Dtest=DesktopMobileLifecycleServiceTest -DfailIfNoTests=false -Dallure.automaticallyOpen=false test` after Codacy split-catch / loop-branch fixes (14 tests, OK)

## Continuation
Head: 7b45890d7f
State: Codacy findings fixed, waiting for CI then merge
Blockers: previous Codacy medium/high; fix pushed
Next action: watch CI to green, merge, then remaining #4849 slices, then #4851