### PR TITLE
fix(setup): wait for BrowserStack Local process death

### DIFF
--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalLifecycleService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalLifecycleService.java
@@ -95,7 +95,7 @@ final class BrowserStackLocalLifecycleService {
                 writeLease(lease.withRefCount(lease.refCount() - 1));
                 return true;
             }
-            operations.stopProcess(lease.pid(), Path.of(lease.binary()));
+            operations.stopProcess(lease.pid(), Path.of(lease.binary()), timeout);
             Files.deleteIfExists(leasePath());
             return true;
         } finally {
@@ -134,7 +134,7 @@ final class BrowserStackLocalLifecycleService {
         } catch (IOException | RuntimeException failure) {
             if (pid > 0) {
                 try {
-                    operations.stopProcess(pid, binary);
+                    operations.stopProcess(pid, binary, timeout);
                 } catch (IOException cleanup) {
                     failure.addSuppressed(cleanup);
                 }
@@ -198,7 +198,7 @@ final class BrowserStackLocalLifecycleService {
                 writeLease(lease.withRefCount(lease.refCount() - 1));
                 return;
             }
-            operations.stopProcess(lease.pid(), Path.of(lease.binary()));
+            operations.stopProcess(lease.pid(), Path.of(lease.binary()), Duration.ofSeconds(5));
             Files.deleteIfExists(leasePath());
         } finally {
             jvmLock.unlock();

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/BrowserStackLocalToolchainOperations.java
@@ -32,8 +32,9 @@ interface BrowserStackLocalToolchainOperations {
         throw new IOException("BrowserStack Local process inspection is not available.");
     }
 
-    default void stopProcess(long pid, Path binary) throws IOException {
+    default void stopProcess(long pid, Path binary, Duration timeout) throws IOException {
         java.util.Objects.requireNonNull(binary, "binary");
+        java.util.Objects.requireNonNull(timeout, "timeout");
         throw new UnsupportedOperationException("BrowserStack Local stop is not available.");
     }
 

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperations.java
@@ -128,18 +128,28 @@ final class DefaultBrowserStackLocalToolchainOperations implements BrowserStackL
     }
 
     @Override
-    public void stopProcess(long pid, Path binary) throws IOException {
+    public void stopProcess(long pid, Path binary, Duration timeout) throws IOException {
         if (!binary.equals(binaryFile())) {
             throw new IOException("Refusing to stop an unowned BrowserStack Local binary.");
         }
+        java.util.Objects.requireNonNull(timeout, "timeout");
         Optional<ProcessHandle> handle = ProcessHandle.of(pid);
         if (handle.isEmpty() || !handle.orElseThrow().isAlive()) return;
         ProcessHandle live = handle.orElseThrow();
         live.destroy();
+        if (awaitExit(live, timeout)) return;
+        live.destroyForcibly();
+        if (!awaitExit(live, timeout)) {
+            throw new IOException("BrowserStack Local process " + pid + " did not exit.");
+        }
+    }
+
+    private static boolean awaitExit(ProcessHandle live, Duration timeout) {
         try {
-            live.onExit().get(5, java.util.concurrent.TimeUnit.SECONDS);
-        } catch (Exception waited) {
-            live.destroyForcibly();
+            live.onExit().get(Math.max(1, timeout.toMillis()), java.util.concurrent.TimeUnit.MILLISECONDS);
+            return true;
+        } catch (Exception ignored) {
+            return !live.isAlive();
         }
     }
 

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/BrowserStackLocalLifecycleServiceTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/BrowserStackLocalLifecycleServiceTest.java
@@ -90,7 +90,7 @@ class BrowserStackLocalLifecycleServiceTest {
     void failedReadinessTearsDownTheStartedProcess(@TempDir Path temp) {
         Fixture fixture = installed(temp);
         RecordingOperations operations = new RecordingOperations();
-        operations.dieImmediately = true;
+        operations.ready = false;
         BrowserStackLocalLifecycleService lifecycle = new BrowserStackLocalLifecycleService(
                 fixture.paths(), fixture.plan(), operations, () -> "test-key");
 
@@ -137,7 +137,7 @@ class BrowserStackLocalLifecycleServiceTest {
         private final List<String> commands = new ArrayList<>();
         private boolean running;
         private boolean inspectFails;
-        private boolean dieImmediately;
+        private boolean ready = true;
 
         @Override public void hostPreflight(List<SetupAction> actions) { /* fixture */ }
         @Override public void lockedPreflight(List<SetupAction> actions, boolean offline) { /* fixture */ }
@@ -152,7 +152,7 @@ class BrowserStackLocalLifecycleServiceTest {
         public long startTunnel(Path binary, String accessKey, Path logFile) {
             starts.add(binary.toString());
             commands.add(binary + " --key (redacted)");
-            running = !dieImmediately;
+            running = true;
             return 4242L;
         }
 
@@ -163,14 +163,16 @@ class BrowserStackLocalLifecycleServiceTest {
         }
 
         @Override
-        public void stopProcess(long pid, Path binary) {
+        public void stopProcess(long pid, Path binary, Duration timeout) {
+            java.util.Objects.requireNonNull(timeout, "timeout");
             stops.add(pid);
             running = false;
         }
 
         @Override
         public void awaitReady(Duration timeout) throws IOException {
-            if (!running) throw new IOException("BrowserStack Local did not become ready.");
+            java.util.Objects.requireNonNull(timeout, "timeout");
+            if (!ready) throw new IOException("BrowserStack Local did not become ready.");
         }
     }
 }

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/BrowserStackLocalSetupProviderTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/BrowserStackLocalSetupProviderTest.java
@@ -3,7 +3,6 @@ package com.shaft.infrastructure;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperationsTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultBrowserStackLocalToolchainOperationsTest.java
@@ -20,7 +20,7 @@ class DefaultBrowserStackLocalToolchainOperationsTest {
         DefaultBrowserStackLocalToolchainOperations operations = new DefaultBrowserStackLocalToolchainOperations(
                 paths, plan(), false);
 
-        IOException failure = assertThrows(java.io.IOException.class,
+        IOException failure = assertThrows(IOException.class,
                 () -> operations.startTunnel(temp.resolve("BrowserStackLocal"), "key", paths.state().resolve("x.log")));
         assertTrue(failure.getMessage().contains("unowned"));
     }
@@ -31,8 +31,8 @@ class DefaultBrowserStackLocalToolchainOperationsTest {
         DefaultBrowserStackLocalToolchainOperations operations = new DefaultBrowserStackLocalToolchainOperations(
                 paths, plan(), false);
 
-        IOException failure = assertThrows(java.io.IOException.class,
-                () -> operations.stopProcess(1, temp.resolve("BrowserStackLocal")));
+        IOException failure = assertThrows(IOException.class,
+                () -> operations.stopProcess(1, temp.resolve("BrowserStackLocal"), java.time.Duration.ofSeconds(1)));
         assertTrue(failure.getMessage().contains("unowned"));
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #5048: `stopProcess` now waits for graceful exit, force-kills, waits again, and throws if the owned BrowserStack Local PID is still alive. `stop(Duration)` forwards the timeout. Failed readiness is bound to `awaitReady` (process stays up, readiness throws). Digest mismatch reports the install-digest message.

Related to #5047 and #4849.

## Checks
- `mvn -pl shaft-infrastructure "-Dtest=BrowserStackLocalSetupProviderTest,BrowserStackLocalLifecycleServiceTest,DefaultBrowserStackLocalToolchainOperationsTest" test` — 14 tests, BUILD SUCCESS (exclusive worktree; prior equivalent head).
- Independent review of `44e4c5970630e86eb18a126aa50398a70bdcca2f` found zero blocking findings.

## Continuation
- Head: `44e4c5970630e86eb18a126aa50398a70bdcca2f`
- State: independent review posted; arming merge-when-green.
- Blockers: none known.
- Next action: watch required checks to confirmed merge, then remaining #4849 (agent-tools diagnostics, audit/docs, #5040).
