### PR TITLE
feat(chaos-engine): load Caveman and Ponytail by default

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -149,9 +149,8 @@ sends you there; the rest by
 - [third-party notices](../../chaos-engine/THIRD_PARTY_NOTICES.md)
 
 Caveman and Ponytail are pinned vendor companions, not restated in the
-entrypoint. The router loads [Caveman](../../chaos-engine/vendor/caveman/INVENTORY.md)
-or [Ponytail](../../chaos-engine/vendor/ponytail/INVENTORY.md) only when the
-user invokes them or the next action needs that companion. MIT notices stay at
+entrypoint: [Caveman](../../chaos-engine/vendor/caveman/INVENTORY.md) and
+[Ponytail](../../chaos-engine/vendor/ponytail/INVENTORY.md). MIT notices stay at
 [Caveman](../../chaos-engine/references/caveman.LICENSE),
 [Ponytail](../../chaos-engine/references/ponytail.LICENSE),
 [TDD](../../chaos-engine/references/test-driven-development.LICENSE).

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -36,8 +36,8 @@ Graphify CLI, skills, playbooks, five role adapters, ChaosEngine lifecycle
 hooks, the pinned Caveman and Ponytail companion skills and hooks, the MIT license
 and third-party notices, Codex and Claude plugin manifests/marketplaces for
 ChaosEngine plus those companions, retrieval configuration, and runtime ignore
-rules. Companion skills install with the core; they load at runtime only when
-invoked or when they change the next action. When a detected client
+rules. Companion skills install with the core and load by default at runtime;
+user off-switches still win. When a detected client
 requires marketplace registration, the agent registers the project marketplace
 and installs `chaos-engine`, `caveman`, and `ponytail` at project local scope,
 then runs active `doctor` probes. Generated indexes, caches, receipts, and runtimes

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -145,14 +145,10 @@ For the short decision procedure and boundary cases, load
 
 This file is the only router. It does not restate companion rules.
 
-Load a vendor skill only when it changes the next action. Implementation and
-review do not auto-load both. Mechanical one-file edits and consult-only
-answers skip them unless the user invoked `/caveman` or `/ponytail`. User
-`stop caveman`, `stop ponytail`, or `normal mode` still wins. Once loaded,
-each companion's own text applies.
-
-- Caveman: `/caveman`, "talk like caveman", or an explicit token-efficiency request
-- Ponytail: `/ponytail`, or when implementing or designing code
+Load both companion skills at the start of every task, on every host, in every
+main thread and delegate. Default intensity remains each companion's own
+default. Off only: `stop caveman`, `stop ponytail`, or `normal mode`.
+Once loaded, each companion's own text applies.
 
 - [Caveman skill](../../vendor/caveman/skills/caveman/SKILL.md) — [inventory](../../vendor/caveman/INVENTORY.md)
 - [Ponytail skill](../../vendor/ponytail/skills/ponytail/SKILL.md) — [inventory](../../vendor/ponytail/INVENTORY.md)

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1273,6 +1273,23 @@ class ConsultGateTest(unittest.TestCase):
         self.assertIn("when dependencies, components, state, or workflows", content)
         self.assertIn("never ask a question the repository", content)
 
+    def test_companions_load_by_default_on_every_task(self):
+        sections = headed_sections(ENTRYPOINT.read_text(encoding="utf-8"), "companions")
+        self.assertEqual(len(sections), 1, "entrypoint needs exactly one Companions section")
+        companions = re.sub(r"\s+", " ", sections[0]).lower()
+        for required in (
+            "start of every task",
+            "every host",
+            "every main thread and delegate",
+        ):
+            self.assertIn(required, companions)
+        entrypoint = compact(ENTRYPOINT)
+        self.assertNotIn("do not auto-load both", entrypoint)
+        self.assertNotIn("only when it changes the next action", entrypoint)
+        install = compact(ROOT / "chaos-engine/INSTALL.md")
+        self.assertIn("load by default", install)
+        self.assertNotIn("only when invoked", install)
+
     def test_caveman_preserves_exact_meaning_before_compression(self):
         content = compact(VENDOR_CAVEMAN)
         for exact in (

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1289,6 +1289,9 @@ class ConsultGateTest(unittest.TestCase):
         install = compact(ROOT / "chaos-engine/INSTALL.md")
         self.assertIn("load by default", install)
         self.assertNotIn("only when invoked", install)
+        inventory = compact(ROOT / ".agents/skills/README.md")
+        self.assertNotIn("only when the user invokes them", inventory)
+        self.assertNotIn("the next action needs that companion", inventory)
 
     def test_caveman_preserves_exact_meaning_before_compression(self):
         content = compact(VENDOR_CAVEMAN)


### PR DESCRIPTION
Closes #5053

## Summary

ChaosEngine now loads Caveman and Ponytail at the start of every task, on every host, in every main thread and delegate. Default intensity stays each companion's own default. Off only via `stop caveman`, `stop ponytail`, or `normal mode`. Vendor trees and host adapters are unchanged. `INSTALL.md` matches the default-on runtime policy. The harness inventory no longer restates the old opt-in load rule.

Owner override of the #5028 token-cost rejection is applied as the smallest router/install wording change plus a focused contract test.

## Checks

RED 1: `py -3 -m unittest tests.scripts.test_agent_router_contract.ConsultGateTest.test_companions_load_by_default_on_every_task` failed with `AssertionError: 'start of every task' not found` against parent opt-in wording. `py -3 -m pytest` is not installed locally; unittest is the repo/CI runner.

GREEN 1: same test OK after the SKILL.md + INSTALL.md rewrite.

RED 2: after an independent reviewer flagged leftover opt-in in `.agents/skills/README.md`, the same test (extended) failed with `AssertionError: 'only when the user invokes them' unexpectedly found`.

GREEN 2: inventory sentence now only names the vendor inventories; test OK.

Balanced: `py -3 -m unittest tests.scripts.test_agent_router_contract tests.scripts.test_chaos_engine_portable_core tests.scripts.test_chaos_engine_bootstrap` — 172 tests, OK, 31.965s, worktree cwd `default-companions`.

Guidance: `py -3 scripts/ci/validate_agent_setup.py --skip-external` — valid (190511 guidance bytes, 382 memory objects). SKILL.md is 12861 bytes / 264 lines (cap 20000 / 500). Bootstrap pin `tests/scripts/test_chaos_engine_bootstrap.py` remains in SKILL.md.

Consult-first matrices: https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5053#issuecomment-5317437480

## Continuation

Head: 3013fe2942e29870537fd680b1a662ddcf08e0c3
State: sibling-left inventory opt-in removed; independent review of this exact head still required before arming.
Blockers: none known. Dirty primary `ChaosEngine/5024-ios-windows-appium-lifecycle` and setup-agent-tools worktree were not touched.
Next action: independent adversarial review of 3013fe2942, then `gh pr merge 5054 --auto --merge` and watch until `mergedAt` is set.
