### PR TITLE
Keep origin brand and research out of adopter installs

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -44,7 +44,11 @@ user off-switches still win. When a detected client
 requires marketplace registration, the agent registers the project marketplace
 and installs `chaos-engine`, `caveman`, and `ponytail` at project local scope,
 then runs active `doctor` probes. Generated indexes, caches, receipts, and runtimes
-remain untracked; canonical configuration and adapters remain trackable. The
+remain untracked; canonical configuration and adapters remain trackable.
+Origin identity masters under `assets/brand/` and the origin adoption matrix
+`RESEARCH.md` stay in the source tree and are not copied into the adopter
+payload. The
+
 installer also merges receipt-bound LF attributes for canonical harness paths,
 so Windows Git checkouts retain the exact owned bytes while unrelated
 `.gitattributes` rules remain untouched.

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -160,7 +160,7 @@ default; repository-specific distributions require an explicit selection.
 | [`tool.py`](tool.py) | Relocatable launcher for ChaosEngine-owned local tools |
 | [`learning.py`](learning.py) | Privacy-gated queue for reusable improvement candidates |
 | [`RESEARCH.md`](RESEARCH.md) | Dated adoption decisions and their local proof owners |
-| [`assets/brand/`](assets/brand/) | Canonical identity masters and usage rules |
+| [`assets/brand/`](assets/brand/) | Origin identity masters; not copied into adopter installs |
 
 The installer records provenance and per-file ownership in the consumer
 project. Host adapters redirect to the canonical skill; they do not fork its

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -200,6 +200,8 @@ def download_source(
         relative = PurePosixPath(*path.parts[1:])
         if not relative.parts:
             raise ValueError("ChaosEngine source tree has an unexpected layout")
+        if relative.parts[:2] == ("assets", "brand") or relative.as_posix() == "RESEARCH.md":
+            continue
         selected.append((relative, size))
         total += size
 

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -341,6 +341,8 @@ def source_files(source: Path, distribution: str = DEFAULT_DISTRIBUTION) -> tupl
             and relative.parts[1] != selected_profile
         ):
             continue
+        if relative.parts[:2] == ("assets", "brand") or relative.as_posix() == "RESEARCH.md":
+            continue
         if is_link_or_reparse(path):
             raise ValueError(f"source contains a link or reparse point: {relative}")
         if path.is_file():

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -262,5 +262,7 @@ Gambaru.
 The portable distribution's [human overview](../../README.md) uses the
 deterministic light, dark, monochrome, lockup, and small-size identity masters
 documented in the [ChaosEngine identity guide](../../assets/brand/BRAND.md).
+Those masters stay in the origin source tree and are not copied into adopter
+installs.
 
 

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -673,6 +673,44 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
 
                 self.assertFalse((Path(temporary) / ".chaos-engine").exists())
 
+    def test_download_source_omits_origin_brand_masters(self):
+        module = load()
+        tree = {
+            "truncated": False,
+            "tree": [
+                {"path": "chaos-engine/skills/chaos-engine/SKILL.md", "type": "blob", "mode": "100644", "size": 5},
+                {"path": "chaos-engine/assets/brand/symbol-light.svg", "type": "blob", "mode": "100644", "size": 5},
+                {"path": "chaos-engine/RESEARCH.md", "type": "blob", "mode": "100644", "size": 8},
+                {"path": "chaos-engine/assets/memory-v5/config.schema.json", "type": "blob", "mode": "100644", "size": 6},
+            ],
+        }
+        requested: list[str] = []
+
+        def opener(request, timeout=0):
+            del timeout
+            url = request.full_url if hasattr(request, "full_url") else request
+            requested.append(str(url))
+            if "git/trees" in str(url):
+                return Response(json.dumps(tree).encode())
+            if str(url).endswith("SKILL.md"):
+                return Response(b"skill")
+            if str(url).endswith("symbol-light.svg"):
+                return Response(b"brand")
+            if str(url).endswith("RESEARCH.md"):
+                return Response(b"research")
+            if str(url).endswith("config.schema.json"):
+                return Response(b"schema")
+            raise AssertionError(url)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            source = module.download_source("owner/repo", COMMIT_ONE, Path(temporary), opener=opener)
+
+            self.assertTrue((source / "skills/chaos-engine/SKILL.md").is_file())
+            self.assertTrue((source / "assets/memory-v5/config.schema.json").is_file())
+            self.assertFalse((source / "assets/brand/symbol-light.svg").exists())
+            self.assertFalse((source / "RESEARCH.md").exists())
+            self.assertFalse(any("symbol-light.svg" in url or url.endswith("RESEARCH.md") for url in requested if "git/trees" not in url))
+
     def test_bootstrap_is_reachable_and_runs_in_three_os_ci(self):
         skill = (ROOT / "chaos-engine/skills/chaos-engine/SKILL.md").read_text(encoding="utf-8")
         workflow = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -848,6 +848,23 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             self.assertFalse(any(relative.endswith(".pyc") for relative in manifest["files"]))
             self.assertFalse(install_root.joinpath("__pycache__").exists())
 
+    def test_portable_source_files_omit_origin_only_docs(self):
+        relatives = [
+            path.relative_to(SOURCE).as_posix()
+            for path in MODULE.source_files(SOURCE, "portable")
+        ]
+
+        self.assertFalse(
+            any(
+                relative == "assets/brand" or relative.startswith("assets/brand/")
+                for relative in relatives
+            )
+        )
+        self.assertNotIn("RESEARCH.md", relatives)
+        self.assertTrue(any(relative.startswith("assets/memory-v5/") for relative in relatives))
+        self.assertIn("INSTALL.md", relatives)
+        self.assertIn("LICENSE", relatives)
+
     def test_stage_loss_fails_before_publish(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "consumer"


### PR DESCRIPTION
## Summary

Portable ChaosEngine installs no longer copy origin-only identity and research files into adopter repositories.

- `source_files()` and bootstrap download omit `assets/brand/**` and `RESEARCH.md`
- `assets/memory-v5/**`, INSTALL, LICENSE, skills, hooks, and host adapters stay
- Origin brand tests still run against the source tree

Closes #5105

## Checks

- `py -3 -m unittest tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_portable_source_files_omit_origin_only_docs`
- `tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_clean_install_is_complete_and_manifest_bound`
- `tests.scripts.test_chaos_engine_bootstrap.ChaosEngineBootstrapTest.test_download_source_omits_origin_brand_masters`
- `tests.scripts.test_chaos_engine_research`

## Continuation

- Head: `e00bbb1207907f3f1de7fe0701c3d7d284f94ce7`
- State: SHAFT payload fix pushed so iTestFlow can re-run the official install command against this branch
- Blockers: none
- Next action: re-run the official iTestFlow install from this branch, then watch both PRs