### PR TITLE
feat(setup): own managed Healenium backend lifecycle

### DIFF
--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -367,7 +367,7 @@ public final class SetupCommand implements Runnable {
         return switch (plan.profile()) {
             case OCR -> ocrSelection(plan, languages);
             case MOBILE_ANDROID -> android.selectionFromPlan(plan);
-            case MOBILE_IOS, MOBILE_WINDOWS, SELENIUM_GRID -> {
+            case MOBILE_IOS, MOBILE_WINDOWS, SELENIUM_GRID, HEALENIUM -> {
                 android.rejectIfSupplied(plan.profile());
                 yield InfrastructureSetupService.builtIn(plan.platform(), plan.architecture())
                         .selectionFromPlan(plan);

--- a/shaft-engine/src/main/resources/docker-compose/healenium-backend.yml
+++ b/shaft-engine/src/main/resources/docker-compose/healenium-backend.yml
@@ -10,7 +10,7 @@ version: "3.3"
 services:
 
   db:
-    image: postgres:11-alpine
+    image: postgres:15.5-alpine
     ports:
       - "5432:5432"
     volumes:
@@ -24,7 +24,7 @@ services:
       - healenium
 
   healenium:
-    image: healenium/hlm-backend:3.2.0
+    image: healenium/hlm-backend:3.4.6
     ports:
       - "7878:7878"
     links:
@@ -40,7 +40,7 @@ services:
       - healenium
 
   selector-imitator:
-    image: healenium/hlm-selector-imitator:1
+    image: healenium/hlm-selector-imitator:1.4
     restart: on-failure
     ports:
       - "8000:8000"

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultHealeniumToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultHealeniumToolchainOperations.java
@@ -1,0 +1,226 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Host Docker/Compose implementation for the Healenium provider. */
+final class DefaultHealeniumToolchainOperations implements HealeniumToolchainOperations {
+    private final ShaftCachePaths paths;
+    private final SetupPlan plan;
+    private final AndroidCommandRunner runner;
+    private final boolean offline;
+
+    DefaultHealeniumToolchainOperations(ShaftCachePaths paths, SetupPlan plan, boolean offline) {
+        this(paths, plan, AndroidCommandRunner.system(paths, plan.platform(), plan.architecture()), offline);
+    }
+
+    DefaultHealeniumToolchainOperations(ShaftCachePaths paths, SetupPlan plan, AndroidCommandRunner runner,
+                                        boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.plan = java.util.Objects.requireNonNull(plan, "plan");
+        this.runner = java.util.Objects.requireNonNull(runner, "runner");
+        this.offline = offline;
+    }
+
+    @Override
+    public void hostPreflight(List<SetupAction> actions) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
+        requireDocker();
+    }
+
+    @Override
+    public void lockedPreflight(List<SetupAction> actions, boolean requireOffline) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
+        VerifiedArtifactStore.requireUnlinkedAncestors(composeFile());
+        VerifiedArtifactStore.requireUnlinkedAncestors(initFile());
+        if ((offline || requireOffline) && !Files.isRegularFile(composeFile(), LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Offline Healenium setup requires a staged compose file.");
+        }
+    }
+
+    @Override
+    public void install(SetupAction action) throws IOException {
+        if (action.target() == SetupTarget.DOCKER) return;
+        if (action.target() != SetupTarget.HEALENIUM) {
+            throw new IllegalArgumentException("Unsupported Healenium install target: " + action.target());
+        }
+        HealeniumSetupPlanner.HealeniumScale scale = HealeniumSetupPlanner.scaleFromPlan(plan);
+        byte[] artifact = HealeniumSetupPlanner.artifact(scale).getBytes(StandardCharsets.UTF_8);
+        String actual;
+        try {
+            actual = "sha256:" + HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(artifact));
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
+        if (!actual.equalsIgnoreCase(action.checksum())) {
+            throw new IOException("Rendered Healenium compose does not match the approved plan.");
+        }
+        writeAtomic(composeFile(), HealeniumSetupPlanner.compose(scale).getBytes(StandardCharsets.UTF_8));
+        writeAtomic(initFile(), HealeniumSetupPlanner.INIT_SQL.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public SetupStatus status(SetupAction action) {
+        if (action.target() == SetupTarget.DOCKER) {
+            try {
+                requireDocker();
+                return new SetupStatus(action.target(), SetupReadiness.READY, action.version(),
+                        "Docker Engine and Compose are available.");
+            } catch (IOException failure) {
+                return new SetupStatus(action.target(), SetupReadiness.MISSING, "", failure.getMessage());
+            }
+        }
+        try {
+            Path compose = composeFile();
+            Path init = initFile();
+            VerifiedArtifactStore.requireUnlinkedAncestors(compose);
+            VerifiedArtifactStore.requireUnlinkedAncestors(init);
+            if (!Files.isRegularFile(compose, LinkOption.NOFOLLOW_LINKS)
+                    || !Files.isRegularFile(init, LinkOption.NOFOLLOW_LINKS)) {
+                return new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                        "Managed Healenium compose file is missing.");
+            }
+            String staged = Files.readString(compose) + "\n" + Files.readString(init);
+            String actual = "sha256:" + HexFormat.of().formatHex(
+                    MessageDigest.getInstance("SHA-256").digest(staged.getBytes(StandardCharsets.UTF_8)));
+            if (!actual.equalsIgnoreCase(action.checksum())) {
+                return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "",
+                        "Staged compose does not match the approved plan.");
+            }
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(),
+                    "Staged Healenium compose matches the reviewed plan.");
+        } catch (IOException | NoSuchAlgorithmException failure) {
+            return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "", failure.getMessage());
+        }
+    }
+
+    @Override
+    public void composeUp(Path composeFile, String project) throws IOException {
+        requireOwned(project);
+        run(List.of(docker(), "compose", "-p", project, "-f", composeFile.toString(), "up", "-d"),
+                "Failed to start the SHAFT Healenium compose project.");
+    }
+
+    @Override
+    public void composeDown(Path composeFile, String project) throws IOException {
+        requireOwned(project);
+        run(List.of(docker(), "compose", "-p", project, "-f", composeFile.toString(), "down", "--remove-orphans"),
+                "Failed to stop the SHAFT Healenium compose project.");
+    }
+
+    @Override
+    public boolean composeRunning(Path composeFile, String project) throws IOException {
+        requireOwned(project);
+        ReportingSetupService.ProcessResult result = runner.run(
+                List.of(docker(), "compose", "-p", project, "-f", composeFile.toString(), "ps", "-q"),
+                composeFile.getParent(), Map.of(), Set.of(), null, null, Duration.ofSeconds(15));
+        if (result.exitCode() != 0) {
+            throw new IOException("Unable to inspect the SHAFT Healenium compose project. " + result.output());
+        }
+        return !result.output().isBlank();
+    }
+
+    @Override
+    public void awaitReady(URI backend, URI imitate, Duration timeout) throws IOException {
+        Instant deadline = Instant.now().plus(timeout);
+        IOException last = new IOException("Healenium did not become ready.");
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                probe(backend, "Healenium backend");
+                probe(imitate, "Healenium selector imitator");
+                return;
+            } catch (IOException failure) {
+                last = failure;
+            }
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for Healenium.", interrupted);
+            }
+        }
+        throw last;
+    }
+
+    private void requireDocker() throws IOException {
+        try {
+            ReportingSetupService.ProcessResult compose = runner.run(List.of(docker(), "compose", "version"),
+                    paths.cacheRoot(), Map.of(), Set.of(), null, null, Duration.ofSeconds(15));
+            ReportingSetupService.ProcessResult engine = runner.run(List.of(docker(), "version"),
+                    paths.cacheRoot(), Map.of(), Set.of(), null, null, Duration.ofSeconds(15));
+            if (compose.exitCode() != 0 || engine.exitCode() != 0) {
+                throw new IOException("Docker Engine 26.1.4+ and Compose v2 are required.");
+            }
+        } catch (IOException failure) {
+            throw new IOException("Docker Engine 26.1.4+ and Compose v2 are required.", failure);
+        }
+    }
+
+    private void run(List<String> command, String failure) throws IOException {
+        Path log = logFile();
+        Files.createDirectories(log.getParent());
+        ReportingSetupService.ProcessResult result = runner.run(command, composeFile().getParent(), Map.of(),
+                Set.of(), null, log, Duration.ofMinutes(5));
+        if (result.exitCode() != 0) throw new IOException(failure + " " + result.output());
+    }
+
+    private static void requireOwned(String project) throws IOException {
+        if (!HealeniumSetupPlanner.PROJECT.equals(project)) {
+            throw new IOException("Refusing to operate on an unowned Docker Compose project: " + project);
+        }
+    }
+
+    private static void probe(URI endpoint, String owner) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) endpoint.toURL().openConnection();
+        try {
+            connection.setConnectTimeout(1_000);
+            connection.setReadTimeout(1_000);
+            connection.setRequestMethod("GET");
+            int code = connection.getResponseCode();
+            if (code >= 200 && code < 500) return;
+            throw new IOException(owner + " status returned HTTP " + code + '.');
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static void writeAtomic(Path destination, byte[] bytes) throws IOException {
+        Files.createDirectories(destination.getParent());
+        Path temporary = Files.createTempFile(destination.getParent(), destination.getFileName().toString(), ".tmp");
+        try {
+            Files.write(temporary, bytes);
+            VerifiedArtifactStore.move(temporary, destination);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private Path composeFile() {
+        return paths.tools().resolve("healenium").resolve("docker-compose.yml");
+    }
+
+    private Path initFile() {
+        return paths.tools().resolve("healenium").resolve("init.sql");
+    }
+
+    private Path logFile() {
+        return paths.state().resolve("logs").resolve("healenium.log");
+    }
+
+    private String docker() {
+        return plan.platform() == SetupPlatform.WINDOWS ? "docker.exe" : "docker";
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumLifecycleFactory.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumLifecycleFactory.java
@@ -1,0 +1,7 @@
+package com.shaft.infrastructure;
+
+@FunctionalInterface
+interface HealeniumLifecycleFactory {
+    HealeniumLifecycleService create(ShaftCachePaths paths, SetupPlan plan,
+                                     HealeniumToolchainOperations operations);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumLifecycleService.java
@@ -1,0 +1,300 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Lease-safe lifecycle owner for one verified SHAFT Healenium compose project. */
+final class HealeniumLifecycleService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private final ShaftCachePaths paths;
+    private final SetupPlan expectedPlan;
+    private final HealeniumToolchainOperations operations;
+    private final HealeniumSetupPlanner.HealeniumScale scale;
+
+    HealeniumLifecycleService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                              HealeniumToolchainOperations operations) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.expectedPlan = java.util.Objects.requireNonNull(expectedPlan, "expectedPlan");
+        this.operations = java.util.Objects.requireNonNull(operations, "operations");
+        if (expectedPlan.profile() != SetupProfile.HEALENIUM) {
+            throw new IllegalArgumentException("Healenium lifecycle requires the HEALENIUM profile.");
+        }
+        this.scale = HealeniumSetupPlanner.scaleFromPlan(expectedPlan);
+    }
+
+    ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        requireCompatible(plan, options);
+        SetupExecutor.validate(plan, approval);
+        SetupReceipt receipt = requireInstallReceipt(plan);
+        requireInstalled(plan);
+        Path lockPath = lockPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        try {
+            jvmLock.lockInterruptibly();
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                receipt = requireInstallReceipt(plan);
+                requireInstalled(plan);
+                Optional<HealeniumRuntimeLease> reusable = readReusable(plan, options);
+                if (reusable.isPresent()) return environment(receipt, reusable.orElseThrow());
+                return startNew(plan, receipt, options);
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the Healenium runtime lock.", interrupted);
+        } finally {
+            if (jvmLock.isHeldByCurrentThread()) jvmLock.unlock();
+        }
+    }
+
+    boolean stop(Duration timeout) throws IOException {
+        java.util.Objects.requireNonNull(timeout, "timeout");
+        Path lockPath = lockPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        if (Files.notExists(leasePath(), LinkOption.NOFOLLOW_LINKS)) return false;
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        jvmLock.lock();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Optional<HealeniumRuntimeLease> current = readLease();
+            if (current.isEmpty()) return false;
+            HealeniumRuntimeLease lease = current.orElseThrow();
+            requireLeaseIdentity(lease);
+            if (!operations.composeRunning(composeFile(), lease.project())) {
+                Files.deleteIfExists(leasePath());
+                return false;
+            }
+            if (lease.refCount() > 1) {
+                writeLease(lease.withRefCount(lease.refCount() - 1));
+                return true;
+            }
+            operations.composeDown(composeFile(), requireOwnedProject(lease.project()));
+            Files.deleteIfExists(leasePath());
+            return true;
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    String logs() throws IOException {
+        Optional<HealeniumRuntimeLease> current = readLease();
+        if (current.isEmpty()) return "";
+        HealeniumRuntimeLease lease = current.orElseThrow();
+        if (!lease.sameRuntime(expectedIdentity(expectedPlan))) {
+            throw new IOException("Healenium lease does not match the requested runtime.");
+        }
+        return OwnedLogReader.read("Healenium", logFile());
+    }
+
+    Path logFile() {
+        return paths.state().resolve("logs").resolve("healenium.log");
+    }
+
+    private ManagedEnvironment startNew(SetupPlan plan, SetupReceipt receipt, SetupOptions options)
+            throws IOException {
+        requireAvailablePort(scale.backendPort(), "Healenium backend");
+        requireAvailablePort(scale.imitatePort(), "Healenium selector imitator");
+        URI backend = URI.create("http://127.0.0.1:" + scale.backendPort() + "/");
+        URI imitate = URI.create("http://127.0.0.1:" + scale.imitatePort() + "/");
+        try {
+            operations.composeUp(composeFile(), HealeniumSetupPlanner.PROJECT);
+            operations.awaitReady(backend, imitate, options.startupTimeout());
+            HealeniumRuntimeLease lease = new HealeniumRuntimeLease(1, plan.digest(),
+                    HealeniumSetupPlanner.PROJECT, backend.toString(), scale.backendPort(),
+                    scale.imitatePort(), 1);
+            writeLease(lease);
+            return environment(receipt, lease);
+        } catch (IOException | RuntimeException failure) {
+            try {
+                operations.composeDown(composeFile(), HealeniumSetupPlanner.PROJECT);
+            } catch (IOException cleanup) {
+                failure.addSuppressed(cleanup);
+            }
+            throw failure;
+        }
+    }
+
+    private Optional<HealeniumRuntimeLease> readReusable(SetupPlan plan, SetupOptions options) throws IOException {
+        Optional<HealeniumRuntimeLease> existing = readLease();
+        if (existing.isEmpty()) return Optional.empty();
+        HealeniumRuntimeLease lease = existing.orElseThrow();
+        if (!lease.planDigest().equals(plan.digest()) || !lease.sameIdentity(expectedIdentity(plan))) {
+            throw new IOException("An existing SHAFT Healenium lease does not match the reviewed plan.");
+        }
+        if (!operations.composeRunning(composeFile(), lease.project())) {
+            Files.deleteIfExists(leasePath());
+            return Optional.empty();
+        }
+        if (!options.reuseOwnedProcesses()) {
+            throw new IOException("A compatible SHAFT Healenium stack is already active and reuse is disabled.");
+        }
+        operations.awaitReady(URI.create(lease.endpoint()),
+                URI.create("http://127.0.0.1:" + lease.imitatePort() + "/"), options.startupTimeout());
+        HealeniumRuntimeLease incremented = lease.withRefCount(lease.refCount() + 1);
+        writeLease(incremented);
+        return Optional.of(incremented);
+    }
+
+    private HealeniumRuntimeLease expectedIdentity(SetupPlan plan) {
+        return new HealeniumRuntimeLease(1, plan.digest(), HealeniumSetupPlanner.PROJECT,
+                "http://127.0.0.1:" + scale.backendPort() + "/", scale.backendPort(), scale.imitatePort(), 1);
+    }
+
+    private ManagedEnvironment environment(SetupReceipt receipt, HealeniumRuntimeLease lease) {
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("serverHost", "localhost");
+        properties.put("serverPort", String.valueOf(lease.backendPort()));
+        properties.put("imitatePort", String.valueOf(lease.imitatePort()));
+        return new ManagedEnvironment(SetupProfile.HEALENIUM, receipt,
+                Optional.of(URI.create(lease.endpoint())), Map.copyOf(properties), () -> {
+                    try {
+                        release(lease);
+                    } catch (IOException failure) {
+                        throw new IllegalStateException("Failed to release the owned Healenium stack.", failure);
+                    }
+                });
+    }
+
+    private void release(HealeniumRuntimeLease started) throws IOException {
+        Path lockPath = lockPath();
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        jvmLock.lock();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Optional<HealeniumRuntimeLease> current = readLease();
+            if (current.isEmpty()) return;
+            HealeniumRuntimeLease lease = current.orElseThrow();
+            if (!lease.sameIdentity(started)) {
+                throw new IOException("Healenium lease changed; refusing to stop an unowned project.");
+            }
+            if (lease.refCount() > 1) {
+                writeLease(lease.withRefCount(lease.refCount() - 1));
+                return;
+            }
+            operations.composeDown(composeFile(), requireOwnedProject(lease.project()));
+            Files.deleteIfExists(leasePath());
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan, SetupOptions options) {
+        if (plan.profile() != SetupProfile.HEALENIUM || options.profile() != SetupProfile.HEALENIUM) {
+            throw new IllegalArgumentException("Healenium lifecycle requires profile HEALENIUM.");
+        }
+        if (plan.mode() == SetupMode.EXTERNAL || options.effectiveMode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External Healenium setup cannot start local containers.");
+        }
+        if (!expectedPlan.equals(plan)) {
+            throw new IllegalArgumentException("Healenium lifecycle plan does not match the release manifest.");
+        }
+    }
+
+    private SetupReceipt requireInstallReceipt(SetupPlan plan) throws IOException {
+        Path receiptPath = paths.receipts().resolve("healenium.json");
+        VerifiedArtifactStore.requireUnlinkedAncestors(receiptPath);
+        if (!Files.isRegularFile(receiptPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("A complete compatible Healenium install receipt is required before start.");
+        }
+        SetupReceipt receipt;
+        try {
+            receipt = JSON.readValue(receiptPath.toFile(), SetupReceipt.class);
+        } catch (RuntimeException invalid) {
+            throw new IOException("Healenium install receipt is invalid.", invalid);
+        }
+        if (!receipt.planDigest().equals(plan.digest()) || !receipt.completedActions().equals(plan.actions())) {
+            throw new IOException("Healenium install receipt does not match the reviewed plan.");
+        }
+        return receipt;
+    }
+
+    private void requireInstalled(SetupPlan plan) throws IOException {
+        for (SetupAction action : plan.actions()) {
+            SetupStatus status = operations.status(action);
+            if (status.readiness() != SetupReadiness.READY) {
+                throw new IOException(action.target() + " is not ready: " + status.detail());
+            }
+        }
+    }
+
+    private void requireAvailablePort(int port, String owner) throws IOException {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(false);
+            socket.bind(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), port));
+        } catch (IOException occupied) {
+            throw new IOException(owner + " loopback port " + port + " is already occupied.", occupied);
+        }
+    }
+
+    private void requireLeaseIdentity(HealeniumRuntimeLease lease) throws IOException {
+        if (!lease.sameIdentity(expectedIdentity(expectedPlan))) {
+            throw new IOException("Healenium lease does not match the requested plan.");
+        }
+    }
+
+    private static String requireOwnedProject(String project) throws IOException {
+        if (!HealeniumSetupPlanner.PROJECT.equals(project)) {
+            throw new IOException("Refusing to stop an unowned Docker Compose project: " + project);
+        }
+        return project;
+    }
+
+    private Optional<HealeniumRuntimeLease> readLease() throws IOException {
+        Path path = leasePath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(path);
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) return Optional.empty();
+        try {
+            HealeniumRuntimeLease lease = JSON.readValue(path.toFile(), HealeniumRuntimeLease.class);
+            if (lease.schemaVersion() != 1 || lease.refCount() < 1) {
+                throw new IOException("Invalid Healenium lease.");
+            }
+            return Optional.of(lease);
+        } catch (RuntimeException invalid) {
+            throw new IOException("Healenium runtime lease is invalid.", invalid);
+        }
+    }
+
+    private void writeLease(HealeniumRuntimeLease lease) throws IOException {
+        Files.createDirectories(paths.state());
+        Path temporary = Files.createTempFile(paths.state(), "healenium-runtime", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(lease));
+            VerifiedArtifactStore.move(temporary, leasePath());
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private Path composeFile() {
+        return paths.tools().resolve("healenium").resolve("docker-compose.yml");
+    }
+
+    private Path leasePath() {
+        return paths.state().resolve("healenium-runtime.json");
+    }
+
+    private Path lockPath() {
+        return paths.state().resolve("healenium-runtime.lock").toAbsolutePath().normalize();
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumOperationsFactory.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumOperationsFactory.java
@@ -1,0 +1,6 @@
+package com.shaft.infrastructure;
+
+@FunctionalInterface
+interface HealeniumOperationsFactory {
+    HealeniumToolchainOperations create(ShaftCachePaths paths, SetupPlan plan, boolean offline);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumRuntimeLease.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumRuntimeLease.java
@@ -1,0 +1,31 @@
+package com.shaft.infrastructure;
+
+record HealeniumRuntimeLease(int schemaVersion, String planDigest, String project, String endpoint,
+                             int backendPort, int imitatePort, int refCount) {
+    HealeniumRuntimeLease {
+        if (schemaVersion != 1) throw new IllegalArgumentException("Unsupported Healenium lease schema.");
+        if (planDigest == null || planDigest.isBlank()) throw new IllegalArgumentException("Plan digest is required.");
+        if (project == null || project.isBlank()) throw new IllegalArgumentException("Compose project is required.");
+        if (endpoint == null || endpoint.isBlank()) throw new IllegalArgumentException("Endpoint is required.");
+        if (refCount < 1) throw new IllegalArgumentException("Lease refcount must be positive.");
+    }
+
+    HealeniumRuntimeLease withRefCount(int value) {
+        return new HealeniumRuntimeLease(schemaVersion, planDigest, project, endpoint, backendPort, imitatePort,
+                value);
+    }
+
+    boolean sameIdentity(HealeniumRuntimeLease other) {
+        return other != null
+                && planDigest.equals(other.planDigest)
+                && sameRuntime(other);
+    }
+
+    boolean sameRuntime(HealeniumRuntimeLease other) {
+        return other != null
+                && project.equals(other.project)
+                && endpoint.equals(other.endpoint)
+                && backendPort == other.backendPort
+                && imitatePort == other.imitatePort;
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumRuntimeManager.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumRuntimeManager.java
@@ -1,0 +1,12 @@
+package com.shaft.infrastructure;
+
+final class HealeniumRuntimeManager {
+    private HealeniumRuntimeManager() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static HealeniumLifecycleService systemLifecycle(ShaftCachePaths paths, SetupPlan plan,
+                                                     HealeniumToolchainOperations operations) {
+        return new HealeniumLifecycleService(paths, plan, operations);
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumSetupPlanner.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumSetupPlanner.java
@@ -1,0 +1,173 @@
+package com.shaft.infrastructure;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Release-coupled plans for a SHAFT-owned Healenium compose project. */
+final class HealeniumSetupPlanner {
+    static final String BACKEND_IMAGE = "healenium/hlm-backend:3.4.6";
+    static final String IMITATOR_IMAGE = "healenium/hlm-selector-imitator:1.4";
+    static final String POSTGRES_IMAGE = "postgres:15.5-alpine";
+    static final String PIN = "3.4.6+1.4+15.5-alpine";
+    static final String PROJECT = "shaft-healenium";
+    static final int DEFAULT_BACKEND_PORT = 7878;
+    static final int DEFAULT_IMITATE_PORT = 8000;
+    static final String INIT_SQL = """
+            CREATE SCHEMA healenium AUTHORIZATION healenium_user;
+            GRANT USAGE ON SCHEMA healenium TO healenium_user;
+            """;
+    /** Upstream local-dev default from the official Healenium compose example; not a SHAFT secret. */
+    static final String LOCAL_DEV_DB_PASSWORD = "YDk2nmNs4s9aCP6K";
+    private static final Pattern SPEC = Pattern.compile(
+            Pattern.quote(PIN) + ",backend=([0-9]+),imitate=([0-9]+)");
+
+    private HealeniumSetupPlanner() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static SetupPlan plan(SetupPlatform platform, SetupArchitecture architecture, SetupMode mode,
+                          SetupSelection selection) {
+        HealeniumScale scale = scale(selection);
+        SetupActionKind kind = mode == SetupMode.EXTERNAL ? SetupActionKind.DIAGNOSE : SetupActionKind.INSTALL;
+        String artifact = artifact(scale);
+        byte[] bytes = artifact.getBytes(StandardCharsets.UTF_8);
+        return SetupPlan.create(SetupProfile.HEALENIUM, platform, architecture, mode, List.of(
+                new SetupAction(SetupTarget.DOCKER, SetupActionKind.DIAGNOSE, "26.1.4+",
+                        URI.create("urn:shaft:host:docker"),
+                        sha256("docker\026.1.4+"), false, Set.of()),
+                new SetupAction(SetupTarget.HEALENIUM, kind, spec(scale),
+                        URI.create("urn:shaft:healenium:" + PROJECT + ":" + spec(scale)),
+                        sha256(artifact), bytes.length, false, Set.of())));
+    }
+
+    static SetupSelection selectionFromPlan(SetupPlan plan) {
+        return selectionFromScale(scaleFromPlan(plan));
+    }
+
+    static HealeniumScale scaleFromPlan(SetupPlan plan) {
+        if (plan.profile() != SetupProfile.HEALENIUM) {
+            throw new IllegalArgumentException("Healenium scale is only defined for Healenium plans.");
+        }
+        List<SetupAction> actions = plan.actions().stream()
+                .filter(action -> action.target() == SetupTarget.HEALENIUM).toList();
+        if (actions.size() != 1) {
+            throw new IllegalArgumentException("Healenium plan must contain exactly one HEALENIUM action.");
+        }
+        Matcher match = SPEC.matcher(actions.getFirst().version());
+        if (!match.matches()) throw new IllegalArgumentException("Healenium plan metadata is invalid.");
+        return new HealeniumScale(parsePort("backend", match.group(1), DEFAULT_BACKEND_PORT),
+                parsePort("imitate", match.group(2), DEFAULT_IMITATE_PORT));
+    }
+
+    static String compose(HealeniumScale scale) {
+        return """
+                services:
+                  postgres-db:
+                    image: %1$s
+                    environment:
+                      POSTGRES_DB: healenium
+                      POSTGRES_USER: healenium_user
+                      POSTGRES_PASSWORD: %6$s
+                    volumes:
+                      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+                    healthcheck:
+                      test: ["CMD-SHELL", "pg_isready -U healenium_user -d healenium"]
+                      interval: 5s
+                      timeout: 10s
+                      retries: 20
+                  healenium:
+                    image: %2$s
+                    depends_on:
+                      postgres-db:
+                        condition: service_healthy
+                    ports:
+                      - "%4$d:7878"
+                    environment:
+                      - SPRING_POSTGRES_DB=healenium
+                      - SPRING_POSTGRES_SCHEMA=healenium
+                      - SPRING_POSTGRES_USER=healenium_user
+                      - SPRING_POSTGRES_PASSWORD=%6$s
+                      - SPRING_POSTGRES_DB_HOST=postgres-db
+                      - KEY_SELECTOR_URL=false
+                      - COLLECT_METRICS=true
+                      - FIND_ELEMENTS_AUTO_HEALING=false
+                      - HLM_LOG_LEVEL=info
+                  selector-imitator:
+                    image: %3$s
+                    ports:
+                      - "%5$d:8000"
+                """.formatted(POSTGRES_IMAGE, BACKEND_IMAGE, IMITATOR_IMAGE, scale.backendPort(),
+                scale.imitatePort(), LOCAL_DEV_DB_PASSWORD);
+    }
+
+    static String artifact(HealeniumScale scale) {
+        return compose(scale) + "\n" + INIT_SQL;
+    }
+
+    static HealeniumScale scale(SetupSelection selection) {
+        int backend = selected(selection, "backend_", DEFAULT_BACKEND_PORT, 1024, 65535, "Healenium backend port");
+        int imitate = selected(selection, "imitate_", DEFAULT_IMITATE_PORT, 1024, 65535, "Healenium imitate port");
+        if (backend == imitate) {
+            throw new IllegalArgumentException("Healenium backend and imitate ports must be different.");
+        }
+        for (String component : selection.components()) {
+            if (!component.startsWith("backend_") && !component.startsWith("imitate_")) {
+                throw new IllegalArgumentException("Unsupported Healenium component: " + component);
+            }
+        }
+        return new HealeniumScale(backend, imitate);
+    }
+
+    static SetupSelection selectionFromScale(HealeniumScale scale) {
+        java.util.ArrayList<String> components = new java.util.ArrayList<>();
+        if (scale.backendPort() != DEFAULT_BACKEND_PORT) components.add("backend_" + scale.backendPort());
+        if (scale.imitatePort() != DEFAULT_IMITATE_PORT) components.add("imitate_" + scale.imitatePort());
+        return new SetupSelection(components);
+    }
+
+    private static int selected(SetupSelection selection, String prefix, int defaultValue, int min, int max,
+                                String label) {
+        List<String> values = selection.components().stream().filter(component -> component.startsWith(prefix)).toList();
+        if (values.size() > 1) throw new IllegalArgumentException("Select at most one " + label + '.');
+        int value = defaultValue;
+        if (!values.isEmpty()) {
+            try {
+                value = Integer.parseInt(values.getFirst().substring(prefix.length()));
+            } catch (NumberFormatException invalid) {
+                throw new IllegalArgumentException(label + " must be a decimal integer.", invalid);
+            }
+        }
+        if (value < min || value > max) {
+            throw new IllegalArgumentException(label + " must be between " + min + " and " + max + '.');
+        }
+        return value;
+    }
+
+    private static int parsePort(String name, String value, int defaultValue) {
+        return selected(new SetupSelection(List.of(name + "_" + value)), name + "_", defaultValue, 1024, 65535,
+                "Healenium " + name + " port");
+    }
+
+    private static String spec(HealeniumScale scale) {
+        return PIN + ",backend=" + scale.backendPort() + ",imitate=" + scale.imitatePort();
+    }
+
+    private static String sha256(String value) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.UTF_8));
+            return "sha256:" + HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
+    }
+
+    record HealeniumScale(int backendPort, int imitatePort) { }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumSetupProvider.java
@@ -1,0 +1,121 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+
+/** Built-in provider for a pinned Healenium compose project. */
+final class HealeniumSetupProvider implements SetupProvider {
+    private final HealeniumOperationsFactory operationsFactory;
+    private final HealeniumLifecycleFactory lifecycleFactory;
+
+    HealeniumSetupProvider() {
+        this(DefaultHealeniumToolchainOperations::new, HealeniumRuntimeManager::systemLifecycle);
+    }
+
+    HealeniumSetupProvider(HealeniumOperationsFactory operationsFactory) {
+        this(operationsFactory, HealeniumRuntimeManager::systemLifecycle);
+    }
+
+    HealeniumSetupProvider(HealeniumOperationsFactory operationsFactory,
+                           HealeniumLifecycleFactory lifecycleFactory) {
+        this.operationsFactory = java.util.Objects.requireNonNull(operationsFactory, "operationsFactory");
+        this.lifecycleFactory = java.util.Objects.requireNonNull(lifecycleFactory, "lifecycleFactory");
+    }
+
+    @Override
+    public SetupProfile profile() {
+        return SetupProfile.HEALENIUM;
+    }
+
+    @Override
+    public SetupPlan plan(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return plan(options, SetupSelection.defaults(), platform, architecture);
+    }
+
+    @Override
+    public SetupPlan plan(SetupOptions options, SetupSelection selection,
+                          SetupPlatform platform, SetupArchitecture architecture) {
+        return HealeniumSetupPlanner.plan(platform, architecture, options.effectiveMode(), selection);
+    }
+
+    @Override
+    public SetupSelection selectionFromPlan(SetupPlan plan) {
+        return HealeniumSetupPlanner.selectionFromPlan(plan);
+    }
+
+    @Override
+    public SetupReport status(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return status(options, SetupSelection.defaults(), platform, architecture);
+    }
+
+    @Override
+    public SetupReport status(SetupOptions options, SetupSelection selection,
+                              SetupPlatform platform, SetupArchitecture architecture) {
+        SetupPlan plan = plan(options, selection, platform, architecture);
+        if (options.effectiveMode() == SetupMode.EXTERNAL) return externalStatus(plan);
+        HealeniumToolchainOperations operations = operationsFactory.create(options.paths(), plan, options.offline());
+        return SetupReport.from(new HealeniumSetupService(options.paths(), plan, operations, options.offline())
+                .status());
+    }
+
+    @Override
+    public SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        HealeniumToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        SetupReceipt receipt = new HealeniumSetupService(options.paths(), providerPlan, operations,
+                options.offline()).install(providerPlan,
+                new SetupApproval(providerPlan.digest(), approval.approvedAt(), approval.acceptedLicenses()));
+        return new SetupReceipt(plan.digest(), receipt.completedAt(), receipt.completedActions());
+    }
+
+    @Override
+    public ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        HealeniumToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        ManagedEnvironment inner = lifecycleFactory.create(options.paths(), providerPlan, operations)
+                .start(providerPlan, new SetupApproval(providerPlan.digest(), approval.approvedAt(),
+                        approval.acceptedLicenses()), options);
+        SetupReceipt receipt = new SetupReceipt(plan.digest(), inner.receipt().completedAt(),
+                inner.receipt().completedActions());
+        return new ManagedEnvironment(profile(), receipt, inner.endpoint(), inner.connectionProperties(),
+                inner::close);
+    }
+
+    @Override
+    public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        HealeniumToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), providerPlan, operations).stop(options.shutdownTimeout());
+    }
+
+    @Override
+    public String logs(SetupOptions options, SetupSelection selection, SetupPlatform platform,
+                       SetupArchitecture architecture) throws IOException {
+        SetupPlan plan = plan(options, selection, platform, architecture);
+        HealeniumToolchainOperations operations = operationsFactory.create(options.paths(), plan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), plan, operations).logs();
+    }
+
+    private SetupPlan canonicalPlan(SetupPlan plan, SetupOptions options) {
+        if (options.profile() != profile()) {
+            throw new IllegalArgumentException("Options do not select Healenium setup.");
+        }
+        SetupPlan canonical = HealeniumSetupPlanner.plan(plan.platform(), plan.architecture(), plan.mode(),
+                HealeniumSetupPlanner.selectionFromPlan(plan));
+        if (!SetupPlan.bind(canonical, options.policyDigest()).equals(plan)) {
+            throw new IllegalArgumentException("Plan does not match the Healenium manifest shipped with this release.");
+        }
+        return canonical;
+    }
+
+    private SetupReport externalStatus(SetupPlan plan) {
+        return SetupReport.from(new SetupProfileStatus(1, profile(), SetupReadiness.MISSING,
+                plan.actions().stream().map(action -> new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                        "External mode is diagnostic-only and does not execute managed tools.")).toList()));
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumSetupService.java
@@ -1,0 +1,150 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Transaction coordinator for one exact Healenium setup plan. */
+final class HealeniumSetupService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private final ShaftCachePaths paths;
+    private final SetupPlan expectedPlan;
+    private final HealeniumToolchainOperations operations;
+    private final boolean offline;
+
+    HealeniumSetupService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                          HealeniumToolchainOperations operations, boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.expectedPlan = java.util.Objects.requireNonNull(expectedPlan, "expectedPlan");
+        this.operations = java.util.Objects.requireNonNull(operations, "operations");
+        this.offline = offline;
+        if (expectedPlan.profile() != SetupProfile.HEALENIUM) {
+            throw new IllegalArgumentException("Healenium setup requires the HEALENIUM profile.");
+        }
+    }
+
+    SetupProfileStatus status() {
+        List<SetupStatus> targets = expectedPlan.actions().stream().map(operations::status).toList();
+        SetupReadiness readiness = targets.stream().allMatch(target -> target.readiness() == SetupReadiness.READY)
+                ? SetupReadiness.READY
+                : targets.stream().anyMatch(target -> target.readiness() == SetupReadiness.DEGRADED)
+                ? SetupReadiness.DEGRADED : SetupReadiness.MISSING;
+        if (readiness == SetupReadiness.READY && !hasCompatibleReceipt()) {
+            ArrayList<SetupStatus> adjusted = new ArrayList<>(targets);
+            SetupStatus last = adjusted.getLast();
+            adjusted.set(adjusted.size() - 1, new SetupStatus(last.target(), SetupReadiness.DEGRADED,
+                    last.detectedVersion(), "Managed files exist without a compatible SHAFT receipt."));
+            targets = List.copyOf(adjusted);
+            readiness = SetupReadiness.DEGRADED;
+        }
+        return new SetupProfileStatus(1, expectedPlan.profile(), readiness, targets);
+    }
+
+    SetupReceipt install(SetupPlan plan, SetupApproval approval) throws IOException {
+        requireCompatible(plan);
+        SetupExecutor.validate(plan, approval);
+        operations.hostPreflight(plan.actions());
+        Path lockPath = paths.state().resolve("healenium.lock").toAbsolutePath().normalize();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        boolean acquired = false;
+        try {
+            jvmLock.lockInterruptibly();
+            acquired = true;
+            if (!Files.isDirectory(paths.state(), LinkOption.NOFOLLOW_LINKS)) {
+                operations.preStatePreflight(plan.actions(), offline);
+            }
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                operations.lockedPreflight(plan.actions(), offline);
+                invalidateReceipt();
+                SetupReceipt receipt = SetupExecutor.execute(plan, approval, action -> {
+                    try {
+                        operations.install(action);
+                    } catch (IOException failure) {
+                        throw new SetupOperationException(failure);
+                    }
+                });
+                Files.deleteIfExists(previousReceiptPath());
+                writeReceipt(receipt);
+                return receipt;
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the Healenium setup lock.", interrupted);
+        } finally {
+            if (acquired) jvmLock.unlock();
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan) {
+        if (plan.mode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External plans are diagnostic and cannot be installed.");
+        }
+        if (!expectedPlan.equals(plan)) {
+            throw new IllegalArgumentException("Plan does not match the Healenium manifest shipped with this release.");
+        }
+    }
+
+    private void writeReceipt(SetupReceipt receipt) throws IOException {
+        Files.createDirectories(paths.receipts());
+        Path destination = receiptPath();
+        Path temporary = Files.createTempFile(paths.receipts(), "healenium", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(receipt));
+            VerifiedArtifactStore.move(temporary, destination);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private boolean hasCompatibleReceipt() {
+        try {
+            Path receipt = receiptPath();
+            VerifiedArtifactStore.requireUnlinkedAncestors(receipt);
+            if (!Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)) return false;
+            SetupReceipt saved = JSON.readValue(receipt.toFile(), SetupReceipt.class);
+            return saved.planDigest().equals(expectedPlan.digest())
+                    && saved.completedActions().equals(expectedPlan.actions());
+        } catch (IOException | RuntimeException invalid) {
+            return false;
+        }
+    }
+
+    private Path receiptPath() {
+        return paths.receipts().resolve("healenium.json");
+    }
+
+    private Path previousReceiptPath() {
+        return paths.receipts().resolve("healenium.previous.json");
+    }
+
+    private void invalidateReceipt() throws IOException {
+        Path receipt = receiptPath();
+        Path previous = previousReceiptPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(receipt);
+        VerifiedArtifactStore.requireUnlinkedAncestors(previous);
+        if (!Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)) return;
+        Files.deleteIfExists(previous);
+        VerifiedArtifactStore.move(receipt, previous);
+    }
+
+    private static final class SetupOperationException extends RuntimeException {
+        private SetupOperationException(IOException cause) {
+            super(cause);
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/HealeniumToolchainOperations.java
@@ -1,0 +1,50 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+/** Injectable host and mutation boundary for the Healenium setup transaction. */
+interface HealeniumToolchainOperations {
+    void hostPreflight(List<SetupAction> actions) throws IOException;
+
+    default void preStatePreflight(List<SetupAction> actions, boolean offline) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
+        // Healenium has no safe read that must occur before the shared state directory exists.
+        // offline is part of the shared provider SPI and is unused until that read exists.
+        if (offline) return;
+    }
+
+    void lockedPreflight(List<SetupAction> actions, boolean offline) throws IOException;
+
+    void install(SetupAction action) throws IOException;
+
+    SetupStatus status(SetupAction action);
+
+    default void composeUp(Path composeFile, String project) throws IOException {
+        java.util.Objects.requireNonNull(composeFile, "composeFile");
+        java.util.Objects.requireNonNull(project, "project");
+        throw new UnsupportedOperationException("Compose start is not available.");
+    }
+
+    default void composeDown(Path composeFile, String project) throws IOException {
+        java.util.Objects.requireNonNull(composeFile, "composeFile");
+        java.util.Objects.requireNonNull(project, "project");
+        throw new UnsupportedOperationException("Compose stop is not available.");
+    }
+
+    default boolean composeRunning(Path composeFile, String project) throws IOException {
+        java.util.Objects.requireNonNull(composeFile, "composeFile");
+        java.util.Objects.requireNonNull(project, "project");
+        throw new IOException("Compose inspection is not available.");
+    }
+
+    default void awaitReady(URI backend, URI imitate, Duration timeout) throws IOException {
+        java.util.Objects.requireNonNull(backend, "backend");
+        java.util.Objects.requireNonNull(imitate, "imitate");
+        java.util.Objects.requireNonNull(timeout, "timeout");
+        throw new UnsupportedOperationException("Healenium readiness is not available.");
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
@@ -26,7 +26,8 @@ public final class InfrastructureSetupService {
     public static InfrastructureSetupService builtIn(SetupPlatform platform, SetupArchitecture architecture) {
         List<SetupProvider> providers = new java.util.ArrayList<>(List.of(
                 new ReportingSetupProvider(), new OcrSetupProvider(), new LighthouseSetupProvider(),
-                new PlaywrightSetupProvider(), new AndroidSetupProvider(), new SeleniumGridSetupProvider()));
+                new PlaywrightSetupProvider(), new AndroidSetupProvider(), new SeleniumGridSetupProvider(),
+                new HealeniumSetupProvider()));
         if (platform == SetupPlatform.MACOS) providers.add(new IosSetupProvider());
         if (platform == SetupPlatform.WINDOWS) providers.add(new WindowsSetupProvider());
         ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultHealeniumToolchainOperationsTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultHealeniumToolchainOperationsTest.java
@@ -1,0 +1,76 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultHealeniumToolchainOperationsTest {
+    @Test
+    void dockerProbeDoesNotCreateStateOrRequireALogFile(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        AtomicReference<Path> logged = new AtomicReference<>();
+        DefaultHealeniumToolchainOperations operations = new DefaultHealeniumToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) -> {
+                    logged.set(log);
+                    return new ReportingSetupService.ProcessResult(0, "Docker Compose version v2.34.0");
+                }, false);
+
+        operations.hostPreflight(plan().actions());
+
+        assertFalse(Files.exists(paths.state()));
+        assertTrue(logged.get() == null);
+    }
+
+    @Test
+    void composeInspectFailureIsNotTreatedAsStopped(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        DefaultHealeniumToolchainOperations operations = new DefaultHealeniumToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) -> {
+                    throw new java.io.IOException("docker daemon unavailable");
+                }, false);
+
+        assertThrows(java.io.IOException.class, () -> operations.composeRunning(
+                paths.tools().resolve("healenium").resolve("docker-compose.yml"),
+                HealeniumSetupPlanner.PROJECT));
+    }
+
+    @Test
+    void installThenStatusIsReadyAndInitMutationDegrades(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        SetupPlan plan = plan();
+        DefaultHealeniumToolchainOperations operations = new DefaultHealeniumToolchainOperations(
+                paths, plan, (command, workingDirectory, environment, removed, stdin, log, timeout) ->
+                new ReportingSetupService.ProcessResult(0, "Docker Compose version v2.34.0"), false);
+        SetupAction healenium = plan.actions().stream()
+                .filter(action -> action.target() == SetupTarget.HEALENIUM).findFirst().orElseThrow();
+
+        operations.install(healenium);
+
+        assertEquals(SetupReadiness.READY, operations.status(healenium).readiness());
+        assertTrue(Files.isRegularFile(paths.tools().resolve("healenium").resolve("docker-compose.yml")));
+        assertTrue(Files.isRegularFile(paths.tools().resolve("healenium").resolve("init.sql")));
+
+        Files.writeString(paths.tools().resolve("healenium").resolve("init.sql"), "DROP SCHEMA healenium;\n");
+        assertEquals(SetupReadiness.DEGRADED, operations.status(healenium).readiness());
+    }
+
+    private static SetupPlan plan() {
+        return HealeniumSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64, SetupMode.MANAGED,
+                SetupSelection.defaults());
+    }
+
+    private static ShaftCachePaths paths(Path temp) {
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        return new ShaftCachePaths(cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts"));
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/HealeniumLifecycleServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/HealeniumLifecycleServiceTest.java
@@ -1,0 +1,216 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HealeniumLifecycleServiceTest {
+    @Test
+    void missingReceiptStartsNoComposeProject(@TempDir Path temp) {
+        Fixture fixture = uninstalled(temp);
+        RecordingOperations operations = new RecordingOperations();
+        HealeniumLifecycleService lifecycle = new HealeniumLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        IOException failure = assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+        assertTrue(failure.getMessage().contains("receipt"));
+        assertTrue(operations.ups.isEmpty());
+    }
+
+    @Test
+    void occupiedBackendPortStartsNoComposeProject(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        HealeniumLifecycleService lifecycle = new HealeniumLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        try (ServerSocket occupied = new ServerSocket()) {
+            occupied.bind(new InetSocketAddress("127.0.0.1", 7878));
+
+            IOException failure = assertThrows(IOException.class,
+                    () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+            assertTrue(failure.getMessage().contains("7878"));
+            assertTrue(operations.ups.isEmpty());
+        }
+    }
+
+    @Test
+    void occupiedImitatePortStartsNoComposeProject(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        HealeniumLifecycleService lifecycle = new HealeniumLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        try (ServerSocket occupied = new ServerSocket()) {
+            occupied.bind(new InetSocketAddress("127.0.0.1", 8000));
+
+            IOException failure = assertThrows(IOException.class,
+                    () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+            assertTrue(failure.getMessage().contains("8000"));
+            assertTrue(operations.ups.isEmpty());
+        }
+    }
+
+    @Test
+    void startReusesThenStopsOnlyTheOwnedProject(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        HealeniumLifecycleService first = new HealeniumLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        ManagedEnvironment firstEnv = first.start(fixture.plan(), fixture.approval(), fixture.options());
+        ManagedEnvironment secondEnv = first.start(fixture.plan(), fixture.approval(), fixture.options());
+
+        assertEquals(1, operations.ups.size());
+        assertEquals(HealeniumSetupPlanner.PROJECT, operations.ups.getFirst());
+        assertEquals(URI.create("http://127.0.0.1:7878/"), firstEnv.endpoint().orElseThrow());
+        assertEquals("7878", firstEnv.connectionProperties().get("serverPort"));
+        assertEquals("8000", firstEnv.connectionProperties().get("imitatePort"));
+        assertFalse(firstEnv.connectionProperties().containsKey("heal-enabled"));
+        assertFalse(firstEnv.connectionProperties().containsKey("healEnabled"));
+
+        firstEnv.close();
+        assertTrue(operations.downs.isEmpty());
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("healenium-runtime.json")));
+
+        secondEnv.close();
+        assertEquals(List.of(HealeniumSetupPlanner.PROJECT), operations.downs);
+        assertFalse(Files.exists(fixture.paths().state().resolve("healenium-runtime.json")));
+    }
+
+    @Test
+    void composeInspectFailureDoesNotDropTheLeaseOrStopContainers(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        HealeniumLifecycleService lifecycle = new HealeniumLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+        lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+        operations.inspectFails = true;
+
+        assertThrows(IOException.class, () -> lifecycle.stop(Duration.ofSeconds(1)));
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("healenium-runtime.json")));
+        assertTrue(operations.downs.isEmpty());
+    }
+
+    @Test
+    void logsMatchRuntimeIdentityWithoutRequiringTheManagedPlanDigest(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        HealeniumLifecycleService managed = new HealeniumLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+        managed.start(fixture.plan(), fixture.approval(), fixture.options());
+        Files.createDirectories(managed.logFile().getParent());
+        Files.writeString(managed.logFile(), "backend ready");
+
+        SetupPlan external = HealeniumSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64,
+                SetupMode.EXTERNAL, SetupSelection.defaults());
+        HealeniumLifecycleService diagnostic = new HealeniumLifecycleService(
+                fixture.paths(), external, operations);
+
+        assertEquals("backend ready", diagnostic.logs());
+    }
+
+    @Test
+    void failedReadinessTearsDownOnlyTheOwnedProject(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        operations.ready = false;
+        HealeniumLifecycleService lifecycle = new HealeniumLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+        assertEquals(List.of(HealeniumSetupPlanner.PROJECT), operations.ups);
+        assertEquals(List.of(HealeniumSetupPlanner.PROJECT), operations.downs);
+    }
+
+    private static Fixture uninstalled(Path temp) {
+        return fixture(temp, false);
+    }
+
+    private static Fixture installed(Path temp) {
+        return fixture(temp, true);
+    }
+
+    private static Fixture fixture(Path temp, boolean installReceipt) {
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        SetupOptions options = SetupOptions.defaults(SetupProfile.HEALENIUM, paths)
+                .withMode(SetupMode.MANAGED).withTimeouts(Duration.ofSeconds(5), Duration.ofSeconds(5));
+        SetupPlan plan = HealeniumSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64,
+                SetupMode.MANAGED, SetupSelection.defaults());
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+        if (installReceipt) {
+            try {
+                new HealeniumSetupService(paths, plan, new RecordingOperations(), false).install(plan, approval);
+            } catch (IOException failure) {
+                throw new IllegalStateException(failure);
+            }
+        }
+        return new Fixture(paths, options, plan, approval);
+    }
+
+    private record Fixture(ShaftCachePaths paths, SetupOptions options, SetupPlan plan, SetupApproval approval) { }
+
+    private static final class RecordingOperations implements HealeniumToolchainOperations {
+        private final List<String> ups = new ArrayList<>();
+        private final List<String> downs = new ArrayList<>();
+        private boolean running;
+        private boolean ready = true;
+        private boolean inspectFails;
+
+        @Override public void hostPreflight(List<SetupAction> actions) { /* no host mutation in this fixture */ }
+        @Override public void lockedPreflight(List<SetupAction> actions, boolean offline) { /* no locked preflight */ }
+        @Override public void install(SetupAction action) { /* receipt-only fixture */ }
+
+        @Override
+        public SetupStatus status(SetupAction action) {
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(), "fixture");
+        }
+
+        @Override
+        public void composeUp(Path composeFile, String project) {
+            ups.add(project);
+            running = true;
+        }
+
+        @Override
+        public void composeDown(Path composeFile, String project) {
+            downs.add(project);
+            running = false;
+        }
+
+        @Override
+        public boolean composeRunning(Path composeFile, String project) throws IOException {
+            if (inspectFails) throw new IOException("Unable to inspect the SHAFT Healenium compose project.");
+            return running;
+        }
+
+        @Override
+        public void awaitReady(URI backend, URI imitate, Duration timeout) throws IOException {
+            if (!ready) throw new IOException("Healenium did not become ready.");
+        }
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/HealeniumSetupProviderTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/HealeniumSetupProviderTest.java
@@ -1,0 +1,164 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HealeniumSetupProviderTest {
+    @Test
+    void builtInCoordinatorProvidesHealeniumPlan(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupOptions options = managed(temp);
+
+        assertTrue(service.supports(SetupProfile.HEALENIUM));
+        SetupPlan plan = service.plan(options);
+
+        assertEquals(List.of(SetupTarget.DOCKER, SetupTarget.HEALENIUM),
+                plan.actions().stream().map(SetupAction::target).toList());
+        assertEquals(SetupActionKind.DIAGNOSE, plan.actions().getFirst().kind());
+        assertEquals(SetupActionKind.INSTALL, plan.actions().getLast().kind());
+        assertEquals("3.4.6+1.4+15.5-alpine,backend=7878,imitate=8000",
+                plan.actions().getLast().version());
+        assertEquals(SetupSelection.defaults(), service.selectionFromPlan(plan));
+    }
+
+    @Test
+    void selectedPortsAreBoundAndReconstructed(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.WINDOWS, SetupArchitecture.X64);
+        SetupOptions options = managed(temp);
+        SetupSelection selection = new SetupSelection(List.of("backend_8888", "imitate_9000"));
+
+        SetupPlan plan = service.plan(options, selection);
+
+        assertEquals(selection, service.selectionFromPlan(plan));
+        assertTrue(plan.actions().getLast().version().contains("backend=8888"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.plan(options, new SetupSelection(List.of("backend_7878", "imitate_7878"))));
+    }
+
+    @Test
+    void missingDockerPerformsNoInstallWrites(@TempDir Path temp) {
+        RecordingOperations operations = new RecordingOperations();
+        operations.dockerReady = false;
+        InfrastructureSetupService service = coordinator(operations);
+        SetupOptions options = managed(temp);
+        SetupPlan plan = service.plan(options);
+
+        IOException failure = assertThrows(IOException.class,
+                () -> service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+
+        assertTrue(failure.getMessage().contains("Docker"));
+        assertTrue(operations.events.contains("host-preflight"));
+        assertFalse(operations.events.stream().anyMatch(event -> event.startsWith("install:")));
+        assertFalse(Files.exists(options.paths().receipts().resolve("healenium.json")));
+    }
+
+    @Test
+    void managedProviderInstallsTheExactComposeReceipt(@TempDir Path temp) throws Exception {
+        RecordingOperations operations = new RecordingOperations();
+        InfrastructureSetupService service = coordinator(operations);
+        SetupOptions options = managed(temp);
+        SetupPlan plan = service.plan(options);
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+
+        assertEquals(SetupReadiness.MISSING, service.status(options).readiness());
+        SetupReceipt receipt = service.install(plan, approval, options);
+
+        assertEquals(plan.digest(), receipt.planDigest());
+        assertEquals(plan.actions(), receipt.completedActions());
+        assertEquals(SetupReadiness.READY, service.status(options).readiness());
+        assertTrue(operations.events.contains("host-preflight"));
+        assertTrue(operations.events.contains("install:" + SetupTarget.HEALENIUM));
+    }
+
+    @Test
+    void managedComposeUsesOfficialPinsWithoutHostPostgresOrContainerNames() throws Exception {
+        String compose = HealeniumSetupPlanner.compose(new HealeniumSetupPlanner.HealeniumScale(7878, 8000));
+        assertFalse(compose.contains("container_name:"));
+        assertFalse(compose.contains("5432:5432"));
+        assertEquals(Set.of("healenium/hlm-backend:3.4.6", "healenium/hlm-selector-imitator:1.4",
+                "postgres:15.5-alpine"), images(compose));
+        Path engineCompose = Path.of("").toAbsolutePath().resolve(
+                "../shaft-engine/src/main/resources/docker-compose/healenium-backend.yml");
+        assertTrue(Files.isRegularFile(engineCompose), engineCompose.toString());
+        String documented = Files.readString(engineCompose);
+        assertTrue(documented.contains("healenium/hlm-backend:3.4.6"));
+        assertTrue(documented.contains("healenium/hlm-selector-imitator:1.4"));
+        assertTrue(documented.contains("postgres:15.5-alpine"));
+    }
+
+    private static Set<String> images(String compose) {
+        Matcher matcher = Pattern.compile("image:\\s*(\\S+)").matcher(compose);
+        java.util.LinkedHashSet<String> images = new java.util.LinkedHashSet<>();
+        while (matcher.find()) images.add(matcher.group(1));
+        return images;
+    }
+
+    private static InfrastructureSetupService coordinator(RecordingOperations operations) {
+        return new InfrastructureSetupService(new SetupProviderRegistry(
+                List.of(new HealeniumSetupProvider((paths, plan, offline) -> operations))),
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+    }
+
+    private static SetupOptions managed(Path root) {
+        Path cache = root.resolve("cache");
+        Path data = root.resolve("data");
+        return SetupOptions.defaults(SetupProfile.HEALENIUM, new ShaftCachePaths(
+                cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts")))
+                .withMode(SetupMode.MANAGED);
+    }
+
+    private static final class RecordingOperations implements HealeniumToolchainOperations {
+        private final List<String> events = new ArrayList<>();
+        private boolean dockerReady = true;
+        private boolean installed;
+
+        @Override
+        public void hostPreflight(List<SetupAction> actions) throws IOException {
+            events.add("host-preflight");
+            if (!dockerReady) throw new IOException("Docker Engine 26.1.4+ and Compose v2 are required.");
+        }
+
+        @Override
+        public void lockedPreflight(List<SetupAction> actions, boolean offline) {
+            events.add("locked-preflight");
+        }
+
+        @Override
+        public void install(SetupAction action) {
+            events.add("install:" + action.target());
+            if (action.target() == SetupTarget.HEALENIUM) installed = true;
+        }
+
+        @Override
+        public SetupStatus status(SetupAction action) {
+            events.add("status:" + action.target());
+            if (action.target() == SetupTarget.DOCKER) {
+                return new SetupStatus(action.target(),
+                        dockerReady ? SetupReadiness.READY : SetupReadiness.MISSING,
+                        dockerReady ? "26.1.4+" : "", dockerReady ? "fixture" : "Docker is missing.");
+            }
+            return new SetupStatus(action.target(),
+                    installed ? SetupReadiness.READY : SetupReadiness.MISSING,
+                    installed ? action.version() : "", installed ? "fixture" : "Compose is missing.");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
Adds the missing managed `HEALENIUM` setup provider so CLI, Java, and MCP share one deterministic plan, exact approval, compose+init receipt, and ownership-safe start/stop/logs.

- Pins official Healenium images: `hlm-backend:3.4.6`, `hlm-selector-imitator:1.4`, `postgres:15.5-alpine`.
- Owns only compose project `shaft-healenium`. Never uses `container_name` and never publishes host `5432`.
- Docker remains a diagnosed host prerequisite. Default tests use fakes and never pull images.
- Setup never flips `heal-enabled`. Connection properties expose only `serverHost`, `serverPort`, and `imitatePort`.
- Aligns the documented `healenium-backend.yml` image pins with the official example.

Closes #5043. Related to #4849.

## Checks
- First RED: `HealeniumSetupProviderTest.builtInCoordinatorProvidesHealeniumPlan` failed `supports(HEALENIUM)` expected true, was false.
- After implementation: `mvn -pl shaft-infrastructure "-Dtest=HealeniumSetupProviderTest,HealeniumLifecycleServiceTest,DefaultHealeniumToolchainOperationsTest,SetupCatalogTest" test` — 19 tests, 0 failures.
- Nearest regression: `SeleniumGridSetupProviderTest`, `SeleniumGridLifecycleServiceTest`, `DefaultSeleniumGridToolchainOperationsTest` plus catalog — 30 tests green before the review fixes; Healenium+catalog 19 green after.
- Independent review blockers fixed before commit: unused SPI parameters referenced; real `install` then `status` checksum plus init-sql mutation.

## Continuation
- Head: `7cb8236bd0a7deb35d1d0832e71a43c501f10035`
- State: first reviewed checkpoint pushed; ready PR targeting `main`.
- Blockers: none known locally.
- Next action: arm merge-when-green with a merge commit, watch checks, then start the ReportPortal increment.
