### PR TITLE
docs(harness): ground first plans and pin Memory project-scope

### DIFF
--- a/chaos-engine/references/work-github-planning.md
+++ b/chaos-engine/references/work-github-planning.md
@@ -11,6 +11,20 @@ Never ask a question the repository can answer. Before the first question:
 - List open issues and PRs in every repository in play.
 - Re-ground each item's file location with the current code, not stale issue line numbers.
 
+First grounding table, recorded before the plan: issue state, closing PRs, and one live-file contradiction check.
+
+| Check | Record |
+| --- | --- |
+| Issue state | Open or closed, plus `state_reason` |
+| Closing PRs | Each PR GitHub reports as closing the issue, plus merged or open |
+| Live-file contradiction | One current-file check that can falsify an issue claim |
+
+A partial-slice merge (`Related to #N`, not `Closes #N`) must leave remaining-acceptance plus the next RED on the issue before the next writer starts.
+
+When the owner names orchestration, grouped PRs, and kill-after-merge, that named grouping is the stream count. Do not rediscover closed children as new streams.
+
+Issue-backed plans must be copied onto the GitHub issue before the first implementing commit. A host-local `plan.md` is not enough.
+
 Only then ask about a decision the user alone must make.
 
 ## 1. Ask once, at the start, then go unattended

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -496,6 +496,45 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
         self.assertNotIn("graphify refresh", planning.lower())
         self.assertIn("maintenance owner", planning.lower())
 
+    def test_planning_grounds_issue_state_before_first_commit(self):
+        planning = (CORE / "references/work-github-planning.md").read_text(encoding="utf-8")
+
+        for phrase in (
+            "First grounding table",
+            "issue state",
+            "closing PRs",
+            "live-file contradiction",
+            "remaining-acceptance",
+            "next RED",
+            "kill-after-merge",
+            "stream count",
+            "host-local",
+            "plan.md",
+            "not enough",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, planning)
+
+    def test_project_scoped_memory_objects_do_not_set_branch_or_task(self):
+        gotcha = (
+            ROOT
+            / ".memory/memory/gotchas"
+            / "grok-lifecycle-hooks-must-merge-not-overwrite-foreign-handlers.json"
+        )
+        payload = json.loads(gotcha.read_text(encoding="utf-8"))
+        self.assertEqual("project", payload["scope"]["kind"])
+        self.assertIsNone(payload["scope"]["task"])
+        self.assertIsNone(payload["scope"]["branch"])
+
+        offenders = []
+        for path in (ROOT / ".memory/memory").rglob("*.json"):
+            scope = json.loads(path.read_text(encoding="utf-8")).get("scope") or {}
+            if scope.get("kind") != "project":
+                continue
+            if scope.get("branch") is not None or scope.get("task") is not None:
+                offenders.append(str(path.relative_to(ROOT)))
+        self.assertEqual([], offenders)
+
     def test_graphify_cache_is_only_an_untrusted_positive_lead(self):
         graphify = (CORE / "references/graphify.md").read_text(encoding="utf-8").lower()
         for phrase in (


### PR DESCRIPTION
## Summary

Smallest planning/harness change that would have produced a better first plan for #4851.

- `chaos-engine/references/work-github-planning.md` now requires a first grounding table (issue state, closing PRs, one live-file contradiction check), remaining-acceptance plus the next RED after a partial-slice merge, owner-named orchestration / grouped PRs / kill-after-merge as the stream count, and the plan on the GitHub issue before the first implementing commit (a host-local `plan.md` is not enough).
- Focused portable-core assertions pin those phrases.
- #5136 production object is already `scope.task=null` on `origin/main` via #5153. This PR adds the missing regression: the grok gotcha and every project-scoped Memory object must keep `branch` and `task` null.

Closes #5157
Closes #5136

Plan: https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5157#issuecomment-5330563485

## Checks

- RED: `py -3 -m unittest tests.scripts.test_chaos_engine_portable_core.ChaosEnginePortableCoreTest.test_planning_grounds_issue_state_before_first_commit -v` — 11 missing-phrase assertion failures on `origin/main` text.
- GREEN: same command after the planning edit — ok.
- `py -3 -m unittest tests.scripts.test_chaos_engine_portable_core -v` — 24 tests, OK.
- `py -3 -m unittest tests.scripts.test_validate_agent_guidance.ExecutableSpecificationGuidanceValidatorTest -v` — 12 tests, OK.
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` — Agent setup is valid: 204136 guidance bytes, 407 memory objects.
- Learning Loop: `signal` + `assess` with https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5157. Candidate `2c2abd6081a5a796c3091a2964fecfea67ba697aa1c973fe4dcff14b8f1e7253` quarantined, ordinary tier. `evaluate` not run: the frozen adherence corpus has no rule this playbook change can flip, and reports will not be fabricated.

## Continuation

Head: 695461a6aa8648b7dd599e3e8a938846c73c1497
State: First retained checkpoint is pushed. Writer stops here for independent review. Do not merge.
Blockers: none
Next action: Independent adversarial review on this SHA. Do not arm auto-merge.