### PR TITLE
feat(scripts): centralize MemPalace and Graphify access from worktrees

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -108,6 +108,7 @@ jobs:
               - 'scripts/ci/worktree_hygiene.py'
               - 'tools/repository-map/README.md'
               - 'tools/repository-map/resolve_graph_out.py'
+              - 'tools/repository-map/resolve_mempalace.py'
               - 'tools/repository-map/graphify_maintenance.py'
               - 'tools/agent-infra/graphify-refresh.cmd'
               - 'tools/agent-infra/install-agent-tasks.ps1'
@@ -139,6 +140,8 @@ jobs:
               - 'tools/intellij-plugin-recording/**'
               - 'tests/scripts/test_worktree_hygiene.py'
               - 'tests/scripts/test_resolve_graph_out.py'
+              - 'tests/scripts/test_resolve_mempalace.py'
+              - 'tests/scripts/test_knowledge_stores.py'
               - 'tests/scripts/test_graphify_maintenance.py'
               - 'tests/scripts/test_shaft_knowledge_refresh.py'
               - 'tests/scripts/test_validate_skills.py'
@@ -375,6 +378,8 @@ jobs:
           tests.scripts.test_agnix_conformance
           tests.scripts.test_worktree_hygiene
           tests.scripts.test_resolve_graph_out
+          tests.scripts.test_resolve_mempalace
+          tests.scripts.test_knowledge_stores
           tests.scripts.test_graphify_maintenance
           tests.scripts.test_shaft_knowledge_refresh
           tests.scripts.test_build_retry

--- a/chaos-engine/profiles/shaft/entrypoint.md
+++ b/chaos-engine/profiles/shaft/entrypoint.md
@@ -8,7 +8,12 @@ Repository contributors use the source-only Graphify resolver
 `tools/repository-map/resolve_graph_out.py`, its focused regression
 `tests/scripts/test_resolve_graph_out.py`, and the lifecycle controller
 `tools/repository-map/graphify_maintenance.py` through the
-[repository Graphify procedure](references/graphify.md); adopters use the
+[repository Graphify procedure](references/graphify.md); the matching
+MemPalace resolver is `tools/repository-map/resolve_mempalace.py` with
+`tests/scripts/test_resolve_mempalace.py`. From any worktree, query both
+stores with `scripts/agents/knowledge_stores.py` (`status`, `search`;
+`refresh` refuses and points at `SHAFT-Nightly-Knowledge-Refresh`). Cover
+that CLI in `tests/scripts/test_knowledge_stores.py`. Adopters use the
 portable installed launcher instead. Repository PRs are watched to confirmed merge with
 `scripts/ci/watch_pr_checks.py`.
 The canonical [reflection checkpoints](../../references/reflection-checkpoints.md)

--- a/chaos-engine/profiles/shaft/references/routing.md
+++ b/chaos-engine/profiles/shaft/references/routing.md
@@ -29,6 +29,10 @@ before broad manual discovery, not all of them by reflex.
 | What calls or depends on this? | [Graphify](../../../references/graphify.md) | Blast radius is unknown, or you are about to change a shared symbol. |
 | What does the code do right now? | targeted `rg` and exact reads | Always. This is the only source that settles a disagreement. |
 
+From any SHAFT worktree, `py -3 scripts/agents/knowledge_stores.py status`
+or `search` hits the centralized palace and a Graphify `--check`. `refresh`
+refuses and names `SHAFT-Nightly-Knowledge-Refresh`.
+
 Each selected store gets one attempt through the existing host timeout. Record
 irrelevant stores as skipped and unavailable stores as degraded; neither blocks
 ordinary implementation or completion. Explicit install, upgrade, maintenance,

--- a/scripts/agents/knowledge_stores.py
+++ b/scripts/agents/knowledge_stores.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Operator CLI for centralized SHAFT MemPalace and Graphify stores."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+# Fixed list-form calls to repository resolvers and the MemPalace CLI.
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RESOLVE_MEMPALACE = REPO_ROOT / "tools/repository-map/resolve_mempalace.py"
+RESOLVE_GRAPH_OUT = REPO_ROOT / "tools/repository-map/resolve_graph_out.py"
+
+
+def run_python(script: Path, arguments: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run one repository-owned Python helper without a shell."""
+    return subprocess.run(  # nosec B603
+        [sys.executable, str(script), *arguments],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def resolve_palace(cwd: Path) -> str:
+    """Return the centralized palace path or raise a fail-closed error."""
+    completed = run_python(RESOLVE_MEMPALACE, [], cwd)
+    palace = completed.stdout.strip()
+    if completed.returncode != 0 or not palace:
+        raise RuntimeError(completed.stderr.strip() or "cannot resolve MemPalace")
+    return palace
+
+
+def run_mempalace(palace: str, arguments: list[str], cwd: Path) -> int:
+    """Invoke mempalace against the resolved palace only."""
+    executable = shutil.which("mempalace")
+    if executable is None:
+        raise RuntimeError("mempalace is not on PATH")
+    completed = subprocess.run(  # nosec B603
+        [executable, "--palace", palace, "--backend", "sqlite_exact", *arguments],
+        cwd=cwd,
+        check=False,
+    )
+    return completed.returncode
+
+
+def cmd_status(cwd: Path) -> int:
+    """Print the resolved palace, MemPalace status, and a Graphify freshness check."""
+    palace = resolve_palace(cwd)
+    print(f"MemPalace: {palace}", flush=True)
+    status_code = run_mempalace(palace, ["status"], cwd)
+    graph = run_python(RESOLVE_GRAPH_OUT, ["--check"], cwd)
+    if graph.stdout:
+        print(graph.stdout, end="" if graph.stdout.endswith("\n") else "\n")
+    if graph.stderr:
+        print(graph.stderr, end="" if graph.stderr.endswith("\n") else "\n", file=sys.stderr)
+    if graph.returncode != 0:
+        print(
+            "Graphify: degraded (use targeted rg; do not rebuild from this command)",
+            file=sys.stderr,
+        )
+    return status_code
+
+
+def cmd_search(cwd: Path, query: str, wing: str | None, room: str | None, results: int | None) -> int:
+    """Search the resolved palace without creating a checkout-local copy."""
+    palace = resolve_palace(cwd)
+    arguments = ["search", query]
+    if wing:
+        arguments.extend(["--wing", wing])
+    if room:
+        arguments.extend(["--room", room])
+    if results is not None:
+        arguments.extend(["--results", str(results)])
+    return run_mempalace(palace, arguments, cwd)
+
+
+def cmd_refresh() -> int:
+    """Refuse refresh from ordinary checkouts and linked worktrees."""
+    print(
+        "Refresh is owned by SHAFT-Nightly-Knowledge-Refresh (#4809). "
+        "Refuse linked worktrees and ordinary checkouts. "
+        "From the installer-owned maintenance clone run "
+        "py -3 tools/repository-map/graphify_maintenance.py refresh --root .",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the operator command parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("status", help="Show the resolved palace and Graphify check.")
+    search = subparsers.add_parser("search", help="Search the resolved SHAFT palace.")
+    search.add_argument("query", help="Search query")
+    search.add_argument("--wing", help="Limit to one wing")
+    search.add_argument("--room", help="Limit to one room")
+    search.add_argument("--results", type=int, help="Number of results")
+    subparsers.add_parser("refresh", help="Refuse; point at the nightly maintenance owner.")
+    return parser
+
+
+def main(argv: list[str] | None = None, cwd: Path | None = None) -> int:
+    """Run the CLI."""
+    args = build_parser().parse_args(argv)
+    working_directory = cwd or Path.cwd()
+    try:
+        if args.command == "status":
+            return cmd_status(working_directory)
+        if args.command == "search":
+            return cmd_search(
+                working_directory,
+                args.query,
+                args.wing,
+                args.room,
+                args.results,
+            )
+        return cmd_refresh()
+    except (OSError, RuntimeError, subprocess.SubprocessError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/agent_guidance_budget.json
+++ b/scripts/ci/agent_guidance_budget.json
@@ -203,6 +203,7 @@
       "scripts/ci/watch_pr_checks.py",
       "scripts/ci/worktree_hygiene.py",
       "tools/repository-map/resolve_graph_out.py",
+      "tools/repository-map/resolve_mempalace.py",
       "tests/scripts/test_agent_*.py",
       "tests/scripts/test_chaos_engine_portable_core.py",
       "tests/scripts/test_chaos_engine_installer.py",
@@ -223,7 +224,9 @@
       "tests/scripts/test_validate_agent_*.py",
       "tests/scripts/test_validate_skills.py",
       "tests/scripts/test_worktree_hygiene.py",
-      "tests/scripts/test_resolve_graph_out.py"
+      "tests/scripts/test_resolve_graph_out.py",
+      "tests/scripts/test_resolve_mempalace.py",
+      "tests/scripts/test_knowledge_stores.py"
     ],
     "exemptions_note": "Empty, and that is the result rather than a placeholder. #4488 asked for a deliberate decision on the enforcement layer and the inbound adapters, the two categories with a real case for exemption; both were made reachable instead, so no category needs one. The mechanism stays because the next element may not be reachable, and it is exercised by a fixture in tests/scripts/test_agent_harness_reachability.py rather than by live data -- an exemption list is the one place a number can be made to look good without doing the work.",
     "exemptions": [],

--- a/tests/scripts/test_agent_harness_portability.py
+++ b/tests/scripts/test_agent_harness_portability.py
@@ -848,6 +848,21 @@ class AgentHarnessPortabilityTest(unittest.TestCase):
         for pattern in ("entities.json", "graphify-out/", "**/target/"):
             self.assertIn(pattern, ignore)
 
+    def test_knowledge_stores_cli_uses_central_resolvers_and_never_creates_a_checkout_palace(self):
+        command = (ROOT / "scripts/agents/knowledge_stores.py").read_text(encoding="utf-8")
+        resolver = (ROOT / "tools/repository-map/resolve_mempalace.py").read_text(encoding="utf-8")
+
+        self.assertIn("tools/repository-map/resolve_mempalace.py", command)
+        self.assertIn("tools/repository-map/resolve_graph_out.py", command)
+        self.assertIn("SHAFT-Nightly-Knowledge-Refresh", command)
+        self.assertIn("graphify_maintenance.py refresh", command)
+        self.assertIn("--backend", command)
+        self.assertIn("sqlite_exact", command)
+        self.assertNotIn(".chaos-engine-state/mempalace", command)
+        self.assertNotIn(".chaos-engine-state/mempalace", resolver)
+        self.assertIn("SHAFT_MEMPALACE must be absolute", resolver)
+        self.assertIn("git-common-dir", resolver)
+
     def test_default_mcp_configs_do_not_launch_docker(self):
         claude = json.loads((ROOT / ".mcp.json").read_text(encoding="utf-8"))[
             "mcpServers"

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -120,7 +120,7 @@ BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 # from the boundary was invisible. Equality makes shrinking the boundary a
 # deliberate two-line edit that shows up in review, which is the only place the
 # question "why is the harness smaller today" gets asked.
-EXPECTED_ELEMENT_COUNT = 244
+EXPECTED_ELEMENT_COUNT = 248
 
 ATX_HEADING = re.compile(r"(?m)^#{1,6}\s+(.+?)\s*$")
 

--- a/tests/scripts/test_knowledge_stores.py
+++ b/tests/scripts/test_knowledge_stores.py
@@ -1,0 +1,134 @@
+"""Operator CLI for centralized SHAFT knowledge stores (#5068)."""
+
+import os
+import shutil
+import subprocess  # nosec B404 - tests run fixed local Git and Python commands.
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/agents/knowledge_stores.py"
+
+
+class KnowledgeStoresTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.sandbox = Path(self.temporary.name)
+        self.primary = self.sandbox / "primary"
+        self.primary.mkdir()
+        self.git("init", cwd=self.primary)
+        self.git("config", "user.email", "knowledge-stores@example.invalid", cwd=self.primary)
+        self.git("config", "user.name", "Knowledge Stores Test", cwd=self.primary)
+        (self.primary / "source.py").write_text("print('indexed')\n", encoding="utf-8")
+        self.git("add", "source.py", cwd=self.primary)
+        self.git("commit", "-m", "indexed source", cwd=self.primary)
+        self.palace = self.primary / ".git" / "chaos-engine" / "mempalace"
+        self.palace.mkdir(parents=True)
+        self.linked = self.sandbox / "linked"
+        self.git("worktree", "add", "-b", "feature", str(self.linked), cwd=self.primary)
+        self.log = self.sandbox / "mempalace.log"
+        fake_bin = self.sandbox / "fake-bin"
+        fake_bin.mkdir()
+        if os.name == "nt":
+            (fake_bin / "mempalace.cmd").write_text(
+                "@echo off\r\n"
+                "echo mempalace %*>>\"%KNOWLEDGE_STORES_LOG%\"\r\n"
+                "echo MEMPALACE-FAKE-OUTPUT\r\n",
+                encoding="utf-8",
+            )
+        else:
+            (fake_bin / "mempalace").write_text(
+                "#!/bin/sh\n"
+                "printf 'mempalace %s\\n' \"$*\" >>\"$KNOWLEDGE_STORES_LOG\"\n"
+                "printf 'MEMPALACE-FAKE-OUTPUT\\n'\n",
+                encoding="utf-8",
+            )
+            (fake_bin / "mempalace").chmod(0o755)
+        self.env = os.environ.copy()
+        self.env["PATH"] = str(fake_bin) + os.pathsep + self.env.get("PATH", "")
+        self.env["KNOWLEDGE_STORES_LOG"] = str(self.log)
+
+    def git(self, *args, cwd):
+        git_executable = shutil.which("git")
+        self.assertIsNotNone(git_executable)
+        return subprocess.run(  # nosec B603 - resolved Git executable and controlled fixture arguments.
+            [git_executable, *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def cli(self, *args, cwd=None):
+        return subprocess.run(  # nosec B603 - current interpreter and repository-owned harness.
+            [sys.executable, str(SCRIPT), *args],
+            cwd=cwd or self.linked,
+            env=self.env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def checkout_palace_created(self, root):
+        return (root / ".chaos-engine-state" / "mempalace").exists()
+
+    def test_status_from_linked_worktree_uses_central_palace_and_graphify_check(self):
+        completed = self.cli("status")
+        combined = completed.stdout + completed.stderr
+
+        self.assertEqual(0, completed.returncode, combined)
+        self.assertIn(str(self.palace.resolve()), combined)
+        self.assertIn("MEMPALACE-FAKE-OUTPUT", completed.stdout)
+        self.assertTrue(self.log.exists(), combined)
+        logged = self.log.read_text(encoding="utf-8")
+        self.assertIn(str(self.palace.resolve()), logged)
+        self.assertIn("--palace", logged)
+        self.assertIn("sqlite_exact", logged)
+        self.assertIn("status", logged)
+        self.assertRegex(completed.stderr + completed.stdout, r"(?:absent|stale) -")
+        self.assertIn("Graphify: degraded", completed.stderr)
+        self.assertFalse(self.checkout_palace_created(self.linked))
+        self.assertFalse(self.checkout_palace_created(self.primary))
+
+    def test_search_from_linked_worktree_forwards_query_to_resolved_palace(self):
+        completed = self.cli("search", "shared cache", "--wing", "shaft_engine_main")
+        combined = completed.stdout + completed.stderr
+
+        self.assertEqual(0, completed.returncode, combined)
+        self.assertIn("MEMPALACE-FAKE-OUTPUT", completed.stdout)
+        logged = self.log.read_text(encoding="utf-8")
+        self.assertIn(str(self.palace.resolve()), logged)
+        self.assertIn("search", logged)
+        self.assertIn("shared cache", logged)
+        self.assertIn("shaft_engine_main", logged)
+        self.assertFalse(self.checkout_palace_created(self.linked))
+
+    def test_refresh_refuses_linked_worktree_and_ordinary_checkout(self):
+        linked = self.cli("refresh", cwd=self.linked)
+        primary = self.cli("refresh", cwd=self.primary)
+
+        for completed in (linked, primary):
+            combined = completed.stdout + completed.stderr
+            self.assertNotEqual(0, completed.returncode, combined)
+            self.assertIn("SHAFT-Nightly-Knowledge-Refresh", combined)
+            self.assertIn("graphify_maintenance.py refresh", combined)
+            self.assertFalse(self.log.exists())
+        self.assertFalse(self.checkout_palace_created(self.linked))
+        self.assertFalse(self.checkout_palace_created(self.primary))
+
+    def test_relative_override_fails_closed_without_creating_a_palace(self):
+        self.env["SHAFT_MEMPALACE"] = "relative/palace"
+        completed = self.cli("status")
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("SHAFT_MEMPALACE must be absolute", completed.stderr)
+        self.assertFalse(self.checkout_palace_created(self.linked))
+        self.assertFalse(self.log.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_resolve_graph_out.py
+++ b/tests/scripts/test_resolve_graph_out.py
@@ -337,7 +337,7 @@ if (-not ($resolverOk -and $cacheOk -and $queryOk -and $auditOk)) {
     def _assert_graphify_contention_is_a_degraded_continuation(self, files):
         graphify = re.sub(r"\s+", " ", files["graphify"])
         retrieval = re.sub(r"\s+", " ", files["retrieval"])
-        entrypoint = re.sub(r"\s+", " ", files["entrypoint"])
+        receipt = re.sub(r"\s+", " ", files["receipt"])
 
         for required in (
             "The existing maintenance controller is the sole Graphify refresh owner.",
@@ -356,7 +356,7 @@ if (-not ($resolverOk -and $cacheOk -and $queryOk -and $auditOk)) {
         )
         self.assertIn(
             "never blocks work",
-            entrypoint,
+            receipt,
         )
         # This is a closed contract over canonical unsafe permission clauses,
         # not an attempt to parse unrestricted natural language.
@@ -381,8 +381,8 @@ if (-not ($resolverOk -and $cacheOk -and $queryOk -and $auditOk)) {
             "retrieval": (
                 ROOT / "chaos-engine/references/retrieve-first.md"
             ).read_text(encoding="utf-8"),
-            "entrypoint": (
-                ROOT / "chaos-engine/skills/chaos-engine/SKILL.md"
+            "receipt": (
+                ROOT / "chaos-engine/references/research-receipt.md"
             ).read_text(encoding="utf-8"),
         }
 

--- a/tests/scripts/test_resolve_mempalace.py
+++ b/tests/scripts/test_resolve_mempalace.py
@@ -1,0 +1,118 @@
+"""Shared MemPalace path resolver (#5068)."""
+
+import os
+import shutil
+import subprocess  # nosec B404 - tests run fixed local Git and Python commands.
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/repository-map/resolve_mempalace.py"
+
+
+class ResolveMempalaceTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.sandbox = Path(self.temporary.name)
+        self.primary = self.sandbox / "primary"
+        self.primary.mkdir()
+        self.git("init", cwd=self.primary)
+        self.git("config", "user.email", "mempalace-test@example.invalid", cwd=self.primary)
+        self.git("config", "user.name", "MemPalace Test", cwd=self.primary)
+        (self.primary / "source.py").write_text("print('indexed')\n", encoding="utf-8")
+        self.git("add", "source.py", cwd=self.primary)
+        self.git("commit", "-m", "indexed source", cwd=self.primary)
+        self.palace = self.primary / ".git" / "chaos-engine" / "mempalace"
+        self.palace.mkdir(parents=True)
+
+    def git(self, *args, cwd):
+        git_executable = shutil.which("git")
+        self.assertIsNotNone(git_executable)
+        return subprocess.run(  # nosec B603 - resolved Git executable and controlled fixture arguments.
+            [git_executable, *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def resolver(self, *args, cwd=None, env=None):
+        return subprocess.run(  # nosec B603 - current interpreter and repository-owned resolver.
+            [sys.executable, str(SCRIPT), *args],
+            cwd=cwd or self.primary,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_primary_and_linked_worktree_resolve_the_same_palace(self):
+        linked = self.sandbox / "linked"
+        self.git("worktree", "add", "-b", "feature", str(linked), cwd=self.primary)
+
+        primary = self.resolver()
+        worktree = self.resolver(cwd=linked)
+
+        self.assertEqual(0, primary.returncode, primary.stderr)
+        self.assertEqual(0, worktree.returncode, worktree.stderr)
+        self.assertEqual(str(self.palace.resolve()), primary.stdout.strip())
+        self.assertEqual(primary.stdout.strip(), worktree.stdout.strip())
+
+    def test_absolute_environment_override_selects_external_palace(self):
+        external = self.sandbox / "external-palace"
+        environment = os.environ.copy()
+        environment["SHAFT_MEMPALACE"] = str(external)
+
+        completed = self.resolver(env=environment)
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        self.assertEqual(str(external.resolve()), completed.stdout.strip())
+
+    def test_relative_environment_override_fails_closed(self):
+        environment = os.environ.copy()
+        environment["SHAFT_MEMPALACE"] = "relative/palace"
+
+        completed = self.resolver(env=environment)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("SHAFT_MEMPALACE must be absolute", completed.stderr)
+
+    def test_blank_environment_override_fails_closed(self):
+        environment = os.environ.copy()
+        environment["SHAFT_MEMPALACE"] = "   "
+
+        completed = self.resolver(env=environment)
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("SHAFT_MEMPALACE must not be blank", completed.stderr)
+
+    def test_pr_gate_and_guidance_name_the_resolver_and_operator_command(self):
+        workflow = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")
+        readme = (ROOT / "tools/repository-map/README.md").read_text(encoding="utf-8")
+        entrypoint = (ROOT / "chaos-engine/profiles/shaft/entrypoint.md").read_text(
+            encoding="utf-8"
+        )
+        routing = (ROOT / "chaos-engine/profiles/shaft/references/routing.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("tests.scripts.test_resolve_mempalace", workflow)
+        self.assertIn("tests.scripts.test_knowledge_stores", workflow)
+        self.assertIn("'tools/repository-map/resolve_mempalace.py'", workflow)
+        self.assertIn("resolve_mempalace.py", readme)
+        self.assertIn("scripts/agents/knowledge_stores.py", readme)
+        self.assertIn("scripts/agents/knowledge_stores.py", entrypoint)
+        self.assertIn("tools/repository-map/resolve_mempalace.py", entrypoint)
+        self.assertIn("SHAFT-Nightly-Knowledge-Refresh", readme)
+        self.assertIn("knowledge_stores.py", routing)
+        self.assertNotIn("daydream", readme.lower())
+        self.assertNotIn("daydream", entrypoint.lower())
+        self.assertNotIn("daydream", routing.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/repository-map/README.md
+++ b/tools/repository-map/README.md
@@ -85,3 +85,23 @@ Because `graphify-out/` is gitignored, it never exists in a fresh `git worktree`
   it. On the primary maintainer machine the nightly maintenance task invokes
   the same controller automatically.
 - The "mandatory entry point" rule is satisfied by running the `--check` resolve, not by building the graph. If the cache is absent, fall back to `rg` and `.memory` instead of blocking the session on a rebuild.
+
+## Shared MemPalace across worktrees
+
+The SHAFT palace lives at `<git-common-dir>/chaos-engine/mempalace` (today the
+primary `.git` tree). Do not create `<checkout>/.chaos-engine-state/mempalace`
+and do not junction that empty path onto the centralized palace.
+
+- Resolve it from any worktree with `python3 tools/repository-map/resolve_mempalace.py`.
+- Set `SHAFT_MEMPALACE` to an absolute palace path when the shared palace is
+  outside that checkout. An explicitly blank or relative value fails closed.
+- Operator command from any worktree cwd:
+
+```powershell
+py -3 scripts/agents/knowledge_stores.py status
+py -3 scripts/agents/knowledge_stores.py search "shared cache" --wing shaft_engine_main
+```
+
+`refresh` refuses linked worktrees and ordinary checkouts. Overnight mine/sync
+stays with `SHAFT-Nightly-Knowledge-Refresh` (#4809). MemPalace `daemon` is an
+opt-in write serializer, not an overnight miner; do not start a second racer.

--- a/tools/repository-map/resolve_mempalace.py
+++ b/tools/repository-map/resolve_mempalace.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Resolve the shared MemPalace path from any worktree."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+# Only used to run one fixed git command (list-args, no shell) with the
+# executable resolved to an absolute path below.
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+
+def find_shared_mempalace(cwd: Path) -> Path:
+    """Return the shared palace path under the main checkout git directory."""
+    if "SHAFT_MEMPALACE" in os.environ:
+        configured = os.environ["SHAFT_MEMPALACE"].strip()
+        if not configured:
+            raise RuntimeError("SHAFT_MEMPALACE must not be blank")
+        palace = Path(configured).expanduser()
+        if not palace.is_absolute():
+            raise RuntimeError("SHAFT_MEMPALACE must be absolute")
+        return palace.resolve()
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        raise RuntimeError("git is not on PATH")
+    # Absolute executable path, fixed internal arguments, no shell.
+    completed = subprocess.run(  # nosec B603
+        [git_executable, "rev-parse", "--git-common-dir"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    common_dir = Path(completed.stdout.strip())
+    if not common_dir.is_absolute():
+        common_dir = (cwd / common_dir).resolve()
+    return common_dir / "chaos-engine" / "mempalace"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    return argparse.ArgumentParser(description=__doc__)
+
+
+def main(argv: list[str] | None = None, cwd: Path | None = None) -> int:
+    """Run the CLI."""
+    build_parser().parse_args(argv)
+    working_directory = cwd or Path.cwd()
+    try:
+        print(find_shared_mempalace(working_directory))
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Any SHAFT worktree can now hit one centralized MemPalace and a Graphify freshness check through a harness command. This closes #5068.

- ``tools/repository-map/resolve_mempalace.py`` resolves ``<git-common-dir>/chaos-engine/mempalace``. ``SHAFT_MEMPALACE`` is absolute-only and fail-closed.
- ``py -3 scripts/agents/knowledge_stores.py status|search`` works from any worktree cwd. ``refresh`` refuses linked worktrees and ordinary checkouts and points at ``SHAFT-Nightly-Knowledge-Refresh`` (#4809).
- No second palace under ``.chaos-engine-state/mempalace``. Portable ``chaos-engine/hosts.py`` / ``tool.py`` are unchanged.
- Overnight stays one owner. Leftover root ``\graphify-refresh`` was unregistered on the maintainer machine. MemPalace has no ``daydream`` verb; ``daemon`` is a write serializer, not an overnight miner, and was left stopped.

## Checks

- Observed RED, then GREEN: ``py -3 -m unittest tests.scripts.test_resolve_mempalace tests.scripts.test_knowledge_stores tests.scripts.test_agent_harness_portability.AgentHarnessPortabilityTest.test_knowledge_stores_cli_uses_central_resolvers_and_never_creates_a_checkout_palace``
- Balanced: those tests plus ``tests.scripts.test_resolve_graph_out`` (20 tests, including contention contract now pinned to ``research-receipt.md``).
- ``py -3 scripts/ci/validate_agent_setup.py --skip-external`` passed (191493 guidance bytes, 382 memory objects).
- Live from linked worktree: resolve + status (61943 drawers) + search (SHAFT wing hits) + refresh refuse. No checkout-local palace.

## Continuation

Head: d4084e17c31c20063ab8ff8d09498cdf67e1639f
State: second commit pushed (contention test location). Leftover racer removed. Follow-up #5071 filed.
Blockers: independent adversarial review before arming; CI still running.
Next action: independent review, then arm ``--auto --merge`` and watch to confirmed merge.