### PR TITLE
fix(chaos-engine): degrade SHAFT doctor when checkout palace is missing

### DIFF
--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -301,7 +301,7 @@ def mempalace_runtime_status(project: Path) -> dict[str, str]:
             return {
                 "status": "degraded",
                 "detail": (
-                    "Centralized SHAFT MemPalace is the operator path; "
+                    "Centralized MemPalace is the operator path; "
                     "use py -3 scripts/agents/knowledge_stores.py status"
                 ),
             }

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -297,6 +297,14 @@ def mempalace_runtime_status(project: Path) -> dict[str, str]:
             "detail": "MemPalace state is a link or reparse point",
         }
     if not palace.exists():
+        if (project / "tools/repository-map/resolve_mempalace.py").is_file():
+            return {
+                "status": "degraded",
+                "detail": (
+                    "Centralized SHAFT MemPalace is the operator path; "
+                    "use py -3 scripts/agents/knowledge_stores.py status"
+                ),
+            }
         return {"status": "initialization-required", "backend": "sqlite_exact"}
     if not palace.is_dir():
         return {

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -1231,6 +1231,52 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
             self.assertFalse((palace / "sqlite_exact.sqlite3").exists())
 
+    def test_shaft_resolver_without_checkout_palace_is_degraded_and_does_not_initialize(self):
+        module = load(HOSTS, "chaos_engine_mempalace_shaft_resolver")
+        with tempfile.TemporaryDirectory() as temporary:
+            shaft = Path(temporary) / "shaft"
+            resolver = shaft / "tools/repository-map/resolve_mempalace.py"
+            resolver.parent.mkdir(parents=True)
+            resolver.write_text("# fixture SHAFT resolver\n", encoding="utf-8")
+
+            state = module.mempalace_runtime_status(shaft)
+            self.assertEqual("degraded", state["status"])
+            self.assertIn("scripts/agents/knowledge_stores.py status", state["detail"])
+            self.assertIn("centralized", state["detail"].lower())
+            self.assertNotIn(".git", state["detail"])
+
+            module.initialize_mempalace_runtime(shaft)
+            self.assertFalse((shaft / ".chaos-engine-state/mempalace").exists())
+
+            portable = Path(temporary) / "portable"
+            portable.mkdir()
+            self.assertEqual(
+                "initialization-required",
+                module.mempalace_runtime_status(portable)["status"],
+            )
+
+    def test_tool_guard_refuses_shaft_degraded_mempalace_and_names_knowledge_stores(self):
+        hosts = load(HOSTS, "chaos_engine_mempalace_shaft_guard_hosts")
+        tool = load(TOOL, "chaos_engine_mempalace_shaft_guard_tool")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            resolver = project / "tools/repository-map/resolve_mempalace.py"
+            resolver.parent.mkdir(parents=True)
+            resolver.write_text("# fixture SHAFT resolver\n", encoding="utf-8")
+            arguments = [
+                "--palace",
+                ".chaos-engine-state/mempalace",
+                "--backend",
+                "sqlite_exact",
+            ]
+            with mock.patch.object(
+                tool,
+                "load_host_controller",
+                return_value=hosts.__dict__,
+            ):
+                with self.assertRaisesRegex(ValueError, r"knowledge_stores\.py"):
+                    tool.guard_mempalace_mcp(project / ".chaos-engine", arguments)
+
     def test_launcher_rendering_is_explicit_for_windows_and_posix(self):
         module = load(HOSTS, "chaos_engine_hosts")
 

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -1277,6 +1277,14 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, r"knowledge_stores\.py"):
                     tool.guard_mempalace_mcp(project / ".chaos-engine", arguments)
 
+    def test_hosts_module_source_has_no_portable_forbidden_tokens(self):
+        catalog = json.loads((ROOT / "chaos-engine/distributions.json").read_text(encoding="utf-8"))
+        tokens = catalog["distributions"]["portable"]["forbiddenTokens"]
+        text = HOSTS.read_text(encoding="utf-8").casefold()
+        for token in tokens:
+            with self.subTest(token=token):
+                self.assertNotIn(str(token).casefold(), text)
+
     def test_launcher_rendering_is_explicit_for_windows_and_posix(self):
         module = load(HOSTS, "chaos_engine_hosts")
 


### PR DESCRIPTION
## Summary

Portable ChaosEngine doctor/MCP now reports a **degraded** MemPalace status when the project contains `tools/repository-map/resolve_mempalace.py` and checkout `.chaos-engine-state/mempalace` is missing. The detail names `py -3 scripts/agents/knowledge_stores.py status` as the operator path for the centralized palace. The portable detail does not contain the forbidden token `shaft`.

`initialize_mempalace_runtime` stays a no-op in that state and does not create a second palace. Portable adopters without the resolver keep `initialization-required` plus the existing init path. `tool.py` still launches with `--palace .chaos-engine-state/mempalace` and still refuses unless status is `healthy`; the refuse error includes the harness detail.

No junction. No git-dir path in portable `hosts.py` or `tool.py`.

Closes #5071

## Checks

RED observed (parent classifier returned `initialization-required`):
- `tests.scripts.test_chaos_engine_hosts.ChaosEngineHostsTest.test_shaft_resolver_without_checkout_palace_is_degraded_and_does_not_initialize`
- `tests.scripts.test_chaos_engine_hosts.ChaosEngineHostsTest.test_tool_guard_refuses_shaft_degraded_mempalace_and_names_knowledge_stores`

Follow-up RED (`shaft` token still in `hosts.py`):
- `tests.scripts.test_chaos_engine_hosts.ChaosEngineHostsTest.test_hosts_module_source_has_no_portable_forbidden_tokens`
  `AssertionError: 'shaft' unexpectedly found in` hosts.py

GREEN:
`
py -3 -m unittest tests.scripts.test_chaos_engine_hosts tests.scripts.test_knowledge_stores tests.scripts.test_chaos_engine_bootstrap -v
`
hosts module 80 tests OK. Targeted trio + knowledge_stores + bootstrap: 30 tests OK.

`py -3 scripts/ci/validate_red_before_green.py HEAD chaos-engine/hosts.py tests/scripts/test_chaos_engine_hosts.py` exit 0.

Locked approach recorded on #5071 before the implementing commit: https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5071#issuecomment-5320054132

## Continuation

Head: ba2dbea36024570fa94a817fe0acb9875bb4dcc3
State: draft; review F1/F2 patched (dropped SHAFT from portable detail; added forbidden-token scan)
Blockers: waiting ChaosEngine acceptance on this head
Next action: keep draft; do not mark ready; do not merge until CI is green on this SHA