### PR TITLE
feat(harness): portable work-item skill and open-issue Spec Kit hygiene

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -115,6 +115,7 @@ step with the first.
 | --- | --- |
 | [ChaosEngine](../../chaos-engine/skills/chaos-engine/SKILL.md) | The single always-loaded entrypoint and global router. Carries the iron laws, the triage that sizes every task, the always-on working style, and the table that sends each deliverable to exactly one surface. |
 | [local-coding-delegate](../../chaos-engine/skills/local-coding-delegate/SKILL.md) | Optional. Not always-loaded. A local coding loop the decider may use as a mechanical or default delegate after a hardware probe. |
+| [work-item](../../chaos-engine/skills/work-item/SKILL.md) | Optional. Not always-loaded. Open or rewrite a work item under the portable Spec Kit contract; SCM adapters are separate. |
 
 The entrypoint reaches the internal [consultation](../../chaos-engine/references/consult-first.md)
 and [retrieval](../../chaos-engine/references/retrieve-first.md) gates after every
@@ -140,6 +141,8 @@ sends you there; the rest by
 - [lifecycle hooks](../../chaos-engine/references/lifecycle-hooks.md)
 - [work GitHub playbook](../../chaos-engine/references/work-github-playbook.md)
 - [work GitHub planning](../../chaos-engine/references/work-github-planning.md)
+- [work item](../../chaos-engine/references/work-item.md)
+- [work-item adapters](../../chaos-engine/references/work-item-adapters.md)
 - [graphify](../../chaos-engine/references/graphify.md)
 - [repository Graphify procedure](../../chaos-engine/profiles/shaft/references/graphify.md)
 - [research receipt](../../chaos-engine/references/research-receipt.md)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -96,6 +96,42 @@ Gist / attachment link: <!-- https://gist.github.com/... or drag-and-drop a file
 <!-- Drag and drop images or recordings here -->
 
 
+## User Scenarios & Testing
+
+### User Story 1 - <!-- short name --> (Priority: P1)
+
+**Independent Test**: <!-- how to verify this story alone -->
+
+**Acceptance Scenarios**:
+
+1. **Given** <!-- precondition -->, **When** <!-- action -->, **Then** <!-- expected result -->.
+
+
+## Edge Cases
+
+- <!-- boundary or fail-closed case -->
+
+
+## Functional Requirements
+
+- **FR-001**: <!-- requirement -->
+
+
+## Success Criteria
+
+- **SC-001**: <!-- measurable outcome -->
+
+
+## Assumptions
+
+- <!-- assumption, or delete this heading and use Out of scope -->
+
+
+## Out of scope
+
+- <!-- explicit non-goal -->
+
+
 ## 📝 Additional Context
 
 > Any other information that may be relevant (custom properties, special network setup, proxy, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -73,6 +73,42 @@ driver.browser().tabs().switchToTab(1);
 <!-- Example: "Any team running multi-tab E2E tests. This is a daily need for our team and likely for any project testing OAuth flows or file download dialogs." -->
 
 
+## User Scenarios & Testing
+
+### User Story 1 - <!-- short name --> (Priority: P1)
+
+**Independent Test**: <!-- how to verify this story alone -->
+
+**Acceptance Scenarios**:
+
+1. **Given** <!-- precondition -->, **When** <!-- action -->, **Then** <!-- expected result -->.
+
+
+## Edge Cases
+
+- <!-- boundary or fail-closed case -->
+
+
+## Functional Requirements
+
+- **FR-001**: <!-- requirement -->
+
+
+## Success Criteria
+
+- **SC-001**: <!-- measurable outcome -->
+
+
+## Assumptions
+
+- <!-- assumption, or delete this heading and use Out of scope -->
+
+
+## Out of scope
+
+- <!-- explicit non-goal -->
+
+
 ## 📝 Additional Context
 
 > Any other information, links, references, or screenshots that support this request.

--- a/chaos-engine/profiles/portable/references/routing.md
+++ b/chaos-engine/profiles/portable/references/routing.md
@@ -11,8 +11,8 @@ Use the generic GitHub delivery playbook only when the adopter uses GitHub.
 Never infer a provider, organization, default branch, language, build system,
 companion repository, deployment target, or issue taxonomy from ChaosEngine.
 When the deliverable is open or rewrite a work item, load the portable
-[work-item skill](../../../skills/work-item/SKILL.md); keep merged-PR delivery
-on the GitHub playbook. When the adopter asked for a local coding loop, load
-the optional
+`chaos-engine/skills/work-item/SKILL.md`; keep merged-PR delivery on the
+GitHub playbook. When the adopter asked for a local coding loop, load the
+optional
 [local coding delegate](../../../skills/local-coding-delegate/SKILL.md); the
 most-intelligent or default capability stays the decider.

--- a/chaos-engine/profiles/portable/references/routing.md
+++ b/chaos-engine/profiles/portable/references/routing.md
@@ -10,6 +10,9 @@ project-local workflow from its files and explicit user instructions.
 Use the generic GitHub delivery playbook only when the adopter uses GitHub.
 Never infer a provider, organization, default branch, language, build system,
 companion repository, deployment target, or issue taxonomy from ChaosEngine.
-When the adopter asked for a local coding loop, load the optional
+When the deliverable is open or rewrite a work item, load the portable
+[work-item skill](../../../skills/work-item/SKILL.md); keep merged-PR delivery
+on the GitHub playbook. When the adopter asked for a local coding loop, load
+the optional
 [local coding delegate](../../../skills/local-coding-delegate/SKILL.md); the
 most-intelligent or default capability stays the decider.

--- a/chaos-engine/profiles/shaft/references/routing.md
+++ b/chaos-engine/profiles/shaft/references/routing.md
@@ -73,6 +73,7 @@ failure this table exists to prevent.
 | Externally documented behavior that changed | [public docs](playbooks/public-behavior-docs-synchronizer.md) |
 | Any visible SHAFT interface, visual QA, UX copy, accessibility | [UI design](playbooks/shaft-ui-design.md) |
 | Marketing or promotional material | [marketing](playbooks/shaft-marketing-ad-producer.md) |
+| Open or rewrite a work item | [work-item skill](../../../skills/work-item/SKILL.md) |
 | One issue through a merged PR | [GitHub playbook](../../../references/work-github-playbook.md) |
 | Reviewing a diff for behavior that no check would catch | [verification-gap lens](../../../references/verification-gap-lens.md) |
 | Holding main thread at session start | [orchestrator bootstrap](../../../references/orchestrator-bootstrap.md) |

--- a/chaos-engine/references/work-item-adapters.md
+++ b/chaos-engine/references/work-item-adapters.md
@@ -1,0 +1,45 @@
+# Work-item adapters
+
+Adapters only. The [work-item contract](work-item.md) stays SCM-agnostic.
+Select the adapter from the detected CLI; never assume a provider.
+
+## GitHub (`gh`) — live CLI
+
+Only live create/search/edit path in this repository today.
+
+| Action | Command shape |
+| --- | --- |
+| List/search | `gh issue list --repo OWNER/REPO --state STATE --search QUERY --limit 1000 --json url` |
+| Create | `gh issue create --repo OWNER/REPO --title TITLE --body BODY --label LABELS` |
+| Edit labels | `gh issue edit N --repo OWNER/REPO --add-label L --remove-label L` |
+| View | `gh issue view N --repo OWNER/REPO --json labels` |
+
+URL shape: `https://github.com/OWNER/REPO/issues/N`
+
+## GitLab (`glab`) — documented / fake-runner
+
+| Action | Command shape |
+| --- | --- |
+| Create | `glab issue create --repo GROUP/PROJ --title TITLE --description BODY --label LABELS` |
+
+Builder: `scripts.agents.issue_filing.build_glab_issue_create_argv`.
+URL shape: `https://gitlab.com/GROUP/PROJ/-/issues/N` (any https host with `/-/issues/`).
+
+Live GitLab network calls are out of scope; tests use fake runners only.
+
+## Azure Boards (`az boards`) — documented / fake-runner
+
+| Action | Command shape |
+| --- | --- |
+| Create | `az boards work-item create --organization ORG_URL --project PROJECT --title TITLE --type Issue --description BODY` |
+
+Builder: `scripts.agents.issue_filing.build_az_boards_create_argv`.
+URL shape: `https://dev.azure.com/ORG/PROJECT/_workitems/edit/N` or `*.visualstudio.com/.../_workitems/...`.
+
+Live Azure network calls are out of scope; tests use fake runners only.
+
+## Selection
+
+1. Prefer the CLI already authenticated for the adopter repo.
+2. Keep GitHub as the only live path until another CLI is wired end-to-end.
+3. Still accept non-GitHub https dependency URLs for blocked items.

--- a/chaos-engine/references/work-item-adapters.md
+++ b/chaos-engine/references/work-item-adapters.md
@@ -23,7 +23,7 @@ URL shape: `https://github.com/OWNER/REPO/issues/N`
 | Create | `glab issue create --repo GROUP/PROJ --title TITLE --description BODY --label LABELS` |
 
 Builder: `scripts.agents.issue_filing.build_glab_issue_create_argv`.
-URL shape: `https://gitlab.com/GROUP/PROJ/-/issues/N` (any https host with `/-/issues/`).
+URL shape: `https://gitlab.com/GROUP/PROJ` issue pages ending at `issues/N`.
 
 Live GitLab network calls are out of scope; tests use fake runners only.
 
@@ -34,7 +34,7 @@ Live GitLab network calls are out of scope; tests use fake runners only.
 | Create | `az boards work-item create --organization ORG_URL --project PROJECT --title TITLE --type Issue --description BODY` |
 
 Builder: `scripts.agents.issue_filing.build_az_boards_create_argv`.
-URL shape: `https://dev.azure.com/ORG/PROJECT/_workitems/edit/N` or `*.visualstudio.com/.../_workitems/...`.
+URL shape: `https://dev.azure.com/ORG/PROJECT` or `ORG.visualstudio.com` work-item edit pages ending at a numeric id.
 
 Live Azure network calls are out of scope; tests use fake runners only.
 

--- a/chaos-engine/references/work-item.md
+++ b/chaos-engine/references/work-item.md
@@ -2,8 +2,7 @@
 
 Portable, source-control agnostic ticket contract. Adapters live in
 [work-item-adapters.md](work-item-adapters.md). GitHub PR merge and watch stay
-in [work-github-playbook.md](work-github-playbook.md) and
-[work-github-planning.md](work-github-planning.md).
+in `work-github-playbook.md` and `work-github-planning.md`.
 
 ## Required Spec Kit sections
 
@@ -34,9 +33,9 @@ Statement, and so on). Spec Kit sections are additive.
 
 Blocked dependency links must be https. Accepted shapes:
 
-- GitHub issue URLs (`/issues/`)
-- GitLab issue URLs (`/-/issues/`)
-- Azure Boards work-item URLs (`/_workitems/`)
+- GitHub issue URLs on `github.com` ending at `issues/N`
+- GitLab issue URLs on `gitlab.com` (or self-hosted) ending at `issues/N`
+- Azure Boards work-item URLs on `dev.azure.com` or `visualstudio.com` ending at a numeric work-item id
 
 Reject `javascript:`, non-https schemes, and unknown hosts/shapes.
 

--- a/chaos-engine/references/work-item.md
+++ b/chaos-engine/references/work-item.md
@@ -1,0 +1,47 @@
+# Work-item contract
+
+Portable, source-control agnostic ticket contract. Adapters live in
+[work-item-adapters.md](work-item-adapters.md). GitHub PR merge and watch stay
+in [work-github-playbook.md](work-github-playbook.md) and
+[work-github-planning.md](work-github-planning.md).
+
+## Required Spec Kit sections
+
+Every opened or rewritten work item body must contain these section names:
+
+| Section | Purpose |
+| --- | --- |
+| User Scenarios & Testing | Given/When/Then acceptance scenarios and independent tests |
+| Edge Cases | Boundaries, fail-closed paths, and non-goals that can bite |
+| Functional Requirements | Numbered `FR-*` statements |
+| Success Criteria | Numbered `SC-*` measurable outcomes |
+| Assumptions or Out of scope | At least one of these headings |
+
+Adopter templates may keep their own headings (Describe the Bug, Problem
+Statement, and so on). Spec Kit sections are additive.
+
+## Taxonomy rules
+
+- Exactly one primary type.
+- Exactly one lifecycle label.
+- At least one proven subsystem or module label.
+- Multiple modules require explicit `cross-cutting`.
+- Ready requires a proof plan.
+- Blocked requires https dependency links that adapters accept.
+- Missing taxonomy fails closed with a named reason.
+
+## Dependency URLs
+
+Blocked dependency links must be https. Accepted shapes:
+
+- GitHub issue URLs (`/issues/`)
+- GitLab issue URLs (`/-/issues/`)
+- Azure Boards work-item URLs (`/_workitems/`)
+
+Reject `javascript:`, non-https schemes, and unknown hosts/shapes.
+
+## Filing behavior
+
+Validate before create. Confirmation digests bind repository and full content.
+Idempotency markers prevent duplicate creates on retry. One work item owns one
+problem; related items link, they do not merge into a receipt.

--- a/chaos-engine/skills/work-item/SKILL.md
+++ b/chaos-engine/skills/work-item/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: work-item
 description: >-
-  Portable work-item contract for opening or rewriting tickets on any SCM.
+  Use when opening or rewriting a work item on any git-based SCM.
   Source-control agnostic; GitHub, GitLab, and Azure Boards are adapters only.
 license: MIT
 ---
@@ -9,11 +9,10 @@ license: MIT
 # Work item
 
 Load this skill when the deliverable is **open or rewrite a work item**. Do not
-vendor Spec Kit or create `.specify/`. Keep GitHub PR delivery on the
-[GitHub playbook](../../references/work-github-playbook.md).
+vendor Spec Kit or create `.specify/`. Keep GitHub PR delivery on
+`work-github-playbook.md`.
 
-Contract: [work-item.md](../../references/work-item.md).
-Adapters: [work-item-adapters.md](../../references/work-item-adapters.md).
+Contract and adapters: [work-item.md](../../references/work-item.md).
 
 ## One item, one problem
 
@@ -30,8 +29,8 @@ Every body must include:
 - Success Criteria
 - Assumptions or Out of scope
 
-Keep adopter template headings (for example SHAFT bug/feature fields) so
-existing validators still match.
+Keep adopter template headings (for example bug or feature fields) so existing
+validators still match.
 
 ## Taxonomy
 
@@ -42,5 +41,6 @@ plan; blocked needs at least one https dependency URL.
 ## Adapter selection
 
 Detect the live CLI from the adopter environment. Do not assume GitHub.
-Command maps live in the adapters reference. Live create/edit remains whatever
-CLI the adopter already runs; dry-run and fake runners prove the other maps.
+Command maps live in the adapters reference named from the contract. Live
+create/edit remains whatever CLI the adopter already runs; dry-run and fake
+runners prove the other maps.

--- a/chaos-engine/skills/work-item/SKILL.md
+++ b/chaos-engine/skills/work-item/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: work-item
+description: >-
+  Portable work-item contract for opening or rewriting tickets on any SCM.
+  Source-control agnostic; GitHub, GitLab, and Azure Boards are adapters only.
+license: MIT
+---
+
+# Work item
+
+Load this skill when the deliverable is **open or rewrite a work item**. Do not
+vendor Spec Kit or create `.specify/`. Keep GitHub PR delivery on the
+[GitHub playbook](../../references/work-github-playbook.md).
+
+Contract: [work-item.md](../../references/work-item.md).
+Adapters: [work-item-adapters.md](../../references/work-item-adapters.md).
+
+## One item, one problem
+
+One work item owns one actionable problem. Trackers list children; they do not
+absorb them. Preserve existing acceptance when rewriting.
+
+## Required Spec Kit sections
+
+Every body must include:
+
+- User Scenarios & Testing
+- Edge Cases
+- Functional Requirements
+- Success Criteria
+- Assumptions or Out of scope
+
+Keep adopter template headings (for example SHAFT bug/feature fields) so
+existing validators still match.
+
+## Taxonomy
+
+Exactly one primary type, exactly one lifecycle, at least one subsystem or
+module. Missing taxonomy fails closed with a named reason. Ready needs a proof
+plan; blocked needs at least one https dependency URL.
+
+## Adapter selection
+
+Detect the live CLI from the adopter environment. Do not assume GitHub.
+Command maps live in the adapters reference. Live create/edit remains whatever
+CLI the adopter already runs; dry-run and fake runners prove the other maps.

--- a/scripts/agents/issue_filing.py
+++ b/scripts/agents/issue_filing.py
@@ -20,9 +20,28 @@ from urllib.parse import urlparse
 
 
 REQUIRED_HEADINGS = {
-    "bug": ("Describe the Bug", "Steps to Reproduce", "Expected Behavior", "Actual Behavior"),
-    "enhancement": ("Problem Statement", "Proposed Solution", "Alternatives Considered", "Use Case & Impact"),
+    "bug": (
+        "Describe the Bug",
+        "Steps to Reproduce",
+        "Expected Behavior",
+        "Actual Behavior",
+        "User Scenarios & Testing",
+        "Edge Cases",
+        "Functional Requirements",
+        "Success Criteria",
+    ),
+    "enhancement": (
+        "Problem Statement",
+        "Proposed Solution",
+        "Alternatives Considered",
+        "Use Case & Impact",
+        "User Scenarios & Testing",
+        "Edge Cases",
+        "Functional Requirements",
+        "Success Criteria",
+    ),
 }
+SCOPE_HEADINGS = ("Assumptions", "Out of scope")
 
 
 def _text(value) -> bool:
@@ -37,7 +56,34 @@ def _issue_url(value) -> bool:
     if not _text(value):
         return False
     parsed = urlparse(value)
-    return parsed.scheme == "https" and parsed.netloc == "github.com" and "/issues/" in parsed.path
+    if parsed.scheme != "https" or not parsed.netloc:
+        return False
+    host = parsed.netloc.lower()
+    path = parsed.path or ""
+    if host == "github.com" and "/issues/" in path:
+        return True
+    if "/-/issues/" in path:
+        return True
+    if ("dev.azure.com" in host or host.endswith("visualstudio.com")) and "/_workitems/" in path:
+        return True
+    return False
+
+
+def build_glab_issue_create_argv(plan: dict, repository: str, *, executable: str = "glab") -> list[str]:
+    return [
+        executable, "issue", "create", "--repo", repository, "--title", plan["title"],
+        "--description", plan["body"], "--label", ",".join(plan.get("labels") or []),
+    ]
+
+
+def build_az_boards_create_argv(
+    plan: dict, *, organization: str, project: str, executable: str = "az", work_item_type: str = "Issue",
+) -> list[str]:
+    return [
+        executable, "boards", "work-item", "create", "--organization", organization,
+        "--project", project, "--title", plan["title"], "--type", work_item_type,
+        "--description", plan["body"],
+    ]
 
 
 def validate_issue_plan(plan: object, taxonomy: object) -> dict:  # noqa: MC0001
@@ -71,6 +117,8 @@ def validate_issue_plan(plan: object, taxonomy: object) -> dict:  # noqa: MC0001
         for heading in REQUIRED_HEADINGS[issue_type]:
             if heading not in body:
                 reasons.append(f"template field is missing: {heading}")
+        if not any(heading in body for heading in SCOPE_HEADINGS):
+            reasons.append("template field is missing: Assumptions or Out of scope")
     if not _texts(plan.get("acceptanceCriteria")):
         reasons.append("acceptance criteria are required")
     if state == "ready" and not _texts(plan.get("proofPlan")):

--- a/scripts/ci/agent_guidance_budget.json
+++ b/scripts/ci/agent_guidance_budget.json
@@ -111,6 +111,7 @@
     ".agents/skills/*/SKILL.md",
     "chaos-engine/skills/chaos-engine/SKILL.md",
     "chaos-engine/skills/local-coding-delegate/SKILL.md",
+    "chaos-engine/skills/work-item/SKILL.md",
     "chaos-engine/references/*.md",
     "chaos-engine/profiles/shaft/**/*.md",
     ".claude/agents/*.md",
@@ -144,7 +145,8 @@
     ],
     "chaos-engine/skills": [
       "chaos-engine",
-      "local-coding-delegate"
+      "local-coding-delegate",
+      "work-item"
     ]
   },
   "skill_budgets": {
@@ -245,6 +247,7 @@
     ".agents/skills/*/SKILL.md",
     "chaos-engine/skills/chaos-engine/SKILL.md",
     "chaos-engine/skills/local-coding-delegate/SKILL.md",
+    "chaos-engine/skills/work-item/SKILL.md",
     "chaos-engine/references/*.md",
     "chaos-engine/profiles/shaft/**/*.md",
     ".claude/agents/*.md",

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1601,7 +1601,7 @@ class HostParityTest(unittest.TestCase):
     def test_both_hosts_expose_the_same_skill_set(self):
         canonical = {path.parent.name for path in CANONICAL_SKILLS.glob("*/SKILL.md")}
         claude = {path.parent.name for path in CLAUDE_SKILLS.glob("*/SKILL.md")}
-        self.assertEqual(canonical, {"chaos-engine", "local-coding-delegate"})
+        self.assertEqual(canonical, {"chaos-engine", "local-coding-delegate", "work-item"})
         self.assertEqual(claude, {"chaos-engine", "act-as-mohab"})
 
     def test_claude_skills_are_redirects_to_the_canonical_body(self):

--- a/tests/scripts/test_issue_filing.py
+++ b/tests/scripts/test_issue_filing.py
@@ -7,17 +7,46 @@ import threading
 import unittest
 from pathlib import Path
 
-from scripts.agents.issue_filing import confirmation_digest, create_issue, prepare_issue_plan, receipt_digest, reconcile_labels, transition_issue, validate_issue_plan
+from scripts.agents.issue_filing import (
+    build_az_boards_create_argv,
+    build_glab_issue_create_argv,
+    confirmation_digest,
+    create_issue,
+    prepare_issue_plan,
+    receipt_digest,
+    reconcile_labels,
+    transition_issue,
+    validate_issue_plan,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
 TAXONOMY = json.loads((ROOT / ".github/issue-taxonomy.json").read_text(encoding="utf-8"))
+SPEC_KIT_SECTIONS = (
+    "User Scenarios & Testing",
+    "Edge Cases",
+    "Functional Requirements",
+    "Success Criteria",
+    "Assumptions",
+)
 
 
 def planned() -> dict:
     return {
         "title": "Enforce detailed harness plans", "template": "feature_request.md",
-        "body": "## 🎯 Problem Statement\nPlans miss intent.\n## 💡 Proposed Solution\nValidate evidence.\n## 🔄 Alternatives Considered\nProse only.\n## 🗂️ Area of the Framework\nOther: harness\n## 📈 Use Case & Impact\nMaintainers.",
+        "body": (
+            "## 🎯 Problem Statement\nPlans miss intent.\n"
+            "## 💡 Proposed Solution\nValidate evidence.\n"
+            "## 🔄 Alternatives Considered\nProse only.\n"
+            "## 🗂️ Area of the Framework\nOther: harness\n"
+            "## 📈 Use Case & Impact\nMaintainers.\n"
+            "## User Scenarios & Testing\n### User Story 1\n"
+            "**Acceptance Scenarios**:\n1. **Given** a plan, **When** validated, **Then** allow.\n"
+            "## Edge Cases\n- Missing taxonomy fails closed.\n"
+            "## Functional Requirements\n- **FR-001**: Plans require Spec Kit sections.\n"
+            "## Success Criteria\n- **SC-001**: Incomplete plans are rejected.\n"
+            "## Assumptions\n- GitHub remains the live CLI."
+        ),
         "labels": ["enhancement", "subsystem:agent-harness", "ready"],
         "acceptanceCriteria": ["Validator rejects incomplete plans."],
         "proofPlan": ["Run focused tests."], "dependencies": [], "related": ["#4774"],
@@ -183,6 +212,60 @@ class IssueFilingTest(unittest.TestCase):
         edit = next(command for command in calls if command[1:3] == ["issue", "edit"])
         self.assertIn("blocked", edit)
         self.assertIn("deferred", edit)
+
+    def test_missing_success_criteria_blocks(self):
+        item = planned()
+        item["body"] = item["body"].replace("## Success Criteria\n- **SC-001**: Incomplete plans are rejected.\n", "")
+        receipt = validate_issue_plan(item, TAXONOMY)
+        self.assertEqual("block", receipt["decision"])
+        self.assertTrue(any("Success Criteria" in reason for reason in receipt["reasons"]))
+
+    def test_gitlab_dependency_url_allowed_for_blocked(self):
+        item = planned()
+        item["labels"][-1] = "blocked"
+        item["dependencies"] = ["https://gitlab.com/group/proj/-/issues/12"]
+        self.assertEqual("allow", validate_issue_plan(item, TAXONOMY)["decision"])
+
+    def test_garbage_dependency_url_rejected(self):
+        item = planned()
+        item["labels"][-1] = "blocked"
+        for bad in ("javascript:alert(1)", "http://github.com/x/y/issues/1", "not-a-url", "ftp://example.com/x"):
+            item["dependencies"] = [bad]
+            receipt = validate_issue_plan(item, TAXONOMY)
+            self.assertEqual("block", receipt["decision"], bad)
+
+    def test_azure_boards_dependency_url_allowed_for_blocked(self):
+        item = planned()
+        item["labels"][-1] = "blocked"
+        item["dependencies"] = ["https://dev.azure.com/org/project/_workitems/edit/42"]
+        self.assertEqual("allow", validate_issue_plan(item, TAXONOMY)["decision"])
+
+    def test_fake_glab_and_az_boards_argv(self):
+        item = planned()
+        glab = build_glab_issue_create_argv(item, "group/proj", executable="glab")
+        self.assertEqual(
+            ["glab", "issue", "create", "--repo", "group/proj", "--title", item["title"],
+             "--description", item["body"], "--label", ",".join(item["labels"])],
+            glab,
+        )
+        az = build_az_boards_create_argv(item, organization="https://dev.azure.com/org", project="project", executable="az")
+        self.assertEqual(
+            ["az", "boards", "work-item", "create", "--organization", "https://dev.azure.com/org",
+             "--project", "project", "--title", item["title"], "--type", "Issue",
+             "--description", item["body"]],
+            az,
+        )
+
+    def test_ready_plan_still_allows_with_spec_kit_sections(self):
+        receipt = validate_issue_plan(planned(), TAXONOMY)
+        self.assertEqual("allow", receipt["decision"])
+
+    def test_work_item_contract_names_spec_kit_sections(self):
+        skill = (ROOT / "chaos-engine/skills/work-item/SKILL.md").read_text(encoding="utf-8")
+        contract = (ROOT / "chaos-engine/references/work-item.md").read_text(encoding="utf-8")
+        combined = skill + "\n" + contract
+        for section in SPEC_KIT_SECTIONS:
+            self.assertIn(section, combined)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add portable ChaosEngine work-item skill, contract, and SCM adapters (GitHub live; glab/az builders).
- Route "open or rewrite a work item" in portable and SHAFT routing; keep GitHub playbook for merged-PR delivery.
- Lift `issue_filing.py` to accept GitLab/Azure https dependency URLs, reject non-https/javascript, require Spec Kit headings, and extend GitHub issue templates additively.
- Retag and Spec-Kit rewrite currently open issues (including parking #4307, #5144, #5151 as blocked).

Closes #5187
Closes #5188
Closes #5189
Related to #5186

## Checks

- `py -3 -m unittest tests.scripts.test_issue_filing` — 20 tests OK
- Agent Guidance Gate ubuntu/windows SUCCESS
- ChaosEngine acceptance ubuntu/macos/windows SUCCESS
- PR Gate Summary SUCCESS
- Independent orchestrator review: zero blocking findings on `985b4ba29397bc714a193fd045d483a78f1d9f2f`

## Continuation

Head: `985b4ba29397bc714a193fd045d483a78f1d9f2f`
State: required checks green; independent review posted
Blockers: none
Next action: arm merge-commit auto-merge