### PR TITLE
feat(harness): pin sequential local-coder dispatch (#5126)

### DIFF
--- a/chaos-engine/profiles/shaft/references/playbooks/workstation-local-coding-agent.md
+++ b/chaos-engine/profiles/shaft/references/playbooks/workstation-local-coding-agent.md
@@ -5,6 +5,14 @@ and already specified. The default capability's cost and latency are waste
 for those slices. The most-intelligent or default model stays the decider
 and may hand the slice to this loop.
 
+## Orchestration
+
+The host session orchestrates.
+One implementer per batch.
+The writer stops when the PR exists.
+The inner `shaft-java-agent.ps1` loop is optional and allowlisted. The local
+loop still never merges, reviews, or owns GitHub delivery.
+
 ## When to use it
 
 - Read-only `shaft-architect` with the cited-path gate.

--- a/chaos-engine/skills/local-coding-delegate/SKILL.md
+++ b/chaos-engine/skills/local-coding-delegate/SKILL.md
@@ -47,5 +47,7 @@ python3 chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py
 ## Bounds
 
 The local loop never replaces independent review, never owns merge or GitHub
-delivery, and never decides architecture. If the probe refuses, or the task
-outgrows the recommended class, keep the work on the decider model.
+delivery, and never decides architecture. The host session may hand one
+mechanical batch to a writer. Close that writer after its PR exists. If the
+probe refuses, or the task outgrows the recommended class, keep the work on
+the decider model.

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -553,6 +553,10 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
         self.assertIn("local-coding-delegate/SKILL.md", portable_entry.read_text(encoding="utf-8"))
         self.assertIn("local-coding-delegate/SKILL.md", portable_routing.read_text(encoding="utf-8"))
         self.assertIn(
+            "Close that writer after its PR exists.",
+            skill.read_text(encoding="utf-8"),
+        )
+        self.assertIn(
             "local-coding-delegate",
             budget["expected_skill_names"]["chaos-engine/skills"],
         )
@@ -604,6 +608,9 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             "scripts/local-coding-agent/shaft-architect.ps1",
             "scripts/local-coding-agent/shaft-local-ai-stop.ps1",
             "scripts/agents/knowledge_stores.py",
+            "The host session orchestrates.",
+            "One implementer per batch.",
+            "The writer stops when the PR exists.",
         )
 
         self.assertTrue(playbook.is_file())


### PR DESCRIPTION
Closes #5126

## Summary

Smallest playbook and portable-skill pins so the host session orchestrates one sequential implementer per batch and closes that writer after the PR exists. The inner `shaft-java-agent.ps1` loop stays optional and allowlisted. The local loop still never merges, reviews, or owns GitHub delivery. Portable skill still names no vendor model.

## Checks

RED (observed, missing phrases):

```text
py -3 -m unittest tests.scripts.test_chaos_engine_portable_core.ChaosEnginePortableCoreTest.test_shaft_workstation_playbook_is_routed_and_names_the_loop tests.scripts.test_chaos_engine_portable_core.ChaosEnginePortableCoreTest.test_portable_local_coding_delegate_is_optional_and_routed
Ran 2 tests in 0.003s
FAILED (failures=4)
```

GREEN:

```text
py -3 -m unittest tests.scripts.test_chaos_engine_portable_core tests.scripts.test_agent_harness_reachability tests.scripts.test_local_coding_agent
Ran 81 tests in 77.059s
OK
```

Consult-first matrices already on #5124. Related to #5124; this PR does not close the tracker.

## Continuation

- Head: `8cdfc3e6dd06066c95e3193c6b370f3e42e3971d`
- State: Implementation committed and pushed. Writer stops here per kill-after-PR.
- Blockers: None for this subtask. Independent review and merge stay with the host session.
- Next action: Host session reviews this PR, then merges. Do not start #5127 from this writer.
