### PR TITLE
fix(ci): tolerate Codecov action 429 on PR Gate and retry watcher 503

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -534,6 +534,7 @@ jobs:
         uses: ./.github/actions/intellij-verify
       - name: Upload IntelliJ coverage to Codecov
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-jacoco-coverage
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
@@ -587,6 +588,7 @@ jobs:
         run: mvn --batch-mode -pl shaft-cli test '-DheadlessExecution=true' '-Dshaft.intellij.liveToolE2E=true'
       - name: Upload shaft-cli coverage to Codecov
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-jacoco-coverage
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
@@ -635,6 +637,7 @@ jobs:
         uses: ./.github/actions/capture-browser-e2e
       - name: Upload SHAFT Capture coverage to Codecov
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-jacoco-coverage
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
@@ -772,6 +775,7 @@ jobs:
           '-DheadlessExecution=true' '-Dallure.automaticallyOpen=false' -Dgpg.skip
       - name: Upload module coverage to Codecov
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-jacoco-coverage
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
@@ -806,6 +810,7 @@ jobs:
           -Dgpg.skip
       - name: Upload template-coupling coverage to Codecov
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-jacoco-coverage
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/scripts/agents/watch_pr_checks.py
+++ b/scripts/agents/watch_pr_checks.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 # subprocess is used only for read-only `gh`/`git` invocations below, always
 # as a list of args (never shell=True) with the executable resolved to an
@@ -93,9 +94,15 @@ PENDING_STATES = {
 }
 SUCCESS_STATES = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 KNOWN_STATES = RED_STATES | PENDING_STATES | SUCCESS_STATES
+_TRANSIENT_GITHUB_HTTP = re.compile(r"\b(?:HTTP\s*)?(?:429|503)\b", re.IGNORECASE)
 
 class CheckWatchError(RuntimeError):
     """Raised for gh/environment failures that map to exit code 3."""
+
+
+def is_transient_github_http_error(error: BaseException) -> bool:
+    """True when a read-only gh poll failed with HTTP 429 or 503."""
+    return bool(_TRANSIENT_GITHUB_HTTP.search(str(error)))
 
 
 def validate_checks(payload: object, source: str) -> list[dict]:
@@ -356,6 +363,9 @@ def main(argv: list[str] | None = None) -> int:
             checks = poll_once(gh_executable, root, repo, pr)
         except CheckWatchError as error:
             print(f"watch_pr_checks: {error}", file=sys.stderr)
+            if is_transient_github_http_error(error) and attempt < poll_budget - 1:
+                time.sleep(interval)
+                continue
             return 3
 
         bucket, failing = classify_checks(checks)

--- a/scripts/agents/watch_pr_checks.py
+++ b/scripts/agents/watch_pr_checks.py
@@ -94,7 +94,7 @@ PENDING_STATES = {
 }
 SUCCESS_STATES = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 KNOWN_STATES = RED_STATES | PENDING_STATES | SUCCESS_STATES
-_TRANSIENT_GITHUB_HTTP = re.compile(r"\b(?:HTTP\s*)?(?:429|503)\b", re.IGNORECASE)
+_TRANSIENT_GITHUB_HTTP = re.compile(r"\bHTTP\s*(?:429|503)\b", re.IGNORECASE)
 
 class CheckWatchError(RuntimeError):
     """Raised for gh/environment failures that map to exit code 3."""

--- a/tests/scripts/test_validate_quality_configuration.py
+++ b/tests/scripts/test_validate_quality_configuration.py
@@ -2,6 +2,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import yaml
+
 from scripts.ci.validate_quality_configuration import (
     validate_browser_matrix_scope_policy,
     validate_codeql_build_mode,
@@ -815,6 +817,40 @@ jobs:
 
             self.assertIn("root pom.xml must include report-aggregate", errors)
             self.assertIn("report-aggregate/pom.xml is missing", errors)
+
+    def test_required_pr_gate_coverage_uploads_continue_on_error(self):
+        # #5050: GitHub downloads codecov-action before the composite's main-only
+        # `if`, so a 429 fails the required job after Maven is already green.
+        workflow_path = Path(__file__).resolve().parents[2] / ".github/workflows/pr-gate.yml"
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        jobs = workflow["jobs"]
+        required_jobs = {
+            name
+            for name in jobs["summary"]["needs"]
+            if name != "changes"
+        }
+        found = []
+        missing = []
+        for job_id, job in jobs.items():
+            if job_id not in required_jobs or not isinstance(job, dict):
+                continue
+            for index, step in enumerate(job.get("steps") or []):
+                if not isinstance(step, dict):
+                    continue
+                uses = str(step.get("uses") or "").rstrip("/")
+                if uses != "./.github/actions/upload-jacoco-coverage":
+                    continue
+                found.append(job_id)
+                if step.get("continue-on-error") is not True:
+                    missing.append(f"{job_id}[{index}] {step.get('name')}")
+        self.assertIn("cli", found)
+        self.assertGreaterEqual(len(found), 2)
+        self.assertEqual(
+            missing,
+            [],
+            "required PR Gate coverage uploads must continue-on-error so a "
+            "Codecov action download 429 cannot fail a green Maven job",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_watch_pr_checks.py
+++ b/tests/scripts/test_watch_pr_checks.py
@@ -182,6 +182,104 @@ class WatchPrChecksRepositoryContextTest(unittest.TestCase):
                 self.assertEqual("", stdout.getvalue())
                 self.assertNotIn("Traceback", stderr.getvalue())
 
+    def test_transient_github_http_errors_retry_until_green(self):
+        green = [{"name": "gate", "state": "SUCCESS", "link": "https://checks/green"}]
+        for status in ("503", "429"):
+            with self.subTest(status=status):
+                polls = iter(
+                    (
+                        watch_pr_checks.CheckWatchError(
+                            f"gh pr checks failed: HTTP {status}"
+                        ),
+                        green,
+                    )
+                )
+
+                def poll_once(*_args, **_kwargs):
+                    item = next(polls)
+                    if isinstance(item, Exception):
+                        raise item
+                    return item
+
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                slept: list[int] = []
+                with (
+                    unittest.mock.patch.object(
+                        sys,
+                        "argv",
+                        [
+                            "watch_pr_checks.py",
+                            "--pr",
+                            "https://github.com/owner/project/pull/9",
+                            "--max-polls",
+                            "3",
+                            "--interval",
+                            "10",
+                        ],
+                    ),
+                    unittest.mock.patch.object(
+                        watch_pr_checks, "resolve_gh", return_value="gh"
+                    ),
+                    unittest.mock.patch.object(
+                        watch_pr_checks, "poll_once", side_effect=poll_once
+                    ),
+                    unittest.mock.patch.object(
+                        watch_pr_checks.time, "sleep", side_effect=slept.append
+                    ),
+                    unittest.mock.patch("sys.stdout", stdout),
+                    unittest.mock.patch("sys.stderr", stderr),
+                ):
+                    exit_code = watch_pr_checks.main()
+
+                self.assertNotEqual(3, exit_code)
+                self.assertEqual(0, exit_code)
+                self.assertEqual([10], slept)
+                self.assertIn("all checks green", stdout.getvalue())
+
+    def test_exhausted_transient_github_http_errors_still_exit_three(self):
+        for status in ("503", "429"):
+            with self.subTest(status=status):
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                slept: list[int] = []
+                with (
+                    unittest.mock.patch.object(
+                        sys,
+                        "argv",
+                        [
+                            "watch_pr_checks.py",
+                            "--pr",
+                            "https://github.com/owner/project/pull/9",
+                            "--max-polls",
+                            "2",
+                            "--interval",
+                            "10",
+                        ],
+                    ),
+                    unittest.mock.patch.object(
+                        watch_pr_checks, "resolve_gh", return_value="gh"
+                    ),
+                    unittest.mock.patch.object(
+                        watch_pr_checks,
+                        "poll_once",
+                        side_effect=watch_pr_checks.CheckWatchError(
+                            f"gh pr checks failed: HTTP {status}"
+                        ),
+                    ),
+                    unittest.mock.patch.object(
+                        watch_pr_checks.time, "sleep", side_effect=slept.append
+                    ),
+                    unittest.mock.patch("sys.stdout", stdout),
+                    unittest.mock.patch("sys.stderr", stderr),
+                ):
+                    exit_code = watch_pr_checks.main()
+
+                self.assertEqual(3, exit_code)
+                self.assertEqual([10], slept)
+                self.assertEqual("", stdout.getvalue())
+                self.assertIn(status, stderr.getvalue())
+
     def test_pr_gate_runs_every_repository_runtime_test(self):
         workflow = (
             Path(__file__).resolve().parents[2] / ".github/workflows/pr-gate.yml"

--- a/tests/scripts/test_watch_pr_checks.py
+++ b/tests/scripts/test_watch_pr_checks.py
@@ -280,6 +280,57 @@ class WatchPrChecksRepositoryContextTest(unittest.TestCase):
                 self.assertEqual("", stdout.getvalue())
                 self.assertIn(status, stderr.getvalue())
 
+    def test_malformed_json_with_char_or_line_429_does_not_retry(self):
+        cases = (
+            (
+                "char 429",
+                "gh pr checks returned unparseable JSON: Expecting value: line 1 column 430 (char 429)",
+            ),
+            (
+                "line 429",
+                "gh pr checks returned unparseable JSON: Expecting value: line 429 column 1 (char 0)",
+            ),
+        )
+        for label, message in cases:
+            with self.subTest(label=label):
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                slept: list[int] = []
+                with (
+                    unittest.mock.patch.object(
+                        sys,
+                        "argv",
+                        [
+                            "watch_pr_checks.py",
+                            "--pr",
+                            "https://github.com/owner/project/pull/9",
+                            "--max-polls",
+                            "3",
+                            "--interval",
+                            "10",
+                        ],
+                    ),
+                    unittest.mock.patch.object(
+                        watch_pr_checks, "resolve_gh", return_value="gh"
+                    ),
+                    unittest.mock.patch.object(
+                        watch_pr_checks,
+                        "poll_once",
+                        side_effect=watch_pr_checks.CheckWatchError(message),
+                    ),
+                    unittest.mock.patch.object(
+                        watch_pr_checks.time, "sleep", side_effect=slept.append
+                    ),
+                    unittest.mock.patch("sys.stdout", stdout),
+                    unittest.mock.patch("sys.stderr", stderr),
+                ):
+                    exit_code = watch_pr_checks.main()
+
+                self.assertEqual(3, exit_code)
+                self.assertEqual([], slept)
+                self.assertEqual("", stdout.getvalue())
+                self.assertIn("unparseable JSON", stderr.getvalue())
+
     def test_pr_gate_runs_every_repository_runtime_test(self):
         workflow = (
             Path(__file__).resolve().parents[2] / ".github/workflows/pr-gate.yml"


### PR DESCRIPTION
## Summary

Required PR Gate coverage uploads and the PR watcher now tolerate transient GitHub 429/503 failures without treating a green product run as red.

- **#5050:** `continue-on-error: true` on every required `pr-gate.yml` step that uses `./.github/actions/upload-jacoco-coverage` (`cli` both OSes, `intellij-build`, `capture-e2e`, `unit-tests`, `template-coupling`). GitHub downloads `codecov/codecov-action` before the composite's main-only `if`, so a 429 was failing `shaft-cli` after Maven `BUILD SUCCESS`. Inner composite `continue-on-error` does not cover that download.
- **#5055:** `scripts/agents/watch_pr_checks.py` keeps the bounded `for attempt in range(poll_budget)` loop. A single HTTP 503/429 on a read-only `gh` poll consumes one interval and retries. Only persistent API failure after the budget exits 3. Matcher requires an HTTP token (`HTTP 429` / `HTTP 503`) so JSON parse positions like `char 429` do not retry.

Closes #5050
Closes #5055

## Checks

- RED (before production edits): focused quality-config pin plus watcher 503/429 retry and exhaustion tests failed for the right reasons
- RED (F1 patch): `test_malformed_json_with_char_or_line_429_does_not_retry` failed because the optional-HTTP regex slept `[10, 10]`
- GREEN: `py -3 -m unittest tests.scripts.test_watch_pr_checks` plus the coverage-upload pin — 11 tests OK
- Independent review of `2354708d31`: APPROVE, 0 blocking. Non-blocking F2: quality-config pin is not on the required Agent Guidance Gate list (follow-up ticket)

## Continuation

- Head: 2354708d31bee2d5e5d2aa33e1cf956ec736c47a
- State: independent review APPROVE; comment-gate clear (no review threads; Codacy pass); arming auto-merge
- Blockers: none
- Next action: `gh pr merge 5169 --auto --merge` then watch with `scripts/ci/watch_pr_checks.py` until mergedAt
