### PR TITLE
feat(intellij): add Grok CLI assistant route

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/AssistantAgentRoute.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/AssistantAgentRoute.java
@@ -13,6 +13,7 @@ public enum AssistantAgentRoute {
     CLAUDE_DESKTOP("Claude Desktop", "LOCAL", "CLAUDE", "DESKTOP_APP", "CLAUDE_CODE", "CLAUDE_DESKTOP"),
     CODEX_CLI("Codex CLI", "LOCAL", "CODEX", "CLI", "CODEX", "CODEX"),
     GEMINI_INTELLIJ("Gemini in IntelliJ", "CLOUD", "GEMINI", "IDE_PLUGIN", "CODEX", "INTELLIJ_PLUGIN"),
+    GROK("Grok CLI", "LOCAL", "GROK", "CLI", "GROK", "GROK"),
     COPILOT_CLI("GitHub Copilot CLI", "LOCAL", "COPILOT", "CLI", "COPILOT_CLI", "COPILOT_CLI"),
     COPILOT_INTELLIJ("GitHub Copilot in IntelliJ", "LOCAL", "COPILOT", "IDE_PLUGIN", "COPILOT_CLI", "COPILOT_INTELLIJ");
 
@@ -88,6 +89,7 @@ public enum AssistantAgentRoute {
             family = switch (normalize(settings.defaultAutobotClient, "CODEX")) {
                 case "CLAUDE_CODE" -> "CLAUDE";
                 case "COPILOT_CLI" -> "COPILOT";
+                case "GROK" -> "GROK";
                 default -> "CODEX";
             };
         }
@@ -95,6 +97,7 @@ public enum AssistantAgentRoute {
         return switch (family) {
             case "CLAUDE" -> "DESKTOP_APP".equals(runtime) ? CLAUDE_DESKTOP : CLAUDE_CODE;
             case "COPILOT" -> "IDE_PLUGIN".equals(runtime) ? COPILOT_INTELLIJ : COPILOT_CLI;
+            case "GROK" -> GROK;
             default -> CODEX_CLI;
         };
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -293,7 +293,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         assistantAgent.getAccessibleContext().setAccessibleDescription(
                 "Select the agent route used by SHAFT Assistant and MCP setup.");
         assistantAgent.addActionListener(event -> syncLegacyAgentControls());
-        assistantFamily = new JComboBox<>(model("CODEX", "CLAUDE", "COPILOT"));
+        assistantFamily = new JComboBox<>(model("CODEX", "CLAUDE", "COPILOT", "GROK"));
         ShaftUiLabels.applyFriendlyRenderer(assistantFamily);
         assistantFamily.getAccessibleContext().setAccessibleName("Assistant family");
         assistantFamily.getAccessibleContext().setAccessibleDescription("Local assistant family used by the Assistant tab.");
@@ -318,7 +318,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         cloudCredentialSource.getAccessibleContext().setAccessibleName("Assistant cloud credential source");
         cloudCredentialSource.getAccessibleContext().setAccessibleDescription(
                 "Use a provider-standard environment variable without storing its secret value, or use Password Safe.");
-        defaultClient = new JComboBox<>(model("CODEX", "CLAUDE_CODE", "COPILOT_CLI"));
+        defaultClient = new JComboBox<>(model("CODEX", "CLAUDE_CODE", "COPILOT_CLI", "GROK"));
         ShaftUiLabels.applyFriendlyRenderer(defaultClient);
         defaultClient.getAccessibleContext().setAccessibleName("Default assistant provider");
         defaultClient.getAccessibleContext().setAccessibleDescription("Default assistant provider used when opening the assistant panel.");
@@ -735,6 +735,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         return switch (normalize(state.defaultAutobotClient, "CODEX")) {
             case "CLAUDE_CODE" -> "CLAUDE";
             case "COPILOT_CLI" -> "COPILOT";
+            case "GROK" -> "GROK";
             default -> "CODEX";
         };
     }
@@ -743,6 +744,7 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
         return switch (normalize(family, "CODEX")) {
             case "CLAUDE" -> "CLAUDE_CODE";
             case "COPILOT" -> "COPILOT_CLI";
+            case "GROK" -> "GROK";
             default -> "CODEX";
         };
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -410,6 +410,7 @@ final class AssistantLocalAgentRunner {
         String executable = switch (normalize(client)) {
             case "CLAUDE_CODE" -> "claude";
             case "COPILOT_CLI" -> "copilot";
+            case "GROK" -> "grok";
             default -> "codex";
         };
         String displayName = displayName(client);
@@ -443,6 +444,7 @@ final class AssistantLocalAgentRunner {
         return switch (normalize(client)) {
             case "CLAUDE_CODE" -> List.of("claude", "mcp", "get", "shaft-mcp");
             case "COPILOT_CLI" -> List.of();
+            case "GROK" -> List.of("grok", "mcp", "list");
             default -> List.of("codex", "mcp", "get", "shaft-mcp");
         };
     }
@@ -2218,6 +2220,7 @@ final class AssistantLocalAgentRunner {
         return switch (normalize(client)) {
             case "CLAUDE_CODE" -> "Claude Code";
             case "COPILOT_CLI" -> "GitHub Copilot CLI";
+            case "GROK" -> "Grok CLI";
             default -> "Codex CLI";
         };
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/SetupPrerequisites.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/SetupPrerequisites.java
@@ -54,7 +54,8 @@ final class SetupPrerequisites {
         String agentExecutable = agentExecutableFor(family);
         if (agentExecutable != null) {
             boolean agentPresent = commandAvailable.test(agentExecutable);
-            if (!agentPresent && !commandAvailable.test("node")) {
+            if (!agentPresent && agentInstallCommandFor(family).startsWith("npm ")
+                    && !commandAvailable.test("node")) {
                 prerequisites.add(new Prerequisite("Node.js (required to install " + agentDisplayNameFor(family) + ")",
                         false, true, nodeInstallCommand(windows, mac)));
             }
@@ -68,6 +69,7 @@ final class SetupPrerequisites {
         return switch (normalize(family)) {
             case "CLAUDE" -> "claude";
             case "COPILOT" -> "copilot";
+            case "GROK" -> "grok";
             case "GEMINI" -> null;
             default -> "codex";
         };
@@ -77,6 +79,7 @@ final class SetupPrerequisites {
         return switch (normalize(family)) {
             case "CLAUDE" -> "Claude Code CLI";
             case "COPILOT" -> "GitHub Copilot CLI";
+            case "GROK" -> "Grok CLI";
             default -> "Codex CLI";
         };
     }
@@ -85,6 +88,7 @@ final class SetupPrerequisites {
         return switch (normalize(family)) {
             case "CLAUDE" -> "npm install -g @anthropic-ai/claude-code";
             case "COPILOT" -> "npm install -g @github/copilot";
+            case "GROK" -> "Install the Grok CLI (grok) and ensure it is on PATH";
             default -> "npm install -g @openai/codex";
         };
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -485,7 +485,7 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
         providerType = combo("Assistant provider type", "LOCAL", "CLOUD");
         providerType.setSelectedItem(normalize(settings.assistantProviderType, "LOCAL"));
         providerType.setToolTipText("Use Local for CLI agents; Cloud for provider Ask and Plan");
-        assistantFamily = combo("Assistant family", "CODEX", "CLAUDE", "COPILOT");
+        assistantFamily = combo("Assistant family", "CODEX", "CLAUDE", "COPILOT", "GROK");
         assistantFamily.setSelectedItem(resolveFamily(settings));
         assistantFamily.setToolTipText("Local assistant client");
         assistantRuntime = combo("Assistant runtime", "CLI", "IDE_PLUGIN", "DESKTOP_APP");
@@ -5681,6 +5681,7 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
         return switch (normalize(settings.defaultAutobotClient, "CODEX")) {
             case "CLAUDE_CODE" -> "CLAUDE";
             case "COPILOT_CLI" -> "COPILOT";
+            case "GROK" -> "GROK";
             default -> "CODEX";
         };
     }
@@ -5689,6 +5690,7 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
         return switch (normalize(family, "CODEX")) {
             case "CLAUDE" -> "CLAUDE_CODE";
             case "COPILOT" -> "COPILOT_CLI";
+            case "GROK" -> "GROK";
             default -> "CODEX";
         };
     }

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftMcpSetupPanel.java
@@ -75,6 +75,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
             "CLAUDE_DESKTOP",
             "COPILOT_CLI",
             "COPILOT_INTELLIJ",
+            "GROK",
             "INTELLIJ_PLUGIN"
     };
     private static final String GUIDE_SETUP_STEP =
@@ -309,7 +310,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
         progress.setIndeterminate(true);
         progress.setVisible(false);
         progress.setPreferredSize(JBUI.size(96, 14));
-        family = new JComboBox<>(new String[]{"CODEX", "CLAUDE", "COPILOT", GEMINI_FAMILY});
+        family = new JComboBox<>(new String[]{"CODEX", "CLAUDE", "COPILOT", "GROK", GEMINI_FAMILY});
         ShaftUiLabels.applyFriendlyRenderer(family);
         family.setSelectedItem(initialFamily(settings));
         family.getAccessibleContext().setAccessibleName("Assistant family");
@@ -1418,6 +1419,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
         return switch (normalize(settings.defaultAutobotClient, "CODEX")) {
             case "CLAUDE_CODE" -> "CLAUDE";
             case "COPILOT_CLI" -> "COPILOT";
+            case "GROK" -> "GROK";
             default -> "CODEX";
         };
     }
@@ -1624,7 +1626,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
         if (!"CLI".equals(normalize(settings.assistantRuntime, "CLI"))) {
             return new Recommendation(resolved, RecommendationBasis.SAVED_SELECTION);
         }
-        for (String familyCandidate : List.of("CODEX", "CLAUDE", "COPILOT")) {
+        for (String familyCandidate : List.of("CODEX", "CLAUDE", "COPILOT", "GROK")) {
             ShaftMcpToolResult result = readinessProbe.test(clientFromFamily(familyCandidate), "CLI");
             if (result != null && result.success()) {
                 return new Recommendation(familyCandidate, RecommendationBasis.DETECTED);
@@ -1647,6 +1649,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
         return switch (normalize(family, "CODEX")) {
             case "CLAUDE" -> "Claude Code CLI";
             case "COPILOT" -> "GitHub Copilot CLI";
+            case "GROK" -> "Grok CLI";
             default -> "Codex CLI";
         };
     }
@@ -1655,6 +1658,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
         return switch (normalize(family, "CODEX")) {
             case "CLAUDE" -> "CLAUDE_CODE";
             case "COPILOT" -> "COPILOT_CLI";
+            case "GROK" -> "GROK";
             default -> "CODEX";
         };
     }
@@ -2002,6 +2006,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
         String executable = switch (normalize(String.valueOf(family.getSelectedItem()), "CODEX")) {
             case "CLAUDE" -> "claude";
             case "COPILOT" -> "copilot";
+            case "GROK" -> "grok";
             case GEMINI_FAMILY -> "";
             default -> "codex";
         };
@@ -2038,6 +2043,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
         return switch (normalize(String.valueOf(family.getSelectedItem()), "CODEX")) {
             case "CLAUDE" -> "claude --version";
             case "COPILOT" -> "copilot --version";
+            case "GROK" -> "grok --version";
             case GEMINI_FAMILY -> "";
             default -> "codex --version";
         };
@@ -2136,6 +2142,7 @@ final class ShaftMcpSetupPanel extends JPanel implements Disposable {
         return switch (normalize(String.valueOf(family.getSelectedItem()), "CODEX")) {
             case "CLAUDE" -> "For Claude, run `claude mcp list` for Claude Code or restart Claude Desktop after desktop config changes.";
             case "COPILOT" -> "For GitHub Copilot, check the Copilot MCP client configuration and any organization MCP policy.";
+            case "GROK" -> "For Grok, run `grok mcp list` and verify the SHAFT MCP server in ~/.grok/config.toml.";
             case GEMINI_FAMILY -> "For Gemini, paste a valid Google AI Studio API key in the setup form, then check again.";
             default -> "For Codex, run `codex mcp list` and verify the SHAFT MCP server in the Codex config.";
         };

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftUiLabels.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftUiLabels.java
@@ -56,6 +56,7 @@ public final class ShaftUiLabels {
             case "CODEX" -> "Codex";
             case "CLAUDE" -> "Claude";
             case "COPILOT" -> "GitHub Copilot";
+            case "GROK" -> "Grok";
             case "CLAUDE_CODE" -> "Claude Code CLI";
             case "CLAUDE_DESKTOP" -> "Claude Desktop";
             case "COPILOT_CLI" -> "GitHub Copilot CLI";

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/AssistantAgentRouteTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/AssistantAgentRouteTest.java
@@ -19,11 +19,11 @@ class AssistantAgentRouteTest {
 
         assertEquals(List.of(
                         "Claude Code", "Claude Desktop", "Codex CLI", "Gemini in IntelliJ",
-                        "GitHub Copilot CLI", "GitHub Copilot in IntelliJ"),
+                        "Grok CLI", "GitHub Copilot CLI", "GitHub Copilot in IntelliJ"),
                 Arrays.stream(routes).map(route -> String.valueOf(invoke(displayName, route))).toList());
         assertEquals(List.of(
                         "CLAUDE_CODE", "CLAUDE_DESKTOP", "CODEX", "INTELLIJ_PLUGIN",
-                        "COPILOT_CLI", "COPILOT_INTELLIJ"),
+                        "GROK", "COPILOT_CLI", "COPILOT_INTELLIJ"),
                 Arrays.stream(routes).map(route -> String.valueOf(invoke(installerTarget, route))).toList());
     }
 
@@ -38,6 +38,7 @@ class AssistantAgentRouteTest {
         assertEquals("CODEX_CLI", routeName(fromSettings, settings("LOCAL", "CODEX", "CLI")));
         assertEquals("CLAUDE_CODE", routeName(fromSettings, settings("LOCAL", "CLAUDE", "CLI")));
         assertEquals("COPILOT_CLI", routeName(fromSettings, settings("LOCAL", "COPILOT", "CLI")));
+        assertEquals("GROK", routeName(fromSettings, settings("LOCAL", "GROK", "CLI")));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
@@ -260,7 +260,7 @@ class ShaftSettingsConfigurableTest {
         JLabel agentLabel = (JLabel) getField(configurable, "assistantAgentLabel");
         JLabel githubKeyLabel = (JLabel) getField(configurable, "githubKeyLabel");
 
-        assertEquals(6, agent.getItemCount());
+        assertEquals(7, agent.getItemCount());
         assertNotEquals(agentLabel.getDisplayedMnemonic(), githubKeyLabel.getDisplayedMnemonic());
         selectDisplayValue(agent, "Claude Desktop");
         configurable.apply();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerReadinessTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerReadinessTest.java
@@ -121,6 +121,8 @@ class AssistantLocalAgentRunnerReadinessTest {
         assertEquals(List.of("claude", "mcp", "get", "shaft-mcp"), launched.get());
         assertEquals(List.of("codex", "mcp", "get", "shaft-mcp"),
                 AssistantLocalAgentRunner.mcpAccessCommandFor("CODEX"));
+        assertEquals(List.of("grok", "mcp", "list"),
+                AssistantLocalAgentRunner.mcpAccessCommandFor("GROK"));
     }
 
     private static AssistantLocalAgentRunner.ProcessLauncher stub(String stdout, int exitCode) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/SetupPrerequisitesTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/SetupPrerequisitesTest.java
@@ -54,6 +54,22 @@ class SetupPrerequisitesTest {
     }
 
     @Test
+    void grokFamilyAsksForGrokCliWithoutNpmOrNode() {
+        List<SetupPrerequisites.Prerequisite> detected =
+                SetupPrerequisites.detect("GROK", NOTHING_INSTALLED, true, false);
+
+        SetupPrerequisites.Prerequisite agent = detected.stream()
+                .filter(item -> item.name().equals("Grok CLI"))
+                .findFirst().orElseThrow();
+        assertAll(
+                () -> assertFalse(agent.present()),
+                () -> assertTrue(agent.installCommand().contains("Grok CLI"), agent.installCommand()),
+                () -> assertFalse(agent.installCommand().startsWith("npm "), agent.installCommand()),
+                () -> assertTrue(detected.stream().noneMatch(item -> item.name().startsWith("Node.js")),
+                        "Grok is not an npm-installed CLI"));
+    }
+
+    @Test
     void geminiCloudFamilyNeedsNoAgentCli() {
         List<SetupPrerequisites.Prerequisite> detected =
                 SetupPrerequisites.detect("GEMINI", NOTHING_INSTALLED, true, false);

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1018,7 +1018,7 @@ class ShaftPanelSetupTest {
                     () -> assertTrue(command instanceof JBTextArea),
                     () -> assertTrue(((JBTextArea) command).getRows() >= 4),
                     () -> assertFalse(findByAccessibleName(panel, "MCP installer target", JComboBox.class).isVisible()),
-                    () -> assertEquals(6, findByAccessibleName(panel, "MCP installer target", JComboBox.class)
+                    () -> assertEquals(7, findByAccessibleName(panel, "MCP installer target", JComboBox.class)
                             .getItemCount()),
                     () -> assertEquals("INTELLIJ_PLUGIN", lastComboItem(
                             findByAccessibleName(panel, "MCP installer target", JComboBox.class))),
@@ -1068,9 +1068,9 @@ class ShaftPanelSetupTest {
                 () -> assertNotNull(manualTarget),
                 () -> assertFalse(manualTarget.isVisible()),
                 () -> assertFalse(target.isVisible()),
-                () -> assertEquals(6, agent.getItemCount()),
+                () -> assertEquals(7, agent.getItemCount()),
                 () -> assertEquals("Claude Code", String.valueOf(agent.getItemAt(0))),
-                () -> assertEquals("GitHub Copilot in IntelliJ", String.valueOf(agent.getItemAt(5))),
+                () -> assertEquals("GitHub Copilot in IntelliJ", String.valueOf(agent.getItemAt(6))),
                 () -> assertEquals("CODEX", target.getSelectedItem()),
                 () -> assertTrue(installer.getText().contains("codex")),
                 () -> assertTrue(installer.getText().contains("--install-shaft-skills")));
@@ -1099,6 +1099,11 @@ class ShaftPanelSetupTest {
         assertEquals("INTELLIJ_PLUGIN", target.getSelectedItem());
         assertTrue(installer.getText().contains("intellij-plugin"));
 
+        selectDisplayValue(agent, "Grok CLI");
+        assertAll(
+                () -> assertEquals("GROK", target.getSelectedItem()),
+                () -> assertTrue(installer.getText().contains("grok")));
+
         manualTarget.doClick();
         target.setSelectedItem("CLAUDE_CODE");
         assertAll(
@@ -1106,16 +1111,16 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(installer.getText().contains("intellij-plugin")),
                 () -> assertFalse(installer.getText().contains("--claude ")));
 
-        // Regression lock: INTELLIJ_PLUGIN stays last among exactly the 6 known installer targets.
+        // Regression lock: INTELLIJ_PLUGIN stays last among the known installer targets.
         List<String> installerTargetTokens = new ArrayList<>();
         for (int index = 0; index < target.getItemCount(); index++) {
             installerTargetTokens.add(String.valueOf(target.getItemAt(index)));
         }
         assertAll(
-                () -> assertEquals(6, target.getItemCount()),
+                () -> assertEquals(7, target.getItemCount()),
                 () -> assertEquals("INTELLIJ_PLUGIN", lastComboItem(target)),
                 () -> assertEquals(List.of("CODEX", "CLAUDE_CODE", "CLAUDE_DESKTOP", "COPILOT_CLI",
-                        "COPILOT_INTELLIJ", "INTELLIJ_PLUGIN"), installerTargetTokens));
+                        "COPILOT_INTELLIJ", "GROK", "INTELLIJ_PLUGIN"), installerTargetTokens));
 
         // The disambiguated label must not collapse back to a bare peer-agent name, and the
         // distinct IDE_PLUGIN runtime token (used by the runtime combo, not this target combo)
@@ -3077,7 +3082,7 @@ class ShaftPanelSetupTest {
         assertAll(
                 () -> assertNotNull(agent),
                 () -> assertTrue(agent.isVisible()),
-                () -> assertEquals(6, agent.getItemCount()),
+                () -> assertEquals(7, agent.getItemCount()),
                 () -> assertFalse(family.isVisible()),
                 () -> assertFalse(runtime.isVisible()));
     }

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -1099,17 +1099,17 @@ class ShaftPanelSetupTest {
         assertEquals("INTELLIJ_PLUGIN", target.getSelectedItem());
         assertTrue(installer.getText().contains("intellij-plugin"));
 
-        selectDisplayValue(agent, "Grok CLI");
-        assertAll(
-                () -> assertEquals("GROK", target.getSelectedItem()),
-                () -> assertTrue(installer.getText().contains("grok")));
-
         manualTarget.doClick();
         target.setSelectedItem("CLAUDE_CODE");
         assertAll(
                 () -> assertFalse(target.isVisible()),
                 () -> assertTrue(installer.getText().contains("intellij-plugin")),
                 () -> assertFalse(installer.getText().contains("--claude ")));
+
+        selectDisplayValue(agent, "Grok CLI");
+        assertAll(
+                () -> assertEquals("GROK", target.getSelectedItem()),
+                () -> assertTrue(installer.getText().contains("grok")));
 
         // Regression lock: INTELLIJ_PLUGIN stays last among the known installer targets.
         List<String> installerTargetTokens = new ArrayList<>();


### PR DESCRIPTION
Closes #5101

Related to #5086.

## Summary

Add Grok CLI as an IntelliJ Assistant agent route and MCP installer destination.

- `AssistantAgentRoute.GROK` display name `Grok CLI`, installer target `GROK` → `--client grok`.
- Setup and Settings list the route with the other agents. Copy still installs skills + CLI by default.
- Changing the route invalidates stale MCP/agent verification (existing contract).
- Detection uses the PATH readiness probe only. A config file alone never claims the executable is ready.
- Prerequisites name Grok CLI instead of falling through to Codex. Family/client maps persist `GROK` instead of remapping to Codex.

Autobot default commands stay in #5102.

## Checks

- `.\gradlew.bat test` focused: `AssistantAgentRouteTest`, `AssistantLocalAgentRunnerReadinessTest`, `ShaftSettingsConfigurableTest`, selected `ShaftPanelSetupTest` methods, `SetupPrerequisitesTest` — BUILD SUCCESSFUL.
- `py -3 scripts/ci/validate_installer_contract.py` — valid.

## Continuation

- Head: `7a5a5d0a30153857b544cbcd387477ce74090178`
- State: Phase 2 committed and pushed. Phase 1 is on main via PR #5109.
- Blockers: none.
- Next action: review-gate, arm auto-merge, watch checks, then #5102 from updated main.
