### PR TITLE
fix(chaos-engine): pin babysit duties and drop flagged installer parsers

### DIFF
--- a/chaos-engine/install.ps1
+++ b/chaos-engine/install.ps1
@@ -77,7 +77,7 @@ New-Item -ItemType Directory -Path $work | Out-Null
 try {
     $bootstrap = Join-Path $work "bootstrap.py"
     $url = "https://raw.githubusercontent.com/$repository/$branch/chaos-engine/bootstrap.py"
-    Write-Host "Installing ChaosEngine into $project from $repository@$branch"
+    Write-Output "Installing ChaosEngine into $project from $repository@$branch"
     $response = Read-ChaosEngineUrl $url
     [System.IO.File]::WriteAllText($bootstrap, [string]$response.Content)
     $invoke = @($python) + @(

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -15,7 +15,6 @@ import shutil
 import sys
 import tempfile
 import types
-import xml.etree.ElementTree as ET  # nosec B405 - local pom.xml only.
 import zipfile
 from pathlib import Path
 
@@ -154,27 +153,52 @@ def require_absent(path: Path, label: str) -> None:
         raise ValueError(f"{label} collision: {path}")
 
 
-def _xml_local_name(tag: str) -> str:
-    return tag.rsplit("}", 1)[-1]
+_XML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+_XML_TAG = re.compile(
+    r"<(/?)(?:[\w.-]+:)?([A-Za-z_][\w.-]*)(?:\s[^>]*)?(/?)>",
+    re.DOTALL,
+)
+_MAX_POM_BYTES = 2_000_000
+_MAVEN_ID_PARENTS = {
+    ("project", "artifactId"),
+    ("modules", "module"),
+    ("dependency", "artifactId"),
+}
 
 
 def maven_coordinate_ids(pom: Path) -> set[str]:
     """Return project, module, and dependency artifact ids from one POM."""
     try:
-        root = ET.parse(pom).getroot()
-    except (OSError, ET.ParseError):
+        raw = pom.read_bytes()
+    except OSError:
+        return set()
+    if len(raw) > _MAX_POM_BYTES:
+        return set()
+    try:
+        text = _XML_COMMENT.sub("", raw.decode("utf-8"))
+    except UnicodeDecodeError:
         return set()
     ids: set[str] = set()
-    for parent in root.iter():
-        parent_name = _xml_local_name(parent.tag)
-        if parent_name not in {"project", "modules", "dependency"}:
+    stack: list[str] = []
+    pending_parent: str | None = None
+    last_end = 0
+    for match in _XML_TAG.finditer(text):
+        if pending_parent is not None:
+            value = text[last_end:match.start()].strip()
+            if value:
+                ids.add(value)
+            pending_parent = None
+        closing, name, self_close = match.group(1), match.group(2), match.group(3)
+        last_end = match.end()
+        if closing:
+            if stack and stack[-1] == name:
+                stack.pop()
             continue
-        for child in list(parent):
-            child_name = _xml_local_name(child.tag)
-            if child_name not in {"artifactId", "module"}:
-                continue
-            if isinstance(child.text, str) and child.text.strip():
-                ids.add(child.text.strip())
+        if self_close:
+            continue
+        stack.append(name)
+        if len(stack) >= 2 and (stack[-2], stack[-1]) in _MAVEN_ID_PARENTS:
+            pending_parent = stack[-2]
     return ids
 
 

--- a/chaos-engine/references/consult-first.md
+++ b/chaos-engine/references/consult-first.md
@@ -90,7 +90,7 @@ rule overrides an imported skill's default path.
 Work runs in this order, and each phase ends before the next begins:
 
 analyze -> plan -> design -> RED -> GREEN -> refactor -> commit ->
-pull request -> babysit to green -> merge.
+pull request -> babysit (fix review comments and failed tests) to green -> merge.
 
 Every phase that changes behavior ends with the independent adversarial review
 defined in [delegation](delegation.md), at the depth this task's triage set.

--- a/chaos-engine/references/work-github-playbook.md
+++ b/chaos-engine/references/work-github-playbook.md
@@ -138,10 +138,11 @@ by ancestry. Squash and rebase merging are disabled; do not substitute them.
 4. **Ask for unseen states** with `gh pr view <n> --json
    mergeStateStatus,mergedAt`; `DIRTY` conflicts and `BEHIND` stale heads need
    action even when no event fires.
-5. **Fix** red checks on the branch, review comments, or bot findings on the
-   branch, or merge the fetched configured upstream default branch for a conflict or
-   stale head, then return to watch. Never force-push away owner-visible history.
-   Any new push restarts the comment gate before auto-merge may remain armed.
+5. **Fix** red checks, failed tests, review comments, and bot findings on the
+   branch, or merge the fetched configured upstream default branch for a
+   conflict or stale head, then return to watch. Never force-push away
+   owner-visible history. Any new push restarts the comment gate before
+   auto-merge may remain armed.
 6. **Confirm** remotely that `mergedAt` is non-null; armed is not merged.
 
 ## 8. Report

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -833,6 +833,30 @@ class EntrypointDutyTest(unittest.TestCase):
                 self.assertIn(link, content, f"the entrypoint must link {link}")
                 self.assertIn(anchor, slugs, f"{anchor} names no heading in the playbook")
 
+    def test_pr_merger_babysit_must_fix_review_comments_and_failed_tests(self):
+        """Babysitting is not watch-only: comments and failed tests are in-scope."""
+        playbook = section_body(
+            self.PLAYBOOK.read_text(encoding="utf-8"),
+            "### PR-merger workflow: arm, watch, fix, confirm",
+        )
+        compact = re.sub(r"\s+", " ", playbook).casefold()
+        self.assertTrue(playbook, "the PR-merger workflow section must exist")
+        self.assertIn("review comments", compact)
+        self.assertIn("failed tests", compact)
+        self.assertIsNone(OPTIONALITY_HEDGE.search(playbook))
+        lifecycle = section_body(
+            (ROOT / "chaos-engine/references/consult-first.md").read_text(
+                encoding="utf-8"
+            ),
+            "## Lifecycle",
+        )
+        lifecycle_compact = re.sub(r"\s+", " ", lifecycle).casefold()
+        self.assertTrue(lifecycle, "the consult-first Lifecycle section must exist")
+        self.assertIn("babysit", lifecycle_compact)
+        self.assertIn("review comments", lifecycle_compact)
+        self.assertIn("failed tests", lifecycle_compact)
+        self.assertIsNone(OPTIONALITY_HEDGE.search(lifecycle))
+
     def test_the_learning_loop_is_required_before_every_report_of_done(self):
         """#4487: the routing table is the classifier; running it is the duty."""
         section = section_body(

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -568,6 +568,55 @@ class ChaosEngineInstallerTest(unittest.TestCase):
     def test_detect_distribution_selects_repository_from_reactor_module(self):
         self.assertEqual("repository", MODULE.detect_distribution(ROOT, SOURCE))
 
+    def test_maven_coordinate_ids_ignore_plugins_comments_and_broken_xml(self):
+        wanted = json.loads(
+            (SOURCE / "profiles/shaft/profile.json").read_text(encoding="utf-8")
+        )["installWhen"]["mavenArtifactIds"][0]
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            project.joinpath("pom.xml").write_text(
+                f"""<project>
+                  <parent>
+                    <artifactId>{wanted}</artifactId>
+                  </parent>
+                  <artifactId>demo</artifactId>
+                  <build>
+                    <plugins>
+                      <plugin>
+                        <artifactId>{wanted}</artifactId>
+                      </plugin>
+                    </plugins>
+                  </build>
+                  <dependencies>
+                    <dependency>
+                      <artifactId>junit-jupiter</artifactId>
+                      <exclusions>
+                        <exclusion>
+                          <artifactId>{wanted}</artifactId>
+                        </exclusion>
+                      </exclusions>
+                    </dependency>
+                  </dependencies>
+                  <!-- <dependency><artifactId>{wanted}</artifactId></dependency> -->
+                </project>
+                """,
+                encoding="utf-8",
+            )
+            self.assertEqual("portable", MODULE.detect_distribution(project, SOURCE))
+            self.assertEqual(
+                {"demo", "junit-jupiter"},
+                MODULE.maven_coordinate_ids(project / "pom.xml"),
+            )
+            project.joinpath("pom.xml").write_text("<project><unclosed>", encoding="utf-8")
+            self.assertEqual("portable", MODULE.detect_distribution(project, SOURCE))
+
+    def test_portable_installer_avoids_flagged_host_and_xml_parsers(self):
+        installer = INSTALLER.read_text(encoding="utf-8")
+        self.assertNotIn("xml.etree", installer)
+        self.assertNotIn("ElementTree", installer)
+        self.assertNotIn("Write-Host", (SOURCE / "install.ps1").read_text(encoding="utf-8"))
+
     def test_portable_installer_source_does_not_name_the_repository_profile(self):
         text = INSTALLER.read_text(encoding="utf-8").casefold()
         self.assertNotIn("shaft", text)


### PR DESCRIPTION
## Summary

#5094 merged with two Codacy medium findings and a babysit wording gap.

- Portable installer no longer uses `xml.etree.ElementTree` or `Write-Host`. Maven profile selection still reads only `project/artifactId`, `modules/module`, and `dependency/artifactId`.
- PR-merger and consult-first lifecycle now require fixing review comments and failed tests, not watch-only green.

Related to #5094.

## Checks

- `py -3 -m unittest tests.scripts.test_chaos_engine_installer` (83 tests, OK)
- `py -3 -m unittest tests.scripts.test_agent_harness_reachability.EntrypointDutyTest.test_pr_merger_babysit_must_fix_review_comments_and_failed_tests` (OK)
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` (OK)
- Independent review: pin originally read all of consult-first; now scoped to `## Lifecycle`

## Continuation

- Head: 09d4d6b2952131bd4d3f31de59ab378f479e2418
- State: follow-up after merged #5094; Codacy annotations and babysit instruction pin
- Blockers: none
- Next action: arm auto-merge after independent GitHub review
