### PR TITLE
fix(harness): fail project-scoped Memory task and branch

### DIFF
--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -339,14 +339,16 @@ def memory_update_timestamps(root: Path) -> dict[str, set[str]]:
 
 
 def validate_memory_integrity(root: Path = ROOT) -> list[dict[str, str]]:
-    """Enforce the two store signals that were recorded but never read.
+    """Enforce the store signals `--skip-external` must still catch.
 
     `memory check` reports a stale `content_hash` as a *warning* and still
     exits 0 (#4460), so `run_memory_check` sees success; and nothing at all
     compares `updated_at` against the event log (#4465). Both are recomputed
     here, in-process, so they run under `--skip-external` -- the command
     AGENTS.md prescribes for memory work, and the one CI runs without the
-    pinned CLI on PATH.
+    pinned CLI on PATH. Project-scoped objects that set `scope.task` or
+    `scope.branch` are the same class of hole: the CLI fail-closes with
+    `ObjectScopeInvalid` (#5136) while this validator used to exit 0 (#5156).
 
     Deliberately no grandfathering set. Every one of the 245 live objects
     with a bumped `updated_at` and an event carries an event whose timestamp
@@ -364,6 +366,20 @@ def validate_memory_integrity(root: Path = ROOT) -> list[dict[str, str]]:
         except (OSError, json.JSONDecodeError) as error:
             errors.append(issue("memory-object", relative, str(error)))
             continue
+        scope = sidecar.get("scope")
+        if isinstance(scope, dict) and scope.get("kind") == "project":
+            set_fields = [
+                field for field in ("branch", "task") if scope.get(field) is not None
+            ]
+            if set_fields:
+                errors.append(
+                    issue(
+                        "memory-project-scope",
+                        relative,
+                        "Project-scoped memory must not set "
+                        f"{' or '.join(set_fields)} (issue #5136).",
+                    )
+                )
         body_path = sidecar.get("body_path")
         if not isinstance(body_path, str) or not body_path:
             # Not a body-backed object; nothing to hash against.

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -778,14 +778,18 @@ class MemoryIntegrityTest(unittest.TestCase):
         blob = canonical + "\n" + body.replace("\r\n", "\n")
         return "sha256:" + hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
-    def write_object(self, name, body, *, created, updated=None, hash_body=None):
+    def write_object(
+        self, name, body, *, created, updated=None, hash_body=None, scope=None
+    ):
         """Write one hash-correct object; `hash_body` fakes a pre-edit body."""
         relative_body = f"memory/gotchas/{name}.md"
         sidecar = {
             "body_path": relative_body,
             "created_at": created,
             "id": f"gotcha.{name}",
-            "scope": {"kind": "project", "project": "project.shaft-engine"},
+            "scope": scope
+            if scope is not None
+            else {"kind": "project", "project": "project.shaft-engine"},
             "status": "active",
             "title": name,
             "type": "gotcha",
@@ -815,6 +819,36 @@ class MemoryIntegrityTest(unittest.TestCase):
         if not (self.root / ".memory/events.jsonl").is_file():
             self.write_events()
         return [error["code"] for error in validate_memory_integrity(self.root)]
+
+    def test_project_scoped_object_with_task_set_fails_the_gate(self):
+        # #5156: restoring scope.task on a project-scoped object used to pass
+        # --skip-external while search_memory fail-closed with ObjectScopeInvalid.
+        self.write_object(
+            "taskset",
+            "A project-scoped body that should not carry a task.",
+            created="2026-08-01T10:00:00+03:00",
+            scope={
+                "kind": "project",
+                "project": "project.shaft-engine",
+                "branch": None,
+                "task": "5090",
+            },
+        )
+        self.assertEqual(self.codes(), ["memory-project-scope"])
+
+    def test_project_scoped_object_with_branch_set_fails_the_gate(self):
+        self.write_object(
+            "branchset",
+            "A project-scoped body that should not carry a branch.",
+            created="2026-08-01T10:00:00+03:00",
+            scope={
+                "kind": "project",
+                "project": "project.shaft-engine",
+                "branch": "ChaosEngine/memory-project-scope-task-guard-5156",
+                "task": None,
+            },
+        )
+        self.assertEqual(self.codes(), ["memory-project-scope"])
 
     def test_a_body_edited_without_its_hash_fails_the_gate(self):
         # The #4460 flow: the body on disk is the corrected text, the hash


### PR DESCRIPTION
## Summary

`validate_agent_setup.py --skip-external` now fail-closes when a project-scoped Memory object sets `scope.task` or `scope.branch`. That is the #5136 `ObjectScopeInvalid` condition; the validator previously only checked hashes and events.

Closes #5156.

Related to #5141.

## Checks

- RED: `py -3 -m unittest tests.scripts.test_validate_agent_setup.MemoryIntegrityTest.test_project_scoped_object_with_task_set_fails_the_gate` failed with `[] != ['memory-project-scope']` before the check existed.
- GREEN: same focused test plus `test_project_scoped_object_with_branch_set_fails_the_gate` passed after the in-process check.
- `py -3 -m unittest tests.scripts.test_validate_agent_setup` — 55 tests, OK.
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` — exit 0 on current valid objects (`204136 guidance bytes, 407 memory objects`).

Did not edit `test_chaos_engine_portable_core.py`. Did not rewrite secret-warning objects. Did not start Soup train.

## Continuation

Head: d76b3cf4784efdcde3dfc422bd6657621c04366b
State: implementer checkpoint landed; PR opened; writer stopping per assignment.
Blockers: none.
Next action: independent adversarial review of this exact SHA, then merge with `--merge` (do not squash).