### PR TITLE
docs(harness): SHAFT multi-ticket assignments orchestrate by default

### DIFF
--- a/chaos-engine/profiles/shaft/entrypoint.md
+++ b/chaos-engine/profiles/shaft/entrypoint.md
@@ -40,6 +40,21 @@ apply unchanged to repository and portable installed hosts.
 - Cheap, bounded, already-specified local coding work uses the
   [workstation local coding agent](references/playbooks/workstation-local-coding-agent.md).
 
+## Multi-ticket assignment orchestration
+
+This specializes the portable solo-or-orchestrate rule: two or more SHAFT
+issues in one owner request **are** orchestration. Do not wait for the owner
+to say "orchestrate".
+
+- Load every assigned ticket (and linked/deferred children) before grouping or dispatching.
+- Group related work to the fewest PRs that still keep one problem per issue
+  (`Closes #N` per completed subtask).
+- Main session orchestrates: status, owner commands, review, merge. It does
+  not implement product or guidance chunks.
+- Remaining chunks run one at a time, ordered by dependency then priority.
+- After a chunk's PR is merged, destroy that writer and start the next from a
+  fresh `ChaosEngine/*` branch off fetched `origin/main`.
+
 ## Standing artifact sharing authorization
 
 The standing authorization applies to artifacts produced for SHAFT repository

--- a/tests/scripts/test_agent_harness_portability.py
+++ b/tests/scripts/test_agent_harness_portability.py
@@ -486,6 +486,24 @@ class AgentHarnessPortabilityTest(unittest.TestCase):
         ):
             self.assertIn(required, compact)
 
+    def test_shaft_profile_orchestrates_multi_ticket_assignments_by_default(self):
+        content = (ROOT / "chaos-engine/profiles/shaft/entrypoint.md").read_text(
+            encoding="utf-8"
+        )
+        compact = re.sub(r"\s+", " ", content)
+        for required in (
+            "Load every assigned ticket (and linked/deferred children) before grouping or dispatching.",
+            "fewest PRs that still keep one problem per issue",
+            "`Closes #N` per completed subtask",
+            "Main session orchestrates: status, owner commands, review, merge.",
+            "does not implement product or guidance chunks",
+            "Remaining chunks run one at a time, ordered by dependency then priority.",
+            "destroy that writer and start the next from a fresh `ChaosEngine/*` branch off fetched `origin/main`",
+            "two or more SHAFT issues in one owner request **are** orchestration",
+            'Do not wait for the owner to say "orchestrate"',
+        ):
+            self.assertIn(required, compact)
+
     def test_host_token_budgets_include_mandatory_entrypoint(self):
         budget = json.loads(
             (ROOT / "scripts/ci/agent_guidance_budget.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

SHAFT multi-ticket assignments now orchestrate by default in the standing profile, not only when the owner names orchestration.

- `chaos-engine/profiles/shaft/entrypoint.md` loads every assigned ticket and linked/deferred children, groups related work to the fewest PRs that still keep one problem per issue (`Closes #N` per completed subtask), keeps the main session on status/owner commands/review/merge, and runs remaining chunks one at a time.
- Two or more SHAFT issues in one owner request **are** orchestration. Do not wait for the owner to say "orchestrate".
- After a chunk PR merges, destroy that writer and start the next from a fresh `ChaosEngine/*` branch off fetched `origin/main`.
- Portable ChaosEngine solo-or-orchestrate is unchanged for non-SHAFT profiles.

Closes #5160

## Checks

- RED: `py -3 -m unittest tests.scripts.test_agent_harness_portability.AgentHarnessPortabilityTest.test_shaft_profile_orchestrates_multi_ticket_assignments_by_default` — `AssertionError: 'Load every assigned ticket (and linked/deferred children) before grouping or dispatching.' not found`
- GREEN: `py -3 -m unittest tests.scripts.test_agent_harness_portability tests.scripts.test_chaos_engine_portable_core` — 71 tests OK

## Continuation

Head: 385f0156c56f991c891cba48b5d8370d78bd6644
State: Ready PR opened. Writer stopped after the checkpoint. Does not merge.
Blockers: none
Next action: Main session reviews this PR, then merges with a merge commit. Do not squash. Do not arm from this writer.
