### PR TITLE
feat(ai): close managed local AI operations, inventory, and docs (#4866)

### DIFF
--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiSetupProvider.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiSetupProvider.java
@@ -138,10 +138,12 @@ public final class ManagedLocalAiSetupProvider implements SetupProvider {
         if (model == SetupReadiness.READY && snapshot.selectedModelId() != null) {
             modelVersion = snapshot.models().get(snapshot.selectedModelId()).revision();
         }
+        String inventory = ManagedLocalAiStatus.reviewedInventory(snapshot);
+        String detail = snapshot.action() + " " + inventory;
         return new SetupReport(1, SetupProfile.LOCAL_AI, overall, List.of(
-                new SetupStatus(SetupTarget.MANAGED_LOCAL_AI_RUNTIME, runtime, runtimeVersion, snapshot.action()),
-                new SetupStatus(SetupTarget.MANAGED_LOCAL_AI_MODEL, model, modelVersion, snapshot.action())),
-                List.of());
+                new SetupStatus(SetupTarget.MANAGED_LOCAL_AI_RUNTIME, runtime, runtimeVersion, detail),
+                new SetupStatus(SetupTarget.MANAGED_LOCAL_AI_MODEL, model, modelVersion, detail)),
+                List.of(inventory));
     }
 
     @Override

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiStatus.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiStatus.java
@@ -30,7 +30,11 @@ public record ManagedLocalAiStatus(State state, String action) {
                     "Provision the reviewed managed runtime and model explicitly. " + inventory);
         }
         try {
-            ManagedLocalAiCache.verify(cache, installationId);
+            ManagedLocalAiCache.Installation installed = ManagedLocalAiCache.verify(cache, installationId);
+            if (!matchesReviewedPin(installed, manifest)) {
+                return new ManagedLocalAiStatus(State.CORRUPT,
+                        "Rebuild the changed managed installation; unknown files will be preserved. " + inventory);
+            }
             return new ManagedLocalAiStatus(State.READY, "No lifecycle action is required. " + inventory);
         } catch (IllegalStateException missingOrChanged) {
             try {
@@ -81,6 +85,30 @@ public record ManagedLocalAiStatus(State state, String action) {
                 + " update=explicit reviewed plan; pin-bound; no silent float"
                 + " cleanup=owner-manifest only; unknown siblings preserved"
                 + " fallback=deterministic SHAFT result remains authoritative";
+    }
+
+    private static boolean matchesReviewedPin(ManagedLocalAiCache.Installation installed,
+                                             ManagedLocalAiManifest manifest) {
+        for (ManagedLocalAiManifest.RuntimeAsset asset : manifest.runtime().assets()) {
+            if (installed.id().equals(ManagedLocalAiService.runtimeInstallationId(manifest, asset.platform()))) {
+                return hasExactOwnedFile(installed, asset.file(), asset.size(), asset.sha256());
+            }
+        }
+        for (ManagedLocalAiManifest.ModelManifest model : manifest.models()) {
+            if (installed.id().equals(ManagedLocalAiService.modelInstallationId(model))) {
+                return hasExactOwnedFile(installed, model.file(), model.size(), model.sha256());
+            }
+        }
+        return true;
+    }
+
+    private static boolean hasExactOwnedFile(ManagedLocalAiCache.Installation installed, String name, long size,
+                                             String sha256) {
+        return installed.files().stream().filter(file -> {
+            Path path = Path.of(file.path());
+            return path.getFileName() != null && name.equals(path.getFileName().toString())
+                    && file.size() == size && sha256.equals(file.sha256());
+        }).count() == 1;
     }
 
     private static String trimNumber(double value) {

--- a/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiStatus.java
+++ b/shaft-ai/src/main/java/com/shaft/ai/local/ManagedLocalAiStatus.java
@@ -15,38 +15,75 @@ public record ManagedLocalAiStatus(State state, String action) {
 
     public static ManagedLocalAiStatus inspect(Path cache, boolean enabled, String osName, String architecture,
                                                String abi, String abiVersion, String installationId) {
+        String inventory = reviewedInventory(osName, architecture, abi, abiVersion);
         if (!enabled) {
-            return new ManagedLocalAiStatus(State.DISABLED, "Enable managed local AI to provision a local model.");
+            return new ManagedLocalAiStatus(State.DISABLED,
+                    "Enable managed local AI to provision a local model. " + inventory);
         }
         ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
         if (!manifest.supportsRuntime(osName, architecture, abi, abiVersion)) {
             return new ManagedLocalAiStatus(State.UNSUPPORTED,
-                    "Use an external local provider or a supported desktop OS, architecture, and ABI.");
+                    "Use an external local provider or a supported desktop OS, architecture, and ABI. " + inventory);
         }
         if (installationId == null || installationId.isBlank()) {
             return new ManagedLocalAiStatus(State.NOT_PROVISIONED,
-                    "Provision the reviewed managed runtime and model explicitly.");
+                    "Provision the reviewed managed runtime and model explicitly. " + inventory);
         }
         try {
             ManagedLocalAiCache.verify(cache, installationId);
-            return new ManagedLocalAiStatus(State.READY, "No lifecycle action is required.");
+            return new ManagedLocalAiStatus(State.READY, "No lifecycle action is required. " + inventory);
         } catch (IllegalStateException missingOrChanged) {
             try {
                 if (!ManagedLocalAiCache.ownsInstallation(cache, installationId)) {
                     return new ManagedLocalAiStatus(State.NOT_PROVISIONED,
-                            "Provision the reviewed managed runtime and model explicitly.");
+                            "Provision the reviewed managed runtime and model explicitly. " + inventory);
                 }
             } catch (IOException | IllegalStateException unreadable) {
                 return new ManagedLocalAiStatus(State.CORRUPT,
-                        "Inspect cache permissions and rebuild the managed installation.");
+                        "Inspect cache permissions and rebuild the managed installation. " + inventory);
             }
             {
                 return new ManagedLocalAiStatus(State.CORRUPT,
-                        "Rebuild the changed managed installation; unknown files will be preserved.");
+                        "Rebuild the changed managed installation; unknown files will be preserved. " + inventory);
             }
         } catch (IOException unreadable) {
             return new ManagedLocalAiStatus(State.CORRUPT,
-                    "Inspect cache permissions and rebuild the managed installation.");
+                    "Inspect cache permissions and rebuild the managed installation. " + inventory);
         }
+    }
+
+    static String reviewedInventory(ManagedLocalAiSnapshot snapshot) {
+        return reviewedInventoryForPlatform(snapshot.platform());
+    }
+
+    static String reviewedInventory(String osName, String architecture, String abi, String abiVersion) {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        if (!manifest.supportsRuntime(osName, architecture, abi, abiVersion)) {
+            return reviewedInventoryForPlatform("");
+        }
+        return reviewedInventoryForPlatform(manifest.selectRuntime(osName, architecture, abi, abiVersion).platform());
+    }
+
+    private static String reviewedInventoryForPlatform(String platform) {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        ManagedLocalAiManifest.RuntimeAsset runtime = manifest.runtime().assets().stream()
+                .filter(asset -> asset.platform().equals(platform)).findFirst().orElse(null);
+        ManagedLocalAiManifest.ModelManifest model = manifest.models().stream()
+                .filter(candidate -> candidate.id().equals("qwen3-0.6b-q8_0")).findFirst().orElseThrow();
+        String runtimeSize = runtime == null ? "" : Long.toString(runtime.size());
+        return "revision=" + manifest.runtime().version() + "/" + model.revision()
+                + " license=" + manifest.runtime().license() + "/" + model.license()
+                + " provenance=github.com/ggml-org/llama.cpp|huggingface.co/" + model.source()
+                + " size=" + runtimeSize + "/" + model.size()
+                + " storage=SHAFT_USER_CACHE"
+                + " resources=" + trimNumber(model.minimumRamGb()) + "/" + model.minimumCpuCount()
+                + "/" + trimNumber(model.minimumFreeDiskGb())
+                + " update=explicit reviewed plan; pin-bound; no silent float"
+                + " cleanup=owner-manifest only; unknown siblings preserved"
+                + " fallback=deterministic SHAFT result remains authoritative";
+    }
+
+    private static String trimNumber(double value) {
+        return value == Math.rint(value) ? Long.toString(Math.round(value)) : Double.toString(value);
     }
 }

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiArtifactsTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiArtifactsTest.java
@@ -71,8 +71,12 @@ class ManagedLocalAiArtifactsTest {
                 new ByteArrayInputStream(content), content.length + 1, sha256(content), target, () -> false));
         assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiArtifacts.download(
                 new ByteArrayInputStream(content), content.length - 1, sha256(content), target, () -> false));
-        assertThrows(IllegalArgumentException.class, () -> ManagedLocalAiArtifacts.download(
-                new ByteArrayInputStream(content), content.length, "0".repeat(64), target, () -> false));
+        IllegalArgumentException revoked = assertThrows(IllegalArgumentException.class,
+                () -> ManagedLocalAiArtifacts.download(new ByteArrayInputStream(content), content.length,
+                        "0".repeat(64), target, () -> false));
+        assertFalse(revoked.getMessage().contains("http"), revoked.getMessage());
+        assertFalse(revoked.getMessage().toLowerCase(java.util.Locale.ROOT).contains("fallback"),
+                revoked.getMessage());
         AtomicBoolean cancelled = new AtomicBoolean(true);
         assertThrows(InterruptedException.class, () -> ManagedLocalAiArtifacts.download(
                 new ByteArrayInputStream(content), content.length, sha256(content), target, cancelled::get));

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiCacheTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiCacheTest.java
@@ -83,7 +83,9 @@ class ManagedLocalAiCacheTest {
         assertTrue(first.deletedFiles() >= 2);
         assertFalse(Files.exists(installed.root()));
         assertTrue(Files.exists(unrelated));
+        assertTrue(Files.isDirectory(cache), "cleanup must never delete the cache root");
         assertEquals(0, second.deletedFiles());
+        assertTrue(Files.isDirectory(cache));
     }
 
     @Test

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiSetupProviderTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiSetupProviderTest.java
@@ -308,6 +308,9 @@ class ManagedLocalAiSetupProviderTest {
             assertEquals(List.of(SetupTarget.MANAGED_LOCAL_AI_RUNTIME, SetupTarget.MANAGED_LOCAL_AI_MODEL),
                     report.targets().stream().map(status -> status.target()).toList());
             assertEquals(0, lifecycle.provisions.get());
+            String listed = String.join("\n", report.diagnostics()) + "\n"
+                    + report.targets().stream().map(status -> status.detail()).reduce("", (left, right) -> left + "\n" + right);
+            ManagedLocalAiStatusTest.assertReviewedInventory(listed, "windows-x86_64");
         }
         assertFalse(Files.exists(options.paths().cacheRoot()));
         assertFalse(Files.exists(options.paths().dataRoot()));

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiSetupProviderTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiSetupProviderTest.java
@@ -228,6 +228,23 @@ class ManagedLocalAiSetupProviderTest {
     }
 
     @Test
+    void offlineReadyInstallReusesTheReviewedCacheWithoutDownloading(@TempDir Path temp) throws Exception {
+        SetupOptions options = options(temp).withOffline(true);
+        FakeLifecycle lifecycle = new FakeLifecycle(snapshot(options, ManagedLocalAiSnapshot.State.READY));
+        InfrastructureSetupService setup = setup(lifecycle);
+        SetupPlan plan = setup.plan(options);
+
+        SetupReceipt receipt = setup.install(plan, approval(plan), options);
+
+        assertEquals(plan.actions(), receipt.completedActions());
+        assertEquals(1, lifecycle.provisions.get());
+        assertFalse(lifecycle.allowDownloads);
+        assertEquals(0, lifecycle.downloadAttempts.get());
+        assertEquals(0, lifecycle.rollbacks.get());
+        assertEquals(0, lifecycle.cleans.get());
+    }
+
+    @Test
     void offlineReadyPreflightCannotAuthorizeDownloadsAfterAReadinessRace(@TempDir Path temp) {
         SetupOptions options = options(temp).withOffline(true);
         FakeLifecycle lifecycle = new FakeLifecycle(snapshot(options, ManagedLocalAiSnapshot.State.READY));
@@ -426,6 +443,9 @@ class ManagedLocalAiSetupProviderTest {
         assertTrue(failure.get() instanceof IOException);
         assertTrue(failure.get().getMessage().contains("interrupted"));
         assertFalse(lifecycle.lastOperation.cancel(), "provider must already have requested cancellation");
+        assertEquals(0, lifecycle.cleans.get());
+        assertEquals(0, lifecycle.rollbacks.get());
+        assertEquals(ManagedLocalAiSnapshot.State.NOT_PROVISIONED, lifecycle.inspect().state());
     }
 
     @Test

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiStatusTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiStatusTest.java
@@ -54,6 +54,29 @@ class ManagedLocalAiStatusTest {
         assertReviewedInventory(status.action(), "windows-x86_64");
     }
 
+    @Test
+    void revokedOwnedBytesAreNotReportedReady() throws Exception {
+        Path cache = temp.resolve("revoked-cache");
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        ManagedLocalAiManifest.RuntimeAsset runtime = manifest.runtime().assets().stream()
+                .filter(asset -> asset.platform().equals("windows-x86_64")).findFirst().orElseThrow();
+        String pinId = ManagedLocalAiService.runtimeInstallationId(manifest, "windows-x86_64");
+        Path stage = cache.resolve("staging/revoked.extract-test");
+        Files.createDirectories(stage);
+        Files.writeString(stage.resolve(runtime.file()), "revoked-bytes");
+        Files.writeString(stage.resolve(".shaft-ready"), "");
+        ManagedLocalAiCache.withLock(cache, java.time.Duration.ofSeconds(1),
+                () -> ManagedLocalAiCache.adopt(cache, pinId, stage));
+
+        ManagedLocalAiStatus status = ManagedLocalAiStatus.inspect(cache, true, "Windows 11", "amd64",
+                "windows-msvc", "", pinId);
+
+        assertEquals(ManagedLocalAiStatus.State.CORRUPT, status.state());
+        assertTrue(status.action().contains("Rebuild"));
+        assertReviewedInventory(status.action(), "windows-x86_64");
+        assertTrue(ManagedLocalAiCache.ownsInstallation(cache, pinId));
+    }
+
     static void assertReviewedInventory(String listed, String platform) {
         ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
         ManagedLocalAiManifest.RuntimeAsset runtime = manifest.runtime().assets().stream()

--- a/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiStatusTest.java
+++ b/shaft-ai/src/test/java/com/shaft/ai/local/ManagedLocalAiStatusTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ManagedLocalAiStatusTest {
     @TempDir
@@ -23,6 +24,17 @@ class ManagedLocalAiStatusTest {
         ManagedLocalAiStatus missing = ManagedLocalAiStatus.inspect(cache, true, "Windows 11", "amd64",
                 "windows-msvc", "", "runtime-b10400-windows-x86_64");
         assertEquals(ManagedLocalAiStatus.State.NOT_PROVISIONED, missing.state());
+        assertReviewedInventory(missing.action(), "windows-x86_64");
+        assertFalse(Files.exists(cache));
+    }
+
+    @Test
+    void disabledInspectionStillListsReviewedInventoryWithoutCreatingCache() {
+        Path cache = temp.resolve("disabled-cache");
+        ManagedLocalAiStatus disabled = ManagedLocalAiStatus.inspect(cache, false, "Windows 11", "amd64",
+                "windows-msvc", "", null);
+        assertEquals(ManagedLocalAiStatus.State.DISABLED, disabled.state());
+        assertReviewedInventory(disabled.action(), "windows-x86_64");
         assertFalse(Files.exists(cache));
     }
 
@@ -39,5 +51,37 @@ class ManagedLocalAiStatusTest {
         ManagedLocalAiStatus status = ManagedLocalAiStatus.inspect(cache, true, "Windows 11", "amd64",
                 "windows-msvc", "", "missing");
         assertEquals(ManagedLocalAiStatus.State.NOT_PROVISIONED, status.state());
+        assertReviewedInventory(status.action(), "windows-x86_64");
+    }
+
+    static void assertReviewedInventory(String listed, String platform) {
+        ManagedLocalAiManifest manifest = ManagedLocalAiManifest.loadDefault();
+        ManagedLocalAiManifest.RuntimeAsset runtime = manifest.runtime().assets().stream()
+                .filter(asset -> asset.platform().equals(platform)).findFirst().orElseThrow();
+        ManagedLocalAiManifest.ModelManifest model = manifest.models().stream()
+                .filter(candidate -> candidate.id().equals("qwen3-0.6b-q8_0")).findFirst().orElseThrow();
+        assertTrue(listed.contains(manifest.runtime().version()), listed);
+        assertTrue(listed.contains(model.revision()), listed);
+        assertTrue(listed.contains(manifest.runtime().license()), listed);
+        assertTrue(listed.contains(model.license()), listed);
+        assertTrue(listed.contains("github.com/ggml-org/llama.cpp"), listed);
+        assertTrue(listed.contains("huggingface.co/" + model.source()), listed);
+        assertTrue(listed.contains(Long.toString(runtime.size())), listed);
+        assertTrue(listed.contains(Long.toString(model.size())), listed);
+        assertTrue(listed.contains("SHAFT_USER_CACHE"), listed);
+        assertTrue(listed.contains(trimNumber(model.minimumRamGb())), listed);
+        assertTrue(listed.contains(Integer.toString(model.minimumCpuCount())), listed);
+        assertTrue(listed.contains(trimNumber(model.minimumFreeDiskGb())), listed);
+        assertTrue(listed.contains("explicit reviewed plan"), listed);
+        assertTrue(listed.contains("pin-bound"), listed);
+        assertTrue(listed.contains("no silent float"), listed);
+        assertTrue(listed.contains("owner-manifest only"), listed);
+        assertTrue(listed.contains("unknown siblings preserved"), listed);
+        assertTrue(listed.contains("deterministic SHAFT result remains authoritative"), listed);
+        assertFalse(listed.contains(platform + "/installations"), listed);
+    }
+
+    private static String trimNumber(double value) {
+        return value == Math.rint(value) ? Long.toString(Math.round(value)) : Double.toString(value);
     }
 }


### PR DESCRIPTION
Closes #4866
Related to #4851

## Summary

Closeout for managed local AI operations. Defaults stay OFF. Normal Maven never downloads runtime or model. No evidence, prompt, or response telemetry leaves the host by default.

- User-facing inventory lists revision, license, provenance, size, storage class, resource floors, pin-bound update policy, owner-manifest cleanup, and deterministic fallback on Status and Setup.
- Status reports CORRUPT when owned bytes no longer match the reviewed pin. Offline ready setup reuses the cache without download. Cleanup keeps the cache root and unknown siblings. Hash-mismatch download errors stay pin-bound with no fallback URL.
- Companion docs: ShaftHQ/shafthq.github.io#988

## Checks

- RED: Status/Setup inventory tokens missing from action/detail.
- GREEN: Status and Setup publish the reviewed inventory.
- RED: revoked owned bytes were reported READY.
- GREEN: Status reports CORRUPT for a reviewed pin whose owned bytes no longer match.
- Balanced: mvn -pl shaft-ai,shaft-engine "-Dtest=ManagedLocalAiSetupProviderTest,ManagedLocalAiCacheTest,ManagedLocalAiStatusTest,ManagedLocalAiPropertiesTest,ManagedLocalAiArtifactsTest,ManagedLocalAiActivationHistoryTest" "-Dallure.automaticallyOpen=false" test
  - shaft-engine ManagedLocalAiPropertiesTest: 2 passed
  - shaft-ai: SetupProvider 22, Cache 14, Status 4, Artifacts 7, ActivationHistory 1 — 48 passed
  - Surefire reports confirmed 0 failures

## Continuation

Head: 8b28c00bd881f204defae33d66ff1e43f4a673e3
State: Engine closeout and companion docs PR 988 are pushed. Do not merge either PR; orchestrator reviews and merges.
Blockers: none.
Next action: independent review of this head and shafthq.github.io#988, then orchestrator merge.