### PR TITLE
test(tools): pin source_endpoint and accept quoted operationIds

### DIFF
--- a/tests/scripts/test_soup_delegate_poc.py
+++ b/tests/scripts/test_soup_delegate_poc.py
@@ -71,6 +71,12 @@ class SoupDelegatePocRowTest(unittest.TestCase):
         blockers = MODULE.validate_row(row)
         self.assertTrue(any("messages" in item.lower() for item in blockers))
 
+    def test_row_missing_source_endpoint_fails(self):
+        row = valid_row()
+        del row["source_endpoint"]
+        blockers = MODULE.validate_row(row)
+        self.assertTrue(any("source_endpoint" in item.lower() for item in blockers))
+
     def test_assistant_tool_name_mismatch_fails(self):
         row = valid_row("read_file")
         row["messages"][1]["tool_calls"][0]["function"]["name"] = "replace_file"
@@ -101,6 +107,28 @@ class SoupDelegatePocSpecTest(unittest.TestCase):
             path.write_text(yaml_text, encoding="utf-8")
             blockers = MODULE.validate_spec(path)
         self.assertTrue(any("run_focused_test" in item for item in blockers))
+
+    def test_spec_accepts_quoted_and_unquoted_operation_ids(self):
+        yaml_text = (
+            "openapi: 3.0.3\n"
+            "info:\n"
+            "  title: quoted\n"
+            "  version: '1.0.0'\n"
+            "paths:\n"
+            "  /read_file:\n"
+            "    post:\n"
+            "      operationId: \"read_file\"\n"
+            "  /replace_file:\n"
+            "    post:\n"
+            "      operationId: replace_file\n"
+            "  /run_focused_test:\n"
+            "    post:\n"
+            "      operationId: \"run_focused_test\"\n"
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "mechanical-tools.yaml"
+            path.write_text(yaml_text, encoding="utf-8")
+            self.assertEqual([], MODULE.validate_spec(path))
 
 
 def _valid_report(**overrides):

--- a/tools/soup-delegate-poc/soup_delegate_poc.py
+++ b/tools/soup-delegate-poc/soup_delegate_poc.py
@@ -97,7 +97,7 @@ def validate_spec(path: str | Path) -> list[str]:
         text = Path(path).read_text(encoding="utf-8")
     except OSError as error:
         return [f"cannot read spec {path}: {error}"]
-    found = set(OPERATION_ID_PATTERN.findall(text))
+    found = {item.strip("\"'") for item in OPERATION_ID_PATTERN.findall(text)}
     return [
         f"spec missing operationId {name}"
         for name in REQUIRED_OPERATION_IDS


### PR DESCRIPTION
## Summary

Pins a `source_endpoint` missing-key regression and accepts quoted YAML `operationId`s in `validate_spec`. Existing unquoted `mechanical-tools.yaml` still passes. Fixture stays valid.

Closes #5132
Closes #5133

Related to #5141.

## Checks

- RED: `py -3 -m unittest tests.scripts.test_soup_delegate_poc` — Ran 11 tests, 1 failure. `test_spec_accepts_quoted_and_unquoted_operation_ids` reported missing quoted `read_file` and `run_focused_test`. `test_row_missing_source_endpoint_fails` already passed because production already required the key.
- GREEN: same command after stripping optional quotes from captured ids — Ran 11 tests in 0.015s, OK.

## Continuation

Head: 5860995f30668b26786aee2ba8ed1b5ab713537c
State: Batch 1 implementation complete. Writer stops here for independent review.
Blockers: none
Next action: Independent adversarial review on this SHA, then merge with `--merge`. Do not start batch 2/3.