### PR TITLE
feat(tools): harvest local-loop reports into Soup JSONL

### DIFF
--- a/tests/scripts/test_soup_delegate_poc.py
+++ b/tests/scripts/test_soup_delegate_poc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,6 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 POC_ROOT = ROOT / "tools" / "soup-delegate-poc"
 SCRIPT = POC_ROOT / "soup_delegate_poc.py"
+HARVEST_SCRIPT = POC_ROOT / "harvest.py"
 SPEC_PATH = POC_ROOT / "mechanical-tools.yaml"
 FIXTURE_PATH = POC_ROOT / "fixtures" / "valid.jsonl"
 
@@ -99,6 +101,96 @@ class SoupDelegatePocSpecTest(unittest.TestCase):
             path.write_text(yaml_text, encoding="utf-8")
             blockers = MODULE.validate_spec(path)
         self.assertTrue(any("run_focused_test" in item for item in blockers))
+
+
+def _valid_report(**overrides):
+    data = {
+        "ok": True,
+        "model": "mechanical",
+        "worktree": "C:/tmp/wt",
+        "files_allowed": ["scripts/local-coding-agent/agent.py"],
+        "files_changed": ["scripts/local-coding-agent/agent.py"],
+        "commit": "abc123",
+        "test_command": "py -3 -m unittest tests.scripts.test_local_coding_agent",
+        "test_exit": 0,
+        "elapsed_ms": 10,
+        "loopback": "127.0.0.1:11434",
+        "blockers": [],
+    }
+    data.update(overrides)
+    return data
+
+
+def _write_report_dir(root: Path, report: dict, spec_text: str | None = None) -> Path:
+    report_dir = root / "report"
+    report_dir.mkdir()
+    (report_dir / "report.json").write_text(json.dumps(report), encoding="utf-8")
+    if spec_text is not None:
+        (report_dir / "spec.md").write_text(spec_text, encoding="utf-8")
+    return report_dir
+
+
+def _load_harvest():
+    spec = importlib.util.spec_from_file_location("soup_harvest", HARVEST_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("harvest module could not be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SoupDelegatePocHarvestTest(unittest.TestCase):
+    def test_valid_report_writes_one_valid_row(self):
+        harvest_mod = _load_harvest()
+        with tempfile.TemporaryDirectory() as temporary:
+            tmp_path = Path(temporary)
+            report_dir = _write_report_dir(
+                tmp_path,
+                _valid_report(),
+                spec_text="Please replace one allowlisted file.",
+            )
+            corpus = tmp_path / "corpus" / "rows.jsonl"
+            result = harvest_mod.harvest(str(report_dir), str(corpus))
+            self.assertTrue(result["ok"])
+            self.assertFalse(result["skipped"])
+            self.assertIsInstance(result["row"], dict)
+            self.assertTrue(corpus.is_file())
+            rows = MODULE.load_jsonl(corpus)
+            self.assertEqual(1, len(rows))
+            self.assertEqual([], MODULE.validate_row(rows[0]))
+            self.assertEqual([], MODULE.validate_row(result["row"]))
+
+    def test_allowlist_violation_skips_without_write(self):
+        harvest_mod = _load_harvest()
+        with tempfile.TemporaryDirectory() as temporary:
+            tmp_path = Path(temporary)
+            report_dir = _write_report_dir(
+                tmp_path,
+                _valid_report(files_changed=["scripts/ci/watch_pr_checks.py"]),
+            )
+            corpus = tmp_path / "corpus.jsonl"
+            result = harvest_mod.harvest(str(report_dir), str(corpus))
+            self.assertFalse(result["ok"])
+            self.assertTrue(result["skipped"])
+            self.assertFalse(corpus.exists())
+
+    def test_missing_report_key_skips_without_write(self):
+        harvest_mod = _load_harvest()
+        with tempfile.TemporaryDirectory() as temporary:
+            tmp_path = Path(temporary)
+            report = _valid_report()
+            del report["loopback"]
+            report_dir = _write_report_dir(tmp_path, report)
+            corpus = tmp_path / "corpus.jsonl"
+            result = harvest_mod.harvest(str(report_dir), str(corpus))
+            self.assertFalse(result["ok"])
+            self.assertTrue(result["skipped"])
+            self.assertFalse(corpus.exists())
+
+    def test_harvest_source_has_no_soup_train_or_loop_watch(self):
+        text = HARVEST_SCRIPT.read_text(encoding="utf-8")
+        self.assertNotIn("soup train", text)
+        self.assertNotIn("soup loop watch", text)
 
 
 if __name__ == "__main__":

--- a/tools/soup-delegate-poc/harvest.py
+++ b/tools/soup-delegate-poc/harvest.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Turn a local-loop report directory into one Soup-shaped JSONL row (#5127)."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+AGENT_SCRIPT = ROOT / "scripts" / "local-coding-agent" / "agent.py"
+POC_SCRIPT = Path(__file__).resolve().parent / "soup_delegate_poc.py"
+SECRET_MARKERS = ("hf_", "sk-", "AKIA", "-----BEGIN", "Bearer ")
+DEFAULT_SPEC = "mechanical local-loop harvest"
+
+
+def _load_module(name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"{name} could not be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+AGENT = _load_module("local_coding_agent_harvest", AGENT_SCRIPT)
+POC = _load_module("soup_delegate_poc_harvest", POC_SCRIPT)
+
+
+def _skip(reason: str) -> dict[str, Any]:
+    return {"ok": False, "skipped": True, "reason": reason, "row": None}
+
+
+def _secret_marker(text: str) -> str | None:
+    for marker in SECRET_MARKERS:
+        if marker in text:
+            return marker
+    return None
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def harvest(report_dir: str | Path, corpus_path: str | Path) -> dict[str, Any]:
+    """Append one Soup row from a local-loop report directory, or skip."""
+    report_file = Path(report_dir) / "report.json"
+    if not report_file.is_file():
+        return _skip("missing report.json")
+    try:
+        raw_report = _read_text(report_file)
+        data = json.loads(raw_report)
+    except (OSError, json.JSONDecodeError, UnicodeError) as error:
+        return _skip(f"cannot load report.json: {error}")
+    if not isinstance(data, dict):
+        return _skip("report.json must be an object")
+
+    blockers = AGENT.validate_report(data)
+    if blockers:
+        return _skip(blockers[0])
+
+    spec_file = Path(report_dir) / "spec.md"
+    diff_file = Path(report_dir) / "diff.patch"
+    spec_present = spec_file.is_file()
+    try:
+        spec_text = _read_text(spec_file) if spec_present else ""
+        diff_text = _read_text(diff_file) if diff_file.is_file() else ""
+    except (OSError, UnicodeError) as error:
+        return _skip(f"cannot read report siblings: {error}")
+
+    for label, text in (("report", raw_report), ("spec", spec_text), ("diff", diff_text)):
+        if text and _secret_marker(text):
+            return _skip(f"secret-shaped text in {label}")
+
+    changed = AGENT.as_path_list(data.get("files_changed"))
+    tool = "replace_file" if changed else "read_file"
+    user_content = spec_text if spec_present else DEFAULT_SPEC
+    row = {
+        "source": "local-loop-report",
+        "tool": tool,
+        "source_endpoint": f"/{tool}",
+        "messages": [
+            {"role": "user", "content": user_content},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_0",
+                        "type": "function",
+                        "function": {
+                            "name": tool,
+                            "arguments": json.dumps({"paths": changed}),
+                        },
+                    }
+                ],
+            },
+        ],
+    }
+    row_blockers = POC.validate_row(row)
+    if row_blockers:
+        return _skip(row_blockers[0])
+
+    dest = Path(corpus_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    return {"ok": True, "skipped": False, "reason": "wrote", "row": row}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report-dir", required=True)
+    parser.add_argument("--corpus", required=True)
+    args = parser.parse_args(argv)
+    result = harvest(args.report_dir, args.corpus)
+    print(result["reason"])
+    return 0 if result["ok"] else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #5127

## Summary
Adds a stdlib harvester that turns one local-loop report directory into a single Soup-shaped JSONL row, or a skip receipt. Valid allowlisted reports append one `validate_row`-clean object to a caller-supplied corpus path. Missing report keys, allowlist violations, bad loopback, and secret-shaped text fail closed with no write. Corpus stays off-git. The harvester does not start train, watch, serve, or UI work.

## Checks
- RED: four new harvest tests failed with `FileNotFoundError` on missing `tools/soup-delegate-poc/harvest.py`; five existing row/spec tests still passed.
- GREEN: `py -3 -m unittest tests.scripts.test_soup_delegate_poc` — 9 tests, OK.
- Harvest source has no `soup train` / `soup loop watch` strings.
- Tests write only under tempfile; no `D:\AI` corpus path.

## Continuation
Head: `8a975c509ad05ea374ae851155e546278db79545`
State: PR opened from isolated `ChaosEngine/5127-harvest-loop` (base `main` at `18217f14`). Writer stops here. Independent adversarial review still owed before merge.
Blockers: none for this subtask. Native Memory search was `degraded` (`ObjectScopeInvalid` on a project-scoped gotcha); work continued from live files.
Next action: independent review of this PR. Do not merge from this writer. Do not start train/serve/ui/loop.
