### PR TITLE
fix(chaos-engine): skip empty SHAFT checkout palace init

### DIFF
--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -324,7 +324,7 @@ def _sqlite_runtime_valid(
             connection.close()
 
 
-def shaft_resolver_present(project: Path) -> bool:
+def repository_map_resolver_present(project: Path) -> bool:
     return (project / "tools/repository-map/resolve_mempalace.py").is_file()
 
 
@@ -347,7 +347,7 @@ def mempalace_runtime_status(project: Path) -> dict[str, str]:
             "detail": "MemPalace state is a link or reparse point",
         }
     if not palace.exists():
-        if shaft_resolver_present(project):
+        if repository_map_resolver_present(project):
             return centralized_mempalace_status()
         return {"status": "initialization-required", "backend": "sqlite_exact"}
     if not palace.is_dir():
@@ -431,7 +431,7 @@ def mempalace_runtime_status(project: Path) -> dict[str, str]:
                 "detail": "SQLite-exact MemPalace state is unreadable or malformed",
             }
         return {"status": "healthy", "backend": "sqlite_exact"}
-    if shaft_resolver_present(project):
+    if repository_map_resolver_present(project):
         return centralized_mempalace_status()
     return {"status": "initialization-required", "backend": "sqlite_exact"}
 

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -324,6 +324,20 @@ def _sqlite_runtime_valid(
             connection.close()
 
 
+def shaft_resolver_present(project: Path) -> bool:
+    return (project / "tools/repository-map/resolve_mempalace.py").is_file()
+
+
+def centralized_mempalace_status() -> dict[str, str]:
+    return {
+        "status": "degraded",
+        "detail": (
+            "Centralized MemPalace is the operator path; "
+            "use py -3 scripts/agents/knowledge_stores.py status"
+        ),
+    }
+
+
 def mempalace_runtime_status(project: Path) -> dict[str, str]:
     """Classify project-local MemPalace state without importing its native backend."""
     palace = project / ".chaos-engine-state/mempalace"
@@ -333,14 +347,8 @@ def mempalace_runtime_status(project: Path) -> dict[str, str]:
             "detail": "MemPalace state is a link or reparse point",
         }
     if not palace.exists():
-        if (project / "tools/repository-map/resolve_mempalace.py").is_file():
-            return {
-                "status": "degraded",
-                "detail": (
-                    "Centralized MemPalace is the operator path; "
-                    "use py -3 scripts/agents/knowledge_stores.py status"
-                ),
-            }
+        if shaft_resolver_present(project):
+            return centralized_mempalace_status()
         return {"status": "initialization-required", "backend": "sqlite_exact"}
     if not palace.is_dir():
         return {
@@ -423,6 +431,8 @@ def mempalace_runtime_status(project: Path) -> dict[str, str]:
                 "detail": "SQLite-exact MemPalace state is unreadable or malformed",
             }
         return {"status": "healthy", "backend": "sqlite_exact"}
+    if shaft_resolver_present(project):
+        return centralized_mempalace_status()
     return {"status": "initialization-required", "backend": "sqlite_exact"}
 
 

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -1377,6 +1377,33 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 module.mempalace_runtime_status(portable)["status"],
             )
 
+    def test_shaft_resolver_with_empty_checkout_palace_is_degraded_and_does_not_initialize(self):
+        module = load(HOSTS, "chaos_engine_mempalace_empty_checkout")
+        with tempfile.TemporaryDirectory() as temporary:
+            shaft = Path(temporary) / "shaft"
+            resolver = shaft / "tools/repository-map/resolve_mempalace.py"
+            resolver.parent.mkdir(parents=True)
+            resolver.write_text("# fixture SHAFT resolver\n", encoding="utf-8")
+            palace = shaft / ".chaos-engine-state/mempalace"
+            palace.mkdir(parents=True)
+
+            state = module.mempalace_runtime_status(shaft)
+            self.assertEqual("degraded", state["status"])
+            self.assertIn("scripts/agents/knowledge_stores.py status", state["detail"])
+            self.assertIn("centralized", state["detail"].lower())
+            self.assertNotIn(".git", state["detail"])
+
+            module.initialize_mempalace_runtime(shaft)
+            self.assertFalse((palace / "sqlite_exact.sqlite3").exists())
+            self.assertEqual([], list(palace.iterdir()))
+
+            portable = Path(temporary) / "portable"
+            (portable / ".chaos-engine-state/mempalace").mkdir(parents=True)
+            self.assertEqual(
+                "initialization-required",
+                module.mempalace_runtime_status(portable)["status"],
+            )
+
     def test_tool_guard_refuses_shaft_degraded_mempalace_and_names_knowledge_stores(self):
         hosts = load(HOSTS, "chaos_engine_mempalace_shaft_guard_hosts")
         tool = load(TOOL, "chaos_engine_mempalace_shaft_guard_tool")


### PR DESCRIPTION
## Summary

When the SHAFT MemPalace resolver exists, an empty `.chaos-engine-state/mempalace` directory is now `degraded` instead of `initialization-required`. `initialize_mempalace_runtime` no longer writes a second `sqlite_exact.sqlite3` next to the centralized palace.

Portable trees without `tools/repository-map/resolve_mempalace.py` still initialize.

Closes #5082

## Checks

- RED: `test_shaft_resolver_with_empty_checkout_palace_is_degraded_and_does_not_initialize` failed with `initialization-required`.
- GREEN: that test plus `test_shaft_resolver_without_checkout_palace_is_degraded_and_does_not_initialize`, `test_tool_guard_refuses_shaft_degraded_mempalace_and_names_knowledge_stores`, `test_fresh_mempalace_state_initializes_once_without_claiming_user_data`, `test_mempalace_runtime_state_is_fail_closed_before_native_launch`, `test_fresh_mempalace_initializer_revalidates_paths_after_creation`.

## Continuation

- Head: c8eedc78905117436bf8f00a123c82fde055f1c9
- State: first checkpoint pushed
- Blockers: none
- Next action: review actual diff, arm auto-merge, watch to MERGED


