### PR TITLE
fix(chaos-engine): accept healthy Memory v4 and exclude-first MemPalace YAML

### DIFF
--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -119,30 +119,60 @@ def project_identity_name(project: Path) -> str:
     return project.name
 
 
+def _memory_project_valid(project_config: object) -> bool:
+    return (
+        isinstance(project_config, dict)
+        and set(project_config) == {"id", "name"}
+        and isinstance(project_config.get("id"), str)
+        and re.fullmatch(r"project\.[a-z0-9][a-z0-9-]*", project_config["id"]) is not None
+        and isinstance(project_config.get("name"), str)
+        and bool(project_config["name"].strip())
+    )
+
+
+def _memory_options_valid(memory_options: object, required: set[str]) -> bool:
+    budget = memory_options.get("defaultTokenBudget") if isinstance(memory_options, dict) else None
+    return (
+        isinstance(memory_options, dict)
+        and set(memory_options) == required
+        and isinstance(memory_options.get("autoIndex"), bool)
+        and isinstance(budget, int)
+        and not isinstance(budget, bool)
+        and 501 <= budget <= 50000
+        and (
+            "saveContextPacks" not in required
+            or isinstance(memory_options.get("saveContextPacks"), bool)
+        )
+    )
+
+
 def validate_memory_config(content: bytes) -> None:
     try:
         config = json.loads(content)
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ValueError("invalid Memory configuration") from error
-    project_config = config.get("project") if isinstance(config, dict) else None
-    memory_options = config.get("memory") if isinstance(config, dict) else None
-    if (
-        not isinstance(config, dict)
-        or set(config) != {"version", "project", "memory"}
-        or config.get("version") != 5
-        or not isinstance(project_config, dict)
-        or set(project_config) != {"id", "name"}
-        or not isinstance(project_config.get("id"), str)
-        or re.fullmatch(r"project\.[a-z0-9][a-z0-9-]*", project_config["id"]) is None
-        or not isinstance(project_config.get("name"), str)
-        or not project_config["name"].strip()
-        or not isinstance(memory_options, dict)
-        or set(memory_options) != {"autoIndex", "defaultTokenBudget"}
-        or not isinstance(memory_options.get("autoIndex"), bool)
-        or not isinstance(memory_options.get("defaultTokenBudget"), int)
-        or isinstance(memory_options.get("defaultTokenBudget"), bool)
-        or not 501 <= memory_options["defaultTokenBudget"] <= 50000
-    ):
+    if not isinstance(config, dict) or not _memory_project_valid(config.get("project")):
+        raise ValueError("invalid Memory configuration")
+    version = config.get("version")
+    if version == 5:
+        valid = set(config) == {"version", "project", "memory"} and _memory_options_valid(
+            config.get("memory"), {"autoIndex", "defaultTokenBudget"}
+        )
+    elif version == 4:
+        git_options = config.get("git")
+        valid = (
+            set(config) == {"version", "project", "memory", "git"}
+            and _memory_options_valid(
+                config.get("memory"),
+                {"autoIndex", "defaultTokenBudget", "saveContextPacks"},
+            )
+            and isinstance(git_options, dict)
+            and set(git_options) == {"trackContextPacks"}
+            and isinstance(git_options.get("trackContextPacks"), bool)
+        )
+    else:
+        valid = False
+    if not valid:
         raise ValueError("invalid Memory configuration")
 
 
@@ -177,15 +207,21 @@ def validate_mempalace_config(content: bytes) -> None:
     except UnicodeDecodeError as error:
         raise ValueError("invalid MemPalace configuration") from error
     wing_matches = re.findall(r"(?m)^wing:\s*([A-Za-z0-9_.-]+)\s*$", text)
-    rooms = re.search(r"(?ms)^rooms:\s*\n(?P<body>.*?)(?=^exclude_patterns:\s*$)", text)
-    excludes = re.search(r"(?ms)^exclude_patterns:\s*\n(?P<body>.*)\Z", text)
+    rooms = re.search(
+        r"(?ms)^rooms:\s*\n(?P<body>.*?)(?=^[A-Za-z_][\w-]*:\s*$|\Z)",
+        text,
+    )
+    excludes = re.search(
+        r"(?ms)^exclude_patterns:\s*\n(?P<body>.*?)(?=^[A-Za-z_][\w-]*:\s*$|\Z)",
+        text,
+    )
     if (
         len(wing_matches) != 1
         or rooms is None
-        or re.search(r"(?m)^\s{2}- name:\s*\S+\s*$", rooms.group("body")) is None
-        or re.search(r"(?m)^\s{4}description:\s*\S+.*$", rooms.group("body")) is None
+        or re.search(r"(?m)^\s*- name:\s*\S+", rooms.group("body")) is None
+        or re.search(r"(?m)^\s*description:\s*\S+", rooms.group("body")) is None
         or excludes is None
-        or re.search(r"(?m)^\s{2}-\s+\S+\s*$", excludes.group("body")) is None
+        or re.search(r"(?m)^\s*-\s+\S+", excludes.group("body")) is None
     ):
         raise ValueError("invalid MemPalace configuration")
 

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -868,6 +868,81 @@ class ChaosEngineHostsTest(unittest.TestCase):
                     module.install(project)
                 self.assertFalse(project.joinpath(module.RECEIPT_NAME).exists())
 
+    def test_healthy_adopter_v4_memory_and_unindented_mempalace_installs(self):
+        module = load(HOSTS, "chaos_engine_healthy_v4_retrieval")
+        v4_config = {
+            "version": 4,
+            "project": {"id": "project.itestflow-agent", "name": "iTestFlow Agent"},
+            "memory": {
+                "autoIndex": True,
+                "defaultTokenBudget": 600,
+                "saveContextPacks": False,
+            },
+            "git": {"trackContextPacks": False},
+        }
+        v4_schema = {"$id": "https://aictx.dev/schemas/v4/config.schema.json", "type": "object"}
+        object_bytes = json.dumps(
+            {
+                "id": "architecture.adopter-core",
+                "type": "architecture",
+                "title": "Adopter core",
+            },
+            indent=2,
+        ).encode() + b"\n"
+        yaml_text = (
+            "wing: itestflow_agent\n"
+            "exclude_patterns:\n"
+            "- .git/**\n"
+            "- .memory/**\n"
+            "rooms:\n"
+            "- name: general\n"
+            "  description: Project source and documentation\n"
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.joinpath(".chaos-engine/skills/chaos-engine").mkdir(parents=True)
+            project.joinpath(".chaos-engine/skills/chaos-engine/SKILL.md").write_text("# C\n")
+            project.joinpath(".memory/schema").mkdir(parents=True)
+            project.joinpath(".memory/memory").mkdir()
+            project.joinpath(".memory/relations").mkdir()
+            project.joinpath(".memory/config.json").write_text(
+                json.dumps(v4_config, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            for name in module.MEMORY_SCHEMA_FILES:
+                project.joinpath(".memory/schema", name).write_text(
+                    json.dumps(v4_schema, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+            object_path = project / ".memory/memory/architecture.json"
+            object_path.write_bytes(object_bytes)
+            project.joinpath("mempalace.yaml").write_bytes(yaml_text.encode())
+            before_config = project.joinpath(".memory/config.json").read_bytes()
+            before_schemas = {
+                name: project.joinpath(".memory/schema", name).read_bytes()
+                for name in module.MEMORY_SCHEMA_FILES
+            }
+            before_yaml = project.joinpath("mempalace.yaml").read_bytes()
+
+            receipt = module.install(project)
+            second = module.install(project)
+
+            self.assertTrue(project.joinpath(module.RECEIPT_NAME).exists())
+            self.assertEqual("installed", receipt["phase"])
+            self.assertEqual("installed", second["phase"])
+            self.assertTrue(module.retrieval_configs_healthy(project))
+            self.assertEqual(before_config, project.joinpath(".memory/config.json").read_bytes())
+            for name, payload in before_schemas.items():
+                self.assertEqual(payload, project.joinpath(".memory/schema", name).read_bytes())
+                self.assertNotIn(b"/v5/", payload)
+            self.assertEqual(object_bytes, object_path.read_bytes())
+            self.assertEqual(before_yaml, project.joinpath("mempalace.yaml").read_bytes())
+            self.assertTrue(before_yaml.startswith(b"wing: itestflow_agent\nexclude_patterns:\n"))
+            kept = json.loads(before_config)
+            self.assertEqual(4, kept["version"])
+            self.assertIn("git", kept)
+            self.assertIn("saveContextPacks", kept["memory"])
+
     def test_repository_remote_defines_identity_in_a_named_worktree(self):
         module = load(HOSTS, "chaos_engine_repository_identity")
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
Closes #5107

## Summary

Official host install now keeps a healthy adopter Memory v4 store and a custom MemPalace YAML in place.

`validate_memory_config` accepts v5 exact keys or healthy v4 exact keys (`version`, `project`, `memory`, `git` with `saveContextPacks` / `trackContextPacks`). `validate_mempalace_config` accepts `wing` + `rooms` + `exclude_patterns` in any order and 0-or-more-space list items. Incomplete v4 and empty YAML still fail before mutation. Fresh installs still seed Memory v5. Existing object files and project-local v4 schemas are not rewritten.

## Checks

- RED: `py -3 -m unittest tests.scripts.test_chaos_engine_hosts.ChaosEngineHostsTest.test_healthy_adopter_v4_memory_and_unindented_mempalace_installs` raised `ValueError: invalid Memory configuration` on current `hosts.py` before the validator change
- GREEN: same test plus `test_invalid_retrieval_configs_fail_before_mutation` and `test_complete_host_harness_installs_inventory_roles_hooks_and_plugin` (3 tests, OK)
- Live SHAFT checkout `.memory/config.json` (v4) and exclude-first `mempalace.yaml` now pass `retrieval_configs_healthy`

## Continuation

Head: 57575a3cb614cef74add599511f38e324b0d717b
State: implementation committed and pushed; independent review then arm auto-merge
Blockers: none
Next action: independent adversarial review of this exact diff, then `gh pr merge --auto --merge` and watch checks to confirmed merge
