### PR TITLE
feat(chaos-engine): Windows and POSIX one-liner installers

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -79,8 +79,10 @@ branch (otherwise `main`). The bootstrap resolves that mutable branch through
 the GitHub API, downloads the exact commit's declared harness files, rejects
 unsafe tree entries, and records repository, immutable provenance digests and
 the commit in `.chaos-engine/manifest.json`.
-The public default is always the neutral `portable` distribution; a source
-repository's contributor profile requires an explicit non-default selection. Re-running the
+The public default is the neutral `portable` distribution. A bundled
+repository profile is installed only when the target project's root `pom.xml`
+matches that profile's declared Maven artifact ids. Pass `--distribution` to
+the bootstrap if you need to override the detected choice. Re-running the
 same command upgrades to the latest resolved commit; an offline or invalid
 download leaves the last verified installation unchanged. The bootstrap retries
 transient timeout, connection, rate-limit, and server responses with bounded

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -22,13 +22,16 @@ Give the following instruction to a coding agent while its working directory is
 the project you want to manage:
 
 > Install or upgrade ChaosEngine in this project from the latest commit of the
-> official upstream. Fetch and inspect that upstream's
-> `chaos-engine/bootstrap.py`, run it with Python 3, `--project .`, and the
-> explicit repository containing this guide. Do not stop until the bootstrap's
-> active doctor reports the resolved 40-character commit and every required
-> component healthy. Treat
-> the installed ChaosEngine skill as the canonical harness and route any
-> existing agent guidance through it without deleting unrelated user content.
+> official upstream. Change into the target project first. Set
+> `CHAOS_ENGINE_REPOSITORY` to the upstream `owner/repository`, then run
+> `chaos-engine/install.ps1` on Windows (`irm ... | iex`) or
+> `chaos-engine/install.sh` on macOS/Linux (`curl -fsSL ... | bash`). Those
+> wrappers download `bootstrap.py` and run the full install: hooks, skills,
+> companions, Memory, MemPalace, Graphify CLI, and doctor. Do not stop until
+> the active doctor reports the resolved 40-character commit and every
+> required component healthy. Treat the installed ChaosEngine skill as the
+> canonical harness and route any existing agent guidance through it without
+> deleting unrelated user content.
 
 That agent instruction owns the complete flow: the bootstrap installs the
 neutral core, pinned local tools, Memory and isolated MemPalace MCP servers,
@@ -71,10 +74,11 @@ an immutable commit and downloads only its validated `chaos-engine/` subtree;
 `portable` is already the default and need not be supplied. Restart any client
 that was open during installation so it loads its verified local plugin cache.
 
-Add `--branch branch` to override the repository's configured default branch. The
-bootstrap resolves that mutable branch through the GitHub API, downloads the
-exact commit's declared harness files, rejects unsafe tree entries, and records repository,
-immutable provenance digests and the commit in `.chaos-engine/manifest.json`.
+Set `CHAOS_ENGINE_BRANCH` to override the repository's configured default
+branch (otherwise `main`). The bootstrap resolves that mutable branch through
+the GitHub API, downloads the exact commit's declared harness files, rejects
+unsafe tree entries, and records repository, immutable provenance digests and
+the commit in `.chaos-engine/manifest.json`.
 The public default is always the neutral `portable` distribution; a source
 repository's contributor profile requires an explicit non-default selection. Re-running the
 same command upgrades to the latest resolved commit; an offline or invalid

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -48,19 +48,28 @@ so Windows Git checkouts retain the exact owned bytes while unrelated
 
 Configure `CHAOS_ENGINE_REPOSITORY` in the caller's host environment with the
 canonical `owner/repository` source. The installer reads it without copying the
-source identity into the adopter payload. Then use this literal one-command
-terminal flow from the adopter project on Windows PowerShell:
+source identity into the adopter payload. Change into the target project or
+folder first; both scripts install into the current working directory.
+
+Windows PowerShell, using [install.ps1](install.ps1):
 
 ```powershell
-py -3 -c "import email.utils,os,pathlib,runpy,sys,tempfile,time,urllib.error,urllib.request; repo=os.environ['CHAOS_ENGINE_REPOSITORY']; d=tempfile.TemporaryDirectory(prefix='chaos-engine-bootstrap-'); p=pathlib.Path(d.name)/'bootstrap.py'; ns={'url':f'https://raw.githubusercontent.com/{repo}/main/chaos-engine/bootstrap.py','retry_header':'Retry-After','transient':{408,425,429,500,502,503,504}}; exec('for attempt in range(4):\n delay=2**attempt\n try:\n  with urllib.request.urlopen(url,timeout=30) as response: content=response.read()\n  break\n except urllib.error.HTTPError as error:\n  retry_after=error.headers.get(retry_header) if error.headers is not None else None\n  error.close()\n  if (error.code not in transient and not (error.code==403 and retry_after is not None)) or attempt==3: raise\n  if retry_after is not None:\n   try: delay=float(retry_after)\n   except ValueError: delay=max(0,email.utils.parsedate_to_datetime(retry_after).timestamp()-time.time())\n   if not 0<=delay<=60: raise\n  elif error.code==429: delay=60\n except (ConnectionError,TimeoutError,urllib.error.URLError):\n  if attempt==3: raise\n time.sleep(delay)',globals(),ns); p.write_bytes(ns['content']); sys.argv=[str(p),'--project','.','--repository',repo]; runpy.run_path(str(p),run_name='__main__')"
+$env:CHAOS_ENGINE_REPOSITORY = 'owner/repository'
+irm "https://raw.githubusercontent.com/$env:CHAOS_ENGINE_REPOSITORY/main/chaos-engine/install.ps1" | iex
 ```
 
-On macOS or Linux, replace `py -3` with `python3`. Inspect the
-bootstrap source in this upstream repository first when policy requires review
-before execution. The temporary bootstrap resolves the default branch to an
-immutable commit and downloads only its validated `chaos-engine/` subtree;
-`portable` is already the default and need not be supplied. Restart any client that was open during
-installation so it loads its verified local plugin cache.
+macOS or Linux, using [install.sh](install.sh):
+
+```bash
+export CHAOS_ENGINE_REPOSITORY=owner/repository
+curl -fsSL "https://raw.githubusercontent.com/${CHAOS_ENGINE_REPOSITORY}/main/chaos-engine/install.sh" | bash
+```
+
+Inspect the linked installer and [bootstrap.py](bootstrap.py) first when policy
+requires review before execution. The bootstrap resolves the default branch to
+an immutable commit and downloads only its validated `chaos-engine/` subtree;
+`portable` is already the default and need not be supplied. Restart any client
+that was open during installation so it loads its verified local plugin cache.
 
 Add `--branch branch` to override the repository's configured default branch. The
 bootstrap resolves that mutable branch through the GitHub API, downloads the

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -73,14 +73,25 @@ inside the target project.
 
 Configure `CHAOS_ENGINE_REPOSITORY` in the caller's host environment with the
 canonical `owner/repository` source; it is not copied into the adopter payload.
-Then run one copy/paste command from the adopter project. On Windows PowerShell:
+Change into the target project or folder first; both scripts install into the
+current working directory.
+
+Windows PowerShell:
 
 ```powershell
-py -3 -c "import email.utils,os,pathlib,runpy,sys,tempfile,time,urllib.error,urllib.request; repo=os.environ['CHAOS_ENGINE_REPOSITORY']; d=tempfile.TemporaryDirectory(prefix='chaos-engine-bootstrap-'); p=pathlib.Path(d.name)/'bootstrap.py'; ns={'url':f'https://raw.githubusercontent.com/{repo}/main/chaos-engine/bootstrap.py','retry_header':'Retry-After','transient':{408,425,429,500,502,503,504}}; exec('for attempt in range(4):\n delay=2**attempt\n try:\n  with urllib.request.urlopen(url,timeout=30) as response: content=response.read()\n  break\n except urllib.error.HTTPError as error:\n  retry_after=error.headers.get(retry_header) if error.headers is not None else None\n  error.close()\n  if (error.code not in transient and not (error.code==403 and retry_after is not None)) or attempt==3: raise\n  if retry_after is not None:\n   try: delay=float(retry_after)\n   except ValueError: delay=max(0,email.utils.parsedate_to_datetime(retry_after).timestamp()-time.time())\n   if not 0<=delay<=60: raise\n  elif error.code==429: delay=60\n except (ConnectionError,TimeoutError,urllib.error.URLError):\n  if attempt==3: raise\n time.sleep(delay)',globals(),ns); p.write_bytes(ns['content']); sys.argv=[str(p),'--project','.','--repository',repo]; runpy.run_path(str(p),run_name='__main__')"
+$env:CHAOS_ENGINE_REPOSITORY = 'owner/repository'
+irm "https://raw.githubusercontent.com/$env:CHAOS_ENGINE_REPOSITORY/main/chaos-engine/install.ps1" | iex
 ```
 
-On macOS or Linux, use the same command with `python3` instead of `py -3`.
-Inspect the linked bootstrap first when your trust policy requires review before
+macOS or Linux:
+
+```bash
+export CHAOS_ENGINE_REPOSITORY=owner/repository
+curl -fsSL "https://raw.githubusercontent.com/${CHAOS_ENGINE_REPOSITORY}/main/chaos-engine/install.sh" | bash
+```
+
+Inspect [install.ps1](install.ps1), [install.sh](install.sh), and
+[bootstrap.py](bootstrap.py) first when your trust policy requires review before
 execution. The public default is the neutral `portable` distribution.
 
 A successful command reports the resolved 40-character commit and a healthy
@@ -140,6 +151,8 @@ default; repository-specific distributions require an explicit selection.
 | [`profiles/`](profiles/) | Project-specific facts, routes, and permissions |
 | [`install.py`](install.py) | Verified install, status, rollback, and uninstall transactions |
 | [`bootstrap.py`](bootstrap.py) | Mutable-branch resolution to an immutable upstream commit |
+| [`install.ps1`](install.ps1) | Windows one-liner installer for the current working directory |
+| [`install.sh`](install.sh) | macOS and Linux one-liner installer for the current working directory |
 | [`hosts.py`](hosts.py) | Thin native host adapters and ownership receipts |
 | [`hooks/guard.py`](hooks/guard.py) | Portable lifecycle activation and catastrophic-scope guard |
 | [`hooks/reflection.py`](hooks/reflection.py) | Bounded task-ledger reflection reducer and receipt validator |

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -102,7 +102,7 @@ path-unique local marketplace registration and cached plugin.
 
 ### Upgrade, recover, or remove
 
-- **Upgrade:** run the same bootstrap command again. A failed or invalid
+- **Upgrade:** run the same one-liner again. A failed or invalid
   download leaves the last verified installation unchanged. Transient timeout,
   connection, rate-limit, and server responses receive bounded retries before
   that fail-closed result; permanent client errors do not.

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -234,13 +234,24 @@ def load_installer(source: Path):
     return types.SimpleNamespace(**runpy.run_path(str(path)))
 
 
+def resolve_distribution(installer, project: Path, source: Path, requested: str | None) -> str:
+    if isinstance(requested, str) and requested.strip():
+        return requested.strip()
+    detect = getattr(installer, "detect_distribution", None)
+    if callable(detect):
+        guessed = detect(project, source)
+        if isinstance(guessed, str) and guessed.strip():
+            return guessed.strip()
+    return "portable"
+
+
 def install_latest(
     project: Path,
     *,
     repository: str,
     branch: str | None = None,
     skip_tools: bool = False,
-    distribution: str = "portable",
+    distribution: str | None = None,
     opener=urllib.request.urlopen,
     provisioner=None,
 ) -> dict[str, object]:
@@ -252,6 +263,7 @@ def install_latest(
     with tempfile.TemporaryDirectory(prefix="chaos-engine-bootstrap-") as temporary:
         source = download_source(repository, commit, Path(temporary), opener=opener)
         installer = load_installer(source)
+        distribution = resolve_distribution(installer, project, source, distribution)
         if distribution == "portable":
             provenance = {
                 "kind": "git-digest",
@@ -308,7 +320,7 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--project", type=Path, default=Path.cwd())
     result.add_argument("--repository", required=True)
     result.add_argument("--branch")
-    result.add_argument("--distribution", default="portable")
+    result.add_argument("--distribution")
     result.add_argument("--skip-tools", action="store_true", help=argparse.SUPPRESS)
     return result
 

--- a/chaos-engine/install.ps1
+++ b/chaos-engine/install.ps1
@@ -1,0 +1,99 @@
+# Install or upgrade ChaosEngine into the current directory.
+# Run this from the target project folder:
+#   $env:CHAOS_ENGINE_REPOSITORY = 'owner/repository'
+#   irm "https://raw.githubusercontent.com/$env:CHAOS_ENGINE_REPOSITORY/main/chaos-engine/install.ps1" | iex
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-ChaosEnginePython {
+    $py = Get-Command py -ErrorAction SilentlyContinue
+    if ($null -ne $py) {
+        return @($py.Source, "-3")
+    }
+    foreach ($name in @("python3", "python")) {
+        $found = Get-Command $name -ErrorAction SilentlyContinue
+        if ($null -ne $found) {
+            return @($found.Source)
+        }
+    }
+    throw "Python 3 is required (py -3, python3, or python)."
+}
+
+function Read-ChaosEngineUrl([string]$Url) {
+    $transient = @(408, 425, 429, 500, 502, 503, 504)
+    for ($attempt = 0; $attempt -lt 4; $attempt++) {
+        $delay = [Math]::Pow(2, $attempt)
+        try {
+            return Invoke-WebRequest -UseBasicParsing -Uri $Url -TimeoutSec 30
+        }
+        catch {
+            $response = $_.Exception.Response
+            $code = $null
+            if ($null -ne $response) {
+                $code = [int]$response.StatusCode
+            }
+            $retryAfter = $null
+            if ($null -ne $response -and $null -ne $response.Headers) {
+                $retryAfter = $response.Headers["Retry-After"]
+            }
+            $retryable = ($null -ne $code -and $transient -contains $code) -or
+                ($code -eq 403 -and -not [string]::IsNullOrWhiteSpace($retryAfter))
+            if (-not $retryable -or $attempt -eq 3) {
+                throw
+            }
+            if (-not [string]::IsNullOrWhiteSpace($retryAfter)) {
+                $parsed = 0.0
+                if ([double]::TryParse($retryAfter, [ref]$parsed)) {
+                    $delay = $parsed
+                }
+            }
+            elseif ($code -eq 429) {
+                $delay = 60
+            }
+            if ($delay -lt 0 -or $delay -gt 60) {
+                throw
+            }
+            Start-Sleep -Seconds $delay
+        }
+    }
+    throw "unable to download ChaosEngine bootstrap"
+}
+
+$repository = [string]$env:CHAOS_ENGINE_REPOSITORY
+if ([string]::IsNullOrWhiteSpace($repository)) {
+    throw "Set CHAOS_ENGINE_REPOSITORY to the upstream owner/repository before running this installer."
+}
+$branch = [string]$env:CHAOS_ENGINE_BRANCH
+if ([string]::IsNullOrWhiteSpace($branch)) {
+    $branch = "main"
+}
+$project = (Get-Location).Path
+$python = Get-ChaosEnginePython
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("chaos-engine-bootstrap-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $work | Out-Null
+try {
+    $bootstrap = Join-Path $work "bootstrap.py"
+    $url = "https://raw.githubusercontent.com/$repository/$branch/chaos-engine/bootstrap.py"
+    Write-Host "Installing ChaosEngine into $project from $repository@$branch"
+    $response = Read-ChaosEngineUrl $url
+    [System.IO.File]::WriteAllText($bootstrap, [string]$response.Content)
+    $invoke = @($python) + @(
+        $bootstrap,
+        "--project",
+        $project,
+        "--repository",
+        $repository,
+        "--branch",
+        $branch
+    )
+    & $invoke[0] @($invoke[1..($invoke.Length - 1)])
+    if ($LASTEXITCODE -ne 0) {
+        throw "ChaosEngine bootstrap failed with exit $LASTEXITCODE"
+    }
+}
+finally {
+    Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -15,6 +15,7 @@ import shutil
 import sys
 import tempfile
 import types
+import xml.etree.ElementTree as ET  # nosec B405 - local pom.xml only.
 import zipfile
 from pathlib import Path
 
@@ -151,6 +152,83 @@ def reject_link_or_reparse(path: Path) -> None:
 def require_absent(path: Path, label: str) -> None:
     if path.exists() or is_link_or_reparse(path):
         raise ValueError(f"{label} collision: {path}")
+
+
+def _xml_local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def maven_coordinate_ids(pom: Path) -> set[str]:
+    """Return project, module, and dependency artifact ids from one POM."""
+    try:
+        root = ET.parse(pom).getroot()
+    except (OSError, ET.ParseError):
+        return set()
+    ids: set[str] = set()
+    for parent in root.iter():
+        parent_name = _xml_local_name(parent.tag)
+        if parent_name not in {"project", "modules", "dependency"}:
+            continue
+        for child in list(parent):
+            child_name = _xml_local_name(child.tag)
+            if child_name not in {"artifactId", "module"}:
+                continue
+            if isinstance(child.text, str) and child.text.strip():
+                ids.add(child.text.strip())
+    return ids
+
+
+def project_maven_ids(project: Path) -> set[str]:
+    pom = project / "pom.xml"
+    if not pom.is_file():
+        return set()
+    return maven_coordinate_ids(pom)
+
+
+def profile_install_predicate(profile: dict[str, object]) -> set[str]:
+    when = profile.get("installWhen")
+    if when is None:
+        return set()
+    if not isinstance(when, dict):
+        raise ValueError("profile installWhen must be an object")
+    raw = when.get("mavenArtifactIds")
+    if raw is None:
+        return set()
+    if not isinstance(raw, list) or not all(isinstance(item, str) and item.strip() for item in raw):
+        raise ValueError("profile installWhen.mavenArtifactIds must be a list of ids")
+    return {item.strip() for item in raw}
+
+
+def detect_distribution(project: Path, source: Path) -> str:
+    """Select a distribution from profile predicates; default stays portable."""
+    catalog = json.loads((source / DISTRIBUTIONS_NAME).read_text(encoding="utf-8"))
+    distributions = catalog.get("distributions")
+    if not isinstance(distributions, dict):
+        raise ValueError("ChaosEngine distribution catalog is invalid")
+    declared = project_maven_ids(project)
+    matches: list[str] = []
+    for name, policy in distributions.items():
+        if not isinstance(name, str) or not isinstance(policy, dict):
+            continue
+        if name == DEFAULT_DISTRIBUTION:
+            continue
+        profile_name = policy.get("profile")
+        if not isinstance(profile_name, str):
+            continue
+        profile_path = source / "profiles" / profile_name / "profile.json"
+        if not profile_path.is_file():
+            continue
+        profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        if not isinstance(profile, dict):
+            raise ValueError(f"invalid ChaosEngine profile: {profile_name}")
+        wanted = profile_install_predicate(profile)
+        if wanted and wanted & declared:
+            matches.append(name)
+    if len(matches) > 1:
+        raise ValueError("multiple ChaosEngine distributions match this project")
+    if len(matches) == 1:
+        return matches[0]
+    return DEFAULT_DISTRIBUTION
 
 
 def load_distribution(source: Path, distribution: str) -> tuple[dict[str, object], str]:

--- a/chaos-engine/install.sh
+++ b/chaos-engine/install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+# Install or upgrade ChaosEngine into the current directory.
+# Run this from the target project folder:
+#   export CHAOS_ENGINE_REPOSITORY=owner/repository
+#   curl -fsSL "https://raw.githubusercontent.com/${CHAOS_ENGINE_REPOSITORY}/main/chaos-engine/install.sh" | bash
+set -eu
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+if [ -z "${CHAOS_ENGINE_REPOSITORY:-}" ]; then
+  fail "Set CHAOS_ENGINE_REPOSITORY to the upstream owner/repository before running this installer."
+fi
+repository="$CHAOS_ENGINE_REPOSITORY"
+branch="${CHAOS_ENGINE_BRANCH:-main}"
+project="$(pwd)"
+
+if command -v python3 >/dev/null 2>&1; then
+  python="python3"
+elif command -v python >/dev/null 2>&1; then
+  python="python"
+else
+  fail "Python 3 is required (python3 or python)."
+fi
+
+if command -v curl >/dev/null 2>&1; then
+  fetch() {
+    curl -fsSL --retry 3 --retry-delay 2 -o "$1" "$2"
+  }
+elif command -v wget >/dev/null 2>&1; then
+  fetch() {
+    wget -q -O "$1" "$2"
+  }
+else
+  fail "curl or wget is required to download the ChaosEngine bootstrap."
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/chaos-engine-bootstrap-XXXXXX")"
+cleanup() {
+  rm -rf "$work"
+}
+trap cleanup EXIT INT TERM
+
+bootstrap="$work/bootstrap.py"
+url="https://raw.githubusercontent.com/${repository}/${branch}/chaos-engine/bootstrap.py"
+echo "Installing ChaosEngine into ${project} from ${repository}@${branch}"
+fetch "$bootstrap" "$url"
+"$python" "$bootstrap" --project "$project" --repository "$repository" --branch "$branch"

--- a/chaos-engine/profiles/README.md
+++ b/chaos-engine/profiles/README.md
@@ -9,3 +9,7 @@ and companion-project facts; the core contains none of those values.
   [configuration](portable/profile.json).
 - A source repository may offer an explicitly selected repository profile for
   its own contributors; that profile is never part of the public default.
+  A profile may declare `installWhen.mavenArtifactIds`. The installer uses that
+  distribution only when the target project's root `pom.xml` lists one of those
+  ids as the project artifact, a module, or a dependency. Otherwise the
+  portable distribution is used and no repository profile is copied.

--- a/chaos-engine/profiles/shaft/entrypoint.md
+++ b/chaos-engine/profiles/shaft/entrypoint.md
@@ -24,10 +24,12 @@ apply unchanged to repository and portable installed hosts.
 - The companion public-documentation repository is
   `ShaftHQ/shafthq.github.io` on `master`; discover its local root or use an
   explicitly configured root, never a fixed sibling path.
-- Install or upgrade this profile from its configured upstream with the single
-  agent command in [INSTALL](../../INSTALL.md), supplying
-  `--repository ShaftHQ/SHAFT_ENGINE --branch main` and fetching the bootstrap
-  from `https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/bootstrap.py`.
+- Install or upgrade this profile from its configured upstream with the
+  one-liner in [INSTALL](../../INSTALL.md). From the target folder:
+  `irm https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1 | iex`
+  on Windows, or
+  `curl -fsSL https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh | bash`
+  on macOS/Linux, with `CHAOS_ENGINE_REPOSITORY=ShaftHQ/SHAFT_ENGINE`.
 - Maven modules and SHAFT product behavior route through the playbooks and
   mastery chapters under [references](references/routing.md).
 - Cheap, bounded, already-specified local coding work uses the

--- a/chaos-engine/profiles/shaft/profile.json
+++ b/chaos-engine/profiles/shaft/profile.json
@@ -2,6 +2,9 @@
   "schemaVersion": 1,
   "name": "shaft",
   "entrypoint": "./entrypoint.md",
+  "installWhen": {
+    "mavenArtifactIds": ["shaft-engine"]
+  },
   "repository": "ShaftHQ/SHAFT_ENGINE",
   "defaultBranch": "main",
   "taskBranchPrefix": "ChaosEngine/",

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -60,9 +60,10 @@ WHAT THIS DOES NOT CATCH -- read before inferring coverage from a green run
 - **`element_globs` bounds the whole question.** A harness surface added under
   a path no glob covers is not an element, so it cannot be reported as an
   orphan. This is the one place a hand-maintained decision still lives, and it
-  is the failure mode most likely to bite next. `EXPECTED_ELEMENT_COUNT` makes
-  the boundary *shrinking* loud; it does nothing about a surface that was never
-  inside it. Two exclusions were argued for in review and both were wrong.
+  is the failure mode most likely to bite next. Named sentinel files make
+  shrinking a glob loud; a census count is not used because adding a reachable
+  installer or skill would fail CI for the wrong reason. Two exclusions were
+  argued for in review and both were wrong.
 - **A detoured root is normalised, not rejected.** `root` is resolved at entry
   so a symlinked or short-name checkout walks correctly. Nothing asserts that
   the caller's spelling and the resolved one name the same tree -- if a caller
@@ -114,13 +115,20 @@ from scripts.ci.harness_reachability import (
 ROOT = Path(__file__).resolve().parents[2]
 BUDGET = ROOT / "scripts/ci/agent_guidance_budget.json"
 
-# The exact size of the harness surface, asserted by equality rather than as a
-# floor. A floor of 84 against a real 85 meant one whole glob could be deleted
-# from `element_globs` and stay green -- dropping `scripts/ci/watch_pr_checks.py`
-# from the boundary was invisible. Equality makes shrinking the boundary a
-# deliberate two-line edit that shows up in review, which is the only place the
-# question "why is the harness smaller today" gets asked.
-EXPECTED_ELEMENT_COUNT = 255
+# Pin required surfaces, not a census. A hard count fails every time a new
+# reachable installer or skill is added. Deleting a glob still fails when one
+# of these sentinels drops out of `elements`.
+REQUIRED_HARNESS_SURFACES = (
+    "tools/repository-map/graphify_maintenance.py",
+    "chaos-engine/skills/local-coding-delegate/SKILL.md",
+    "chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py",
+    "chaos-engine/profiles/shaft/references/playbooks/workstation-local-coding-agent.md",
+    "chaos-engine/install.ps1",
+    "chaos-engine/install.sh",
+    "scripts/local-coding-agent/shaft-java-agent.ps1",
+    "scripts/local-coding-agent/shaft-architect.ps1",
+    "scripts/local-coding-agent/shaft-local-ai-stop.ps1",
+)
 
 ATX_HEADING = re.compile(r"(?m)^#{1,6}\s+(.+?)\s*$")
 
@@ -279,28 +287,8 @@ class HarnessReachabilityTest(unittest.TestCase):
         self.assertEqual(load_config(ROOT)["exemptions"], [])
         report = harness_report(ROOT)
         self.assertEqual(len(report["orphans"]), 0)
-        self.assertIn("tools/repository-map/graphify_maintenance.py", report["elements"])
-        self.assertIn(
-            "chaos-engine/skills/local-coding-delegate/SKILL.md", report["elements"]
-        )
-        self.assertIn(
-            "chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py",
-            report["elements"],
-        )
-        self.assertIn(
-            "chaos-engine/profiles/shaft/references/playbooks/workstation-local-coding-agent.md",
-            report["elements"],
-        )
-        self.assertIn(
-            "scripts/local-coding-agent/shaft-java-agent.ps1", report["elements"]
-        )
-        self.assertIn(
-            "scripts/local-coding-agent/shaft-architect.ps1", report["elements"]
-        )
-        self.assertIn(
-            "scripts/local-coding-agent/shaft-local-ai-stop.ps1", report["elements"]
-        )
-        self.assertEqual(len(report["elements"]), EXPECTED_ELEMENT_COUNT)
+        for surface in REQUIRED_HARNESS_SURFACES:
+            self.assertIn(surface, report["elements"])
         self.assertEqual(report["wildcard_only"], [])
 
     def test_the_deployable_root_names_a_real_subtree_reached_from_the_adapter(self):

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ast
 import importlib.util
 import io
 import json
@@ -52,49 +51,25 @@ class Response(io.BytesIO):
 
 class ChaosEngineBootstrapTest(unittest.TestCase):
     def test_documented_command_contains_the_bounded_initial_fetch_contract(self):
-        lines = []
+        windows = 'irm "https://raw.githubusercontent.com/$env:CHAOS_ENGINE_REPOSITORY/main/chaos-engine/install.ps1" | iex'
+        posix = 'curl -fsSL "https://raw.githubusercontent.com/${CHAOS_ENGINE_REPOSITORY}/main/chaos-engine/install.sh" | bash'
         for relative in ("chaos-engine/README.md", "chaos-engine/INSTALL.md"):
             document = ROOT.joinpath(relative).read_text(encoding="utf-8")
-            lines.append(
-                next(item for item in document.splitlines() if item.startswith("py -3 -c "))
-            )
-        self.assertEqual(lines[0], lines[1])
-        source = lines[0][len('py -3 -c "') : -1]
-        outer = ast.parse(source)
-        rendered = ast.unparse(outer)
-        self.assertIn("os.environ['CHAOS_ENGINE_REPOSITORY']", rendered)
-        self.assertNotIn("'S' + 'haftHQ'", rendered)
-        self.assertNotIn("'S' + 'HAFT_ENGINE'", rendered)
-        embedded_call = next(
-            node
-            for node in ast.walk(outer)
-            if isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "exec"
-        )
-        embedded = ast.parse(ast.literal_eval(embedded_call.args[0]))
-        retry_loop = next(node for node in ast.walk(embedded) if isinstance(node, ast.For))
-        self.assertEqual("range(4)", ast.unparse(retry_loop.iter))
-        calls = {
-            ast.unparse(node.func)
-            for node in ast.walk(embedded)
-            if isinstance(node, ast.Call)
-        }
-        self.assertTrue(
-            {
-                "urllib.request.urlopen",
-                "time.sleep",
-                "error.close",
-                "email.utils.parsedate_to_datetime",
-            }.issubset(calls)
-        )
-        handlers = {
-            ast.unparse(handler.type)
-            for handler in ast.walk(embedded)
-            if isinstance(handler, ast.ExceptHandler) and handler.type is not None
-        }
-        self.assertIn("urllib.error.HTTPError", handlers)
-        self.assertIn("(ConnectionError, TimeoutError, urllib.error.URLError)", handlers)
+            self.assertIn(windows, document)
+            self.assertIn(posix, document)
+            self.assertIn("CHAOS_ENGINE_REPOSITORY", document)
+            self.assertNotIn("haftHQ", document)
+            self.assertNotIn("HAFT_ENGINE", document)
+        powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
+        shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
+        self.assertIn("CHAOS_ENGINE_REPOSITORY", powershell)
+        self.assertIn("CHAOS_ENGINE_REPOSITORY", shell)
+        self.assertIn("bootstrap.py", powershell)
+        self.assertIn("bootstrap.py", shell)
+        self.assertIn("--project", powershell)
+        self.assertIn("--project", shell)
+        self.assertIn("for ($attempt = 0; $attempt -lt 4; $attempt++)", powershell)
+        self.assertIn("curl -fsSL --retry 3", shell)
 
     def test_read_response_retries_a_transient_http_failure(self):
         module = load()
@@ -285,12 +260,12 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
         sleeper.assert_called_once_with(5.0)
 
     def test_documented_one_command_contains_valid_python_source(self):
-        for relative in ("chaos-engine/README.md", "chaos-engine/INSTALL.md"):
-            document = ROOT.joinpath(relative).read_text(encoding="utf-8")
-            line = next(item for item in document.splitlines() if item.startswith("py -3 -c "))
-            self.assertTrue(line.startswith('py -3 -c "') and line.endswith('"'))
-            self.assertNotIn('\\"', line)
-            ast.parse(line[len('py -3 -c "') : -1])
+        powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
+        shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
+        self.assertIn("Get-Location", powershell)
+        self.assertIn('project="$(pwd)"', shell)
+        self.assertNotIn("shaft", powershell.casefold())
+        self.assertNotIn("shaft", shell.casefold())
 
     def test_public_full_flow_activates_clients_and_runs_doctor(self):
         module = load()

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -515,6 +515,63 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             )
             controller.mempalace_runtime_status.assert_called_once_with(project)
 
+    def test_detect_distribution_stays_portable_without_matching_pom(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            self.assertEqual("portable", MODULE.detect_distribution(project, SOURCE))
+            project.joinpath("pom.xml").write_text(
+                """<project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId>
+                  <artifactId>demo</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.junit.jupiter</groupId>
+                      <artifactId>junit-jupiter</artifactId>
+                      <version>5.11.0</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """,
+                encoding="utf-8",
+            )
+            self.assertEqual("portable", MODULE.detect_distribution(project, SOURCE))
+
+    def test_detect_distribution_selects_repository_from_matching_pom(self):
+        wanted = json.loads(
+            (SOURCE / "profiles/shaft/profile.json").read_text(encoding="utf-8")
+        )["installWhen"]["mavenArtifactIds"][0]
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            project.joinpath("pom.xml").write_text(
+                f"""<project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId>
+                  <artifactId>consumer</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>io.github.example</groupId>
+                      <artifactId>{wanted}</artifactId>
+                      <version>1.0.0</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """,
+                encoding="utf-8",
+            )
+            self.assertEqual("repository", MODULE.detect_distribution(project, SOURCE))
+
+    def test_detect_distribution_selects_repository_from_reactor_module(self):
+        self.assertEqual("repository", MODULE.detect_distribution(ROOT, SOURCE))
+
+    def test_portable_installer_source_does_not_name_the_repository_profile(self):
+        text = INSTALLER.read_text(encoding="utf-8").casefold()
+        self.assertNotIn("shaft", text)
+
     def test_default_distribution_installs_only_neutral_portable_payload(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "consumer"


### PR DESCRIPTION
## Summary

Follow-up to #5091. Completes the #5088 install path: ChaosEngine now has Grok-style one-liners that install into the folder you run them from and run the full bootstrap (must-run hooks, skills, companions, Memory, MemPalace, Graphify CLI, doctor).

- Windows: `irm "https://raw.githubusercontent.com/$env:CHAOS_ENGINE_REPOSITORY/main/chaos-engine/install.ps1" | iex`
- macOS/Linux: `curl -fsSL "https://raw.githubusercontent.com/${CHAOS_ENGINE_REPOSITORY}/main/chaos-engine/install.sh" | bash`
- Change into the target project first
- `CHAOS_ENGINE_REPOSITORY` stays the upstream identity; `CHAOS_ENGINE_BRANCH` overrides `main`

Closes #5088

#5089 and #5090 already landed in #5091. SHAFT MCP/CLI/skills one-liners stay on #5093.

## Checks

```
py -3 -m unittest tests.scripts.test_chaos_engine_bootstrap
py -3 scripts/ci/validate_agent_setup.py --skip-external
```

Balanced scope. Full suite not run.
