### PR TITLE
fix(chaos-engine): persist portable MCP interpreters

### DIFF
--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -1693,21 +1693,34 @@ def discover_maven_tools_runtime() -> tuple[Path, Path] | None:
     return None
 
 
+def portable_python_server(
+    script_args: list[str], extra: dict[str, object] | None = None
+) -> dict[str, object]:
+    posix_command, posix_prefix = interpreter("posix")
+    windows_command, windows_prefix = interpreter("nt")
+    server: dict[str, object] = {
+        "command": posix_command,
+        "args": [*posix_prefix, *script_args],
+        "commandWindows": windows_command,
+        "argsWindows": [*windows_prefix, *script_args],
+        "cwd": ".",
+    }
+    if extra:
+        server.update(extra)
+    return server
+
+
 def owned_servers(
     platform_name: str | None = None,
     maven_runtime: tuple[Path, Path] | None = None,
 ) -> dict[str, dict[str, object]]:
-    command, prefix = interpreter(platform_name)
+    del platform_name
     servers: dict[str, dict[str, object]] = {
-        "chaosengine-memory": {
-            "command": command,
-            "args": [*prefix, ".chaos-engine/tool.py", "memory-mcp"],
-            "cwd": ".",
-        },
-        "chaosengine-mempalace": {
-            "command": command,
-            "args": [
-                *prefix,
+        "chaosengine-memory": portable_python_server(
+            [".chaos-engine/tool.py", "memory-mcp"]
+        ),
+        "chaosengine-mempalace": portable_python_server(
+            [
                 ".chaos-engine/tool.py",
                 "mempalace-mcp",
                 "--palace",
@@ -1715,9 +1728,8 @@ def owned_servers(
                 "--backend",
                 "sqlite_exact",
             ],
-            "cwd": ".",
-            "env": {"MEMPALACE_EMBEDDING_MODEL": "minilm"},
-        },
+            extra={"env": {"MEMPALACE_EMBEDDING_MODEL": "minilm"}},
+        ),
     }
     if maven_runtime is not None:
         java, jar = maven_runtime
@@ -2016,6 +2028,51 @@ def instruction_content(before: bytes | None, instruction: str) -> bytes:
     return (existing + separator + instruction).encode()
 
 
+def legacy_owned_python_server(name: str, platform_name: str) -> dict[str, object]:
+    command, prefix = interpreter(platform_name)
+    args = {
+        "chaosengine-memory": [*prefix, ".chaos-engine/tool.py", "memory-mcp"],
+        "chaosengine-mempalace": [
+            *prefix,
+            ".chaos-engine/tool.py",
+            "mempalace-mcp",
+            "--palace",
+            ".chaos-engine-state/mempalace",
+            "--backend",
+            "sqlite_exact",
+        ],
+    }[name]
+    server: dict[str, object] = {"command": command, "args": args, "cwd": "."}
+    if name == "chaosengine-mempalace":
+        server["env"] = {"MEMPALACE_EMBEDDING_MODEL": "minilm"}
+    return server
+
+
+def replaceable_owned_server(name: str, existing: object, desired: dict[str, object]) -> bool:
+    if existing == desired:
+        return True
+    if name not in {"chaosengine-memory", "chaosengine-mempalace"}:
+        return False
+    return existing in (
+        legacy_owned_python_server(name, "nt"),
+        legacy_owned_python_server(name, "posix"),
+    )
+
+
+def legacy_codex_python_block(platform_name: str) -> str:
+    command, prefix = interpreter(platform_name)
+    prefix_text = '"-3", ' if prefix else ""
+    return (
+        "# CHAOSENGINE:START\n"
+        f'[mcp_servers."chaosengine-memory"]\ncommand = "{command}"\n'
+        f'args = [{prefix_text}".chaos-engine/tool.py", "memory-mcp"]\ncwd = ".."\n\n'
+        f'[mcp_servers."chaosengine-mempalace"]\ncommand = "{command}"\n'
+        f'args = [{prefix_text}".chaos-engine/tool.py", "mempalace-mcp", "--palace", '
+        '".chaos-engine-state/mempalace", "--backend", "sqlite_exact"]\ncwd = ".."\n'
+        'env = { MEMPALACE_EMBEDDING_MODEL = "minilm" }\n# CHAOSENGINE:END\n'
+    )
+
+
 def json_content(
     before: bytes | None, maven_runtime: tuple[Path, Path] | None = None
 ) -> bytes:
@@ -2031,7 +2088,7 @@ def json_content(
     if servers.get("maven-tools-mcp") == LEGACY_MAVEN_TOOLS_SERVER:
         del servers["maven-tools-mcp"]
     for name, desired in owned_servers(maven_runtime=maven_runtime).items():
-        if name in servers and servers[name] != desired:
+        if name in servers and not replaceable_owned_server(name, servers[name], desired):
             raise ValueError(f"ChaosEngine MCP server collision: {name}")
         servers[name] = desired
     return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
@@ -2057,15 +2114,26 @@ def codex_content(
     for legacy in legacy_blocks:
         for newline_variant in (legacy, legacy.replace("\n", "\r\n")):
             existing = existing.replace(newline_variant, "")
-    command, prefix = interpreter(platform_name)
-    prefix_text = '"-3", ' if prefix else ""
+    del platform_name
+    posix_command, _posix_prefix = interpreter("posix")
+    windows_command, _windows_prefix = interpreter("nt")
+    memory_args = '".chaos-engine/tool.py", "memory-mcp"'
+    mempalace_args = (
+        '".chaos-engine/tool.py", "mempalace-mcp", "--palace", '
+        '".chaos-engine-state/mempalace", "--backend", "sqlite_exact"'
+    )
     block = (
         "# CHAOSENGINE:START\n"
-        f'[mcp_servers."chaosengine-memory"]\ncommand = "{command}"\n'
-        f'args = [{prefix_text}".chaos-engine/tool.py", "memory-mcp"]\ncwd = ".."\n\n'
-        f'[mcp_servers."chaosengine-mempalace"]\ncommand = "{command}"\n'
-        f'args = [{prefix_text}".chaos-engine/tool.py", "mempalace-mcp", "--palace", '
-        '".chaos-engine-state/mempalace", "--backend", "sqlite_exact"]\ncwd = ".."\n'
+        f'[mcp_servers."chaosengine-memory"]\ncommand = "{posix_command}"\n'
+        f"args = [{memory_args}]\n"
+        f'commandWindows = "{windows_command}"\n'
+        f'argsWindows = ["-3", {memory_args}]\n'
+        'cwd = ".."\n\n'
+        f'[mcp_servers."chaosengine-mempalace"]\ncommand = "{posix_command}"\n'
+        f"args = [{mempalace_args}]\n"
+        f'commandWindows = "{windows_command}"\n'
+        f'argsWindows = ["-3", {mempalace_args}]\n'
+        'cwd = ".."\n'
         'env = { MEMPALACE_EMBEDDING_MODEL = "minilm" }\n# CHAOSENGINE:END\n'
     )
     if maven_runtime is not None:
@@ -2080,9 +2148,14 @@ def codex_content(
             "# CHAOSENGINE:END\n",
         )
     if "# CHAOSENGINE:START" in existing or "# CHAOSENGINE:END" in existing:
-        if block not in existing:
-            raise ValueError("ChaosEngine Codex configuration collision")
-        return existing.encode()
+        if block in existing:
+            return existing.encode()
+        for platform in ("nt", "posix"):
+            legacy = legacy_codex_python_block(platform)
+            for candidate in (legacy, legacy.replace("\n", "\r\n")):
+                if candidate in existing:
+                    return existing.replace(candidate, block).encode()
+        raise ValueError("ChaosEngine Codex configuration collision")
     for name in owned_servers(maven_runtime=maven_runtime):
         if f'mcp_servers."{name}"' in existing or f"mcp_servers.{name}" in existing:
             raise ValueError(f"ChaosEngine Codex server collision: {name}")

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -386,10 +386,12 @@ class ChaosEngineHostsTest(unittest.TestCase):
                     {"chaosengine-memory", "chaosengine-mempalace"}, set(servers)
                 )
                 for server in servers.values():
-                    self.assertEqual("py" if os.name == "nt" else "python3", server["command"])
-                    if os.name == "nt":
-                        self.assertEqual("-3", server["args"][0])
+                    self.assertEqual("python3", server["command"])
+                    self.assertNotEqual("-3", server["args"][0])
+                    self.assertEqual("py", server["commandWindows"])
+                    self.assertEqual("-3", server["argsWindows"][0])
                     self.assertIn(".chaos-engine/tool.py", server["args"])
+                    self.assertIn(".chaos-engine/tool.py", server["argsWindows"])
                 mempalace = servers["chaosengine-mempalace"]
                 self.assertEqual(
                     ["--backend", "sqlite_exact"],
@@ -1411,12 +1413,55 @@ class ChaosEngineHostsTest(unittest.TestCase):
         windows = module.owned_servers("nt")
         posix = module.owned_servers("posix")
 
-        for server in windows.values():
-            self.assertEqual("py", server["command"])
-            self.assertEqual("-3", server["args"][0])
-        for server in posix.values():
+        self.assertEqual(windows, posix)
+        for server in (*windows.values(), *posix.values()):
             self.assertEqual("python3", server["command"])
             self.assertNotEqual("-3", server["args"][0])
+            self.assertEqual("py", server["commandWindows"])
+            self.assertEqual("-3", server["argsWindows"][0])
+
+    def test_windows_install_writes_portable_mcp_launchers(self):
+        module = load(HOSTS, "chaos_engine_hosts_portable_mcp")
+        with mock.patch.object(module.os, "name", "nt"):
+            windows_json = json.loads(module.json_content(None))["mcpServers"]
+            windows_codex = module.codex_content(None).decode("utf-8")
+        with mock.patch.object(module.os, "name", "posix"):
+            posix_json = json.loads(module.json_content(None))["mcpServers"]
+            posix_codex = module.codex_content(None).decode("utf-8")
+
+        self.assertEqual(windows_json, posix_json)
+        self.assertEqual(windows_codex, posix_codex)
+        for name, server in windows_json.items():
+            self.assertEqual("python3", server["command"], name)
+            self.assertNotEqual("-3", server["args"][0], name)
+            self.assertIn(".chaos-engine/tool.py", server["args"], name)
+            self.assertEqual("py", server["commandWindows"], name)
+            self.assertEqual("-3", server["argsWindows"][0], name)
+            self.assertIn(".chaos-engine/tool.py", server["argsWindows"], name)
+        self.assertIn('command = "python3"', windows_codex)
+        self.assertNotIn('command = "py"', windows_codex)
+        self.assertIn('commandWindows = "py"', windows_codex)
+        self.assertIn('"-3", ".chaos-engine/tool.py"', windows_codex)
+
+    def test_legacy_os_baked_mcp_servers_are_replaced_not_collided(self):
+        module = load(HOSTS, "chaos_engine_hosts_legacy_mcp_launch")
+        desired = json.loads(module.json_content(None))
+        desired_codex = module.codex_content(None)
+        for platform in ("nt", "posix"):
+            legacy = {
+                "mcpServers": {
+                    name: module.legacy_owned_python_server(name, platform)
+                    for name in ("chaosengine-memory", "chaosengine-mempalace")
+                }
+            }
+            upgraded = json.loads(module.json_content(json.dumps(legacy).encode()))
+            self.assertEqual(desired, upgraded)
+            legacy_codex = module.legacy_codex_python_block(platform).encode()
+            self.assertEqual(desired_codex, module.codex_content(legacy_codex))
+            self.assertEqual(
+                desired_codex,
+                module.codex_content(legacy_codex.replace(b"\n", b"\r\n")),
+            )
 
     def test_native_maven_tools_runtime_uses_resolved_host_paths(self):
         module = load(HOSTS, "chaos_engine_hosts_native_maven")


### PR DESCRIPTION
## Summary

Official ChaosEngine install no longer bakes the installing OS interpreter into tracked MCP configs.

- .mcp.json, .gemini/settings.json, and .codex/config.toml always write `command = python3` plus `commandWindows = py` / `argsWindows` with `-3`.
- Windows and POSIX installs now emit identical python server launch lines.
- Legacy OS-baked ChaosEngine servers are replaced on upgrade; user-owned collisions still fail closed.

Closes #5108

## Checks

- RED: `tests.scripts.test_chaos_engine_hosts.ChaosEngineHostsTest.test_windows_install_writes_portable_mcp_launchers` failed because a Windows render used `py`/`-3` while POSIX used `python3`.
- GREEN: that test plus `test_legacy_os_baked_mcp_servers_are_replaced_not_collided`, `test_launcher_rendering_is_explicit_for_windows_and_posix`, `test_host_configs_use_project_relative_local_runtime_launchers`, `test_existing_unrelated_config_is_preserved_and_owned_collision_fails_closed`, `test_legacy_docker_maven_server_is_removed_during_host_rendering`, `test_native_maven_tools_runtime_uses_resolved_host_paths`, `test_native_maven_tools_runtime_is_rendered_for_both_host_configs`, `test_complete_host_harness_installs_inventory_roles_hooks_and_plugin`, `test_hosts_module_source_has_no_portable_forbidden_tokens`, `test_late_host_collision_leaves_the_project_unchanged`, `test_mcp_runtime_executes_both_initialize_handshakes`.

## Continuation

- Head: 2c963ac7266ce1e33d9050c65532a6101b7e35ac
- State: first checkpoint pushed; independent review of the actual diff next, then arm auto-merge
- Blockers: none
- Next action: adversarial review of the diff, then `gh pr merge --auto --merge` and watch to MERGED