### PR TITLE
fix(scripts): rewrite worktree git index to v2 before Aider

### DIFF
--- a/scripts/local-coding-agent/run_agent.ps1
+++ b/scripts/local-coding-agent/run_agent.ps1
@@ -59,6 +59,11 @@ if (-not (Test-Path -LiteralPath $Worktree)) {
     Write-Error "worktree does not exist: $Worktree"
     exit 2
 }
+git -C $Worktree update-index --index-version 2
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "git update-index --index-version 2 failed: $LASTEXITCODE"
+    exit 2
+}
 if (-not (Test-Path -LiteralPath $Spec)) {
     Write-Error "spec does not exist: $Spec"
     exit 2

--- a/scripts/local-coding-agent/shaft-architect.ps1
+++ b/scripts/local-coding-agent/shaft-architect.ps1
@@ -26,6 +26,11 @@ if (-not (Test-Path -LiteralPath $Worktree)) {
     Write-Error "worktree does not exist: $Worktree"
     exit 2
 }
+git -C $Worktree update-index --index-version 2
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "git update-index --index-version 2 failed: $LASTEXITCODE"
+    exit 2
+}
 if (-not (Test-Path -LiteralPath $Spec)) {
     Write-Error "spec does not exist: $Spec"
     exit 2

--- a/tests/scripts/test_local_coding_agent.py
+++ b/tests/scripts/test_local_coding_agent.py
@@ -254,6 +254,14 @@ class LocalCodingAgentPackagingTest(unittest.TestCase):
         self.assertIn("--text-file", architect_text)
         self.assertIn("PositionalBinding = $false", architect_text)
 
+    def test_launchers_downgrade_worktree_index_to_version_2(self):
+        for path in (RUN_AGENT, ARCHITECT):
+            with self.subTest(path.name):
+                text = path.read_text(encoding="utf-8")
+                self.assertIn("update-index", text)
+                self.assertIn("--index-version", text)
+                self.assertIn("--index-version 2", text)
+
 
 class LocalCodingAgentCitedPathTest(unittest.TestCase):
     HALLUCINATED = "shaft-ai/src/main/java/com/shaft/ai/ollama/OllamaClient.java"


### PR DESCRIPTION
## Summary

Aider 0.86.2 vendors GitPython 3.1.46, which asserts git index versions 1/2/3 only. A live worktree created with local `feature.manyFiles=true` gets a DIRC v4 index, so Aider prints `Unable to read staged files: Unsupported git index version 4, only 1, 2, and 3 are supported`.

After the target worktree exists and before Aider starts, both `scripts/local-coding-agent/run_agent.ps1` and `scripts/local-coding-agent/shaft-architect.ps1` run `git -C $Worktree update-index --index-version 2` and fail closed if that command fails. That rewrites only the worktree index under `.git/worktrees/...`. Machine Git stays on manyFiles / index v4. Aider stays on 0.86.2. No `--no-git`. No tracked git config change. No primary checkout index rewrite.

Closes #5072
Related to #5017

## Checks

`py -3 -m unittest tests.scripts.test_local_coding_agent`

- RED: 37 tests, 2 failures (`update-index` missing in both launchers)
- GREEN: 37 tests, OK

## Continuation

Head: ff78b85a5fff4e4b6eeebed67143e7230e1c8f09
State: draft PR; waiting independent parent review
Blockers: none from implementer
Next action: independent adversarial review; do not mark ready; do not merge