### PR TITLE
feat(chaos-engine): add portable local-coding-delegate skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -33,7 +33,7 @@ flowchart TD
     CF --> R
 
     R["<b>routing</b><br/>deliverable to one surface"]
-    R --> P["Repository playbooks<br/><i>13</i>"]
+    R --> P["Repository playbooks<br/><i>14</i>"]
     R --> M["SHAFT mastery chapters<br/><i>10</i>"]
     R --> D["Method references"]
     E --> D
@@ -114,6 +114,7 @@ step with the first.
 | Skill | What it does |
 | --- | --- |
 | [ChaosEngine](../../chaos-engine/skills/chaos-engine/SKILL.md) | The single always-loaded entrypoint and global router. Carries the iron laws, the triage that sizes every task, the always-on working style, and the table that sends each deliverable to exactly one surface. |
+| [local-coding-delegate](../../chaos-engine/skills/local-coding-delegate/SKILL.md) | Optional. Not always-loaded. A local coding loop the decider may use as a mechanical or default delegate after a hardware probe. |
 
 The entrypoint reaches the internal [consultation](../../chaos-engine/references/consult-first.md)
 and [retrieval](../../chaos-engine/references/retrieve-first.md) gates after every
@@ -174,6 +175,7 @@ list is the inventory, not a second copy of the triggers.
 - [public docs](../../chaos-engine/profiles/shaft/references/playbooks/public-behavior-docs-synchronizer.md)
 - [UI design](../../chaos-engine/profiles/shaft/references/playbooks/shaft-ui-design.md)
 - [marketing](../../chaos-engine/profiles/shaft/references/playbooks/shaft-marketing-ad-producer.md)
+- [workstation local coding](../../chaos-engine/profiles/shaft/references/playbooks/workstation-local-coding-agent.md)
 
 ### SHAFT mastery chapters
 

--- a/.memory/memory/decisions/portable-local-coding-delegate-excludes-shaft-workstation-facts.json
+++ b/.memory/memory/decisions/portable-local-coding-delegate-excludes-shaft-workstation-facts.json
@@ -1,0 +1,40 @@
+{
+  "body_path": "memory/decisions/portable-local-coding-delegate-excludes-shaft-workstation-facts.md",
+  "content_hash": "sha256:6546258312a2383378e91caf28e2c22c72ea78545a7edea4f96da40649d17d06",
+  "created_at": "2026-08-18T00:24:41+03:00",
+  "evidence": [
+    {
+      "id": "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5081",
+      "kind": "task"
+    }
+  ],
+  "facets": {
+    "applies_to": [
+      "chaos-engine/skills/local-coding-delegate/",
+      "chaos-engine/profiles/portable/references/routing.md",
+      "chaos-engine/profiles/shaft/references/playbooks/workstation-local-coding-agent.md"
+    ],
+    "category": "decision-rationale"
+  },
+  "id": "decision.portable-local-coding-delegate-excludes-shaft-workstation-facts",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Record the locked #5081 portable-versus-SHAFT local-coding split so later work does not reopen it."
+  },
+  "status": "active",
+  "tags": [
+    "chaos-engine",
+    "portable",
+    "local-coding-delegate",
+    "5081"
+  ],
+  "title": "Portable local-coding-delegate excludes SHAFT workstation facts",
+  "type": "decision",
+  "updated_at": "2026-08-18T00:24:41+03:00"
+}

--- a/.memory/memory/decisions/portable-local-coding-delegate-excludes-shaft-workstation-facts.md
+++ b/.memory/memory/decisions/portable-local-coding-delegate-excludes-shaft-workstation-facts.md
@@ -1,0 +1,1 @@
+Issue #5081 locked the split. The optional portable skill chaos-engine/skills/local-coding-delegate and portable routing must not contain D:\AI, shaft-java-agent, qwen, Ollama, Aider, or SHAFT_LOCAL_AI. Workstation commands live only in the SHAFT playbook workstation-local-coding-agent.md. Do not reopen the SHAFT-versus-portable split or put those facts into portable ChaosEngine.

--- a/chaos-engine/profiles/portable/entrypoint.md
+++ b/chaos-engine/profiles/portable/entrypoint.md
@@ -7,5 +7,8 @@ assumes a product, organization, hosting provider, or repository layout.
 
 Route project-specific work through the portable
 [routing table](references/routing.md).
+An optional [local coding delegate](../../skills/local-coding-delegate/SKILL.md)
+may run a user-configured local loop when the decider model and a hardware
+probe both say it adds value.
 Keep canonical non-secret harness configuration tracked; keep generated
 runtime state, indexes, reports, and caches untracked.

--- a/chaos-engine/profiles/portable/references/routing.md
+++ b/chaos-engine/profiles/portable/references/routing.md
@@ -10,3 +10,6 @@ project-local workflow from its files and explicit user instructions.
 Use the generic GitHub delivery playbook only when the adopter uses GitHub.
 Never infer a provider, organization, default branch, language, build system,
 companion repository, deployment target, or issue taxonomy from ChaosEngine.
+When the adopter asked for a local coding loop, load the optional
+[local coding delegate](../../../skills/local-coding-delegate/SKILL.md); the
+most-intelligent or default capability stays the decider.

--- a/chaos-engine/profiles/shaft/entrypoint.md
+++ b/chaos-engine/profiles/shaft/entrypoint.md
@@ -30,6 +30,8 @@ apply unchanged to repository and portable installed hosts.
   from `https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/bootstrap.py`.
 - Maven modules and SHAFT product behavior route through the playbooks and
   mastery chapters under [references](references/routing.md).
+- Cheap, bounded, already-specified local coding work uses the
+  [workstation local coding agent](references/playbooks/workstation-local-coding-agent.md).
 
 ## Standing artifact sharing authorization
 

--- a/chaos-engine/profiles/shaft/references/playbooks/workstation-local-coding-agent.md
+++ b/chaos-engine/profiles/shaft/references/playbooks/workstation-local-coding-agent.md
@@ -1,0 +1,39 @@
+# Workstation local coding agent
+
+Use the already-installed workstation loop when the work is cheap, bounded,
+and already specified. The default capability's cost and latency are waste
+for those slices. The most-intelligent or default model stays the decider
+and may hand the slice to this loop.
+
+## When to use it
+
+- Read-only `shaft-architect` with the cited-path gate.
+- Mechanical script-string pins the loop can apply without inventing scope.
+- A fully specified edit the loop can run, with an allowlist and a test
+  command, where default-capability time is waste.
+
+## When not to use it
+
+- Product changes under `src/main/java`.
+- PR merge, GitHub delivery, or review.
+- Harness architecture, routing, or guidance design.
+- Anything the loop cannot run: missing allowlist, missing spec, work that
+  needs a public-API judgment, or a host that is not this workstation.
+
+## Commands
+
+Keep one model loaded. Loopback only. No startup apps, tray icons, or cloud
+endpoints.
+
+- `scripts/local-coding-agent/shaft-java-agent.ps1` — bounded edit loop.
+- `scripts/local-coding-agent/shaft-architect.ps1` — read-only architect;
+  cited-path gate fail-closes invented slashy paths.
+- `scripts/local-coding-agent/shaft-local-ai-stop.ps1` — stop the loopback
+  runtime.
+- `scripts/agents/knowledge_stores.py` — `status` or `search` from any
+  worktree. `refresh` refuses.
+
+## Output
+
+Return the command that ran, the report path, cited-path or allowlist
+failures, and whether the decider must take the work back.

--- a/chaos-engine/profiles/shaft/references/routing.md
+++ b/chaos-engine/profiles/shaft/references/routing.md
@@ -79,6 +79,7 @@ failure this table exists to prevent.
 | A repository CI script or guard under `scripts/`, outside agent guidance | [agent guidance](playbooks/agent-guidance-boundary-guard.md), then the guard's own test |
 | In-repo Markdown for humans, such as README or CONTRIBUTING | [public docs](playbooks/public-behavior-docs-synchronizer.md) |
 | The `.memory` store itself: entries, relations, or hygiene | [agent guidance](playbooks/agent-guidance-boundary-guard.md) |
+| Cheap, bounded, already-specified workstation coding | [workstation local coding](playbooks/workstation-local-coding-agent.md) |
 
 ## Deep SHAFT internals
 

--- a/chaos-engine/skills/local-coding-delegate/SKILL.md
+++ b/chaos-engine/skills/local-coding-delegate/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: local-coding-delegate
+description: >-
+  Optional local coding loop as a mechanical or default delegate. Use when the
+  decider model wants a cheap local coder and a hardware probe says the host
+  can run one.
+license: MIT
+---
+
+# Local coding delegate
+
+Optional. Not always-loaded. A user-configurable local coding loop that runs
+as a **mechanical** or **default** delegate only.
+
+The most-intelligent or default capability model stays the decider. Load this
+skill when that decider judges a local loop would add value, then probe the
+host before configuring anything.
+
+## When it may run
+
+- The adopter asked for a local loop, or the decider chose one for cheap,
+  bounded, already-specified work.
+- The [hardware probe](scripts/probe_hardware.py) recommends a size class
+  other than `refuse`.
+- The task is mechanical or default-capability labor, not review, not the
+  GitHub playbook, and not a public-API change unless both the probe and the
+  task say the local coder is enough.
+
+Honest `refuse` is a valid completion. Do not download or configure a local
+coder unless the adopter asked and the probe says the host can run a useful
+one. Never invent a default vendor model name. Speak in capability levels and
+size classes (`small`, `medium`, `large`, or `refuse`).
+
+## Probe
+
+Run the stdlib probe. It reports OS, RAM, and GPU memory when present, then
+recommends a size class or refuses.
+
+```text
+python3 chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py
+```
+
+- `refuse` — do not install or invoke a local coder.
+- `small` / `medium` / `large` — the host can run a useful coder in that
+  class. The adopter chooses the vendor and the model. This skill does not.
+
+## Bounds
+
+The local loop never replaces independent review, never owns merge or GitHub
+delivery, and never decides architecture. If the probe refuses, or the task
+outgrows the recommended class, keep the work on the decider model.

--- a/chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py
+++ b/chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Probe host RAM, optional GPU memory, and OS. Recommend a size class or refuse."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess  # nosec B404 - only a fixed local GPU query is used.
+import sys
+from pathlib import Path
+
+GIB = 1024 ** 3
+REFUSE_RAM_GIB = 8
+MEDIUM_RAM_GIB = 16
+LARGE_RAM_GIB = 32
+MEDIUM_GPU_GIB = 4
+LARGE_GPU_GIB = 8
+
+
+def classify(ram_bytes: int, gpu_bytes: int | None, os_name: str) -> dict:
+    """Return a size-class recommendation from measured or injected hardware."""
+    ram_gib = ram_bytes / GIB
+    gpu_gib = None if gpu_bytes is None else gpu_bytes / GIB
+    if ram_gib < REFUSE_RAM_GIB:
+        recommendation = "refuse"
+        reason = "less than 8 GiB RAM cannot run a useful local coder"
+    elif ram_gib >= LARGE_RAM_GIB or (gpu_gib is not None and gpu_gib >= LARGE_GPU_GIB):
+        recommendation = "large"
+        reason = "RAM or GPU memory supports a large local coder"
+    elif ram_gib >= MEDIUM_RAM_GIB or (gpu_gib is not None and gpu_gib >= MEDIUM_GPU_GIB):
+        recommendation = "medium"
+        reason = "RAM or GPU memory supports a medium local coder"
+    else:
+        recommendation = "small"
+        reason = "host can run a small local coder only"
+    return {
+        "os": os_name,
+        "ram_bytes": ram_bytes,
+        "gpu_bytes": gpu_bytes,
+        "recommendation": recommendation,
+        "reason": reason,
+    }
+
+
+def _ram_bytes() -> int:
+    system = platform.system()
+    if system == "Windows":
+        import ctypes
+
+        class MemoryStatusEx(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        status = MemoryStatusEx()
+        status.dwLength = ctypes.sizeof(status)
+        if not ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):
+            raise OSError("GlobalMemoryStatusEx failed")
+        return int(status.ullTotalPhys)
+    if system == "Linux":
+        meminfo = Path(os.sep) / "proc" / "meminfo"
+        for line in meminfo.read_text(encoding="utf-8").splitlines():
+            if line.startswith("MemTotal:"):
+                return int(line.split()[1]) * 1024
+        raise OSError("MemTotal missing from proc meminfo")
+    if system == "Darwin":
+        output = subprocess.run(  # nosec B603 B607 - fixed sysctl invocation.
+            ["sysctl", "-n", "hw.memsize"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return int(output.stdout.strip())
+    raise OSError(f"unsupported OS for RAM probe: {system}")
+
+
+def _gpu_bytes() -> int | None:
+    try:
+        output = subprocess.run(  # nosec B603 B607 - fixed nvidia-smi query.
+            [
+                "nvidia-smi",
+                "--query-gpu=memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return None
+    totals = []
+    for line in output.stdout.splitlines():
+        text = line.strip()
+        if text:
+            totals.append(float(text) * 1024 * 1024)
+    if not totals:
+        return None
+    return int(max(totals))
+
+
+def probe() -> dict:
+    """Measure this host and classify it."""
+    return classify(_ram_bytes(), _gpu_bytes(), platform.system())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args(argv)
+    json.dump(probe(), sys.stdout, indent=2)
+    sys.stdout.write(os.linesep)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/agent_guidance_budget.json
+++ b/scripts/ci/agent_guidance_budget.json
@@ -110,6 +110,7 @@
     ".agents/skills/README.md",
     ".agents/skills/*/SKILL.md",
     "chaos-engine/skills/chaos-engine/SKILL.md",
+    "chaos-engine/skills/local-coding-delegate/SKILL.md",
     "chaos-engine/references/*.md",
     "chaos-engine/profiles/shaft/**/*.md",
     ".claude/agents/*.md",
@@ -140,6 +141,10 @@
       "release-dependency-guard",
       "shaft-marketing-ad-producer",
       "shaft-ui-design"
+    ],
+    "chaos-engine/skills": [
+      "chaos-engine",
+      "local-coding-delegate"
     ]
   },
   "skill_budgets": {
@@ -239,6 +244,7 @@
     ".agents/skills/README.md",
     ".agents/skills/*/SKILL.md",
     "chaos-engine/skills/chaos-engine/SKILL.md",
+    "chaos-engine/skills/local-coding-delegate/SKILL.md",
     "chaos-engine/references/*.md",
     "chaos-engine/profiles/shaft/**/*.md",
     ".claude/agents/*.md",

--- a/scripts/ci/assemble_act_as_mohab_plugin.py
+++ b/scripts/ci/assemble_act_as_mohab_plugin.py
@@ -9,7 +9,7 @@ import xml.etree.ElementTree as ET  # nosec B405
 from pathlib import Path
 
 SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
-PORTABLE_SOURCE_SUFFIXES = {".md", ".LICENSE", ".json", ".yaml", ".yml", ".py", ".svg"}
+PORTABLE_SOURCE_SUFFIXES = {".md", ".LICENSE", ".json", ".yaml", ".yml", ".py", ".svg", ".js"}
 RELEASE_FILES = (
     (Path("LICENSE"), Path("LICENSE")),
     (Path("agent-plugins/act-as-mohab/CHANGELOG.md"), Path("CHANGELOG.md")),
@@ -90,7 +90,7 @@ def copy_tree(source: Path, destination: Path, allowed_files: set[Path]) -> None
     source = require_contained(source.parent, source, "canonical reference directory")
     for path in sorted(path for path in allowed_files if path.is_relative_to(source)):
         path = require_contained(source, path, "canonical reference")
-        if path.suffix not in PORTABLE_SOURCE_SUFFIXES:
+        if path.suffix not in PORTABLE_SOURCE_SUFFIXES and path.name != "LICENSE":
             continue
         target = destination / path.relative_to(source)
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -120,7 +120,7 @@ BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 # from the boundary was invisible. Equality makes shrinking the boundary a
 # deliberate two-line edit that shows up in review, which is the only place the
 # question "why is the harness smaller today" gets asked.
-EXPECTED_ELEMENT_COUNT = 248
+EXPECTED_ELEMENT_COUNT = 254
 
 ATX_HEADING = re.compile(r"(?m)^#{1,6}\s+(.+?)\s*$")
 
@@ -280,6 +280,26 @@ class HarnessReachabilityTest(unittest.TestCase):
         report = harness_report(ROOT)
         self.assertEqual(len(report["orphans"]), 0)
         self.assertIn("tools/repository-map/graphify_maintenance.py", report["elements"])
+        self.assertIn(
+            "chaos-engine/skills/local-coding-delegate/SKILL.md", report["elements"]
+        )
+        self.assertIn(
+            "chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py",
+            report["elements"],
+        )
+        self.assertIn(
+            "chaos-engine/profiles/shaft/references/playbooks/workstation-local-coding-agent.md",
+            report["elements"],
+        )
+        self.assertIn(
+            "scripts/local-coding-agent/shaft-java-agent.ps1", report["elements"]
+        )
+        self.assertIn(
+            "scripts/local-coding-agent/shaft-architect.ps1", report["elements"]
+        )
+        self.assertIn(
+            "scripts/local-coding-agent/shaft-local-ai-stop.ps1", report["elements"]
+        )
         self.assertEqual(len(report["elements"]), EXPECTED_ELEMENT_COUNT)
         self.assertEqual(report["wildcard_only"], [])
 

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1601,7 +1601,7 @@ class HostParityTest(unittest.TestCase):
     def test_both_hosts_expose_the_same_skill_set(self):
         canonical = {path.parent.name for path in CANONICAL_SKILLS.glob("*/SKILL.md")}
         claude = {path.parent.name for path in CLAUDE_SKILLS.glob("*/SKILL.md")}
-        self.assertEqual(canonical, {"chaos-engine"})
+        self.assertEqual(canonical, {"chaos-engine", "local-coding-delegate"})
         self.assertEqual(claude, {"chaos-engine", "act-as-mohab"})
 
     def test_claude_skills_are_redirects_to_the_canonical_body(self):

--- a/tests/scripts/test_assemble_act_as_mohab_plugin.py
+++ b/tests/scripts/test_assemble_act_as_mohab_plugin.py
@@ -98,7 +98,7 @@ class AssembleActAsMohabPluginTest(unittest.TestCase):
             path.name for path in (self.package_root / "skills").iterdir()
             if (path / "SKILL.md").is_file()
         }
-        self.assertEqual(packaged_skills, {"act-as-mohab", "chaos-engine"})
+        self.assertEqual(packaged_skills, {"act-as-mohab", "chaos-engine", "local-coding-delegate"})
         for relative in ("plugin.json", ".claude-plugin/plugin.json", ".codex-plugin/plugin.json"):
             manifest = json.loads((self.package_root / relative).read_text(encoding="utf-8"))
             self.assertEqual(manifest["version"], version)

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -539,6 +539,136 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
                 links = re.findall(r"\[[^]]+\]\(([^)]+)\)", content)
                 self.assertIn(REPOSITORY_ADAPTER.resolve(), {(alias.parent / link).resolve() for link in links})
 
+    def test_portable_local_coding_delegate_is_optional_and_routed(self):
+        skill = CORE / "skills/local-coding-delegate/SKILL.md"
+        probe = CORE / "skills/local-coding-delegate/scripts/probe_hardware.py"
+        portable_entry = CORE / "profiles/portable/entrypoint.md"
+        portable_routing = CORE / "profiles/portable/references/routing.md"
+        budget = json.loads(
+            (ROOT / "scripts/ci/agent_guidance_budget.json").read_text(encoding="utf-8")
+        )
+
+        self.assertTrue(skill.is_file())
+        self.assertTrue(probe.is_file())
+        self.assertIn("local-coding-delegate/SKILL.md", portable_entry.read_text(encoding="utf-8"))
+        self.assertIn("local-coding-delegate/SKILL.md", portable_routing.read_text(encoding="utf-8"))
+        self.assertIn(
+            "local-coding-delegate",
+            budget["expected_skill_names"]["chaos-engine/skills"],
+        )
+        self.assertIn(
+            "chaos-engine/skills/local-coding-delegate/SKILL.md",
+            budget["total_guidance_globs"],
+        )
+        self.assertIn(
+            "chaos-engine/skills/local-coding-delegate/SKILL.md",
+            budget["reference_scan_globs"],
+        )
+        self.assertNotIn(
+            "chaos-engine/skills/local-coding-delegate/SKILL.md",
+            budget["active_guidance_globs"],
+        )
+        for files in budget["host_contexts"].values():
+            self.assertNotIn(
+                "chaos-engine/skills/local-coding-delegate/SKILL.md", files
+            )
+
+    def test_portable_local_coding_delegate_and_routing_do_not_leak_shaft_facts(self):
+        skill_root = CORE / "skills/local-coding-delegate"
+        portable_routing = CORE / "profiles/portable/references/routing.md"
+        leaks = (
+            r"D:\AI",
+            "shaft-java-agent",
+            "qwen",
+            "Ollama",
+            "Aider",
+            "SHAFT_LOCAL_AI",
+        )
+
+        self.assertTrue(skill_root.is_dir(), "optional portable skill must exist to be scanned")
+        texts = [portable_routing.read_text(encoding="utf-8")]
+        for path in skill_root.rglob("*"):
+            if path.is_file() and "__pycache__" not in path.parts:
+                texts.append(path.read_text(encoding="utf-8", errors="ignore"))
+        combined = "\n".join(texts)
+        for leak in leaks:
+            with self.subTest(leak=leak):
+                self.assertNotIn(leak, combined)
+
+    def test_shaft_workstation_playbook_is_routed_and_names_the_loop(self):
+        playbook = CORE / "profiles/shaft/references/playbooks/workstation-local-coding-agent.md"
+        shaft_entry = CORE / "profiles/shaft/entrypoint.md"
+        shaft_routing = CORE / "profiles/shaft/references/routing.md"
+        required = (
+            "scripts/local-coding-agent/shaft-java-agent.ps1",
+            "scripts/local-coding-agent/shaft-architect.ps1",
+            "scripts/local-coding-agent/shaft-local-ai-stop.ps1",
+            "scripts/agents/knowledge_stores.py",
+        )
+
+        self.assertTrue(playbook.is_file())
+        body = playbook.read_text(encoding="utf-8")
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, body)
+        self.assertIn("playbooks/workstation-local-coding-agent.md", shaft_routing.read_text(encoding="utf-8"))
+        self.assertIn("playbooks/workstation-local-coding-agent.md", shaft_entry.read_text(encoding="utf-8"))
+
+    def test_local_coding_probe_is_stdlib_and_classifies_or_refuses(self):
+        import ast
+        import importlib.util
+
+        probe = CORE / "skills/local-coding-delegate/scripts/probe_hardware.py"
+        self.assertTrue(probe.is_file())
+        tree = ast.parse(probe.read_text(encoding="utf-8"))
+        imported = {
+            alias.name.split(".", 1)[0]
+            for node in tree.body
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in (node.names if isinstance(node, ast.Import) else [ast.alias(node.module or "", None)])
+        }
+        allowed = {
+            "__future__",
+            "argparse",
+            "json",
+            "os",
+            "platform",
+            "ctypes",
+            "subprocess",
+            "sys",
+            "pathlib",
+        }
+        self.assertTrue(imported <= allowed, imported - allowed)
+
+        spec = importlib.util.spec_from_file_location("probe_hardware", probe)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        gib = 1024 ** 3
+        self.assertEqual(
+            "refuse",
+            module.classify(ram_bytes=4 * gib, gpu_bytes=None, os_name="Windows")[
+                "recommendation"
+            ],
+        )
+        self.assertEqual(
+            "small",
+            module.classify(ram_bytes=12 * gib, gpu_bytes=None, os_name="Linux")[
+                "recommendation"
+            ],
+        )
+        self.assertEqual(
+            "medium",
+            module.classify(ram_bytes=24 * gib, gpu_bytes=6 * gib, os_name="Darwin")[
+                "recommendation"
+            ],
+        )
+        self.assertEqual(
+            "large",
+            module.classify(ram_bytes=64 * gib, gpu_bytes=16 * gib, os_name="Linux")[
+                "recommendation"
+            ],
+        )
+
     def test_portable_contract_is_scanned_and_run_by_pull_request_ci(self):
         budget = json.loads(
             (ROOT / "scripts/ci/agent_guidance_budget.json").read_text(encoding="utf-8")

--- a/tests/scripts/test_validate_skills.py
+++ b/tests/scripts/test_validate_skills.py
@@ -44,7 +44,7 @@ import unittest
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from scripts.ci.validate_agent_guidance import expand_reported_globs, require_glob_list
-from scripts.ci.validate_skills import validate_repository
+from scripts.ci.validate_skills import validate_repository, validate_skill
 
 MARKETPLACE_PATH = ".claude-plugin/marketplace.json"
 
@@ -530,6 +530,12 @@ class MarketplaceManifestTest(unittest.TestCase):
     def test_current_repository_marketplace_matches_the_skill_directories(self):
         repository_root = Path(__file__).resolve().parents[2]
         self.assertEqual(marketplace_errors(repository_root), [])
+
+    def test_optional_portable_local_coding_delegate_passes_hygiene(self):
+        repository_root = Path(__file__).resolve().parents[2]
+        skill_dir = repository_root / "chaos-engine/skills/local-coding-delegate"
+        self.assertTrue((skill_dir / "SKILL.md").is_file())
+        self.assertEqual(validate_skill(repository_root, skill_dir, 20000), [])
 
 
 class SourceShapeTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds the optional portable `local-coding-delegate` skill and the SHAFT-only workstation playbook locked on #5081.

- Portable skill `chaos-engine/skills/local-coding-delegate/SKILL.md` is not always-loaded. The most-intelligent or default capability stays the decider. A stdlib hardware probe recommends `small` / `medium` / `large` or `refuse`. Download or configure only when the adopter asked and the probe says the host can run a useful coder. No default vendor model name.
- Portable routing and the portable entrypoint each link the skill in one sentence.
- SHAFT playbook `workstation-local-coding-agent.md` names `scripts/local-coding-agent/shaft-java-agent.ps1`, `shaft-architect.ps1`, `shaft-local-ai-stop.ps1`, and `scripts/agents/knowledge_stores.py`. Use only for cheap, bounded, already-specified work. Not for `src/main/java` product changes, PR merge, harness architecture, or anything the loop cannot run. One model, loopback only.
- Portability test fails if `D:\AI`, `shaft-java-agent`, `qwen`, `Ollama`, `Aider`, or `SHAFT_LOCAL_AI` leak into the portable skill tree or portable routing.
- `EXPECTED_ELEMENT_COUNT` is 254. Budget lists the optional skill under `chaos-engine/skills` and scans it from `total_guidance_globs` / `reference_scan_globs`, not `host_contexts`.

Closes #5081.
Related to #5017 (already closed; this PR does not close it).

## Checks

RED recorded on #5081 before the implementing commit: missing skill/playbook files failed routing, reachability, and portability for the right reason.

GREEN after implementation:

```text
py -3 -m unittest tests.scripts.test_agent_harness_reachability tests.scripts.test_chaos_engine_portable_core tests.scripts.test_validate_skills
Ran 89 tests in 64.537s
OK
```

```text
py -3 scripts/ci/validate_agent_setup.py --skip-external
Agent setup is valid: 191779 guidance bytes (+3447 untracked), 382 memory objects (12 untracked).
```

Also green: `HostParityTest.test_both_hosts_expose_the_same_skill_set`, ProgressiveDisclosure, Frontmatter YAML, and `test_current_repository_configuration_is_valid`.

## Continuation

Head: 90cf963f71b670353022744f847f49d4b4a1a6d5
State: Draft PR opened for independent parent review. Not marked ready. Not merged.
Blockers: None known locally. Parent review is required before ready/merge.
Next action: Independent parent review of this draft. Do not arm auto-merge from this implementer turn.
