### PR TITLE
fix: split IntelliJ Marketplace verify and publish timeouts

### DIFF
--- a/.github/actions/intellij-verify/action.yml
+++ b/.github/actions/intellij-verify/action.yml
@@ -8,6 +8,12 @@ inputs:
     description: 'When "true", also sign and publish the plugin to the JetBrains Marketplace.'
     required: false
     default: 'false'
+  verify:
+    description: >-
+      When "false", skip check/buildPlugin/verifyPlugin. Use with publish=="true"
+      so a long :verifyPlugin cannot consume the Marketplace publish timeout.
+    required: false
+    default: 'true'
   marketplace-token:
     description: 'JetBrains Marketplace publishing token. Required when publish=="true".'
     required: false
@@ -79,6 +85,7 @@ runs:
     # established for Maven Central, and it retries a transfer refusal only:
     # a verifier finding or a compile error still fails on the first attempt.
     - name: Run Gradle build
+      if: inputs.verify != 'false'
       shell: bash
       run: bash scripts/ci/build_retry.sh 2 15 bash shaft-intellij/gradlew -p shaft-intellij check buildPlugin verifyPlugin
     # Deliberately not retried. A JetBrains Marketplace version number is
@@ -94,4 +101,10 @@ runs:
         ORG_GRADLE_PROJECT_intellijPlatformCertificateChain: ${{ inputs.certificate-chain }}
         ORG_GRADLE_PROJECT_intellijPlatformPrivateKey: ${{ inputs.private-key }}
         ORG_GRADLE_PROJECT_intellijPlatformPrivateKeyPassword: ${{ inputs.private-key-password }}
-      run: bash shaft-intellij/gradlew -p shaft-intellij signPlugin publishPlugin
+      run: |
+        set -euo pipefail
+        log="${RUNNER_TEMP:-/tmp}/shaft-intellij-publishPlugin.log"
+        bash shaft-intellij/gradlew -p shaft-intellij signPlugin publishPlugin --console=plain 2>&1 | tee "$log"
+        python3 scripts/ci/assert_intellij_marketplace_receipt.py \
+          --log "$log" \
+          --properties shaft-intellij/gradle.properties

--- a/.github/actions/notify-intellij-marketplace-publish/action.yml
+++ b/.github/actions/notify-intellij-marketplace-publish/action.yml
@@ -1,0 +1,99 @@
+name: 'Notify IntelliJ Marketplace Publish Miss'
+description: >-
+  Fail closed when a Publish IntelliJ Plugin run does not complete publishPlugin.
+  A release cancelled/timeout/failure files or keeps a dedicated tracking issue.
+  Nightly cancelled=skip must not own this path.
+inputs:
+  verify-result:
+    description: 'needs.verify.result'
+    required: true
+  publish-result:
+    description: 'needs.publish.result'
+    required: true
+  event-name:
+    description: 'github.event_name'
+    required: true
+  plugin-version:
+    description: 'Plugin version. Falls back to shaft-intellij/gradle.properties.'
+    required: false
+    default: ''
+  label:
+    description: 'Dedupe label for the dedicated miss tracker.'
+    required: false
+    default: 'intellij-marketplace-publish-miss'
+  github-token:
+    description: 'Token with issues:write. Defaults to the job token.'
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: 'composite'
+  steps:
+    - name: File, keep, or close the Marketplace publish tracker
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        VERIFY_RESULT: ${{ inputs.verify-result }}
+        PUBLISH_RESULT: ${{ inputs.publish-result }}
+        EVENT_NAME: ${{ inputs.event-name }}
+        PLUGIN_VERSION: ${{ inputs.plugin-version }}
+        LABEL: ${{ inputs.label }}
+        REPO: ${{ github.repository }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+
+        version="$PLUGIN_VERSION"
+        if [ -z "$version" ] && [ -f shaft-intellij/gradle.properties ]; then
+          version=$(awk -F= '/^pluginVersion=/{print $2; exit}' shaft-intellij/gradle.properties)
+        fi
+        if [ -z "$version" ]; then
+          version="unknown"
+        fi
+
+        if [ "$PUBLISH_RESULT" = "success" ]; then
+          if [ "$EVENT_NAME" = "release" ]; then
+            existing=$(gh issue list --repo "$REPO" --state open --label "$LABEL" \
+              --json number --jq '.[0].number // empty')
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --repo "$REPO" \
+                --body "✅ Recovered: IntelliJ Marketplace publish of \`$version\` succeeded on [\`run $GITHUB_RUN_ID\`]($RUN_URL). Closing this dedicated tracker."
+              gh issue close "$existing" --repo "$REPO" --reason completed
+              echo "Closed recovered tracking issue #$existing."
+            fi
+          fi
+          echo "Marketplace publish succeeded for $version."
+          exit 0
+        fi
+
+        echo "::error::IntelliJ Marketplace publish did not succeed (verify=$VERIFY_RESULT publish=$PUBLISH_RESULT version=$version). Coverage success must not hide this miss."
+
+        if [ "$EVENT_NAME" = "release" ]; then
+          gh label create "$LABEL" --repo "$REPO" --color B60205 \
+            --description "Dedicated tracker for a missed IntelliJ Marketplace publish" --force >/dev/null 2>&1 || true
+          existing=$(gh issue list --repo "$REPO" --state open --label "$LABEL" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" \
+              --body "❌ Still missing: release publish of \`$version\` ended with verify=\`$VERIFY_RESULT\` publish=\`$PUBLISH_RESULT\` on [\`run $GITHUB_RUN_ID\`]($RUN_URL)."
+            echo "Updated existing tracking issue #$existing."
+          else
+            BODY=$(printf '%s\n' \
+              "A **release-triggered** IntelliJ Marketplace publish did not complete \`publishPlugin\`." \
+              "" \
+              "- Version: \`$version\`" \
+              "- Verify job: \`$VERIFY_RESULT\`" \
+              "- Publish job: \`$PUBLISH_RESULT\`" \
+              "- Run: $RUN_URL" \
+              "" \
+              "Cancelled or timed out is a **failure**, not a nightly skip. Coverage upload success does not mean Marketplace received this version." \
+              "" \
+              "Filed automatically. Dedupes on the \`$LABEL\` label.")
+            url=$(gh issue create --repo "$REPO" \
+              --title "IntelliJ Marketplace publish missed: $version" \
+              --label "$LABEL" \
+              --body "$BODY")
+            echo "Filed new tracking issue: $url"
+          fi
+        fi
+
+        exit 1

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -276,6 +276,13 @@ jobs:
               # build a second attempt -- so it belongs to the same filter that
               # re-runs on any workflow edit, not to the agent-guidance one.
               - 'tests/scripts/test_intellij_verify_retry.py'
+              # Issue #5221: a 20-minute verify+publish job cancelled before
+              # Marketplace. These pins live next to the timeout guard so a
+              # workflow edit cannot drop the split, receipt, or miss tracker.
+              - 'scripts/ci/assert_intellij_marketplace_receipt.py'
+              - 'tests/scripts/test_assert_intellij_marketplace_receipt.py'
+              - 'scripts/ci/validate_shaft_pilot_release.py'
+              - 'tests/scripts/test_validate_shaft_pilot_release.py'
               # Issue #4529: the timeout guard's own implementation and test
               # were in no filter, so a timeout could not be lowered unnoticed
               # but the check preventing it could be gutted green. A guard
@@ -842,6 +849,8 @@ jobs:
           python3 -m unittest
           tests.scripts.test_validate_workflow_timeouts
           tests.scripts.test_intellij_verify_retry
+          tests.scripts.test_assert_intellij_marketplace_receipt
+          tests.scripts.test_validate_shaft_pilot_release
           -v
       - name: Validate every workflow job declares timeout-minutes
         run: python3 scripts/ci/validate_workflow_timeouts.py

--- a/.github/workflows/publish-intellij-plugin.yml
+++ b/.github/workflows/publish-intellij-plugin.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
+  verify:
     # Runs only for an actual published SHAFT release (created by mavenCentral_cd.yml's
     # announce_release job), not merely because that workflow's run concluded successfully -
     # its build_release_and_deliver job now also concludes successfully when it skips a
@@ -21,8 +21,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: ubuntu-22.04
     # Room for the one retry the verification half of intellij-verify now takes
-    # when the JetBrains host refuses a connect (issue #4494). The publish half
-    # is never retried.
+    # when the JetBrains host refuses a connect (issue #4494). Publish is a
+    # separate job so this budget cannot cancel Marketplace upload.
     timeout-minutes: 20
     steps:
       - name: Checkout Code
@@ -31,14 +31,8 @@ jobs:
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       - name: Validate release metadata
         run: python3 scripts/ci/validate_shaft_pilot_release.py
-      - name: Publish to JetBrains Marketplace
+      - name: Verify IntelliJ plugin
         uses: ./.github/actions/intellij-verify
-        with:
-          publish: 'true'
-          marketplace-token: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
-          certificate-chain: ${{ secrets.JETBRAINS_PLUGIN_CERTIFICATE_CHAIN }}
-          private-key: ${{ secrets.JETBRAINS_PLUGIN_PRIVATE_KEY }}
-          private-key-password: ${{ secrets.JETBRAINS_PLUGIN_PRIVATE_KEY_PASSWORD }}
       - name: Upload IntelliJ coverage to Codecov
         if: always()
         uses: ./.github/actions/upload-jacoco-coverage
@@ -47,3 +41,48 @@ jobs:
           files: ./shaft-intellij/build/reports/jacoco/test/jacocoTestReport.xml
           required-files: ./shaft-intellij/build/reports/jacoco/test/jacocoTestReport.xml
           source-id: publish-intellij-plugin
+
+  publish:
+    needs: verify
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
+    runs-on: ubuntu-22.04
+    # Own budget for sign and Marketplace upload. Never wrap that upload in
+    # the verify retry helper: a Marketplace version number is single-use.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+      - name: Publish to JetBrains Marketplace
+        uses: ./.github/actions/intellij-verify
+        with:
+          publish: 'true'
+          verify: 'false'
+          marketplace-token: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+          certificate-chain: ${{ secrets.JETBRAINS_PLUGIN_CERTIFICATE_CHAIN }}
+          private-key: ${{ secrets.JETBRAINS_PLUGIN_PRIVATE_KEY }}
+          private-key-password: ${{ secrets.JETBRAINS_PLUGIN_PRIVATE_KEY_PASSWORD }}
+
+  notify-missed-publish:
+    name: Fail closed on missed Marketplace publish
+    needs: [verify, publish]
+    if: always()
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+      - name: File a dedicated miss issue when a release does not publish
+        uses: ./.github/actions/notify-intellij-marketplace-publish
+        with:
+          verify-result: ${{ needs.verify.result }}
+          publish-result: ${{ needs.publish.result }}
+          event-name: ${{ github.event_name }}
+          plugin-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+          label: intellij-marketplace-publish-miss

--- a/scripts/ci/assert_intellij_marketplace_receipt.py
+++ b/scripts/ci/assert_intellij_marketplace_receipt.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Fail if publishPlugin left no Gradle or Marketplace receipt for this version.
+
+Issue #5221: a cancelled verify+publish composite looked partly healthy because
+coverage uploaded `if: always()`. A successful Marketplace publish must leave a
+Gradle `BUILD SUCCESSFUL` receipt and the version must appear on plugin 32529.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+MARKETPLACE_PLUGIN_ID = 32529
+MARKETPLACE_UPDATES_URL = (
+    f"https://plugins.jetbrains.com/api/plugins/{MARKETPLACE_PLUGIN_ID}/updates"
+)
+USER_AGENT = "SHAFT_ENGINE-ci-intellij-marketplace-receipt"
+
+
+def plugin_version_from_properties(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("pluginVersion="):
+            version = stripped.split("=", 1)[1].strip()
+            if version:
+                return version
+    raise ValueError("pluginVersion is missing from gradle.properties")
+
+
+def gradle_receipt_errors(log_text: str) -> list[str]:
+    if "BUILD SUCCESSFUL" not in log_text:
+        return ["Gradle publish log is missing BUILD SUCCESSFUL"]
+    return []
+
+
+def marketplace_versions(updates_json: str) -> list[str]:
+    payload = json.loads(updates_json)
+    if isinstance(payload, dict):
+        payload = payload.get("updates") or payload.get("plugins") or payload.get("data") or []
+    if not isinstance(payload, list):
+        raise ValueError("Marketplace updates payload is not a list")
+    versions: list[str] = []
+    for item in payload:
+        if isinstance(item, dict) and item.get("version"):
+            versions.append(str(item["version"]))
+    return versions
+
+
+def marketplace_receipt_errors(updates_json: str, version: str) -> list[str]:
+    try:
+        versions = marketplace_versions(updates_json)
+    except (ValueError, json.JSONDecodeError) as error:
+        return [f"Marketplace updates JSON is unreadable: {error}"]
+    if version not in versions:
+        return [
+            f"Marketplace plugin {MARKETPLACE_PLUGIN_ID} does not list version {version}"
+        ]
+    return []
+
+
+def receipt_errors(log_text: str, properties_text: str, updates_json: str) -> list[str]:
+    errors = gradle_receipt_errors(log_text)
+    try:
+        version = plugin_version_from_properties(properties_text)
+    except ValueError as error:
+        return errors + [str(error)]
+    errors.extend(marketplace_receipt_errors(updates_json, version))
+    return errors
+
+
+def fetch_updates(url: str = MARKETPLACE_UPDATES_URL, timeout: int = 30) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read().decode("utf-8")
+
+
+def fetch_updates_with_retry(
+    url: str = MARKETPLACE_UPDATES_URL,
+    attempts: int = 5,
+    delay_seconds: float = 15,
+    sleeper=time.sleep,
+    fetcher=fetch_updates,
+) -> str:
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return fetcher(url)
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            last_error = error
+            if attempt < attempts:
+                sleeper(delay_seconds)
+    raise RuntimeError(f"Marketplace updates fetch failed: {last_error}") from last_error
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--properties", type=Path, required=True)
+    parser.add_argument("--updates-json", type=Path)
+    parser.add_argument("--updates-url", default=MARKETPLACE_UPDATES_URL)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    log_text = args.log.read_text(encoding="utf-8")
+    properties_text = args.properties.read_text(encoding="utf-8")
+    if args.updates_json is not None:
+        updates_json = args.updates_json.read_text(encoding="utf-8")
+    else:
+        try:
+            updates_json = fetch_updates_with_retry(url=args.updates_url)
+        except RuntimeError as error:
+            print(str(error), file=sys.stderr)
+            return 1
+    errors = receipt_errors(log_text, properties_text, updates_json)
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    version = plugin_version_from_properties(properties_text)
+    print(
+        f"Marketplace receipt confirmed for plugin {MARKETPLACE_PLUGIN_ID} version {version}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/assert_intellij_marketplace_receipt.py
+++ b/scripts/ci/assert_intellij_marketplace_receipt.py
@@ -86,15 +86,31 @@ def fetch_updates_with_retry(
     delay_seconds: float = 15,
     sleeper=time.sleep,
     fetcher=fetch_updates,
+    version: str | None = None,
 ) -> str:
     last_error: Exception | None = None
+    last_json: str | None = None
     for attempt in range(1, attempts + 1):
         try:
-            return fetcher(url)
+            updates_json = fetcher(url)
         except (urllib.error.URLError, TimeoutError, OSError) as error:
             last_error = error
             if attempt < attempts:
                 sleeper(delay_seconds)
+            continue
+        last_json = updates_json
+        if version is None:
+            return updates_json
+        try:
+            versions = marketplace_versions(updates_json)
+        except (ValueError, json.JSONDecodeError):
+            return updates_json
+        if version in versions:
+            return updates_json
+        if attempt < attempts:
+            sleeper(delay_seconds)
+    if last_json is not None:
+        return last_json
     raise RuntimeError(f"Marketplace updates fetch failed: {last_error}") from last_error
 
 
@@ -115,7 +131,15 @@ def main(argv: list[str] | None = None) -> int:
         updates_json = args.updates_json.read_text(encoding="utf-8")
     else:
         try:
-            updates_json = fetch_updates_with_retry(url=args.updates_url)
+            version = plugin_version_from_properties(properties_text)
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 1
+        try:
+            updates_json = fetch_updates_with_retry(
+                url=args.updates_url,
+                version=version,
+            )
         except RuntimeError as error:
             print(str(error), file=sys.stderr)
             return 1

--- a/scripts/ci/validate_shaft_pilot_release.py
+++ b/scripts/ci/validate_shaft_pilot_release.py
@@ -382,9 +382,18 @@ def validate_intellij_marketplace_publish(
         errors.append(
             "publish-intellij-plugin.yml must grant issues: write for the dedicated miss tracker"
         )
-    if "if: always()" not in workflow_text:
+    notify_block = _workflow_job_block(workflow_text, "notify-missed-publish")
+    if notify_block is None:
+        notify_block = _workflow_job_block(
+            workflow_text, "notify-intellij-marketplace-publish"
+        )
+    if notify_block is None:
         errors.append(
-            "publish-intellij-plugin.yml must fail closed with if: always() when publishPlugin is missed"
+            "publish-intellij-plugin.yml must fail closed with a notify-missed-publish job"
+        )
+    elif not re.search(r"(?m)^    if: always\(\)\s*$", notify_block):
+        errors.append(
+            "publish-intellij-plugin.yml notify-missed-publish job must use if: always()"
         )
     verify_block = _workflow_job_block(workflow_text, "verify")
     publish_block = _workflow_job_block(workflow_text, "publish")

--- a/scripts/ci/validate_shaft_pilot_release.py
+++ b/scripts/ci/validate_shaft_pilot_release.py
@@ -258,6 +258,21 @@ def validate_static(root: Path = ROOT) -> list[str]:
         errors.append("Maven Central workflow does not enforce the Pilot release gate")
 
     errors.extend(validate_release_candidate_isolation(pilot_release_workflow))
+    publish_workflow_path = root / ".github/workflows/publish-intellij-plugin.yml"
+    if not publish_workflow_path.is_file():
+        errors.append("publish-intellij-plugin.yml must publish the IntelliJ plugin to Marketplace")
+    else:
+        action_text = (
+            intellij_verify_action.read_text(encoding="utf-8")
+            if intellij_verify_action.is_file()
+            else ""
+        )
+        errors.extend(
+            validate_intellij_marketplace_publish(
+                publish_workflow_path.read_text(encoding="utf-8"),
+                action_text,
+            )
+        )
     return errors
 
 
@@ -336,6 +351,78 @@ def validate_release_candidate_isolation(workflow_text: str) -> list[str]:
             "shaft-pilot-release.yml release-candidate aggregator must stay fail-closed "
             "on DETECT_RESULT/DETECT_CHANGED and isolated slice success"
         )
+    return errors
+
+
+def validate_intellij_marketplace_publish(
+    workflow_text: str, action_text: str = ""
+) -> list[str]:
+    """Reject a publish-on-release workflow that can cancel before Marketplace.
+
+    Stdlib-only: this validator runs on a bare setup-python runner without
+    requirements-ci.txt, so it cannot import PyYAML.
+    """
+    errors: list[str] = []
+    if "notify-nightly-failure" in workflow_text:
+        errors.append(
+            "publish-intellij-plugin.yml must not reuse nightly cancelled=skip for Marketplace publish"
+        )
+    if re.search(
+        r"contains\(needs\.\*\.result,\s*'cancelled'\)\s*&&\s*'skip'",
+        workflow_text,
+    ):
+        errors.append(
+            "publish-intellij-plugin.yml must not map a cancelled release publish to skip"
+        )
+    if "intellij-marketplace-publish-miss" not in workflow_text:
+        errors.append(
+            "publish-intellij-plugin.yml must file a dedicated intellij-marketplace-publish-miss issue"
+        )
+    if "issues: write" not in workflow_text:
+        errors.append(
+            "publish-intellij-plugin.yml must grant issues: write for the dedicated miss tracker"
+        )
+    if "if: always()" not in workflow_text:
+        errors.append(
+            "publish-intellij-plugin.yml must fail closed with if: always() when publishPlugin is missed"
+        )
+    verify_block = _workflow_job_block(workflow_text, "verify")
+    publish_block = _workflow_job_block(workflow_text, "publish")
+    if verify_block is None:
+        errors.append("publish-intellij-plugin.yml must isolate verify as its own job")
+    if publish_block is None:
+        errors.append("publish-intellij-plugin.yml must isolate publish as its own job")
+    if verify_block is not None:
+        if "timeout-minutes:" not in verify_block:
+            errors.append("publish-intellij-plugin.yml verify job must declare timeout-minutes")
+        if re.search(r"publish:\s*'true'", verify_block):
+            errors.append("publish-intellij-plugin.yml verify job must not publish to Marketplace")
+    if publish_block is not None:
+        if "timeout-minutes:" not in publish_block:
+            errors.append("publish-intellij-plugin.yml publish job must declare timeout-minutes")
+        if "needs: verify" not in publish_block:
+            errors.append("publish-intellij-plugin.yml publish job must need the verify job")
+        if not re.search(r"verify:\s*'false'", publish_block):
+            errors.append(
+                "publish-intellij-plugin.yml publish job must skip verifyPlugin so it cannot eat the publish timeout"
+            )
+        for run_match in re.finditer(
+            r"(?m)^\s+run:\s*(?:\|[^\n]*\n((?:[ \t]+.*\n?)+)|(.+))$",
+            publish_block,
+        ):
+            run_text = run_match.group(1) or run_match.group(2) or ""
+            if "build_retry.sh" in run_text and "publishPlugin" in run_text:
+                errors.append("publishPlugin must not be wrapped in build_retry.sh")
+    blob = workflow_text + "\n" + action_text
+    if "assert_intellij_marketplace_receipt" not in blob:
+        errors.append(
+            "publishPlugin must assert a Gradle or Marketplace receipt via assert_intellij_marketplace_receipt"
+        )
+    if action_text:
+        for match in re.finditer(r"run:\s*\|?(.*?)(?=\n    - |\n    [A-Za-z]|\Z)", action_text, re.S):
+            run_text = match.group(1)
+            if "publishPlugin" in run_text and "build_retry.sh" in run_text:
+                errors.append("intellij-verify must not retry publishPlugin")
     return errors
 
 

--- a/tests/scripts/test_assert_intellij_marketplace_receipt.py
+++ b/tests/scripts/test_assert_intellij_marketplace_receipt.py
@@ -1,0 +1,120 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from urllib.error import URLError
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/ci/assert_intellij_marketplace_receipt.py"
+SPEC = importlib.util.spec_from_file_location("assert_intellij_marketplace_receipt", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+SUCCESS_LOG = "> Task :signPlugin\n> Task :publishPlugin\nBUILD SUCCESSFUL in 1m 2s\n"
+PROPERTIES = "pluginVersion=10.3.20260818\npluginSinceBuild=243\n"
+LISTED = '[{"version":"10.3.20260818"},{"version":"10.3.20260817"}]'
+MISSING = '[{"version":"10.3.20260817"}]'
+
+
+class IntellijMarketplaceReceiptTest(unittest.TestCase):
+    def test_successful_log_and_listed_version_pass(self):
+        self.assertEqual(
+            [],
+            MODULE.receipt_errors(SUCCESS_LOG, PROPERTIES, LISTED),
+        )
+
+    def test_missing_build_successful_fails(self):
+        errors = MODULE.receipt_errors(
+            "> Task :publishPlugin\nBUILD FAILED in 12s\n",
+            PROPERTIES,
+            LISTED,
+        )
+        self.assertTrue(any("BUILD SUCCESSFUL" in error for error in errors), errors)
+
+    def test_marketplace_without_the_version_fails(self):
+        errors = MODULE.receipt_errors(SUCCESS_LOG, PROPERTIES, MISSING)
+        self.assertTrue(
+            any("10.3.20260818" in error for error in errors),
+            errors,
+        )
+
+    def test_empty_log_fails_even_if_marketplace_lists_the_version(self):
+        errors = MODULE.receipt_errors("", PROPERTIES, LISTED)
+        self.assertTrue(any("BUILD SUCCESSFUL" in error for error in errors), errors)
+
+    def test_missing_plugin_version_fails(self):
+        errors = MODULE.receipt_errors(SUCCESS_LOG, "pluginSinceBuild=243\n", LISTED)
+        self.assertTrue(any("pluginVersion" in error for error in errors), errors)
+
+    def test_unreadable_updates_json_fails(self):
+        errors = MODULE.receipt_errors(SUCCESS_LOG, PROPERTIES, "not-json")
+        self.assertTrue(any("unreadable" in error for error in errors), errors)
+
+    def test_cli_accepts_fixture_updates_json(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            log = root / "publish.log"
+            properties = root / "gradle.properties"
+            updates = root / "updates.json"
+            log.write_text(SUCCESS_LOG, encoding="utf-8")
+            properties.write_text(PROPERTIES, encoding="utf-8")
+            updates.write_text(LISTED, encoding="utf-8")
+            self.assertEqual(
+                0,
+                MODULE.main(
+                    [
+                        "--log",
+                        str(log),
+                        "--properties",
+                        str(properties),
+                        "--updates-json",
+                        str(updates),
+                    ]
+                ),
+            )
+
+    def test_cli_fails_when_marketplace_omits_the_version(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            log = root / "publish.log"
+            properties = root / "gradle.properties"
+            updates = root / "updates.json"
+            log.write_text(SUCCESS_LOG, encoding="utf-8")
+            properties.write_text(PROPERTIES, encoding="utf-8")
+            updates.write_text(MISSING, encoding="utf-8")
+            self.assertEqual(
+                1,
+                MODULE.main(
+                    [
+                        "--log",
+                        str(log),
+                        "--properties",
+                        str(properties),
+                        "--updates-json",
+                        str(updates),
+                    ]
+                ),
+            )
+
+    def test_fetch_retries_then_raises(self):
+        attempts = {"n": 0}
+
+        def fetcher(_url: str) -> str:
+            attempts["n"] += 1
+            raise URLError("timed out")
+
+        sleeps: list[float] = []
+        with self.assertRaises(RuntimeError):
+            MODULE.fetch_updates_with_retry(
+                attempts=3,
+                delay_seconds=0.01,
+                sleeper=sleeps.append,
+                fetcher=fetcher,
+            )
+        self.assertEqual(3, attempts["n"])
+        self.assertEqual([0.01, 0.01], sleeps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_assert_intellij_marketplace_receipt.py
+++ b/tests/scripts/test_assert_intellij_marketplace_receipt.py
@@ -74,6 +74,37 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
                 ),
             )
 
+    def test_cli_live_fetch_passes_plugin_version_into_retry(self):
+        seen: dict[str, str | None] = {}
+        original = MODULE.fetch_updates_with_retry
+
+        def wrapper(*args, **kwargs):
+            seen["version"] = kwargs.get("version")
+            return LISTED
+
+        MODULE.fetch_updates_with_retry = wrapper
+        try:
+            with tempfile.TemporaryDirectory() as temp:
+                root = Path(temp)
+                log = root / "publish.log"
+                properties = root / "gradle.properties"
+                log.write_text(SUCCESS_LOG, encoding="utf-8")
+                properties.write_text(PROPERTIES, encoding="utf-8")
+                self.assertEqual(
+                    0,
+                    MODULE.main(
+                        [
+                            "--log",
+                            str(log),
+                            "--properties",
+                            str(properties),
+                        ]
+                    ),
+                )
+        finally:
+            MODULE.fetch_updates_with_retry = original
+        self.assertEqual("10.3.20260818", seen.get("version"))
+
     def test_cli_fails_when_marketplace_omits_the_version(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
@@ -114,6 +145,47 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
             )
         self.assertEqual(3, attempts["n"])
         self.assertEqual([0.01, 0.01], sleeps)
+
+    def test_fetch_retries_when_version_is_absent_then_listed(self):
+        payloads = [MISSING, LISTED]
+        attempts = {"n": 0}
+
+        def fetcher(_url: str) -> str:
+            attempts["n"] += 1
+            return payloads[attempts["n"] - 1]
+
+        sleeps: list[float] = []
+        body = MODULE.fetch_updates_with_retry(
+            attempts=5,
+            delay_seconds=0.01,
+            sleeper=sleeps.append,
+            fetcher=fetcher,
+            version="10.3.20260818",
+        )
+        self.assertEqual(LISTED, body)
+        self.assertEqual(2, attempts["n"])
+        self.assertEqual([0.01], sleeps)
+
+    def test_fetch_fails_closed_when_version_stays_absent(self):
+        attempts = {"n": 0}
+
+        def fetcher(_url: str) -> str:
+            attempts["n"] += 1
+            return MISSING
+
+        sleeps: list[float] = []
+        body = MODULE.fetch_updates_with_retry(
+            attempts=3,
+            delay_seconds=0.01,
+            sleeper=sleeps.append,
+            fetcher=fetcher,
+            version="10.3.20260818",
+        )
+        self.assertEqual(MISSING, body)
+        self.assertEqual(3, attempts["n"])
+        self.assertEqual([0.01, 0.01], sleeps)
+        errors = MODULE.marketplace_receipt_errors(body, "10.3.20260818")
+        self.assertTrue(any("10.3.20260818" in error for error in errors), errors)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_intellij_verify_retry.py
+++ b/tests/scripts/test_intellij_verify_retry.py
@@ -13,6 +13,7 @@ composite action leaves room for a second attempt instead of trading a red
 check for a timed-out one.
 """
 
+import importlib.util
 import unittest
 from pathlib import Path
 
@@ -214,10 +215,61 @@ class IntellijMarketplacePublishSplitTest(unittest.TestCase):
                 text,
                 f"cancelled/timeout before publishPlugin must file a dedicated tracker ({marker})",
             )
-        self.assertIn(
-            "if: always()",
-            text,
-            "coverage success must not hide a cancelled Marketplace publish",
+        jobs = _publish_workflow()["jobs"]
+        notify = jobs.get("notify-missed-publish") or jobs.get(
+            "notify-intellij-marketplace-publish"
+        )
+        self.assertIsNotNone(
+            notify,
+            "cancelled/timeout before publishPlugin must run notify-missed-publish",
+        )
+        self.assertEqual(
+            "always()",
+            notify.get("if"),
+            "notify-missed-publish must use if: always(); coverage upload always() is not the pin",
+        )
+
+    def test_coverage_upload_always_does_not_satisfy_notify_always_pin(self):
+        text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+        mutated = text.replace(
+            "  notify-missed-publish:\n"
+            "    name: Fail closed on missed Marketplace publish\n"
+            "    needs: [verify, publish]\n"
+            "    if: always()\n",
+            "  notify-missed-publish:\n"
+            "    name: Fail closed on missed Marketplace publish\n"
+            "    needs: [verify, publish]\n",
+            1,
+        )
+        self.assertIn("if: always()", mutated)
+        jobs = (yaml.safe_load(mutated) or {}).get("jobs") or {}
+        notify = jobs.get("notify-missed-publish") or jobs.get(
+            "notify-intellij-marketplace-publish"
+        )
+        self.assertIsNotNone(notify)
+        self.assertNotEqual(
+            "always()",
+            notify.get("if"),
+            "deleting notify-missed-publish if: always() must fail even when coverage keeps if: always()",
+        )
+        coverage_always = any(
+            isinstance(step, dict) and step.get("if") == "always()"
+            for step in (jobs.get("verify") or {}).get("steps") or []
+        )
+        self.assertTrue(coverage_always, mutated)
+        spec = importlib.util.spec_from_file_location(
+            "validate_shaft_pilot_release",
+            REPO_ROOT / "scripts/ci/validate_shaft_pilot_release.py",
+        )
+        validator = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(validator)
+        errors = validator.validate_intellij_marketplace_publish(
+            mutated, ACTION.read_text(encoding="utf-8")
+        )
+        self.assertTrue(
+            any("always()" in error and "notify" in error for error in errors),
+            errors,
         )
 
     def test_publish_plugin_requires_a_marketplace_or_gradle_receipt(self):

--- a/tests/scripts/test_intellij_verify_retry.py
+++ b/tests/scripts/test_intellij_verify_retry.py
@@ -22,7 +22,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ACTION = REPO_ROOT / ".github/actions/intellij-verify/action.yml"
 RETRY_SCRIPT = REPO_ROOT / "scripts/ci/build_retry.sh"
 WORKFLOWS = REPO_ROOT / ".github/workflows"
+PUBLISH_WORKFLOW = WORKFLOWS / "publish-intellij-plugin.yml"
 BUILD_FILE = REPO_ROOT / "shaft-intellij/build.gradle.kts"
+MARKETPLACE_RECEIPT_MARKERS = (
+    "assert_intellij_marketplace_receipt",
+    "BUILD SUCCESSFUL",
+)
+MARKETPLACE_MISS_MARKERS = (
+    "intellij-marketplace-publish-miss",
+    "issues: write",
+)
 
 # One failed attempt (2m38s in the run this issue was filed from) plus a pause
 # plus a full successful build (5m11s in run 30940070004) does not fit in ten
@@ -34,6 +43,21 @@ MINIMUM_TIMEOUT_MINUTES = 20
 def _run_steps() -> list[dict]:
     document = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
     return [step for step in document["runs"]["steps"] if "run" in step]
+
+
+def _publish_workflow() -> dict:
+    return yaml.safe_load(PUBLISH_WORKFLOW.read_text(encoding="utf-8")) or {}
+
+
+def _intellij_verify_with(step: dict) -> dict:
+    if "intellij-verify" not in str(step.get("uses", "")):
+        return {}
+    with_block = step.get("with") or {}
+    return with_block if isinstance(with_block, dict) else {}
+
+
+def _truthy(value: object) -> bool:
+    return str(value).strip().strip("'\"").lower() == "true"
 
 
 class IntellijVerifyRetryTest(unittest.TestCase):
@@ -77,8 +101,17 @@ class IntellijVerifyRetryTest(unittest.TestCase):
             for name, job in (document.get("jobs") or {}).items():
                 if not isinstance(job, dict):
                     continue
-                steps = job.get("steps") or []
-                if any("intellij-verify" in str(step.get("uses", "")) for step in steps):
+                runs_verify = False
+                for step in job.get("steps") or []:
+                    if not isinstance(step, dict):
+                        continue
+                    extras = _intellij_verify_with(step)
+                    if "intellij-verify" not in str(step.get("uses", "")):
+                        continue
+                    if "verify" in extras and not _truthy(extras.get("verify")):
+                        continue
+                    runs_verify = True
+                if runs_verify:
                     callers.append((path.name, name, job.get("timeout-minutes")))
         self.assertTrue(callers, "no workflow calls the intellij-verify action")
         for workflow, job, timeout in callers:
@@ -108,6 +141,105 @@ class IntellijVerifyRetryTest(unittest.TestCase):
             setup_gradle.get("with", {}).get("gradle-home-cache-excludes", ""),
             "the shared 10 GiB Actions cache must not retain Gradle's multi-gigabyte artifact transforms",
         )
+
+
+class IntellijMarketplacePublishSplitTest(unittest.TestCase):
+    """Issue #5221: a 20-minute verify+publish job can cancel before Marketplace."""
+
+    def test_publish_on_release_does_not_share_the_verify_timeout(self):
+        jobs = _publish_workflow().get("jobs") or {}
+        verify_jobs = []
+        publish_jobs = []
+        shared = []
+        for name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            publish_true = False
+            verify_enabled = False
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                extras = _intellij_verify_with(step)
+                if not extras and "intellij-verify" not in str(step.get("uses", "")):
+                    continue
+                publish_true = publish_true or _truthy(extras.get("publish"))
+                # Default verify stays on. An explicit false is the publish-only path.
+                verify_enabled = verify_enabled or not (
+                    "verify" in extras and not _truthy(extras.get("verify"))
+                )
+            if publish_true and verify_enabled:
+                shared.append((name, job.get("timeout-minutes")))
+            elif publish_true:
+                publish_jobs.append((name, job.get("timeout-minutes")))
+            elif verify_enabled and any(
+                "intellij-verify" in str(step.get("uses", ""))
+                for step in job.get("steps") or []
+                if isinstance(step, dict)
+            ):
+                verify_jobs.append((name, job.get("timeout-minutes")))
+
+        self.assertEqual(
+            [],
+            shared,
+            "publish-on-release still runs verifyPlugin and publishPlugin in one job; "
+            "a 20-minute timeout can cancel before Marketplace",
+        )
+        self.assertTrue(verify_jobs, "publish-intellij-plugin.yml has no verify-only job")
+        self.assertTrue(publish_jobs, "publish-intellij-plugin.yml has no publish-only job")
+        for name, timeout in verify_jobs:
+            self.assertGreaterEqual(
+                timeout,
+                MINIMUM_TIMEOUT_MINUTES,
+                f"{name} cannot fit a retried IntelliJ verify",
+            )
+        for name, timeout in publish_jobs:
+            self.assertIsNotNone(timeout, f"{name} declares no timeout")
+            self.assertGreater(timeout, 0, f"{name} timeout must be a real bound")
+
+    def test_release_cancelled_or_timed_out_publish_is_a_failure_not_skip(self):
+        text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn(
+            "notify-nightly-failure",
+            text,
+            "nightly cancelled=skip must not own a missed Marketplace publish",
+        )
+        self.assertNotRegex(
+            text,
+            r"contains\(needs\.\*\.result,\s*'cancelled'\)\s*&&\s*'skip'",
+            "a cancelled release publish must not be mapped to skip",
+        )
+        for marker in MARKETPLACE_MISS_MARKERS:
+            self.assertIn(
+                marker,
+                text,
+                f"cancelled/timeout before publishPlugin must file a dedicated tracker ({marker})",
+            )
+        self.assertIn(
+            "if: always()",
+            text,
+            "coverage success must not hide a cancelled Marketplace publish",
+        )
+
+    def test_publish_plugin_requires_a_marketplace_or_gradle_receipt(self):
+        action = ACTION.read_text(encoding="utf-8")
+        workflow = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+        blob = action + "\n" + workflow
+        self.assertIn("publishPlugin", blob)
+        self.assertTrue(
+            any(marker in blob for marker in MARKETPLACE_RECEIPT_MARKERS),
+            "successful publishPlugin must assert a Gradle or Marketplace receipt",
+        )
+
+    def test_pr_gate_runs_the_marketplace_publish_pins(self):
+        gate = (REPO_ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")
+        for token in (
+            "tests.scripts.test_intellij_verify_retry",
+            "tests.scripts.test_assert_intellij_marketplace_receipt",
+            "tests.scripts.test_validate_shaft_pilot_release",
+            "scripts/ci/assert_intellij_marketplace_receipt.py",
+            "tests/scripts/test_assert_intellij_marketplace_receipt.py",
+        ):
+            self.assertIn(token, gate, f"PR Gate must re-run {token} on workflow edits")
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_validate_shaft_pilot_release.py
+++ b/tests/scripts/test_validate_shaft_pilot_release.py
@@ -185,6 +185,10 @@ Deploy to Maven Central
 Verify published Maven Central coordinates
 """,
     )
+    _write_text(
+        root / ".github/workflows/publish-intellij-plugin.yml",
+        _minimal_publish_intellij_workflow_text(),
+    )
     isolated = _minimal_isolated_workflow_text()
     # Named-check tokens remain discoverable for static contract scans that
     # still look for the historical release-step phrases in this fixture.
@@ -226,6 +230,38 @@ def _step_blob(job: dict) -> str:
 
 
 SLICE_CHANGED_IF = "needs.detect-shaft-version-change.outputs.changed == 'true'"
+
+
+def _minimal_publish_intellij_workflow_text() -> str:
+    return """name: Publish IntelliJ Plugin
+jobs:
+  verify:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: ./.github/actions/intellij-verify
+  publish:
+    needs: verify
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: ./.github/actions/intellij-verify
+        with:
+          publish: 'true'
+          verify: 'false'
+      - run: python3 scripts/ci/assert_intellij_marketplace_receipt.py --log log --properties props
+  notify-missed-publish:
+    if: always()
+    needs: [verify, publish]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - uses: ./.github/actions/notify-intellij-marketplace-publish
+        with:
+          label: intellij-marketplace-publish-miss
+"""
 
 
 def _minimal_isolated_workflow_text() -> str:
@@ -711,6 +747,96 @@ Run deterministic SHAFT Pilot tests
             _minimal_isolated_workflow_text()
         )
         self.assertEqual([], errors)
+
+
+class IntellijMarketplacePublishContractTest(unittest.TestCase):
+    def test_live_publish_workflow_matches_the_marketplace_contract(self):
+        workflow = (
+            ROOT / ".github/workflows/publish-intellij-plugin.yml"
+        ).read_text(encoding="utf-8")
+        action = (ROOT / ".github/actions/intellij-verify/action.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual([], MODULE.validate_intellij_marketplace_publish(workflow, action))
+
+    def test_minimal_publish_fixture_passes(self):
+        self.assertEqual(
+            [],
+            MODULE.validate_intellij_marketplace_publish(
+                _minimal_publish_intellij_workflow_text()
+            ),
+        )
+
+    def test_one_job_verify_and_publish_fails(self):
+        collapsed = """name: Publish IntelliJ Plugin
+jobs:
+  publish:
+    timeout-minutes: 20
+    steps:
+      - uses: ./.github/actions/intellij-verify
+        with:
+          publish: 'true'
+      - run: python3 scripts/ci/assert_intellij_marketplace_receipt.py
+  notify-missed-publish:
+    if: always()
+    permissions:
+      issues: write
+    steps:
+      - uses: ./.github/actions/notify-intellij-marketplace-publish
+        with:
+          label: intellij-marketplace-publish-miss
+"""
+        errors = MODULE.validate_intellij_marketplace_publish(collapsed)
+        self.assertTrue(
+            any("isolate verify" in error or "skip verifyPlugin" in error for error in errors),
+            errors,
+        )
+
+    def test_nightly_cancelled_skip_fails(self):
+        mutated = _minimal_publish_intellij_workflow_text().replace(
+            "if: always()",
+            "uses: ./.github/actions/notify-nightly-failure\n"
+            "        with:\n"
+            "          outcome: ${{ contains(needs.*.result, 'cancelled') && 'skip' || 'success' }}",
+            1,
+        )
+        errors = MODULE.validate_intellij_marketplace_publish(mutated)
+        self.assertTrue(
+            any("nightly" in error or "skip" in error for error in errors),
+            errors,
+        )
+
+    def test_missing_receipt_pin_fails(self):
+        mutated = _minimal_publish_intellij_workflow_text().replace(
+            "assert_intellij_marketplace_receipt.py --log log --properties props",
+            "echo no receipt",
+        )
+        errors = MODULE.validate_intellij_marketplace_publish(mutated)
+        self.assertTrue(any("receipt" in error for error in errors), errors)
+
+    def test_publish_wrapped_in_build_retry_fails(self):
+        action = """
+    - name: Sign and publish the plugin
+      run: bash scripts/ci/build_retry.sh 2 15 bash shaft-intellij/gradlew signPlugin publishPlugin
+"""
+        errors = MODULE.validate_intellij_marketplace_publish(
+            _minimal_publish_intellij_workflow_text(),
+            action,
+        )
+        self.assertTrue(any("retry publishPlugin" in error for error in errors), errors)
+
+    def test_missing_publish_workflow_fails_static_contract(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            _write_minimal_reactor(
+                root, reactor_version="10.2.20260630", plugin_version="10.2.20260630"
+            )
+            (root / ".github/workflows/publish-intellij-plugin.yml").unlink()
+            errors = MODULE.validate_static(root)
+        self.assertTrue(
+            any("publish-intellij-plugin.yml" in error for error in errors),
+            errors,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_validate_shaft_pilot_release.py
+++ b/tests/scripts/test_validate_shaft_pilot_release.py
@@ -792,6 +792,37 @@ jobs:
             errors,
         )
 
+    def test_always_must_bind_to_notify_missed_publish_job(self):
+        workflow = (
+            ROOT / ".github/workflows/publish-intellij-plugin.yml"
+        ).read_text(encoding="utf-8")
+        action = (ROOT / ".github/actions/intellij-verify/action.yml").read_text(
+            encoding="utf-8"
+        )
+        mutated = workflow.replace(
+            "  notify-missed-publish:\n"
+            "    name: Fail closed on missed Marketplace publish\n"
+            "    needs: [verify, publish]\n"
+            "    if: always()\n",
+            "  notify-missed-publish:\n"
+            "    name: Fail closed on missed Marketplace publish\n"
+            "    needs: [verify, publish]\n",
+            1,
+        )
+        self.assertNotEqual(workflow, mutated)
+        self.assertIn("if: always()", mutated)
+        notify_at = mutated.index("  notify-missed-publish:")
+        notify_block = mutated[notify_at:]
+        next_job = notify_block.find("\n  ", 4)
+        if next_job != -1:
+            notify_block = notify_block[:next_job]
+        self.assertNotIn("if: always()", notify_block)
+        errors = MODULE.validate_intellij_marketplace_publish(mutated, action)
+        self.assertTrue(
+            any("always()" in error and "notify" in error for error in errors),
+            errors,
+        )
+
     def test_nightly_cancelled_skip_fails(self):
         mutated = _minimal_publish_intellij_workflow_text().replace(
             "if: always()",


### PR DESCRIPTION
Closes #5221
Related to #5212

## Summary

Release `10.3.20260818` triggered Publish IntelliJ Plugin run 32171528453. That run cancelled at the 20-minute job timeout while `intellij-verify` with `publish: true` was still inside `:verifyPlugin`. Coverage uploaded `if: always()` and succeeded. The GitHub release already existed. JetBrains Marketplace plugin 32529 still lists `10.3.20260817` only, so this version is not burned.

This PR splits verify and Marketplace publish into separate jobs with separate timeouts, fails a release cancelled/timeout before `publishPlugin` (dedicated `intellij-marketplace-publish-miss` tracker, not nightly `skip`), and requires a Gradle `BUILD SUCCESSFUL` plus Marketplace version receipt after `publishPlugin`. `publishPlugin` stays off `build_retry.sh`.

Review F1: live receipt retries while a valid updates list omits the version (same 5x15s budget as transport errors) and fails closed if it never appears. `--updates-json` stays a no-retry unit-test path.

Review F2: `if: always()` is required on the `notify-missed-publish` job itself, not merely somewhere in the workflow file.

`workflow_dispatch` of `10.3.20260818` waits until this workflow is on `main`. Dispatching the current default-branch workflow would reuse the 20-minute combined job.

## Checks

GREEN after review F1/F2:

```
py -3 -m unittest tests.scripts.test_intellij_verify_retry tests.scripts.test_validate_shaft_pilot_release tests.scripts.test_assert_intellij_marketplace_receipt tests.scripts.test_validate_workflow_timeouts
```

Ran 68 tests in 1.125s. OK.

```
py -3 scripts/ci/validate_shaft_pilot_release.py
```

SHAFT Pilot release contract is valid.

Marketplace preflight 2026-08-19: `https://plugins.jetbrains.com/api/plugins/32529/updates` has `10.3.20260817`, not `10.3.20260818`.

## Continuation

Head: 5e66184bf8936c3bb77de2c76ad6eba171243268
State: review F1 (listing-lag receipt retry) and F2 (notify-job if: always() pin) committed and pushed. This is the retained checkpoint. Independent review is a new instance.
Blockers: `workflow_dispatch` for missed `10.3.20260818` cannot use the new split until this workflow file is on `main`. Marketplace has not consumed that version. Do not dispatch that version until this receipt retry is on `main` and Marketplace still omits it.
Next action: independent review of this HEAD, then CI babysit. Do not merge in this instance.
