### PR TITLE
ci: isolate shaft-pilot-release jobs for faster feedback

### DIFF
--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -2,8 +2,9 @@ name: Maven Central Continuous Delivery
 # Executed automatically when a new PR is merged to main.
 # Already-published immutable Maven Central versions skip delivery cleanly (see check_release_needed)
 # instead of failing, since most pushes to main land between releases with nothing new to deliver.
-# build_release_and_deliver's build/test/package steps are MIRRORED in shaft-pilot-release.yml's
-# release-candidate job (PR gate vs. real release execution of the same steps) - keep both in sync.
+# build_release_and_deliver stays sequential so deploy cannot run after a failed test.
+# Named checks stay mirrored with shaft-pilot-release.yml's isolated jobs. Keep the
+# named checks in sync; do not re-serialize the PR gate to match this deploy path.
 
 on:
   push:

--- a/.github/workflows/shaft-pilot-release.yml
+++ b/.github/workflows/shaft-pilot-release.yml
@@ -1,6 +1,9 @@
 name: SHAFT Pilot Release Candidate
-# MIRRORED in mavenCentral_cd.yml's build_release_and_deliver job (PR gate vs. real
-# release execution of the same steps) - keep both step sequences in sync.
+# Named release checks stay mirrored with mavenCentral_cd.yml's
+# build_release_and_deliver steps. This workflow runs those checks as isolated
+# parallel jobs plus a release-candidate aggregator so an early failure cannot
+# hide a later one. Keep the named checks in sync; do not re-serialize this PR
+# gate to match Central's sequential deploy path.
 
 on:
   pull_request:
@@ -68,22 +71,45 @@ jobs:
             echo "SHAFT version changed: ${base_version} -> ${head_version}"
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
-  release-candidate:
+
+  intellij-verify:
     needs: detect-shaft-version-change
     if: needs.detect-shaft-version-change.outputs.changed == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 25
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
-      - name: Reclaim disk space
-        uses: ./.github/actions/reclaim-disk-space
+      - name: Verify IntelliJ plugin release candidate
+        uses: ./.github/actions/intellij-verify
+
+  release-contracts:
+    needs: detect-shaft-version-change
+    if: needs.detect-shaft-version-change.outputs.changed == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
       - name: Set up Python 3.13
         uses: actions/setup-python@v7
         with:
           python-version: "3.13"
-      - name: Verify IntelliJ plugin release candidate
-        uses: ./.github/actions/intellij-verify
+      - name: Validate release contracts
+        uses: ./.github/actions/release-contract-validators
+
+  pilot-tests:
+    needs: detect-shaft-version-change
+    if: needs.detect-shaft-version-change.outputs.changed == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
       - name: Set up JDK 25
         uses: actions/setup-java@v5.7.0
         with:
@@ -98,8 +124,6 @@ jobs:
         uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.12
-      - name: Validate release contracts
-        uses: ./.github/actions/release-contract-validators
       - name: Install SHAFT Pilot prerequisites without tests
         run: >-
           mvn --batch-mode
@@ -112,16 +136,15 @@ jobs:
             find "${module}/allure-results" -mindepth 1 -delete
           done
       - name: Run deterministic SHAFT Pilot tests
+        id: pilot_tests
         run: >-
           mvn --batch-mode
           -pl shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-mcp
           test -Dgpg.skip
       - name: Verify populated Pilot Allure results
         run: python3 scripts/ci/validate_shaft_pilot_release.py --check-test-results
-      - name: Run headless SHAFT Capture release journey
-        uses: ./.github/actions/capture-browser-e2e
       - name: Upload coverage to Codecov
-        if: always() && github.event_name != 'pull_request'
+        if: always() && github.event_name != 'pull_request' && steps.pilot_tests.outcome != 'skipped'
         uses: ./.github/actions/upload-jacoco-coverage
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
@@ -132,6 +155,61 @@ jobs:
             ./shaft-ai/target/jacoco/jacoco.xml,
             ./shaft-heal/target/jacoco/jacoco.xml,
             ./shaft-mcp/target/jacoco/jacoco.xml
+
+  capture-journey:
+    needs: detect-shaft-version-change
+    if: needs.detect-shaft-version-change.outputs.changed == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5.7.0
+        with:
+          java-version: "25"
+          distribution: "zulu"
+          check-latest: true
+      - name: Cache Maven repository
+        uses: ./.github/actions/cache-maven-repo
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5.1
+        with:
+          maven-version: 3.9.12
+      - name: Install SHAFT Pilot prerequisites without tests
+        run: >-
+          mvn --batch-mode
+          -pl shaft-engine,shaft-pilot-core,shaft-capture,shaft-doctor,shaft-ai,shaft-heal,shaft-mcp
+          -am install -DskipTests -Dgpg.skip
+      - name: Run headless SHAFT Capture release journey
+        uses: ./.github/actions/capture-browser-e2e
+
+  package-and-validate:
+    needs: detect-shaft-version-change
+    if: needs.detect-shaft-version-change.outputs.changed == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 40
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Reclaim disk space
+        uses: ./.github/actions/reclaim-disk-space
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5.7.0
+        with:
+          java-version: "25"
+          distribution: "zulu"
+          check-latest: true
+      - name: Cache Maven repository
+        uses: ./.github/actions/cache-maven-repo
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5.1
+        with:
+          maven-version: 3.9.12
       - name: Package the complete reactor
         run: mvn --batch-mode clean install -DskipTests -Dgpg.skip
       - name: Validate packaged release outputs and MCP transports
@@ -149,13 +227,81 @@ jobs:
             verify "-Dshaft.version=${VERSION}" -DskipTests
           mvn --batch-mode -f tools/modularization/consumer-fixtures/mcp/pom.xml \
             verify "-Dshaft.version=${VERSION}" -DskipTests
-      - name: Reclaim disk space before container build
+
+  container-smoke:
+    needs: detect-shaft-version-change
+    if: needs.detect-shaft-version-change.outputs.changed == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Reclaim disk space
         uses: ./.github/actions/reclaim-disk-space
-        with:
-          prune-build-outputs: 'true'
       - name: Build and smoke the release container
         uses: ./.github/actions/mcp-container-smoke
         with:
           image-tag: shaft-pilot-release:test
           container-name: shaft-pilot-release-smoke
           client-name: release-smoke
+
+  release-candidate:
+    name: release-candidate
+    needs:
+      - detect-shaft-version-change
+      - intellij-verify
+      - release-contracts
+      - pilot-tests
+      - capture-journey
+      - package-and-validate
+      - container-smoke
+    if: always()
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Evaluate isolated slice results
+        env:
+          DETECT_RESULT: ${{ needs.detect-shaft-version-change.result }}
+          DETECT_CHANGED: ${{ needs.detect-shaft-version-change.outputs.changed }}
+          INTELLIJ_RESULT: ${{ needs.intellij-verify.result }}
+          CONTRACTS_RESULT: ${{ needs.release-contracts.result }}
+          PILOT_RESULT: ${{ needs.pilot-tests.result }}
+          CAPTURE_RESULT: ${{ needs.capture-journey.result }}
+          PACKAGE_RESULT: ${{ needs.package-and-validate.result }}
+          CONTAINER_RESULT: ${{ needs.container-smoke.result }}
+        run: |
+          set -uo pipefail
+
+          {
+            echo "| Slice | Result |"
+            echo "| --- | --- |"
+            echo "| detect-shaft-version-change | ${DETECT_RESULT} |"
+            echo "| intellij-verify | ${INTELLIJ_RESULT} |"
+            echo "| release-contracts | ${CONTRACTS_RESULT} |"
+            echo "| pilot-tests | ${PILOT_RESULT} |"
+            echo "| capture-journey | ${CAPTURE_RESULT} |"
+            echo "| package-and-validate | ${PACKAGE_RESULT} |"
+            echo "| container-smoke | ${CONTAINER_RESULT} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${DETECT_RESULT}" != "success" ]; then
+            echo "::error::detect-shaft-version-change did not succeed (${DETECT_RESULT})"
+            exit 1
+          fi
+
+          if [ "${DETECT_CHANGED}" != "true" ]; then
+            echo "No version or release-candidate infra change; isolated slices skipped."
+            exit 0
+          fi
+
+          status=0
+          for result in "${INTELLIJ_RESULT}" "${CONTRACTS_RESULT}" "${PILOT_RESULT}" "${CAPTURE_RESULT}" "${PACKAGE_RESULT}" "${CONTAINER_RESULT}"; do
+            case "$result" in
+              success) ;;
+              *)
+                echo "::error::a release-candidate slice did not pass (result: ${result})"
+                status=1
+                ;;
+            esac
+          done
+          exit "${status}"

--- a/scripts/ci/validate_shaft_pilot_release.py
+++ b/scripts/ci/validate_shaft_pilot_release.py
@@ -257,6 +257,52 @@ def validate_static(root: Path = ROOT) -> list[str]:
     if any(position < 0 for position in positions) or positions != sorted(positions):
         errors.append("Maven Central workflow does not enforce the Pilot release gate")
 
+    errors.extend(validate_release_candidate_isolation(pilot_release_workflow))
+    return errors
+
+
+ISOLATED_RELEASE_CANDIDATE_JOBS = (
+    "intellij-verify",
+    "release-contracts",
+    "pilot-tests",
+    "capture-journey",
+    "package-and-validate",
+    "container-smoke",
+)
+
+def validate_release_candidate_isolation(workflow_text: str) -> list[str]:
+    """Reject a serialized release-candidate job when the file is a real workflow.
+
+    Stdlib-only: this validator runs on a bare setup-python runner without
+    requirements-ci.txt, so it cannot import PyYAML.
+    """
+    if "jobs:" not in workflow_text:
+        return []
+
+    errors: list[str] = []
+    for name in ISOLATED_RELEASE_CANDIDATE_JOBS:
+        heading = f"  {name}:"
+        if not re.search(rf"(?m)^{re.escape(heading)}\s*$", workflow_text):
+            errors.append(f"shaft-pilot-release.yml must isolate {name} as its own job")
+            continue
+        needs_only_detect = (
+            f"{heading}\n    needs: detect-shaft-version-change" in workflow_text
+            or f"{heading}\r\n    needs: detect-shaft-version-change" in workflow_text
+        )
+        if not needs_only_detect:
+            errors.append(
+                f"shaft-pilot-release.yml job {name} must depend only on detect-shaft-version-change"
+            )
+    if not re.search(r"(?m)^  release-candidate:\s*$", workflow_text):
+        errors.append("shaft-pilot-release.yml must keep a release-candidate aggregator job")
+        return errors
+    if not re.search(r"(?m)^    if: always\(\)\s*$", workflow_text):
+        errors.append(
+            "shaft-pilot-release.yml release-candidate aggregator must use if: always()"
+        )
+    for name in ISOLATED_RELEASE_CANDIDATE_JOBS:
+        if f"- {name}" not in workflow_text:
+            errors.append(f"release-candidate aggregator must need isolated job {name}")
     return errors
 
 

--- a/tests/scripts/test_validate_shaft_pilot_release.py
+++ b/tests/scripts/test_validate_shaft_pilot_release.py
@@ -4,6 +4,8 @@ import unittest
 import zipfile
 from pathlib import Path
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts/ci/validate_shaft_pilot_release.py"
@@ -11,6 +13,15 @@ SPEC = importlib.util.spec_from_file_location("validate_shaft_pilot_release", SC
 MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(MODULE)
+WORKFLOW_PATH = ROOT / ".github/workflows/shaft-pilot-release.yml"
+ISOLATED_SLICES = (
+    "intellij-verify",
+    "release-contracts",
+    "pilot-tests",
+    "capture-journey",
+    "package-and-validate",
+    "container-smoke",
+)
 
 
 def _write_text(path: Path, text: str) -> None:
@@ -186,6 +197,26 @@ Deploy to Maven Central
 Verify published Maven Central coordinates
 """,
     )
+
+
+def _needs_list(job: dict) -> list[str]:
+    needs = job.get("needs", [])
+    if needs is None:
+        return []
+    if isinstance(needs, str):
+        return [needs]
+    return list(needs)
+
+
+def _step_blob(job: dict) -> str:
+    parts = []
+    for step in job.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        parts.append(str(step.get("name") or ""))
+        parts.append(str(step.get("uses") or ""))
+        parts.append(str(step.get("run") or ""))
+    return "\n".join(parts)
 
 
 class ShaftPilotReleaseValidatorTest(unittest.TestCase):
@@ -434,6 +465,40 @@ Verify published Maven Central coordinates
             f"Expected {len(MODULE.PILOT_MODULES)} failed modules, got {len(failed_modules)}: {failed_modules}",
         )
 
+    def test_serial_release_candidate_job_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_minimal_reactor(
+                root, reactor_version="10.2.20260630", plugin_version="10.2.20260630"
+            )
+            _write_text(
+                root / ".github/workflows/shaft-pilot-release.yml",
+                """name: SHAFT Pilot Release Candidate
+jobs:
+  detect-shaft-version-change:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+  release-candidate:
+    needs: detect-shaft-version-change
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - name: Verify IntelliJ plugin release candidate
+        uses: ./.github/actions/intellij-verify
+      - name: Run deterministic SHAFT Pilot tests
+        run: echo tests
+""",
+            )
+
+            errors = MODULE.validate_static(root)
+
+        self.assertTrue(
+            any("must isolate" in error for error in errors),
+            errors,
+        )
+
     def test_broken_allure_status_is_rejected_across_all_modules(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
@@ -451,6 +516,50 @@ Verify published Maven Central coordinates
             any("broken" in error for error in errors),
             f"Expected broken status error, got: {errors}",
         )
+
+
+class ShaftPilotReleaseIsolationTest(unittest.TestCase):
+    def test_isolated_slices_run_in_parallel_after_detect_only(self):
+        workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+        jobs = workflow["jobs"]
+
+        for name in ISOLATED_SLICES:
+            self.assertIn(name, jobs, f"missing isolated job {name}")
+            self.assertEqual(
+                ["detect-shaft-version-change"],
+                _needs_list(jobs[name]),
+                f"{name} must depend only on detect-shaft-version-change",
+            )
+            self.assertIn("timeout-minutes", jobs[name], name)
+            self.assertIn("actions/checkout@", _step_blob(jobs[name]), name)
+
+    def test_release_candidate_aggregates_isolated_slices(self):
+        workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+        aggregator = workflow["jobs"]["release-candidate"]
+        needs = _needs_list(aggregator)
+
+        self.assertIn("always()", str(aggregator.get("if", "")))
+        self.assertIn("detect-shaft-version-change", needs)
+        for name in ISOLATED_SLICES:
+            self.assertIn(name, needs)
+        self.assertNotIn("mvn --batch-mode", _step_blob(aggregator))
+        self.assertNotIn("./.github/actions/intellij-verify", _step_blob(aggregator))
+
+    def test_isolated_slices_keep_the_named_release_checks(self):
+        workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+        jobs = workflow["jobs"]
+        required = {
+            "intellij-verify": "./.github/actions/intellij-verify",
+            "release-contracts": "./.github/actions/release-contract-validators",
+            "pilot-tests": "Run deterministic SHAFT Pilot tests",
+            "capture-journey": "./.github/actions/capture-browser-e2e",
+            "package-and-validate": "Validate packaged release outputs and MCP transports",
+            "container-smoke": "./.github/actions/mcp-container-smoke",
+        }
+
+        for name, token in required.items():
+            self.assertIn(name, jobs, f'missing isolated job {name}')
+            self.assertIn(token, _step_blob(jobs[name]), name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #5179

## Summary
Restructure `SHAFT Pilot Release Candidate` so independent checks run as isolated parallel jobs instead of one serial `release-candidate` chain. An early failure no longer hides later slices, and first-failure feedback no longer waits on IntelliJ, Pilot tests, packaging, and container smoke in sequence.

Isolated slices after `detect-shaft-version-change`:
- `intellij-verify`
- `release-contracts`
- `pilot-tests`
- `capture-journey`
- `package-and-validate`
- `container-smoke`

`release-candidate` is now an `always()` aggregator, same shape as `PR Gate Summary`. Maven Central delivery stays sequential so deploy cannot run after a failed test. Named checks stay mirrored.

Not user-facing SHAFT product behavior. No companion docs PR.

## Checks
- RED: `py -3 -m unittest tests.scripts.test_validate_shaft_pilot_release.ShaftPilotReleaseIsolationTest` failed because the live workflow had only `detect-shaft-version-change` and a serial `release-candidate` job.
- RED: `test_serial_release_candidate_job_is_rejected` failed with `AssertionError: False is not true : []` before the isolation contract existed.
- GREEN: `py -3 -m unittest tests.scripts.test_validate_shaft_pilot_release` — 19 tests OK.
- GREEN: `py -3 scripts/ci/validate_shaft_pilot_release.py` — SHAFT Pilot release contract is valid.
- GREEN: `py -3 -m unittest tests.scripts.test_validate_workflow_timeouts.ValidateWorkflowTimeoutsTest.test_current_repository_workflows_all_declare_timeout_minutes` — OK.

## Continuation
Head: b89c97a315dac0b243284c6ce3fa956b4032de91
State: implementation committed and pushed; independent review is a new instance.
Blockers: none.
Next action: independent review, then CI babysit. Do not merge in this instance.