### PR TITLE
fix(harness): specialize Spec Kit hygiene rewrites per issue acceptance

### DIFF
--- a/chaos-engine/references/work-item.md
+++ b/chaos-engine/references/work-item.md
@@ -19,6 +19,11 @@ Every opened or rewritten work item body must contain these section names:
 Adopter templates may keep their own headings (Describe the Bug, Problem
 Statement, and so on). Spec Kit sections are additive.
 
+Hygiene rewrites must specialize User Story / `FR-*` / `SC-*` from the issue's
+own acceptance via `rewrite_body_spec_kit`. Do not stamp
+`Deliver the stated acceptance` (or identical FR/SC boilerplate) onto unrelated
+issues. Trackers may keep a campaign-level story. Closed issues need no rewrite.
+
 ## Taxonomy rules
 
 - Exactly one primary type.

--- a/chaos-engine/skills/work-item/SKILL.md
+++ b/chaos-engine/skills/work-item/SKILL.md
@@ -32,6 +32,12 @@ Every body must include:
 Keep adopter template headings (for example bug or feature fields) so existing
 validators still match.
 
+When rewriting an existing item for Spec Kit hygiene, specialize User Story,
+`FR-*`, and `SC-*` from that issue's own acceptance (see
+`scripts.agents.issue_filing.rewrite_body_spec_kit`). Keep the shared heading
+checklist; never paste the generic stamp `Deliver the stated acceptance` onto
+unrelated tickets. Trackers may keep a campaign-level story.
+
 ## Taxonomy
 
 Exactly one primary type, exactly one lifecycle, at least one subsystem or

--- a/scripts/agents/issue_filing.py
+++ b/scripts/agents/issue_filing.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess  # nosec B404 - fixed gh list/create arguments, no shell.
 import tempfile
@@ -42,7 +43,112 @@ REQUIRED_HEADINGS = {
     ),
 }
 SCOPE_HEADINGS = ("Assumptions", "Out of scope")
+GENERIC_USER_STORY_STAMP = "Deliver the stated acceptance"
+_SPEC_KIT_FALLBACK_RE = re.compile(
+    r"## User Scenarios & Testing\b.*?(?=\n## (?!User Scenarios & Testing\b)|$)",
+    re.DOTALL,
+)
+_SPEC_KIT_CLUSTER_RE = re.compile(
+    r"## User Scenarios & Testing\b.*?"
+    r"(?=(?:\n## Dependencies\b|\n## Blocked\b|\n## Additional Context\b|\n## 📝|\Z))",
+    re.DOTALL,
+)
 
+
+def has_generic_spec_kit_stamp(body: str) -> bool:
+    return GENERIC_USER_STORY_STAMP in (body or "")
+
+
+def _acceptance_lines(body: str, acceptance: list[str] | None) -> list[str]:
+    if acceptance:
+        return [item.strip() for item in acceptance if _text(item)]
+    lines: list[str] = []
+    in_acceptance = False
+    for raw in (body or "").splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("## ") and "Acceptance" in stripped and "Scenario" not in stripped:
+            in_acceptance = True
+            continue
+        if in_acceptance and stripped.startswith("## "):
+            break
+        if in_acceptance and stripped.startswith(("- ", "* ")):
+            lines.append(stripped[2:].strip())
+    return lines
+
+
+def _story_title(title: str, *, tracker: bool) -> str:
+    cleaned = " ".join((title or "").split()).strip() or "Deliver this work item"
+    if tracker:
+        return cleaned
+    for prefix in ("Tracking:", "[Feature Request]:", "[Bug]:", "Bug:", "Feature:"):
+        if cleaned.lower().startswith(prefix.lower()):
+            cleaned = cleaned[len(prefix):].strip(" -:")
+            break
+    return cleaned or "Deliver this work item"
+
+
+def _specialized_spec_kit_block(title: str, acceptance: list[str], *, tracker: bool) -> str:
+    story = _story_title(title, tracker=tracker)
+    primary = acceptance[0] if acceptance else story
+    secondary = acceptance[1] if len(acceptance) > 1 else primary
+    return "\n".join(
+        [
+            "## User Scenarios & Testing",
+            f"### User Story 1 - {story} (Priority: P1)",
+            "",
+            f"**Independent Test**: {primary}",
+            "",
+            "**Acceptance Scenarios**:",
+            "",
+            f"1. **Given** the current state described in this issue, **When** the proposed fix lands, "
+            f"**Then** {primary}",
+            "",
+            "## Edge Cases",
+            "",
+            "- Preserve prior acceptance; do not reopen closed parents named in this issue.",
+            "- Do not broaden into unrelated leftovers.",
+            "",
+            "## Functional Requirements",
+            "",
+            f"- **FR-001**: {primary}",
+            "- **FR-002**: Keep taxonomy labels valid (one primary, one lifecycle, at least one subsystem/module).",
+            "",
+            "## Success Criteria",
+            "",
+            f"- **SC-001**: {secondary}",
+            "- **SC-002**: Existing related acceptance is preserved, not weakened.",
+            "",
+            "## Assumptions",
+            "",
+            "- Prior problem statement and acceptance on this issue remain authoritative.",
+            "",
+            "## Out of scope",
+            "",
+            "- Unrelated campaign leftovers not named above.",
+        ]
+    )
+
+
+def rewrite_body_spec_kit(
+    body: str,
+    *,
+    title: str,
+    acceptance: list[str] | None = None,
+    tracker: bool = False,
+) -> str:
+    """Specialize Spec Kit User Story / FR / SC from this issue's acceptance.
+
+    Shared heading names stay required. Trackers may keep a campaign-level story
+    when tracker=True. Never paste GENERIC_USER_STORY_STAMP onto unrelated issues.
+    """
+    text = body or ""
+    criteria = _acceptance_lines(text, acceptance)
+    block = _specialized_spec_kit_block(title, criteria, tracker=tracker)
+    if _SPEC_KIT_CLUSTER_RE.search(text):
+        return _SPEC_KIT_CLUSTER_RE.sub(block.rstrip() + "\n", text, count=1).rstrip() + "\n"
+    if "## User Scenarios & Testing" in text:
+        return _SPEC_KIT_FALLBACK_RE.sub(block.rstrip() + "\n", text, count=1).rstrip() + "\n"
+    return text.rstrip() + "\n\n" + block + "\n"
 
 def _text(value) -> bool:
     return isinstance(value, str) and bool(value.strip())
@@ -119,6 +225,10 @@ def validate_issue_plan(plan: object, taxonomy: object) -> dict:  # noqa: MC0001
                 reasons.append(f"template field is missing: {heading}")
         if not any(heading in body for heading in SCOPE_HEADINGS):
             reasons.append("template field is missing: Assumptions or Out of scope")
+        if has_generic_spec_kit_stamp(body):
+            reasons.append(
+                f"generic Spec Kit stamp is forbidden: {GENERIC_USER_STORY_STAMP}"
+            )
     if not _texts(plan.get("acceptanceCriteria")):
         reasons.append("acceptance criteria are required")
     if state == "ready" and not _texts(plan.get("proofPlan")):

--- a/tests/scripts/test_issue_filing.py
+++ b/tests/scripts/test_issue_filing.py
@@ -8,13 +8,16 @@ import unittest
 from pathlib import Path
 
 from scripts.agents.issue_filing import (
+    GENERIC_USER_STORY_STAMP,
     build_az_boards_create_argv,
     build_glab_issue_create_argv,
     confirmation_digest,
     create_issue,
+    has_generic_spec_kit_stamp,
     prepare_issue_plan,
     receipt_digest,
     reconcile_labels,
+    rewrite_body_spec_kit,
     transition_issue,
     validate_issue_plan,
 )
@@ -266,6 +269,71 @@ class IssueFilingTest(unittest.TestCase):
         combined = skill + "\n" + contract
         for section in SPEC_KIT_SECTIONS:
             self.assertIn(section, combined)
+
+    def test_hygiene_rewrite_specializes_user_story_from_acceptance(self):
+        stamped = (
+            "## Describe the Bug\nSelenium logging drift.\n"
+            "## Steps to Reproduce\n1. Enable debug.\n"
+            "## Expected Behavior\nConsistent JUL.\n"
+            "## Actual Behavior\nTwo switches disagree.\n"
+            "## User Scenarios & Testing\n"
+            f"### User Story 1 - {GENERIC_USER_STORY_STAMP} (Priority: P1)\n"
+            "**Acceptance Scenarios**:\n1. **Given** x, **When** y, **Then** z.\n"
+            "## Edge Cases\n- Preserve prior acceptance.\n"
+            "## Functional Requirements\n"
+            "- **FR-001**: Implement only the problem and proposed solution already stated above.\n"
+            "## Success Criteria\n"
+            "- **SC-001**: The Acceptance / proof statements on this issue pass under the focused checks named here.\n"
+            "## Assumptions\n- Prior acceptance remains authoritative."
+        )
+        selenium = rewrite_body_spec_kit(
+            stamped,
+            title="Selenium Java logging consistency",
+            acceptance=["Unify Debug switches onto SE_DEBUG / logger level-setting."],
+        )
+        soup = rewrite_body_spec_kit(
+            stamped,
+            title="Aider Java flow against Soup-trained Ollama name",
+            acceptance=["One accepted report.json using the new Ollama model name."],
+        )
+        self.assertFalse(has_generic_spec_kit_stamp(selenium))
+        self.assertFalse(has_generic_spec_kit_stamp(soup))
+        self.assertIn("### User Story 1 - Selenium Java logging consistency", selenium)
+        self.assertIn("### User Story 1 - Aider Java flow against Soup-trained Ollama name", soup)
+        self.assertNotEqual(
+            _first_fr(selenium),
+            _first_fr(soup),
+        )
+        self.assertIn("Unify Debug switches", _first_fr(selenium))
+        self.assertIn("accepted report.json", _first_fr(soup))
+        for section in SPEC_KIT_SECTIONS:
+            self.assertIn(section, selenium)
+            self.assertIn(section, soup)
+
+    def test_generic_deliver_the_stated_acceptance_stamp_is_rejected(self):
+        item = planned()
+        item["body"] = item["body"].replace(
+            "### User Story 1\n",
+            f"### User Story 1 - {GENERIC_USER_STORY_STAMP} (Priority: P1)\n",
+        )
+        self.assertTrue(has_generic_spec_kit_stamp(item["body"]))
+        receipt = validate_issue_plan(item, TAXONOMY)
+        self.assertEqual("block", receipt["decision"])
+        self.assertTrue(any("Deliver the stated acceptance" in reason for reason in receipt["reasons"]))
+
+    def test_work_item_contract_forbids_generic_spec_kit_stamp(self):
+        skill = (ROOT / "chaos-engine/skills/work-item/SKILL.md").read_text(encoding="utf-8")
+        contract = (ROOT / "chaos-engine/references/work-item.md").read_text(encoding="utf-8")
+        combined = skill + "\n" + contract
+        self.assertIn("Deliver the stated acceptance", combined)
+        self.assertRegex(combined, r"(?i)specialize")
+
+
+def _first_fr(body: str) -> str:
+    for line in body.splitlines():
+        if line.strip().startswith("- **FR-001**"):
+            return line
+    raise AssertionError("FR-001 missing")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `rewrite_body_spec_kit` so hygiene rewrites specialize User Story / FR-* / SC-* from each issue's own acceptance.
- Pin/reject the generic stamp `Deliver the stated acceptance` in `validate_issue_plan`.
- Document the specialize rule in the work-item skill and contract.
- Live-repaired still-open stamped issues #4307 and #5144 (bodies only; product work unchanged).

Closes #5193
Related to #5186
Tracker remains #5186

## Checks

- `py -3 -m unittest tests.scripts.test_issue_filing` — 23 tests OK
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` — Agent setup valid

## Notes

- Do not merge from this writer; orchestrator owns review/merge.