### PR TITLE
fix(harness): pin playbook first-occurrence companion-docs nouns

### DIFF
--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -620,12 +620,18 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             self.assertEqual(2, content.count("AI-supported details"))
             self.assertEqual(2, content.count("properties"))
             self.assertEqual(2, content.count("exact commands"))
+            self.assertEqual(2, content.count("never a fixed sibling path"))
+            self.assertEqual(2, content.count("description of the change"))
+            self.assertEqual(2, content.count("locator policy"))
 
         assert_playbook_first_occurrence_nouns(playbook)
         for noun, weakened_noun in (
             ("AI-supported details", "model-supported details"),
             ("properties", "settings"),
             ("exact commands", "exact invocations"),
+            ("never a fixed sibling path", "never a hardcoded sibling path"),
+            ("description of the change", "description of the edit"),
+            ("locator policy", "selector policy"),
         ):
             weakened = playbook.replace(noun, weakened_noun, 1)
             self.assertNotEqual(playbook, weakened)


### PR DESCRIPTION
## Summary
Extends `assert_playbook_first_occurrence_nouns` so playbook first-occurrence rewrites of `never a fixed sibling path`, `description of the change`, and `locator policy` fail the companion-docs pin the same way `AI-supported details` / `properties` / `exact commands` already do. No policy wording change; no reopen of #5173/#5175 parents.

## Checks
- RED: added three first-only weakening mutations; focused unittest failed with `AssertionError not raised` for each new noun.
- GREEN: extended helper `count==2` asserts for the three nouns.
- Proof: `py -3 -m unittest tests.scripts.test_chaos_engine_portable_core.ChaosEnginePortableCoreTest.test_shaft_user_facing_changes_require_companion_docs_prs` → OK

## Continuation
Independent review is a separate agent. Do not merge from this implementer. Tracker remains #5186.

Closes #5180
Closes #5182
Closes #5183
Related to #5186
