### PR TITLE
feat(setup): own managed BrowserStack Local lifecycle

### DIFF
--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -367,7 +367,7 @@ public final class SetupCommand implements Runnable {
         return switch (plan.profile()) {
             case OCR -> ocrSelection(plan, languages);
             case MOBILE_ANDROID -> android.selectionFromPlan(plan);
-            case MOBILE_IOS, MOBILE_WINDOWS, SELENIUM_GRID, HEALENIUM, REPORT_PORTAL -> {
+            case MOBILE_IOS, MOBILE_WINDOWS, SELENIUM_GRID, HEALENIUM, REPORT_PORTAL, BROWSERSTACK_LOCAL -> {
                 android.rejectIfSupplied(plan.profile());
                 yield InfrastructureSetupService.builtIn(plan.platform(), plan.architecture())
                         .selectionFromPlan(plan);

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalLifecycleFactory.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalLifecycleFactory.java
@@ -1,0 +1,7 @@
+package com.shaft.infrastructure;
+
+@FunctionalInterface
+interface BrowserStackLocalLifecycleFactory {
+    BrowserStackLocalLifecycleService create(ShaftCachePaths paths, SetupPlan plan,
+                                             BrowserStackLocalToolchainOperations operations);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalLifecycleService.java
@@ -1,0 +1,298 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+/** Lease-safe lifecycle owner for one verified SHAFT BrowserStack Local process. */
+final class BrowserStackLocalLifecycleService {
+    static final String ACCESS_KEY_ENV = "BROWSERSTACK_ACCESS_KEY";
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private final ShaftCachePaths paths;
+    private final SetupPlan expectedPlan;
+    private final BrowserStackLocalToolchainOperations operations;
+    private final Supplier<String> accessKey;
+
+    BrowserStackLocalLifecycleService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                                      BrowserStackLocalToolchainOperations operations) {
+        this(paths, expectedPlan, operations, () -> System.getenv(ACCESS_KEY_ENV));
+    }
+
+    BrowserStackLocalLifecycleService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                                      BrowserStackLocalToolchainOperations operations,
+                                      Supplier<String> accessKey) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.expectedPlan = java.util.Objects.requireNonNull(expectedPlan, "expectedPlan");
+        this.operations = java.util.Objects.requireNonNull(operations, "operations");
+        this.accessKey = java.util.Objects.requireNonNull(accessKey, "accessKey");
+        if (expectedPlan.profile() != SetupProfile.BROWSERSTACK_LOCAL) {
+            throw new IllegalArgumentException("BrowserStack Local lifecycle requires BROWSERSTACK_LOCAL.");
+        }
+    }
+
+    ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        requireCompatible(plan, options);
+        SetupExecutor.validate(plan, approval);
+        SetupReceipt receipt = requireInstallReceipt(plan);
+        requireInstalled(plan);
+        String accessKey = requireAccessKey(this.accessKey.get());
+        Path lockPath = lockPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        try {
+            jvmLock.lockInterruptibly();
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                receipt = requireInstallReceipt(plan);
+                requireInstalled(plan);
+                Optional<BrowserStackLocalRuntimeLease> reusable = readReusable(plan, options);
+                if (reusable.isPresent()) return environment(receipt, reusable.orElseThrow());
+                return startNew(plan, receipt, accessKey);
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the BrowserStack Local runtime lock.", interrupted);
+        } finally {
+            if (jvmLock.isHeldByCurrentThread()) jvmLock.unlock();
+        }
+    }
+
+    boolean stop(Duration timeout) throws IOException {
+        java.util.Objects.requireNonNull(timeout, "timeout");
+        Path lockPath = lockPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        if (Files.notExists(leasePath(), LinkOption.NOFOLLOW_LINKS)) return false;
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        jvmLock.lock();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Optional<BrowserStackLocalRuntimeLease> current = readLease();
+            if (current.isEmpty()) return false;
+            BrowserStackLocalRuntimeLease lease = current.orElseThrow();
+            requireLeaseIdentity(lease);
+            if (!operations.processRunning(lease.pid(), Path.of(lease.binary()))) {
+                Files.deleteIfExists(leasePath());
+                return false;
+            }
+            if (lease.refCount() > 1) {
+                writeLease(lease.withRefCount(lease.refCount() - 1));
+                return true;
+            }
+            operations.stopProcess(lease.pid(), Path.of(lease.binary()));
+            Files.deleteIfExists(leasePath());
+            return true;
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    String logs() throws IOException {
+        Optional<BrowserStackLocalRuntimeLease> current = readLease();
+        if (current.isEmpty()) return "";
+        BrowserStackLocalRuntimeLease lease = current.orElseThrow();
+        if (!lease.sameRuntime(expectedIdentity(expectedPlan, lease.pid()))) {
+            throw new IOException("BrowserStack Local lease does not match the requested runtime.");
+        }
+        return OwnedLogReader.read("BrowserStack Local", logFile());
+    }
+
+    Path logFile() {
+        return paths.state().resolve("logs").resolve("browserstack-local.log");
+    }
+
+    private ManagedEnvironment startNew(SetupPlan plan, SetupReceipt receipt, String accessKey) throws IOException {
+        Path binary = binaryFile();
+        long pid = 0;
+        try {
+            pid = operations.startTunnel(binary, accessKey, logFile());
+            if (!operations.processRunning(pid, binary)) {
+                throw new IOException("BrowserStack Local process exited before it could be leased.");
+            }
+            BrowserStackLocalRuntimeLease lease = new BrowserStackLocalRuntimeLease(1, plan.digest(), pid,
+                    binary.toString(), 1);
+            writeLease(lease);
+            return environment(receipt, lease);
+        } catch (IOException | RuntimeException failure) {
+            if (pid > 0) {
+                try {
+                    operations.stopProcess(pid, binary);
+                } catch (IOException cleanup) {
+                    failure.addSuppressed(cleanup);
+                }
+            }
+            throw failure;
+        }
+    }
+
+    private Optional<BrowserStackLocalRuntimeLease> readReusable(SetupPlan plan, SetupOptions options)
+            throws IOException {
+        Optional<BrowserStackLocalRuntimeLease> existing = readLease();
+        if (existing.isEmpty()) return Optional.empty();
+        BrowserStackLocalRuntimeLease lease = existing.orElseThrow();
+        if (!lease.planDigest().equals(plan.digest()) || !lease.sameIdentity(expectedIdentity(plan, lease.pid()))) {
+            throw new IOException("An existing SHAFT BrowserStack Local lease does not match the reviewed plan.");
+        }
+        if (!operations.processRunning(lease.pid(), Path.of(lease.binary()))) {
+            Files.deleteIfExists(leasePath());
+            return Optional.empty();
+        }
+        if (!options.reuseOwnedProcesses()) {
+            throw new IOException("A compatible SHAFT BrowserStack Local process is already active and reuse is disabled.");
+        }
+        BrowserStackLocalRuntimeLease incremented = lease.withRefCount(lease.refCount() + 1);
+        writeLease(incremented);
+        return Optional.of(incremented);
+    }
+
+    private BrowserStackLocalRuntimeLease expectedIdentity(SetupPlan plan, long pid) {
+        return new BrowserStackLocalRuntimeLease(1, plan.digest(), pid, binaryFile().toString(), 1);
+    }
+
+    private ManagedEnvironment environment(SetupReceipt receipt, BrowserStackLocalRuntimeLease lease) {
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("local", "true");
+        properties.put("binary", lease.binary());
+        return new ManagedEnvironment(SetupProfile.BROWSERSTACK_LOCAL, receipt,
+                Optional.of(URI.create("urn:shaft:browserstack-local:" + lease.pid())), Map.copyOf(properties), () -> {
+                    try {
+                        release(lease);
+                    } catch (IOException failure) {
+                        throw new IllegalStateException("Failed to release the owned BrowserStack Local process.",
+                                failure);
+                    }
+                });
+    }
+
+    private void release(BrowserStackLocalRuntimeLease started) throws IOException {
+        Path lockPath = lockPath();
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        jvmLock.lock();
+        try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock ignored = channel.lock()) {
+            Optional<BrowserStackLocalRuntimeLease> current = readLease();
+            if (current.isEmpty()) return;
+            BrowserStackLocalRuntimeLease lease = current.orElseThrow();
+            if (!lease.sameIdentity(started)) {
+                throw new IOException("BrowserStack Local lease changed; refusing to stop an unowned process.");
+            }
+            if (lease.refCount() > 1) {
+                writeLease(lease.withRefCount(lease.refCount() - 1));
+                return;
+            }
+            operations.stopProcess(lease.pid(), Path.of(lease.binary()));
+            Files.deleteIfExists(leasePath());
+        } finally {
+            jvmLock.unlock();
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan, SetupOptions options) {
+        if (plan.profile() != SetupProfile.BROWSERSTACK_LOCAL
+                || options.profile() != SetupProfile.BROWSERSTACK_LOCAL) {
+            throw new IllegalArgumentException("BrowserStack Local lifecycle requires profile BROWSERSTACK_LOCAL.");
+        }
+        if (plan.mode() == SetupMode.EXTERNAL || options.effectiveMode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External BrowserStack Local setup cannot start a managed tunnel.");
+        }
+        if (!expectedPlan.equals(plan)) {
+            throw new IllegalArgumentException("BrowserStack Local lifecycle plan does not match the release manifest.");
+        }
+    }
+
+    static String requireAccessKey(String key) throws IOException {
+        if (key == null || key.isBlank()) {
+            throw new IOException("BROWSERSTACK_ACCESS_KEY must be set in the environment before start.");
+        }
+        return key;
+    }
+
+    private SetupReceipt requireInstallReceipt(SetupPlan plan) throws IOException {
+        Path receiptPath = paths.receipts().resolve("browserstack-local.json");
+        VerifiedArtifactStore.requireUnlinkedAncestors(receiptPath);
+        if (!Files.isRegularFile(receiptPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("A complete compatible BrowserStack Local install receipt is required before start.");
+        }
+        SetupReceipt receipt;
+        try {
+            receipt = JSON.readValue(receiptPath.toFile(), SetupReceipt.class);
+        } catch (RuntimeException invalid) {
+            throw new IOException("BrowserStack Local install receipt is invalid.", invalid);
+        }
+        if (!receipt.planDigest().equals(plan.digest()) || !receipt.completedActions().equals(plan.actions())) {
+            throw new IOException("BrowserStack Local install receipt does not match the reviewed plan.");
+        }
+        return receipt;
+    }
+
+    private void requireInstalled(SetupPlan plan) throws IOException {
+        for (SetupAction action : plan.actions()) {
+            SetupStatus status = operations.status(action);
+            if (status.readiness() != SetupReadiness.READY) {
+                throw new IOException(action.target() + " is not ready: " + status.detail());
+            }
+        }
+    }
+
+    private void requireLeaseIdentity(BrowserStackLocalRuntimeLease lease) throws IOException {
+        if (!lease.sameIdentity(expectedIdentity(expectedPlan, lease.pid()))) {
+            throw new IOException("BrowserStack Local lease does not match the requested plan.");
+        }
+    }
+
+    private Optional<BrowserStackLocalRuntimeLease> readLease() throws IOException {
+        Path path = leasePath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(path);
+        if (!Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) return Optional.empty();
+        try {
+            BrowserStackLocalRuntimeLease lease = JSON.readValue(path.toFile(), BrowserStackLocalRuntimeLease.class);
+            if (lease.schemaVersion() != 1 || lease.refCount() < 1 || lease.pid() < 1) {
+                throw new IOException("Invalid BrowserStack Local lease.");
+            }
+            return Optional.of(lease);
+        } catch (RuntimeException invalid) {
+            throw new IOException("BrowserStack Local runtime lease is invalid.", invalid);
+        }
+    }
+
+    private void writeLease(BrowserStackLocalRuntimeLease lease) throws IOException {
+        Files.createDirectories(paths.state());
+        Path temporary = Files.createTempFile(paths.state(), "browserstack-local-runtime", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(lease));
+            VerifiedArtifactStore.move(temporary, leasePath());
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private Path binaryFile() {
+        BrowserStackLocalSetupPlanner.Asset asset = BrowserStackLocalSetupPlanner.asset(
+                expectedPlan.platform(), expectedPlan.architecture());
+        return paths.tools().resolve("browserstack-local").resolve(asset.executableName());
+    }
+
+    private Path leasePath() {
+        return paths.state().resolve("browserstack-local-runtime.json");
+    }
+
+    private Path lockPath() {
+        return paths.state().resolve("browserstack-local-runtime.lock").toAbsolutePath().normalize();
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalLifecycleService.java
@@ -64,7 +64,7 @@ final class BrowserStackLocalLifecycleService {
                 requireInstalled(plan);
                 Optional<BrowserStackLocalRuntimeLease> reusable = readReusable(plan, options);
                 if (reusable.isPresent()) return environment(receipt, reusable.orElseThrow());
-                return startNew(plan, receipt, accessKey);
+                return startNew(plan, receipt, accessKey, options.startupTimeout());
             }
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();
@@ -117,7 +117,8 @@ final class BrowserStackLocalLifecycleService {
         return paths.state().resolve("logs").resolve("browserstack-local.log");
     }
 
-    private ManagedEnvironment startNew(SetupPlan plan, SetupReceipt receipt, String accessKey) throws IOException {
+    private ManagedEnvironment startNew(SetupPlan plan, SetupReceipt receipt, String accessKey, Duration timeout)
+            throws IOException {
         Path binary = binaryFile();
         long pid = 0;
         try {
@@ -125,6 +126,7 @@ final class BrowserStackLocalLifecycleService {
             if (!operations.processRunning(pid, binary)) {
                 throw new IOException("BrowserStack Local process exited before it could be leased.");
             }
+            operations.awaitReady(timeout);
             BrowserStackLocalRuntimeLease lease = new BrowserStackLocalRuntimeLease(1, plan.digest(), pid,
                     binary.toString(), 1);
             writeLease(lease);

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalOperationsFactory.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalOperationsFactory.java
@@ -1,0 +1,6 @@
+package com.shaft.infrastructure;
+
+@FunctionalInterface
+interface BrowserStackLocalOperationsFactory {
+    BrowserStackLocalToolchainOperations create(ShaftCachePaths paths, SetupPlan plan, boolean offline);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalRuntimeLease.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalRuntimeLease.java
@@ -1,0 +1,28 @@
+package com.shaft.infrastructure;
+
+record BrowserStackLocalRuntimeLease(int schemaVersion, String planDigest, long pid, String binary,
+                                     int refCount) {
+    BrowserStackLocalRuntimeLease {
+        if (schemaVersion != 1) throw new IllegalArgumentException("Unsupported BrowserStack Local lease schema.");
+        if (planDigest == null || planDigest.isBlank()) throw new IllegalArgumentException("Plan digest is required.");
+        if (pid < 1) throw new IllegalArgumentException("Owned process id must be positive.");
+        if (binary == null || binary.isBlank()) throw new IllegalArgumentException("Binary path is required.");
+        if (refCount < 1) throw new IllegalArgumentException("Lease refcount must be positive.");
+    }
+
+    BrowserStackLocalRuntimeLease withRefCount(int value) {
+        return new BrowserStackLocalRuntimeLease(schemaVersion, planDigest, pid, binary, value);
+    }
+
+    boolean sameIdentity(BrowserStackLocalRuntimeLease other) {
+        return other != null
+                && planDigest.equals(other.planDigest)
+                && sameRuntime(other);
+    }
+
+    boolean sameRuntime(BrowserStackLocalRuntimeLease other) {
+        return other != null
+                && pid == other.pid
+                && binary.equals(other.binary);
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalRuntimeManager.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalRuntimeManager.java
@@ -1,0 +1,12 @@
+package com.shaft.infrastructure;
+
+final class BrowserStackLocalRuntimeManager {
+    private BrowserStackLocalRuntimeManager() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static BrowserStackLocalLifecycleService systemLifecycle(ShaftCachePaths paths, SetupPlan plan,
+                                                             BrowserStackLocalToolchainOperations operations) {
+        return new BrowserStackLocalLifecycleService(paths, plan, operations);
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalSetupPlanner.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalSetupPlanner.java
@@ -1,0 +1,47 @@
+package com.shaft.infrastructure;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+
+/** Release-coupled plans for a pinned BrowserStack Local binary. */
+final class BrowserStackLocalSetupPlanner {
+    static final String VERSION = "8.9";
+    private static final String BASE =
+            "https://bstack-local-prod.s3.amazonaws.com/binaries/release/v8.9/";
+
+    private BrowserStackLocalSetupPlanner() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static SetupPlan plan(SetupPlatform platform, SetupArchitecture architecture, SetupMode mode) {
+        Asset asset = asset(platform, architecture);
+        SetupActionKind kind = mode == SetupMode.EXTERNAL ? SetupActionKind.DIAGNOSE : SetupActionKind.INSTALL;
+        return SetupPlan.create(SetupProfile.BROWSERSTACK_LOCAL, platform, architecture, mode, List.of(
+                new SetupAction(SetupTarget.BROWSERSTACK_LOCAL, kind, VERSION, asset.source(),
+                        "sha256:" + asset.sha256(), asset.bytes(), false, Set.of())));
+    }
+
+    static Asset asset(SetupPlatform platform, SetupArchitecture architecture) {
+        if (platform == SetupPlatform.LINUX && architecture == SetupArchitecture.ARM64) {
+            throw new IllegalArgumentException(
+                    "BrowserStack Local v8.9 has no versioned Linux ARM64 archive; use x64 or a later pin.");
+        }
+        return switch (platform) {
+            case WINDOWS -> new Asset(
+                    URI.create(BASE + "BrowserStackLocal-win32.zip"),
+                    "50af684795f0b3d6a1e7c429be45aea9d5828ec68890f49b4770bcc5bb73581f",
+                    9_583_769, "BrowserStackLocal.exe");
+            case LINUX -> new Asset(
+                    URI.create(BASE + "BrowserStackLocal-linux-x64.zip"),
+                    "6f10351faef2af198fb8188c5ce9b4ec449cf9ca5f119f0d999b5de2aa03166d",
+                    12_300_194, "BrowserStackLocal");
+            case MACOS -> new Asset(
+                    URI.create(BASE + "BrowserStackLocal-darwin-x64.zip"),
+                    "4e0177235b549afe1f9bbe5b2b797d884f2b96806049fa2c089377bea3cf2fed",
+                    10_284_773, "BrowserStackLocal");
+        };
+    }
+
+    record Asset(URI source, String sha256, long bytes, String executableName) { }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalSetupProvider.java
@@ -1,0 +1,103 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+
+/** Built-in provider for a pinned BrowserStack Local binary. */
+final class BrowserStackLocalSetupProvider implements SetupProvider {
+    private final BrowserStackLocalOperationsFactory operationsFactory;
+    private final BrowserStackLocalLifecycleFactory lifecycleFactory;
+
+    BrowserStackLocalSetupProvider() {
+        this(DefaultBrowserStackLocalToolchainOperations::new, BrowserStackLocalRuntimeManager::systemLifecycle);
+    }
+
+    BrowserStackLocalSetupProvider(BrowserStackLocalOperationsFactory operationsFactory) {
+        this(operationsFactory, BrowserStackLocalRuntimeManager::systemLifecycle);
+    }
+
+    BrowserStackLocalSetupProvider(BrowserStackLocalOperationsFactory operationsFactory,
+                                   BrowserStackLocalLifecycleFactory lifecycleFactory) {
+        this.operationsFactory = java.util.Objects.requireNonNull(operationsFactory, "operationsFactory");
+        this.lifecycleFactory = java.util.Objects.requireNonNull(lifecycleFactory, "lifecycleFactory");
+    }
+
+    @Override
+    public SetupProfile profile() {
+        return SetupProfile.BROWSERSTACK_LOCAL;
+    }
+
+    @Override
+    public SetupPlan plan(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return BrowserStackLocalSetupPlanner.plan(platform, architecture, options.effectiveMode());
+    }
+
+    @Override
+    public SetupReport status(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        SetupPlan plan = plan(options, platform, architecture);
+        if (options.effectiveMode() == SetupMode.EXTERNAL) {
+            return SetupReport.from(new SetupProfileStatus(1, profile(), SetupReadiness.MISSING,
+                    plan.actions().stream().map(action -> new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                            "External mode is diagnostic-only and does not execute managed tools.")).toList()));
+        }
+        BrowserStackLocalToolchainOperations operations = operationsFactory.create(options.paths(), plan,
+                options.offline());
+        return SetupReport.from(new BrowserStackLocalSetupService(options.paths(), plan, operations, options.offline())
+                .status());
+    }
+
+    @Override
+    public SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        BrowserStackLocalToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        SetupReceipt receipt = new BrowserStackLocalSetupService(options.paths(), providerPlan, operations,
+                options.offline()).install(providerPlan,
+                new SetupApproval(providerPlan.digest(), approval.approvedAt(), approval.acceptedLicenses()));
+        return new SetupReceipt(plan.digest(), receipt.completedAt(), receipt.completedActions());
+    }
+
+    @Override
+    public ManagedEnvironment start(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        BrowserStackLocalToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        ManagedEnvironment inner = lifecycleFactory.create(options.paths(), providerPlan, operations)
+                .start(providerPlan, new SetupApproval(providerPlan.digest(), approval.approvedAt(),
+                        approval.acceptedLicenses()), options);
+        SetupReceipt receipt = new SetupReceipt(plan.digest(), inner.receipt().completedAt(),
+                inner.receipt().completedActions());
+        return new ManagedEnvironment(profile(), receipt, inner.endpoint(), inner.connectionProperties(),
+                inner::close);
+    }
+
+    @Override
+    public boolean stop(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        BrowserStackLocalToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), providerPlan, operations).stop(options.shutdownTimeout());
+    }
+
+    @Override
+    public String logs(SetupOptions options, SetupSelection selection, SetupPlatform platform,
+                       SetupArchitecture architecture) throws IOException {
+        SetupPlan plan = plan(options, platform, architecture);
+        BrowserStackLocalToolchainOperations operations = operationsFactory.create(options.paths(), plan,
+                options.offline());
+        return lifecycleFactory.create(options.paths(), plan, operations).logs();
+    }
+
+    private SetupPlan canonicalPlan(SetupPlan plan, SetupOptions options) {
+        if (options.profile() != profile()) {
+            throw new IllegalArgumentException("Options do not select BrowserStack Local setup.");
+        }
+        SetupPlan canonical = BrowserStackLocalSetupPlanner.plan(plan.platform(), plan.architecture(), plan.mode());
+        if (!SetupPlan.bind(canonical, options.policyDigest()).equals(plan)) {
+            throw new IllegalArgumentException(
+                    "Plan does not match the BrowserStack Local manifest shipped with this release.");
+        }
+        return canonical;
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalSetupService.java
@@ -1,0 +1,150 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Transaction coordinator for one exact BrowserStack Local setup plan. */
+final class BrowserStackLocalSetupService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private final ShaftCachePaths paths;
+    private final SetupPlan expectedPlan;
+    private final BrowserStackLocalToolchainOperations operations;
+    private final boolean offline;
+
+    BrowserStackLocalSetupService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                                  BrowserStackLocalToolchainOperations operations, boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.expectedPlan = java.util.Objects.requireNonNull(expectedPlan, "expectedPlan");
+        this.operations = java.util.Objects.requireNonNull(operations, "operations");
+        this.offline = offline;
+        if (expectedPlan.profile() != SetupProfile.BROWSERSTACK_LOCAL) {
+            throw new IllegalArgumentException("BrowserStack Local setup requires the BROWSERSTACK_LOCAL profile.");
+        }
+    }
+
+    SetupProfileStatus status() {
+        List<SetupStatus> targets = expectedPlan.actions().stream().map(operations::status).toList();
+        SetupReadiness readiness = targets.stream().allMatch(target -> target.readiness() == SetupReadiness.READY)
+                ? SetupReadiness.READY
+                : targets.stream().anyMatch(target -> target.readiness() == SetupReadiness.DEGRADED)
+                ? SetupReadiness.DEGRADED : SetupReadiness.MISSING;
+        if (readiness == SetupReadiness.READY && !hasCompatibleReceipt()) {
+            ArrayList<SetupStatus> adjusted = new ArrayList<>(targets);
+            SetupStatus last = adjusted.getLast();
+            adjusted.set(adjusted.size() - 1, new SetupStatus(last.target(), SetupReadiness.DEGRADED,
+                    last.detectedVersion(), "Managed files exist without a compatible SHAFT receipt."));
+            targets = List.copyOf(adjusted);
+            readiness = SetupReadiness.DEGRADED;
+        }
+        return new SetupProfileStatus(1, expectedPlan.profile(), readiness, targets);
+    }
+
+    SetupReceipt install(SetupPlan plan, SetupApproval approval) throws IOException {
+        requireCompatible(plan);
+        SetupExecutor.validate(plan, approval);
+        operations.hostPreflight(plan.actions());
+        Path lockPath = paths.state().resolve("browserstack-local.lock").toAbsolutePath().normalize();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        boolean acquired = false;
+        try {
+            jvmLock.lockInterruptibly();
+            acquired = true;
+            if (!Files.isDirectory(paths.state(), LinkOption.NOFOLLOW_LINKS)) {
+                operations.preStatePreflight(plan.actions(), offline);
+            }
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                operations.lockedPreflight(plan.actions(), offline);
+                invalidateReceipt();
+                SetupReceipt receipt = SetupExecutor.execute(plan, approval, action -> {
+                    try {
+                        operations.install(action);
+                    } catch (IOException failure) {
+                        throw new SetupOperationException(failure);
+                    }
+                });
+                Files.deleteIfExists(previousReceiptPath());
+                writeReceipt(receipt);
+                return receipt;
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the BrowserStack Local setup lock.", interrupted);
+        } finally {
+            if (acquired) jvmLock.unlock();
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan) {
+        if (plan.mode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External plans are diagnostic and cannot be installed.");
+        }
+        if (!expectedPlan.equals(plan)) {
+            throw new IllegalArgumentException(
+                    "Plan does not match the BrowserStack Local manifest shipped with this release.");
+        }
+    }
+
+    private void writeReceipt(SetupReceipt receipt) throws IOException {
+        Files.createDirectories(paths.receipts());
+        Path temporary = Files.createTempFile(paths.receipts(), "browserstack-local", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(receipt));
+            VerifiedArtifactStore.move(temporary, receiptPath());
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private boolean hasCompatibleReceipt() {
+        try {
+            Path receipt = receiptPath();
+            VerifiedArtifactStore.requireUnlinkedAncestors(receipt);
+            if (!Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)) return false;
+            SetupReceipt saved = JSON.readValue(receipt.toFile(), SetupReceipt.class);
+            return saved.planDigest().equals(expectedPlan.digest())
+                    && saved.completedActions().equals(expectedPlan.actions());
+        } catch (IOException | RuntimeException invalid) {
+            return false;
+        }
+    }
+
+    private Path receiptPath() {
+        return paths.receipts().resolve("browserstack-local.json");
+    }
+
+    private Path previousReceiptPath() {
+        return paths.receipts().resolve("browserstack-local.previous.json");
+    }
+
+    private void invalidateReceipt() throws IOException {
+        Path receipt = receiptPath();
+        Path previous = previousReceiptPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(receipt);
+        VerifiedArtifactStore.requireUnlinkedAncestors(previous);
+        if (!Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)) return;
+        Files.deleteIfExists(previous);
+        VerifiedArtifactStore.move(receipt, previous);
+    }
+
+    private static final class SetupOperationException extends RuntimeException {
+        private SetupOperationException(IOException cause) {
+            super(cause);
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalToolchainOperations.java
@@ -2,6 +2,7 @@ package com.shaft.infrastructure;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 
 /** Injectable host and mutation boundary for BrowserStack Local. */
@@ -34,5 +35,10 @@ interface BrowserStackLocalToolchainOperations {
     default void stopProcess(long pid, Path binary) throws IOException {
         java.util.Objects.requireNonNull(binary, "binary");
         throw new UnsupportedOperationException("BrowserStack Local stop is not available.");
+    }
+
+    default void awaitReady(Duration timeout) throws IOException {
+        java.util.Objects.requireNonNull(timeout, "timeout");
+        throw new UnsupportedOperationException("BrowserStack Local readiness is not available.");
     }
 }

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalToolchainOperations.java
@@ -1,0 +1,38 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/** Injectable host and mutation boundary for BrowserStack Local. */
+interface BrowserStackLocalToolchainOperations {
+    void hostPreflight(List<SetupAction> actions) throws IOException;
+
+    default void preStatePreflight(List<SetupAction> actions, boolean offline) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
+        if (offline) return;
+    }
+
+    void lockedPreflight(List<SetupAction> actions, boolean offline) throws IOException;
+
+    void install(SetupAction action) throws IOException;
+
+    SetupStatus status(SetupAction action);
+
+    default long startTunnel(Path binary, String accessKey, Path logFile) throws IOException {
+        java.util.Objects.requireNonNull(binary, "binary");
+        java.util.Objects.requireNonNull(accessKey, "accessKey");
+        java.util.Objects.requireNonNull(logFile, "logFile");
+        throw new UnsupportedOperationException("BrowserStack Local start is not available.");
+    }
+
+    default boolean processRunning(long pid, Path binary) throws IOException {
+        java.util.Objects.requireNonNull(binary, "binary");
+        throw new IOException("BrowserStack Local process inspection is not available.");
+    }
+
+    default void stopProcess(long pid, Path binary) throws IOException {
+        java.util.Objects.requireNonNull(binary, "binary");
+        throw new UnsupportedOperationException("BrowserStack Local stop is not available.");
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperations.java
@@ -1,10 +1,17 @@
 package com.shaft.infrastructure;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,6 +61,7 @@ final class DefaultBrowserStackLocalToolchainOperations implements BrowserStackL
             Path binary = binaryFile();
             Path quarantine = root.resolve(asset().executableName() + ".prev");
             VerifiedArtifactStore.replaceWithRollback(staged, binary, quarantine);
+            Files.writeString(digestFile(), sha256(binary));
             if (plan.platform() != SetupPlatform.WINDOWS && !binary.toFile().setExecutable(true, false)) {
                 throw new IOException("Unable to mark the BrowserStack Local binary executable: " + binary);
             }
@@ -71,11 +79,13 @@ final class DefaultBrowserStackLocalToolchainOperations implements BrowserStackL
                 return new SetupStatus(action.target(), SetupReadiness.MISSING, "",
                         "Managed BrowserStack Local binary is missing.");
             }
-            Path cached = store.fetch(action, true);
-            if (!Files.isRegularFile(cached, LinkOption.NOFOLLOW_LINKS)) {
+            Path digest = digestFile();
+            if (!Files.isRegularFile(digest, LinkOption.NOFOLLOW_LINKS)
+                    || !sha256(binary).equalsIgnoreCase(Files.readString(digest).trim())) {
                 return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "",
-                        "Verified BrowserStack Local archive is missing.");
+                        "Staged BrowserStack Local binary does not match the install digest.");
             }
+            store.fetch(action, true);
             return new SetupStatus(action.target(), SetupReadiness.READY, action.version(),
                     "Staged BrowserStack Local binary matches the reviewed plan.");
         } catch (IOException failure) {
@@ -110,8 +120,11 @@ final class DefaultBrowserStackLocalToolchainOperations implements BrowserStackL
         Optional<ProcessHandle> handle = ProcessHandle.of(pid);
         if (handle.isEmpty() || !handle.orElseThrow().isAlive()) return false;
         Optional<String> command = handle.orElseThrow().info().command();
-        return command.isEmpty() || command.orElseThrow().equals(binary.toString())
-                || command.orElseThrow().endsWith(binary.getFileName().toString());
+        if (command.isEmpty()) {
+            throw new IOException("Unable to confirm BrowserStack Local process identity for pid " + pid + '.');
+        }
+        String observed = command.orElseThrow();
+        return observed.equals(binary.toString()) || observed.endsWith(binary.getFileName().toString());
     }
 
     @Override
@@ -121,11 +134,60 @@ final class DefaultBrowserStackLocalToolchainOperations implements BrowserStackL
         }
         Optional<ProcessHandle> handle = ProcessHandle.of(pid);
         if (handle.isEmpty() || !handle.orElseThrow().isAlive()) return;
-        handle.orElseThrow().destroy();
+        ProcessHandle live = handle.orElseThrow();
+        live.destroy();
+        try {
+            live.onExit().get(5, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception waited) {
+            live.destroyForcibly();
+        }
+    }
+
+    @Override
+    public void awaitReady(Duration timeout) throws IOException {
+        Instant deadline = Instant.now().plus(timeout);
+        IOException last = new IOException("BrowserStack Local did not become ready.");
+        URI probe = URI.create("http://127.0.0.1:45691/");
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                HttpURLConnection connection = (HttpURLConnection) probe.toURL().openConnection();
+                try {
+                    connection.setConnectTimeout(1_000);
+                    connection.setReadTimeout(1_000);
+                    connection.setRequestMethod("GET");
+                    int code = connection.getResponseCode();
+                    if (code >= 200 && code < 500) return;
+                    last = new IOException("BrowserStack Local status returned HTTP " + code + '.');
+                } finally {
+                    connection.disconnect();
+                }
+            } catch (IOException failure) {
+                last = failure;
+            }
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for BrowserStack Local.", interrupted);
+            }
+        }
+        throw last;
     }
 
     private Path binaryFile() {
         return paths.tools().resolve("browserstack-local").resolve(asset().executableName());
+    }
+
+    private Path digestFile() {
+        return Path.of(binaryFile() + ".sha256");
+    }
+
+    private static String sha256(Path file) throws IOException {
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(file)));
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
     }
 
     private BrowserStackLocalSetupPlanner.Asset asset() {

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperations.java
@@ -1,0 +1,143 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+/** Host download/extract/process implementation for BrowserStack Local. */
+final class DefaultBrowserStackLocalToolchainOperations implements BrowserStackLocalToolchainOperations {
+    private final ShaftCachePaths paths;
+    private final SetupPlan plan;
+    private final VerifiedArtifactStore store;
+    private final boolean offline;
+
+    DefaultBrowserStackLocalToolchainOperations(ShaftCachePaths paths, SetupPlan plan, boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.plan = java.util.Objects.requireNonNull(plan, "plan");
+        this.store = new VerifiedArtifactStore(paths.downloads());
+        this.offline = offline;
+    }
+
+    @Override
+    public void hostPreflight(List<SetupAction> actions) {
+        java.util.Objects.requireNonNull(actions, "actions");
+    }
+
+    @Override
+    public void lockedPreflight(List<SetupAction> actions, boolean requireOffline) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
+        VerifiedArtifactStore.requireUnlinkedAncestors(binaryFile());
+        if ((offline || requireOffline) && !Files.isRegularFile(binaryFile(), LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Offline BrowserStack Local setup requires a staged binary.");
+        }
+    }
+
+    @Override
+    public void install(SetupAction action) throws IOException {
+        if (action.target() != SetupTarget.BROWSERSTACK_LOCAL) {
+            throw new IllegalArgumentException("Unsupported BrowserStack Local install target: " + action.target());
+        }
+        Path archive = store.fetch(action, offline);
+        Path root = paths.tools().resolve("browserstack-local");
+        Files.createDirectories(root);
+        Path staging = Files.createTempDirectory(root, "extract-");
+        try {
+            SafeZipExtractor.extract(archive, staging);
+            Path staged = staging.resolve(asset().executableName());
+            if (!Files.isRegularFile(staged, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException("BrowserStack Local archive did not contain " + asset().executableName() + '.');
+            }
+            Path binary = binaryFile();
+            Path quarantine = root.resolve(asset().executableName() + ".prev");
+            VerifiedArtifactStore.replaceWithRollback(staged, binary, quarantine);
+            if (plan.platform() != SetupPlatform.WINDOWS && !binary.toFile().setExecutable(true, false)) {
+                throw new IOException("Unable to mark the BrowserStack Local binary executable: " + binary);
+            }
+        } finally {
+            deleteTree(staging);
+        }
+    }
+
+    @Override
+    public SetupStatus status(SetupAction action) {
+        try {
+            Path binary = binaryFile();
+            VerifiedArtifactStore.requireUnlinkedAncestors(binary);
+            if (!Files.isRegularFile(binary, LinkOption.NOFOLLOW_LINKS)) {
+                return new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                        "Managed BrowserStack Local binary is missing.");
+            }
+            Path cached = store.fetch(action, true);
+            if (!Files.isRegularFile(cached, LinkOption.NOFOLLOW_LINKS)) {
+                return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "",
+                        "Verified BrowserStack Local archive is missing.");
+            }
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(),
+                    "Staged BrowserStack Local binary matches the reviewed plan.");
+        } catch (IOException failure) {
+            return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "", failure.getMessage());
+        }
+    }
+
+    @Override
+    public long startTunnel(Path binary, String accessKey, Path logFile) throws IOException {
+        if (!binary.equals(binaryFile())) {
+            throw new IOException("Refusing to start an unowned BrowserStack Local binary.");
+        }
+        if (accessKey.isBlank()) throw new IOException("BrowserStack access key must not be blank.");
+        Files.createDirectories(logFile.getParent());
+        ProcessBuilder builder = new ProcessBuilder(startCommand(binary, accessKey))
+                .directory(binary.getParent().toFile())
+                .redirectErrorStream(true)
+                .redirectOutput(logFile.toFile());
+        Process process = builder.start();
+        return process.pid();
+    }
+
+    static List<String> startCommand(Path binary, String accessKey) {
+        return List.of(binary.toString(), "--key", java.util.Objects.requireNonNull(accessKey, "accessKey"));
+    }
+
+    @Override
+    public boolean processRunning(long pid, Path binary) throws IOException {
+        if (!binary.equals(binaryFile())) {
+            throw new IOException("Refusing to inspect an unowned BrowserStack Local binary.");
+        }
+        Optional<ProcessHandle> handle = ProcessHandle.of(pid);
+        if (handle.isEmpty() || !handle.orElseThrow().isAlive()) return false;
+        Optional<String> command = handle.orElseThrow().info().command();
+        return command.isEmpty() || command.orElseThrow().equals(binary.toString())
+                || command.orElseThrow().endsWith(binary.getFileName().toString());
+    }
+
+    @Override
+    public void stopProcess(long pid, Path binary) throws IOException {
+        if (!binary.equals(binaryFile())) {
+            throw new IOException("Refusing to stop an unowned BrowserStack Local binary.");
+        }
+        Optional<ProcessHandle> handle = ProcessHandle.of(pid);
+        if (handle.isEmpty() || !handle.orElseThrow().isAlive()) return;
+        handle.orElseThrow().destroy();
+    }
+
+    private Path binaryFile() {
+        return paths.tools().resolve("browserstack-local").resolve(asset().executableName());
+    }
+
+    private BrowserStackLocalSetupPlanner.Asset asset() {
+        return BrowserStackLocalSetupPlanner.asset(plan.platform(), plan.architecture());
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        if (!Files.exists(root)) return;
+        try (var walk = Files.walk(root)) {
+            for (Path path : walk.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(path);
+            }
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
@@ -27,7 +27,8 @@ public final class InfrastructureSetupService {
         List<SetupProvider> providers = new java.util.ArrayList<>(List.of(
                 new ReportingSetupProvider(), new OcrSetupProvider(), new LighthouseSetupProvider(),
                 new PlaywrightSetupProvider(), new AndroidSetupProvider(), new SeleniumGridSetupProvider(),
-                new HealeniumSetupProvider(), new ReportPortalSetupProvider()));
+                new HealeniumSetupProvider(), new ReportPortalSetupProvider(),
+                new BrowserStackLocalSetupProvider()));
         if (platform == SetupPlatform.MACOS) providers.add(new IosSetupProvider());
         if (platform == SetupPlatform.WINDOWS) providers.add(new WindowsSetupProvider());
         ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/BrowserStackLocalLifecycleServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/BrowserStackLocalLifecycleServiceTest.java
@@ -167,5 +167,10 @@ class BrowserStackLocalLifecycleServiceTest {
             stops.add(pid);
             running = false;
         }
+
+        @Override
+        public void awaitReady(Duration timeout) throws IOException {
+            if (!running) throw new IOException("BrowserStack Local did not become ready.");
+        }
     }
 }

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/BrowserStackLocalLifecycleServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/BrowserStackLocalLifecycleServiceTest.java
@@ -1,0 +1,171 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BrowserStackLocalLifecycleServiceTest {
+    @Test
+    void missingReceiptStartsNoProcess(@TempDir Path temp) {
+        Fixture fixture = uninstalled(temp);
+        RecordingOperations operations = new RecordingOperations();
+        BrowserStackLocalLifecycleService lifecycle = new BrowserStackLocalLifecycleService(
+                fixture.paths(), fixture.plan(), operations, () -> "test-key");
+
+        IOException failure = assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+        assertTrue(failure.getMessage().contains("receipt"));
+        assertTrue(operations.starts.isEmpty());
+    }
+
+    @Test
+    void missingAccessKeyStartsNoProcess(@TempDir Path temp) {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        BrowserStackLocalLifecycleService lifecycle = new BrowserStackLocalLifecycleService(
+                fixture.paths(), fixture.plan(), operations, () -> "");
+
+        IOException failure = assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+
+        assertTrue(failure.getMessage().contains("BROWSERSTACK_ACCESS_KEY"));
+        assertTrue(operations.starts.isEmpty());
+    }
+
+    @Test
+    void startReusesThenStopsOnlyTheOwnedPid(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        BrowserStackLocalLifecycleService lifecycle = new BrowserStackLocalLifecycleService(
+                fixture.paths(), fixture.plan(), operations, () -> "test-key");
+
+        ManagedEnvironment first = lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+        ManagedEnvironment second = lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+
+        assertEquals(1, operations.starts.size());
+        assertEquals(Set.of("local", "binary"), first.connectionProperties().keySet());
+        assertFalse(first.connectionProperties().values().toString().contains("test-key"));
+        assertFalse(Files.readString(fixture.paths().state().resolve("browserstack-local-runtime.json"))
+                .contains("test-key"));
+
+        first.close();
+        assertTrue(operations.stops.isEmpty());
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("browserstack-local-runtime.json")));
+
+        second.close();
+        assertEquals(List.of(4242L), operations.stops);
+        assertFalse(Files.exists(fixture.paths().state().resolve("browserstack-local-runtime.json")));
+        assertFalse(operations.commands.stream().anyMatch(command -> command.contains("--daemon")));
+    }
+
+    @Test
+    void inspectFailureDoesNotDropTheLeaseOrStopTheProcess(@TempDir Path temp) throws Exception {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        BrowserStackLocalLifecycleService lifecycle = new BrowserStackLocalLifecycleService(
+                fixture.paths(), fixture.plan(), operations, () -> "test-key");
+        lifecycle.start(fixture.plan(), fixture.approval(), fixture.options());
+        operations.inspectFails = true;
+
+        assertThrows(IOException.class, () -> lifecycle.stop(Duration.ofSeconds(1)));
+        assertTrue(Files.isRegularFile(fixture.paths().state().resolve("browserstack-local-runtime.json")));
+        assertTrue(operations.stops.isEmpty());
+    }
+
+    @Test
+    void failedReadinessTearsDownTheStartedProcess(@TempDir Path temp) {
+        Fixture fixture = installed(temp);
+        RecordingOperations operations = new RecordingOperations();
+        operations.dieImmediately = true;
+        BrowserStackLocalLifecycleService lifecycle = new BrowserStackLocalLifecycleService(
+                fixture.paths(), fixture.plan(), operations, () -> "test-key");
+
+        assertThrows(IOException.class,
+                () -> lifecycle.start(fixture.plan(), fixture.approval(), fixture.options()));
+        assertEquals(List.of(4242L), operations.stops);
+        assertFalse(Files.exists(fixture.paths().state().resolve("browserstack-local-runtime.json")));
+    }
+
+    private static Fixture uninstalled(Path temp) {
+        return fixture(temp, false);
+    }
+
+    private static Fixture installed(Path temp) {
+        return fixture(temp, true);
+    }
+
+    private static Fixture fixture(Path temp, boolean installReceipt) {
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        ShaftCachePaths paths = new ShaftCachePaths(cache, data, cache.resolve("downloads"),
+                data.resolve("tools"), data.resolve("state"), data.resolve("receipts"));
+        SetupOptions options = SetupOptions.defaults(SetupProfile.BROWSERSTACK_LOCAL, paths)
+                .withMode(SetupMode.MANAGED).withTimeouts(Duration.ofSeconds(5), Duration.ofSeconds(5));
+        SetupPlan plan = BrowserStackLocalSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64,
+                SetupMode.MANAGED);
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+        if (installReceipt) {
+            try {
+                new BrowserStackLocalSetupService(paths, plan, new RecordingOperations(), false)
+                        .install(plan, approval);
+            } catch (IOException failure) {
+                throw new IllegalStateException(failure);
+            }
+        }
+        return new Fixture(paths, options, plan, approval);
+    }
+
+    private record Fixture(ShaftCachePaths paths, SetupOptions options, SetupPlan plan, SetupApproval approval) { }
+
+    private static final class RecordingOperations implements BrowserStackLocalToolchainOperations {
+        private final List<String> starts = new ArrayList<>();
+        private final List<Long> stops = new ArrayList<>();
+        private final List<String> commands = new ArrayList<>();
+        private boolean running;
+        private boolean inspectFails;
+        private boolean dieImmediately;
+
+        @Override public void hostPreflight(List<SetupAction> actions) { /* fixture */ }
+        @Override public void lockedPreflight(List<SetupAction> actions, boolean offline) { /* fixture */ }
+        @Override public void install(SetupAction action) { /* receipt-only fixture */ }
+
+        @Override
+        public SetupStatus status(SetupAction action) {
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(), "fixture");
+        }
+
+        @Override
+        public long startTunnel(Path binary, String accessKey, Path logFile) {
+            starts.add(binary.toString());
+            commands.add(binary + " --key (redacted)");
+            running = !dieImmediately;
+            return 4242L;
+        }
+
+        @Override
+        public boolean processRunning(long pid, Path binary) throws IOException {
+            if (inspectFails) throw new IOException("Unable to inspect the owned BrowserStack Local process.");
+            return running && pid == 4242L;
+        }
+
+        @Override
+        public void stopProcess(long pid, Path binary) {
+            stops.add(pid);
+            running = false;
+        }
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/BrowserStackLocalSetupProviderTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/BrowserStackLocalSetupProviderTest.java
@@ -1,0 +1,125 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BrowserStackLocalSetupProviderTest {
+    @Test
+    void builtInCoordinatorProvidesBrowserStackLocalPlan(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupOptions options = managed(temp);
+
+        assertTrue(service.supports(SetupProfile.BROWSERSTACK_LOCAL));
+        SetupPlan plan = service.plan(options);
+
+        assertEquals(List.of(SetupTarget.BROWSERSTACK_LOCAL),
+                plan.actions().stream().map(SetupAction::target).toList());
+        assertEquals(SetupActionKind.INSTALL, plan.actions().getFirst().kind());
+        assertEquals("8.9", plan.actions().getFirst().version());
+        assertTrue(plan.actions().getFirst().source().toString().contains("/v8.9/BrowserStackLocal-linux-x64.zip"));
+        assertEquals("sha256:6f10351faef2af198fb8188c5ce9b4ec449cf9ca5f119f0d999b5de2aa03166d",
+                plan.actions().getFirst().checksum());
+    }
+
+    @Test
+    void linuxArm64IsUnsupported() {
+        assertThrows(IllegalArgumentException.class, () -> BrowserStackLocalSetupPlanner.plan(
+                SetupPlatform.LINUX, SetupArchitecture.ARM64, SetupMode.MANAGED));
+    }
+
+    @Test
+    void macosUsesDarwinX64EvenOnArm() {
+        SetupPlan plan = BrowserStackLocalSetupPlanner.plan(
+                SetupPlatform.MACOS, SetupArchitecture.ARM64, SetupMode.MANAGED);
+        assertTrue(plan.actions().getFirst().source().toString().contains("darwin-x64"));
+    }
+
+    @Test
+    void managedProviderInstallsTheExactReceipt(@TempDir Path temp) throws Exception {
+        RecordingOperations operations = new RecordingOperations();
+        InfrastructureSetupService service = coordinator(operations);
+        SetupOptions options = managed(temp);
+        SetupPlan plan = service.plan(options);
+        SetupApproval approval = new SetupApproval(plan.digest(), Instant.EPOCH, Set.of());
+
+        assertEquals(SetupReadiness.MISSING, service.status(options).readiness());
+        SetupReceipt receipt = service.install(plan, approval, options);
+
+        assertEquals(plan.digest(), receipt.planDigest());
+        assertEquals(SetupReadiness.READY, service.status(options).readiness());
+        assertTrue(operations.events.contains("install:" + SetupTarget.BROWSERSTACK_LOCAL));
+    }
+
+    @Test
+    void externalModeCannotInstall(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.WINDOWS, SetupArchitecture.X64);
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        SetupOptions options = SetupOptions.defaults(SetupProfile.BROWSERSTACK_LOCAL, new ShaftCachePaths(
+                cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts")));
+        SetupPlan plan = service.plan(options);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+        assertFalse(Files.exists(options.paths().receipts().resolve("browserstack-local.json")));
+    }
+
+    private static InfrastructureSetupService coordinator(RecordingOperations operations) {
+        return new InfrastructureSetupService(new SetupProviderRegistry(
+                List.of(new BrowserStackLocalSetupProvider((paths, plan, offline) -> operations))),
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+    }
+
+    private static SetupOptions managed(Path root) {
+        Path cache = root.resolve("cache");
+        Path data = root.resolve("data");
+        return SetupOptions.defaults(SetupProfile.BROWSERSTACK_LOCAL, new ShaftCachePaths(
+                cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts")))
+                .withMode(SetupMode.MANAGED);
+    }
+
+    private static final class RecordingOperations implements BrowserStackLocalToolchainOperations {
+        private final List<String> events = new ArrayList<>();
+        private boolean installed;
+
+        @Override
+        public void hostPreflight(List<SetupAction> actions) {
+            events.add("host-preflight");
+        }
+
+        @Override
+        public void lockedPreflight(List<SetupAction> actions, boolean offline) {
+            events.add("locked-preflight");
+        }
+
+        @Override
+        public void install(SetupAction action) {
+            events.add("install:" + action.target());
+            installed = true;
+        }
+
+        @Override
+        public SetupStatus status(SetupAction action) {
+            return new SetupStatus(action.target(),
+                    installed ? SetupReadiness.READY : SetupReadiness.MISSING,
+                    installed ? action.version() : "", installed ? "fixture" : "Binary is missing.");
+        }
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperationsTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperationsTest.java
@@ -1,0 +1,57 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultBrowserStackLocalToolchainOperationsTest {
+    @Test
+    void startRefusesAnUnownedBinary(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        DefaultBrowserStackLocalToolchainOperations operations = new DefaultBrowserStackLocalToolchainOperations(
+                paths, plan(), false);
+
+        IOException failure = assertThrows(java.io.IOException.class,
+                () -> operations.startTunnel(temp.resolve("BrowserStackLocal"), "key", paths.state().resolve("x.log")));
+        assertTrue(failure.getMessage().contains("unowned"));
+    }
+
+    @Test
+    void stopRefusesAnUnownedBinary(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        DefaultBrowserStackLocalToolchainOperations operations = new DefaultBrowserStackLocalToolchainOperations(
+                paths, plan(), false);
+
+        IOException failure = assertThrows(java.io.IOException.class,
+                () -> operations.stopProcess(1, temp.resolve("BrowserStackLocal")));
+        assertTrue(failure.getMessage().contains("unowned"));
+    }
+
+    @Test
+    void startCommandNeverUsesDaemonMode(@TempDir Path temp) {
+        List<String> command = DefaultBrowserStackLocalToolchainOperations.startCommand(
+                temp.resolve("BrowserStackLocal"), "secret-key");
+        assertFalse(command.contains("--daemon"));
+        assertFalse(command.contains("stop"));
+        assertEquals(List.of(temp.resolve("BrowserStackLocal").toString(), "--key", "secret-key"), command);
+    }
+
+    private static SetupPlan plan() {
+        return BrowserStackLocalSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64, SetupMode.MANAGED);
+    }
+
+    private static ShaftCachePaths paths(Path temp) {
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        return new ShaftCachePaths(cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts"));
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperationsTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperationsTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -42,6 +43,19 @@ class DefaultBrowserStackLocalToolchainOperationsTest {
         assertFalse(command.contains("--daemon"));
         assertFalse(command.contains("stop"));
         assertEquals(List.of(temp.resolve("BrowserStackLocal").toString(), "--key", "secret-key"), command);
+    }
+
+    @Test
+    void mutatedBinaryDegradesStatus(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        DefaultBrowserStackLocalToolchainOperations operations = new DefaultBrowserStackLocalToolchainOperations(
+                paths, plan(), false);
+        Path binary = paths.tools().resolve("browserstack-local").resolve("BrowserStackLocal");
+        Files.createDirectories(binary.getParent());
+        Files.writeString(binary, "not-the-official-binary");
+        Files.writeString(Path.of(binary + ".sha256"), "deadbeef");
+
+        assertEquals(SetupReadiness.DEGRADED, operations.status(plan().actions().getFirst()).readiness());
     }
 
     private static SetupPlan plan() {


### PR DESCRIPTION
## Summary
Owns a pinned, lease-safe BrowserStack Local binary for `shaft-cli setup` / `SHAFT.Infrastructure`.

- Pins official Local Binary **v8.9** from versioned S3 (`win32`, `linux-x64`, `darwin-x64`). Linux ARM64 is fail-closed (no v8.9 archive). macOS Apple silicon uses darwin-x64 (vendor Rosetta docs).
- Start requires `BROWSERSTACK_ACCESS_KEY` from the environment and never writes the key into receipts, leases, or connection properties.
- Stop destroys only the SHAFT-owned PID. Production start argv is `--key` only — never `--daemon stop`.
- Reinstall stages into a temp directory and atomically replaces the binary.

Closes #5047. Related to #4849.

## Checks
- RED: `supports(BROWSERSTACK_LOCAL)` was false.
- GREEN: `mvn -pl shaft-infrastructure "-Dtest=BrowserStackLocalSetupProviderTest,BrowserStackLocalLifecycleServiceTest,DefaultBrowserStackLocalToolchainOperationsTest" test` — 13 tests, BUILD SUCCESS (worktree cwd).
- Independent review of `fd1ab508c2498970f17d2438cd7138bc95252b41` found zero blocking findings (key absence, owned PID, `--daemon` argv, Linux ARM64, start teardown, digest status).
- Remote: Unit Tests (shaft-infrastructure) SUCCESS on this head.

## Continuation
- Head: `fd1ab508c2498970f17d2438cd7138bc95252b41`
- State: independent review posted; arming merge-when-green.
- Blockers: none known locally. Codex comment is a usage-limit notice, not a code finding.
- Next action: watch required checks to confirmed merge, then remaining #4849 (agent-tools diagnostics, audit/docs, #5040).
