### PR TITLE
fix: emit one Allure step per reported action including navigate

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/ReportManager.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/ReportManager.java
@@ -32,11 +32,7 @@ public class ReportManager {
      */
     public static void log(String logText) {
         if (logText != null && !logText.isBlank()) {
-            if (getDiscreteLogging() && isInternalStep()) {
-                createLogEntry(logText, Level.INFO);
-            } else {
-                writeStepToReport(logText);
-            }
+            writeStepToReport(logText);
         }
     }
 
@@ -48,11 +44,7 @@ public class ReportManager {
      */
     public static void log(String logText, Level logLevel) {
         if (logText != null && !logText.isBlank()) {
-            if (getDiscreteLogging() && isInternalStep()) {
-                createLogEntry(logText, logLevel);
-            } else {
-                writeStepToReport(logText, logLevel);
-            }
+            writeStepToReport(logText, logLevel);
         }
     }
 
@@ -69,11 +61,7 @@ public class ReportManager {
     public static void log(String logText, Status stepStatus) {
         if (logText != null && !logText.isBlank()) {
             boolean isFailure = Status.FAILED.equals(stepStatus) || Status.BROKEN.equals(stepStatus);
-            if (!isFailure && getDiscreteLogging() && isInternalStep()) {
-                createLogEntry(logText, Level.INFO);
-            } else {
-                writeStepToReport(logText, isFailure ? Level.ERROR : Level.INFO, stepStatus);
-            }
+            writeStepToReport(logText, isFailure ? Level.ERROR : Level.INFO, stepStatus);
         }
     }
 

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -975,35 +975,45 @@ public class ReportManagerHelper {
         return currentStatus == null ? Status.PASSED : currentStatus;
     }
 
-    @Step("{logText}")
     static void writeStepToReport(String logText, List<List<Object>> attachments, CheckpointStatus status) {
+        if (SHAFT.Properties.reporting.disableLogging()) {
+            return;
+        }
         createLogEntry(logText, true);
-        if (attachments != null && !attachments.isEmpty()) {
-            attachments.forEach(attachment -> {
-                if (attachment != null && !attachment.isEmpty() && attachment.get(2)!=null && attachment.get(2).getClass().toString().toLowerCase().contains("string")
-                        && !attachment.get(2).getClass().toString().contains("StringInputStream")) {
-                    if (!attachment.get(2).toString().isEmpty()) {
-                        attach(attachment.get(0).toString(), attachment.get(1).toString(), attachment.get(2).toString());
-                    }
-                } else if (attachment != null && !attachment.isEmpty()) {
-                    if (attachment.get(2) instanceof byte[]) {
-                        attach(attachment.get(0).toString(), attachment.get(1).toString(), new ByteArrayInputStream((byte[]) attachment.get(2)));
-                    } else {
-                        attach(attachment.get(0).toString(), attachment.get(1).toString(), (InputStream) attachment.get(2));
-                    }
-                }
-                if (status.equals(CheckpointStatus.FAIL)) {
-                    Allure.getLifecycle().updateStep(update -> {
-                        update.setStatus(Status.FAILED);
-                        if (attachment != null && !attachment.isEmpty() && attachment.get(2) != null) {
-                            String trace = update.getStatusDetails() == null ? attachment.get(2).toString() : update.getStatusDetails().getTrace() + System.lineSeparator() + attachment.get(2).toString();
-                            StatusDetails details = update.getStatusDetails() == null ? new StatusDetails() : update.getStatusDetails();
-                            details.setTrace(trace.trim());
-                            update.setStatusDetails(details);
+        var lifecycle = Allure.getLifecycle();
+        var uuid = UUID.randomUUID().toString();
+        Status stepStatus = status == CheckpointStatus.FAIL ? Status.FAILED : Status.PASSED;
+        lifecycle.startStep(uuid, new StepResult().setName(logText).setStatus(stepStatus));
+        try {
+            if (attachments != null && !attachments.isEmpty()) {
+                attachments.forEach(attachment -> {
+                    if (attachment != null && !attachment.isEmpty() && attachment.get(2)!=null && attachment.get(2).getClass().toString().toLowerCase().contains("string")
+                            && !attachment.get(2).getClass().toString().contains("StringInputStream")) {
+                        if (!attachment.get(2).toString().isEmpty()) {
+                            attach(attachment.get(0).toString(), attachment.get(1).toString(), attachment.get(2).toString());
                         }
-                    });
-                }
-            });
+                    } else if (attachment != null && !attachment.isEmpty()) {
+                        if (attachment.get(2) instanceof byte[]) {
+                            attach(attachment.get(0).toString(), attachment.get(1).toString(), new ByteArrayInputStream((byte[]) attachment.get(2)));
+                        } else {
+                            attach(attachment.get(0).toString(), attachment.get(1).toString(), (InputStream) attachment.get(2));
+                        }
+                    }
+                    if (status.equals(CheckpointStatus.FAIL)) {
+                        lifecycle.updateStep(uuid, update -> {
+                            update.setStatus(Status.FAILED);
+                            if (attachment != null && !attachment.isEmpty() && attachment.get(2) != null) {
+                                String trace = update.getStatusDetails() == null ? attachment.get(2).toString() : update.getStatusDetails().getTrace() + System.lineSeparator() + attachment.get(2).toString();
+                                StatusDetails details = update.getStatusDetails() == null ? new StatusDetails() : update.getStatusDetails();
+                                details.setTrace(trace.trim());
+                                update.setStatusDetails(details);
+                            }
+                        });
+                    }
+                });
+            }
+        } finally {
+            lifecycle.stopStep(uuid);
         }
     }
 
@@ -1113,32 +1123,12 @@ public class ReportManagerHelper {
         if (!SHAFT.Properties.reporting.disableLogging()) {
             boolean hasAttachments = attachments != null && !attachments.isEmpty()
                     && (attachments.size() > 1 || (attachments.getFirst() != null && !attachments.getFirst().isEmpty()));
-            if (status != CheckpointStatus.FAIL && getDiscreteLogging() && isInternalStep()) {
-                createLogEntry(logText, Level.DEBUG);
-                if (hasAttachments) {
-                    attachments.forEach(attachment -> {
-                        if (attachment != null && !attachment.isEmpty()) {
-                            if (attachment.get(2) instanceof String string) {
-                                attachAsStep(attachment.get(0).toString(), attachment.get(1).toString(),
-                                        new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8)));
-                            } else if (attachment.get(2) instanceof StringBuilder stringBuilder) {
-                                attachAsStep(attachment.get(0).toString(), attachment.get(1).toString(),
-                                        new ByteArrayInputStream(stringBuilder.toString().getBytes(StandardCharsets.UTF_8)));
-                            } else {
-                                attachAsStep(attachment.get(0).toString(), attachment.get(1).toString(),
-                                        (InputStream) attachment.get(2));
-                            }
-                        }
-                    });
-                }
+            if (hasAttachments) {
+                writeStepToReport(logText, attachments, status);
             } else {
-                if (hasAttachments) {
-                    writeStepToReport(logText, attachments, status);
-                } else {
-                    writeStepToReport(logText,
-                            status == CheckpointStatus.FAIL ? Level.ERROR : Level.INFO,
-                            status == CheckpointStatus.FAIL ? Status.FAILED : Status.PASSED);
-                }
+                writeStepToReport(logText,
+                        status == CheckpointStatus.FAIL ? Level.ERROR : Level.INFO,
+                        status == CheckpointStatus.FAIL ? Status.FAILED : Status.PASSED);
             }
         }
     }

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
@@ -1,0 +1,151 @@
+package com.shaft.tools.io.internal;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.shaft.driver.SHAFT;
+import io.qameta.allure.Allure;
+import io.qameta.allure.FileSystemResultsWriter;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import testPackage.TestPageServer;
+import testPackage.Tests;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Comparator;
+
+/**
+ * Locks Allure action-step reporting for {@code navigateToURL} (#5208).
+ * The test snapshots the current Allure uuid to a {@code *-result.json} file
+ * and asserts that file, not the in-memory lifecycle view alone.
+ *
+ * <p>Inventory of report sinks after the shared-path fix:
+ * <ul>
+ *   <li>{@code ReportManager.log} / {@code ReportManagerHelper.log} / {@code writeStepToReport}
+ *       — one Allure step per call (browser, Playwright, API/CLI helpers that already report).</li>
+ *   <li>{@code BrowserActionsHelper.reportActionResult} and {@code ElementActionsHelper.reportActionResult}
+ *       — same owner; screenshot stays an attachment inside the step.</li>
+ *   <li>{@code Actions} public {@code @Step} methods — already start a step; locator metadata
+ *       ({@code decision.element-actions-normalize-allure-locator-metadata}) stays intact.</li>
+ *   <li>{@code ReportManager.logDiscrete} — not an action; must not become a step.</li>
+ *   <li>{@code attachAsStep} — attachment, not a second action step.</li>
+ * </ul>
+ */
+public class AllureActionStepReportingTest extends Tests {
+
+    @Test
+    public void navigateToLocalFixtureWritesExactlyOneAllureNavigateStep() throws IOException {
+        String url = TestPageServer.url("coverageTestPage.html");
+        driver.get().browser().navigateToURL(url);
+
+        JsonObject result = snapshotCurrentAllureResult();
+        List<JsonObject> navigateSteps = navigateActionSteps(result, url);
+
+        Assert.assertEquals(navigateSteps.size(), 1,
+                "Allure result " + result.get("uuid") + " should contain exactly one navigate step for "
+                        + url + " but was " + summarizeSteps(result));
+        Assert.assertFalse(isFailedOrBroken(navigateSteps.getFirst()),
+                "Successful navigate must not be reported as failed/broken: " + navigateSteps.getFirst());
+    }
+
+    @Test
+    public void failedNavigateStillWritesFailedOrBrokenAllureStep() throws IOException {
+        String url = TestPageServer.url("navigationErrorFixture.html");
+        SHAFT.Properties.flags.set().forceCheckNavigationWasSuccessful(true);
+        RuntimeException thrown = null;
+        try {
+            driver.get().browser().navigateToURL(url);
+        } catch (RuntimeException exception) {
+            thrown = exception;
+        }
+        Assert.assertNotNull(thrown, "Forced navigation check against navigationErrorFixture.html must fail navigateToURL.");
+
+        JsonObject result = snapshotCurrentAllureResult();
+        List<JsonObject> navigateSteps = navigateActionSteps(result, url);
+        Assert.assertFalse(navigateSteps.isEmpty(),
+                "Failed navigate must still produce an Allure step identifying the URL. Steps: "
+                        + summarizeSteps(result));
+        Assert.assertTrue(navigateSteps.stream().anyMatch(AllureActionStepReportingTest::isFailedOrBroken),
+                "Failed navigate step must be failed or broken, not omitted or passed: " + navigateSteps);
+    }
+
+    private static JsonObject snapshotCurrentAllureResult() throws IOException {
+        String uuid = Allure.getLifecycle().getCurrentTestCase()
+                .orElseThrow(() -> new AssertionError("Allure has no current test case uuid to snapshot."));
+        Path snapshotDirectory = Files.createTempDirectory("shaft-5208-allure-" + uuid);
+        Allure.getLifecycle().updateTestCase(new FileSystemResultsWriter(snapshotDirectory)::write);
+        Path resultFile = snapshotDirectory.resolve(uuid + "-result.json");
+        Assert.assertTrue(Files.isRegularFile(resultFile),
+                "Expected Allure result JSON at " + resultFile.toAbsolutePath());
+        return JsonParser.parseString(Files.readString(resultFile)).getAsJsonObject();
+    }
+
+    private static List<JsonObject> navigateActionSteps(JsonObject result, String url) {
+        List<JsonObject> matches = new ArrayList<>();
+        for (JsonObject step : allSteps(result.get("steps"))) {
+            if (isNavigateActionStep(step, url)) {
+                matches.add(step);
+            }
+        }
+        return matches;
+    }
+
+    private static boolean isNavigateActionStep(JsonObject step, String url) {
+        String name = stepName(step);
+        String normalized = name.toLowerCase(Locale.ROOT);
+        if (normalized.startsWith("attachment:")) {
+            return false;
+        }
+        boolean identifiesNavigate = normalized.contains("navigate to url")
+                || normalized.contains("navigatetourl");
+        return identifiesNavigate && name.contains(url);
+    }
+
+    private static List<JsonObject> allSteps(JsonElement stepsElement) {
+        List<JsonObject> steps = new ArrayList<>();
+        collectSteps(stepsElement, steps);
+        return steps;
+    }
+
+    private static void collectSteps(JsonElement stepsElement, List<JsonObject> sink) {
+        if (stepsElement == null || !stepsElement.isJsonArray()) {
+            return;
+        }
+        JsonArray steps = stepsElement.getAsJsonArray();
+        for (JsonElement element : steps) {
+            if (!element.isJsonObject()) {
+                continue;
+            }
+            JsonObject step = element.getAsJsonObject();
+            sink.add(step);
+            collectSteps(step.get("steps"), sink);
+        }
+    }
+
+    private static String stepName(JsonObject step) {
+        return step.has("name") && !step.get("name").isJsonNull() ? step.get("name").getAsString() : "";
+    }
+
+    private static boolean isFailedOrBroken(JsonObject step) {
+        if (!step.has("status") || step.get("status").isJsonNull()) {
+            return false;
+        }
+        String status = step.get("status").getAsString();
+        return "failed".equals(status) || "broken".equals(status);
+    }
+
+    private static String summarizeSteps(JsonObject result) {
+        List<String> names = new ArrayList<>();
+        for (JsonObject step : allSteps(result.get("steps"))) {
+            names.add(stepName(step) + "[" + (step.has("status") ? step.get("status").getAsString() : "none") + "]");
+        }
+        names.sort(Comparator.naturalOrder());
+        return names.toString();
+    }
+}

--- a/shaft-engine/src/test/resources/testDataFiles/navigationErrorFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/navigationErrorFixture.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Navigation error fixture</title>
+</head>
+<body>Invalid URL</body>
+</html>


### PR DESCRIPTION
Closes #5208
Related to #5204
Related to #5212

Keep #5204 open.

## Summary

SHAFT actions that already write a console report line now emit one Allure step from the shared report path, including `navigateToURL`.

- `ReportManager.log` and `ReportManagerHelper.log` always call `writeStepToReport`. Discrete logging no longer swallows passed internal actions.
- `writeStepToReport(logText, attachments, status)` starts and stops a programmatic Allure step with the checkpoint status. It no longer depends on `@Step` weaving.
- Screenshots stay attachments inside that step, not a second action step.
- Locator metadata on element `Actions` (`decision.element-actions-normalize-allure-locator-metadata`) is untouched.
- Playwright `ReportManager.log("Navigate to url ...")` uses the same owner.

Checked-in exceptions: `logDiscrete` is not an action; `attachAsStep` is an attachment.

## Checks

Balanced scope, headless, `-Dallure.automaticallyOpen=false`:

```
mvn -pl shaft-engine "-Dtest=AllureActionStepReportingTest,ReportManagerHelperUnitTests" "-Dallure.automaticallyOpen=false" "-DheadlessExecution=true" test
```

- RED (test only): `AllureActionStepReportingTest` 2 failures. Pass navigate had zero Allure steps (`expected [1] but found [0]`). Fail navigate later asserted a failed/broken step after the URL actually failed.
- GREEN: Surefire `TEST-TestSuite.xml` `tests="35" failures="0"`. JUnit `junitreports/TEST-com.shaft.tools.io.internal.AllureActionStepReportingTest.xml` `tests="2" failures="0"` at 2026-08-19T11:42:52 EEST. `junitreports/TEST-testPackage.unitTests.ReportManagerHelperUnitTests.xml` `tests="33" failures="0"`.

## Continuation

Head: `0903aeb0b59d124e6fc1a2933ca0f2b5aa455015`
State: First retained commit pushed. Navigate Allure-step sub-item is on this PR. Independent review of this behavior step is still owed before merge. Do not merge from this implementer turn.
Blockers: none for the navigate sub-item.
Next action: independent reviewer verifies the Allure step contract and the shared-path diff. Fluent-chain and per-surface sweep tests can follow on this branch after review if the reviewer wants them locked before merge.
