### PR TITLE
feat(mcp): add grok loop to shaft_project_init_agents

### DIFF
--- a/shaft-cli/src/main/resources/tool-index-cache.json
+++ b/shaft-cli/src/main/resources/tool-index-cache.json
@@ -3452,7 +3452,7 @@
     {
       "name": "shaft_project_init_agents",
       "service": "ShaftProjectService",
-      "description": "scaffolds SHAFT skill bridges and managed host-instruction blocks into an existing test repo for one or all coding-agent loops (all, claude, codex, opencode, vscode); preserves user-authored instruction text and only overwrites SHAFT-owned skill files when overwrite=true",
+      "description": "scaffolds SHAFT skill bridges and managed host-instruction blocks into an existing test repo for one or all coding-agent loops (all, claude, codex, opencode, vscode, grok); preserves user-authored instruction text and only overwrites SHAFT-owned skill files when overwrite=true",
       "params": [
         {
           "name": "loop",

--- a/shaft-mcp/src/main/java/com/shaft/mcp/ShaftProjectService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/ShaftProjectService.java
@@ -42,8 +42,8 @@ public class ShaftProjectService {
     private static final String ROUTER_SKILL_NAME = "shaft-developer";
     private static final String SKILL_PACK_MANIFEST = ".shaft-mcp-managed-files";
     private static final String SKILL_PACK_MANIFEST_HEADER = "# SHAFT MCP managed skill files";
-    private static final List<String> ALL_AGENT_HOSTS = List.of("codex", "claude", "vscode", "opencode");
-    private static final Set<String> AGENT_LOOPS = Set.of("all", "claude", "codex", "opencode", "vscode");
+    private static final List<String> ALL_AGENT_HOSTS = List.of("codex", "claude", "vscode", "opencode", "grok");
+    private static final Set<String> AGENT_LOOPS = Set.of("all", "claude", "codex", "opencode", "vscode", "grok");
     private static final String SHAFT_ENGINE_MAVEN_METADATA_URL =
             "https://repo.maven.apache.org/maven2/io/github/shafthq/shaft-engine/maven-metadata.xml";
     private static final int DEFAULT_COMPILE_TIMEOUT_SECONDS = 900;
@@ -302,14 +302,14 @@ public class ShaftProjectService {
      * thin bridge: verbatim for claude/codex/opencode, and with an injected {@code applyTo: "**"} frontmatter
      * key (body otherwise verbatim) for vscode. Skills without that key keep the thin bridge.
      *
-     * @param loop all, claude, codex, opencode, or vscode
+     * @param loop all, claude, codex, opencode, vscode, or grok
      * @param targetDirectory workspace-relative existing test repo directory
      * @param overwrite whether existing SHAFT-owned skill files may be replaced
      * @return generated agent-scaffolding details
      */
     @Tool(name = "shaft_project_init_agents",
             description = "scaffolds SHAFT skill bridges and managed host-instruction blocks into an existing "
-                    + "test repo for one or all coding-agent loops (all, claude, codex, opencode, vscode); "
+                    + "test repo for one or all coding-agent loops (all, claude, codex, opencode, vscode, grok); "
                     + "preserves user-authored instruction text and only overwrites SHAFT-owned skill files when "
                     + "overwrite=true")
     public McpShaftProjectInitAgentsResult initAgents(String loop, String targetDirectory, boolean overwrite) {
@@ -323,6 +323,9 @@ public class ShaftProjectService {
             Set<String> hosts = agentHosts(target, selectedLoop);
             Map<String, String> skills = bundledSkillFiles();
             for (String host : hosts) {
+                if ("grok".equals(host) && hosts.contains("codex")) {
+                    continue;
+                }
                 installSkills(target, host, skills, overwrite, generatedFiles, warnings);
             }
             installHostAdapters(target, hosts, generatedFiles, warnings);
@@ -347,7 +350,7 @@ public class ShaftProjectService {
 
     private static String agentLoopSkillsDirectory(String loop) {
         return switch (loop) {
-            case "codex" -> ".agents/skills";
+            case "codex", "grok" -> ".agents/skills";
             case "claude" -> ".claude/skills";
             case "opencode" -> ".opencode/skills";
             default -> throw new IllegalArgumentException("Unsupported skill host: " + loop);
@@ -370,6 +373,9 @@ public class ShaftProjectService {
             }
             if (openCodeManaged) {
                 hosts.add("opencode");
+            }
+            if (content.contains(managedBlockStart("grok"))) {
+                hosts.add("grok");
             }
         }
         if (Files.exists(target.resolve("CLAUDE.md")) || Files.exists(target.resolve(".claude/CLAUDE.md"))) {
@@ -410,6 +416,10 @@ public class ShaftProjectService {
             List<String> warnings) throws IOException {
         if (hosts.contains("codex")) {
             writeManagedBlock(target.resolve("AGENTS.md"), target, "codex",
+                    ".agents/skills/shaft-developer/SKILL.md", generatedFiles, warnings);
+        }
+        if (hosts.contains("grok")) {
+            writeManagedBlock(target.resolve("AGENTS.md"), target, "grok",
                     ".agents/skills/shaft-developer/SKILL.md", generatedFiles, warnings);
         }
         if (hosts.contains("opencode")) {

--- a/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index-mechanical.json
+++ b/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index-mechanical.json
@@ -1898,7 +1898,7 @@
   }, {
     "name" : "shaft_project_init_agents",
     "service" : "ShaftProjectService",
-    "description" : "scaffolds SHAFT skill bridges and managed host-instruction blocks into an existing test repo for one or all coding-agent loops (all, claude, codex, opencode, vscode); preserves user-authored instruction text and only overwrites SHAFT-owned skill files when overwrite=true",
+    "description" : "scaffolds SHAFT skill bridges and managed host-instruction blocks into an existing test repo for one or all coding-agent loops (all, claude, codex, opencode, vscode, grok); preserves user-authored instruction text and only overwrites SHAFT-owned skill files when overwrite=true",
     "params" : [ {
       "name" : "loop",
       "type" : "string",

--- a/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index.json
+++ b/shaft-mcp/src/main/resources/META-INF/shaft-mcp/tool-index.json
@@ -3452,7 +3452,7 @@
     {
       "name": "shaft_project_init_agents",
       "service": "ShaftProjectService",
-      "description": "scaffolds SHAFT skill bridges and managed host-instruction blocks into an existing test repo for one or all coding-agent loops (all, claude, codex, opencode, vscode); preserves user-authored instruction text and only overwrites SHAFT-owned skill files when overwrite=true",
+      "description": "scaffolds SHAFT skill bridges and managed host-instruction blocks into an existing test repo for one or all coding-agent loops (all, claude, codex, opencode, vscode, grok); preserves user-authored instruction text and only overwrites SHAFT-owned skill files when overwrite=true",
       "params": [
         {
           "name": "loop",

--- a/shaft-mcp/src/test/java/com/shaft/mcp/ShaftProjectServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/ShaftProjectServiceTest.java
@@ -216,7 +216,9 @@ class ShaftProjectServiceTest {
         assertEquals(repo, result.targetDirectory());
         assertEquals("all", result.loop());
         assertTrue(result.warnings().isEmpty());
+        String agents = Files.readString(repo.resolve("AGENTS.md"));
         assertHostAdapter(repo.resolve("AGENTS.md"), ".agents/skills/shaft-developer/SKILL.md");
+        assertTrue(agents.contains("SHAFT-MANAGED:BEGIN shaft-developer:grok"));
         assertHostAdapter(repo.resolve("CLAUDE.md"), ".claude/skills/shaft-developer/SKILL.md");
         assertHostAdapter(repo.resolve(".github/copilot-instructions.md"),
                 "instructions/shaft-developer/SKILL.md");
@@ -240,6 +242,44 @@ class ShaftProjectServiceTest {
         assertFalse(Files.exists(repo.resolve(".github/instructions/act-as-shaft-dev.instructions.md")));
         assertFalse(Files.exists(repo.resolve(".codex")));
         assertFalse(Files.exists(repo.resolve("SHAFT-AGENTS.md")));
+    }
+
+    @Test
+    void initAgentsScaffoldsGrokLoopOnAgentsMdOnly() throws Exception {
+        ShaftProjectService service = new ShaftProjectService(
+                McpWorkspacePolicy.of(temp),
+                new FakeRunner(),
+                temp.resolve("upgrade_to_modular_shaft.py"),
+                List.of("python"));
+
+        McpShaftProjectInitAgentsResult result = service.initAgents("grok", "grok-repo", false);
+
+        assertEquals("grok", result.loop());
+        Path repo = temp.resolve("grok-repo");
+        Path agents = repo.resolve("AGENTS.md");
+        assertTrue(Files.exists(repo.resolve(".agents/skills/shaft-developer/SKILL.md")));
+        assertHostAdapter(agents, ".agents/skills/shaft-developer/SKILL.md");
+        assertTrue(Files.readString(agents).contains("SHAFT-MANAGED:BEGIN shaft-developer:grok"));
+        assertFalse(Files.exists(repo.resolve(".grok")));
+        assertFalse(Files.exists(repo.resolve("SHAFT-AGENTS.md")));
+    }
+
+    @Test
+    void initAgentsPreservesUserAgentsProseOutsideGrokManagedBlock() throws Exception {
+        ShaftProjectService service = new ShaftProjectService(
+                McpWorkspacePolicy.of(temp),
+                new FakeRunner(),
+                temp.resolve("upgrade_to_modular_shaft.py"),
+                List.of("python"));
+        Path repo = Files.createDirectories(temp.resolve("grok-prose"));
+        Path agents = repo.resolve("AGENTS.md");
+        Files.writeString(agents, "user owned grok notes\n");
+
+        service.initAgents("grok", "grok-prose", false);
+
+        String text = Files.readString(agents);
+        assertTrue(text.startsWith("user owned grok notes"));
+        assertHostAdapter(agents, ".agents/skills/shaft-developer/SKILL.md");
     }
 
     @Test

--- a/shaft-skills/references/shaft-mcp-tools.md
+++ b/shaft-skills/references/shaft-mcp-tools.md
@@ -136,7 +136,7 @@ Agents should use these exact tool names instead of guessing or listing tools at
 
 - `shaft_project_create` — creates a new SHAFT Maven project from the same examples and rules used by the guide generator
 - `shaft_project_upgrade` — runs the existing SHAFT modular project upgrader script against the current Java project
-- `shaft_project_init_agents` — scaffolds SHAFT skill bridges and managed host-instruction blocks into an existing test repo for one or all coding-agent loops (all, claude, codex, opencode, vscode); preserves user-authored instruction text and only overwrites SHAFT-owned skill files when overwrite=true
+- `shaft_project_init_agents` — scaffolds SHAFT skill bridges and managed host-instruction blocks into an existing test repo for one or all coding-agent loops (all, claude, codex, opencode, vscode, grok); preserves user-authored instruction text and only overwrites SHAFT-owned skill files when overwrite=true
 
 ## Test Automation (TestAutomationService)
 


### PR DESCRIPTION
Closes #5103

Related to #5086.

## Summary

Add `grok` to `shaft_project_init_agents`.

- `loop=grok` writes the AGENTS.md managed block pointing at `.agents/skills/shaft-developer/SKILL.md`.
- User prose outside the managed block is preserved.
- `loop=all` includes grok. Skills are not copied twice when Codex is also selected.
- No `.grok/skills` policy tree.
- Tool catalog descriptions list `grok`.

## Checks

- `mvn -pl shaft-mcp -Dtest=ShaftProjectServiceTest -Dallure.automaticallyOpen=false test` — 20 tests, BUILD SUCCESS.

## Continuation

- Head: `d882596b83c056b92e286c604cbe6ebe0e5c049b`
- State: Phase 4 committed and pushed. Phases 1–3 are on main.
- Blockers: none.
- Next action: review-gate, arm, watch, then #5104 leftovers and companion docs.
