### PR TITLE
fix(harness): require a MemPalace attempt after plan approval

### DIFF
--- a/chaos-engine/references/research-receipt.md
+++ b/chaos-engine/references/research-receipt.md
@@ -14,7 +14,9 @@ Do these in order:
 3. Query native Memory once for a concrete prior constraint or gotcha; otherwise
    record irrelevance.
 4. Query MemPalace once for concrete cross-session history or relations;
-   otherwise record irrelevance.
+   otherwise record irrelevance. After a plan is approved, do not start the
+   first implementation mutation until this MemPalace attempt has been made
+   (`used`, `skipped` with a concrete irrelevance reason, or `degraded`).
 5. Query Graphify once for structural leads; live-verify returned paths and use
    targeted `rg` for blast radius, or record irrelevance.
 6. Do authoritative online research, preferring current primary documentation,

--- a/chaos-engine/references/retrieve-first.md
+++ b/chaos-engine/references/retrieve-first.md
@@ -45,6 +45,10 @@ budget on a store of any size; `memory search` is the one to reach for.
 
 ## Bounded retrieval
 
+After a plan is approved, the MemPalace attempt in the research receipt is
+mandatory before the first implementation mutation. Record `used`, `skipped`
+with a concrete irrelevance reason, or `degraded`. Do not skip the attempt.
+
 When a store can answer a concrete question, query it before broad discovery.
 Allow one attempt through the existing host timeout, with no retries, repair,
 refresh, mining, checkpointing, polling, or watching. Ordinary tasks launch no

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -489,6 +489,10 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
         self.assertIn("status", retrieval.lower())
         self.assertIn("doctor", retrieval.lower())
         self.assertIn("strict", retrieval.lower())
+        receipt = (CORE / "references/research-receipt.md").read_text(encoding="utf-8").lower()
+        self.assertIn("after a plan is approved", receipt)
+        self.assertIn("first implementation mutation", receipt)
+        self.assertIn("after a plan is approved", retrieval.lower())
         self.assertNotIn("graphify refresh", planning.lower())
         self.assertIn("maintenance owner", planning.lower())
 


### PR DESCRIPTION
## Summary
After a plan is approved, implementation must attempt a MemPalace query (`used`, `skipped` with irrelevance, or `degraded`) before the first mutation. Store failure stays non-blocking. Live probe in this session returned drawers.

## Checks
- `py -3 -m unittest tests.scripts.test_chaos_engine_portable_core.ChaosEnginePortableCoreTest.test_ordinary_tasks_do_not_maintain_or_wait_for_knowledge_stores`
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`

## Continuation
Head: 2812ad23f2
State: ready to merge
Blockers: none
Next action: merge to main