### PR TITLE
feat(setup): own managed Selenium Grid lifecycle

### DIFF
--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -367,7 +367,7 @@ public final class SetupCommand implements Runnable {
         return switch (plan.profile()) {
             case OCR -> ocrSelection(plan, languages);
             case MOBILE_ANDROID -> android.selectionFromPlan(plan);
-            case MOBILE_IOS, MOBILE_WINDOWS -> {
+            case MOBILE_IOS, MOBILE_WINDOWS, SELENIUM_GRID -> {
                 android.rejectIfSupplied(plan.profile());
                 yield InfrastructureSetupService.builtIn(plan.platform(), plan.architecture())
                         .selectionFromPlan(plan);

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultSeleniumGridToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultSeleniumGridToolchainOperations.java
@@ -1,0 +1,205 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Host Docker/Compose implementation for the Selenium Grid provider. */
+final class DefaultSeleniumGridToolchainOperations implements SeleniumGridToolchainOperations {
+    private final ShaftCachePaths paths;
+    private final SetupPlan plan;
+    private final AndroidCommandRunner runner;
+    private final boolean offline;
+
+    DefaultSeleniumGridToolchainOperations(ShaftCachePaths paths, SetupPlan plan, boolean offline) {
+        this(paths, plan, AndroidCommandRunner.system(paths, plan.platform(), plan.architecture()), offline);
+    }
+
+    DefaultSeleniumGridToolchainOperations(ShaftCachePaths paths, SetupPlan plan, AndroidCommandRunner runner,
+                                           boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.plan = java.util.Objects.requireNonNull(plan, "plan");
+        this.runner = java.util.Objects.requireNonNull(runner, "runner");
+        this.offline = offline;
+    }
+
+    @Override
+    public void hostPreflight(List<SetupAction> actions) throws IOException {
+        requireDocker();
+    }
+
+    @Override
+    public void lockedPreflight(List<SetupAction> actions, boolean requireOffline) throws IOException {
+        VerifiedArtifactStore.requireUnlinkedAncestors(composeFile());
+        if ((offline || requireOffline) && !Files.isRegularFile(composeFile(), LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Offline Selenium Grid setup requires a staged compose file.");
+        }
+    }
+
+    @Override
+    public void install(SetupAction action) throws IOException {
+        if (action.target() == SetupTarget.DOCKER) return;
+        if (action.target() != SetupTarget.SELENIUM_GRID) {
+            throw new IllegalArgumentException("Unsupported Grid install target: " + action.target());
+        }
+        SeleniumGridSetupPlanner.GridScale scale = SeleniumGridSetupPlanner.scaleFromPlan(plan);
+        byte[] compose = SeleniumGridSetupPlanner.compose(scale.port()).getBytes(StandardCharsets.UTF_8);
+        String actual;
+        try {
+            actual = "sha256:" + HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(compose));
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
+        if (!actual.equalsIgnoreCase(action.checksum())) {
+            throw new IOException("Rendered Selenium Grid compose does not match the approved plan.");
+        }
+        Path destination = composeFile();
+        Files.createDirectories(destination.getParent());
+        Path temporary = Files.createTempFile(destination.getParent(), "docker-compose", ".tmp");
+        try {
+            Files.write(temporary, compose);
+            VerifiedArtifactStore.move(temporary, destination);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    @Override
+    public SetupStatus status(SetupAction action) {
+        if (action.target() == SetupTarget.DOCKER) {
+            try {
+                requireDocker();
+                return new SetupStatus(action.target(), SetupReadiness.READY, action.version(),
+                        "Docker Engine and Compose are available.");
+            } catch (IOException failure) {
+                return new SetupStatus(action.target(), SetupReadiness.MISSING, "", failure.getMessage());
+            }
+        }
+        try {
+            Path compose = composeFile();
+            VerifiedArtifactStore.requireUnlinkedAncestors(compose);
+            if (!Files.isRegularFile(compose, LinkOption.NOFOLLOW_LINKS)) {
+                return new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                        "Managed Selenium Grid compose file is missing.");
+            }
+            String actual = "sha256:" + VerifiedArtifactStore.digest(compose);
+            if (!actual.equalsIgnoreCase(action.checksum())) {
+                return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "",
+                        "Staged compose does not match the approved plan.");
+            }
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(),
+                    "Staged Selenium Grid compose matches the reviewed plan.");
+        } catch (IOException failure) {
+            return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "", failure.getMessage());
+        }
+    }
+
+    @Override
+    public void composeUp(Path composeFile, String project, SeleniumGridSetupPlanner.GridScale scale)
+            throws IOException {
+        requireOwned(project);
+        List<String> command = List.of(docker(), "compose", "-p", project, "-f", composeFile.toString(),
+                "up", "-d", "--scale", "chrome=" + scale.chrome(), "--scale", "edge=" + scale.edge(),
+                "--scale", "firefox=" + scale.firefox());
+        run(command, "Failed to start the SHAFT Selenium Grid compose project.");
+    }
+
+    @Override
+    public void composeDown(Path composeFile, String project) throws IOException {
+        requireOwned(project);
+        run(List.of(docker(), "compose", "-p", project, "-f", composeFile.toString(), "down", "--remove-orphans"),
+                "Failed to stop the SHAFT Selenium Grid compose project.");
+    }
+
+    @Override
+    public boolean composeRunning(Path composeFile, String project) throws IOException {
+        requireOwned(project);
+        ReportingSetupService.ProcessResult result = runner.run(
+                List.of(docker(), "compose", "-p", project, "-f", composeFile.toString(), "ps", "-q"),
+                composeFile.getParent(), Map.of(), Set.of(), null, null, Duration.ofSeconds(15));
+        if (result.exitCode() != 0) {
+            throw new IOException("Unable to inspect the SHAFT Selenium Grid compose project. " + result.output());
+        }
+        return !result.output().isBlank();
+    }
+
+    @Override
+    public void awaitReady(URI endpoint, Duration timeout) throws IOException {
+        Instant deadline = Instant.now().plus(timeout);
+        URI status = endpoint.resolve("wd/hub/status");
+        IOException last = new IOException("Selenium Grid did not become ready.");
+        while (Instant.now().isBefore(deadline)) {
+            HttpURLConnection connection = (HttpURLConnection) status.toURL().openConnection();
+            try {
+                connection.setConnectTimeout(1_000);
+                connection.setReadTimeout(1_000);
+                connection.setRequestMethod("GET");
+                if (connection.getResponseCode() == 200) return;
+                last = new IOException("Selenium Grid status returned HTTP " + connection.getResponseCode() + '.');
+            } catch (IOException failure) {
+                last = failure;
+            } finally {
+                connection.disconnect();
+            }
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for Selenium Grid.", interrupted);
+            }
+        }
+        throw last;
+    }
+
+    private void requireDocker() throws IOException {
+        try {
+            ReportingSetupService.ProcessResult compose = runner.run(List.of(docker(), "compose", "version"),
+                    paths.cacheRoot(), Map.of(), Set.of(), null, null, Duration.ofSeconds(15));
+            ReportingSetupService.ProcessResult engine = runner.run(List.of(docker(), "version"),
+                    paths.cacheRoot(), Map.of(), Set.of(), null, null, Duration.ofSeconds(15));
+            if (compose.exitCode() != 0 || engine.exitCode() != 0) {
+                throw new IOException("Docker Engine 26.1.4+ and Compose v2 are required.");
+            }
+        } catch (IOException failure) {
+            throw new IOException("Docker Engine 26.1.4+ and Compose v2 are required.", failure);
+        }
+    }
+
+    private void run(List<String> command, String failure) throws IOException {
+        Path log = logFile();
+        Files.createDirectories(log.getParent());
+        ReportingSetupService.ProcessResult result = runner.run(command, composeFile().getParent(), Map.of(),
+                Set.of(), null, log, Duration.ofMinutes(5));
+        if (result.exitCode() != 0) throw new IOException(failure + " " + result.output());
+    }
+
+    private static void requireOwned(String project) throws IOException {
+        if (!SeleniumGridSetupPlanner.PROJECT.equals(project)) {
+            throw new IOException("Refusing to operate on an unowned Docker Compose project: " + project);
+        }
+    }
+
+    private Path composeFile() {
+        return paths.tools().resolve("selenium-grid").resolve("docker-compose.yml");
+    }
+
+    private Path logFile() {
+        return paths.state().resolve("logs").resolve("selenium-grid.log");
+    }
+
+    private String docker() {
+        return plan.platform() == SetupPlatform.WINDOWS ? "docker.exe" : "docker";
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
@@ -26,7 +26,7 @@ public final class InfrastructureSetupService {
     public static InfrastructureSetupService builtIn(SetupPlatform platform, SetupArchitecture architecture) {
         List<SetupProvider> providers = new java.util.ArrayList<>(List.of(
                 new ReportingSetupProvider(), new OcrSetupProvider(), new LighthouseSetupProvider(),
-                new PlaywrightSetupProvider(), new AndroidSetupProvider()));
+                new PlaywrightSetupProvider(), new AndroidSetupProvider(), new SeleniumGridSetupProvider()));
         if (platform == SetupPlatform.MACOS) providers.add(new IosSetupProvider());
         if (platform == SetupPlatform.WINDOWS) providers.add(new WindowsSetupProvider());
         ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridLifecycleFactory.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridLifecycleFactory.java
@@ -1,0 +1,7 @@
+package com.shaft.infrastructure;
+
+@FunctionalInterface
+interface SeleniumGridLifecycleFactory {
+    SeleniumGridLifecycleService create(ShaftCachePaths paths, SetupPlan plan,
+                                        SeleniumGridToolchainOperations operations);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridLifecycleService.java
@@ -57,7 +57,7 @@ final class SeleniumGridLifecycleService {
                 receipt = requireInstallReceipt(plan);
                 requireInstalled(plan);
                 Optional<SeleniumGridRuntimeLease> reusable = readReusable(plan, options);
-                if (reusable.isPresent()) return environment(receipt, reusable.orElseThrow(), options);
+                if (reusable.isPresent()) return environment(receipt, reusable.orElseThrow());
                 return startNew(plan, receipt, options);
             }
         } catch (InterruptedException interrupted) {
@@ -124,7 +124,7 @@ final class SeleniumGridLifecycleService {
                     SeleniumGridSetupPlanner.PROJECT, endpoint.toString(), scale.port(), scale.chrome(),
                     scale.edge(), scale.firefox(), 1);
             writeLease(lease);
-            return environment(receipt, lease, options);
+            return environment(receipt, lease);
         } catch (IOException | RuntimeException failure) {
             try {
                 operations.composeDown(composeFile(), SeleniumGridSetupPlanner.PROJECT);
@@ -161,8 +161,7 @@ final class SeleniumGridLifecycleService {
                 scale.firefox(), 1);
     }
 
-    private ManagedEnvironment environment(SetupReceipt receipt, SeleniumGridRuntimeLease lease,
-                                           SetupOptions options) {
+    private ManagedEnvironment environment(SetupReceipt receipt, SeleniumGridRuntimeLease lease) {
         Map<String, String> properties = new LinkedHashMap<>();
         properties.put("executionAddress", "localhost:" + lease.port());
         properties.put("selenium.grid.endpoint", lease.endpoint());

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridLifecycleService.java
@@ -170,14 +170,14 @@ final class SeleniumGridLifecycleService {
         return new ManagedEnvironment(SetupProfile.SELENIUM_GRID, receipt,
                 Optional.of(URI.create(lease.endpoint())), Map.copyOf(properties), () -> {
                     try {
-                        release(lease, options.shutdownTimeout());
+                        release(lease);
                     } catch (IOException failure) {
                         throw new IllegalStateException("Failed to release the owned Selenium Grid.", failure);
                     }
                 });
     }
 
-    private void release(SeleniumGridRuntimeLease started, Duration timeout) throws IOException {
+    private void release(SeleniumGridRuntimeLease started) throws IOException {
         Path lockPath = lockPath();
         ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
         jvmLock.lock();

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridLifecycleService.java
@@ -1,0 +1,301 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Lease-safe lifecycle owner for one verified SHAFT Selenium Grid compose project. */
+final class SeleniumGridLifecycleService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private final ShaftCachePaths paths;
+    private final SetupPlan expectedPlan;
+    private final SeleniumGridToolchainOperations operations;
+    private final SeleniumGridSetupPlanner.GridScale scale;
+
+    SeleniumGridLifecycleService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                                 SeleniumGridToolchainOperations operations) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.expectedPlan = java.util.Objects.requireNonNull(expectedPlan, "expectedPlan");
+        this.operations = java.util.Objects.requireNonNull(operations, "operations");
+        if (expectedPlan.profile() != SetupProfile.SELENIUM_GRID) {
+            throw new IllegalArgumentException("Selenium Grid lifecycle requires the SELENIUM_GRID profile.");
+        }
+        this.scale = SeleniumGridSetupPlanner.scaleFromPlan(expectedPlan);
+    }
+
+    ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        requireCompatible(plan, options);
+        SetupExecutor.validate(plan, approval);
+        SetupReceipt receipt = requireInstallReceipt(plan);
+        requireInstalled(plan);
+        Path lockPath = lockPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        try {
+            jvmLock.lockInterruptibly();
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                receipt = requireInstallReceipt(plan);
+                requireInstalled(plan);
+                Optional<SeleniumGridRuntimeLease> reusable = readReusable(plan, options);
+                if (reusable.isPresent()) return environment(receipt, reusable.orElseThrow(), options);
+                return startNew(plan, receipt, options);
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the Selenium Grid runtime lock.", interrupted);
+        } finally {
+            if (jvmLock.isHeldByCurrentThread()) jvmLock.unlock();
+        }
+    }
+
+    boolean stop(Duration timeout) throws IOException {
+        java.util.Objects.requireNonNull(timeout, "timeout");
+        Path lockPath = lockPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        if (Files.notExists(leasePath(), LinkOption.NOFOLLOW_LINKS)) return false;
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        jvmLock.lock();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Optional<SeleniumGridRuntimeLease> current = readLease();
+            if (current.isEmpty()) return false;
+            SeleniumGridRuntimeLease lease = current.orElseThrow();
+            requireLeaseIdentity(lease);
+            if (!operations.composeRunning(composeFile(), lease.project())) {
+                Files.deleteIfExists(leasePath());
+                return false;
+            }
+            if (lease.refCount() > 1) {
+                writeLease(lease.withRefCount(lease.refCount() - 1));
+                return true;
+            }
+            operations.composeDown(composeFile(), requireOwnedProject(lease.project()));
+            Files.deleteIfExists(leasePath());
+            return true;
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    String logs() throws IOException {
+        Optional<SeleniumGridRuntimeLease> current = readLease();
+        if (current.isEmpty()) return "";
+        SeleniumGridRuntimeLease lease = current.orElseThrow();
+        if (!lease.sameRuntime(expectedIdentity(expectedPlan))) {
+            throw new IOException("Selenium Grid lease does not match the requested runtime.");
+        }
+        return OwnedLogReader.read("Selenium Grid", logFile());
+    }
+
+    Path logFile() {
+        return paths.state().resolve("logs").resolve("selenium-grid.log");
+    }
+
+    private ManagedEnvironment startNew(SetupPlan plan, SetupReceipt receipt, SetupOptions options)
+            throws IOException {
+        requireAvailablePort(4442, "Selenium Grid event-bus publish");
+        requireAvailablePort(4443, "Selenium Grid event-bus subscribe");
+        requireAvailablePort(scale.port(), "Selenium Grid");
+        URI endpoint = URI.create("http://127.0.0.1:" + scale.port() + "/");
+        try {
+            operations.composeUp(composeFile(), SeleniumGridSetupPlanner.PROJECT, scale);
+            operations.awaitReady(endpoint, options.startupTimeout());
+            SeleniumGridRuntimeLease lease = new SeleniumGridRuntimeLease(1, plan.digest(),
+                    SeleniumGridSetupPlanner.PROJECT, endpoint.toString(), scale.port(), scale.chrome(),
+                    scale.edge(), scale.firefox(), 1);
+            writeLease(lease);
+            return environment(receipt, lease, options);
+        } catch (IOException | RuntimeException failure) {
+            try {
+                operations.composeDown(composeFile(), SeleniumGridSetupPlanner.PROJECT);
+            } catch (IOException cleanup) {
+                failure.addSuppressed(cleanup);
+            }
+            throw failure;
+        }
+    }
+
+    private Optional<SeleniumGridRuntimeLease> readReusable(SetupPlan plan, SetupOptions options) throws IOException {
+        Optional<SeleniumGridRuntimeLease> existing = readLease();
+        if (existing.isEmpty()) return Optional.empty();
+        SeleniumGridRuntimeLease lease = existing.orElseThrow();
+        if (!lease.planDigest().equals(plan.digest()) || !lease.sameIdentity(expectedIdentity(plan))) {
+            throw new IOException("An existing SHAFT Selenium Grid lease does not match the reviewed plan.");
+        }
+        if (!operations.composeRunning(composeFile(), lease.project())) {
+            Files.deleteIfExists(leasePath());
+            return Optional.empty();
+        }
+        if (!options.reuseOwnedProcesses()) {
+            throw new IOException("A compatible SHAFT Selenium Grid is already active and reuse is disabled.");
+        }
+        operations.awaitReady(URI.create(lease.endpoint()), options.startupTimeout());
+        SeleniumGridRuntimeLease incremented = lease.withRefCount(lease.refCount() + 1);
+        writeLease(incremented);
+        return Optional.of(incremented);
+    }
+
+    private SeleniumGridRuntimeLease expectedIdentity(SetupPlan plan) {
+        return new SeleniumGridRuntimeLease(1, plan.digest(), SeleniumGridSetupPlanner.PROJECT,
+                "http://127.0.0.1:" + scale.port() + "/", scale.port(), scale.chrome(), scale.edge(),
+                scale.firefox(), 1);
+    }
+
+    private ManagedEnvironment environment(SetupReceipt receipt, SeleniumGridRuntimeLease lease,
+                                           SetupOptions options) {
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("executionAddress", "localhost:" + lease.port());
+        properties.put("selenium.grid.endpoint", lease.endpoint());
+        properties.put("selenium.grid.project", lease.project());
+        return new ManagedEnvironment(SetupProfile.SELENIUM_GRID, receipt,
+                Optional.of(URI.create(lease.endpoint())), Map.copyOf(properties), () -> {
+                    try {
+                        release(lease, options.shutdownTimeout());
+                    } catch (IOException failure) {
+                        throw new IllegalStateException("Failed to release the owned Selenium Grid.", failure);
+                    }
+                });
+    }
+
+    private void release(SeleniumGridRuntimeLease started, Duration timeout) throws IOException {
+        Path lockPath = lockPath();
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        jvmLock.lock();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Optional<SeleniumGridRuntimeLease> current = readLease();
+            if (current.isEmpty()) return;
+            SeleniumGridRuntimeLease lease = current.orElseThrow();
+            if (!lease.sameIdentity(started)) {
+                throw new IOException("Selenium Grid lease changed; refusing to stop an unowned project.");
+            }
+            if (lease.refCount() > 1) {
+                writeLease(lease.withRefCount(lease.refCount() - 1));
+                return;
+            }
+            operations.composeDown(composeFile(), requireOwnedProject(lease.project()));
+            Files.deleteIfExists(leasePath());
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan, SetupOptions options) {
+        if (plan.profile() != SetupProfile.SELENIUM_GRID || options.profile() != SetupProfile.SELENIUM_GRID) {
+            throw new IllegalArgumentException("Selenium Grid lifecycle requires profile SELENIUM_GRID.");
+        }
+        if (plan.mode() == SetupMode.EXTERNAL || options.effectiveMode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External Selenium Grid setup cannot start local containers.");
+        }
+        if (!expectedPlan.equals(plan)) {
+            throw new IllegalArgumentException("Selenium Grid lifecycle plan does not match the release manifest.");
+        }
+    }
+
+    private SetupReceipt requireInstallReceipt(SetupPlan plan) throws IOException {
+        Path receiptPath = paths.receipts().resolve("selenium-grid.json");
+        VerifiedArtifactStore.requireUnlinkedAncestors(receiptPath);
+        if (!Files.isRegularFile(receiptPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("A complete compatible Selenium Grid install receipt is required before start.");
+        }
+        SetupReceipt receipt;
+        try {
+            receipt = JSON.readValue(receiptPath.toFile(), SetupReceipt.class);
+        } catch (RuntimeException invalid) {
+            throw new IOException("Selenium Grid install receipt is invalid.", invalid);
+        }
+        if (!receipt.planDigest().equals(plan.digest()) || !receipt.completedActions().equals(plan.actions())) {
+            throw new IOException("Selenium Grid install receipt does not match the reviewed plan.");
+        }
+        return receipt;
+    }
+
+    private void requireInstalled(SetupPlan plan) throws IOException {
+        for (SetupAction action : plan.actions()) {
+            SetupStatus status = operations.status(action);
+            if (status.readiness() != SetupReadiness.READY) {
+                throw new IOException(action.target() + " is not ready: " + status.detail());
+            }
+        }
+    }
+
+    private void requireAvailablePort(int port, String owner) throws IOException {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(false);
+            socket.bind(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), port));
+        } catch (IOException occupied) {
+            throw new IOException(owner + " loopback port " + port + " is already occupied.", occupied);
+        }
+    }
+
+    private void requireLeaseIdentity(SeleniumGridRuntimeLease lease) throws IOException {
+        if (!lease.sameIdentity(expectedIdentity(expectedPlan))) {
+            throw new IOException("Selenium Grid lease does not match the requested plan.");
+        }
+    }
+
+    private static String requireOwnedProject(String project) throws IOException {
+        if (!SeleniumGridSetupPlanner.PROJECT.equals(project)) {
+            throw new IOException("Refusing to stop an unowned Docker Compose project: " + project);
+        }
+        return project;
+    }
+
+    private Optional<SeleniumGridRuntimeLease> readLease() throws IOException {
+        Path path = leasePath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(path);
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) return Optional.empty();
+        try {
+            SeleniumGridRuntimeLease lease = JSON.readValue(path.toFile(), SeleniumGridRuntimeLease.class);
+            if (lease.schemaVersion() != 1 || lease.refCount() < 1) {
+                throw new IOException("Invalid Selenium Grid lease.");
+            }
+            return Optional.of(lease);
+        } catch (RuntimeException invalid) {
+            throw new IOException("Selenium Grid runtime lease is invalid.", invalid);
+        }
+    }
+
+    private void writeLease(SeleniumGridRuntimeLease lease) throws IOException {
+        Files.createDirectories(paths.state());
+        Path temporary = Files.createTempFile(paths.state(), "selenium-grid-runtime", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(lease));
+            VerifiedArtifactStore.move(temporary, leasePath());
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private Path composeFile() {
+        return paths.tools().resolve("selenium-grid").resolve("docker-compose.yml");
+    }
+
+    private Path leasePath() {
+        return paths.state().resolve("selenium-grid-runtime.json");
+    }
+
+    private Path lockPath() {
+        return paths.state().resolve("selenium-grid-runtime.lock").toAbsolutePath().normalize();
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridOperationsFactory.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridOperationsFactory.java
@@ -1,0 +1,6 @@
+package com.shaft.infrastructure;
+
+@FunctionalInterface
+interface SeleniumGridOperationsFactory {
+    SeleniumGridToolchainOperations create(ShaftCachePaths paths, SetupPlan plan, boolean offline);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridRuntimeLease.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridRuntimeLease.java
@@ -1,0 +1,33 @@
+package com.shaft.infrastructure;
+
+record SeleniumGridRuntimeLease(int schemaVersion, String planDigest, String project, String endpoint,
+                                int port, int chrome, int edge, int firefox, int refCount) {
+    SeleniumGridRuntimeLease {
+        if (schemaVersion != 1) throw new IllegalArgumentException("Unsupported Grid lease schema.");
+        if (planDigest == null || planDigest.isBlank()) throw new IllegalArgumentException("Plan digest is required.");
+        if (project == null || project.isBlank()) throw new IllegalArgumentException("Compose project is required.");
+        if (endpoint == null || endpoint.isBlank()) throw new IllegalArgumentException("Endpoint is required.");
+        if (refCount < 1) throw new IllegalArgumentException("Lease refcount must be positive.");
+    }
+
+    SeleniumGridRuntimeLease withRefCount(int value) {
+        return new SeleniumGridRuntimeLease(schemaVersion, planDigest, project, endpoint, port, chrome, edge,
+                firefox, value);
+    }
+
+    boolean sameIdentity(SeleniumGridRuntimeLease other) {
+        return other != null
+                && planDigest.equals(other.planDigest)
+                && sameRuntime(other);
+    }
+
+    boolean sameRuntime(SeleniumGridRuntimeLease other) {
+        return other != null
+                && project.equals(other.project)
+                && endpoint.equals(other.endpoint)
+                && port == other.port
+                && chrome == other.chrome
+                && edge == other.edge
+                && firefox == other.firefox;
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridRuntimeManager.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridRuntimeManager.java
@@ -1,0 +1,12 @@
+package com.shaft.infrastructure;
+
+final class SeleniumGridRuntimeManager {
+    private SeleniumGridRuntimeManager() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static SeleniumGridLifecycleService systemLifecycle(ShaftCachePaths paths, SetupPlan plan,
+                                                        SeleniumGridToolchainOperations operations) {
+        return new SeleniumGridLifecycleService(paths, plan, operations);
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridSetupPlanner.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridSetupPlanner.java
@@ -1,0 +1,190 @@
+package com.shaft.infrastructure;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Release-coupled plans for a SHAFT-owned Selenium Grid compose project. */
+final class SeleniumGridSetupPlanner {
+    static final String IMAGE_TAG = "4.47.0-20260808";
+    static final String PROJECT = "shaft-selenium-grid";
+    static final int DEFAULT_PORT = 4444;
+    static final int DEFAULT_CHROME = 1;
+    static final int DEFAULT_EDGE = 0;
+    static final int DEFAULT_FIREFOX = 0;
+    private static final Pattern SPEC = Pattern.compile(
+            Pattern.quote(IMAGE_TAG) + ",port=([0-9]+),chrome=([0-9]+),edge=([0-9]+),firefox=([0-9]+)");
+
+    private SeleniumGridSetupPlanner() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static SetupPlan plan(SetupPlatform platform, SetupArchitecture architecture, SetupMode mode,
+                          SetupSelection selection) {
+        GridScale scale = scale(selection);
+        SetupActionKind gridKind = mode == SetupMode.EXTERNAL ? SetupActionKind.DIAGNOSE : SetupActionKind.INSTALL;
+        String compose = compose(scale.port());
+        byte[] bytes = compose.getBytes(StandardCharsets.UTF_8);
+        return SetupPlan.create(SetupProfile.SELENIUM_GRID, platform, architecture, mode, List.of(
+                new SetupAction(SetupTarget.DOCKER, SetupActionKind.DIAGNOSE, "26.1.4+",
+                        URI.create("urn:shaft:host:docker"),
+                        sha256("docker\026.1.4+"), false, Set.of()),
+                new SetupAction(SetupTarget.SELENIUM_GRID, gridKind, spec(scale),
+                        URI.create("urn:shaft:selenium-grid:" + PROJECT + ":" + spec(scale)),
+                        sha256(compose), bytes.length, false, Set.of())));
+    }
+
+    static SetupSelection selectionFromPlan(SetupPlan plan) {
+        return selectionFromScale(scaleFromPlan(plan));
+    }
+
+    static GridScale scaleFromPlan(SetupPlan plan) {
+        if (plan.profile() != SetupProfile.SELENIUM_GRID) {
+            throw new IllegalArgumentException("Grid scale is only defined for Selenium Grid plans.");
+        }
+        List<SetupAction> actions = plan.actions().stream()
+                .filter(action -> action.target() == SetupTarget.SELENIUM_GRID).toList();
+        if (actions.size() != 1) {
+            throw new IllegalArgumentException("Selenium Grid plan must contain exactly one SELENIUM_GRID action.");
+        }
+        Matcher match = SPEC.matcher(actions.getFirst().version());
+        if (!match.matches()) throw new IllegalArgumentException("Selenium Grid plan metadata is invalid.");
+        return new GridScale(parsePort(match.group(1)), parseScale("chrome", match.group(2)),
+                parseScale("edge", match.group(3)), parseScale("firefox", match.group(4)));
+    }
+
+    static String compose(int port) {
+        return """
+                services:
+                  chrome:
+                    image: selenium/node-chrome:%1$s
+                    shm_size: 2gb
+                    depends_on:
+                      selenium-hub:
+                        condition: service_healthy
+                    extra_hosts:
+                      - "host.docker.internal:host-gateway"
+                    environment:
+                      - SE_EVENT_BUS_HOST=selenium-hub
+                      - SE_NODE_GRID_URL=http://localhost:%2$d
+                      - SE_NODE_CONNECTION_LIMIT_PER_SESSION=1000
+                      - SE_NODE_SESSION_TIMEOUT=7200
+                      - SE_RECORD_VIDEO=true
+                  edge:
+                    image: selenium/node-edge:%1$s
+                    shm_size: 2gb
+                    depends_on:
+                      selenium-hub:
+                        condition: service_healthy
+                    extra_hosts:
+                      - "host.docker.internal:host-gateway"
+                    environment:
+                      - SE_EVENT_BUS_HOST=selenium-hub
+                      - SE_NODE_GRID_URL=http://localhost:%2$d
+                      - SE_NODE_CONNECTION_LIMIT_PER_SESSION=1000
+                      - SE_NODE_SESSION_TIMEOUT=7200
+                      - SE_RECORD_VIDEO=true
+                  firefox:
+                    image: selenium/node-firefox:%1$s
+                    shm_size: 2gb
+                    depends_on:
+                      selenium-hub:
+                        condition: service_healthy
+                    extra_hosts:
+                      - "host.docker.internal:host-gateway"
+                    environment:
+                      - SE_EVENT_BUS_HOST=selenium-hub
+                      - SE_NODE_GRID_URL=http://localhost:%2$d
+                      - SE_NODE_CONNECTION_LIMIT_PER_SESSION=1000
+                      - SE_NODE_SESSION_TIMEOUT=7200
+                      - SE_RECORD_VIDEO=true
+                  selenium-hub:
+                    image: selenium/hub:%1$s
+                    ports:
+                      - "4442:4442"
+                      - "4443:4443"
+                      - "%2$d:4444"
+                    healthcheck:
+                      test: [ "CMD-SHELL", "curl -sf http://localhost:4444/wd/hub/status >/dev/null || exit 1" ]
+                      interval: 5s
+                      timeout: 10s
+                      retries: 20
+                """.formatted(IMAGE_TAG, port);
+    }
+
+    static GridScale scale(SetupSelection selection) {
+        int port = selected(selection, "port_", DEFAULT_PORT, 1024, 65535, "Grid port");
+        int chrome = selected(selection, "chrome_", DEFAULT_CHROME, 0, 20, "chrome scale");
+        int edge = selected(selection, "edge_", DEFAULT_EDGE, 0, 20, "edge scale");
+        int firefox = selected(selection, "firefox_", DEFAULT_FIREFOX, 0, 20, "firefox scale");
+        for (String component : selection.components()) {
+            if (!component.startsWith("port_") && !component.startsWith("chrome_")
+                    && !component.startsWith("edge_") && !component.startsWith("firefox_")) {
+                throw new IllegalArgumentException("Unsupported Selenium Grid component: " + component);
+            }
+        }
+        if (chrome + edge + firefox == 0) {
+            throw new IllegalArgumentException("Select at least one Grid browser replica.");
+        }
+        return new GridScale(port, chrome, edge, firefox);
+    }
+
+    static SetupSelection selectionFromScale(GridScale scale) {
+        java.util.ArrayList<String> components = new java.util.ArrayList<>();
+        if (scale.port() != DEFAULT_PORT) components.add("port_" + scale.port());
+        if (scale.chrome() != DEFAULT_CHROME) components.add("chrome_" + scale.chrome());
+        if (scale.edge() != DEFAULT_EDGE) components.add("edge_" + scale.edge());
+        if (scale.firefox() != DEFAULT_FIREFOX) components.add("firefox_" + scale.firefox());
+        return new SetupSelection(components);
+    }
+
+    private static int selected(SetupSelection selection, String prefix, int defaultValue, int min, int max,
+                                String label) {
+        List<String> values = selection.components().stream().filter(component -> component.startsWith(prefix)).toList();
+        if (values.size() > 1) throw new IllegalArgumentException("Select at most one " + label + '.');
+        int value = defaultValue;
+        if (!values.isEmpty()) {
+            try {
+                value = Integer.parseInt(values.getFirst().substring(prefix.length()));
+            } catch (NumberFormatException invalid) {
+                throw new IllegalArgumentException(label + " must be a decimal integer.", invalid);
+            }
+        }
+        if (value < min || value > max) {
+            throw new IllegalArgumentException(label + " must be between " + min + " and " + max + '.');
+        }
+        return value;
+    }
+
+    private static int parsePort(String value) {
+        return selected(new SetupSelection(List.of("port_" + value)), "port_", DEFAULT_PORT, 1024, 65535, "Grid port");
+    }
+
+    private static int parseScale(String browser, String value) {
+        return selected(new SetupSelection(List.of(browser + "_" + value)), browser + "_", 0, 0, 20,
+                browser + " scale");
+    }
+
+    private static String spec(GridScale scale) {
+        return IMAGE_TAG + ",port=" + scale.port() + ",chrome=" + scale.chrome() + ",edge=" + scale.edge()
+                + ",firefox=" + scale.firefox();
+    }
+
+    private static String sha256(String value) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.UTF_8));
+            return "sha256:" + HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
+    }
+
+    record GridScale(int port, int chrome, int edge, int firefox) { }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridSetupProvider.java
@@ -1,0 +1,121 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+
+/** Built-in provider for a pinned Selenium Grid compose project. */
+final class SeleniumGridSetupProvider implements SetupProvider {
+    private final SeleniumGridOperationsFactory operationsFactory;
+    private final SeleniumGridLifecycleFactory lifecycleFactory;
+
+    SeleniumGridSetupProvider() {
+        this(DefaultSeleniumGridToolchainOperations::new, SeleniumGridRuntimeManager::systemLifecycle);
+    }
+
+    SeleniumGridSetupProvider(SeleniumGridOperationsFactory operationsFactory) {
+        this(operationsFactory, SeleniumGridRuntimeManager::systemLifecycle);
+    }
+
+    SeleniumGridSetupProvider(SeleniumGridOperationsFactory operationsFactory,
+                              SeleniumGridLifecycleFactory lifecycleFactory) {
+        this.operationsFactory = java.util.Objects.requireNonNull(operationsFactory, "operationsFactory");
+        this.lifecycleFactory = java.util.Objects.requireNonNull(lifecycleFactory, "lifecycleFactory");
+    }
+
+    @Override
+    public SetupProfile profile() {
+        return SetupProfile.SELENIUM_GRID;
+    }
+
+    @Override
+    public SetupPlan plan(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return plan(options, SetupSelection.defaults(), platform, architecture);
+    }
+
+    @Override
+    public SetupPlan plan(SetupOptions options, SetupSelection selection,
+                          SetupPlatform platform, SetupArchitecture architecture) {
+        return SeleniumGridSetupPlanner.plan(platform, architecture, options.effectiveMode(), selection);
+    }
+
+    @Override
+    public SetupSelection selectionFromPlan(SetupPlan plan) {
+        return SeleniumGridSetupPlanner.selectionFromPlan(plan);
+    }
+
+    @Override
+    public SetupReport status(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return status(options, SetupSelection.defaults(), platform, architecture);
+    }
+
+    @Override
+    public SetupReport status(SetupOptions options, SetupSelection selection,
+                              SetupPlatform platform, SetupArchitecture architecture) {
+        SetupPlan plan = plan(options, selection, platform, architecture);
+        if (options.effectiveMode() == SetupMode.EXTERNAL) return externalStatus(plan);
+        SeleniumGridToolchainOperations operations = operationsFactory.create(options.paths(), plan, options.offline());
+        return SetupReport.from(new SeleniumGridSetupService(options.paths(), plan, operations, options.offline())
+                .status());
+    }
+
+    @Override
+    public SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        SeleniumGridToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        SetupReceipt receipt = new SeleniumGridSetupService(options.paths(), providerPlan, operations,
+                options.offline()).install(providerPlan,
+                new SetupApproval(providerPlan.digest(), approval.approvedAt(), approval.acceptedLicenses()));
+        return new SetupReceipt(plan.digest(), receipt.completedAt(), receipt.completedActions());
+    }
+
+    @Override
+    public ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        SeleniumGridToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        ManagedEnvironment inner = lifecycleFactory.create(options.paths(), providerPlan, operations)
+                .start(providerPlan, new SetupApproval(providerPlan.digest(), approval.approvedAt(),
+                        approval.acceptedLicenses()), options);
+        SetupReceipt receipt = new SetupReceipt(plan.digest(), inner.receipt().completedAt(),
+                inner.receipt().completedActions());
+        return new ManagedEnvironment(profile(), receipt, inner.endpoint(), inner.connectionProperties(),
+                inner::close);
+    }
+
+    @Override
+    public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        SeleniumGridToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), providerPlan, operations).stop(options.shutdownTimeout());
+    }
+
+    @Override
+    public String logs(SetupOptions options, SetupSelection selection, SetupPlatform platform,
+                       SetupArchitecture architecture) throws IOException {
+        SetupPlan plan = plan(options, selection, platform, architecture);
+        SeleniumGridToolchainOperations operations = operationsFactory.create(options.paths(), plan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), plan, operations).logs();
+    }
+
+    private SetupPlan canonicalPlan(SetupPlan plan, SetupOptions options) {
+        if (options.profile() != profile()) {
+            throw new IllegalArgumentException("Options do not select Selenium Grid setup.");
+        }
+        SetupPlan canonical = SeleniumGridSetupPlanner.plan(plan.platform(), plan.architecture(), plan.mode(),
+                SeleniumGridSetupPlanner.selectionFromPlan(plan));
+        if (!SetupPlan.bind(canonical, options.policyDigest()).equals(plan)) {
+            throw new IllegalArgumentException("Plan does not match the Selenium Grid manifest shipped with this release.");
+        }
+        return canonical;
+    }
+
+    private SetupReport externalStatus(SetupPlan plan) {
+        return SetupReport.from(new SetupProfileStatus(1, profile(), SetupReadiness.MISSING,
+                plan.actions().stream().map(action -> new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                        "External mode is diagnostic-only and does not execute managed tools.")).toList()));
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridSetupService.java
@@ -1,0 +1,150 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Transaction coordinator for one exact Selenium Grid setup plan. */
+final class SeleniumGridSetupService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private final ShaftCachePaths paths;
+    private final SetupPlan expectedPlan;
+    private final SeleniumGridToolchainOperations operations;
+    private final boolean offline;
+
+    SeleniumGridSetupService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                             SeleniumGridToolchainOperations operations, boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.expectedPlan = java.util.Objects.requireNonNull(expectedPlan, "expectedPlan");
+        this.operations = java.util.Objects.requireNonNull(operations, "operations");
+        this.offline = offline;
+        if (expectedPlan.profile() != SetupProfile.SELENIUM_GRID) {
+            throw new IllegalArgumentException("Selenium Grid setup requires the SELENIUM_GRID profile.");
+        }
+    }
+
+    SetupProfileStatus status() {
+        List<SetupStatus> targets = expectedPlan.actions().stream().map(operations::status).toList();
+        SetupReadiness readiness = targets.stream().allMatch(target -> target.readiness() == SetupReadiness.READY)
+                ? SetupReadiness.READY
+                : targets.stream().anyMatch(target -> target.readiness() == SetupReadiness.DEGRADED)
+                ? SetupReadiness.DEGRADED : SetupReadiness.MISSING;
+        if (readiness == SetupReadiness.READY && !hasCompatibleReceipt()) {
+            ArrayList<SetupStatus> adjusted = new ArrayList<>(targets);
+            SetupStatus last = adjusted.getLast();
+            adjusted.set(adjusted.size() - 1, new SetupStatus(last.target(), SetupReadiness.DEGRADED,
+                    last.detectedVersion(), "Managed files exist without a compatible SHAFT receipt."));
+            targets = List.copyOf(adjusted);
+            readiness = SetupReadiness.DEGRADED;
+        }
+        return new SetupProfileStatus(1, expectedPlan.profile(), readiness, targets);
+    }
+
+    SetupReceipt install(SetupPlan plan, SetupApproval approval) throws IOException {
+        requireCompatible(plan);
+        SetupExecutor.validate(plan, approval);
+        operations.hostPreflight(plan.actions());
+        Path lockPath = paths.state().resolve("selenium-grid.lock").toAbsolutePath().normalize();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        boolean acquired = false;
+        try {
+            jvmLock.lockInterruptibly();
+            acquired = true;
+            if (!Files.isDirectory(paths.state(), LinkOption.NOFOLLOW_LINKS)) {
+                operations.preStatePreflight(plan.actions(), offline);
+            }
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                operations.lockedPreflight(plan.actions(), offline);
+                invalidateReceipt();
+                SetupReceipt receipt = SetupExecutor.execute(plan, approval, action -> {
+                    try {
+                        operations.install(action);
+                    } catch (IOException failure) {
+                        throw new SetupOperationException(failure);
+                    }
+                });
+                Files.deleteIfExists(previousReceiptPath());
+                writeReceipt(receipt);
+                return receipt;
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the Selenium Grid setup lock.", interrupted);
+        } finally {
+            if (acquired) jvmLock.unlock();
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan) {
+        if (plan.mode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External plans are diagnostic and cannot be installed.");
+        }
+        if (!expectedPlan.equals(plan)) {
+            throw new IllegalArgumentException("Plan does not match the Selenium Grid manifest shipped with this release.");
+        }
+    }
+
+    private void writeReceipt(SetupReceipt receipt) throws IOException {
+        Files.createDirectories(paths.receipts());
+        Path destination = receiptPath();
+        Path temporary = Files.createTempFile(paths.receipts(), "selenium-grid", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(receipt));
+            VerifiedArtifactStore.move(temporary, destination);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private boolean hasCompatibleReceipt() {
+        try {
+            Path receipt = receiptPath();
+            VerifiedArtifactStore.requireUnlinkedAncestors(receipt);
+            if (!Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)) return false;
+            SetupReceipt saved = JSON.readValue(receipt.toFile(), SetupReceipt.class);
+            return saved.planDigest().equals(expectedPlan.digest())
+                    && saved.completedActions().equals(expectedPlan.actions());
+        } catch (IOException | RuntimeException invalid) {
+            return false;
+        }
+    }
+
+    private Path receiptPath() {
+        return paths.receipts().resolve("selenium-grid.json");
+    }
+
+    private Path previousReceiptPath() {
+        return paths.receipts().resolve("selenium-grid.previous.json");
+    }
+
+    private void invalidateReceipt() throws IOException {
+        Path receipt = receiptPath();
+        Path previous = previousReceiptPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(receipt);
+        VerifiedArtifactStore.requireUnlinkedAncestors(previous);
+        if (!Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)) return;
+        Files.deleteIfExists(previous);
+        VerifiedArtifactStore.move(receipt, previous);
+    }
+
+    private static final class SetupOperationException extends RuntimeException {
+        private SetupOperationException(IOException cause) {
+            super(cause);
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridToolchainOperations.java
@@ -11,7 +11,10 @@ interface SeleniumGridToolchainOperations {
     void hostPreflight(List<SetupAction> actions) throws IOException;
 
     default void preStatePreflight(List<SetupAction> actions, boolean offline) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
         // Grid has no safe read that must occur before the shared state directory exists.
+        // offline is part of the shared provider SPI and is unused until that read exists.
+        if (offline) return;
     }
 
     void lockedPreflight(List<SetupAction> actions, boolean offline) throws IOException;

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/SeleniumGridToolchainOperations.java
@@ -1,0 +1,39 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+/** Injectable host and mutation boundary for the Selenium Grid setup transaction. */
+interface SeleniumGridToolchainOperations {
+    void hostPreflight(List<SetupAction> actions) throws IOException;
+
+    default void preStatePreflight(List<SetupAction> actions, boolean offline) throws IOException {
+        // Grid has no safe read that must occur before the shared state directory exists.
+    }
+
+    void lockedPreflight(List<SetupAction> actions, boolean offline) throws IOException;
+
+    void install(SetupAction action) throws IOException;
+
+    SetupStatus status(SetupAction action);
+
+    default void composeUp(Path composeFile, String project, SeleniumGridSetupPlanner.GridScale scale)
+            throws IOException {
+        throw new UnsupportedOperationException("Compose start is not available.");
+    }
+
+    default void composeDown(Path composeFile, String project) throws IOException {
+        throw new UnsupportedOperationException("Compose stop is not available.");
+    }
+
+    default boolean composeRunning(Path composeFile, String project) throws IOException {
+        throw new IOException("Compose inspection is not available.");
+    }
+
+    default void awaitReady(URI endpoint, Duration timeout) throws IOException {
+        throw new UnsupportedOperationException("Grid readiness is not available.");
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultSeleniumGridToolchainOperationsTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultSeleniumGridToolchainOperationsTest.java
@@ -1,0 +1,55 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultSeleniumGridToolchainOperationsTest {
+    @Test
+    void dockerProbeDoesNotCreateStateOrRequireALogFile(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        AtomicReference<Path> logged = new AtomicReference<>();
+        DefaultSeleniumGridToolchainOperations operations = new DefaultSeleniumGridToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) -> {
+                    logged.set(log);
+                    return new ReportingSetupService.ProcessResult(0, "Docker Compose version v2.34.0");
+                }, false);
+
+        operations.hostPreflight(plan().actions());
+
+        assertFalse(Files.exists(paths.state()));
+        assertTrue(logged.get() == null);
+    }
+
+    @Test
+    void composeInspectFailureIsNotTreatedAsStopped(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        DefaultSeleniumGridToolchainOperations operations = new DefaultSeleniumGridToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) -> {
+                    throw new java.io.IOException("docker daemon unavailable");
+                }, false);
+
+        assertThrows(java.io.IOException.class, () -> operations.composeRunning(
+                paths.tools().resolve("selenium-grid").resolve("docker-compose.yml"),
+                SeleniumGridSetupPlanner.PROJECT));
+    }
+
+    private static SetupPlan plan() {
+        return SeleniumGridSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64, SetupMode.MANAGED,
+                SetupSelection.defaults());
+    }
+
+    private static ShaftCachePaths paths(Path temp) {
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        return new ShaftCachePaths(cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts"));
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/SeleniumGridLifecycleServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/SeleniumGridLifecycleServiceTest.java
@@ -160,9 +160,9 @@ class SeleniumGridLifecycleServiceTest {
         private boolean ready = true;
         private boolean inspectFails;
 
-        @Override public void hostPreflight(List<SetupAction> actions) { }
-        @Override public void lockedPreflight(List<SetupAction> actions, boolean offline) { }
-        @Override public void install(SetupAction action) { }
+        @Override public void hostPreflight(List<SetupAction> actions) { /* no host mutation in this fixture */ }
+        @Override public void lockedPreflight(List<SetupAction> actions, boolean offline) { /* no locked preflight */ }
+        @Override public void install(SetupAction action) { /* receipt-only fixture */ }
 
         @Override
         public SetupStatus status(SetupAction action) {

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/SeleniumGridLifecycleServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/SeleniumGridLifecycleServiceTest.java
@@ -1,0 +1,195 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SeleniumGridLifecycleServiceTest {
+    @Test
+    void missingReceiptStartsNoComposeProject(@TempDir Path temp) {
+        Fixture fixture = uninstalled(temp);
+        RecordingOperations operations = new RecordingOperations();
+        SeleniumGridLifecycleService lifecycle = new SeleniumGridLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        IOException failure = assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+        assertTrue(failure.getMessage().contains("receipt"));
+        assertTrue(operations.ups.isEmpty());
+    }
+
+    @Test
+    void occupiedGridPortStartsNoComposeProject(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        SeleniumGridLifecycleService lifecycle = new SeleniumGridLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        try (ServerSocket occupied = new ServerSocket()) {
+            occupied.bind(new InetSocketAddress("127.0.0.1", 4444));
+
+            IOException failure = assertThrows(IOException.class,
+                    () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+            assertTrue(failure.getMessage().contains("4444"));
+            assertTrue(operations.ups.isEmpty());
+        }
+    }
+
+    @Test
+    void startReusesThenStopsOnlyTheOwnedProject(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        SeleniumGridLifecycleService first = new SeleniumGridLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        ManagedEnvironment firstEnv = first.start(fixture.plan(), fixture.approval(), fixture.options());
+        ManagedEnvironment secondEnv = first.start(fixture.plan(), fixture.approval(), fixture.options());
+
+        assertEquals(1, operations.ups.size());
+        assertEquals(SeleniumGridSetupPlanner.PROJECT, operations.ups.getFirst());
+        assertEquals(URI.create("http://127.0.0.1:4444/"), firstEnv.endpoint().orElseThrow());
+        assertEquals("localhost:4444", firstEnv.connectionProperties().get("executionAddress"));
+
+        firstEnv.close();
+        assertTrue(operations.downs.isEmpty());
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("selenium-grid-runtime.json")));
+
+        secondEnv.close();
+        assertEquals(List.of(SeleniumGridSetupPlanner.PROJECT), operations.downs);
+        assertFalse(Files.exists(fixture.paths().state().resolve("selenium-grid-runtime.json")));
+    }
+
+    @Test
+    void composeInspectFailureDoesNotDropTheLeaseOrStopContainers(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        SeleniumGridLifecycleService lifecycle = new SeleniumGridLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+        lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+        operations.inspectFails = true;
+
+        assertThrows(IOException.class, () -> lifecycle.stop(Duration.ofSeconds(1)));
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("selenium-grid-runtime.json")));
+        assertTrue(operations.downs.isEmpty());
+    }
+
+    @Test
+    void logsMatchRuntimeIdentityWithoutRequiringTheManagedPlanDigest(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        SeleniumGridLifecycleService managed = new SeleniumGridLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+        managed.start(fixture.plan(), fixture.approval(), fixture.options());
+        Files.createDirectories(managed.logFile().getParent());
+        Files.writeString(managed.logFile(), "hub ready");
+
+        SetupPlan external = SeleniumGridSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64,
+                SetupMode.EXTERNAL, SetupSelection.defaults());
+        SeleniumGridLifecycleService diagnostic = new SeleniumGridLifecycleService(
+                fixture.paths(), external, operations);
+
+        assertEquals("hub ready", diagnostic.logs());
+    }
+
+    @Test
+    void failedReadinessTearsDownOnlyTheOwnedProject(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        operations.ready = false;
+        SeleniumGridLifecycleService lifecycle = new SeleniumGridLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+        assertEquals(List.of(SeleniumGridSetupPlanner.PROJECT), operations.ups);
+        assertEquals(List.of(SeleniumGridSetupPlanner.PROJECT), operations.downs);
+    }
+
+    private static Fixture uninstalled(Path temp) {
+        return fixture(temp, false);
+    }
+
+    private static Fixture installed(Path temp) {
+        return fixture(temp, true);
+    }
+
+    private static Fixture fixture(Path temp, boolean installReceipt) {
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        SetupOptions options = SetupOptions.defaults(SetupProfile.SELENIUM_GRID, paths)
+                .withMode(SetupMode.MANAGED).withTimeouts(Duration.ofSeconds(5), Duration.ofSeconds(5));
+        SetupPlan plan = SeleniumGridSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64,
+                SetupMode.MANAGED, SetupSelection.defaults());
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+        if (installReceipt) {
+            try {
+                new SeleniumGridSetupService(paths, plan, new RecordingOperations(), false).install(plan, approval);
+            } catch (IOException failure) {
+                throw new IllegalStateException(failure);
+            }
+        }
+        return new Fixture(paths, options, plan, approval);
+    }
+
+    private record Fixture(ShaftCachePaths paths, SetupOptions options, SetupPlan plan, SetupApproval approval) { }
+
+    private static final class RecordingOperations implements SeleniumGridToolchainOperations {
+        private final List<String> ups = new ArrayList<>();
+        private final List<String> downs = new ArrayList<>();
+        private boolean running;
+        private boolean ready = true;
+        private boolean inspectFails;
+
+        @Override public void hostPreflight(List<SetupAction> actions) { }
+        @Override public void lockedPreflight(List<SetupAction> actions, boolean offline) { }
+        @Override public void install(SetupAction action) { }
+
+        @Override
+        public SetupStatus status(SetupAction action) {
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(), "fixture");
+        }
+
+        @Override
+        public void composeUp(Path composeFile, String project, SeleniumGridSetupPlanner.GridScale scale) {
+            ups.add(project);
+            running = true;
+        }
+
+        @Override
+        public void composeDown(Path composeFile, String project) {
+            downs.add(project);
+            running = false;
+        }
+
+        @Override
+        public boolean composeRunning(Path composeFile, String project) throws IOException {
+            if (inspectFails) throw new IOException("Unable to inspect the SHAFT Selenium Grid compose project.");
+            return running;
+        }
+
+        @Override
+        public void awaitReady(URI endpoint, Duration timeout) throws IOException {
+            if (!ready) throw new IOException("Grid did not become ready.");
+        }
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/SeleniumGridSetupProviderTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/SeleniumGridSetupProviderTest.java
@@ -1,0 +1,159 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SeleniumGridSetupProviderTest {
+    @Test
+    void builtInCoordinatorProvidesSeleniumGridPlan(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupOptions options = managed(temp);
+
+        assertTrue(service.supports(SetupProfile.SELENIUM_GRID));
+        SetupPlan plan = service.plan(options);
+
+        assertEquals(List.of(SetupTarget.DOCKER, SetupTarget.SELENIUM_GRID),
+                plan.actions().stream().map(SetupAction::target).toList());
+        assertEquals(SetupActionKind.DIAGNOSE, plan.actions().getFirst().kind());
+        assertEquals(SetupActionKind.INSTALL, plan.actions().getLast().kind());
+        assertEquals("4.47.0-20260808,port=4444,chrome=1,edge=0,firefox=0",
+                plan.actions().getLast().version());
+        assertEquals(SetupSelection.defaults(), service.selectionFromPlan(plan));
+    }
+
+    @Test
+    void selectedScaleIsBoundAndReconstructed(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.WINDOWS, SetupArchitecture.X64);
+        SetupOptions options = managed(temp);
+        SetupSelection selection = new SetupSelection(List.of("port_5555", "chrome_2", "firefox_1"));
+
+        SetupPlan plan = service.plan(options, selection);
+
+        assertEquals(selection, service.selectionFromPlan(plan));
+        assertTrue(plan.actions().getLast().version().contains("port=5555"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.plan(options, new SetupSelection(List.of("chrome_0", "edge_0", "firefox_0"))));
+    }
+
+    @Test
+    void missingDockerPerformsNoInstallWrites(@TempDir Path temp) {
+        RecordingOperations operations = new RecordingOperations();
+        operations.dockerReady = false;
+        InfrastructureSetupService service = coordinator(operations);
+        SetupOptions options = managed(temp);
+        SetupPlan plan = service.plan(options);
+
+        IOException failure = assertThrows(IOException.class,
+                () -> service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+
+        assertTrue(failure.getMessage().contains("Docker"));
+        assertTrue(operations.events.contains("host-preflight"));
+        assertFalse(operations.events.stream().anyMatch(event -> event.startsWith("install:")));
+        assertFalse(Files.exists(options.paths().receipts().resolve("selenium-grid.json")));
+    }
+
+    @Test
+    void managedProviderInstallsTheExactComposeReceipt(@TempDir Path temp) throws Exception {
+        RecordingOperations operations = new RecordingOperations();
+        InfrastructureSetupService service = coordinator(operations);
+        SetupOptions options = managed(temp);
+        SetupPlan plan = service.plan(options);
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+
+        assertEquals(SetupReadiness.MISSING, service.status(options).readiness());
+        SetupReceipt receipt = service.install(plan, approval, options);
+
+        assertEquals(plan.digest(), receipt.planDigest());
+        assertEquals(plan.actions(), receipt.completedActions());
+        assertEquals(SetupReadiness.READY, service.status(options).readiness());
+        assertTrue(operations.events.contains("host-preflight"));
+        assertTrue(operations.events.contains("install:" + SetupTarget.SELENIUM_GRID));
+    }
+
+    @Test
+    void managedComposePinsMatchSelenium4AndEachOther() throws Exception {
+        String compose = SeleniumGridSetupPlanner.compose(4444);
+        assertFalse(compose.contains("container_name:"));
+        assertEquals(Set.of("4.47.0-20260808"), imageTags(compose));
+        Path engineCompose = Path.of("").toAbsolutePath().resolve(
+                "../shaft-engine/src/main/resources/docker-compose/selenium4.yml");
+        assertTrue(Files.isRegularFile(engineCompose), engineCompose.toString());
+        assertEquals(Set.of("4.47.0-20260808"), imageTags(Files.readString(engineCompose)));
+    }
+
+    private static Set<String> imageTags(String compose) {
+        Matcher matcher = Pattern.compile("selenium/(?:hub|node-chrome|node-edge|node-firefox):(\\S+)")
+                .matcher(compose);
+        java.util.LinkedHashSet<String> tags = new java.util.LinkedHashSet<>();
+        while (matcher.find()) tags.add(matcher.group(1));
+        return tags;
+    }
+
+    private static InfrastructureSetupService coordinator(RecordingOperations operations) {
+        return new InfrastructureSetupService(new SetupProviderRegistry(
+                List.of(new SeleniumGridSetupProvider((paths, plan, offline) -> operations))),
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+    }
+
+    private static SetupOptions managed(Path root) {
+        Path cache = root.resolve("cache");
+        Path data = root.resolve("data");
+        return SetupOptions.defaults(SetupProfile.SELENIUM_GRID, new ShaftCachePaths(
+                cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts")))
+                .withMode(SetupMode.MANAGED);
+    }
+
+    private static final class RecordingOperations implements SeleniumGridToolchainOperations {
+        private final List<String> events = new ArrayList<>();
+        private boolean dockerReady = true;
+        private boolean installed;
+
+        @Override
+        public void hostPreflight(List<SetupAction> actions) throws IOException {
+            events.add("host-preflight");
+            if (!dockerReady) throw new IOException("Docker Engine 26.1.4+ and Compose v2 are required.");
+        }
+
+        @Override
+        public void lockedPreflight(List<SetupAction> actions, boolean offline) {
+            events.add("locked-preflight");
+        }
+
+        @Override
+        public void install(SetupAction action) {
+            events.add("install:" + action.target());
+            if (action.target() == SetupTarget.SELENIUM_GRID) installed = true;
+        }
+
+        @Override
+        public SetupStatus status(SetupAction action) {
+            events.add("status:" + action.target());
+            if (action.target() == SetupTarget.DOCKER) {
+                return new SetupStatus(action.target(),
+                        dockerReady ? SetupReadiness.READY : SetupReadiness.MISSING,
+                        dockerReady ? "26.1.4+" : "", dockerReady ? "fixture" : "Docker is missing.");
+            }
+            return new SetupStatus(action.target(),
+                    installed ? SetupReadiness.READY : SetupReadiness.MISSING,
+                    installed ? action.version() : "", installed ? "fixture" : "Compose is missing.");
+        }
+    }
+}


### PR DESCRIPTION
Closes #5041
Related to #4849

## Summary
Adds the missing `SELENIUM_GRID` setup provider so Java, CLI, and MCP share one plan/status/install/start/stop/logs path.

- Docker stays a diagnosed host prerequisite. SHAFT never installs Docker.
- Install stages a release-pinned compose file. Hub, Chrome, Edge, and Firefox share `4.47.0-20260808`, matching `${selenium.version}` and `selenium4.yml`.
- Start/stop own only compose project `shaft-selenium-grid`. Occupied ports, inspect failures, and foreign projects fail closed. The managed compose has no `container_name`.
- Default scale is chrome=1, edge=0, firefox=0. Java/MCP can select `port_`, `chrome_`, `edge_`, and `firefox_`.
- CLI `setup logs` matches runtime identity so an EXTERNAL diagnostic plan can still read a managed lease.

## Checks
- Focused Grid tests green after Codacy unused-parameter fixes
- Nearest infrastructure, CLI, and MCP setup tests green on the first checkpoint
- Independent review: three blockers fixed; re-review zero blockers

## Continuation
Head: `b2b2a8ec8fae77f3ffd6687749cc53f8f47ce6b7`
State: Codacy unused-parameter findings addressed; auto-merge armed
Blockers: none known
Next action: watch checks to confirmed merge, then update #4849