### PR TITLE
feat(harness): force-include SHAFT families in MemPalace mine

### DIFF
--- a/chaos-engine/profiles/shaft/references/graphify.md
+++ b/chaos-engine/profiles/shaft/references/graphify.md
@@ -109,8 +109,10 @@ Unclassified extract skips are corpus policy, not a failed install. Noise
 families belong in `.graphifyignore` and `mempalace.yaml` `exclude_patterns`.
 Known first-class SHAFT families that Graphifyy 0.9.43 still drops
 (`.properties`, `META-INF/services/*`, Dockerfiles, plugin XML, `.toml`,
-`.feature`, wrappers) stay on the maintenance allowlist until an upstream
-promote lands. A new suffix is `unclassified_unexpected` and fails
+`.feature`, wrappers) stay on the Graphify allowlist until an upstream
+promote lands. Nightly MemPalace mine force-includes the exact
+`git ls-files` set for `.properties`, SPI, Dockerfiles, plugin XML, and
+`.feature` via `--include-ignored` (#5119). A new suffix is `unclassified_unexpected` and fails
 `graphify_maintenance.py audit`. `knowledge_stores.py refresh` still refuses;
 status/search remain the ordinary-task path. See #5087.
 

--- a/tests/scripts/test_mempalace_promote.py
+++ b/tests/scripts/test_mempalace_promote.py
@@ -1,0 +1,92 @@
+"""SHAFT MemPalace promote-family listing (#5119)."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess  # nosec B404 - resolved Git and controlled fixture paths.
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/repository-map/mempalace_promote.py"
+
+
+class MempalacePromoteTest(unittest.TestCase):
+    def load(self):
+        self.assertTrue(SCRIPT.is_file(), SCRIPT)
+        spec = importlib.util.spec_from_file_location("mempalace_promote", SCRIPT)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_lists_exact_promote_families_and_skips_pom(self):
+        git = shutil.which("git")
+        if git is None:
+            self.skipTest("git is required")
+        module = self.load()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "repo"
+            files = {
+                "src/main/resources/properties/custom.properties": "k=v\n",
+                "src/main/resources/META-INF/services/com.shaft.plugin.Listener": "impl\n",
+                "src/main/resources/META-INF/plugin.xml": "<idea-plugin/>\n",
+                "pom.xml": "<project/>\n",
+                "samples/login.feature": "Feature: login\n",
+                "shaft-mcp/Dockerfile": "FROM scratch\n",
+                "shaft-mcp/Dockerfile.fly": "FROM scratch\n",
+                "src/ok.py": "print(1)\n",
+            }
+            root.mkdir()
+            for relative, content in files.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+
+            def run_git(*args):
+                return subprocess.run(  # nosec B603 - resolved Git and fixture cwd.
+                    [git, *args],
+                    cwd=root,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+
+            run_git("init")
+            run_git("config", "user.email", "promote@example.invalid")
+            run_git("config", "user.name", "Promote Test")
+            run_git("add", ".")
+            run_git("commit", "-m", "fixture")
+
+            listed = module.list_promote_paths(root)
+            self.assertEqual(
+                [
+                    "samples/login.feature",
+                    "shaft-mcp/Dockerfile",
+                    "shaft-mcp/Dockerfile.fly",
+                    "src/main/resources/META-INF/plugin.xml",
+                    "src/main/resources/META-INF/services/com.shaft.plugin.Listener",
+                    "src/main/resources/properties/custom.properties",
+                ],
+                listed,
+            )
+            self.assertNotIn("pom.xml", listed)
+            self.assertNotIn("src/ok.py", listed)
+            batches = module.include_ignored_batches(listed, max_chars=80)
+            self.assertGreater(len(batches), 1)
+            joined = ",".join(batches)
+            for path in listed:
+                self.assertIn(path, joined)
+
+    def test_missing_git_repo_returns_no_paths(self):
+        module = self.load()
+        with tempfile.TemporaryDirectory() as temporary:
+            self.assertEqual([], module.list_promote_paths(Path(temporary)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_shaft_knowledge_refresh.py
+++ b/tests/scripts/test_shaft_knowledge_refresh.py
@@ -140,6 +140,45 @@ class ShaftKnowledgeRefreshTest(unittest.TestCase):
         self.assertTrue(any(command[0:2] == ["mempalace", "sync"] for command in commands))
         self.assertTrue(any(command[0:2] == ["mempalace", "mine"] for command in commands))
 
+    def test_refresh_force_includes_exact_promote_paths_on_mine(self):
+        module = self.module()
+        root = Path(tempfile.mkdtemp()) / "SHAFT_ENGINE-main"
+        sentinel = root.parent / ".shaft-nightly-maintenance.json"
+        commands = []
+
+        def run(arguments, cwd, environment=None, allowed_exit_codes=(0,)):
+            del cwd, environment, allowed_exit_codes
+            commands.append(arguments)
+            if arguments[1:2] == ["rev-parse"]:
+                return SHA + "\n"
+            if arguments[1:2] == ["ls-remote"]:
+                return f"{SHA}\trefs/heads/main\n"
+            return ""
+
+        with mock.patch.object(
+            module, "validate_owned_clone", return_value=(root.resolve(), sentinel.resolve())
+        ), mock.patch.object(
+            module, "validate_owned_paths", return_value=(root.resolve(), sentinel.resolve())
+        ), mock.patch.object(
+            module, "required", side_effect=lambda value: value
+        ), mock.patch.object(module, "run", side_effect=run), mock.patch.object(
+            module, "job_lock", return_value=nullcontext()
+        ), mock.patch.object(
+            module, "trusted_graph_output", return_value=nullcontext()
+        ), mock.patch.object(
+            module,
+            "list_promote_paths",
+            return_value=["src/custom.properties", "META-INF/plugin.xml"],
+        ):
+            module.refresh(root, sentinel)
+
+        mines = [command for command in commands if command[0:2] == ["mempalace", "mine"]]
+        self.assertTrue(mines)
+        included = " ".join(" ".join(command) for command in mines)
+        self.assertIn("--include-ignored", included)
+        self.assertIn("src/custom.properties", included)
+        self.assertIn("META-INF/plugin.xml", included)
+
     def test_mempalace_failure_keeps_the_successful_graphify_outcome(self):
         module = self.module()
         root = Path(tempfile.mkdtemp()) / "SHAFT_ENGINE-main"

--- a/tools/agent-infra/shaft_knowledge_refresh.py
+++ b/tools/agent-infra/shaft_knowledge_refresh.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from contextlib import contextmanager
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -30,6 +31,21 @@ GIT_ROUTING_VARIABLES = (
     "GIT_CONFIG_COUNT",
     "GIT_CONFIG_PARAMETERS",
 )
+
+
+def _load_promote():
+    path = Path(__file__).resolve().parents[1] / "repository-map/mempalace_promote.py"
+    spec = importlib.util.spec_from_file_location("mempalace_promote", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load MemPalace promote helper: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_promote = _load_promote()
+list_promote_paths = _promote.list_promote_paths
+include_ignored_batches = _promote.include_ignored_batches
 
 
 def required(name: str) -> str:
@@ -316,8 +332,18 @@ def refresh(requested_root: Path, requested_sentinel: Path) -> None:
             outcomes["Graphify"] = "healthy"
         try:
             run([mempalace, "sync", str(root), "--wing", WING, "--apply"], root, git_env)
-            run([mempalace, "mine", str(root), "--wing", WING,
-                 "--agent", "scheduled-refresh"], root, git_env)
+            mine = [
+                mempalace,
+                "mine",
+                str(root),
+                "--wing",
+                WING,
+                "--agent",
+                "scheduled-refresh",
+            ]
+            run(mine, root, git_env)
+            for batch in include_ignored_batches(list_promote_paths(root)):
+                run([*mine, "--include-ignored", batch], root, git_env)
         except (OSError, ValueError, RuntimeError, subprocess.SubprocessError):
             outcomes["MemPalace"] = "failed"
         else:

--- a/tools/repository-map/mempalace_promote.py
+++ b/tools/repository-map/mempalace_promote.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""List SHAFT MemPalace force-include paths for families 3.7.0 cannot classify."""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - resolved git, list-form, no shell.
+from pathlib import Path, PurePosixPath
+import shutil
+
+
+def is_promote_path(relative: str) -> bool:
+    posix = PurePosixPath(relative.replace("\\", "/"))
+    name = posix.name
+    suffix = posix.suffix.lower()
+    if suffix == ".properties" or suffix == ".feature":
+        return True
+    if suffix == ".xml" and name.casefold() != "pom.xml":
+        return True
+    if name.startswith("Dockerfile"):
+        return True
+    return "/META-INF/services/" in f"/{posix.as_posix()}"
+
+
+def list_promote_paths(root: Path) -> list[str]:
+    git = shutil.which("git")
+    if git is None:
+        return []
+    try:
+        completed = subprocess.run(  # nosec B603 - resolved git, no shell.
+            [git, "ls-files", "-z"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+        )
+    except OSError:
+        return []
+    if completed.returncode != 0:
+        return []
+    listed: list[str] = []
+    for raw in completed.stdout.split(b"\0"):
+        if not raw:
+            continue
+        relative = PurePosixPath(raw.decode("utf-8", "surrogateescape")).as_posix()
+        if is_promote_path(relative):
+            listed.append(relative)
+    return sorted(listed)
+
+
+def include_ignored_batches(paths: list[str], *, max_chars: int = 4000) -> list[str]:
+    batches: list[str] = []
+    current: list[str] = []
+    size = 0
+    for path in paths:
+        extra = len(path) + (1 if current else 0)
+        if current and size + extra > max_chars:
+            batches.append(",".join(current))
+            current = [path]
+            size = len(path)
+            continue
+        current.append(path)
+        size += extra
+    if current:
+        batches.append(",".join(current))
+    return batches


### PR DESCRIPTION
## Summary

Nightly SHAFT MemPalace mine now force-includes exact `git ls-files` paths for families MemPalace 3.7.0 cannot classify: `.properties`, `META-INF/services/*`, `Dockerfile*`, non-POM plugin XML, and `.feature`.

Portable ChaosEngine is unchanged. `pom.xml` stays out. Paths are batched under `--include-ignored` so Windows argv stays short.

Closes #5119

## Checks

- RED: `test_mempalace_promote` failed because `mempalace_promote.py` was absent.
- GREEN: `tests.scripts.test_mempalace_promote` and `tests.scripts.test_shaft_knowledge_refresh` (24 tests). Live listing: 239 paths, 7 batches. `validate_agent_setup.py --skip-external` reported Agent setup is valid.

## Continuation

- Head: e764652b378b22b72e9798b9acea51bdb89016c2
- State: first checkpoint pushed
- Blockers: none
- Next action: review, arm auto-merge, watch to MERGED
