### PR TITLE
fix(ci): align pilot-release coverage policy for three JVM jobs

### DIFF
--- a/.github/workflows/shaft-pilot-release.yml
+++ b/.github/workflows/shaft-pilot-release.yml
@@ -82,6 +82,14 @@ jobs:
         uses: actions/checkout@v7
       - name: Verify IntelliJ plugin release candidate
         uses: ./.github/actions/intellij-verify
+      - name: Upload IntelliJ coverage to Codecov
+        if: always()
+        uses: ./.github/actions/upload-jacoco-coverage
+        with:
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./shaft-intellij/build/reports/jacoco/test/jacocoTestReport.xml
+          required-files: ./shaft-intellij/build/reports/jacoco/test/jacocoTestReport.xml
+          source-id: shaft-pilot-release-intellij-verify
 
   release-contracts:
     needs: detect-shaft-version-change
@@ -183,6 +191,13 @@ jobs:
           -am install -DskipTests -Dgpg.skip
       - name: Run headless SHAFT Capture release journey
         uses: ./.github/actions/capture-browser-e2e
+      - name: Upload Capture journey coverage to Codecov
+        if: always()
+        uses: ./.github/actions/upload-jacoco-coverage
+        with:
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          required-files: ./shaft-capture/target/jacoco/jacoco.xml
+          source-id: shaft-pilot-release-capture-journey
 
   package-and-validate:
     needs: detect-shaft-version-change

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -228,6 +228,17 @@ def _normalize_workflow_condition(condition: str) -> str:
     return condition.strip().lower().replace("${{", "").replace("}}", "").strip()
 
 
+_SAFE_COVERAGE_GUARDS = (
+    r"steps\.[a-z0-9_-]+\.outcome\s*!=\s*['\"]skipped['\"]",
+    r"github\.event_name\s*!=\s*['\"]pull_request['\"]",
+    r"github\.ref\s*==\s*['\"]refs/heads/main['\"]",
+)
+
+
+def _coverage_guard_is_safe(guard: str) -> bool:
+    return any(re.fullmatch(pattern, guard) for pattern in _SAFE_COVERAGE_GUARDS)
+
+
 def _coverage_step_runs_after_failure_on_main(
     step: dict[object, object], test_conditions: set[str]
 ) -> bool:
@@ -238,16 +249,16 @@ def _coverage_step_runs_after_failure_on_main(
     if not isinstance(condition, str):
         return False
     normalized = _normalize_workflow_condition(condition)
-    safe_conditions = (
-        r"always\(\)",
-        r"always\(\)\s*&&\s*steps\.[a-z0-9_-]+\.outcome\s*!=\s*['\"]skipped['\"]",
-        r"always\(\)\s*&&\s*github\.event_name\s*!=\s*['\"]pull_request['\"]",
-        r"always\(\)\s*&&\s*github\.ref\s*==\s*['\"]refs/heads/main['\"]",
-    )
-    if any(re.fullmatch(pattern, normalized) for pattern in safe_conditions):
+    if normalized == "always()":
         return True
     conditional = re.fullmatch(r"always\(\)\s*&&\s*(.+)", normalized)
-    return bool(conditional and conditional.group(1).strip() in test_conditions)
+    if not conditional:
+        return False
+    remainder = conditional.group(1).strip()
+    if remainder in test_conditions:
+        return True
+    guards = [part.strip() for part in re.split(r"\s*&&\s*", remainder) if part.strip()]
+    return bool(guards) and all(_coverage_guard_is_safe(guard) for guard in guards)
 
 
 def validate_workflow_coverage_policy(root: Path = ROOT) -> list[str]:

--- a/tests/scripts/test_validate_quality_configuration.py
+++ b/tests/scripts/test_validate_quality_configuration.py
@@ -643,6 +643,35 @@ jobs:
 
             self.assertEqual(validate_workflow_coverage_policy(root), [])
 
+    def test_accepts_conjunction_of_individually_safe_coverage_guards(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "coverage.yml").write_text(
+                "jobs:\n"
+                "  combined-safe-guards:\n"
+                "    steps:\n"
+                "      - id: pilot_tests\n"
+                "        run: mvn -pl shaft-pilot-core test\n"
+                "      - if: always() && github.event_name != 'pull_request' && steps.pilot_tests.outcome != 'skipped'\n"
+                "        uses: ./.github/actions/upload-jacoco-coverage\n"
+                "  single-event-guard:\n"
+                "    steps:\n"
+                "      - run: mvn test\n"
+                "      - if: always() && github.event_name != 'pull_request'\n"
+                "        uses: ./.github/actions/upload-jacoco-coverage\n"
+                "  single-outcome-guard:\n"
+                "    steps:\n"
+                "      - id: unit_tests\n"
+                "        run: mvn test\n"
+                "      - if: always() && steps.unit_tests.outcome != 'skipped'\n"
+                "        uses: ./.github/actions/upload-jacoco-coverage\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(validate_workflow_coverage_policy(root), [])
+
     def test_detects_maven_wrapper_lifecycle_and_explicit_skip_tests_false(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
Closes #5198
Related to #5186

Tracker remains #5186.

## Summary

`validate_workflow_coverage_policy` rejected `shaft-pilot-release.yml` jobs `intellij-verify`, `pilot-tests`, and `capture-journey`.

- Teach `_coverage_step_runs_after_failure_on_main` to accept `always() &&` followed by one or more already-safe atomic guards, so the live `pilot-tests` upload condition keeps both the PR skip and skipped-step skip without weakening the pin.
- Add post-test `upload-jacoco-coverage` steps to `intellij-verify` and `capture-journey`, matching the existing IntelliJ/Capture report paths used elsewhere.

## Checks

```text
py -3 -m unittest tests.scripts.test_validate_quality_configuration.ValidateQualityConfigurationTest.test_repository_configuration_is_valid
# OK

py -3 -m unittest `
  tests.scripts.test_validate_quality_configuration.ValidateQualityConfigurationTest.test_accepts_conjunction_of_individually_safe_coverage_guards `
  tests.scripts.test_validate_quality_configuration.ValidateQualityConfigurationTest.test_rejects_coverage_that_cannot_run_after_the_last_test_on_main `
  tests.scripts.test_validate_quality_configuration.ValidateQualityConfigurationTest.test_accepts_same_job_coverage_actions_and_ignores_skip_tests_setup `
  tests.scripts.test_validate_quality_configuration.ValidateQualityConfigurationTest.test_rejects_jvm_test_job_without_jacoco_upload `
  tests.scripts.test_validate_quality_configuration.ValidateQualityConfigurationTest.test_detects_jvm_tests_inside_local_composite_action `
  tests.scripts.test_validate_quality_configuration.ValidateQualityConfigurationTest.test_ignores_echoed_commands_and_rejects_disabled_or_fake_coverage_steps
# OK

py -3 -m unittest tests.scripts.test_validate_shaft_pilot_release
# OK (24 tests)
```

## Continuation

Head: a5678875f8ff8d5808c7bf212e36357801ceebe7
State: PR opened; implementer delivery complete; do not merge from this agent.
Blockers: none
Next action: independent review / orchestrator merge decision.