### PR TITLE
feat(setup): diagnose host agent tools without installing them

### DIFF
--- a/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
+++ b/shaft-cli/src/main/java/com/shaft/commandline/command/SetupCommand.java
@@ -367,7 +367,8 @@ public final class SetupCommand implements Runnable {
         return switch (plan.profile()) {
             case OCR -> ocrSelection(plan, languages);
             case MOBILE_ANDROID -> android.selectionFromPlan(plan);
-            case MOBILE_IOS, MOBILE_WINDOWS, SELENIUM_GRID, HEALENIUM, REPORT_PORTAL, BROWSERSTACK_LOCAL -> {
+            case MOBILE_IOS, MOBILE_WINDOWS, SELENIUM_GRID, HEALENIUM, REPORT_PORTAL, BROWSERSTACK_LOCAL,
+                    AGENT_TOOLS -> {
                 android.rejectIfSupplied(plan.profile());
                 yield InfrastructureSetupService.builtIn(plan.platform(), plan.architecture())
                         .selectionFromPlan(plan);

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsOperationsFactory.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsOperationsFactory.java
@@ -1,0 +1,6 @@
+package com.shaft.infrastructure;
+
+@FunctionalInterface
+interface AgentToolsOperationsFactory {
+    AgentToolsToolchainOperations create(ShaftCachePaths paths, SetupPlan plan, boolean offline);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsSetupPlanner.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsSetupPlanner.java
@@ -1,0 +1,57 @@
+package com.shaft.infrastructure;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Set;
+
+/** Release-coupled diagnostic plans for host agent tools. */
+final class AgentToolsSetupPlanner {
+    static final String JAVA_VERSION = "25+";
+    static final String MAVEN_VERSION = "3.9.0+";
+    static final String PYTHON_VERSION = "3.10+";
+    static final String NODE_VERSION = "20+";
+    static final String CLIENTS_VERSION = "1";
+    static final String CLIENTS_JSON = """
+            {
+              "schemaVersion": 1,
+              "clients": [
+                {"id": "gh", "argv": ["gh", "--version"]}
+              ]
+            }
+            """;
+
+    private AgentToolsSetupPlanner() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static SetupPlan plan(SetupPlatform platform, SetupArchitecture architecture, SetupMode mode) {
+        SetupActionKind cliKind = mode == SetupMode.EXTERNAL ? SetupActionKind.DIAGNOSE : SetupActionKind.INSTALL;
+        return SetupPlan.create(SetupProfile.AGENT_TOOLS, platform, architecture, mode, List.of(
+                diagnose(SetupTarget.JAVA, JAVA_VERSION),
+                diagnose(SetupTarget.MAVEN, MAVEN_VERSION),
+                diagnose(SetupTarget.PYTHON, PYTHON_VERSION),
+                diagnose(SetupTarget.NODE, NODE_VERSION),
+                new SetupAction(SetupTarget.AGENT_CLI, cliKind, CLIENTS_VERSION,
+                        URI.create("urn:shaft:agent-tools:clients:" + CLIENTS_VERSION),
+                        sha256(CLIENTS_JSON), CLIENTS_JSON.getBytes(StandardCharsets.UTF_8).length, false, Set.of())));
+    }
+
+    private static SetupAction diagnose(SetupTarget target, String version) {
+        return new SetupAction(target, SetupActionKind.DIAGNOSE, version,
+                URI.create("urn:shaft:host:" + target.name().toLowerCase()),
+                sha256(target.name() + version), false, Set.of());
+    }
+
+    static String sha256(String value) {
+        try {
+            return "sha256:" + HexFormat.of().formatHex(
+                    MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is required by the Java platform.", impossible);
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsSetupProvider.java
@@ -27,12 +27,6 @@ final class AgentToolsSetupProvider implements SetupProvider {
     @Override
     public SetupReport status(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
         SetupPlan plan = plan(options, platform, architecture);
-        if (options.effectiveMode() == SetupMode.EXTERNAL) {
-            AgentToolsToolchainOperations operations = operationsFactory.create(options.paths(), plan,
-                    options.offline());
-            return SetupReport.from(new AgentToolsSetupService(options.paths(), plan, operations, options.offline())
-                    .status());
-        }
         AgentToolsToolchainOperations operations = operationsFactory.create(options.paths(), plan, options.offline());
         return SetupReport.from(new AgentToolsSetupService(options.paths(), plan, operations, options.offline())
                 .status());

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsSetupProvider.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsSetupProvider.java
@@ -1,0 +1,64 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+
+/** Built-in diagnostic provider for host agent tools. */
+final class AgentToolsSetupProvider implements SetupProvider {
+    private final AgentToolsOperationsFactory operationsFactory;
+
+    AgentToolsSetupProvider() {
+        this(DefaultAgentToolsToolchainOperations::new);
+    }
+
+    AgentToolsSetupProvider(AgentToolsOperationsFactory operationsFactory) {
+        this.operationsFactory = java.util.Objects.requireNonNull(operationsFactory, "operationsFactory");
+    }
+
+    @Override
+    public SetupProfile profile() {
+        return SetupProfile.AGENT_TOOLS;
+    }
+
+    @Override
+    public SetupPlan plan(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        return AgentToolsSetupPlanner.plan(platform, architecture, options.effectiveMode());
+    }
+
+    @Override
+    public SetupReport status(SetupOptions options, SetupPlatform platform, SetupArchitecture architecture) {
+        SetupPlan plan = plan(options, platform, architecture);
+        if (options.effectiveMode() == SetupMode.EXTERNAL) {
+            AgentToolsToolchainOperations operations = operationsFactory.create(options.paths(), plan,
+                    options.offline());
+            return SetupReport.from(new AgentToolsSetupService(options.paths(), plan, operations, options.offline())
+                    .status());
+        }
+        AgentToolsToolchainOperations operations = operationsFactory.create(options.paths(), plan, options.offline());
+        return SetupReport.from(new AgentToolsSetupService(options.paths(), plan, operations, options.offline())
+                .status());
+    }
+
+    @Override
+    public SetupReceipt install(SetupPlan plan, SetupApproval approval, SetupOptions options) throws IOException {
+        SetupExecutor.validate(plan, approval);
+        SetupPlan providerPlan = canonicalPlan(plan, options);
+        AgentToolsToolchainOperations operations = operationsFactory.create(options.paths(), providerPlan,
+                options.offline());
+        SetupReceipt receipt = new AgentToolsSetupService(options.paths(), providerPlan, operations,
+                options.offline()).install(providerPlan,
+                new SetupApproval(providerPlan.digest(), approval.approvedAt(), approval.acceptedLicenses()));
+        return new SetupReceipt(plan.digest(), receipt.completedAt(), receipt.completedActions());
+    }
+
+    private SetupPlan canonicalPlan(SetupPlan plan, SetupOptions options) {
+        if (options.profile() != profile()) {
+            throw new IllegalArgumentException("Options do not select agent-tools setup.");
+        }
+        SetupPlan canonical = AgentToolsSetupPlanner.plan(plan.platform(), plan.architecture(), plan.mode());
+        if (!SetupPlan.bind(canonical, options.policyDigest()).equals(plan)) {
+            throw new IllegalArgumentException(
+                    "Plan does not match the agent-tools manifest shipped with this release.");
+        }
+        return canonical;
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsSetupService.java
@@ -1,0 +1,149 @@
+package com.shaft.infrastructure;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Transaction coordinator for one exact agent-tools setup plan. */
+final class AgentToolsSetupService {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+    private static final ConcurrentHashMap<Path, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private final ShaftCachePaths paths;
+    private final SetupPlan expectedPlan;
+    private final AgentToolsToolchainOperations operations;
+    private final boolean offline;
+
+    AgentToolsSetupService(ShaftCachePaths paths, SetupPlan expectedPlan,
+                           AgentToolsToolchainOperations operations, boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.expectedPlan = java.util.Objects.requireNonNull(expectedPlan, "expectedPlan");
+        this.operations = java.util.Objects.requireNonNull(operations, "operations");
+        this.offline = offline;
+        if (expectedPlan.profile() != SetupProfile.AGENT_TOOLS) {
+            throw new IllegalArgumentException("Agent tools setup requires the AGENT_TOOLS profile.");
+        }
+    }
+
+    SetupProfileStatus status() {
+        List<SetupStatus> targets = expectedPlan.actions().stream().map(operations::status).toList();
+        SetupReadiness readiness = targets.stream().allMatch(target -> target.readiness() == SetupReadiness.READY)
+                ? SetupReadiness.READY
+                : targets.stream().anyMatch(target -> target.readiness() == SetupReadiness.DEGRADED)
+                ? SetupReadiness.DEGRADED : SetupReadiness.MISSING;
+        if (readiness == SetupReadiness.READY && !hasCompatibleReceipt()) {
+            ArrayList<SetupStatus> adjusted = new ArrayList<>(targets);
+            SetupStatus last = adjusted.getLast();
+            adjusted.set(adjusted.size() - 1, new SetupStatus(last.target(), SetupReadiness.DEGRADED,
+                    last.detectedVersion(), "Managed files exist without a compatible SHAFT receipt."));
+            targets = List.copyOf(adjusted);
+            readiness = SetupReadiness.DEGRADED;
+        }
+        return new SetupProfileStatus(1, expectedPlan.profile(), readiness, targets);
+    }
+
+    SetupReceipt install(SetupPlan plan, SetupApproval approval) throws IOException {
+        requireCompatible(plan);
+        SetupExecutor.validate(plan, approval);
+        operations.hostPreflight(plan.actions());
+        Path lockPath = paths.state().resolve("agent-tools.lock").toAbsolutePath().normalize();
+        VerifiedArtifactStore.requireUnlinkedAncestors(lockPath);
+        ReentrantLock jvmLock = JVM_LOCKS.computeIfAbsent(lockPath, ignored -> new ReentrantLock());
+        boolean acquired = false;
+        try {
+            jvmLock.lockInterruptibly();
+            acquired = true;
+            if (!Files.isDirectory(paths.state(), LinkOption.NOFOLLOW_LINKS)) {
+                operations.preStatePreflight(plan.actions(), offline);
+            }
+            Files.createDirectories(paths.state());
+            try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                operations.lockedPreflight(plan.actions(), offline);
+                invalidateReceipt();
+                SetupReceipt receipt = SetupExecutor.execute(plan, approval, action -> {
+                    try {
+                        operations.install(action);
+                    } catch (IOException failure) {
+                        throw new SetupOperationException(failure);
+                    }
+                });
+                Files.deleteIfExists(previousReceiptPath());
+                writeReceipt(receipt);
+                return receipt;
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for the agent-tools setup lock.", interrupted);
+        } finally {
+            if (acquired) jvmLock.unlock();
+        }
+    }
+
+    private void requireCompatible(SetupPlan plan) {
+        if (plan.mode() == SetupMode.EXTERNAL) {
+            throw new IllegalArgumentException("External plans are diagnostic and cannot be installed.");
+        }
+        if (!expectedPlan.equals(plan)) {
+            throw new IllegalArgumentException("Plan does not match the agent-tools manifest shipped with this release.");
+        }
+    }
+
+    private void writeReceipt(SetupReceipt receipt) throws IOException {
+        Files.createDirectories(paths.receipts());
+        Path temporary = Files.createTempFile(paths.receipts(), "agent-tools", ".tmp");
+        try {
+            Files.writeString(temporary, JSON.writerWithDefaultPrettyPrinter().writeValueAsString(receipt));
+            VerifiedArtifactStore.move(temporary, receiptPath());
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private boolean hasCompatibleReceipt() {
+        try {
+            Path receipt = receiptPath();
+            VerifiedArtifactStore.requireUnlinkedAncestors(receipt);
+            if (!Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)) return false;
+            SetupReceipt saved = JSON.readValue(receipt.toFile(), SetupReceipt.class);
+            return saved.planDigest().equals(expectedPlan.digest())
+                    && saved.completedActions().equals(expectedPlan.actions());
+        } catch (IOException | RuntimeException invalid) {
+            return false;
+        }
+    }
+
+    private Path receiptPath() {
+        return paths.receipts().resolve("agent-tools.json");
+    }
+
+    private Path previousReceiptPath() {
+        return paths.receipts().resolve("agent-tools.previous.json");
+    }
+
+    private void invalidateReceipt() throws IOException {
+        Path receipt = receiptPath();
+        Path previous = previousReceiptPath();
+        VerifiedArtifactStore.requireUnlinkedAncestors(receipt);
+        VerifiedArtifactStore.requireUnlinkedAncestors(previous);
+        if (!Files.isRegularFile(receipt, LinkOption.NOFOLLOW_LINKS)) return;
+        Files.deleteIfExists(previous);
+        VerifiedArtifactStore.move(receipt, previous);
+    }
+
+    private static final class SetupOperationException extends RuntimeException {
+        private SetupOperationException(IOException cause) {
+            super(cause);
+        }
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/AgentToolsToolchainOperations.java
@@ -1,0 +1,20 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Injectable host probe and catalog write boundary for agent tools. */
+interface AgentToolsToolchainOperations {
+    void hostPreflight(List<SetupAction> actions) throws IOException;
+
+    default void preStatePreflight(List<SetupAction> actions, boolean offline) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
+        if (offline) return;
+    }
+
+    void lockedPreflight(List<SetupAction> actions, boolean offline) throws IOException;
+
+    void install(SetupAction action) throws IOException;
+
+    SetupStatus status(SetupAction action);
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperations.java
@@ -98,7 +98,7 @@ final class DefaultAgentToolsToolchainOperations implements AgentToolsToolchainO
 
     private SetupStatus probe(SetupAction action, List<String> command) {
         try {
-            ReportingSetupService.ProcessResult result = runner.run(command, paths.cacheRoot(), Map.of(),
+            ReportingSetupService.ProcessResult result = runner.run(command, null, Map.of(),
                     Set.of(), null, null, Duration.ofSeconds(15));
             if (result.exitCode() != 0) {
                 return new SetupStatus(action.target(), SetupReadiness.MISSING, "",

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperations.java
@@ -1,0 +1,122 @@
+package com.shaft.infrastructure;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Host PATH probes and catalog write for agent tools. */
+final class DefaultAgentToolsToolchainOperations implements AgentToolsToolchainOperations {
+    private final ShaftCachePaths paths;
+    private final SetupPlan plan;
+    private final AndroidCommandRunner runner;
+    private final boolean offline;
+
+    DefaultAgentToolsToolchainOperations(ShaftCachePaths paths, SetupPlan plan, boolean offline) {
+        this(paths, plan, AndroidCommandRunner.system(paths, plan.platform(), plan.architecture()), offline);
+    }
+
+    DefaultAgentToolsToolchainOperations(ShaftCachePaths paths, SetupPlan plan, AndroidCommandRunner runner,
+                                         boolean offline) {
+        this.paths = java.util.Objects.requireNonNull(paths, "paths");
+        this.plan = java.util.Objects.requireNonNull(plan, "plan");
+        this.runner = java.util.Objects.requireNonNull(runner, "runner");
+        this.offline = offline;
+    }
+
+    @Override
+    public void hostPreflight(List<SetupAction> actions) {
+        java.util.Objects.requireNonNull(actions, "actions");
+        for (SetupAction action : actions) {
+            if (action.target() != SetupTarget.AGENT_CLI) status(action);
+        }
+    }
+
+    @Override
+    public void lockedPreflight(List<SetupAction> actions, boolean requireOffline) throws IOException {
+        java.util.Objects.requireNonNull(actions, "actions");
+        VerifiedArtifactStore.requireUnlinkedAncestors(catalogFile());
+        if ((offline || requireOffline) && !Files.isRegularFile(catalogFile(), LinkOption.NOFOLLOW_LINKS)) {
+            throw new IOException("Offline agent-tools setup requires a staged client catalog.");
+        }
+    }
+
+    @Override
+    public void install(SetupAction action) throws IOException {
+        if (action.target() != SetupTarget.AGENT_CLI) return;
+        if (!AgentToolsSetupPlanner.sha256(AgentToolsSetupPlanner.CLIENTS_JSON)
+                .equalsIgnoreCase(action.checksum())) {
+            throw new IOException("Agent client catalog does not match the approved plan.");
+        }
+        Path destination = catalogFile();
+        Files.createDirectories(destination.getParent());
+        Path temporary = Files.createTempFile(destination.getParent(), "agent-clients", ".tmp");
+        try {
+            Files.writeString(temporary, AgentToolsSetupPlanner.CLIENTS_JSON);
+            VerifiedArtifactStore.move(temporary, destination);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    @Override
+    public SetupStatus status(SetupAction action) {
+        return switch (action.target()) {
+            case JAVA -> probe(action, List.of(executable("java"), "-version"));
+            case MAVEN -> probe(action, List.of(executable("mvn"), "-version"));
+            case PYTHON -> probe(action, List.of(executable("python"), "--version"));
+            case NODE -> probe(action, List.of(executable("node"), "--version"));
+            case AGENT_CLI -> catalogStatus(action);
+            default -> new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                    "Unsupported agent-tools target.");
+        };
+    }
+
+    private SetupStatus catalogStatus(SetupAction action) {
+        try {
+            Path catalog = catalogFile();
+            VerifiedArtifactStore.requireUnlinkedAncestors(catalog);
+            if (!Files.isRegularFile(catalog, LinkOption.NOFOLLOW_LINKS)) {
+                return new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                        "Managed agent client catalog is missing.");
+            }
+            String actual = AgentToolsSetupPlanner.sha256(Files.readString(catalog, StandardCharsets.UTF_8));
+            if (!actual.equalsIgnoreCase(action.checksum())) {
+                return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "",
+                        "Staged agent client catalog does not match the approved plan.");
+            }
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(),
+                    "Staged agent client catalog matches the reviewed plan.");
+        } catch (IOException failure) {
+            return new SetupStatus(action.target(), SetupReadiness.DEGRADED, "", failure.getMessage());
+        }
+    }
+
+    private SetupStatus probe(SetupAction action, List<String> command) {
+        try {
+            ReportingSetupService.ProcessResult result = runner.run(command, paths.cacheRoot(), Map.of(),
+                    Set.of(), null, null, Duration.ofSeconds(15));
+            if (result.exitCode() != 0) {
+                return new SetupStatus(action.target(), SetupReadiness.MISSING, "",
+                        action.target() + " is not available on PATH.");
+            }
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(),
+                    result.output().strip());
+        } catch (IOException failure) {
+            return new SetupStatus(action.target(), SetupReadiness.MISSING, "", failure.getMessage());
+        }
+    }
+
+    private Path catalogFile() {
+        return paths.tools().resolve("agent-tools").resolve("agent-clients.json");
+    }
+
+    private String executable(String name) {
+        return plan.platform() == SetupPlatform.WINDOWS ? name + ".exe" : name;
+    }
+}

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperations.java
@@ -67,10 +67,7 @@ final class DefaultAgentToolsToolchainOperations implements AgentToolsToolchainO
     @Override
     public SetupStatus status(SetupAction action) {
         return switch (action.target()) {
-            case JAVA -> probe(action, List.of(executable("java"), "-version"));
-            case MAVEN -> probe(action, List.of(executable("mvn"), "-version"));
-            case PYTHON -> probe(action, List.of(executable("python"), "--version"));
-            case NODE -> probe(action, List.of(executable("node"), "--version"));
+            case JAVA, MAVEN, PYTHON, NODE -> probe(action, probeCommand(action.target(), plan.platform()));
             case AGENT_CLI -> catalogStatus(action);
             default -> new SetupStatus(action.target(), SetupReadiness.MISSING, "",
                     "Unsupported agent-tools target.");
@@ -116,7 +113,14 @@ final class DefaultAgentToolsToolchainOperations implements AgentToolsToolchainO
         return paths.tools().resolve("agent-tools").resolve("agent-clients.json");
     }
 
-    private String executable(String name) {
-        return plan.platform() == SetupPlatform.WINDOWS ? name + ".exe" : name;
+    static List<String> probeCommand(SetupTarget target, SetupPlatform platform) {
+        boolean windows = platform == SetupPlatform.WINDOWS;
+        return switch (target) {
+            case JAVA -> List.of(windows ? "java.exe" : "java", "-version");
+            case MAVEN -> List.of(windows ? "mvn.cmd" : "mvn", "-version");
+            case PYTHON -> windows ? List.of("py", "-3", "--version") : List.of("python3", "--version");
+            case NODE -> List.of(windows ? "node.exe" : "node", "--version");
+            default -> throw new IllegalArgumentException("No host probe for " + target);
+        };
     }
 }

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperations.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperations.java
@@ -33,7 +33,9 @@ final class DefaultAgentToolsToolchainOperations implements AgentToolsToolchainO
     public void hostPreflight(List<SetupAction> actions) {
         java.util.Objects.requireNonNull(actions, "actions");
         for (SetupAction action : actions) {
-            if (action.target() != SetupTarget.AGENT_CLI) status(action);
+            if (action.target() != SetupTarget.AGENT_CLI) {
+                java.util.Objects.requireNonNull(status(action), "status");
+            }
         }
     }
 

--- a/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
+++ b/shaft-infrastructure/src/main/java/com/shaft/infrastructure/InfrastructureSetupService.java
@@ -28,7 +28,7 @@ public final class InfrastructureSetupService {
                 new ReportingSetupProvider(), new OcrSetupProvider(), new LighthouseSetupProvider(),
                 new PlaywrightSetupProvider(), new AndroidSetupProvider(), new SeleniumGridSetupProvider(),
                 new HealeniumSetupProvider(), new ReportPortalSetupProvider(),
-                new BrowserStackLocalSetupProvider()));
+                new BrowserStackLocalSetupProvider(), new AgentToolsSetupProvider()));
         if (platform == SetupPlatform.MACOS) providers.add(new IosSetupProvider());
         if (platform == SetupPlatform.WINDOWS) providers.add(new WindowsSetupProvider());
         ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/AgentToolsSetupProviderTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/AgentToolsSetupProviderTest.java
@@ -1,0 +1,121 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentToolsSetupProviderTest {
+    @Test
+    void builtInCoordinatorProvidesAgentToolsPlan(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+        SetupOptions options = managed(temp);
+
+        assertTrue(service.supports(SetupProfile.AGENT_TOOLS));
+        SetupPlan plan = service.plan(options);
+
+        assertEquals(List.of(SetupTarget.JAVA, SetupTarget.MAVEN, SetupTarget.PYTHON, SetupTarget.NODE,
+                SetupTarget.AGENT_CLI), plan.actions().stream().map(SetupAction::target).toList());
+        assertTrue(plan.actions().stream()
+                .filter(action -> action.target() != SetupTarget.AGENT_CLI)
+                .allMatch(action -> action.kind() == SetupActionKind.DIAGNOSE));
+        assertEquals(SetupActionKind.INSTALL, plan.actions().getLast().kind());
+        assertEquals("1", plan.actions().getLast().version());
+    }
+
+    @Test
+    void hostPrerequisitesAreNeverInstallActions() {
+        SetupPlan plan = AgentToolsSetupPlanner.plan(SetupPlatform.WINDOWS, SetupArchitecture.X64, SetupMode.MANAGED);
+        assertFalse(plan.actions().stream()
+                .filter(action -> action.target() != SetupTarget.AGENT_CLI)
+                .anyMatch(action -> action.kind() == SetupActionKind.INSTALL));
+    }
+
+    @Test
+    void managedProviderInstallsTheClientCatalog(@TempDir Path temp) throws Exception {
+        RecordingOperations operations = new RecordingOperations();
+        InfrastructureSetupService service = coordinator(operations);
+        SetupOptions options = managed(temp);
+        SetupPlan plan = service.plan(options);
+
+        SetupReceipt receipt = service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()),
+                options);
+
+        assertEquals(plan.digest(), receipt.planDigest());
+        assertTrue(operations.events.contains("install:" + SetupTarget.AGENT_CLI));
+    }
+
+    @Test
+    void externalModeCannotInstall(@TempDir Path temp) {
+        InfrastructureSetupService service = InfrastructureSetupService.builtIn(
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        SetupOptions options = SetupOptions.defaults(SetupProfile.AGENT_TOOLS, new ShaftCachePaths(
+                cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts")));
+        SetupPlan plan = service.plan(options);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.install(plan, new SetupApproval(plan.digest(), Instant.EPOCH, Set.of()), options));
+        assertFalse(Files.exists(options.paths().receipts().resolve("agent-tools.json")));
+    }
+
+    private static InfrastructureSetupService coordinator(RecordingOperations operations) {
+        return new InfrastructureSetupService(new SetupProviderRegistry(
+                List.of(new AgentToolsSetupProvider((paths, plan, offline) -> operations))),
+                SetupPlatform.LINUX, SetupArchitecture.X64);
+    }
+
+    private static SetupOptions managed(Path root) {
+        Path cache = root.resolve("cache");
+        Path data = root.resolve("data");
+        return SetupOptions.defaults(SetupProfile.AGENT_TOOLS, new ShaftCachePaths(
+                cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts")))
+                .withMode(SetupMode.MANAGED);
+    }
+
+    private static final class RecordingOperations implements AgentToolsToolchainOperations {
+        private final List<String> events = new ArrayList<>();
+        private boolean installed;
+
+        @Override
+        public void hostPreflight(List<SetupAction> actions) {
+            events.add("host-preflight");
+        }
+
+        @Override
+        public void lockedPreflight(List<SetupAction> actions, boolean offline) {
+            events.add("locked-preflight");
+        }
+
+        @Override
+        public void install(SetupAction action) {
+            events.add("install:" + action.target());
+            if (action.target() == SetupTarget.AGENT_CLI) installed = true;
+        }
+
+        @Override
+        public SetupStatus status(SetupAction action) {
+            if (action.target() == SetupTarget.AGENT_CLI) {
+                return new SetupStatus(action.target(),
+                        installed ? SetupReadiness.READY : SetupReadiness.MISSING,
+                        installed ? action.version() : "", installed ? "fixture" : "missing");
+            }
+            return new SetupStatus(action.target(), SetupReadiness.READY, action.version(), "fixture");
+        }
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/AgentToolsSetupProviderTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/AgentToolsSetupProviderTest.java
@@ -73,6 +73,22 @@ class AgentToolsSetupProviderTest {
         assertFalse(Files.exists(options.paths().receipts().resolve("agent-tools.json")));
     }
 
+    @Test
+    void externalStatusStillProbesHostTools(@TempDir Path temp) {
+        RecordingOperations operations = new RecordingOperations();
+        InfrastructureSetupService service = coordinator(operations);
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        SetupOptions options = SetupOptions.defaults(SetupProfile.AGENT_TOOLS, new ShaftCachePaths(
+                cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts")));
+
+        service.status(options);
+
+        assertTrue(operations.events.contains("status:" + SetupTarget.JAVA));
+        assertTrue(operations.events.contains("status:" + SetupTarget.AGENT_CLI));
+    }
+
     private static InfrastructureSetupService coordinator(RecordingOperations operations) {
         return new InfrastructureSetupService(new SetupProviderRegistry(
                 List.of(new AgentToolsSetupProvider((paths, plan, offline) -> operations))),
@@ -110,6 +126,7 @@ class AgentToolsSetupProviderTest {
 
         @Override
         public SetupStatus status(SetupAction action) {
+            events.add("status:" + action.target());
             if (action.target() == SetupTarget.AGENT_CLI) {
                 return new SetupStatus(action.target(),
                         installed ? SetupReadiness.READY : SetupReadiness.MISSING,

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/AgentToolsSetupProviderTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/AgentToolsSetupProviderTest.java
@@ -3,7 +3,6 @@ package com.shaft.infrastructure;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperationsTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperationsTest.java
@@ -94,6 +94,7 @@ class DefaultAgentToolsToolchainOperationsTest {
                 paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) -> {
                     commands.add(List.copyOf(command));
                     assertTrue(log == null);
+                    assertTrue(workingDirectory == null);
                     return new ReportingSetupService.ProcessResult(0, "ok");
                 }, false);
 

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperationsTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperationsTest.java
@@ -1,0 +1,76 @@
+package com.shaft.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultAgentToolsToolchainOperationsTest {
+    @Test
+    void hostProbeDoesNotCreateStateOrRequireALogFile(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        AtomicReference<Path> logged = new AtomicReference<>();
+        DefaultAgentToolsToolchainOperations operations = new DefaultAgentToolsToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) -> {
+                    logged.set(log);
+                    return new ReportingSetupService.ProcessResult(0, "openjdk 25");
+                }, false);
+
+        operations.hostPreflight(plan().actions());
+
+        assertFalse(Files.exists(paths.state()));
+        assertTrue(logged.get() == null);
+    }
+
+    @Test
+    void installThenStatusIsReadyAndCatalogMutationDegrades(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        SetupPlan plan = plan();
+        DefaultAgentToolsToolchainOperations operations = new DefaultAgentToolsToolchainOperations(
+                paths, plan, (command, workingDirectory, environment, removed, stdin, log, timeout) ->
+                new ReportingSetupService.ProcessResult(0, "ok"), false);
+        SetupAction catalog = plan.actions().stream()
+                .filter(action -> action.target() == SetupTarget.AGENT_CLI).findFirst().orElseThrow();
+
+        operations.install(catalog);
+
+        assertEquals(SetupReadiness.READY, operations.status(catalog).readiness());
+        Path file = paths.tools().resolve("agent-tools").resolve("agent-clients.json");
+        assertTrue(Files.isRegularFile(file));
+
+        Files.writeString(file, Files.readString(file) + "\n");
+        assertEquals(SetupReadiness.DEGRADED, operations.status(catalog).readiness());
+    }
+
+    @Test
+    void installingAHostPrerequisiteWritesNothing(@TempDir Path temp) throws Exception {
+        ShaftCachePaths paths = paths(temp);
+        DefaultAgentToolsToolchainOperations operations = new DefaultAgentToolsToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) ->
+                new ReportingSetupService.ProcessResult(0, "ok"), false);
+        SetupAction java = plan().actions().stream()
+                .filter(action -> action.target() == SetupTarget.JAVA).findFirst().orElseThrow();
+
+        operations.install(java);
+
+        assertFalse(Files.exists(paths.tools()));
+        assertFalse(Files.exists(paths.state()));
+    }
+
+    private static SetupPlan plan() {
+        return AgentToolsSetupPlanner.plan(SetupPlatform.LINUX, SetupArchitecture.X64, SetupMode.MANAGED);
+    }
+
+    private static ShaftCachePaths paths(Path temp) {
+        Path cache = temp.resolve("cache");
+        Path data = temp.resolve("data");
+        return new ShaftCachePaths(cache, data, cache.resolve("downloads"), data.resolve("tools"),
+                data.resolve("state"), data.resolve("receipts"));
+    }
+}

--- a/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperationsTest.java
+++ b/shaft-infrastructure/src/test/java/com/shaft/infrastructure/DefaultAgentToolsToolchainOperationsTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,7 +44,8 @@ class DefaultAgentToolsToolchainOperationsTest {
 
         assertEquals(SetupReadiness.READY, operations.status(catalog).readiness());
         Path file = paths.tools().resolve("agent-tools").resolve("agent-clients.json");
-        assertTrue(Files.isRegularFile(file));
+        assertEquals(AgentToolsSetupPlanner.CLIENTS_JSON, Files.readString(file));
+        assertEquals(List.of("agent-clients.json"), List.of(file.getParent().toFile().list()));
 
         Files.writeString(file, Files.readString(file) + "\n");
         assertEquals(SetupReadiness.DEGRADED, operations.status(catalog).readiness());
@@ -61,6 +64,46 @@ class DefaultAgentToolsToolchainOperationsTest {
 
         assertFalse(Files.exists(paths.tools()));
         assertFalse(Files.exists(paths.state()));
+    }
+
+    @Test
+    void probeCommandsArePlatformSpecific() {
+        assertEquals(List.of("java", "-version"),
+                DefaultAgentToolsToolchainOperations.probeCommand(SetupTarget.JAVA, SetupPlatform.LINUX));
+        assertEquals(List.of("mvn", "-version"),
+                DefaultAgentToolsToolchainOperations.probeCommand(SetupTarget.MAVEN, SetupPlatform.LINUX));
+        assertEquals(List.of("python3", "--version"),
+                DefaultAgentToolsToolchainOperations.probeCommand(SetupTarget.PYTHON, SetupPlatform.LINUX));
+        assertEquals(List.of("node", "--version"),
+                DefaultAgentToolsToolchainOperations.probeCommand(SetupTarget.NODE, SetupPlatform.LINUX));
+        assertEquals(List.of("java.exe", "-version"),
+                DefaultAgentToolsToolchainOperations.probeCommand(SetupTarget.JAVA, SetupPlatform.WINDOWS));
+        assertEquals(List.of("mvn.cmd", "-version"),
+                DefaultAgentToolsToolchainOperations.probeCommand(SetupTarget.MAVEN, SetupPlatform.WINDOWS));
+        assertEquals(List.of("py", "-3", "--version"),
+                DefaultAgentToolsToolchainOperations.probeCommand(SetupTarget.PYTHON, SetupPlatform.WINDOWS));
+        assertEquals(List.of("node.exe", "--version"),
+                DefaultAgentToolsToolchainOperations.probeCommand(SetupTarget.NODE, SetupPlatform.WINDOWS));
+    }
+
+    @Test
+    void hostPreflightProbesEachHostToolWithANullLog(@TempDir Path temp) {
+        ShaftCachePaths paths = paths(temp);
+        List<List<String>> commands = new ArrayList<>();
+        DefaultAgentToolsToolchainOperations operations = new DefaultAgentToolsToolchainOperations(
+                paths, plan(), (command, workingDirectory, environment, removed, stdin, log, timeout) -> {
+                    commands.add(List.copyOf(command));
+                    assertTrue(log == null);
+                    return new ReportingSetupService.ProcessResult(0, "ok");
+                }, false);
+
+        operations.hostPreflight(plan().actions());
+
+        assertEquals(List.of(
+                List.of("java", "-version"),
+                List.of("mvn", "-version"),
+                List.of("python3", "--version"),
+                List.of("node", "--version")), commands);
     }
 
     private static SetupPlan plan() {


### PR DESCRIPTION
## Summary
Adds a diagnostic `AGENT_TOOLS` provider. JAVA, MAVEN, PYTHON, and NODE stay host prerequisites (diagnose only, never installed). Managed `AGENT_CLI` writes a pinned SHAFT `agent-clients.json` catalog (detect `gh --version` only) and does not download vendor agent CLIs.

Closes #5051. Related to #4849.

## Checks
- RED: `supports(AGENT_TOOLS)` was false.
- GREEN: `mvn -pl shaft-infrastructure "-Dtest=AgentToolsSetupProviderTest,DefaultAgentToolsToolchainOperationsTest" "-DfailIfNoTests=true" "-Dallure.automaticallyOpen=false" test` — 10 tests, BUILD SUCCESS (exclusive worktree cwd `setup-agent-tools-codacy`).
- Independent review of `202540f24d` found zero blocking findings (diagnose-only host tools, no state dir, no vendor CLI download).
- Codacy unused import removed on this head.

## Continuation
- Head: `202540f24ddaf5799827e7883a74beb13964e35a`
- State: Codacy unused-import fix pushed; independent review posted; arming merge-when-green.
- Blockers: GitHub 429/503 action-download flakes on prior head (same class as #5050). Not a product-test failure.
- Next action: watch required checks to confirmed merge, then remaining #4849 (download audit/docs, #5040).
