### PR TITLE
fix(scripts): accept --query on knowledge_stores search

### DIFF
--- a/scripts/agents/knowledge_stores.py
+++ b/scripts/agents/knowledge_stores.py
@@ -91,13 +91,51 @@ def cmd_refresh() -> int:
     return 1
 
 
+COMMANDS = frozenset({"status", "search", "refresh"})
+
+
+def argv_with_implicit_search(argv: list[str]) -> list[str]:
+    """Treat a top-level --query as search when no subcommand is present."""
+    skip_value = False
+    for token in argv:
+        if skip_value:
+            skip_value = False
+            continue
+        if token in COMMANDS:
+            return argv
+        if token == "--query":
+            skip_value = True
+    if any(token == "--query" or token.startswith("--query=") for token in argv):
+        return ["search", *argv]
+    return argv
+
+
+def resolve_search_query(
+    parser: argparse.ArgumentParser,
+    positional: str | None,
+    flag: str | None,
+) -> str:
+    """Require one query; positional and --query must match when both are set."""
+    if positional and flag and positional != flag:
+        parser.error("positional query and --query must match")
+    query = positional or flag
+    if not query:
+        parser.error("search requires a query")
+    return query
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the operator command parser."""
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("status", help="Show the resolved palace and Graphify check.")
     search = subparsers.add_parser("search", help="Search the resolved SHAFT palace.")
-    search.add_argument("query", help="Search query")
+    search.add_argument("query", nargs="?", help="Search query")
+    search.add_argument(
+        "--query",
+        dest="query_flag",
+        help="Search query alias. If both this and the positional query are given they must match.",
+    )
     search.add_argument("--wing", help="Limit to one wing")
     search.add_argument("--room", help="Limit to one room")
     search.add_argument("--results", type=int, help="Number of results")
@@ -107,7 +145,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None, cwd: Path | None = None) -> int:
     """Run the CLI."""
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    tokens = sys.argv[1:] if argv is None else list(argv)
+    args = parser.parse_args(argv_with_implicit_search(tokens))
     working_directory = cwd or Path.cwd()
     try:
         if args.command == "status":
@@ -115,7 +155,7 @@ def main(argv: list[str] | None = None, cwd: Path | None = None) -> int:
         if args.command == "search":
             return cmd_search(
                 working_directory,
-                args.query,
+                resolve_search_query(parser, args.query, args.query_flag),
                 args.wing,
                 args.room,
                 args.results,

--- a/tests/scripts/test_knowledge_stores.py
+++ b/tests/scripts/test_knowledge_stores.py
@@ -36,7 +36,7 @@ class KnowledgeStoresTest(unittest.TestCase):
         if os.name == "nt":
             (fake_bin / "mempalace.cmd").write_text(
                 "@echo off\r\n"
-                "echo mempalace %*>>\"%KNOWLEDGE_STORES_LOG%\"\r\n"
+                "echo mempalace %* >>\"%KNOWLEDGE_STORES_LOG%\"\r\n"  # space before >>; cmd treats N>> as fd N
                 "echo MEMPALACE-FAKE-OUTPUT\r\n",
                 encoding="utf-8",
             )
@@ -116,6 +116,76 @@ class KnowledgeStoresTest(unittest.TestCase):
         logged = self.log.read_text(encoding="utf-8")
         self.assertIn("shared cache", logged)
         self.assertIn("shaft_engine_main", tokens)
+        self.assertFalse(self.checkout_palace_created(self.linked))
+
+    def test_search_query_flag_forwards_to_resolved_palace(self):
+        completed = self.cli(
+            "search",
+            "--query",
+            "flag query",
+            "--wing",
+            "shaft_engine_main",
+            "--room",
+            "scripts",
+            "--results",
+            "4",
+        )
+        combined = completed.stdout + completed.stderr
+
+        self.assertEqual(0, completed.returncode, combined)
+        self.assertIn("MEMPALACE-FAKE-OUTPUT", completed.stdout)
+        tokens = self.assert_global_flags_before("search")
+        logged = self.log.read_text(encoding="utf-8")
+        self.assertIn("flag query", logged)
+        self.assertIn("shaft_engine_main", tokens)
+        self.assertIn("scripts", tokens)
+        self.assertIn("--results", tokens)
+        self.assertIn("4", tokens)
+        self.assertFalse(self.checkout_palace_created(self.linked))
+
+    def test_top_level_query_flag_runs_search(self):
+        completed = self.cli(
+            "--query",
+            "top level query",
+            "--wing",
+            "shaft_engine_main",
+            "--room",
+            "scripts",
+            "--results",
+            "3",
+        )
+        combined = completed.stdout + completed.stderr
+
+        self.assertEqual(0, completed.returncode, combined)
+        self.assertIn("MEMPALACE-FAKE-OUTPUT", completed.stdout)
+        tokens = self.assert_global_flags_before("search")
+        logged = self.log.read_text(encoding="utf-8")
+        self.assertIn("top level query", logged)
+        self.assertIn("shaft_engine_main", tokens)
+        self.assertIn("scripts", tokens)
+        self.assertIn("--results", tokens)
+        self.assertIn("3", tokens)
+        self.assertFalse(self.checkout_palace_created(self.linked))
+
+    def test_search_rejects_disagreeing_positional_and_query_flag(self):
+        completed = self.cli("search", "alpha", "--query", "beta")
+        combined = completed.stdout + completed.stderr
+
+        self.assertNotEqual(0, completed.returncode, combined)
+        self.assertIn("must match", combined)
+        self.assertFalse(self.log.exists())
+        self.assertFalse(self.checkout_palace_created(self.linked))
+
+    def test_search_matching_positional_and_query_flag_forwards_once(self):
+        completed = self.cli("search", "same query", "--query", "same query")
+        combined = completed.stdout + completed.stderr
+
+        self.assertEqual(0, completed.returncode, combined)
+        tokens = self.assert_global_flags_before("search")
+        logged = self.log.read_text(encoding="utf-8")
+        self.assertIn("same query", logged)
+        self.assertEqual(1, logged.count("same query"))
+        self.assertEqual("search", tokens[tokens.index("search")])
         self.assertFalse(self.checkout_palace_created(self.linked))
 
     def test_refresh_refuses_linked_worktree_and_ordinary_checkout(self):


### PR DESCRIPTION
## Summary

`scripts/agents/knowledge_stores.py search` now accepts `--query` as an alias of the positional query. A top-level `--query` with no subcommand runs `search`. If both forms are present they must match; `--query` is used only when the positional is omitted. `--wing` / `--room` / `--results` work with either form. `--palace` / `--backend` stay before the mempalace subcommand.

Closes #5084

## Checks

- RED: `py -3 -m unittest tests.scripts.test_knowledge_stores` — 4 new tests failed with `unrecognized arguments: --query` and `invalid choice: 'top level query'`.
- GREEN: `py -3 -m unittest tests.scripts.test_knowledge_stores` — 8 tests OK after the argparse change.
- No in-repo caller passed `--query`; none edited.
- Did not run `validate_agent_setup.py` (no guidance touched).

## Continuation

Head: 694d1f49ec0a90c37f332d6da6a35a50cac2cc48
State: draft PR opened; parent reviews independently.
Blockers: none for this subtask.
Next action: independent review; do not mark ready, merge, or arm from this worktree.