### PR TITLE
test(harness): pin companion-docs first-occurrence and leftover nouns (#5173, #5174, #5175)

### DIFF
--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -559,14 +559,16 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
         self.assertIsNone(windows_absolute.search("https://example.com/tool"))
 
     def test_shaft_behavior_is_selected_by_a_project_profile(self):
-        profile = json.loads(SHAFT_PROFILE.read_text(encoding="utf-8"))
+        profile_text = SHAFT_PROFILE.read_text(encoding="utf-8")
+        profile = json.loads(profile_text)
 
         self.assertEqual(1, profile["schemaVersion"])
         self.assertEqual("shaft", profile["name"])
         self.assertEqual("ChaosEngine/", profile["taskBranchPrefix"])
         self.assertEqual("ShaftHQ/SHAFT_ENGINE", profile["repository"])
         self.assertEqual("ShaftHQ/shafthq.github.io", profile["companionRepositories"][0]["repository"])
-        self.assertNotIn("localRoot", profile["companionRepositories"][0])
+        self.assertNotIn("localRoot", profile_text)
+        self.assertNotIn("../shafthq.github.io", profile_text)
 
     def test_shaft_user_facing_changes_require_companion_docs_prs(self):
         entry = (CORE / "profiles/shaft/entrypoint.md").read_text(encoding="utf-8")
@@ -574,7 +576,9 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             CORE
             / "profiles/shaft/references/playbooks/public-behavior-docs-synchronizer.md"
         ).read_text(encoding="utf-8")
-        profile = json.loads(SHAFT_PROFILE.read_text(encoding="utf-8"))
+        agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        profile_text = SHAFT_PROFILE.read_text(encoding="utf-8")
+        profile = json.loads(profile_text)
         windows_absolute = re.compile(r"(?<![A-Za-z0-9+.-])[A-Za-z]:[\\/]")
 
         for phrase in (
@@ -585,6 +589,7 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             "human-facing instructions",
             "replay-proven snippets",
             "locator policy",
+            "AI-supported details",
             "properties",
             "exact commands",
             "never a fixed sibling path",
@@ -593,6 +598,7 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
                 self.assertIn(phrase, entry)
         for phrase in (
             "companion PR",
+            "same delivery",
             "description of the change",
             "screenshots where a human sees UI",
             "human-facing instructions",
@@ -603,18 +609,41 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             "native relative xpath",
             "discover",
             "never a fixed sibling path",
+            "AI-supported details",
             "properties",
             "exact commands",
         ):
             with self.subTest(surface="playbook", phrase=phrase):
                 self.assertIn(phrase, playbook)
+
+        def assert_playbook_first_occurrence_nouns(content: str) -> None:
+            self.assertEqual(2, content.count("properties"))
+            self.assertEqual(2, content.count("exact commands"))
+
+        assert_playbook_first_occurrence_nouns(playbook)
+        for noun, weakened_noun in (
+            ("properties", "settings"),
+            ("exact commands", "exact invocations"),
+        ):
+            weakened = playbook.replace(noun, weakened_noun, 1)
+            self.assertNotEqual(playbook, weakened)
+            with self.subTest(first_occurrence=noun), self.assertRaises(AssertionError):
+                assert_playbook_first_occurrence_nouns(weakened)
+
         self.assertEqual(
             "ShaftHQ/shafthq.github.io",
             profile["companionRepositories"][0]["repository"],
         )
-        self.assertNotIn("localRoot", profile["companionRepositories"][0])
+        self.assertNotIn("localRoot", profile_text)
+        self.assertNotIn("../shafthq.github.io", profile_text)
         self.assertNotIn("../shafthq.github.io", entry)
         self.assertNotIn("../shafthq.github.io", playbook)
+        working_rules = agents.split("## Working rules", 1)[1].split(
+            "## Windows and GUI safety", 1
+        )[0]
+        self.assertIn("never a fixed sibling path", working_rules)
+        self.assertNotIn("../shafthq.github.io", working_rules)
+        self.assertNotIn("../shafthq.github.io", agents)
         self.assertIsNone(windows_absolute.search(entry))
         self.assertIsNone(windows_absolute.search(playbook))
         self.assertNotIn("C:\\Users\\Mohab", entry)

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -617,11 +617,13 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
                 self.assertIn(phrase, playbook)
 
         def assert_playbook_first_occurrence_nouns(content: str) -> None:
+            self.assertEqual(2, content.count("AI-supported details"))
             self.assertEqual(2, content.count("properties"))
             self.assertEqual(2, content.count("exact commands"))
 
         assert_playbook_first_occurrence_nouns(playbook)
         for noun, weakened_noun in (
+            ("AI-supported details", "model-supported details"),
             ("properties", "settings"),
             ("exact commands", "exact invocations"),
         ):


### PR DESCRIPTION
## Summary

Strengthen the existing companion-docs pins in `tests/scripts/test_chaos_engine_portable_core.py` so the residuals found on #5170 review cannot stay green.

- #5173: pin playbook first-occurrence of `properties` and `exact commands` the same way cleanup policy is pinned. Occurrence counts plus an in-test weakening mutation that rewrites only the first noun must fail. Replacing every occurrence still fails.
- #5174: assert SHAFT `profile.json` text contains no `localRoot` and no `../shafthq.github.io`. Adding `localRoot` at the profile root, on any `companionRepositories` entry, or encoding the sibling path under another key fails both `test_shaft_behavior_is_selected_by_a_project_profile` and `test_shaft_user_facing_changes_require_companion_docs_prs`.
- #5175: pin leftover nouns on the surfaces that already carry them. Entrypoint and playbook tuples now include `AI-supported details`. Playbook tuple now includes `same delivery`. `AGENTS.md` Working Rules must keep `never a fixed sibling path` and must not contain `../shafthq.github.io`. Playbook first-occurrence of `AI-supported details` is now pinned the same way as `properties` / `exact commands`: occurrence count 2 plus an in-test first-only rewrite to `model-supported details` must fail.

Test-only. No guidance or `profile.json` wording changes. No Soup, Ollama, docs checkout, or retro sync (#5147). No runtime `localRoot` reader. Does not reopen #5152 / #5154 / #5155. Review F2 (playbook first-occurrence of `never a fixed sibling path`) is left unpatched.

Closes #5173
Closes #5174
Closes #5175
Related to #5145.

## Checks

- RED on current `origin/main` pins (`50cc472745`) before this change:
  - #5173 replace only first playbook `properties` or only first `exact commands`: `rc=0`
  - #5174 add `localRoot` at profile root, on a second `companionRepositories` entry, or `../shafthq.github.io` under another key: `rc=0`
  - #5175 rewrite entrypoint `AI-supported details`, playbook `same delivery` / `AI-supported details`, or rewrite / add sibling path in `AGENTS.md` Working Rules: `rc=0`
  - Replacing every playbook `properties` / `exact commands` already failed (`rc=1`)
- After the first pin (`d4a5da43c108eb24beea5d1cf11275fdb5742ca0`), the same residual mutations fail (`rc=1`) except review F1: replacing only the first playbook `AI-supported details` with `model-supported details` stayed green (`before=2 after=1 rc=0`). Replacing every occurrence already failed.
- After this F1 pin (`cac88440111084c6745e00a55f1700c1cfbb4ec5`), the same first-only rewrite fails (`before=2 after=1 rc=1`, `AssertionError: 2 != 1`). Source files restored.
- `py -3 -m unittest tests.scripts.test_chaos_engine_portable_core` — Ran 24 tests in 0.206s, OK (isolated worktree on `ChaosEngine/5173-5175-companion-docs-pin-residuals`).

## Continuation

- Head: `cac88440111084c6745e00a55f1700c1cfbb4ec5`
- State: F1 first-occurrence pin for playbook `AI-supported details` landed. Ready for independent review of this SHA. Do not merge in this assignment.
- Blockers: none.
- Next action: independent review of this PR. Do not merge until the review gate passes.
