### PR TITLE
test(harness): pin companion-docs sibling path and AI-detail nouns (#5154, #5155)

### DIFF
--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -585,6 +585,9 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             "human-facing instructions",
             "replay-proven snippets",
             "locator policy",
+            "properties",
+            "exact commands",
+            "never a fixed sibling path",
         ):
             with self.subTest(surface="entrypoint", phrase=phrase):
                 self.assertIn(phrase, entry)
@@ -600,6 +603,8 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             "native relative xpath",
             "discover",
             "never a fixed sibling path",
+            "properties",
+            "exact commands",
         ):
             with self.subTest(surface="playbook", phrase=phrase):
                 self.assertIn(phrase, playbook)
@@ -608,6 +613,8 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             profile["companionRepositories"][0]["repository"],
         )
         self.assertNotIn("localRoot", profile["companionRepositories"][0])
+        self.assertNotIn("../shafthq.github.io", entry)
+        self.assertNotIn("../shafthq.github.io", playbook)
         self.assertIsNone(windows_absolute.search(entry))
         self.assertIsNone(windows_absolute.search(playbook))
         self.assertNotIn("C:\\Users\\Mohab", entry)


### PR DESCRIPTION
## Summary

Strengthen `test_shaft_user_facing_changes_require_companion_docs_prs` so companion-docs guidance cannot regress two ways that the previous pin missed.

- #5154: forbid `../shafthq.github.io` on the SHAFT entrypoint and public-docs playbook. Pin `never a fixed sibling path` on the entrypoint tuple as well as the playbook. Keep `profile.json` free of `localRoot`.
- #5155: require the AI-detail nouns `properties` and `exact commands` in both `assertIn` tuples.

No guidance or `profile.json` edits. No Soup, Ollama, or docs-checkout work.

Closes #5154.
Closes #5155.
Related to #5145 / #5146.

## Checks

- RED (current pin, before this change): adding `../shafthq.github.io`, deleting `never a fixed sibling path` from the entrypoint, or rewriting `properties` / `exact commands` in either file still returned `OK`.
- After the pin: the same mutations fail (`rc=1`). Restored files stay green.
- `py -3 -m unittest tests.scripts.test_chaos_engine_portable_core` — Ran 24 tests in 0.212s, OK (isolated worktree `eb8276a8ea` + this commit).

## Continuation

- Head: `779d3ed55c88380af6303fb6eb4d3218a77e9347`
- State: first checkpoint landed. Ready for independent review. Do not merge in this assignment.
- Blockers: none.
- Next action: independent review of this PR. Do not merge until the review gate passes.