### PR TITLE
fix(harness): pin index-v2 order, retry nested hook flake, promote .toml

### DIFF
--- a/tests/scripts/test_agent_harness_portability.py
+++ b/tests/scripts/test_agent_harness_portability.py
@@ -732,17 +732,25 @@ class AgentHarnessPortabilityTest(unittest.TestCase):
             command = handler.get("commandWindows") or subprocess.list2cmdline(
                 [handler["command"], *handler.get("args", [])]
             )
-            completed = subprocess.run(
-                command,
-                shell=True,  # nosec B602 - executes the repository's tracked hook definition.
-                input=payload,
-                cwd=ROOT / "shaft-engine",
-                env=dict(os.environ, SHAFT_GUARD_HOST=config_path.parent.name),
-                capture_output=True,
-                text=True,
-                timeout=10,
-                check=False,
-            )
+
+            def run_hook():
+                return subprocess.run(
+                    command,
+                    shell=True,  # nosec B602 - executes the repository's tracked hook definition.
+                    input=payload,
+                    cwd=ROOT / "shaft-engine",
+                    env=dict(os.environ, SHAFT_GUARD_HOST=config_path.parent.name),
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=False,
+                )
+
+            try:
+                completed = run_hook()
+            except subprocess.TimeoutExpired:
+                # Windows CI can flake once on cold py -3 startup; retry once only.
+                completed = run_hook()
             self.assertEqual(completed.returncode, 0, completed.stderr)
             self.assertIn("R1", completed.stdout)
 

--- a/tests/scripts/test_local_coding_agent.py
+++ b/tests/scripts/test_local_coding_agent.py
@@ -288,12 +288,30 @@ class LocalCodingAgentPackagingTest(unittest.TestCase):
         self.assertIn("PositionalBinding = $false", architect_text)
 
     def test_launchers_downgrade_worktree_index_to_version_2(self):
+        needle = "git -C $Worktree update-index --index-version 2"
         for path in (RUN_AGENT, ARCHITECT):
             with self.subTest(path.name):
                 text = path.read_text(encoding="utf-8")
-                self.assertIn("update-index", text)
-                self.assertIn("--index-version", text)
-                self.assertIn("--index-version 2", text)
+                index_at = text.find(needle)
+                self.assertNotEqual(-1, index_at, f"missing {needle}")
+                aider_at = text.find("& $aider")
+                self.assertNotEqual(-1, aider_at, "missing Aider invocation")
+                self.assertLess(
+                    index_at,
+                    aider_at,
+                    "index downgrade must run before Aider starts",
+                )
+                fail_closed = text[index_at:aider_at]
+                self.assertIn(
+                    "if ($LASTEXITCODE -ne 0)",
+                    fail_closed,
+                    "index downgrade must fail closed on nonzero exit",
+                )
+                self.assertIn(
+                    "git update-index --index-version 2 failed",
+                    fail_closed,
+                )
+                self.assertIn("exit 2", fail_closed)
 
 
 class LocalCodingAgentCitedPathTest(unittest.TestCase):

--- a/tests/scripts/test_mempalace_promote.py
+++ b/tests/scripts/test_mempalace_promote.py
@@ -39,6 +39,7 @@ class MempalacePromoteTest(unittest.TestCase):
                 "samples/login.feature": "Feature: login\n",
                 "shaft-mcp/Dockerfile": "FROM scratch\n",
                 "shaft-mcp/Dockerfile.fly": "FROM scratch\n",
+                "chaos-engine/hosts.toml": "name = \"fixture\"\n",
                 "src/ok.py": "print(1)\n",
             }
             root.mkdir()
@@ -65,6 +66,7 @@ class MempalacePromoteTest(unittest.TestCase):
             listed = module.list_promote_paths(root)
             self.assertEqual(
                 [
+                    "chaos-engine/hosts.toml",
                     "samples/login.feature",
                     "shaft-mcp/Dockerfile",
                     "shaft-mcp/Dockerfile.fly",

--- a/tools/repository-map/mempalace_promote.py
+++ b/tools/repository-map/mempalace_promote.py
@@ -12,7 +12,7 @@ def is_promote_path(relative: str) -> bool:
     posix = PurePosixPath(relative.replace("\\", "/"))
     name = posix.name
     suffix = posix.suffix.lower()
-    if suffix == ".properties" or suffix == ".feature":
+    if suffix == ".properties" or suffix == ".feature" or suffix == ".toml":
         return True
     if suffix == ".xml" and name.casefold() != "pom.xml":
         return True


### PR DESCRIPTION
## Summary
Pins local-coding-agent launcher index-v2 command order and fail-closed exit handling, retries the Windows nested-dir hook flake once, and force-includes `.toml` in MemPalace promote paths.

Closes #5078
Closes #5117
Closes #5128
Related to #5186
Tracker remains #5186

## Changes
- **#5078:** Strengthen `test_launchers_downgrade_worktree_index_to_version_2` so it fails if `git -C $Worktree update-index --index-version 2` is not before `& $aider`, or if the fail-closed `LASTEXITCODE` / update-index error path is missing. Production launchers already satisfied the invariant.
- **#5117:** Retry `test_windows_hook_commands_execute_from_a_nested_directory` once on `TimeoutExpired`; second timeout still fails. Production hook timeout unchanged.
- **#5128:** `is_promote_path` includes `.toml`; fixture expects `chaos-engine/hosts.toml`.

## Checks
```text
py -3 -m unittest tests.scripts.test_local_coding_agent tests.scripts.test_agent_harness_portability.AgentHarnessPortabilityTest.test_windows_hook_commands_execute_from_a_nested_directory tests.scripts.test_mempalace_promote
```
Result: OK (42 tests).

## Continuation
Head: f4215a82efd32a609df6f03859566396e2b049ba
State: PR open; awaiting review gate. Implementer must not merge.
Blockers: none
Next action: independent adversarial review, then authorized merge path.

## Out of scope
Does not upgrade Aider, change `feature.manyFiles`, close #5017, raise production hook timeout, pin-bump Graphify, or close #5119/#5120.