### PR TITLE
fix: classify mvn test as runtime and gate coverage continue-on-error

### DIFF
--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -702,7 +702,9 @@ def validate_scheduled_build_retry(workflows: dict[str, str]) -> list[str]:
     """Require transfer-only retries for restartable builds, never runtime tests."""
     errors: list[str] = []
     build_launch = re.compile(r"(?:^|\s)(?:mvn|(?:\./)?gradlew)(?:\s|$)")
-    runtime_test = re.compile(r"(?:^|\s)mvn\s+.*(?:^|\s)test(?:\s|$)")
+    # `(?:.*\s)?` lets `test` be the first token after `mvn ` (`mvn test`),
+    # which the previous `(?:^|\s)test` form missed after consuming that space.
+    runtime_test = re.compile(r"(?:^|\s)mvn\s+(?:.*\s)?test(?:\s|$)")
     for workflow_name, workflow_text in workflows.items():
         try:
             document = yaml.safe_load(workflow_text) or {}

--- a/tests/scripts/test_agent_router_contract.py
+++ b/tests/scripts/test_agent_router_contract.py
@@ -1849,6 +1849,61 @@ class CiGateIsBlockingTest(unittest.TestCase):
             workflow["jobs"]["dependency-review"]["if"],
         )
 
+    def test_coverage_continue_on_error_pin_runs_in_agent_guidance_gate(self):
+        # #5172: deleting continue-on-error must fail required CI, not only a
+        # local module the Agent Guidance Gate never runs.
+        pin_def = "def test_required_pr_gate_coverage_uploads_continue_on_error"
+        yaml = __import__("yaml")
+        workflow = yaml.safe_load(self.WORKFLOW.read_text(encoding="utf-8"))
+        commands = " ".join(
+            str(step.get("run", "")) for step in workflow["jobs"]["agent-guidance"]["steps"]
+        )
+        owners = []
+        for path in (ROOT / "tests" / "scripts").glob("test_*.py"):
+            if pin_def in path.read_text(encoding="utf-8"):
+                owners.append(f"tests.scripts.{path.stem}")
+        self.assertTrue(owners, "continue-on-error coverage pin is missing")
+        missing = [module for module in owners if module not in commands]
+        self.assertEqual(
+            missing,
+            [],
+            "coverage continue-on-error pin must live in an Agent Guidance Gate unittest module",
+        )
+
+    def test_required_pr_gate_coverage_uploads_continue_on_error(self):
+        # #5050 / #5172: codecov-action downloads before the composite's
+        # main-only `if`, so a 429 fails the required job after Maven is green.
+        yaml = __import__("yaml")
+        workflow = yaml.safe_load(self.WORKFLOW.read_text(encoding="utf-8"))
+        jobs = workflow["jobs"]
+        required_jobs = {
+            name
+            for name in jobs["summary"]["needs"]
+            if name != "changes"
+        }
+        found = []
+        missing = []
+        for job_id, job in jobs.items():
+            if job_id not in required_jobs or not isinstance(job, dict):
+                continue
+            for index, step in enumerate(job.get("steps") or []):
+                if not isinstance(step, dict):
+                    continue
+                uses = str(step.get("uses") or "").rstrip("/")
+                if uses != "./.github/actions/upload-jacoco-coverage":
+                    continue
+                found.append(job_id)
+                if step.get("continue-on-error") is not True:
+                    missing.append(f"{job_id}[{index}] {step.get('name')}")
+        self.assertIn("cli", found)
+        self.assertGreaterEqual(len(found), 2)
+        self.assertEqual(
+            missing,
+            [],
+            "required PR Gate coverage uploads must continue-on-error so a "
+            "Codecov action download 429 cannot fail a green Maven job",
+        )
+
 
 class GlobFilesHelperTest(unittest.TestCase):
     """The resolver every GUIDANCE_GLOBS consumer in this file shares.

--- a/tests/scripts/test_validate_quality_configuration.py
+++ b/tests/scripts/test_validate_quality_configuration.py
@@ -2,8 +2,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import yaml
-
 from scripts.ci.validate_quality_configuration import (
     validate_browser_matrix_scope_policy,
     validate_codeql_build_mode,
@@ -817,40 +815,6 @@ jobs:
 
             self.assertIn("root pom.xml must include report-aggregate", errors)
             self.assertIn("report-aggregate/pom.xml is missing", errors)
-
-    def test_required_pr_gate_coverage_uploads_continue_on_error(self):
-        # #5050: GitHub downloads codecov-action before the composite's main-only
-        # `if`, so a 429 fails the required job after Maven is already green.
-        workflow_path = Path(__file__).resolve().parents[2] / ".github/workflows/pr-gate.yml"
-        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
-        jobs = workflow["jobs"]
-        required_jobs = {
-            name
-            for name in jobs["summary"]["needs"]
-            if name != "changes"
-        }
-        found = []
-        missing = []
-        for job_id, job in jobs.items():
-            if job_id not in required_jobs or not isinstance(job, dict):
-                continue
-            for index, step in enumerate(job.get("steps") or []):
-                if not isinstance(step, dict):
-                    continue
-                uses = str(step.get("uses") or "").rstrip("/")
-                if uses != "./.github/actions/upload-jacoco-coverage":
-                    continue
-                found.append(job_id)
-                if step.get("continue-on-error") is not True:
-                    missing.append(f"{job_id}[{index}] {step.get('name')}")
-        self.assertIn("cli", found)
-        self.assertGreaterEqual(len(found), 2)
-        self.assertEqual(
-            missing,
-            [],
-            "required PR Gate coverage uploads must continue-on-error so a "
-            "Codecov action download 429 cannot fail a green Maven job",
-        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **#5178:** Fix `validate_scheduled_build_retry` `runtime_test` so `mvn test` is classified as a runtime test. The old `(?:^|\s)test` form required extra whitespace after the space consumed by `mvn\s+`, so bare `mvn test` was treated as a restartable build.
- **#5172:** Move `test_required_pr_gate_coverage_uploads_continue_on_error` onto `tests.scripts.test_agent_router_contract` (already required by Agent Guidance Gate) and add a registration pin so the continue-on-error owner module must stay in that gate.

## Checks

- RED observed for #5178 synthetic retry tests and for the #5172 registration pin.
- GREEN:
  - `py -3 -m unittest tests.scripts.test_validate_quality_configuration.ValidateQualityConfigurationTest.test_scheduled_builds_retry_only_restartable_launches tests.scripts.test_validate_quality_configuration.ValidateQualityConfigurationTest.test_scheduled_build_retry_rejects_unwrapped_prep_and_wrapped_tests`
  - `py -3 -m unittest tests.scripts.test_agent_router_contract.CiGateIsBlockingTest.test_coverage_continue_on_error_pin_runs_in_agent_guidance_gate tests.scripts.test_agent_router_contract.CiGateIsBlockingTest.test_required_pr_gate_coverage_uploads_continue_on_error`
- Full `py -3 -m unittest tests.scripts.test_validate_quality_configuration`: #5178 cases pass; pre-existing `test_repository_configuration_is_valid` failure remains on this base for `shaft-pilot-release.yml` jobs missing coverage upload (unrelated to this diff; reproduced on clean `origin/main` SHA before edits).

## Continuation

Closes #5178
Closes #5172
Related to #5186
Tracker remains #5186