### PR TITLE
fix(doctor): firstFailedLocator same-line getBy* and Autobot shared sanitize

### DIFF
--- a/shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorProviderDiagnosis.java
+++ b/shaft-doctor/src/main/java/com/shaft/doctor/internal/DoctorProviderDiagnosis.java
@@ -94,26 +94,30 @@ public final class DoctorProviderDiagnosis {
         if (text == null || text.isBlank()) {
             return "";
         }
-        Matcher earliest = null;
-        int start = Integer.MAX_VALUE;
-        boolean useGroup1 = false;
+        Matcher earliestSpecific = null;
+        int specificStart = Integer.MAX_VALUE;
         for (Pattern pattern : SPECIFIC_LOCATORS) {
             Matcher matcher = pattern.matcher(text);
-            if (matcher.find() && matcher.start() < start) {
-                earliest = matcher;
-                start = matcher.start();
-                useGroup1 = false;
+            if (matcher.find() && matcher.start() < specificStart) {
+                earliestSpecific = matcher;
+                specificStart = matcher.start();
             }
         }
         Matcher failed = FAILED_LOCATOR.matcher(text);
-        if (failed.find() && failed.start() < start) {
-            earliest = failed;
-            useGroup1 = true;
+        boolean failedFound = failed.find();
+        int failedStart = failedFound ? failed.start() : Integer.MAX_VALUE;
+        int failedEnd = failedFound ? failed.end() : -1;
+        // Prefer a specific dialect that starts inside a greedy By.* span so same-line
+        // By.cssSelector: ... getByRole(...) does not return truncated getByRole("button".
+        boolean specificSwallowedByFailed = failedFound && earliestSpecific != null
+                && failedStart < specificStart && specificStart < failedEnd;
+        if (earliestSpecific != null
+                && (specificStart <= failedStart || specificSwallowedByFailed)) {
+            return earliestSpecific.group().replaceAll("\\s+", " ").trim();
         }
-        if (earliest == null) {
-            return "";
+        if (failedFound) {
+            return failed.group(1).replaceAll("\\s+", " ").trim();
         }
-        String match = useGroup1 ? earliest.group(1) : earliest.group();
-        return match.replaceAll("\\s+", " ").trim();
+        return "";
     }
 }

--- a/shaft-doctor/src/test/java/com/shaft/doctor/internal/DoctorProviderDiagnosisTest.java
+++ b/shaft-doctor/src/test/java/com/shaft/doctor/internal/DoctorProviderDiagnosisTest.java
@@ -1,0 +1,21 @@
+package com.shaft.doctor.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class DoctorProviderDiagnosisTest {
+
+    @Test
+    void firstFailedLocatorDoesNotSwallowLaterGetByRoleAfterByCssSelectorOnSameLine() {
+        String evidence = "checklist: By.cssSelector: #submit-canary getByRole(\"button\", { name: \"Submit canary\" })";
+        String truncatedSwallow = "By.cssSelector: #submit-canary getByRole(\"button\"";
+
+        String locator = DoctorProviderDiagnosis.firstFailedLocator(evidence);
+
+        assertFalse(locator.contains(truncatedSwallow),
+                "Same-line By.cssSelector: must not swallow into truncated getByRole(\"button\": " + locator);
+        assertEquals("getByRole(\"button\", { name: \"Submit canary\" })", locator);
+    }
+}

--- a/shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java
+++ b/shaft-mcp/src/main/java/com/shaft/mcp/AutobotService.java
@@ -2,6 +2,7 @@ package com.shaft.mcp;
 
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import com.shaft.doctor.internal.DoctorProviderDiagnosis;
 import com.shaft.driver.SHAFT;
 import com.shaft.pilot.ai.AiBudget;
 import com.shaft.pilot.ai.AiExecutionService;
@@ -31,7 +32,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 /**
  * MCP adapter for SHAFT Autobot local agent routing.
@@ -40,11 +40,6 @@ import java.util.regex.Pattern;
 public class AutobotService {
     private static final int DEFAULT_TIMEOUT_SECONDS = 300;
     private static final int MAX_PROMPT_CHARS = 4_000;
-    private static final Pattern SECRET_LIKE = Pattern.compile(
-            "(?i)([\"']?authorization[\"']?\\s*[:=]\\s*(?:(?:basic|bearer)\\s+)?(?:\"[^\"]+\"|'[^']+'|[^\\s,;]+)"
-                    + "|[\"']?bearer[\"']?\\s+[a-z0-9._\\-]{8,}"
-                    + "|[\"']?api[_-]?key[\"']?\\s*[:=]\\s*(?:\"[^\"]+\"|'[^']+'|[^\\s,;]+)"
-                    + "|sk-[a-z0-9._\\-]{8,})");
     static final String CLOUD_AGENT_MODE_WARNING =
             "Cloud provider chat supports Ask and Plan only; use a local CLI runtime for Agent edits.";
     private static final ObjectMapper JSON = new ObjectMapper();
@@ -428,7 +423,7 @@ public class AutobotService {
     }
 
     private static String boundedPrompt(String prompt) {
-        String sanitized = SECRET_LIKE.matcher(text(prompt)).replaceAll("[REDACTED]");
+        String sanitized = DoctorProviderDiagnosis.sanitize(text(prompt));
         return sanitized.length() > MAX_PROMPT_CHARS ? sanitized.substring(0, MAX_PROMPT_CHARS) : sanitized;
     }
 

--- a/shaft-mcp/src/test/java/com/shaft/mcp/AutobotServiceTest.java
+++ b/shaft-mcp/src/test/java/com/shaft/mcp/AutobotServiceTest.java
@@ -19,11 +19,14 @@ import com.shaft.driver.SHAFT;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -135,6 +138,45 @@ class AutobotServiceTest {
         assertEquals(AiResponseStatus.SUCCESS.name(), response.status());
         assertEquals("ok", response.answer());
         assertEquals("Explain this failure", capturedText.get());
+    }
+
+    @Test
+    void autobotDoesNotShipPrivateSecretLikeCopyThatCanDriftFromSharedHelper() throws Exception {
+        Path source = Path.of("src/main/java/com/shaft/mcp/AutobotService.java");
+        String text = Files.readString(source, StandardCharsets.UTF_8);
+        assertFalse(Pattern.compile("private\\s+static\\s+final\\s+Pattern\\s+SECRET_LIKE\\b").matcher(text).find(),
+                "AutobotService must not keep a private SECRET_LIKE copy; use DoctorProviderDiagnosis");
+        assertTrue(text.contains("DoctorProviderDiagnosis"),
+                "AutobotService must call the shared DoctorProviderDiagnosis helper");
+    }
+
+    @Test
+    void providerChatRedactsLocatorDialectsThroughSharedHelper() {
+        AtomicReference<String> capturedText = new AtomicReference<>("");
+        AutobotService service = new AutobotService(McpWorkspacePolicy.of(workspace),
+                new LocalAgentService(client -> true, new CapturingRunner()), request -> {
+                    capturedText.set(request.text());
+                    return AiResponse.success("ollama", "local-model",
+                            tools.jackson.databind.node.JsonNodeFactory.instance.objectNode().put("answer", "ok"),
+                            Duration.ofMillis(10), com.shaft.pilot.ai.AiUsage.empty(),
+                            request.deterministicFallback());
+                });
+
+        AutobotProviderChatResponse response = service.runProviderChat(
+                "ollama",
+                "local-model",
+                "ASK",
+                "Explain failure around getByRole(\"button\", { name: \"Submit canary\" }) "
+                        + "and By.cssSelector: #submit-canary",
+                "",
+                10,
+                false);
+
+        assertEquals(AiResponseStatus.SUCCESS.name(), response.status());
+        String text = capturedText.get();
+        assertFalse(text.contains("getByRole(\"button\", { name: \"Submit canary\" })"), text);
+        assertFalse(text.contains("By.cssSelector: #submit-canary"), text);
+        assertTrue(text.contains("[LOCATOR]"), text);
     }
 
     @Test


### PR DESCRIPTION
Closes #5165
Closes #5166
Related to #5186

Tracker remains #5186.

## Summary

`DoctorProviderDiagnosis.firstFailedLocator` now prefers a specific locator dialect (`getBy*`, `SHAFT.GUI.Locator.*`, Selenium 3 JSON) when a greedy `By.*` span would otherwise swallow it on the same line. Provider `sanitize()` order from #5164 is unchanged.

`AutobotService` drops its private `SECRET_LIKE` copy and routes provider prompts through `DoctorProviderDiagnosis.sanitize`, so Autobot shares secret and locator redaction with Repair, Analysis, and MCP.

## Checks

RED (assertion failures observed before the production fix):

```
mvn -pl shaft-doctor "-Dtest=DoctorProviderDiagnosisTest" "-Dallure.automaticallyOpen=false" test
mvn -pl shaft-mcp -am test "-Dtest=AutobotServiceTest#autobotDoesNotShipPrivateSecretLikeCopyThatCanDriftFromSharedHelper+providerChatRedactsLocatorDialectsThroughSharedHelper" "-Dallure.automaticallyOpen=false" "-Dsurefire.failIfNoSpecifiedTests=false"
```

GREEN (balanced proof):

```
mvn -pl shaft-doctor,shaft-mcp -am test "-Dtest=DoctorProviderDiagnosis*,AutobotServiceTest" "-Dallure.automaticallyOpen=false" "-Dsurefire.failIfNoSpecifiedTests=false"
```

DoctorProviderDiagnosisTest: 1 passed. AutobotServiceTest: 22 passed. BUILD SUCCESS.

## Continuation

- Head: 382bd20c6626c498978252dbea2ac57d18697372
- State: Ready PR for #5165 and #5166. Independent adversarial review not yet run. Auto-merge not armed by assignment.
- Blockers: none from the focused checks.
- Next action: independent adversarial review of this diff, then arm or request changes. Do not merge from this assignment.
