### PR TITLE
feat(setup): own managed dev-only ReportPortal lifecycle

### DIFF
--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -367,7 +367,7 @@ public final class SetupCommand implements Runnable {
         return switch (plan.profile()) {
             case OCR -> ocrSelection(plan, languages);
             case MOBILE_ANDROID -> android.selectionFromPlan(plan);
-            case MOBILE_IOS, MOBILE_WINDOWS, SELENIUM_GRID, HEALENIUM -> {
+            case MOBILE_IOS, MOBILE_WINDOWS, SELENIUM_GRID, HEALENIUM, REPORT_PORTAL -> {
                 android.rejectIfSupplied(plan.profile());
                 yield InfrastructureSetupService.builtIn(plan.platform(), plan.architecture())
                         .selectionFromPlan(plan);

--- a/shaft-engine/src/main/resources/docker-compose/report-portal.yml
+++ b/shaft-engine/src/main/resources/docker-compose/report-portal.yml
@@ -53,7 +53,7 @@ services:
   ##
   ## ReportPortal dependencies
   gateway:
-    image: traefik:v2.11.15
+    image: traefik:v2.11.54
     logging:
       <<: *logging
     ports:
@@ -168,7 +168,7 @@ services:
   ##
   ## ReportPortal Core services
   migrations:
-    image: ${MIGRATIONS_IMAGE-reportportal/migrations:5.13.0}
+    image: ${MIGRATIONS_IMAGE-reportportal/migrations:5.15.4}
     build: ./migrations
     logging:
       <<: *logging
@@ -189,7 +189,7 @@ services:
       - ''
 
   index:
-    image: ${INDEX_IMAGE-reportportal/service-index:5.13.0}
+    image: ${INDEX_IMAGE-reportportal/service-index:5.15.1}
     build: ./service-index
     logging:
       <<: *logging
@@ -219,7 +219,7 @@ services:
       - ''
 
   ui:
-    image: ${UI_IMAGE-reportportal/service-ui:5.12.3}
+    image: ${UI_IMAGE-reportportal/service-ui:5.15.5}
     build: ./service-ui
     environment:
       RP_SERVER_PORT: "8080"
@@ -245,7 +245,7 @@ services:
       - ''
 
   api:
-    image: ${API_IMAGE-reportportal/service-api:5.13.3}
+    image: ${API_IMAGE-reportportal/service-api:5.15.4}
     build: ./service-api
     logging:
       <<: *logging
@@ -308,7 +308,7 @@ services:
       - ''
 
   uat:
-    image: ${UAT_IMAGE-reportportal/service-authorization:5.13.1}
+    image: ${UAT_IMAGE-reportportal/service-authorization:5.15.1}
     build: ./service-authorization
     logging:
       <<: *logging
@@ -352,7 +352,7 @@ services:
       - ''
 
   jobs:
-    image: ${JOBS_IMAGE-reportportal/service-jobs:5.13.1}
+    image: ${JOBS_IMAGE-reportportal/service-jobs:5.15.2}
     build: ./service-jobs
     logging:
       <<: *logging
@@ -415,7 +415,7 @@ services:
   ## Analyzer stack
   ## You can commit the following services if you don't need the Analyzer stack
   analyzer:
-    image: &analyzer_image ${ANALYZER_IMAGE-reportportal/service-auto-analyzer:5.13.1}
+    image: &analyzer_image ${ANALYZER_IMAGE-reportportal/service-auto-analyzer:5.15.5}
     build: &analyzer_build ./service-auto-analyzer
     logging:
       <<: *logging

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultReportPortalToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultReportPortalToolchainOperations.java
@@ -1,0 +1,216 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Host Docker/Compose implementation for the ReportPortal provider. */
+final class DefaultReportPortalToolchainOperations implements ReportPortalToolchainOperations {
+    private final ShaftCachePaths paths;
+    private final SetupPlan plan;
+    private final AndroidCommandRunner runner;
+    private final boolean offline;
+
+    DefaultReportPortalToolchainOperations(ShaftCachePaths paths, SetupPlan plan, boolean offline) {
+        this(paths, plan, AndroidCommandRunner.system(paths, plan.platform(), plan.architecture()), offline);
+    }
+
+    DefaultReportPortalToolchainOperations(ShaftCachePaths paths, SetupPlan plan, AndroidCommandRunner runner,
+                                           boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.plan = java.util.Objects.requireNonNull(plan, "plan");
+        this.runner = java.util.Objects.requireNonNull(runner, "runner");
+        this.offline = offline;
+    }
+
+    @Override
+    public void hostPreflight(List<SetupAction> actions) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
+        requireDocker();
+    }
+
+    @Override
+    public void lockedPreflight(List<SetupAction> actions, boolean requireOffline) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
+        VerifiedArtifactStore.requireUnlinkedAncestors(composeFile());
+        if ((offline || requireOffline) && !Files.isRegularFile(composeFile(), LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Offline ReportPortal setup requires a staged compose file.");
+        }
+    }
+
+    @Override
+    public void install(SetupAction action) throws IOException {
+        if (action.target() == SetupTarget.DOCKER) return;
+        if (action.target() != SetupTarget.REPORT_PORTAL) {
+            throw new IllegalArgumentException("Unsupported ReportPortal install target: " + action.target());
+        }
+        ReportPortalSetupPlanner.ReportPortalScale scale = ReportPortalSetupPlanner.scaleFromPlan(plan);
+        byte[] artifact = ReportPortalSetupPlanner.compose(scale).getBytes(StandardCharsets.UTF_8);
+        String actual;
+        try {
+            actual = "sha256:" + HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(artifact));
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
+        if (!actual.equalsIgnoreCase(action.checksum())) {
+            throw new IOException("Rendered ReportPortal compose does not match the approved plan.");
+        }
+        writeAtomic(composeFile(), artifact);
+    }
+
+    @Override
+    public SetupStatus status(SetupAction action) {
+        if (action.target() == SetupTarget.DOCKER) {
+            try {
+                requireDocker();
+                return new SetupStatus(action.target(), SetupReadiness.READY, action.version(),
+                        "Docker Engine and Compose are available.");
+            } catch (IOException failure) {
+                return new SetupStatus(action.target(), SetupReadiness.MISSING, "", failure.getMessage());
+            }
+        }
+        try {
+            Path compose = composeFile();
+            VerifiedArtifactStore.requireUnlinkedAncestors(compose);
+            if (!Files.isRegularFile(compose, LinkOption.NOFOLLOW_LINKS)) {
+                return new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                        "Managed ReportPortal compose file is missing.");
+            }
+            String staged = Files.readString(compose);
+            String actual = "sha256:" + HexFormat.of().formatHex(
+                    MessageDigest.getInstance("SHA-256").digest(staged.getBytes(StandardCharsets.UTF_8)));
+            if (!actual.equalsIgnoreCase(action.checksum())) {
+                return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "",
+                        "Staged compose does not match the approved plan.");
+            }
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(),
+                    "Staged ReportPortal compose matches the reviewed plan.");
+        } catch (IOException | NoSuchAlgorithmException failure) {
+            return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "", failure.getMessage());
+        }
+    }
+
+    @Override
+    public void composeUp(Path composeFile, String project) throws IOException {
+        requireOwned(project);
+        run(List.of(docker(), "compose", "-p", project, "-f", composeFile.toString(), "up", "-d"),
+                "Failed to start the SHAFT ReportPortal compose project.");
+    }
+
+    @Override
+    public void composeDown(Path composeFile, String project) throws IOException {
+        requireOwned(project);
+        run(List.of(docker(), "compose", "-p", project, "-f", composeFile.toString(), "down", "--remove-orphans"),
+                "Failed to stop the SHAFT ReportPortal compose project.");
+    }
+
+    @Override
+    public boolean composeRunning(Path composeFile, String project) throws IOException {
+        requireOwned(project);
+        ReportingSetupService.ProcessResult result = runner.run(
+                List.of(docker(), "compose", "-p", project, "-f", composeFile.toString(), "ps", "-q"),
+                composeFile.getParent(), Map.of(), Set.of(), null, null, Duration.ofSeconds(15));
+        if (result.exitCode() != 0) {
+            throw new IOException("Unable to inspect the SHAFT ReportPortal compose project. " + result.output());
+        }
+        return !result.output().isBlank();
+    }
+
+    @Override
+    public void awaitReady(URI ui, Duration timeout) throws IOException {
+        Instant deadline = Instant.now().plus(timeout);
+        IOException last = new IOException("ReportPortal did not become ready.");
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                probe(ui, "ReportPortal UI");
+                return;
+            } catch (IOException failure) {
+                last = failure;
+            }
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for ReportPortal.", interrupted);
+            }
+        }
+        throw last;
+    }
+
+    private void requireDocker() throws IOException {
+        try {
+            ReportingSetupService.ProcessResult compose = runner.run(List.of(docker(), "compose", "version"),
+                    paths.cacheRoot(), Map.of(), Set.of(), null, null, Duration.ofSeconds(15));
+            ReportingSetupService.ProcessResult engine = runner.run(List.of(docker(), "version"),
+                    paths.cacheRoot(), Map.of(), Set.of(), null, null, Duration.ofSeconds(15));
+            if (compose.exitCode() != 0 || engine.exitCode() != 0) {
+                throw new IOException("Docker Engine 26.1.4+ and Compose v2 are required.");
+            }
+        } catch (IOException failure) {
+            throw new IOException("Docker Engine 26.1.4+ and Compose v2 are required.", failure);
+        }
+    }
+
+    private void run(List<String> command, String failure) throws IOException {
+        Path log = logFile();
+        Files.createDirectories(log.getParent());
+        ReportingSetupService.ProcessResult result = runner.run(command, composeFile().getParent(), Map.of(),
+                Set.of(), null, log, Duration.ofMinutes(5));
+        if (result.exitCode() != 0) throw new IOException(failure + " " + result.output());
+    }
+
+    private static void requireOwned(String project) throws IOException {
+        if (!ReportPortalSetupPlanner.PROJECT.equals(project)) {
+            throw new IOException("Refusing to operate on an unowned Docker Compose project: " + project);
+        }
+    }
+
+    private static void probe(URI endpoint, String owner) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) endpoint.toURL().openConnection();
+        try {
+            connection.setConnectTimeout(1_000);
+            connection.setReadTimeout(1_000);
+            connection.setRequestMethod("GET");
+            int code = connection.getResponseCode();
+            if (code >= 200 && code < 500) return;
+            throw new IOException(owner + " status returned HTTP " + code + '.');
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static void writeAtomic(Path destination, byte[] bytes) throws IOException {
+        Files.createDirectories(destination.getParent());
+        Path temporary = Files.createTempFile(destination.getParent(), destination.getFileName().toString(), ".tmp");
+        try {
+            Files.write(temporary, bytes);
+            VerifiedArtifactStore.move(temporary, destination);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private Path composeFile() {
+        return paths.tools().resolve("reportportal").resolve("docker-compose.yml");
+    }
+
+    private Path logFile() {
+        return paths.state().resolve("logs").resolve("reportportal.log");
+    }
+
+    private String docker() {
+        return plan.platform() == SetupPlatform.WINDOWS ? "docker.exe" : "docker";
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
@@ -27,7 +27,7 @@ public final class InfrastructureSetupService {
         List<SetupProvider> providers = new java.util.ArrayList<>(List.of(
                 new ReportingSetupProvider(), new OcrSetupProvider(), new LighthouseSetupProvider(),
                 new PlaywrightSetupProvider(), new AndroidSetupProvider(), new SeleniumGridSetupProvider(),
-                new HealeniumSetupProvider()));
+                new HealeniumSetupProvider(), new ReportPortalSetupProvider()));
         if (platform == SetupPlatform.MACOS) providers.add(new IosSetupProvider());
         if (platform == SetupPlatform.WINDOWS) providers.add(new WindowsSetupProvider());
         ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalLifecycleFactory.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalLifecycleFactory.java
@@ -1,0 +1,7 @@
+package com.shaft.infrastructure;
+
+@FunctionalInterface
+interface ReportPortalLifecycleFactory {
+    ReportPortalLifecycleService create(ShaftCachePaths paths, SetupPlan plan,
+                                        ReportPortalToolchainOperations operations);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalLifecycleService.java
@@ -1,0 +1,295 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Lease-safe lifecycle owner for one verified SHAFT ReportPortal compose project. */
+final class ReportPortalLifecycleService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private final ShaftCachePaths paths;
+    private final SetupPlan expectedPlan;
+    private final ReportPortalToolchainOperations operations;
+    private final ReportPortalSetupPlanner.ReportPortalScale scale;
+
+    ReportPortalLifecycleService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                                 ReportPortalToolchainOperations operations) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.expectedPlan = java.util.Objects.requireNonNull(expectedPlan, "expectedPlan");
+        this.operations = java.util.Objects.requireNonNull(operations, "operations");
+        if (expectedPlan.profile() != SetupProfile.REPORT_PORTAL) {
+            throw new IllegalArgumentException("ReportPortal lifecycle requires the REPORT_PORTAL profile.");
+        }
+        this.scale = ReportPortalSetupPlanner.scaleFromPlan(expectedPlan);
+    }
+
+    ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        requireCompatible(plan, options);
+        SetupExecutor.validate(plan, approval);
+        SetupReceipt receipt = requireInstallReceipt(plan);
+        requireInstalled(plan);
+        Path lockPath = lockPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        try {
+            jvmLock.lockInterruptibly();
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                receipt = requireInstallReceipt(plan);
+                requireInstalled(plan);
+                Optional<ReportPortalRuntimeLease> reusable = readReusable(plan, options);
+                if (reusable.isPresent()) return environment(receipt, reusable.orElseThrow());
+                return startNew(plan, receipt, options);
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the ReportPortal runtime lock.", interrupted);
+        } finally {
+            if (jvmLock.isHeldByCurrentThread()) jvmLock.unlock();
+        }
+    }
+
+    boolean stop(Duration timeout) throws IOException {
+        java.util.Objects.requireNonNull(timeout, "timeout");
+        Path lockPath = lockPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        if (Files.notExists(leasePath(), LinkOption.NOFOLLOW_LINKS)) return false;
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        jvmLock.lock();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Optional<ReportPortalRuntimeLease> current = readLease();
+            if (current.isEmpty()) return false;
+            ReportPortalRuntimeLease lease = current.orElseThrow();
+            requireLeaseIdentity(lease);
+            if (!operations.composeRunning(composeFile(), lease.project())) {
+                Files.deleteIfExists(leasePath());
+                return false;
+            }
+            if (lease.refCount() > 1) {
+                writeLease(lease.withRefCount(lease.refCount() - 1));
+                return true;
+            }
+            operations.composeDown(composeFile(), requireOwnedProject(lease.project()));
+            Files.deleteIfExists(leasePath());
+            return true;
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    String logs() throws IOException {
+        Optional<ReportPortalRuntimeLease> current = readLease();
+        if (current.isEmpty()) return "";
+        ReportPortalRuntimeLease lease = current.orElseThrow();
+        if (!lease.sameRuntime(expectedIdentity(expectedPlan))) {
+            throw new IOException("ReportPortal lease does not match the requested runtime.");
+        }
+        return OwnedLogReader.read("ReportPortal", logFile());
+    }
+
+    Path logFile() {
+        return paths.state().resolve("logs").resolve("reportportal.log");
+    }
+
+    private ManagedEnvironment startNew(SetupPlan plan, SetupReceipt receipt, SetupOptions options)
+            throws IOException {
+        requireAvailablePort(scale.uiPort(), "ReportPortal UI");
+        URI ui = URI.create("http://127.0.0.1:" + scale.uiPort() + "/ui/");
+        try {
+            operations.composeUp(composeFile(), ReportPortalSetupPlanner.PROJECT);
+            operations.awaitReady(ui, options.startupTimeout());
+            ReportPortalRuntimeLease lease = new ReportPortalRuntimeLease(1, plan.digest(),
+                    ReportPortalSetupPlanner.PROJECT, ui.toString(), scale.uiPort(), 1);
+            writeLease(lease);
+            return environment(receipt, lease);
+        } catch (IOException | RuntimeException failure) {
+            try {
+                operations.composeDown(composeFile(), ReportPortalSetupPlanner.PROJECT);
+            } catch (IOException cleanup) {
+                failure.addSuppressed(cleanup);
+            }
+            throw failure;
+        }
+    }
+
+    private Optional<ReportPortalRuntimeLease> readReusable(SetupPlan plan, SetupOptions options) throws IOException {
+        Optional<ReportPortalRuntimeLease> existing = readLease();
+        if (existing.isEmpty()) return Optional.empty();
+        ReportPortalRuntimeLease lease = existing.orElseThrow();
+        if (!lease.planDigest().equals(plan.digest()) || !lease.sameIdentity(expectedIdentity(plan))) {
+            throw new IOException("An existing SHAFT ReportPortal lease does not match the reviewed plan.");
+        }
+        if (!operations.composeRunning(composeFile(), lease.project())) {
+            Files.deleteIfExists(leasePath());
+            return Optional.empty();
+        }
+        if (!options.reuseOwnedProcesses()) {
+            throw new IOException("A compatible SHAFT ReportPortal stack is already active and reuse is disabled.");
+        }
+        operations.awaitReady(URI.create(lease.endpoint()), options.startupTimeout());
+        ReportPortalRuntimeLease incremented = lease.withRefCount(lease.refCount() + 1);
+        writeLease(incremented);
+        return Optional.of(incremented);
+    }
+
+    private ReportPortalRuntimeLease expectedIdentity(SetupPlan plan) {
+        return new ReportPortalRuntimeLease(1, plan.digest(), ReportPortalSetupPlanner.PROJECT,
+                "http://127.0.0.1:" + scale.uiPort() + "/ui/", scale.uiPort(), 1);
+    }
+
+    private ManagedEnvironment environment(SetupReceipt receipt, ReportPortalRuntimeLease lease) {
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("serverHost", "localhost");
+        properties.put("serverPort", String.valueOf(lease.uiPort()));
+        return new ManagedEnvironment(SetupProfile.REPORT_PORTAL, receipt,
+                Optional.of(URI.create(lease.endpoint())), Map.copyOf(properties), () -> {
+                    try {
+                        release(lease);
+                    } catch (IOException failure) {
+                        throw new IllegalStateException("Failed to release the owned ReportPortal stack.", failure);
+                    }
+                });
+    }
+
+    private void release(ReportPortalRuntimeLease started) throws IOException {
+        Path lockPath = lockPath();
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        jvmLock.lock();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Optional<ReportPortalRuntimeLease> current = readLease();
+            if (current.isEmpty()) return;
+            ReportPortalRuntimeLease lease = current.orElseThrow();
+            if (!lease.sameIdentity(started)) {
+                throw new IOException("ReportPortal lease changed; refusing to stop an unowned project.");
+            }
+            if (lease.refCount() > 1) {
+                writeLease(lease.withRefCount(lease.refCount() - 1));
+                return;
+            }
+            operations.composeDown(composeFile(), requireOwnedProject(lease.project()));
+            Files.deleteIfExists(leasePath());
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan, SetupOptions options) {
+        if (plan.profile() != SetupProfile.REPORT_PORTAL || options.profile() != SetupProfile.REPORT_PORTAL) {
+            throw new IllegalArgumentException("ReportPortal lifecycle requires profile REPORT_PORTAL.");
+        }
+        if (plan.mode() == SetupMode.EXTERNAL || options.effectiveMode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External ReportPortal setup cannot start local containers.");
+        }
+        if (!expectedPlan.equals(plan)) {
+            throw new IllegalArgumentException("ReportPortal lifecycle plan does not match the release manifest.");
+        }
+    }
+
+    private SetupReceipt requireInstallReceipt(SetupPlan plan) throws IOException {
+        Path receiptPath = paths.receipts().resolve("reportportal.json");
+        VerifiedArtifactStore.requireUnlinkedAncestors(receiptPath);
+        if (!Files.isRegularFile(receiptPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("A complete compatible ReportPortal install receipt is required before start.");
+        }
+        SetupReceipt receipt;
+        try {
+            receipt = JSON.readValue(receiptPath.toFile(), SetupReceipt.class);
+        } catch (RuntimeException invalid) {
+            throw new IOException("ReportPortal install receipt is invalid.", invalid);
+        }
+        if (!receipt.planDigest().equals(plan.digest()) || !receipt.completedActions().equals(plan.actions())) {
+            throw new IOException("ReportPortal install receipt does not match the reviewed plan.");
+        }
+        return receipt;
+    }
+
+    private void requireInstalled(SetupPlan plan) throws IOException {
+        for (SetupAction action : plan.actions()) {
+            SetupStatus status = operations.status(action);
+            if (status.readiness() != SetupReadiness.READY) {
+                throw new IOException(action.target() + " is not ready: " + status.detail());
+            }
+        }
+    }
+
+    private void requireAvailablePort(int port, String owner) throws IOException {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(false);
+            socket.bind(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), port));
+        } catch (IOException occupied) {
+            throw new IOException(owner + " loopback port " + port + " is already occupied.", occupied);
+        }
+    }
+
+    private void requireLeaseIdentity(ReportPortalRuntimeLease lease) throws IOException {
+        if (!lease.sameIdentity(expectedIdentity(expectedPlan))) {
+            throw new IOException("ReportPortal lease does not match the requested plan.");
+        }
+    }
+
+    private static String requireOwnedProject(String project) throws IOException {
+        if (!ReportPortalSetupPlanner.PROJECT.equals(project)) {
+            throw new IOException("Refusing to stop an unowned Docker Compose project: " + project);
+        }
+        return project;
+    }
+
+    private Optional<ReportPortalRuntimeLease> readLease() throws IOException {
+        Path path = leasePath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(path);
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) return Optional.empty();
+        try {
+            ReportPortalRuntimeLease lease = JSON.readValue(path.toFile(), ReportPortalRuntimeLease.class);
+            if (lease.schemaVersion() != 1 || lease.refCount() < 1) {
+                throw new IOException("Invalid ReportPortal lease.");
+            }
+            return Optional.of(lease);
+        } catch (RuntimeException invalid) {
+            throw new IOException("ReportPortal runtime lease is invalid.", invalid);
+        }
+    }
+
+    private void writeLease(ReportPortalRuntimeLease lease) throws IOException {
+        Files.createDirectories(paths.state());
+        Path temporary = Files.createTempFile(paths.state(), "reportportal-runtime", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(lease));
+            VerifiedArtifactStore.move(temporary, leasePath());
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private Path composeFile() {
+        return paths.tools().resolve("reportportal").resolve("docker-compose.yml");
+    }
+
+    private Path leasePath() {
+        return paths.state().resolve("reportportal-runtime.json");
+    }
+
+    private Path lockPath() {
+        return paths.state().resolve("reportportal-runtime.lock").toAbsolutePath().normalize();
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalOperationsFactory.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalOperationsFactory.java
@@ -1,0 +1,6 @@
+package com.shaft.infrastructure;
+
+@FunctionalInterface
+interface ReportPortalOperationsFactory {
+    ReportPortalToolchainOperations create(ShaftCachePaths paths, SetupPlan plan, boolean offline);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalRuntimeLease.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalRuntimeLease.java
@@ -1,0 +1,29 @@
+package com.shaft.infrastructure;
+
+record ReportPortalRuntimeLease(int schemaVersion, String planDigest, String project, String endpoint,
+                                int uiPort, int refCount) {
+    ReportPortalRuntimeLease {
+        if (schemaVersion != 1) throw new IllegalArgumentException("Unsupported ReportPortal lease schema.");
+        if (planDigest == null || planDigest.isBlank()) throw new IllegalArgumentException("Plan digest is required.");
+        if (project == null || project.isBlank()) throw new IllegalArgumentException("Compose project is required.");
+        if (endpoint == null || endpoint.isBlank()) throw new IllegalArgumentException("Endpoint is required.");
+        if (refCount < 1) throw new IllegalArgumentException("Lease refcount must be positive.");
+    }
+
+    ReportPortalRuntimeLease withRefCount(int value) {
+        return new ReportPortalRuntimeLease(schemaVersion, planDigest, project, endpoint, uiPort, value);
+    }
+
+    boolean sameIdentity(ReportPortalRuntimeLease other) {
+        return other != null
+                && planDigest.equals(other.planDigest)
+                && sameRuntime(other);
+    }
+
+    boolean sameRuntime(ReportPortalRuntimeLease other) {
+        return other != null
+                && project.equals(other.project)
+                && endpoint.equals(other.endpoint)
+                && uiPort == other.uiPort;
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalRuntimeManager.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalRuntimeManager.java
@@ -1,0 +1,12 @@
+package com.shaft.infrastructure;
+
+final class ReportPortalRuntimeManager {
+    private ReportPortalRuntimeManager() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static ReportPortalLifecycleService systemLifecycle(ShaftCachePaths paths, SetupPlan plan,
+                                                        ReportPortalToolchainOperations operations) {
+        return new ReportPortalLifecycleService(paths, plan, operations);
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalSetupPlanner.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalSetupPlanner.java
@@ -1,0 +1,342 @@
+package com.shaft.infrastructure;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Release-coupled plans for a SHAFT-owned ReportPortal compose project. */
+final class ReportPortalSetupPlanner {
+    static final String GATEWAY_IMAGE = "traefik:v2.11.54";
+    static final String POSTGRES_IMAGE = "postgres:18.4";
+    static final String RABBITMQ_IMAGE = "rabbitmq:4.3.4-management";
+    static final String MIGRATIONS_IMAGE = "reportportal/migrations:5.15.4";
+    static final String INDEX_IMAGE = "reportportal/service-index:5.15.1";
+    static final String UI_IMAGE = "reportportal/service-ui:5.15.5";
+    static final String API_IMAGE = "reportportal/service-api:5.15.4";
+    static final String UAT_IMAGE = "reportportal/service-authorization:5.15.1";
+    static final String JOBS_IMAGE = "reportportal/service-jobs:5.15.2";
+    static final String PIN = "5.15.5+5.15.4+18.4";
+    static final String PROJECT = "shaft-reportportal";
+    static final int DEFAULT_UI_PORT = 8080;
+    /** Official local-dev defaults from reportportal/reportportal docker-compose.yml; not SHAFT secrets. */
+    static final String LOCAL_DEV_DB_PASSWORD = "rppass";
+    static final String LOCAL_DEV_AMQP_PASSWORD = "rabbitmq";
+    static final String LOCAL_DEV_ADMIN_PASSWORD = "erebus";
+    private static final Pattern SPEC = Pattern.compile(Pattern.quote(PIN) + ",ui=([0-9]+)");
+
+    private ReportPortalSetupPlanner() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static SetupPlan plan(SetupPlatform platform, SetupArchitecture architecture, SetupMode mode,
+                          SetupSelection selection) {
+        ReportPortalScale scale = scale(selection);
+        SetupActionKind kind = mode == SetupMode.EXTERNAL ? SetupActionKind.DIAGNOSE : SetupActionKind.INSTALL;
+        String artifact = compose(scale);
+        byte[] bytes = artifact.getBytes(StandardCharsets.UTF_8);
+        return SetupPlan.create(SetupProfile.REPORT_PORTAL, platform, architecture, mode, List.of(
+                new SetupAction(SetupTarget.DOCKER, SetupActionKind.DIAGNOSE, "26.1.4+",
+                        URI.create("urn:shaft:host:docker"),
+                        sha256("docker\026.1.4+"), false, Set.of()),
+                new SetupAction(SetupTarget.REPORT_PORTAL, kind, spec(scale),
+                        URI.create("urn:shaft:reportportal:" + PROJECT + ":" + spec(scale)),
+                        sha256(artifact), bytes.length, false, Set.of())));
+    }
+
+    static SetupSelection selectionFromPlan(SetupPlan plan) {
+        return selectionFromScale(scaleFromPlan(plan));
+    }
+
+    static ReportPortalScale scaleFromPlan(SetupPlan plan) {
+        if (plan.profile() != SetupProfile.REPORT_PORTAL) {
+            throw new IllegalArgumentException("ReportPortal scale is only defined for ReportPortal plans.");
+        }
+        List<SetupAction> actions = plan.actions().stream()
+                .filter(action -> action.target() == SetupTarget.REPORT_PORTAL).toList();
+        if (actions.size() != 1) {
+            throw new IllegalArgumentException("ReportPortal plan must contain exactly one REPORT_PORTAL action.");
+        }
+        Matcher match = SPEC.matcher(actions.getFirst().version());
+        if (!match.matches()) throw new IllegalArgumentException("ReportPortal plan metadata is invalid.");
+        return new ReportPortalScale(parsePort(match.group(1)));
+    }
+
+    static String compose(ReportPortalScale scale) {
+        return """
+                services:
+                  gateway:
+                    image: %s
+                    ports:
+                      - "%d:8080"
+                    volumes:
+                      - /var/run/docker.sock:/var/run/docker.sock
+                    command:
+                      - --providers.docker=true
+                      - --providers.docker.constraints=Label(`traefik.expose`, `true`)
+                      - --entrypoints.web.address=:8080
+                      - --entrypoints.traefik.address=:8081
+                      - --api.dashboard=true
+                      - --api.insecure=true
+                    networks:
+                      - reportportal
+                    restart: always
+                  postgres:
+                    image: %s
+                    shm_size: '512m'
+                    environment:
+                      POSTGRES_USER: rpuser
+                      POSTGRES_PASSWORD: %s
+                      POSTGRES_DB: reportportal
+                    volumes:
+                      - postgres:/var/lib/postgresql
+                    healthcheck:
+                      test: ["CMD-SHELL", "pg_isready -d $$POSTGRES_DB -U $$POSTGRES_USER"]
+                      interval: 10s
+                      timeout: 120s
+                      retries: 10
+                    networks:
+                      - reportportal
+                    restart: always
+                  rabbitmq:
+                    image: %s
+                    environment:
+                      RABBITMQ_DEFAULT_USER: rabbitmq
+                      RABBITMQ_DEFAULT_PASS: %s
+                    configs:
+                      - source: rabbitmq_extra_config
+                        target: /etc/rabbitmq/conf.d/99-extra.conf
+                      - source: rabbitmq_enabled_plugins
+                        target: /etc/rabbitmq/enabled_plugins
+                    healthcheck:
+                      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+                      interval: 30s
+                      timeout: 30s
+                      retries: 5
+                      start_period: 60s
+                    networks:
+                      - reportportal
+                    restart: always
+                  migrations:
+                    image: %s
+                    depends_on:
+                      postgres:
+                        condition: service_healthy
+                    environment:
+                      POSTGRES_SERVER: postgres
+                      POSTGRES_PORT: 5432
+                      POSTGRES_DB: reportportal
+                      POSTGRES_USER: rpuser
+                      POSTGRES_PASSWORD: %s
+                    networks:
+                      - reportportal
+                    restart: on-failure
+                  index:
+                    image: %s
+                    depends_on:
+                      gateway:
+                        condition: service_started
+                    environment:
+                      LB_URL: http://gateway:8081
+                      TRAEFIK_V2_MODE: 'true'
+                    labels:
+                      - "traefik.http.routers.index.rule=PathPrefix(`/`)"
+                      - "traefik.http.services.index.loadbalancer.server.port=8080"
+                      - "traefik.expose=true"
+                    networks:
+                      - reportportal
+                    restart: always
+                  ui:
+                    image: %s
+                    environment:
+                      RP_SERVER_PORT: "8080"
+                    labels:
+                      - "traefik.http.middlewares.ui-strip-prefix.stripprefix.prefixes=/ui"
+                      - "traefik.http.routers.ui.middlewares=ui-strip-prefix@docker"
+                      - "traefik.http.routers.ui.rule=PathPrefix(`/ui`)"
+                      - "traefik.http.services.ui.loadbalancer.server.port=8080"
+                      - "traefik.expose=true"
+                    networks:
+                      - reportportal
+                    restart: always
+                  api:
+                    image: %s
+                    depends_on:
+                      rabbitmq:
+                        condition: service_healthy
+                      gateway:
+                        condition: service_started
+                      postgres:
+                        condition: service_healthy
+                      jobs:
+                        condition: service_healthy
+                    environment:
+                      RP_DB_HOST: postgres
+                      RP_DB_PORT: 5432
+                      RP_DB_USER: rpuser
+                      RP_DB_PASS: %s
+                      RP_DB_NAME: reportportal
+                      RP_AMQP_HOST: rabbitmq
+                      RP_AMQP_PORT: 5672
+                      RP_AMQP_APIPORT: 15672
+                      RP_AMQP_USER: rabbitmq
+                      RP_AMQP_PASS: %s
+                      RP_AMQP_APIUSER: rabbitmq
+                      RP_AMQP_APIPASS: %s
+                      RP_JOBS_BASEURL: http://jobs:8686
+                      DATASTORE_TYPE: filesystem
+                      MANAGEMENT_HEALTH_ELASTICSEARCH_ENABLED: "false"
+                    volumes:
+                      - storage:/data/storage
+                    labels:
+                      - "traefik.http.middlewares.api-strip-prefix.stripprefix.prefixes=/api"
+                      - "traefik.http.routers.api.middlewares=api-strip-prefix@docker"
+                      - "traefik.http.routers.api.rule=PathPrefix(`/api`)"
+                      - "traefik.http.services.api.loadbalancer.server.port=8585"
+                      - "traefik.expose=true"
+                    networks:
+                      - reportportal
+                    restart: always
+                  uat:
+                    image: %s
+                    environment:
+                      RP_DB_HOST: postgres
+                      RP_DB_PORT: 5432
+                      RP_DB_USER: rpuser
+                      RP_DB_PASS: %s
+                      RP_DB_NAME: reportportal
+                      RP_AMQP_HOST: rabbitmq
+                      RP_AMQP_PORT: 5672
+                      RP_AMQP_USER: rabbitmq
+                      RP_AMQP_PASS: %s
+                      RP_INITIAL_ADMIN_PASSWORD: %s
+                    volumes:
+                      - storage:/data/storage
+                    labels:
+                      - "traefik.http.middlewares.uat-strip-prefix.stripprefix.prefixes=/uat"
+                      - "traefik.http.routers.uat.middlewares=uat-strip-prefix@docker"
+                      - "traefik.http.routers.uat.rule=PathPrefix(`/uat`)"
+                      - "traefik.http.services.uat.loadbalancer.server.port=9999"
+                      - "traefik.expose=true"
+                    depends_on:
+                      postgres:
+                        condition: service_healthy
+                    networks:
+                      - reportportal
+                    restart: always
+                  jobs:
+                    image: %s
+                    depends_on:
+                      rabbitmq:
+                        condition: service_healthy
+                      gateway:
+                        condition: service_started
+                      postgres:
+                        condition: service_healthy
+                    environment:
+                      RP_DB_HOST: postgres
+                      RP_DB_PORT: 5432
+                      RP_DB_USER: rpuser
+                      RP_DB_PASS: %s
+                      RP_DB_NAME: reportportal
+                      RP_AMQP_HOST: rabbitmq
+                      RP_AMQP_PORT: 5672
+                      RP_AMQP_USER: rabbitmq
+                      RP_AMQP_PASS: %s
+                      DATASTORE_TYPE: filesystem
+                    volumes:
+                      - storage:/data/storage
+                    healthcheck:
+                      test: ["CMD-SHELL", "curl -f http://localhost:8686/health || wget -q --spider http://localhost:8686/health || exit 1"]
+                      interval: 30s
+                      timeout: 10s
+                      retries: 3
+                      start_period: 60s
+                    labels:
+                      - "traefik.http.middlewares.jobs-strip-prefix.stripprefix.prefixes=/jobs"
+                      - "traefik.http.routers.jobs.middlewares=jobs-strip-prefix@docker"
+                      - "traefik.http.routers.jobs.rule=PathPrefix(`/jobs`)"
+                      - "traefik.http.services.jobs.loadbalancer.server.port=8686"
+                      - "traefik.expose=true"
+                    networks:
+                      - reportportal
+                    restart: always
+                configs:
+                  rabbitmq_extra_config:
+                    content: |
+                      deprecated_features.permit.queue_master_locator = true
+                      disk_free_limit.absolute = 50MB
+                  rabbitmq_enabled_plugins:
+                    content: |
+                      [rabbitmq_management,rabbitmq_consistent_hash_exchange,rabbitmq_auth_backend_ldap,rabbitmq_shovel,rabbitmq_shovel_management].
+                volumes:
+                  storage:
+                  postgres:
+                networks:
+                  reportportal:
+                """.formatted(GATEWAY_IMAGE, scale.uiPort(), POSTGRES_IMAGE, LOCAL_DEV_DB_PASSWORD,
+                RABBITMQ_IMAGE, LOCAL_DEV_AMQP_PASSWORD, MIGRATIONS_IMAGE, LOCAL_DEV_DB_PASSWORD,
+                INDEX_IMAGE, UI_IMAGE, API_IMAGE, LOCAL_DEV_DB_PASSWORD, LOCAL_DEV_AMQP_PASSWORD,
+                LOCAL_DEV_AMQP_PASSWORD, UAT_IMAGE, LOCAL_DEV_DB_PASSWORD, LOCAL_DEV_AMQP_PASSWORD,
+                LOCAL_DEV_ADMIN_PASSWORD, JOBS_IMAGE, LOCAL_DEV_DB_PASSWORD, LOCAL_DEV_AMQP_PASSWORD);
+    }
+
+    static ReportPortalScale scale(SetupSelection selection) {
+        int ui = selected(selection, "ui_", DEFAULT_UI_PORT, 1024, 65535, "ReportPortal UI port");
+        for (String component : selection.components()) {
+            if (!component.startsWith("ui_")) {
+                throw new IllegalArgumentException("Unsupported ReportPortal component: " + component);
+            }
+        }
+        return new ReportPortalScale(ui);
+    }
+
+    static SetupSelection selectionFromScale(ReportPortalScale scale) {
+        if (scale.uiPort() == DEFAULT_UI_PORT) return SetupSelection.defaults();
+        return new SetupSelection(List.of("ui_" + scale.uiPort()));
+    }
+
+    private static int selected(SetupSelection selection, String prefix, int defaultValue, int min, int max,
+                                String label) {
+        List<String> values = selection.components().stream().filter(component -> component.startsWith(prefix)).toList();
+        if (values.size() > 1) throw new IllegalArgumentException("Select at most one " + label + '.');
+        int value = defaultValue;
+        if (!values.isEmpty()) {
+            try {
+                value = Integer.parseInt(values.getFirst().substring(prefix.length()));
+            } catch (NumberFormatException invalid) {
+                throw new IllegalArgumentException(label + " must be a decimal integer.", invalid);
+            }
+        }
+        if (value < min || value > max) {
+            throw new IllegalArgumentException(label + " must be between " + min + " and " + max + '.');
+        }
+        return value;
+    }
+
+    private static int parsePort(String value) {
+        return selected(new SetupSelection(List.of("ui_" + value)), "ui_", DEFAULT_UI_PORT, 1024, 65535,
+                "ReportPortal UI port");
+    }
+
+    private static String spec(ReportPortalScale scale) {
+        return PIN + ",ui=" + scale.uiPort();
+    }
+
+    private static String sha256(String value) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.UTF_8));
+            return "sha256:" + HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
+    }
+
+    record ReportPortalScale(int uiPort) { }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalSetupProvider.java
@@ -1,0 +1,122 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+
+/** Built-in provider for a pinned, dev-only ReportPortal compose project. */
+final class ReportPortalSetupProvider implements SetupProvider {
+    private final ReportPortalOperationsFactory operationsFactory;
+    private final ReportPortalLifecycleFactory lifecycleFactory;
+
+    ReportPortalSetupProvider() {
+        this(DefaultReportPortalToolchainOperations::new, ReportPortalRuntimeManager::systemLifecycle);
+    }
+
+    ReportPortalSetupProvider(ReportPortalOperationsFactory operationsFactory) {
+        this(operationsFactory, ReportPortalRuntimeManager::systemLifecycle);
+    }
+
+    ReportPortalSetupProvider(ReportPortalOperationsFactory operationsFactory,
+                              ReportPortalLifecycleFactory lifecycleFactory) {
+        this.operationsFactory = java.util.Objects.requireNonNull(operationsFactory, "operationsFactory");
+        this.lifecycleFactory = java.util.Objects.requireNonNull(lifecycleFactory, "lifecycleFactory");
+    }
+
+    @Override
+    public SetupProfile profile() {
+        return SetupProfile.REPORT_PORTAL;
+    }
+
+    @Override
+    public SetupPlan plan(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return plan(options, SetupSelection.defaults(), platform, architecture);
+    }
+
+    @Override
+    public SetupPlan plan(SetupOptions options, SetupSelection selection,
+                          SetupPlatform platform, SetupArchitecture architecture) {
+        return ReportPortalSetupPlanner.plan(platform, architecture, options.effectiveMode(), selection);
+    }
+
+    @Override
+    public SetupSelection selectionFromPlan(SetupPlan plan) {
+        return ReportPortalSetupPlanner.selectionFromPlan(plan);
+    }
+
+    @Override
+    public SetupReport status(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return status(options, SetupSelection.defaults(), platform, architecture);
+    }
+
+    @Override
+    public SetupReport status(SetupOptions options, SetupSelection selection,
+                              SetupPlatform platform, SetupArchitecture architecture) {
+        SetupPlan plan = plan(options, selection, platform, architecture);
+        if (options.effectiveMode() == SetupMode.EXTERNAL) return externalStatus(plan);
+        ReportPortalToolchainOperations operations = operationsFactory.create(options.paths(), plan, options.offline());
+        return SetupReport.from(new ReportPortalSetupService(options.paths(), plan, operations, options.offline())
+                .status());
+    }
+
+    @Override
+    public SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        ReportPortalToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        SetupReceipt receipt = new ReportPortalSetupService(options.paths(), providerPlan, operations,
+                options.offline()).install(providerPlan,
+                new SetupApproval(providerPlan.digest(), approval.approvedAt(), approval.acceptedLicenses()));
+        return new SetupReceipt(plan.digest(), receipt.completedAt(), receipt.completedActions());
+    }
+
+    @Override
+    public ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        ReportPortalToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        ManagedEnvironment inner = lifecycleFactory.create(options.paths(), providerPlan, operations)
+                .start(providerPlan, new SetupApproval(providerPlan.digest(), approval.approvedAt(),
+                        approval.acceptedLicenses()), options);
+        SetupReceipt receipt = new SetupReceipt(plan.digest(), inner.receipt().completedAt(),
+                inner.receipt().completedActions());
+        return new ManagedEnvironment(profile(), receipt, inner.endpoint(), inner.connectionProperties(),
+                inner::close);
+    }
+
+    @Override
+    public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        ReportPortalToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), providerPlan, operations).stop(options.shutdownTimeout());
+    }
+
+    @Override
+    public String logs(SetupOptions options, SetupSelection selection, SetupPlatform platform,
+                       SetupArchitecture architecture) throws IOException {
+        SetupPlan plan = plan(options, selection, platform, architecture);
+        ReportPortalToolchainOperations operations = operationsFactory.create(options.paths(), plan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), plan, operations).logs();
+    }
+
+    private SetupPlan canonicalPlan(SetupPlan plan, SetupOptions options) {
+        if (options.profile() != profile()) {
+            throw new IllegalArgumentException("Options do not select ReportPortal setup.");
+        }
+        SetupPlan canonical = ReportPortalSetupPlanner.plan(plan.platform(), plan.architecture(), plan.mode(),
+                ReportPortalSetupPlanner.selectionFromPlan(plan));
+        if (!SetupPlan.bind(canonical, options.policyDigest()).equals(plan)) {
+            throw new IllegalArgumentException(
+                    "Plan does not match the ReportPortal manifest shipped with this release.");
+        }
+        return canonical;
+    }
+
+    private SetupReport externalStatus(SetupPlan plan) {
+        return SetupReport.from(new SetupProfileStatus(1, profile(), SetupReadiness.MISSING,
+                plan.actions().stream().map(action -> new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                        "External mode is diagnostic-only and does not execute managed tools.")).toList()));
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalSetupService.java
@@ -1,0 +1,151 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Transaction coordinator for one exact ReportPortal setup plan. */
+final class ReportPortalSetupService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private final ShaftCachePaths paths;
+    private final SetupPlan expectedPlan;
+    private final ReportPortalToolchainOperations operations;
+    private final boolean offline;
+
+    ReportPortalSetupService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                             ReportPortalToolchainOperations operations, boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.expectedPlan = java.util.Objects.requireNonNull(expectedPlan, "expectedPlan");
+        this.operations = java.util.Objects.requireNonNull(operations, "operations");
+        this.offline = offline;
+        if (expectedPlan.profile() != SetupProfile.REPORT_PORTAL) {
+            throw new IllegalArgumentException("ReportPortal setup requires the REPORT_PORTAL profile.");
+        }
+    }
+
+    SetupProfileStatus status() {
+        List<SetupStatus> targets = expectedPlan.actions().stream().map(operations::status).toList();
+        SetupReadiness readiness = targets.stream().allMatch(target -> target.readiness() == SetupReadiness.READY)
+                ? SetupReadiness.READY
+                : targets.stream().anyMatch(target -> target.readiness() == SetupReadiness.DEGRADED)
+                ? SetupReadiness.DEGRADED : SetupReadiness.MISSING;
+        if (readiness == SetupReadiness.READY && !hasCompatibleReceipt()) {
+            ArrayList<SetupStatus> adjusted = new ArrayList<>(targets);
+            SetupStatus last = adjusted.getLast();
+            adjusted.set(adjusted.size() - 1, new SetupStatus(last.target(), SetupReadiness.DEGRADED,
+                    last.detectedVersion(), "Managed files exist without a compatible SHAFT receipt."));
+            targets = List.copyOf(adjusted);
+            readiness = SetupReadiness.DEGRADED;
+        }
+        return new SetupProfileStatus(1, expectedPlan.profile(), readiness, targets);
+    }
+
+    SetupReceipt install(SetupPlan plan, SetupApproval approval) throws IOException {
+        requireCompatible(plan);
+        SetupExecutor.validate(plan, approval);
+        operations.hostPreflight(plan.actions());
+        Path lockPath = paths.state().resolve("reportportal.lock").toAbsolutePath().normalize();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        boolean acquired = false;
+        try {
+            jvmLock.lockInterruptibly();
+            acquired = true;
+            if (!Files.isDirectory(paths.state(), LinkOption.NOFOLLOW_LINKS)) {
+                operations.preStatePreflight(plan.actions(), offline);
+            }
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                operations.lockedPreflight(plan.actions(), offline);
+                invalidateReceipt();
+                SetupReceipt receipt = SetupExecutor.execute(plan, approval, action -> {
+                    try {
+                        operations.install(action);
+                    } catch (IOException failure) {
+                        throw new SetupOperationException(failure);
+                    }
+                });
+                Files.deleteIfExists(previousReceiptPath());
+                writeReceipt(receipt);
+                return receipt;
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the ReportPortal setup lock.", interrupted);
+        } finally {
+            if (acquired) jvmLock.unlock();
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan) {
+        if (plan.mode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External plans are diagnostic and cannot be installed.");
+        }
+        if (!expectedPlan.equals(plan)) {
+            throw new IllegalArgumentException(
+                    "Plan does not match the ReportPortal manifest shipped with this release.");
+        }
+    }
+
+    private void writeReceipt(SetupReceipt receipt) throws IOException {
+        Files.createDirectories(paths.receipts());
+        Path destination = receiptPath();
+        Path temporary = Files.createTempFile(paths.receipts(), "reportportal", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(receipt));
+            VerifiedArtifactStore.move(temporary, destination);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private boolean hasCompatibleReceipt() {
+        try {
+            Path receipt = receiptPath();
+            VerifiedArtifactStore.requireUnlinkedAncestors(receipt);
+            if (!Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)) return false;
+            SetupReceipt saved = JSON.readValue(receipt.toFile(), SetupReceipt.class);
+            return saved.planDigest().equals(expectedPlan.digest())
+                    && saved.completedActions().equals(expectedPlan.actions());
+        } catch (IOException | RuntimeException invalid) {
+            return false;
+        }
+    }
+
+    private Path receiptPath() {
+        return paths.receipts().resolve("reportportal.json");
+    }
+
+    private Path previousReceiptPath() {
+        return paths.receipts().resolve("reportportal.previous.json");
+    }
+
+    private void invalidateReceipt() throws IOException {
+        Path receipt = receiptPath();
+        Path previous = previousReceiptPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(receipt);
+        VerifiedArtifactStore.requireUnlinkedAncestors(previous);
+        if (!Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)) return;
+        Files.deleteIfExists(previous);
+        VerifiedArtifactStore.move(receipt, previous);
+    }
+
+    private static final class SetupOperationException extends RuntimeException {
+        private SetupOperationException(IOException cause) {
+            super(cause);
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/ReportPortalToolchainOperations.java
@@ -1,0 +1,49 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+/** Injectable host and mutation boundary for the ReportPortal setup transaction. */
+interface ReportPortalToolchainOperations {
+    void hostPreflight(List<SetupAction> actions) throws IOException;
+
+    default void preStatePreflight(List<SetupAction> actions, boolean offline) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
+        // ReportPortal has no safe read that must occur before the shared state directory exists.
+        // offline is part of the shared provider SPI and is unused until that read exists.
+        if (offline) return;
+    }
+
+    void lockedPreflight(List<SetupAction> actions, boolean offline) throws IOException;
+
+    void install(SetupAction action) throws IOException;
+
+    SetupStatus status(SetupAction action);
+
+    default void composeUp(Path composeFile, String project) throws IOException {
+        java.util.Objects.requireNonNull(composeFile, "composeFile");
+        java.util.Objects.requireNonNull(project, "project");
+        throw new UnsupportedOperationException("Compose start is not available.");
+    }
+
+    default void composeDown(Path composeFile, String project) throws IOException {
+        java.util.Objects.requireNonNull(composeFile, "composeFile");
+        java.util.Objects.requireNonNull(project, "project");
+        throw new UnsupportedOperationException("Compose stop is not available.");
+    }
+
+    default boolean composeRunning(Path composeFile, String project) throws IOException {
+        java.util.Objects.requireNonNull(composeFile, "composeFile");
+        java.util.Objects.requireNonNull(project, "project");
+        throw new IOException("Compose inspection is not available.");
+    }
+
+    default void awaitReady(URI ui, Duration timeout) throws IOException {
+        java.util.Objects.requireNonNull(ui, "ui");
+        java.util.Objects.requireNonNull(timeout, "timeout");
+        throw new UnsupportedOperationException("ReportPortal readiness is not available.");
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultReportPortalToolchainOperationsTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultReportPortalToolchainOperationsTest.java
@@ -1,0 +1,101 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultReportPortalToolchainOperationsTest {
+    @Test
+    void dockerProbeDoesNotCreateStateOrRequireALogFile(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        AtomicReference<Path> logged = new AtomicReference<>();
+        DefaultReportPortalToolchainOperations operations = new DefaultReportPortalToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) -> {
+                    logged.set(log);
+                    return new ReportingSetupService.ProcessResult(0, "Docker Compose version v2.34.0");
+                }, false);
+
+        operations.hostPreflight(plan().actions());
+
+        assertFalse(Files.exists(paths.state()));
+        assertTrue(logged.get() == null);
+    }
+
+    @Test
+    void composeInspectFailureIsNotTreatedAsStopped(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        DefaultReportPortalToolchainOperations operations = new DefaultReportPortalToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) -> {
+                    throw new java.io.IOException("docker daemon unavailable");
+                }, false);
+
+        assertThrows(java.io.IOException.class, () -> operations.composeRunning(
+                paths.tools().resolve("reportportal").resolve("docker-compose.yml"),
+                ReportPortalSetupPlanner.PROJECT));
+    }
+
+    @Test
+    void composeInspectNonZeroExitIsNotTreatedAsStopped(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        DefaultReportPortalToolchainOperations operations = new DefaultReportPortalToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) ->
+                new ReportingSetupService.ProcessResult(1, "cannot connect to docker"), false);
+
+        assertThrows(java.io.IOException.class, () -> operations.composeRunning(
+                paths.tools().resolve("reportportal").resolve("docker-compose.yml"),
+                ReportPortalSetupPlanner.PROJECT));
+    }
+
+    @Test
+    void composeInspectRefusesAnUnownedProject(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        DefaultReportPortalToolchainOperations operations = new DefaultReportPortalToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) ->
+                new ReportingSetupService.ProcessResult(0, "abc123"), false);
+
+        IOException failure = assertThrows(java.io.IOException.class, () -> operations.composeRunning(
+                paths.tools().resolve("reportportal").resolve("docker-compose.yml"), "reportportal"));
+        assertTrue(failure.getMessage().contains("unowned"));
+    }
+
+    @Test
+    void installThenStatusIsReadyAndComposeMutationDegrades(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        SetupPlan plan = plan();
+        DefaultReportPortalToolchainOperations operations = new DefaultReportPortalToolchainOperations(
+                paths, plan, (command, workingDirectory, environment, removed, stdin, log, timeout) ->
+                new ReportingSetupService.ProcessResult(0, "Docker Compose version v2.34.0"), false);
+        SetupAction reportPortal = plan.actions().stream()
+                .filter(action -> action.target() == SetupTarget.REPORT_PORTAL).findFirst().orElseThrow();
+
+        operations.install(reportPortal);
+
+        assertEquals(SetupReadiness.READY, operations.status(reportPortal).readiness());
+        Path compose = paths.tools().resolve("reportportal").resolve("docker-compose.yml");
+        assertTrue(Files.isRegularFile(compose));
+
+        Files.writeString(compose, Files.readString(compose) + "\n# mutated\n");
+        assertEquals(SetupReadiness.DEGRADED, operations.status(reportPortal).readiness());
+    }
+
+    private static SetupPlan plan() {
+        return ReportPortalSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64, SetupMode.MANAGED,
+                SetupSelection.defaults());
+    }
+
+    private static ShaftCachePaths paths(Path temp) {
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        return new ShaftCachePaths(cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts"));
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/ReportPortalLifecycleServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/ReportPortalLifecycleServiceTest.java
@@ -1,0 +1,197 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReportPortalLifecycleServiceTest {
+    @Test
+    void missingReceiptStartsNoComposeProject(@TempDir Path temp) {
+        Fixture fixture = uninstalled(temp);
+        RecordingOperations operations = new RecordingOperations();
+        ReportPortalLifecycleService lifecycle = new ReportPortalLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        IOException failure = assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+        assertTrue(failure.getMessage().contains("receipt"));
+        assertTrue(operations.ups.isEmpty());
+    }
+
+    @Test
+    void occupiedUiPortStartsNoComposeProject(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        ReportPortalLifecycleService lifecycle = new ReportPortalLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        try (ServerSocket occupied = new ServerSocket()) {
+            occupied.bind(new InetSocketAddress("127.0.0.1", 8080));
+
+            IOException failure = assertThrows(IOException.class,
+                    () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+            assertTrue(failure.getMessage().contains("8080"));
+            assertTrue(operations.ups.isEmpty());
+        }
+    }
+
+    @Test
+    void startReusesThenStopsOnlyTheOwnedProject(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        ReportPortalLifecycleService first = new ReportPortalLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        ManagedEnvironment firstEnv = first.start(fixture.plan(), fixture.approval(), fixture.options());
+        ManagedEnvironment secondEnv = first.start(fixture.plan(), fixture.approval(), fixture.options());
+
+        assertEquals(1, operations.ups.size());
+        assertEquals(ReportPortalSetupPlanner.PROJECT, operations.ups.getFirst());
+        assertEquals(URI.create("http://127.0.0.1:8080/ui/"), firstEnv.endpoint().orElseThrow());
+        assertEquals("8080", firstEnv.connectionProperties().get("serverPort"));
+        assertEquals("localhost", firstEnv.connectionProperties().get("serverHost"));
+        assertEquals(Set.of("serverHost", "serverPort"), firstEnv.connectionProperties().keySet());
+
+        firstEnv.close();
+        assertTrue(operations.downs.isEmpty());
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("reportportal-runtime.json")));
+
+        secondEnv.close();
+        assertEquals(List.of(ReportPortalSetupPlanner.PROJECT), operations.downs);
+        assertFalse(Files.exists(fixture.paths().state().resolve("reportportal-runtime.json")));
+    }
+
+    @Test
+    void composeInspectFailureDoesNotDropTheLeaseOrStopContainers(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        ReportPortalLifecycleService lifecycle = new ReportPortalLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+        lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+        operations.inspectFails = true;
+
+        assertThrows(IOException.class, () -> lifecycle.stop(Duration.ofSeconds(1)));
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("reportportal-runtime.json")));
+        assertTrue(operations.downs.isEmpty());
+    }
+
+    @Test
+    void logsMatchRuntimeIdentityWithoutRequiringTheManagedPlanDigest(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        ReportPortalLifecycleService managed = new ReportPortalLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+        managed.start(fixture.plan(), fixture.approval(), fixture.options());
+        Files.createDirectories(managed.logFile().getParent());
+        Files.writeString(managed.logFile(), "ui ready");
+
+        SetupPlan external = ReportPortalSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64,
+                SetupMode.EXTERNAL, SetupSelection.defaults());
+        ReportPortalLifecycleService diagnostic = new ReportPortalLifecycleService(
+                fixture.paths(), external, operations);
+
+        assertEquals("ui ready", diagnostic.logs());
+    }
+
+    @Test
+    void failedReadinessTearsDownOnlyTheOwnedProject(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        operations.ready = false;
+        ReportPortalLifecycleService lifecycle = new ReportPortalLifecycleService(
+                fixture.paths(), fixture.plan(), operations);
+
+        assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+        assertEquals(List.of(ReportPortalSetupPlanner.PROJECT), operations.ups);
+        assertEquals(List.of(ReportPortalSetupPlanner.PROJECT), operations.downs);
+    }
+
+    private static Fixture uninstalled(Path temp) {
+        return fixture(temp, false);
+    }
+
+    private static Fixture installed(Path temp) {
+        return fixture(temp, true);
+    }
+
+    private static Fixture fixture(Path temp, boolean installReceipt) {
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORT_PORTAL, paths)
+                .withMode(SetupMode.MANAGED).withTimeouts(Duration.ofSeconds(5), Duration.ofSeconds(5));
+        SetupPlan plan = ReportPortalSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64,
+                SetupMode.MANAGED, SetupSelection.defaults());
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+        if (installReceipt) {
+            try {
+                new ReportPortalSetupService(paths, plan, new RecordingOperations(), false).install(plan, approval);
+            } catch (IOException failure) {
+                throw new IllegalStateException(failure);
+            }
+        }
+        return new Fixture(paths, options, plan, approval);
+    }
+
+    private record Fixture(ShaftCachePaths paths, SetupOptions options, SetupPlan plan, SetupApproval approval) { }
+
+    private static final class RecordingOperations implements ReportPortalToolchainOperations {
+        private final List<String> ups = new ArrayList<>();
+        private final List<String> downs = new ArrayList<>();
+        private boolean running;
+        private boolean ready = true;
+        private boolean inspectFails;
+
+        @Override public void hostPreflight(List<SetupAction> actions) { /* no host mutation in this fixture */ }
+        @Override public void lockedPreflight(List<SetupAction> actions, boolean offline) { /* no locked preflight */ }
+        @Override public void install(SetupAction action) { /* receipt-only fixture */ }
+
+        @Override
+        public SetupStatus status(SetupAction action) {
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(), "fixture");
+        }
+
+        @Override
+        public void composeUp(Path composeFile, String project) {
+            ups.add(project);
+            running = true;
+        }
+
+        @Override
+        public void composeDown(Path composeFile, String project) {
+            downs.add(project);
+            running = false;
+        }
+
+        @Override
+        public boolean composeRunning(Path composeFile, String project) throws IOException {
+            if (inspectFails) throw new IOException("Unable to inspect the SHAFT ReportPortal compose project.");
+            return running;
+        }
+
+        @Override
+        public void awaitReady(URI ui, Duration timeout) throws IOException {
+            if (!ready) throw new IOException("ReportPortal did not become ready.");
+        }
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/ReportPortalSetupProviderTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/ReportPortalSetupProviderTest.java
@@ -1,0 +1,198 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReportPortalSetupProviderTest {
+    @Test
+    void builtInCoordinatorProvidesReportPortalPlan(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupOptions options = managed(temp);
+
+        assertTrue(service.supports(SetupProfile.REPORT_PORTAL));
+        SetupPlan plan = service.plan(options);
+
+        assertEquals(List.of(SetupTarget.DOCKER, SetupTarget.REPORT_PORTAL),
+                plan.actions().stream().map(SetupAction::target).toList());
+        assertEquals(SetupActionKind.DIAGNOSE, plan.actions().getFirst().kind());
+        assertEquals(SetupActionKind.INSTALL, plan.actions().getLast().kind());
+        assertEquals("5.15.5+5.15.4+18.4,ui=8080", plan.actions().getLast().version());
+        assertEquals(SetupSelection.defaults(), service.selectionFromPlan(plan));
+    }
+
+    @Test
+    void selectedUiPortIsBoundAndReconstructed(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.WINDOWS, SetupArchitecture.X64);
+        SetupOptions options = managed(temp);
+        SetupSelection selection = new SetupSelection(List.of("ui_9080"));
+
+        SetupPlan plan = service.plan(options, selection);
+
+        assertEquals(selection, service.selectionFromPlan(plan));
+        assertTrue(plan.actions().getLast().version().contains("ui=9080"));
+        assertThrows(IllegalArgumentException.class,
+                () -> service.plan(options, new SetupSelection(List.of("backend_8080"))));
+    }
+
+    @Test
+    void missingDockerPerformsNoInstallWrites(@TempDir Path temp) {
+        RecordingOperations operations = new RecordingOperations();
+        operations.dockerReady = false;
+        InfrastructureSetupService service = coordinator(operations);
+        SetupOptions options = managed(temp);
+        SetupPlan plan = service.plan(options);
+
+        IOException failure = assertThrows(IOException.class,
+                () -> service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+
+        assertTrue(failure.getMessage().contains("Docker"));
+        assertTrue(operations.events.contains("host-preflight"));
+        assertFalse(operations.events.stream().anyMatch(event -> event.startsWith("install:")));
+        assertFalse(Files.exists(options.paths().receipts().resolve("reportportal.json")));
+    }
+
+    @Test
+    void managedProviderInstallsTheExactComposeReceipt(@TempDir Path temp) throws Exception {
+        RecordingOperations operations = new RecordingOperations();
+        InfrastructureSetupService service = coordinator(operations);
+        SetupOptions options = managed(temp);
+        SetupPlan plan = service.plan(options);
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+
+        assertEquals(SetupReadiness.MISSING, service.status(options).readiness());
+        SetupReceipt receipt = service.install(plan, approval, options);
+
+        assertEquals(plan.digest(), receipt.planDigest());
+        assertEquals(plan.actions(), receipt.completedActions());
+        assertEquals(SetupReadiness.READY, service.status(options).readiness());
+        assertTrue(operations.events.contains("host-preflight"));
+        assertTrue(operations.events.contains("install:" + SetupTarget.REPORT_PORTAL));
+    }
+
+    @Test
+    void managedComposeUsesOfficialPinsWithoutHostDatabaseDashboardOrContainerNames() throws Exception {
+        String compose = ReportPortalSetupPlanner.compose(new ReportPortalSetupPlanner.ReportPortalScale(8080));
+        assertFalse(compose.contains("container_name:"));
+        assertFalse(compose.contains("5432:5432"));
+        assertFalse(compose.contains("8081:8081"));
+        assertFalse(compose.contains("443:443"));
+        assertEquals(Set.of("traefik:v2.11.54", "postgres:18.4", "rabbitmq:4.3.4-management",
+                "reportportal/migrations:5.15.4", "reportportal/service-index:5.15.1",
+                "reportportal/service-ui:5.15.5", "reportportal/service-api:5.15.4",
+                "reportportal/service-authorization:5.15.1", "reportportal/service-jobs:5.15.2"),
+                images(compose));
+        assertTrue(everyHealthyDependencyHasAHealthcheck(compose));
+        Path engineCompose = Path.of("").toAbsolutePath().resolve(
+                "../shaft-engine/src/main/resources/docker-compose/report-portal.yml");
+        assertTrue(Files.isRegularFile(engineCompose), engineCompose.toString());
+        String documented = Files.readString(engineCompose);
+        assertTrue(documented.contains("reportportal/service-ui:5.15.5"));
+        assertTrue(documented.contains("reportportal/service-api:5.15.4"));
+        assertTrue(documented.contains("reportportal/migrations:5.15.4"));
+        assertTrue(documented.contains("traefik:v2.11.54"));
+    }
+
+    @Test
+    void externalModeCannotInstall(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        SetupOptions options = SetupOptions.defaults(SetupProfile.REPORT_PORTAL, new ShaftCachePaths(
+                cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts")));
+        SetupPlan plan = service.plan(options);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+    }
+
+    private static boolean everyHealthyDependencyHasAHealthcheck(String compose) {
+        Matcher depends = Pattern.compile("(?m)^ {6}([A-Za-z0-9_-]+):\\s*$\\n {8}condition: service_healthy")
+                .matcher(compose);
+        boolean found = false;
+        while (depends.find()) {
+            found = true;
+            String service = depends.group(1);
+            Matcher block = Pattern.compile("(?ms)^ {2}" + Pattern.quote(service) + ":\\n(.*?)(?=^ {2}\\S|\\Z)")
+                    .matcher(compose);
+            if (!block.find() || !block.group(1).contains("healthcheck:")) return false;
+        }
+        return found;
+    }
+
+    private static Set<String> images(String compose) {
+        Matcher matcher = Pattern.compile("image:\\s*(\\S+)").matcher(compose);
+        java.util.LinkedHashSet<String> images = new java.util.LinkedHashSet<>();
+        while (matcher.find()) images.add(matcher.group(1));
+        return images;
+    }
+
+    private static InfrastructureSetupService coordinator(RecordingOperations operations) {
+        return new InfrastructureSetupService(new SetupProviderRegistry(
+                List.of(new ReportPortalSetupProvider((paths, plan, offline) -> operations))),
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+    }
+
+    private static SetupOptions managed(Path root) {
+        Path cache = root.resolve("cache");
+        Path data = root.resolve("data");
+        return SetupOptions.defaults(SetupProfile.REPORT_PORTAL, new ShaftCachePaths(
+                cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts")))
+                .withMode(SetupMode.MANAGED);
+    }
+
+    private static final class RecordingOperations implements ReportPortalToolchainOperations {
+        private final List<String> events = new ArrayList<>();
+        private boolean dockerReady = true;
+        private boolean installed;
+
+        @Override
+        public void hostPreflight(List<SetupAction> actions) throws IOException {
+            events.add("host-preflight");
+            if (!dockerReady) throw new IOException("Docker Engine 26.1.4+ and Compose v2 are required.");
+        }
+
+        @Override
+        public void lockedPreflight(List<SetupAction> actions, boolean offline) {
+            events.add("locked-preflight");
+        }
+
+        @Override
+        public void install(SetupAction action) {
+            events.add("install:" + action.target());
+            if (action.target() == SetupTarget.REPORT_PORTAL) installed = true;
+        }
+
+        @Override
+        public SetupStatus status(SetupAction action) {
+            events.add("status:" + action.target());
+            if (action.target() == SetupTarget.DOCKER) {
+                return new SetupStatus(action.target(),
+                        dockerReady ? SetupReadiness.READY : SetupReadiness.MISSING,
+                        dockerReady ? "26.1.4+" : "", dockerReady ? "fixture" : "Docker is missing.");
+            }
+            return new SetupStatus(action.target(),
+                    installed ? SetupReadiness.READY : SetupReadiness.MISSING,
+                    installed ? action.version() : "", installed ? "fixture" : "Compose is missing.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Owns a pinned, lease-safe, **dev-only** ReportPortal compose lifecycle for `shaft-cli setup` / `SHAFT.Infrastructure` (`SetupProfile.REPORT_PORTAL`).

- Unique compose project `shaft-reportportal` with official 2026-08-17 core pins (UI 5.15.5, API 5.15.4, postgres 18.4, Traefik v2.11.54).
- Docker stays a diagnosed host prerequisite. No `container_name`. Host-publish only UI `8080` (selectable `ui_N`). No host `5432`/`8081`/`443`.
- Setup never flips `rp.enable` and never writes API keys or passwords into connection properties (`serverHost`/`serverPort` only).
- Inspect failure throws (lease kept). Logs match `sameRuntime` so EXTERNAL can read a managed lease.
- Documented engine `report-portal.yml` reportportal/* tags aligned to 5.15.x.

Closes #5045. Related to #4849.

## Checks
- RED: `supports(REPORT_PORTAL)` was false; first test failed for the right reason.
- GREEN: `mvn -pl shaft-infrastructure "-Dtest=ReportPortalSetupProviderTest,ReportPortalLifecycleServiceTest,DefaultReportPortalToolchainOperationsTest" test` — 17 tests, BUILD SUCCESS (worktree cwd).
- Regression: `SetupCatalogTest`, `HealeniumSetupProviderTest`, `SeleniumGridSetupProviderTest` — 28 tests combined earlier, BUILD SUCCESS.
- Independent review requested a jobs `service_healthy` healthcheck plus compose-validity and inspect-nonzero-exit tests; those are in this commit.

## Continuation
- Head: `c9854b5492`
- State: first checkpoint pushed; PR opened against `main`.
- Blockers: none known locally.
- Next action: independent PR review, then `gh pr merge --auto --merge`, watch to confirmed merge, learning loop, next #4849 increment (BrowserStack Local / agent-tool).
