### PR TITLE
docs(harness): discover companion docs root in AGENTS.md (#5152)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ ChaosEngine entrypoint.
 - Reproduce defects and add focused regressions. Preserve public API;
   deprecate before removal.
 - User-facing work starts from rendered intent and finishes only when real
-  user flow passes. Function changes update companion docs under
-  `../shafthq.github.io` in a separate PR.
+  user flow passes. Function changes update companion docs in a separate PR;
+  discover the docs root or use a configured root, never a fixed sibling path.
 - Never expose secrets or run deploy, publish, history rewrite, cleanup, or
   cloud suites unless asked.
 - No generated reports, binaries, caches, `target/`, Graphify output, or


### PR DESCRIPTION
## Summary

Stop encoding `../shafthq.github.io` as the companion docs path in `AGENTS.md` Working Rules. Match the SHAFT profile discover-root rule from #5149: discover the docs root or use a configured root, never a fixed sibling path. Keep the separate-PR requirement.

Always-loaded adapters (`CLAUDE.md`, `.agents/skills/chaos-engine/SKILL.md`, Copilot instruction files) did not repeat the sibling path. No `localRoot` added to `profile.json`. No Soup files. No `tests/scripts/test_chaos_engine_portable_core.py` edits.

Closes #5152. Related to #5145.

## Checks

- `rg` on `AGENTS.md`: no `../shafthq.github.io`
- `py -3 scripts/ci/validate_documentation_boundaries.py` — valid (588 tracked Markdown files)
- `py -3 scripts/ci/validate_agent_guidance.py` — budgets, routing, references valid
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` — guidance and documentation-boundary checks pass; remaining `memory-untracked` is a leftover Soup Memory object in this assigned worktree (out of scope; not committed)
- `AGENTS.md` is 4957 / 6528 UTF-8 bytes

## Continuation

- Head: `2de7f789f25f1f85cc96651ad72e1308a9e36232`
- State: first checkpoint landed. Ready for independent review. Do not merge in this assignment.
- Blockers: none for this PR. Assigned worktree still has untracked Soup Memory files that must stay unstaged.
- Next action: independent review of this PR. Do not merge until the review gate passes.
