### PR TITLE
feat(pilot): add LocalAgentClient.GROK Autobot commands

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -548,6 +548,7 @@ final class AssistantLocalAgentRunner {
         return switch (normalize(string(arguments, "client", "CODEX"))) {
             case "CLAUDE_CODE" -> claudeCommand(mode, allowSourceMutation, model, bridge);
             case "COPILOT_CLI" -> copilotCommand(mode, allowSourceMutation, model);
+            case "GROK" -> grokCommand(mode, allowSourceMutation, string(arguments, "prompt", ""));
             default -> codexCommand(mode, allowSourceMutation, unrestrictedLocalAgentAccess, model, effort);
         };
     }
@@ -1412,6 +1413,18 @@ final class AssistantLocalAgentRunner {
      * display, and the CLI's own built-in safety classifier still auto-allows obviously-safe tool
      * calls without ever reaching the bridge, matching what an interactive user would see.
      */
+    private static List<String> grokCommand(String mode, boolean allowSourceMutation, String prompt) {
+        return switch (mode) {
+            case "PLAN" -> List.of("grok", "-p", prompt, "--permission-mode", "plan");
+            case "AGENT" -> allowSourceMutation
+                    ? List.of("grok", "-p", prompt, "--permission-mode", "acceptEdits")
+                    : List.of("grok", "-p", prompt, "--permission-mode", "default",
+                    "--tools", "read_file,grep,list_dir");
+            default -> List.of("grok", "-p", prompt, "--permission-mode", "default",
+                    "--tools", "read_file,grep,list_dir");
+        };
+    }
+
     private static List<String> claudeCommand(
             String mode, boolean allowSourceMutation, String model, LocalAgentApprovalBridge bridge) {
         List<String> command = new ArrayList<>(List.of("claude", "--print"));

--- a/shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java
@@ -106,7 +106,7 @@ public class AutobotService {
     /**
      * Runs an Ask, Plan, or explicitly approved Agent prompt through a local CLI agent.
      *
-     * @param client local agent client: CODEX, CLAUDE_CODE, or COPILOT_CLI
+     * @param client local agent client: CODEX, CLAUDE_CODE, COPILOT_CLI, or GROK
      * @param mode Autobot mode: ASK, PLAN, or AGENT
      * @param prompt prompt written to the local agent
      * @param workingDirectory optional workspace-relative working directory

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/agent/LocalAgentClient.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/agent/LocalAgentClient.java
@@ -8,7 +8,8 @@ import java.util.Locale;
 public enum LocalAgentClient {
     CODEX("codex", "Codex CLI"),
     CLAUDE_CODE("claude", "Claude Code"),
-    COPILOT_CLI("copilot", "Copilot CLI");
+    COPILOT_CLI("copilot", "Copilot CLI"),
+    GROK("grok", "Grok CLI");
 
     private final String executableName;
     private final String displayName;

--- a/shaft-pilot-core/src/main/java/com/shaft/pilot/agent/LocalAgentService.java
+++ b/shaft-pilot-core/src/main/java/com/shaft/pilot/agent/LocalAgentService.java
@@ -95,6 +95,7 @@ public final class LocalAgentService {
             case CODEX -> codexCommand(request.mode(), request.allowSourceMutation());
             case CLAUDE_CODE -> claudeCommand(request.mode(), request.allowSourceMutation());
             case COPILOT_CLI -> copilotCommand(request.mode(), request.allowSourceMutation());
+            case GROK -> grokCommand(request.mode(), request.allowSourceMutation(), request.prompt());
         };
     }
 
@@ -116,6 +117,18 @@ public final class LocalAgentService {
             case ASK -> List.of("claude", "--print");
             case PLAN -> List.of("claude", "--print", "--permission-mode", "plan");
             case AGENT -> List.of("claude", "--print", "--permission-mode", allowSourceMutation ? "acceptEdits" : "plan");
+        };
+    }
+
+    private static List<String> grokCommand(LocalAgentMode mode, boolean allowSourceMutation, String prompt) {
+        return switch (mode) {
+            case ASK -> List.of("grok", "-p", prompt, "--permission-mode", "default",
+                    "--tools", "read_file,grep,list_dir");
+            case PLAN -> List.of("grok", "-p", prompt, "--permission-mode", "plan");
+            case AGENT -> allowSourceMutation
+                    ? List.of("grok", "-p", prompt, "--permission-mode", "acceptEdits")
+                    : List.of("grok", "-p", prompt, "--permission-mode", "default",
+                    "--tools", "read_file,grep,list_dir");
         };
     }
 

--- a/shaft-pilot-core/src/test/java/com/shaft/pilot/agent/LocalAgentServiceTest.java
+++ b/shaft-pilot-core/src/test/java/com/shaft/pilot/agent/LocalAgentServiceTest.java
@@ -86,6 +86,70 @@ class LocalAgentServiceTest {
     }
 
     @Test
+    void grokAskIsReadOnlyAndNeverUsesYolo() {
+        CapturingRunner runner = new CapturingRunner();
+        LocalAgentService service = new LocalAgentService(client -> true, runner);
+        LocalAgentRequest request = LocalAgentRequest.builder(LocalAgentClient.GROK, LocalAgentMode.ASK,
+                        "Explain this failure")
+                .build();
+
+        LocalAgentResponse response = service.execute(request);
+
+        assertEquals(LocalAgentStatus.SUCCESS, response.status());
+        assertEquals(List.of("grok", "-p", "Explain this failure", "--permission-mode", "default",
+                "--tools", "read_file,grep,list_dir"), runner.command.get());
+        assertFalse(runner.command.get().contains("--yolo"));
+        assertFalse(runner.command.get().contains("--always-approve"));
+        assertFalse(response.toString().contains("secret"));
+    }
+
+    @Test
+    void grokPlanUsesPlanPermissionMode() {
+        CapturingRunner runner = new CapturingRunner();
+        LocalAgentService service = new LocalAgentService(client -> true, runner);
+        LocalAgentRequest request = LocalAgentRequest.builder(LocalAgentClient.GROK, LocalAgentMode.PLAN,
+                        "Plan the fix")
+                .build();
+
+        service.execute(request);
+
+        assertEquals(List.of("grok", "-p", "Plan the fix", "--permission-mode", "plan"), runner.command.get());
+    }
+
+    @Test
+    void grokAgentWithoutMutationStaysReadOnly() {
+        CapturingRunner runner = new CapturingRunner();
+        LocalAgentService service = new LocalAgentService(client -> true, runner);
+        LocalAgentRequest request = LocalAgentRequest.builder(LocalAgentClient.GROK, LocalAgentMode.AGENT,
+                        "Implement the change")
+                .build();
+
+        service.execute(request);
+
+        assertEquals(List.of("grok", "-p", "Implement the change", "--permission-mode", "default",
+                "--tools", "read_file,grep,list_dir"), runner.command.get());
+        assertFalse(runner.command.get().contains("acceptEdits"));
+        assertFalse(runner.command.get().contains("--yolo"));
+    }
+
+    @Test
+    void grokAgentWithMutationUsesAcceptEditsNotYolo() {
+        CapturingRunner runner = new CapturingRunner();
+        LocalAgentService service = new LocalAgentService(client -> true, runner);
+        LocalAgentRequest request = LocalAgentRequest.builder(LocalAgentClient.GROK, LocalAgentMode.AGENT,
+                        "Implement the change")
+                .allowSourceMutation(true)
+                .build();
+
+        service.execute(request);
+
+        assertEquals(List.of("grok", "-p", "Implement the change", "--permission-mode", "acceptEdits"),
+                runner.command.get());
+        assertFalse(runner.command.get().contains("--yolo"));
+        assertFalse(runner.command.get().contains("--always-approve"));
+    }
+
+    @Test
     void configuredCommandOverridesDefaultsAndKeepsEnvironmentOutOfResponse() {
         CapturingRunner runner = new CapturingRunner();
         LocalAgentService service = new LocalAgentService(client -> true, runner);


### PR DESCRIPTION
Closes #5102

Related to #5086.

## Summary

Add `LocalAgentClient.GROK` and Autobot default commands.

- ASK: `grok -p <prompt> --permission-mode default --tools read_file,grep,list_dir`
- PLAN: `grok -p <prompt> --permission-mode plan`
- AGENT without mutation: same as ASK
- AGENT with mutation: `grok -p <prompt> --permission-mode acceptEdits`
- Never `--yolo` / `--always-approve`
- Prompt is on `-p` because Grok headless mode does not read stdin
- IntelliJ `commandFor("GROK")` uses the same flags so assistant selection does not fall through to Codex

## Checks

- `mvn -pl shaft-pilot-core,shaft-mcp -Dtest=LocalAgentServiceTest,AutobotServiceTest -Dallure.automaticallyOpen=false test` — BUILD SUCCESS (AutobotServiceTest 18 tests).

## Continuation

- Head: `18d1521235e71529aa73a0998f4750f515f5f206`
- State: Phase 3 committed and pushed. Phases 1–2 are on main.
- Blockers: none.
- Next action: review-gate, arm, watch, then #5103.
