### PR TITLE
fix(scripts): drop empty existing cited-path blocker

### DIFF
--- a/scripts/local-coding-agent/agent.py
+++ b/scripts/local-coding-agent/agent.py
@@ -129,16 +129,8 @@ def missing_cited_paths(text: str, root: str | object) -> list[str]:
 
 
 def cited_path_blockers(text: str, root: str | object) -> list[str]:
-    """Fail closed: need at least one existing cited path; any missing path blocks."""
-    cited = cited_repo_paths(text)
-    missing = missing_cited_paths(text, root)
-    existing = [path for path in cited if path not in missing]
-    blockers: list[str] = []
-    if not existing:
-        blockers.append("no existing cited repo path")
-    for path in missing:
-        blockers.append(f"cited path does not exist: {path}")
-    return blockers
+    """Fail closed: any cited slashy path that does not exist blocks."""
+    return [f"cited path does not exist: {path}" for path in missing_cited_paths(text, root)]
 
 
 def validate_report(data: dict) -> list[str]:

--- a/tests/scripts/test_knowledge_stores.py
+++ b/tests/scripts/test_knowledge_stores.py
@@ -76,6 +76,22 @@ class KnowledgeStoresTest(unittest.TestCase):
     def checkout_palace_created(self, root):
         return (root / ".chaos-engine-state" / "mempalace").exists()
 
+    def mempalace_tokens(self):
+        logged = self.log.read_text(encoding="utf-8")
+        line = next((item for item in logged.splitlines() if item.strip()), "")
+        return line.split()
+
+    def assert_global_flags_before(self, subcommand):
+        tokens = self.mempalace_tokens()
+        palace_at = tokens.index("--palace")
+        backend_at = tokens.index("--backend")
+        command_at = tokens.index(subcommand)
+        self.assertLess(palace_at, command_at, tokens)
+        self.assertLess(backend_at, command_at, tokens)
+        self.assertEqual("sqlite_exact", tokens[backend_at + 1], tokens)
+        self.assertEqual(str(self.palace.resolve()), tokens[palace_at + 1], tokens)
+        return tokens
+
     def test_status_from_linked_worktree_uses_central_palace_and_graphify_check(self):
         completed = self.cli("status")
         combined = completed.stdout + completed.stderr
@@ -84,11 +100,7 @@ class KnowledgeStoresTest(unittest.TestCase):
         self.assertIn(str(self.palace.resolve()), combined)
         self.assertIn("MEMPALACE-FAKE-OUTPUT", completed.stdout)
         self.assertTrue(self.log.exists(), combined)
-        logged = self.log.read_text(encoding="utf-8")
-        self.assertIn(str(self.palace.resolve()), logged)
-        self.assertIn("--palace", logged)
-        self.assertIn("sqlite_exact", logged)
-        self.assertIn("status", logged)
+        self.assert_global_flags_before("status")
         self.assertRegex(completed.stderr + completed.stdout, r"(?:absent|stale) -")
         self.assertIn("Graphify: degraded", completed.stderr)
         self.assertFalse(self.checkout_palace_created(self.linked))
@@ -100,11 +112,10 @@ class KnowledgeStoresTest(unittest.TestCase):
 
         self.assertEqual(0, completed.returncode, combined)
         self.assertIn("MEMPALACE-FAKE-OUTPUT", completed.stdout)
+        tokens = self.assert_global_flags_before("search")
         logged = self.log.read_text(encoding="utf-8")
-        self.assertIn(str(self.palace.resolve()), logged)
-        self.assertIn("search", logged)
         self.assertIn("shared cache", logged)
-        self.assertIn("shaft_engine_main", logged)
+        self.assertIn("shaft_engine_main", tokens)
         self.assertFalse(self.checkout_palace_created(self.linked))
 
     def test_refresh_refuses_linked_worktree_and_ordinary_checkout(self):

--- a/tests/scripts/test_local_coding_agent.py
+++ b/tests/scripts/test_local_coding_agent.py
@@ -258,6 +258,10 @@ class LocalCodingAgentPackagingTest(unittest.TestCase):
 class LocalCodingAgentCitedPathTest(unittest.TestCase):
     HALLUCINATED = "shaft-ai/src/main/java/com/shaft/ai/ollama/OllamaClient.java"
     EXISTING = "scripts/local-coding-agent/run_agent.ps1"
+    AGENTS_MD_ONLY_BARE_NAMES = (
+        "> Added AGENTS.md to the chat (read-only).\n"
+        "See shaft-architect.ps1 and OllamaProvider.java.\n"
+    )
 
     def test_recorded_ollama_client_hallucination_is_missing(self):
         text = (
@@ -280,11 +284,22 @@ class LocalCodingAgentCitedPathTest(unittest.TestCase):
         text = "OllamaClient and OllamaProvider are class names, not repo paths."
         self.assertEqual([], MODULE.cited_repo_paths(text))
 
-    def test_no_existing_cited_path_is_a_blocker(self):
+    def test_agents_md_only_history_with_bare_real_names_is_ok(self):
         import tempfile
 
         transcript = Path(tempfile.mkdtemp()) / "history.md"
-        transcript.write_text(f"Invented {self.HALLUCINATED}\n", encoding="utf-8")
+        transcript.write_text(self.AGENTS_MD_ONLY_BARE_NAMES, encoding="utf-8")
+        code = MODULE.main(["cited", "--text-file", str(transcript), "--root", str(ROOT)])
+        self.assertEqual(0, code)
+
+    def test_agents_md_only_history_still_blocks_invented_slashy_path(self):
+        import tempfile
+
+        transcript = Path(tempfile.mkdtemp()) / "history.md"
+        transcript.write_text(
+            self.AGENTS_MD_ONLY_BARE_NAMES + f"The Java client is {self.HALLUCINATED}.\n",
+            encoding="utf-8",
+        )
         code = MODULE.main(["cited", "--text-file", str(transcript), "--root", str(ROOT)])
         self.assertEqual(2, code)
 


### PR DESCRIPTION
Closes #5073
Closes #5074
Related to #5065
Related to #5068
Related to #5017

## Summary

Default `shaft-architect` history that only adds `AGENTS.md` and cites bare real names no longer false-reds the cited-path gate.

`cited_path_blockers` no longer requires at least one existing slashy repo path. It still fail-closes on any cited slashy path that does not exist (`OllamaClient.java` style). HTTP(S), Windows absolute paths, and `ollama_chat/qwen2.5...` stay ignored. Extra `-Read` is not required.

Also pins MemPalace `--palace` / `--backend sqlite_exact` before `status`/`search` by parsing the fake log as tokens. No production change for that pin.

## Checks

- Observed RED: `LocalCodingAgentCitedPathTest.test_agents_md_only_history_with_bare_real_names_is_ok` expected exit 0, got 2 (`no existing cited repo path`).
- GREEN: `py -3 -m unittest tests.scripts.test_local_coding_agent tests.scripts.test_knowledge_stores` — 40 tests OK.
- Same AGENTS.md-only history plus `shaft-ai/src/main/java/com/shaft/ai/ollama/OllamaClient.java` is still exit 2.
- Existing ignore tests for HTTP(S), Windows abs paths, and model ids kept.
- Knowledge-store token-order assertions passed against current argv; production `run_mempalace` already places global flags first.

## Continuation

Head: 99d1d161b8
State: #5073 and #5074 both on this draft. Ready for independent parent review.
Blockers: none. Do not mark ready. Do not merge.
Next action: parent independent review. Merge-commits only after that review.
