### PR TITLE
fix(ci): wrap Flutter emulator restartable builds with build_retry.sh

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -1202,8 +1202,8 @@ jobs:
           set -euo pipefail
           cd appium-flutter-server/demo-app
           dart pub global activate rps --version 0.8.0
-          flutter build apk --debug
-          cd android && ./gradlew app:assembleDebug -Ptarget="$(pwd)/../integration_test/appium.dart"
+          bash "$GITHUB_WORKSPACE/scripts/ci/build_retry.sh" 2 60 flutter build apk --debug
+          cd android && bash "$GITHUB_WORKSPACE/scripts/ci/build_retry.sh" 2 60 ./gradlew app:assembleDebug -Ptarget="$(pwd)/../integration_test/appium.dart"
       - name: Install Appium and the Flutter Integration Driver
         run: |
           set -euo pipefail


### PR DESCRIPTION
Closes #5097

## Summary

`Android_Flutter_Emulator_E2E` in `.github/workflows/e2eTests.yml` launched two restartable Flutter/Gradle builds without `scripts/ci/build_retry.sh`. This wrap matches the sibling `Flutter_Demo_App_Build` Gradle line and also wraps `flutter build apk --debug`, as ruled on the issue.

In the `Build demo-app debug APK wired for the Appium Flutter Integration Server` step:

- `flutter build apk --debug` now runs through `bash "$GITHUB_WORKSPACE/scripts/ci/build_retry.sh" 2 60`
- `./gradlew app:assembleDebug -Ptarget="$(pwd)/../integration_test/appium.dart"` now runs through the same helper after `cd android`

Appium server start, session assertion, npm install, emulator boot, and checkout stay unwrapped. The validator was not changed.

## Checks

- RED on `8ab3f4f93bd46f878b355f766531c89c3dbc54e7` before production edit: `test_repository_configuration_is_valid` failed with `e2eTests.yml job 'Android_Flutter_Emulator_E2E' restartable build must use build_retry.sh`
- GREEN on this head: same command `Ran 1 test in 1.876s` / `OK`
- Independent review of `5a2043cdce`: APPROVE, 0 blocking

## Continuation

- Head: 5a2043cdce56c9a27beaf174015e788070d9c73e
- State: independent review APPROVE; comment-gate clear (no threads; Codacy pass); arming auto-merge
- Blockers: none
- Next action: `gh pr merge 5177 --auto --merge` then watch until mergedAt. No further batch chunks.
