### PR TITLE
feat(mcp): add grok installer target

### DIFF
--- a/scripts/mcp/install_shaft_mcp.py
+++ b/scripts/mcp/install_shaft_mcp.py
@@ -1357,6 +1357,11 @@ def project_candidates(directory: Path, client: str) -> list[Path]:
 
 
 def detect_project_override(client: str) -> None:
+    if client == "grok":
+        path = grok_write_path()
+        if path != configuration_path("grok").resolve() and project_entry_exists(path, "grok"):
+            log(f"Existing project configuration at {path} defines {SERVER_NAME}; it will be updated in-place.")
+        return
     user_home = home().resolve()
     directory = Path.cwd().resolve()
     while True:
@@ -1519,17 +1524,29 @@ def verify_grok_entry(path: Path, java: Path, args_file: Path) -> None:
         fail("The resulting shaft-mcp launcher arguments are incorrect.", 5)
 
 
+def git_root(start: Path) -> Path | None:
+    directory = start.resolve()
+    while True:
+        if (directory / ".git").exists():
+            return directory
+        if directory.parent == directory:
+            return None
+        directory = directory.parent
+
+
 def grok_write_path() -> Path:
     user_config = configuration_path("grok").resolve()
-    user_home = home().resolve()
     directory = Path.cwd().resolve()
-    while directory != user_home and directory.parent != directory:
+    stop = git_root(directory)
+    while True:
         for candidate in project_candidates(directory, "grok"):
             resolved = candidate.resolve()
             if resolved == user_config:
                 continue
             if project_entry_exists(candidate, "grok"):
                 return resolved
+        if stop is None or directory == stop or directory.parent == directory:
+            break
         directory = directory.parent
     return user_config
 

--- a/scripts/mcp/install_shaft_mcp.py
+++ b/scripts/mcp/install_shaft_mcp.py
@@ -17,6 +17,7 @@ import tarfile
 import tempfile
 import threading
 import time
+import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -48,6 +49,7 @@ SHAFT_SKILLS_NATIVE_DIRECTORIES = {
     "claude-desktop": (".claude/skills",),
     "copilot": (".github/skills",),
     "copilot-intellij": (".github/skills",),
+    "grok": (".agents/skills",),
     "intellij-plugin": (".agents/skills", ".claude/skills", ".github/skills"),
 }
 SHAFT_SKILLS_ALL_NATIVE_DIRECTORIES = (".agents/skills", ".claude/skills", ".github/skills")
@@ -80,13 +82,14 @@ AGENT_VALIDATION_SCRIPT_FILES = (
     "scripts/ci/agent_guidance_budget.json",
 )
 AGENT_GUIDANCE_SCAFFOLD_MARKER = "AGENTS.md"
-TARGETS = ("codex", "claude", "claude-desktop", "copilot", "copilot-intellij", "intellij-plugin")
+TARGETS = ("codex", "claude", "claude-desktop", "copilot", "copilot-intellij", "grok", "intellij-plugin")
 TARGET_CHOICES = (
     ("codex", "Codex CLI / IDE"),
     ("claude", "Claude Code"),
     ("claude-desktop", "Claude Desktop"),
     ("copilot", "GitHub Copilot CLI"),
     ("copilot-intellij", "GitHub Copilot for IntelliJ IDEA"),
+    ("grok", "Grok CLI"),
     ("intellij-plugin", "SHAFT IntelliJ IDEA plugin"),
 )
 
@@ -206,7 +209,7 @@ def choose_client() -> str:
         normalized = normalize_client(answer)
         if normalized in TARGETS:
             return normalized
-        print("Enter a number from 1 to 6, or a target name.")
+        print(f"Enter a number from 1 to {len(TARGET_CHOICES)}, or a target name.")
 
 
 def choose_component(prompt: str, default: bool) -> bool:
@@ -248,7 +251,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "target",
         nargs="?",
-        help="Optional target name: codex, claude, claude-desktop, copilot, or copilot-intellij.",
+        help="Optional target name: codex, claude, claude-desktop, copilot, copilot-intellij, or grok.",
     )
     args = parser.parse_args(argv)
 
@@ -283,7 +286,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     if args.install_mcp and args.client is None:
         args.client = choose_client()
     if args.client is not None and args.client not in TARGETS:
-        fail("Usage: install-shaft-mcp.py [--client <codex|claude|claude-desktop|copilot|copilot-intellij|intellij-plugin>]", 2)
+        fail("Usage: install-shaft-mcp.py [--client <codex|claude|claude-desktop|copilot|copilot-intellij|grok|intellij-plugin>]", 2)
     return args
 
 
@@ -1221,6 +1224,8 @@ def configuration_path(client: str) -> Path:
                 fail("LOCALAPPDATA is unavailable.", 3)
             return Path(local_app_data) / "github-copilot" / "intellij" / "mcp.json"
         return Path(os.environ.get("XDG_CONFIG_HOME") or user_home / ".config") / "github-copilot" / "intellij" / "mcp.json"
+    if client == "grok":
+        return Path(os.environ.get("GROK_HOME") or user_home / ".grok") / "config.toml"
     fail(f"Unsupported client: {client}", 2)
 
 
@@ -1311,6 +1316,14 @@ def update_json_configuration(path: Path, mutation: Any, verification: Any) -> N
 def project_entry_exists(path: Path, client: str) -> bool:
     if not path.is_file():
         return False
+    if client == "grok":
+        try:
+            raw = path.read_text(encoding="utf-8")
+            parsed = tomllib.loads(raw) if raw.strip() else {}
+        except (OSError, tomllib.TOMLDecodeError):
+            return False
+        servers = parsed.get("mcp_servers") if isinstance(parsed, dict) else None
+        return isinstance(servers, dict) and SERVER_NAME in servers
     if client == "codex":
         text = path.read_text(encoding="utf-8", errors="replace")
         return bool(re.search(r'(?m)^\s*(?:\[\s*mcp_servers\.(?:"shaft-mcp"|shaft-mcp)\s*]|mcp_servers\.(?:"shaft-mcp"|shaft-mcp)\s*=)', text))
@@ -1328,6 +1341,8 @@ def project_entry_exists(path: Path, client: str) -> bool:
 def project_candidates(directory: Path, client: str) -> list[Path]:
     if client == "codex":
         return [directory / ".codex" / "config.toml"]
+    if client == "grok":
+        return [directory / ".grok" / "config.toml"]
     if client in {"claude", "claude-desktop"}:
         return [directory / ".mcp.json"]
     if client == "copilot":
@@ -1443,6 +1458,113 @@ def configure_copilot_intellij(java: Path, args_file: Path) -> None:
     update_json_configuration(configuration, mutate, lambda: verify_json_entry(configuration, "servers", java, args_file))
 
 
+_GROK_SERVER_HEADER = re.compile(
+    r'(?m)^\s*\[\s*mcp_servers\.(?:"shaft-mcp"|shaft-mcp)\s*]'
+)
+
+
+def _toml_basic_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def grok_shaft_mcp_section(java: Path, args_file: Path) -> str:
+    return (
+        "[mcp_servers.shaft-mcp]\n"
+        f"command = {_toml_basic_string(str(java))}\n"
+        f"args = [{_toml_basic_string(f'@{args_file}')}]\n"
+        "enabled = true\n"
+    )
+
+
+def read_toml_mapping(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        return {}
+    try:
+        value = tomllib.loads(raw)
+    except tomllib.TOMLDecodeError as exc:
+        fail(f"Grok configuration is malformed: {path}. {exc}", 5)
+    if not isinstance(value, dict):
+        fail(f"Configuration root must be a TOML table: {path}", 5)
+    return value
+
+
+def replace_or_append_grok_section(text: str, section: str) -> str:
+    header = _GROK_SERVER_HEADER.search(text)
+    if not header:
+        prefix = text
+        if prefix and not prefix.endswith("\n"):
+            prefix += "\n"
+        if prefix and not prefix.endswith("\n\n"):
+            prefix += "\n"
+        return prefix + section
+    next_header = re.search(r"(?m)^\s*\[", text[header.end():])
+    section_end = header.end() + next_header.start() if next_header else len(text)
+    remainder = text[section_end:].lstrip("\n")
+    return text[:header.start()] + section + (("\n" + remainder) if remainder else "")
+
+
+def verify_grok_entry(path: Path, java: Path, args_file: Path) -> None:
+    servers = read_toml_mapping(path).get("mcp_servers")
+    if not isinstance(servers, dict) or SERVER_NAME not in servers:
+        fail(f"The resulting configuration does not contain {SERVER_NAME}.", 5)
+    entry = servers[SERVER_NAME]
+    if not isinstance(entry, dict):
+        fail("The resulting shaft-mcp entry is not an object.", 5)
+    if entry.get("command") != str(java):
+        fail("The resulting shaft-mcp Java command is incorrect.", 5)
+    if entry.get("args") != [f"@{args_file}"]:
+        fail("The resulting shaft-mcp launcher arguments are incorrect.", 5)
+
+
+def grok_write_path() -> Path:
+    user_config = configuration_path("grok").resolve()
+    user_home = home().resolve()
+    directory = Path.cwd().resolve()
+    while directory != user_home and directory.parent != directory:
+        for candidate in project_candidates(directory, "grok"):
+            resolved = candidate.resolve()
+            if resolved == user_config:
+                continue
+            if project_entry_exists(candidate, "grok"):
+                return resolved
+        directory = directory.parent
+    return user_config
+
+
+def configure_grok(java: Path, args_file: Path) -> None:
+    configuration = grok_write_path()
+    if configuration.exists() and configuration.stat().st_size > 0:
+        read_toml_mapping(configuration)
+
+    def mutate() -> None:
+        existed = configuration.exists() and configuration.stat().st_size > 0
+        if existed:
+            existing = configuration.read_text(encoding="utf-8")
+            parsed = read_toml_mapping(configuration)
+            servers = parsed.get("mcp_servers")
+            if (
+                isinstance(servers, dict)
+                and SERVER_NAME in servers
+                and not _GROK_SERVER_HEADER.search(existing)
+            ):
+                fail(
+                    f"Grok configuration already defines {SERVER_NAME} in a form "
+                    f"that cannot be updated in-place: {configuration}",
+                    5,
+                )
+            text = replace_or_append_grok_section(existing, grok_shaft_mcp_section(java, args_file))
+        else:
+            text = grok_shaft_mcp_section(java, args_file)
+        write_text_atomically(configuration, text if text.endswith("\n") else text + "\n")
+
+    update_json_configuration(
+        configuration, mutate, lambda: verify_grok_entry(configuration, java, args_file)
+    )
+
+
 def configure_client(client: str, java: Path, args_file: Path) -> None:
     if client == "intellij-plugin":
         return
@@ -1456,6 +1578,8 @@ def configure_client(client: str, java: Path, args_file: Path) -> None:
         configure_copilot(java, args_file)
     elif client == "copilot-intellij":
         configure_copilot_intellij(java, args_file)
+    elif client == "grok":
+        configure_grok(java, args_file)
     else:
         fail(f"Unsupported client: {client}", 2)
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -1680,6 +1680,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
             case "COPILOT_CLI" -> "copilot";
             case "COPILOT_INTELLIJ" -> "copilot-intellij";
             case "INTELLIJ_PLUGIN" -> "intellij-plugin";
+            case "GROK" -> "grok";
             default -> "codex";
         };
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1134,7 +1134,8 @@ class ShaftPanelSetupTest {
                 () -> assertEquals("claude-desktop", installerArgumentFor("CLAUDE_DESKTOP")),
                 () -> assertEquals("copilot", installerArgumentFor("COPILOT_CLI")),
                 () -> assertEquals("copilot-intellij", installerArgumentFor("COPILOT_INTELLIJ")),
-                () -> assertEquals("intellij-plugin", installerArgumentFor("INTELLIJ_PLUGIN")));
+                () -> assertEquals("intellij-plugin", installerArgumentFor("INTELLIJ_PLUGIN")),
+                () -> assertEquals("grok", installerArgumentFor("GROK")));
         for (String token : installerTargetTokens) {
             String argument = installerArgumentFor(token);
             String command = installerCommandFor(argument);

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -332,6 +332,27 @@ class InstallShaftMcpTest(unittest.TestCase):
             self.assertEqual(original, project_config.read_text(encoding="utf-8"))
             self.assertFalse((grok_home / "config.toml").exists())
 
+    def test_configure_grok_ignores_shaft_mcp_above_the_git_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            outside = root / "outside"
+            repo = outside / "repo"
+            (repo / ".git").mkdir(parents=True)
+            outside_config = outside / ".grok" / "config.toml"
+            outside_config.parent.mkdir(parents=True)
+            outside_config.write_text(
+                '[mcp_servers.shaft-mcp]\ncommand = "outside-old"\nargs = ["@outside-old"]\n',
+                encoding="utf-8",
+            )
+            java = root / "java"
+            args_file = root / "shaft-mcp.args"
+            with isolated_grok_env(root, cwd=repo) as (grok_home, _home, _cwd):
+                MODULE.configure_grok(java, args_file)
+            parsed = tomllib.loads((grok_home / "config.toml").read_text(encoding="utf-8"))
+            outside_parsed = tomllib.loads(outside_config.read_text(encoding="utf-8"))
+            self.assertEqual(str(java), parsed["mcp_servers"]["shaft-mcp"]["command"])
+            self.assertEqual("outside-old", outside_parsed["mcp_servers"]["shaft-mcp"]["command"])
+
     def test_configure_grok_prefers_grok_home_over_default_user_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -9,6 +9,7 @@ import re
 import subprocess  # nosec B404 -- Windows junction test uses resolved System32 cmd.exe only.
 import sys
 import tempfile
+import tomllib
 import unittest
 import zipfile
 from pathlib import Path
@@ -63,6 +64,20 @@ def scripted_stdin(answer: str):
         yield
     finally:
         MODULE.sys.stdin = original_stdin
+
+
+@contextlib.contextmanager
+def isolated_grok_env(root: Path, grok_home: Path | None = None, cwd: Path | None = None):
+    grok_home = grok_home or (root / "grok-home")
+    fake_home = root / "home"
+    cwd = cwd or (root / "cwd")
+    grok_home.mkdir(parents=True, exist_ok=True)
+    fake_home.mkdir(parents=True, exist_ok=True)
+    cwd.mkdir(parents=True, exist_ok=True)
+    with temporary_environment(GROK_HOME=str(grok_home)), mock.patch.object(
+        MODULE, "home", return_value=fake_home
+    ), temporary_current_directory(cwd):
+        yield grok_home, fake_home, cwd
 
 
 class InstallShaftMcpTest(unittest.TestCase):
@@ -148,6 +163,220 @@ class InstallShaftMcpTest(unittest.TestCase):
 
     def test_intellij_plugin_target_does_not_configure_external_client(self):
         MODULE.configure_client("intellij-plugin", Path("java"), Path("shaft-mcp.args"))
+
+    def test_parse_accepts_grok_client(self):
+        args = MODULE.parse_args(["--client", "grok"])
+
+        self.assertEqual("grok", args.client)
+        self.assertIn("grok", MODULE.TARGETS)
+
+    def test_parse_accepts_grok_flag(self):
+        args = MODULE.parse_args(["--grok"])
+
+        self.assertEqual("grok", args.client)
+
+    def test_configuration_path_grok_uses_grok_home(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            grok_home = Path(temp_dir) / "grok-home"
+            with temporary_environment(GROK_HOME=str(grok_home)):
+                self.assertEqual(grok_home / "config.toml", MODULE.configuration_path("grok"))
+
+    def test_configure_grok_writes_shaft_mcp_and_preserves_siblings(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with isolated_grok_env(root) as (grok_home, _home, _cwd):
+                config = grok_home / "config.toml"
+                config.write_text(
+                    "[mcp_servers.other]\n"
+                    'command = "npx"\n'
+                    'api_key = "secret-do-not-touch"\n'
+                    "\n"
+                    "[ui]\n"
+                    'permission_mode = "ask"\n',
+                    encoding="utf-8",
+                )
+                java = root / "java"
+                args_file = root / "shaft-mcp.args"
+                MODULE.configure_grok(java, args_file)
+
+            text = config.read_text(encoding="utf-8")
+            self.assertIn("[mcp_servers.other]", text)
+            self.assertIn('api_key = "secret-do-not-touch"', text)
+            self.assertIn('permission_mode = "ask"', text)
+            parsed = tomllib.loads(text)
+            entry = parsed["mcp_servers"]["shaft-mcp"]
+            self.assertEqual(str(java), entry["command"])
+            self.assertEqual([f"@{args_file}"], entry["args"])
+            self.assertEqual("npx", parsed["mcp_servers"]["other"]["command"])
+            self.assertEqual("secret-do-not-touch", parsed["mcp_servers"]["other"]["api_key"])
+
+    def test_configure_grok_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            java = root / "java"
+            args_file = root / "shaft-mcp.args"
+            with isolated_grok_env(root) as (grok_home, _home, _cwd):
+                MODULE.configure_grok(java, args_file)
+                first = (grok_home / "config.toml").read_text(encoding="utf-8")
+                MODULE.configure_grok(java, args_file)
+                second = (grok_home / "config.toml").read_text(encoding="utf-8")
+            first_entry = tomllib.loads(first)["mcp_servers"]["shaft-mcp"]
+            second_entry = tomllib.loads(second)["mcp_servers"]["shaft-mcp"]
+            self.assertEqual(first_entry["command"], second_entry["command"])
+            self.assertEqual(first_entry["args"], second_entry["args"])
+
+    def test_configure_grok_fails_closed_on_invalid_toml(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            original = "this is not toml [\n"
+            with isolated_grok_env(root) as (grok_home, _home, _cwd):
+                config = grok_home / "config.toml"
+                config.write_text(original, encoding="utf-8")
+                with self.assertRaises(MODULE.InstallError):
+                    MODULE.configure_grok(Path("java"), Path("shaft-mcp.args"))
+            self.assertEqual(original, config.read_text(encoding="utf-8"))
+
+    def test_grok_skills_use_agents_directory(self):
+        self.assertEqual((".agents/skills",), MODULE.SHAFT_SKILLS_NATIVE_DIRECTORIES["grok"])
+
+    def test_project_candidates_grok_use_repo_config(self):
+        directory = Path("repo")
+        self.assertEqual([directory / ".grok" / "config.toml"], MODULE.project_candidates(directory, "grok"))
+
+    def test_configure_grok_creates_config_when_missing_or_empty(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            java = root / "java"
+            args_file = root / "shaft-mcp.args"
+            with isolated_grok_env(root) as (grok_home, _home, _cwd):
+                MODULE.configure_grok(java, args_file)
+                empty = root / "empty-home"
+                empty.mkdir()
+                (empty / "config.toml").write_text("", encoding="utf-8")
+                with isolated_grok_env(root, grok_home=empty):
+                    MODULE.configure_grok(java, args_file)
+            parsed = tomllib.loads((grok_home / "config.toml").read_text(encoding="utf-8"))
+            empty_parsed = tomllib.loads((empty / "config.toml").read_text(encoding="utf-8"))
+            self.assertEqual(str(java), parsed["mcp_servers"]["shaft-mcp"]["command"])
+            self.assertTrue(parsed["mcp_servers"]["shaft-mcp"]["enabled"])
+            self.assertEqual(str(java), empty_parsed["mcp_servers"]["shaft-mcp"]["command"])
+
+    def test_configure_grok_fails_closed_on_inline_assignment(self):
+        original = (
+            'mcp_servers.shaft-mcp = { command = "old", args = ["@old"] }\n'
+            'mcp_servers.other = { command = "npx", api_key = "secret-do-not-touch" }\n'
+            'model = "keep-me"\n'
+            "\n"
+            "[ui]\n"
+            'permission_mode = "ask"\n'
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with isolated_grok_env(root) as (grok_home, _home, _cwd):
+                config = grok_home / "config.toml"
+                config.write_text(original, encoding="utf-8")
+                with self.assertRaises(MODULE.InstallError):
+                    MODULE.configure_grok(Path("java"), Path("shaft-mcp.args"))
+            self.assertEqual(original, config.read_text(encoding="utf-8"))
+
+    def test_configure_grok_fails_closed_on_nested_table(self):
+        original = (
+            "[mcp_servers]\n"
+            'shaft-mcp = { command = "old", args = ["@old"] }\n'
+            'other = { command = "npx" }\n'
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with isolated_grok_env(root) as (grok_home, _home, _cwd):
+                config = grok_home / "config.toml"
+                config.write_text(original, encoding="utf-8")
+                with self.assertRaises(MODULE.InstallError):
+                    MODULE.configure_grok(Path("java"), Path("shaft-mcp.args"))
+            self.assertEqual(original, config.read_text(encoding="utf-8"))
+
+    def test_configure_grok_updates_project_config_instead_of_user(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            grok_home = root / "user-grok"
+            project = root / "project"
+            project_config = project / ".grok" / "config.toml"
+            project_config.parent.mkdir(parents=True)
+            project_config.write_text(
+                '[mcp_servers.shaft-mcp]\ncommand = "old"\nargs = ["@old"]\n',
+                encoding="utf-8",
+            )
+            java = root / "java"
+            args_file = root / "shaft-mcp.args"
+            with isolated_grok_env(root, grok_home=grok_home, cwd=project):
+                MODULE.configure_grok(java, args_file)
+            parsed = tomllib.loads(project_config.read_text(encoding="utf-8"))
+            self.assertEqual(str(java), parsed["mcp_servers"]["shaft-mcp"]["command"])
+            self.assertEqual([f"@{args_file}"], parsed["mcp_servers"]["shaft-mcp"]["args"])
+            self.assertFalse((grok_home / "config.toml").exists())
+
+    def test_configure_grok_nested_project_form_fail_closes_without_user_write(self):
+        original = (
+            "[mcp_servers]\n"
+            'shaft-mcp = { command = "old", args = ["@old"] }\n'
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            grok_home = root / "user-grok"
+            project = root / "project"
+            project_config = project / ".grok" / "config.toml"
+            project_config.parent.mkdir(parents=True)
+            project_config.write_text(original, encoding="utf-8")
+            with isolated_grok_env(root, grok_home=grok_home, cwd=project):
+                with self.assertRaises(MODULE.InstallError):
+                    MODULE.configure_grok(root / "java", root / "shaft-mcp.args")
+            self.assertEqual(original, project_config.read_text(encoding="utf-8"))
+            self.assertFalse((grok_home / "config.toml").exists())
+
+    def test_configure_grok_prefers_grok_home_over_default_user_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            java = root / "java"
+            args_file = root / "shaft-mcp.args"
+            with isolated_grok_env(root) as (grok_home, fake_home, _cwd):
+                default_user = fake_home / ".grok" / "config.toml"
+                default_user.parent.mkdir(parents=True)
+                default_user.write_text(
+                    '[mcp_servers.shaft-mcp]\ncommand = "home-old"\nargs = ["@home-old"]\n',
+                    encoding="utf-8",
+                )
+                MODULE.configure_grok(java, args_file)
+            parsed = tomllib.loads((grok_home / "config.toml").read_text(encoding="utf-8"))
+            home_parsed = tomllib.loads(default_user.read_text(encoding="utf-8"))
+            self.assertEqual(str(java), parsed["mcp_servers"]["shaft-mcp"]["command"])
+            self.assertEqual("home-old", home_parsed["mcp_servers"]["shaft-mcp"]["command"])
+
+    def test_configure_grok_idempotent_keeps_siblings(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            with isolated_grok_env(root) as (grok_home, _home, _cwd):
+                config = grok_home / "config.toml"
+                config.write_text(
+                    "[mcp_servers.other]\n"
+                    'command = "npx"\n'
+                    'api_key = "secret-do-not-touch"\n',
+                    encoding="utf-8",
+                )
+                java = root / "java"
+                args_file = root / "shaft-mcp.args"
+                MODULE.configure_grok(java, args_file)
+                MODULE.configure_grok(java, args_file)
+            parsed = tomllib.loads(config.read_text(encoding="utf-8"))
+            self.assertEqual("npx", parsed["mcp_servers"]["other"]["command"])
+            self.assertEqual("secret-do-not-touch", parsed["mcp_servers"]["other"]["api_key"])
+            self.assertEqual(str(java), parsed["mcp_servers"]["shaft-mcp"]["command"])
+
+    def test_choose_client_error_uses_current_choice_count(self):
+        stdout = io.StringIO()
+        with scripted_stdin("0\n1"):
+            with contextlib.redirect_stdout(stdout):
+                chosen = MODULE.choose_client()
+        self.assertEqual("codex", chosen)
+        self.assertIn(f"1 to {len(MODULE.TARGET_CHOICES)}", stdout.getvalue())
 
     def test_has_agent_guidance_scaffold_requires_agents_md(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -271,7 +500,7 @@ class InstallShaftMcpTest(unittest.TestCase):
         self.assertEqual(1, len(label_line_indexes))
         self.assertGreater(label_line_indexes[0], advanced_index)
 
-        # Numbered entries stay contiguous 1..6, in TARGET_CHOICES order,
+        # Numbered entries stay contiguous 1..N, in TARGET_CHOICES order,
         # regardless of which section they were printed under.
         numbered_lines = [line.strip() for line in lines if line.strip()[:1].isdigit()]
         expected_numbered_lines = [
@@ -290,8 +519,9 @@ class InstallShaftMcpTest(unittest.TestCase):
         )
 
     def test_choose_client_numeric_and_name_input_resolve_to_same_target(self):
+        plugin_index = str(len(MODULE.TARGET_CHOICES))
         results = []
-        for answer in ("6", "intellij-plugin"):
+        for answer in (plugin_index, "intellij-plugin"):
             with scripted_stdin(answer):
                 with contextlib.redirect_stdout(io.StringIO()):
                     results.append(MODULE.choose_client())


### PR DESCRIPTION
Closes #5100

Related to #5086.

## Summary

Add `grok` as a first-class SHAFT MCP installer client. `configure_grok` merges `[mcp_servers.shaft-mcp]` into `GROK_HOME` or `~/.grok/config.toml` without requiring `grok` on PATH.

- Invalid TOML and unsupported table shapes fail closed; original bytes stay put.
- Sibling MCP servers and unrelated tables are preserved.
- Re-run is idempotent.
- If a project `.grok/config.toml` already defines `shaft-mcp`, that file is updated instead of the user file. `GROK_HOME` is never treated as a project path.
- Skills land in `.agents/skills` (Grok already scans that tree). No `.grok/skills` policy copies.
- `installerArgumentFor("GROK")` maps to `grok` so the Python/Java/shell contract stays locked. The IntelliJ route and visible target list stay in #5101.

## Checks

- `py -3 -m unittest tests.scripts.test_install_shaft_mcp tests.scripts.test_validate_installer_contract` — 73 tests, OK.
- `py -3 scripts/ci/validate_installer_contract.py` — valid.
- Independent adversarial review: first pass found inline-assignment splice and contract/UI sequencing notes; splice fixed and fail-closed. Second pass found `~/.grok` treated as a project file and unisolated write tests; write path now stops at user home and tests patch `home()` plus cwd.

## Continuation

- Head: `2b706ee877dec0e4ae38d2b5fc8a6de5bb8df4d5`
- State: Phase 1 plus git-root write-path fix committed. Tracker is #5086. Remaining: #5101 IntelliJ route, #5102 Autobot, #5103 scaffolding, #5104 leftovers + docs.
- Blockers: none.
- Next action: review-gate this PR, arm auto-merge, watch checks, then start #5101 from updated `main`.
