### PR TITLE
fix(hooks): make Claude settings command Grok-resolvable on Windows

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,11 +31,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": [
-              "-c",
-              "import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')"
-            ],
+            "command": "python3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
+            "commandWindows": "py -3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
             "timeout": 10
           }
         ]
@@ -47,11 +44,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": [
-              "-c",
-              "import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')"
-            ],
+            "command": "python3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
+            "commandWindows": "py -3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
             "timeout": 10
           }
         ]
@@ -63,11 +57,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": [
-              "-c",
-              "import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')"
-            ],
+            "command": "python3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
+            "commandWindows": "py -3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
             "timeout": 10
           }
         ]
@@ -78,11 +69,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": [
-              "-c",
-              "import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')"
-            ],
+            "command": "python3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
+            "commandWindows": "py -3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
             "timeout": 30
           }
         ]
@@ -93,11 +81,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": [
-              "-c",
-              "import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')"
-            ],
+            "command": "python3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
+            "commandWindows": "py -3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
             "timeout": 10
           }
         ]
@@ -108,11 +93,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": [
-              "-c",
-              "import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')"
-            ],
+            "command": "python3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
+            "commandWindows": "py -3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
             "timeout": 30
           }
         ]
@@ -123,11 +105,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": [
-              "-c",
-              "import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')"
-            ],
+            "command": "python3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
+            "commandWindows": "py -3 -c \"import pathlib,runpy;p=next(p/'scripts/agents/guard.py' for p in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) if (p/'scripts/agents/guard.py').is_file());runpy.run_path(str(p),run_name='__main__')\"",
             "timeout": 30
           }
         ]

--- a/tests/scripts/test_agent_harness_portability.py
+++ b/tests/scripts/test_agent_harness_portability.py
@@ -630,12 +630,27 @@ class AgentHarnessPortabilityTest(unittest.TestCase):
             )
             self.assertEqual(completed.returncode, 0, completed.stderr)
             self.assertIn("R1", completed.stdout)
+        settings_path = ROOT / ".claude/settings.json"
         for groups in claude_hooks.values():
             for group in groups:
                 for handler in group["hooks"]:
-                    self.assertEqual(handler["command"], "python3")
-                    self.assertEqual(handler["args"][0], "-c")
-                    self.assertIn("scripts/agents/guard.py", handler["args"][1])
+                    command = handler["command"]
+                    # Grok treats a single-token command as a path relative to
+                    # the settings file, so `python3` becomes `.claude\python3`.
+                    self.assertRegex(
+                        command,
+                        r"\s",
+                        "Grok resolves a single-token command relative to .claude/",
+                    )
+                    self.assertTrue(command.startswith("python3 "))
+                    self.assertIn("scripts/agents/guard.py", command)
+                    self.assertFalse(
+                        handler.get("args"),
+                        "Grok ignores Claude args and only runs command",
+                    )
+                    self.assertTrue(handler.get("commandWindows", "").startswith("py -3 "))
+                    self.assertNotIn(str(ROOT), handler.get("commandWindows", ""))
+                    self.assertFalse((settings_path.parent / "python3").exists())
         for groups in codex_hooks.values():
             for group in groups:
                 for handler in group["hooks"]:


### PR DESCRIPTION
## Summary
Grok resolved a single-token `python3` hook command as a path relative to `.claude/settings.json`, so every project hook failed with `command not found: .../.claude\python3`.

This inlines the guard bootstrap into `command` (`python3 -c ...`) so Grok treats it as a shell command, and adds `commandWindows` (`py -3 -c ...`) for Windows Claude/Codex hosts.

Closes #5061

## Checks
- `py -3 -m unittest tests.scripts.test_agent_harness_portability` on the hook worktree
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- Nested-directory hook still emits guard deny R1

## Continuation
Head: 93539312ce
State: PR opened
Blockers: none
Next action: merge to main after review