### PR TITLE
fix(ci): keep infrastructure unit tests off nightly Grid E2E

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -262,6 +262,11 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           module-directory: shaft-video
 
+  # Native Selenium Grid jobs start selenium4.yml before Maven. Do not pass -am on
+  # Run tests: shaft-infrastructure is JUnit and ignores TestNG GLOBAL_TESTING_SCOPE,
+  # so -am would execute SeleniumGridLifecycleServiceTest against the already-running
+  # Grid (issue #5092). Dependencies are installed by the visual-runtime step
+  # (`mvn -pl shaft-visual -am install -DskipTests`).
   Ubuntu_Firefox_Grid:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Firefox_Grid,')
     runs-on: ubuntu-latest
@@ -299,7 +304,7 @@ jobs:
           mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
+        run: mvn -pl shaft-engine -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=firefox" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -345,7 +350,7 @@ jobs:
           mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
+        run: mvn -pl shaft-engine -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
@@ -391,7 +396,7 @@ jobs:
           mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
+        run: mvn -pl shaft-engine -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=DYNAMIC" "-DsetParallel=METHODS" "-DretryMaximumNumberOfAttempts=2" "-DexecutionAddress=http://localhost:4444" "-DtargetOperatingSystem=LINUX" "-DtargetBrowserName=MicrosoftEdge" "-DheadlessExecution=true" "-DremotePreflightEnabled=true" "-DremoteAdaptiveSessionThrottling=true" "-DremotePreflightFailFast=true" "-DremoteServerConnectionAttemptTimeout=15" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || '${GLOBAL_TESTING_SCOPE}' }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -59,6 +59,13 @@ GRID_ONLY_SCOPE_EXCLUSIONS = (
     "!%regex[.*playwright.*PlaywrightActionsE2ETest.*]",
     "!%regex[.*LazyLoadingFixtureLiveTest.*]",
 )
+NATIVE_SELENIUM_GRID_JOBS = (
+    "Ubuntu_Firefox_Grid",
+    "Ubuntu_Chrome_Grid",
+    "Ubuntu_MicrosoftEdge_Grid",
+)
+MAVEN_ALSO_MAKE = re.compile(r"(^|\s)-am(\s|$)")
+SHAFT_ENGINE_PL = re.compile(r"(^|\s)-pl\s+shaft-engine(\s|$)")
 
 
 def text(element: ET.Element, path: str) -> str | None:
@@ -428,6 +435,49 @@ def validate_browser_matrix_scope_policy(root: Path = ROOT) -> list[str]:
     return errors
 
 
+def validate_grid_jobs_skip_infrastructure_tests(root: Path = ROOT) -> list[str]:
+    path = root / ".github" / "workflows" / "e2eTests.yml"
+    if not path.is_file():
+        return ["e2eTests.yml is missing"]
+    document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    jobs = document.get("jobs") if isinstance(document, dict) else None
+    if not isinstance(jobs, dict):
+        return ["e2eTests.yml must define jobs"]
+
+    errors: list[str] = []
+    for job_name in NATIVE_SELENIUM_GRID_JOBS:
+        job = jobs.get(job_name)
+        if not isinstance(job, dict):
+            errors.append(f"e2eTests.yml is missing job {job_name!r}")
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            errors.append(f"e2eTests.yml job {job_name!r} is missing a Run tests step")
+            continue
+        run_tests = next(
+            (
+                step
+                for step in steps
+                if isinstance(step, dict) and step.get("name") == "Run tests"
+            ),
+            None,
+        )
+        if run_tests is None:
+            errors.append(f"e2eTests.yml job {job_name!r} is missing a Run tests step")
+            continue
+        command = str(run_tests.get("run") or "")
+        if not SHAFT_ENGINE_PL.search(command):
+            errors.append(
+                f"e2eTests.yml job {job_name!r} Run tests must select -pl shaft-engine"
+            )
+        if MAVEN_ALSO_MAKE.search(command):
+            errors.append(
+                f"e2eTests.yml job {job_name!r} Run tests must not use -am "
+                "(shaft-infrastructure JUnit tests ignore GLOBAL_TESTING_SCOPE)"
+            )
+    return errors
+
+
 def validate_codeql_build_mode(workflow: str) -> list[str]:
     document = yaml.safe_load(workflow) or {}
     error = ["CodeQL initialization must use explicit manual build mode"]
@@ -474,6 +524,7 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
     errors.extend(validate_workflow_coverage_policy(root))
     errors.extend(validate_workflow_readme_inventory(root))
     errors.extend(validate_browser_matrix_scope_policy(root))
+    errors.extend(validate_grid_jobs_skip_infrastructure_tests(root))
 
     aggregate_path = root / "report-aggregate" / "pom.xml"
     if not aggregate_path.is_file():

--- a/tests/scripts/test_validate_quality_configuration.py
+++ b/tests/scripts/test_validate_quality_configuration.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from scripts.ci.validate_quality_configuration import (
     validate_browser_matrix_scope_policy,
     validate_codeql_build_mode,
+    validate_grid_jobs_skip_infrastructure_tests,
     validate_maven_jvm_configuration,
     validate_quality_configuration,
     validate_scheduled_build_retry,
@@ -137,6 +138,63 @@ jobs:
 
     def test_repository_configuration_is_valid(self):
         self.assertEqual(validate_quality_configuration(), [])
+
+    def test_grid_run_tests_must_not_also_make_infrastructure_modules(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "e2eTests.yml").write_text(
+                "jobs:\n"
+                "  Ubuntu_Firefox_Grid:\n"
+                "    steps:\n"
+                "      - name: Run tests\n"
+                '        run: mvn -pl shaft-engine -am -e test "-Dtest=${GLOBAL_TESTING_SCOPE}"\n'
+                "  Ubuntu_Chrome_Grid:\n"
+                "    steps:\n"
+                "      - name: Run tests\n"
+                '        run: mvn -pl shaft-engine -e test "-Dtest=${GLOBAL_TESTING_SCOPE}"\n'
+                "  Ubuntu_MicrosoftEdge_Grid:\n"
+                "    steps:\n"
+                "      - name: Run tests\n"
+                '        run: mvn -pl shaft-engine -e test "-Dtest=${GLOBAL_TESTING_SCOPE}"\n',
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                validate_grid_jobs_skip_infrastructure_tests(root),
+                [
+                    "e2eTests.yml job 'Ubuntu_Firefox_Grid' Run tests must not use -am "
+                    "(shaft-infrastructure JUnit tests ignore GLOBAL_TESTING_SCOPE)"
+                ],
+            )
+
+    def test_live_grid_jobs_skip_infrastructure_tests(self):
+        self.assertEqual(validate_grid_jobs_skip_infrastructure_tests(), [])
+
+    def test_grid_run_tests_accepts_shaft_engine_without_also_make(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "e2eTests.yml").write_text(
+                "jobs:\n"
+                "  Ubuntu_Firefox_Grid:\n"
+                "    steps:\n"
+                "      - name: Run tests\n"
+                '        run: mvn -pl shaft-engine -e test "-Dtest=${GLOBAL_TESTING_SCOPE}"\n'
+                "  Ubuntu_Chrome_Grid:\n"
+                "    steps:\n"
+                "      - name: Run tests\n"
+                '        run: mvn -pl shaft-engine -e test "-Dtest=${GLOBAL_TESTING_SCOPE}"\n'
+                "  Ubuntu_MicrosoftEdge_Grid:\n"
+                "    steps:\n"
+                "      - name: Run tests\n"
+                '        run: mvn -pl shaft-engine -e test "-Dtest=${GLOBAL_TESTING_SCOPE}"\n',
+                encoding="utf-8",
+            )
+
+            self.assertEqual(validate_grid_jobs_skip_infrastructure_tests(root), [])
 
     def test_codeql_uses_explicit_manual_build_mode(self):
         root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary

Nightly E2E run 32091085106 failed only on `Ubuntu_Firefox_Grid`, `Ubuntu_Chrome_Grid`, and `Ubuntu_MicrosoftEdge_Grid`. `Run tests` exited 0 via `continue-on-error`; Post-Test Report and Check then failed because `shaft-engine` never produced JaCoCo or Allure.

The tests that actually failed are `com.shaft.infrastructure.SeleniumGridLifecycleServiceTest` methods:

- `logsMatchRuntimeIdentityWithoutRequiringTheManagedPlanDigest`
- `startReusesThenStopsOnlyTheOwnedProject`
- `composeInspectFailureDoesNotDropTheLeaseOrStopContainers`
- `failedReadinessTearsDownOnlyTheOwnedProject`
- `occupiedGridPortStartsNoComposeProject`

Those JUnit tests do not belong on nightly Grid. Each job already started `selenium4.yml` before Maven, and `-pl shaft-engine -am test` pulled `shaft-infrastructure` into the reactor. TestNG `GLOBAL_TESTING_SCOPE` does not filter that JUnit module, so the class collided with the live Grid and stopped `shaft-engine` E2E from running. The class stays in the repo and still runs in `pr-gate.yml` `unit-tests` (`matrix.module: shaft-infrastructure`). Tests were not weakened, deleted, or rewritten.

This PR drops `-am` from the three native Grid **Run tests** commands. The existing `mvn -pl shaft-visual -am install -DskipTests` step already installs the dependencies.

Closes #5092

## Checks

- RED: `validate_grid_jobs_skip_infrastructure_tests()` reported `-am` on the three Grid jobs.
- GREEN: `py -3 -m unittest` for `test_grid_run_tests_must_not_also_make_infrastructure_modules`, `test_grid_run_tests_accepts_shaft_engine_without_also_make`, `test_live_grid_jobs_skip_infrastructure_tests`, plus the two nearby `GRID_ONLY_SCOPE_EXCLUSIONS` tests. YAML parse of `e2eTests.yml` succeeded.
- Did not rerun the full nightly E2E suite.

## Continuation

- Head: `01d34cfa86d5d6e4f0d7c5c7c208b74344727a1b`
- State: PR opened against `main`. Grid jobs no longer execute `shaft-infrastructure` tests.
- Blockers: none for this scope.
- Next action: review this PR; do not rerun the full E2E DAG to prove the selector change.