### PR TITLE
feat(harness): require companion user-guide PRs (#5146)

### DIFF
--- a/.memory/events.jsonl
+++ b/.memory/events.jsonl
@@ -1166,3 +1166,4 @@
 {"actor":"agent","event":"memory.updated","id":"gotcha.sk-secret-patterns-must-allow-hyphens","timestamp":"2026-08-18T16:54:45+03:00"}
 {"actor":"agent","event":"memory.deleted","id":"gotcha.sk-secret-patterns-must-allow-hyphens","timestamp":"2026-08-18T17:01:05+03:00"}
 {"actor":"agent","event":"memory.updated","id":"gotcha.secret-like-must-consume-values","timestamp":"2026-08-18T17:01:05+03:00"}
+{"actor":"agent","event":"memory.created","id":"gotcha.portable-core-phrase-pins-do-not-span-newlines","timestamp":"2026-08-18T18:07:05+03:00"}

--- a/.memory/memory/gotchas/portable-core-phrase-pins-do-not-span-newlines.json
+++ b/.memory/memory/gotchas/portable-core-phrase-pins-do-not-span-newlines.json
@@ -1,0 +1,33 @@
+{
+  "body_path": "memory/gotchas/portable-core-phrase-pins-do-not-span-newlines.md",
+  "content_hash": "sha256:d5646de91d65063bf0137bced645475652e42688a68218489e97bdea27e3d78a",
+  "created_at": "2026-08-18T18:07:05+03:00",
+  "evidence": [],
+  "facets": {
+    "applies_to": [
+      "tests/scripts/test_chaos_engine_portable_core.py",
+      "chaos-engine/profiles/shaft"
+    ],
+    "category": "gotcha"
+  },
+  "id": "gotcha.portable-core-phrase-pins-do-not-span-newlines",
+  "scope": {
+    "branch": null,
+    "kind": "project",
+    "project": "project.shaft-engine",
+    "task": null
+  },
+  "source": {
+    "kind": "agent",
+    "task": "Record pin-phrase wrap gotcha from #5146 portable-core assertions"
+  },
+  "status": "active",
+  "tags": [
+    "tests",
+    "guidance",
+    "portable-core"
+  ],
+  "title": "Portable-core phrase pins do not span newlines",
+  "type": "gotcha",
+  "updated_at": "2026-08-18T18:07:05+03:00"
+}

--- a/.memory/memory/gotchas/portable-core-phrase-pins-do-not-span-newlines.md
+++ b/.memory/memory/gotchas/portable-core-phrase-pins-do-not-span-newlines.md
@@ -1,0 +1,1 @@
+tests.scripts.test_chaos_engine_portable_core uses case-sensitive assertIn on exact phrases. A required phrase split across a markdown wrap (for example human-facing\ninstructions) fails GREEN even when the guidance is present. Keep each pinned phrase on one line in entrypoint and playbook files. Observed RED/GREEN on #5146 / PR #5149.

--- a/chaos-engine/profiles/shaft/entrypoint.md
+++ b/chaos-engine/profiles/shaft/entrypoint.md
@@ -23,7 +23,12 @@ apply unchanged to repository and portable installed hosts.
 - Task branches use `ChaosEngine/*` and start from fetched `origin/main`.
 - The companion public-documentation repository is
   `ShaftHQ/shafthq.github.io` on `master`; discover its local root or use an
-  explicitly configured root, never a fixed sibling path.
+  explicitly configured root, never a fixed sibling path. Every user-facing
+  SHAFT behavior change opens a companion PR on that `master` branch in the
+  same delivery. That companion PR must include a description of the change,
+  screenshots where a human sees UI, human-facing instructions, and
+  AI-supported details (locator policy, replay-proven snippets, properties,
+  exact commands).
 - Install or upgrade this profile from its configured upstream with the
   one-liner in [INSTALL](../../INSTALL.md). From the target folder:
   `irm https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1 | iex`

--- a/chaos-engine/profiles/shaft/references/playbooks/public-behavior-docs-synchronizer.md
+++ b/chaos-engine/profiles/shaft/references/playbooks/public-behavior-docs-synchronizer.md
@@ -2,13 +2,33 @@
 
 Use for user-visible SHAFT behavior changes. Keep docs work separate from code unless the task explicitly asks for both.
 
+Every user-facing SHAFT behavior change opens a companion PR on
+`ShaftHQ/shafthq.github.io` `master` in the same delivery: discover the docs
+root, or use an explicitly configured root; never a fixed sibling path. Do
+not add public guide pages to SHAFT_ENGINE. That companion PR must include a
+description of the change, screenshots where a human sees UI, human-facing instructions,
+and AI-supported details (locator policy: unique author-written id via the SHAFT
+locator builder, then ARIA role, then native relative xpath only; replay-proven
+snippets; properties; exact commands).
+
+## Required companion PR content
+
+1. A description of the change.
+2. Screenshots for visible UI. Reuse existing `static/` or test screenshots
+   when still accurate. If a screenshot cannot be produced headless, ship
+   the prose and open one standalone follow-up issue per missing shot. Do
+   not launch a GUI browser without asking.
+3. Human-facing steps.
+4. AI-supported details: locator policy, replay-proven snippets, properties,
+   and exact commands.
+
 ## Workflow
 
 1. Identify the public surface: API, property, module, report output, CLI/MCP tool, README link, or release text.
-2. Search the local `shafthq.github.io` docs checkout (path in `AGENTS.md` Working Rules) with targeted `rg`; update only guide pages affected by the behavior change.
+2. Discover the local `shafthq.github.io` checkout, or use an explicitly configured root; never a fixed sibling path. Search it with targeted `rg`; update only guide pages affected by the behavior change.
 3. Keep canonical links in `README.md`, `.github/RELEASE_BODY_TEMPLATE.md`, and `legacy-shaft-engine/pom.xml`. Run `python3 scripts/ci/validate_modular_documentation.py` when those links or examples are touched.
 4. Run `python3 scripts/ci/validate_documentation_boundaries.py`; for guidance changes also run `python3 scripts/ci/validate_agent_setup.py`.
-5. Report the docs PR/link, or the concrete reason no public docs change is needed.
+5. Open the companion PR on `master` with the required content above. Report the docs PR/link, or the concrete reason no public docs change is needed.
 
 ## Output
 

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -529,6 +529,51 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
         self.assertEqual("ShaftHQ/shafthq.github.io", profile["companionRepositories"][0]["repository"])
         self.assertNotIn("localRoot", profile["companionRepositories"][0])
 
+    def test_shaft_user_facing_changes_require_companion_docs_prs(self):
+        entry = (CORE / "profiles/shaft/entrypoint.md").read_text(encoding="utf-8")
+        playbook = (
+            CORE
+            / "profiles/shaft/references/playbooks/public-behavior-docs-synchronizer.md"
+        ).read_text(encoding="utf-8")
+        profile = json.loads(SHAFT_PROFILE.read_text(encoding="utf-8"))
+        windows_absolute = re.compile(r"(?<![A-Za-z0-9+.-])[A-Za-z]:[\\/]")
+
+        for phrase in (
+            "companion PR",
+            "same delivery",
+            "description of the change",
+            "screenshots where a human sees UI",
+            "human-facing instructions",
+            "replay-proven snippets",
+            "locator policy",
+        ):
+            with self.subTest(surface="entrypoint", phrase=phrase):
+                self.assertIn(phrase, entry)
+        for phrase in (
+            "companion PR",
+            "description of the change",
+            "screenshots where a human sees UI",
+            "human-facing instructions",
+            "replay-proven snippets",
+            "locator policy",
+            "author-written id",
+            "ARIA role",
+            "native relative xpath",
+            "discover",
+            "never a fixed sibling path",
+        ):
+            with self.subTest(surface="playbook", phrase=phrase):
+                self.assertIn(phrase, playbook)
+        self.assertEqual(
+            "ShaftHQ/shafthq.github.io",
+            profile["companionRepositories"][0]["repository"],
+        )
+        self.assertNotIn("localRoot", profile["companionRepositories"][0])
+        self.assertIsNone(windows_absolute.search(entry))
+        self.assertIsNone(windows_absolute.search(playbook))
+        self.assertNotIn("C:\\Users\\Mohab", entry)
+        self.assertNotIn("C:\\Users\\Mohab", playbook)
+
     def test_every_compatibility_alias_selects_the_repository_profile(self):
         for alias in (
             ROOT / ".agents/skills/act-as-mohab/SKILL.md",


### PR DESCRIPTION
## Summary

Require a companion user-guide PR on `ShaftHQ/shafthq.github.io` `master` for every user-facing SHAFT behavior change. The companion PR must include a description of the change, screenshots where a human sees UI, human-facing instructions, and AI-supported details (locator policy, replay-proven snippets, properties, exact commands). Discover the docs root; never a fixed sibling path and never `localRoot` in `profile.json`.

Closes #5146. Related to #5145.

## Checks

- RED: `py -3 -m unittest tests.scripts.test_chaos_engine_portable_core.ChaosEnginePortableCoreTest.test_shaft_user_facing_changes_require_companion_docs_prs` failed with 18 `assertIn` misses (required sentences absent).
- GREEN: same focused test `OK`; full `py -3 -m unittest tests.scripts.test_chaos_engine_portable_core` — 22 tests `OK`.
- `py -3 scripts/ci/validate_documentation_boundaries.py` — valid (586 tracked Markdown files).
- `py -3 scripts/ci/validate_agent_guidance.py` — budgets, routing, references valid.
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` — guidance/docs checks pass; remaining `memory-untracked` is leftover Soup Memory objects in this assigned worktree (out of scope; not committed).
- `git diff --check` clean on the staged files.

This is agent-guidance policy, not a public user-facing SHAFT product change. The retroactive public-guide sync is [shafthq.github.io#989](https://github.com/ShaftHQ/shafthq.github.io/pull/989).

## Continuation

- Head: `f487a62ed40e4c64a9ae299d79afcfd6eb0bdb5a`
- State: policy pins landed; Memory gotcha for pin-wrap committed. Companion docs PR https://github.com/ShaftHQ/shafthq.github.io/pull/989 is open. Do not merge; orchestrator reviews both PRs.
- Blockers: none for this PR. Assigned worktree still has untracked Soup Memory files that must stay unstaged.
- Next action: independent review of this PR and docs PR 989.
