### PR TITLE
fix: lock remaining Allure action-step proofs

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/BrowserActions.java
@@ -29,6 +29,7 @@ import com.shaft.performance.internal.LightHouseGenerateReport;
 import com.shaft.tools.internal.support.JavaScriptHelper;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.tools.io.internal.FlakeProfiler;
+import com.shaft.tools.io.internal.FailureReporter;
 import com.shaft.tools.io.internal.FailureTraceReporter;
 import com.shaft.tools.io.internal.HttpContractRecorder;
 import com.shaft.tools.io.internal.MobileTraceMetadata;
@@ -1341,9 +1342,24 @@ public class BrowserActions extends FluentWebDriverAction implements com.shaft.g
             }
             browserActionsHelper.passAction(driverFactoryHelper.getDriver(), "navigateToUrl", modifiedTargetUrlForLogging);
         } catch (Exception rootCauseException) {
+            if (alreadyReportedByFailureReporter(rootCauseException)) {
+                if (rootCauseException instanceof RuntimeException runtimeException) {
+                    throw runtimeException;
+                }
+                throw new RuntimeException(rootCauseException);
+            }
             browserActionsHelper.failAction(driverFactoryHelper.getDriver(), modifiedTargetUrlForLogging, rootCauseException);
         }
         return this;
+    }
+
+    private static boolean alreadyReportedByFailureReporter(Throwable throwable) {
+        for (StackTraceElement frame : throwable.getStackTrace()) {
+            if (FailureReporter.class.getName().equals(frame.getClassName())) {
+                return true;
+            }
+        }
+        return throwable.getCause() != null && alreadyReportedByFailureReporter(throwable.getCause());
     }
 
     private void forceStopCurrentNavigation() {

--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
@@ -166,11 +166,10 @@ public class BrowserActionsHelper {
     public void failAction(WebDriver driver, String actionName, String testData,
                            Exception... rootCauseException) {
         String message = reportActionResult(driver, actionName, testData, false, rootCauseException);
-        if (rootCauseException != null && rootCauseException.length > 0) {
-            FailureReporter.fail(BrowserActionsHelper.class, message, rootCauseException[0]);
-        } else {
-            FailureReporter.fail(message);
-        }
+        Throwable cause = (rootCauseException != null && rootCauseException.length > 0)
+                ? rootCauseException[0]
+                : new RuntimeException(message);
+        FailureReporter.fail(BrowserActionsHelper.class, message, cause);
     }
 
     private String reportActionResult(WebDriver driver, String actionName, String testData,

--- a/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/element/internal/ElementActionsHelper.java
@@ -875,10 +875,13 @@ public class ElementActionsHelper {
             switch (Integer.parseInt(matchingElementsInformation.get(0).toString())) {
                 case 0 -> {
                     reportActionResult(driver, null, null, null, null, null, false);
-                    if (matchingElementsInformation.size() > 2 && matchingElementsInformation.get(2) instanceof Throwable) {
-                        FailureReporter.fail(ElementActionsHelper.class, "Failed to identify unique element using this locator \"" + JavaHelper.formatLocatorToString(elementLocator) + "\"", (Throwable) matchingElementsInformation.get(2));
-                    }
-                    FailureReporter.fail("Failed to identify unique element using this locator \"" + JavaHelper.formatLocatorToString(elementLocator) + "\"");
+                    String uniqueElementMessage = "Failed to identify unique element using this locator \""
+                            + JavaHelper.formatLocatorToString(elementLocator) + "\"";
+                    Throwable uniqueElementCause = (matchingElementsInformation.size() > 2
+                            && matchingElementsInformation.get(2) instanceof Throwable throwable)
+                            ? throwable
+                            : new RuntimeException(uniqueElementMessage);
+                    FailureReporter.fail(ElementActionsHelper.class, uniqueElementMessage, uniqueElementCause);
                 }
                 case 1 -> {
                     return matchingElementsInformation;

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureReporter.java
@@ -1,6 +1,7 @@
 package com.shaft.tools.io.internal;
 
 import com.google.common.base.Throwables;
+import com.shaft.gui.browser.internal.BrowserActionsHelper;
 import com.shaft.gui.element.internal.ElementActionsHelper;
 import com.shaft.tools.internal.support.JavaHelper;
 
@@ -12,7 +13,7 @@ public class FailureReporter {
     public static void fail(Class<?> failedFileManager, String message, Throwable throwable) {
         String rootCause = getRootCause(throwable);
 
-        if (failedFileManager != ElementActionsHelper.class) {
+        if (failedFileManager != ElementActionsHelper.class && failedFileManager != BrowserActionsHelper.class) {
             String actionName = "fail";
             for (StackTraceElement stackTraceElement : Arrays.stream(Thread.currentThread().getStackTrace()).toList()) {
                 var methodName = stackTraceElement.getMethodName();

--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/ReportManagerHelper.java
@@ -913,10 +913,12 @@ public class ReportManagerHelper {
      * @param logText the text that needs to be logged in this action
      */
     public static void writeStepToReport(String logText) {
-        if (!SHAFT.Properties.reporting.disableLogging()) {
-            createLogEntry(logText, true);
-            Allure.step(logText, getStepStatus());
+        Status stepStatus = getStepStatus();
+        if (shouldSuppressStep(stepStatus)) {
+            return;
         }
+        createLogEntry(logText, true);
+        writeOrReuseAllureStep(logText, stepStatus, null);
     }
 
     /**
@@ -927,10 +929,12 @@ public class ReportManagerHelper {
      * @param logLevel the log level to use for the console log entry
      */
     public static void writeStepToReport(String logText, Level logLevel) {
-        if (!SHAFT.Properties.reporting.disableLogging()) {
-            createLogEntry(logText, logLevel);
-            Allure.step(logText, getStepStatus());
+        Status stepStatus = getStepStatus();
+        if (shouldSuppressStep(stepStatus)) {
+            return;
         }
+        createLogEntry(logText, logLevel);
+        writeOrReuseAllureStep(logText, stepStatus, null);
     }
 
     /**
@@ -942,10 +946,11 @@ public class ReportManagerHelper {
      * @param stepStatus the exact status to render for this step in the execution report
      */
     public static void writeStepToReport(String logText, Level logLevel, Status stepStatus) {
-        if (!SHAFT.Properties.reporting.disableLogging()) {
-            createLogEntry(logText, logLevel);
-            Allure.step(logText, stepStatus);
+        if (shouldSuppressStep(stepStatus)) {
+            return;
         }
+        createLogEntry(logText, logLevel);
+        writeOrReuseAllureStep(logText, stepStatus, null);
     }
 
     /**
@@ -960,14 +965,19 @@ public class ReportManagerHelper {
      * @param stepStartMillis epoch milliseconds at which the summarized work started
      */
     public static void writeStepToReport(String logText, Level logLevel, Status stepStatus, long stepStartMillis) {
-        if (!SHAFT.Properties.reporting.disableLogging()) {
-            createLogEntry(logText, logLevel);
-            var lifecycle = Allure.getLifecycle();
-            var uuid = UUID.randomUUID().toString();
-            lifecycle.startStep(uuid, new StepResult().setName(logText).setStatus(stepStatus));
-            lifecycle.updateStep(uuid, step -> step.setStart(stepStartMillis));
-            lifecycle.stopStep(uuid);
+        if (shouldSuppressStep(stepStatus)) {
+            return;
         }
+        createLogEntry(logText, logLevel);
+        if (isInsideOpenAllureStep()) {
+            updateCurrentStepStatus(stepStatus);
+            return;
+        }
+        var lifecycle = Allure.getLifecycle();
+        var uuid = UUID.randomUUID().toString();
+        lifecycle.startStep(uuid, new StepResult().setName(logText).setStatus(stepStatus));
+        lifecycle.updateStep(uuid, step -> step.setStart(stepStartMillis));
+        lifecycle.stopStep(uuid);
     }
 
     private static Status getStepStatus() {
@@ -976,39 +986,60 @@ public class ReportManagerHelper {
     }
 
     static void writeStepToReport(String logText, List<List<Object>> attachments, CheckpointStatus status) {
-        if (SHAFT.Properties.reporting.disableLogging()) {
+        Status stepStatus = status == CheckpointStatus.FAIL ? Status.FAILED : Status.PASSED;
+        if (shouldSuppressStep(stepStatus)) {
             return;
         }
         createLogEntry(logText, true);
+        writeOrReuseAllureStep(logText, stepStatus, attachments);
+    }
+
+    private static boolean shouldSuppressStep(Status stepStatus) {
+        if (SHAFT.Properties.reporting == null || !SHAFT.Properties.reporting.disableLogging()) {
+            return false;
+        }
+        return stepStatus != Status.FAILED && stepStatus != Status.BROKEN;
+    }
+
+    private static boolean isInsideOpenAllureStep() {
         var lifecycle = Allure.getLifecycle();
+        var current = lifecycle.getCurrentTestCaseOrStep();
+        var testCase = lifecycle.getCurrentTestCase();
+        return current.isPresent() && testCase.isPresent() && !current.get().equals(testCase.get());
+    }
+
+    private static void updateCurrentStepStatus(Status stepStatus) {
+        if (stepStatus != Status.FAILED && stepStatus != Status.BROKEN) {
+            return;
+        }
+        Allure.getLifecycle().updateStep(update -> update.setStatus(stepStatus));
+    }
+
+    private static void writeOrReuseAllureStep(String logText, Status stepStatus, List<List<Object>> attachments) {
+        var lifecycle = Allure.getLifecycle();
+        if (isInsideOpenAllureStep()) {
+            attach(attachments);
+            updateCurrentStepStatus(stepStatus);
+            return;
+        }
         var uuid = UUID.randomUUID().toString();
-        Status stepStatus = status == CheckpointStatus.FAIL ? Status.FAILED : Status.PASSED;
         lifecycle.startStep(uuid, new StepResult().setName(logText).setStatus(stepStatus));
         try {
-            if (attachments != null && !attachments.isEmpty()) {
-                attachments.forEach(attachment -> {
-                    if (attachment != null && !attachment.isEmpty() && attachment.get(2)!=null && attachment.get(2).getClass().toString().toLowerCase().contains("string")
-                            && !attachment.get(2).getClass().toString().contains("StringInputStream")) {
-                        if (!attachment.get(2).toString().isEmpty()) {
-                            attach(attachment.get(0).toString(), attachment.get(1).toString(), attachment.get(2).toString());
-                        }
-                    } else if (attachment != null && !attachment.isEmpty()) {
-                        if (attachment.get(2) instanceof byte[]) {
-                            attach(attachment.get(0).toString(), attachment.get(1).toString(), new ByteArrayInputStream((byte[]) attachment.get(2)));
-                        } else {
-                            attach(attachment.get(0).toString(), attachment.get(1).toString(), (InputStream) attachment.get(2));
-                        }
-                    }
-                    if (status.equals(CheckpointStatus.FAIL)) {
-                        lifecycle.updateStep(uuid, update -> {
-                            update.setStatus(Status.FAILED);
-                            if (attachment != null && !attachment.isEmpty() && attachment.get(2) != null) {
-                                String trace = update.getStatusDetails() == null ? attachment.get(2).toString() : update.getStatusDetails().getTrace() + System.lineSeparator() + attachment.get(2).toString();
+            attach(attachments);
+            if (stepStatus == Status.FAILED || stepStatus == Status.BROKEN) {
+                lifecycle.updateStep(uuid, update -> {
+                    update.setStatus(stepStatus);
+                    if (attachments != null) {
+                        for (List<Object> attachment : attachments) {
+                            if (attachment != null && attachment.size() > 2 && attachment.get(2) != null) {
+                                String trace = update.getStatusDetails() == null
+                                        ? attachment.get(2).toString()
+                                        : update.getStatusDetails().getTrace() + System.lineSeparator() + attachment.get(2).toString();
                                 StatusDetails details = update.getStatusDetails() == null ? new StatusDetails() : update.getStatusDetails();
                                 details.setTrace(trace.trim());
                                 update.setStatusDetails(details);
                             }
-                        });
+                        }
                     }
                 });
             }

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
@@ -121,6 +121,28 @@ public class AllureActionStepReportingTest extends Tests {
     }
 
     @Test
+    public void failedNavigateAgainstInvalidUrlBodyWritesExactlyOneFailedAllureStep() throws IOException {
+        String url = TestPageServer.url("navigationErrorFixture.html");
+        SHAFT.Properties.flags.set().forceCheckNavigationWasSuccessful(true);
+        RuntimeException thrown = null;
+        try {
+            driver.get().browser().navigateToURL(url);
+        } catch (RuntimeException exception) {
+            thrown = exception;
+        }
+        Assert.assertNotNull(thrown,
+                "forceCheckNavigationWasSuccessful against navigationErrorFixture.html must fail navigateToURL.");
+
+        JsonObject result = snapshotCurrentAllureResult();
+        List<JsonObject> failedStepsForUrl = actionSteps(result, step ->
+                isFailedOrBroken(step) && stepName(step).contains(url)
+                        && !stepName(step).toLowerCase(Locale.ROOT).startsWith("attachment:"));
+        Assert.assertEquals(failedStepsForUrl.size(), 1,
+                "failAction with no throwable must not let FailureReporter.fail(String) add a second FAIL step. Steps: "
+                        + summarizeSteps(result));
+    }
+
+    @Test
     public void fluentNavigateTypeClickWritesDistinctActionSteps() throws IOException {
         String url = TestPageServer.url("smartLoginFixture.html");
         var username = SHAFT.GUI.Locator.hasAnyTagName().hasId("username").build();

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.shaft.driver.SHAFT;
+import com.shaft.tools.io.ReportManager;
 import io.qameta.allure.Allure;
 import io.qameta.allure.FileSystemResultsWriter;
 import org.testng.Assert;
@@ -13,31 +14,66 @@ import testPackage.TestPageServer;
 import testPackage.Tests;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 /**
- * Locks Allure action-step reporting for {@code navigateToURL} (#5208).
- * The test snapshots the current Allure uuid to a {@code *-result.json} file
- * and asserts that file, not the in-memory lifecycle view alone.
- *
- * <p>Inventory of report sinks after the shared-path fix:
- * <ul>
- *   <li>{@code ReportManager.log} / {@code ReportManagerHelper.log} / {@code writeStepToReport}
- *       — one Allure step per call (browser, Playwright, API/CLI helpers that already report).</li>
- *   <li>{@code BrowserActionsHelper.reportActionResult} and {@code ElementActionsHelper.reportActionResult}
- *       — same owner; screenshot stays an attachment inside the step.</li>
- *   <li>{@code Actions} public {@code @Step} methods — already start a step; locator metadata
- *       ({@code decision.element-actions-normalize-allure-locator-metadata}) stays intact.</li>
- *   <li>{@code ReportManager.logDiscrete} — not an action; must not become a step.</li>
- *   <li>{@code attachAsStep} — attachment, not a second action step.</li>
- * </ul>
+ * Locks Allure action-step reporting after #5208 / #5219 (#5220 remaining proofs).
+ * Snapshots the current Allure uuid to a {@code *-result.json} file and asserts
+ * that file, not the in-memory lifecycle view alone.
  */
 public class AllureActionStepReportingTest extends Tests {
+
+    private static final Set<String> REQUIRED_SURFACES = new LinkedHashSet<>(List.of(
+            "selenium.navigateToURL",
+            "playwright.navigateToURL",
+            "element.type",
+            "element.click",
+            "api.rest",
+            "cli.terminal"
+    ));
+
+    /**
+     * Inventoried report owners. Omitting a {@link #REQUIRED_SURFACES} key fails
+     * {@link #inventoriedSurfacesAreAllProven()}.
+     */
+    private static final Map<String, String> INVENTORIED_SURFACES = new LinkedHashMap<>();
+
+    static {
+        INVENTORIED_SURFACES.put("selenium.navigateToURL",
+                "BrowserActionsHelper.reportActionResult -> ReportManagerHelper.log / writeStepToReport");
+        INVENTORIED_SURFACES.put("playwright.navigateToURL",
+                "ReportManager.log(\"Navigate to url ...\")");
+        INVENTORIED_SURFACES.put("element.type",
+                "Actions public @Step(\"Type\") plus ElementActionsHelper.reportActionResult");
+        INVENTORIED_SURFACES.put("element.click",
+                "Actions public @Step(\"Click\") plus ElementActionsHelper.reportActionResult");
+        INVENTORIED_SURFACES.put("api.rest",
+                "logDiscrete (justified: RestActions.evaluateResponseStatusCode forces discrete logging)");
+        INVENTORIED_SURFACES.put("cli.terminal",
+                "logDiscrete (justified: TerminalActions command execution logs discretely)");
+    }
+
+    @Test
+    public void inventoriedSurfacesAreAllProven() throws IOException {
+        Assert.assertEquals(INVENTORIED_SURFACES.keySet(), REQUIRED_SURFACES,
+                "Inventory omitted a required surface. Add a proof for the missing owner or restore the key.");
+        for (String surface : REQUIRED_SURFACES) {
+            proveInventoriedSurface(surface);
+        }
+    }
 
     @Test
     public void navigateToLocalFixtureWritesExactlyOneAllureNavigateStep() throws IOException {
@@ -45,7 +81,7 @@ public class AllureActionStepReportingTest extends Tests {
         driver.get().browser().navigateToURL(url);
 
         JsonObject result = snapshotCurrentAllureResult();
-        List<JsonObject> navigateSteps = navigateActionSteps(result, url);
+        List<JsonObject> navigateSteps = actionSteps(result, step -> isNavigateActionStep(step, url));
 
         Assert.assertEquals(navigateSteps.size(), 1,
                 "Allure result " + result.get("uuid") + " should contain exactly one navigate step for "
@@ -55,30 +91,156 @@ public class AllureActionStepReportingTest extends Tests {
     }
 
     @Test
-    public void failedNavigateStillWritesFailedOrBrokenAllureStep() throws IOException {
-        String url = TestPageServer.url("navigationErrorFixture.html");
-        SHAFT.Properties.flags.set().forceCheckNavigationWasSuccessful(true);
+    public void failedNavigateStillWritesExactlyOneFailedOrBrokenAllureStep() throws IOException {
+        // SHAFT defaults pageLoadStrategy=none and readinessState=none, so get()
+        // returns before the document exists. Recreate a driver that waits, then
+        // hit a URL that never writes an HTTP response. That is a navigation the
+        // driver cannot complete, not a 200 page whose body is "Invalid URL".
+        driver.get().quit();
+        SHAFT.Properties.web.set().pageLoadStrategy("normal");
+        SHAFT.Properties.web.set().readinessState("complete");
+        SHAFT.Properties.timeouts.set().pageLoadTimeout(2);
+        driver.set(new SHAFT.GUI.WebDriver());
+        driver.get().getDriver().manage().timeouts().pageLoadTimeout(Duration.ofSeconds(2));
+        String url = TestPageServer.neverRespondUrl();
         RuntimeException thrown = null;
         try {
             driver.get().browser().navigateToURL(url);
         } catch (RuntimeException exception) {
             thrown = exception;
         }
-        Assert.assertNotNull(thrown, "Forced navigation check against navigationErrorFixture.html must fail navigateToURL.");
+        Assert.assertNotNull(thrown, "Navigate to a URL the driver cannot complete must fail navigateToURL.");
 
         JsonObject result = snapshotCurrentAllureResult();
-        List<JsonObject> navigateSteps = navigateActionSteps(result, url);
-        Assert.assertFalse(navigateSteps.isEmpty(),
-                "Failed navigate must still produce an Allure step identifying the URL. Steps: "
+        List<JsonObject> navigateSteps = actionSteps(result, step -> isNavigateActionStep(step, url));
+        Assert.assertEquals(navigateSteps.size(), 1,
+                "Failed navigate must produce exactly one Allure step identifying the URL. Steps: "
                         + summarizeSteps(result));
-        Assert.assertTrue(navigateSteps.stream().anyMatch(AllureActionStepReportingTest::isFailedOrBroken),
-                "Failed navigate step must be failed or broken, not omitted or passed: " + navigateSteps);
+        Assert.assertTrue(isFailedOrBroken(navigateSteps.getFirst()),
+                "Failed navigate step must be failed or broken, not omitted or passed: " + navigateSteps.getFirst());
+    }
+
+    @Test
+    public void fluentNavigateTypeClickWritesDistinctActionSteps() throws IOException {
+        String url = TestPageServer.url("smartLoginFixture.html");
+        var username = SHAFT.GUI.Locator.hasAnyTagName().hasId("username").build();
+        var submit = SHAFT.GUI.Locator.hasTagName("button").hasNormalizedText("Submit").build();
+        driver.get().browser().navigateToURL(url)
+                .and().element().type(username, "student")
+                .and().click(submit);
+
+        JsonObject result = snapshotCurrentAllureResult();
+        List<JsonObject> navigateSteps = actionSteps(result, step -> isNavigateActionStep(step, url));
+        List<JsonObject> typeSteps = actionSteps(result, AllureActionStepReportingTest::isTypeActionStep);
+        List<JsonObject> clickSteps = actionSteps(result, AllureActionStepReportingTest::isClickActionStep);
+
+        Assert.assertEquals(navigateSteps.size(), 1,
+                "Fluent chain must keep navigate as its own step. Steps: " + summarizeSteps(result));
+        Assert.assertEquals(typeSteps.size(), 1,
+                "Fluent chain must write exactly one Type action step, not a collapsed parent or a nested duplicate. Steps: "
+                        + summarizeSteps(result));
+        Assert.assertEquals(clickSteps.size(), 1,
+                "Fluent chain must write exactly one Click action step, not a collapsed parent or a nested duplicate. Steps: "
+                        + summarizeSteps(result));
+    }
+
+    @Test
+    public void disableLoggingStillWritesFailedVerificationStep() throws IOException {
+        boolean original = SHAFT.Properties.reporting.disableLogging();
+        try {
+            SHAFT.Properties.reporting.set().disableLogging(true);
+            String evidence = "failed-verification-evidence-" + UUID.randomUUID();
+            List<List<Object>> attachments = List.of(Arrays.asList("Evidence", "body", evidence));
+            ReportManagerHelper.logNestedSteps("expected [foo] but found [bar]", null, attachments,
+                    CheckpointStatus.FAIL, CheckpointType.VERIFICATION);
+
+            JsonObject result = snapshotCurrentAllureResult();
+            List<JsonObject> failedVerificationSteps = actionSteps(result, step ->
+                    isFailedOrBroken(step) && (stepName(step).toLowerCase(Locale.ROOT).contains("expected [foo]")
+                            || stepName(step).toLowerCase(Locale.ROOT).contains("verification")));
+            Assert.assertFalse(failedVerificationSteps.isEmpty(),
+                    "Failed verification must still create an Allure step when disableLogging is true. Steps: "
+                            + summarizeSteps(result));
+        } finally {
+            SHAFT.Properties.reporting.set().disableLogging(original);
+        }
+    }
+
+    @Test
+    public void typeAndClickWriteOneVisibleActionStepAndLogDiscreteIsNotAStep() throws IOException {
+        String url = TestPageServer.url("coverageTestPage.html");
+        var textInput = SHAFT.GUI.Locator.hasAnyTagName().hasId("textInput").build();
+        var submit = SHAFT.GUI.Locator.hasAnyTagName().hasId("submitBtn").build();
+        driver.get().browser().navigateToURL(url)
+                .and().element().type(textInput, "shaft")
+                .and().click(submit);
+
+        String discreteToken = "discrete-should-not-be-a-step-" + UUID.randomUUID();
+        ReportManager.logDiscrete(discreteToken);
+
+        JsonObject result = snapshotCurrentAllureResult();
+        List<JsonObject> typeSteps = actionSteps(result, AllureActionStepReportingTest::isTypeActionStep);
+        List<JsonObject> clickSteps = actionSteps(result, AllureActionStepReportingTest::isClickActionStep);
+        List<JsonObject> discreteSteps = actionSteps(result, step -> stepName(step).contains(discreteToken));
+
+        Assert.assertEquals(typeSteps.size(), 1,
+                "Type must produce one visible action step, not a programmatic child under @Step(\"Type\"). Steps: "
+                        + summarizeSteps(result));
+        Assert.assertEquals(clickSteps.size(), 1,
+                "Click must produce one visible action step, not a programmatic child under @Step(\"Click\"). Steps: "
+                        + summarizeSteps(result));
+        Assert.assertTrue(discreteSteps.isEmpty(),
+                "logDiscrete must not become an Allure action step. Steps: " + summarizeSteps(result));
+    }
+
+    private static void proveInventoriedSurface(String surface) throws IOException {
+        switch (surface) {
+            case "selenium.navigateToURL" -> Assert.assertTrue(
+                    readModuleSource("com/shaft/gui/browser/internal/BrowserActionsHelper.java")
+                            .contains("ReportManagerHelper.log("),
+                    "Selenium navigate must still report through ReportManagerHelper.log.");
+            case "playwright.navigateToURL" -> {
+                String playwrightNavigate = readModuleSource("com/shaft/gui/playwright/browser/BrowserActions.java");
+                Assert.assertTrue(playwrightNavigate.contains("ReportManager.log(")
+                                && playwrightNavigate.contains("Navigate to url"),
+                        "Playwright navigate must still use ReportManager.log(\"Navigate to url ...\").");
+            }
+            case "element.type" -> Assert.assertTrue(
+                    readModuleSource("com/shaft/gui/element/internal/Actions.java").contains("@Step(\"Type\")"),
+                    "Element type must keep its public @Step(\"Type\").");
+            case "element.click" -> Assert.assertTrue(
+                    readModuleSource("com/shaft/gui/element/internal/Actions.java").contains("@Step(\"Click\")"),
+                    "Element click must keep its public @Step(\"Click\").");
+            case "api.rest" -> {
+                String restActions = readModuleSource("com/shaft/api/RestActions.java");
+                Assert.assertTrue(restActions.contains("ReportManagerHelper.setDiscreteLogging(true)"),
+                        "API status evaluation must still force discrete logging.");
+                Assert.assertTrue(restActions.contains("ReportManager.logDiscrete("),
+                        "API must remain a justified logDiscrete exception while alwaysLogDiscreetly is forced.");
+            }
+            case "cli.terminal" -> Assert.assertTrue(
+                    readModuleSource("com/shaft/cli/TerminalActions.java")
+                            .contains("ReportManager.logDiscrete(\"Executing local command:"),
+                    "CLI must remain a justified logDiscrete exception.");
+            default -> Assert.fail("No proof registered for inventoried surface: " + surface);
+        }
+    }
+
+    private static String readModuleSource(String relativeToJavaRoot) throws IOException {
+        Path moduleRoot = Path.of("src/main/java");
+        Path fromModule = moduleRoot.resolve(relativeToJavaRoot);
+        if (Files.isRegularFile(fromModule)) {
+            return Files.readString(fromModule, StandardCharsets.UTF_8);
+        }
+        Path fromRepo = Path.of("shaft-engine").resolve(fromModule);
+        Assert.assertTrue(Files.isRegularFile(fromRepo), "Missing source inventory file: " + relativeToJavaRoot);
+        return Files.readString(fromRepo, StandardCharsets.UTF_8);
     }
 
     private static JsonObject snapshotCurrentAllureResult() throws IOException {
         String uuid = Allure.getLifecycle().getCurrentTestCase()
                 .orElseThrow(() -> new AssertionError("Allure has no current test case uuid to snapshot."));
-        Path snapshotDirectory = Files.createTempDirectory("shaft-5208-allure-" + uuid);
+        Path snapshotDirectory = Files.createTempDirectory("shaft-5220-allure-" + uuid);
         Allure.getLifecycle().updateTestCase(new FileSystemResultsWriter(snapshotDirectory)::write);
         Path resultFile = snapshotDirectory.resolve(uuid + "-result.json");
         Assert.assertTrue(Files.isRegularFile(resultFile),
@@ -86,10 +248,10 @@ public class AllureActionStepReportingTest extends Tests {
         return JsonParser.parseString(Files.readString(resultFile)).getAsJsonObject();
     }
 
-    private static List<JsonObject> navigateActionSteps(JsonObject result, String url) {
+    private static List<JsonObject> actionSteps(JsonObject result, java.util.function.Predicate<JsonObject> match) {
         List<JsonObject> matches = new ArrayList<>();
         for (JsonObject step : allSteps(result.get("steps"))) {
-            if (isNavigateActionStep(step, url)) {
+            if (match.test(step)) {
                 matches.add(step);
             }
         }
@@ -105,6 +267,24 @@ public class AllureActionStepReportingTest extends Tests {
         boolean identifiesNavigate = normalized.contains("navigate to url")
                 || normalized.contains("navigatetourl");
         return identifiesNavigate && name.contains(url);
+    }
+
+    private static boolean isTypeActionStep(JsonObject step) {
+        String name = stepName(step);
+        String normalized = name.toLowerCase(Locale.ROOT);
+        if (normalized.startsWith("attachment:")) {
+            return false;
+        }
+        return "type".equals(normalized) || normalized.startsWith("type ");
+    }
+
+    private static boolean isClickActionStep(JsonObject step) {
+        String name = stepName(step);
+        String normalized = name.toLowerCase(Locale.ROOT);
+        if (normalized.startsWith("attachment:")) {
+            return false;
+        }
+        return "click".equals(normalized) || normalized.startsWith("click ");
     }
 
     private static List<JsonObject> allSteps(JsonElement stepsElement) {

--- a/shaft-engine/src/test/java/testPackage/TestPageServer.java
+++ b/shaft-engine/src/test/java/testPackage/TestPageServer.java
@@ -29,6 +29,25 @@ public final class TestPageServer {
         return "http://" + browserHost() + ":" + port + "/" + fixtureName;
     }
 
+    /**
+     * URL that accepts TCP and never writes an HTTP response, so a driver that
+     * actually waits for page load cannot complete navigation.
+     */
+    public static String neverRespondUrl() {
+        ensureStarted();
+        return "http://" + browserHost() + ":" + port + "/__never_respond";
+    }
+
+    private static void neverRespond(HttpExchange exchange) {
+        try {
+            Thread.sleep(Long.MAX_VALUE);
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+        } finally {
+            exchange.close();
+        }
+    }
+
     private static void ensureStarted() {
         if (server != null) {
             return;
@@ -41,6 +60,7 @@ public final class TestPageServer {
                 var newServer = HttpServer.create(new InetSocketAddress("0.0.0.0", 0), 0);
                 var root = Path.of(SHAFT.Properties.paths.testData()).toAbsolutePath().normalize();
                 newServer.createContext("/", exchange -> serveFixture(exchange, root));
+                newServer.createContext("/__never_respond", TestPageServer::neverRespond);
                 newServer.setExecutor(Executors.newCachedThreadPool(runnable -> {
                     Thread thread = new Thread(runnable, "test-page-server");
                     thread.setDaemon(true);


### PR DESCRIPTION
Closes #5220
Related to #5208

## Summary

Locks the four remaining Allure action-step proofs after navigate-only #5219.

- Inventory check fails if an inventoried surface is omitted (Playwright `ReportManager.log` owner, API/CLI `logDiscrete` exceptions, element `@Step` owners).
- Fluent `navigate.and().element().type().click()` writes distinct navigate, Type, and Click steps.
- Failed navigate uses a URL the driver cannot complete (`TestPageServer.neverRespondUrl()` with a waiting driver) and asserts exactly one failed/broken navigate step.
- `forceCheckNavigationWasSuccessful` against `navigationErrorFixture.html` (`Invalid URL` body, no throwable) writes exactly one FAIL step. `failAction` always uses `FailureReporter.fail(Class, ...)` so `fail(String)` cannot duplicate after `reportActionResult`.
- `logNestedSteps` still writes a failed verification step when `disableLogging` is true.
- Click/Type stay one visible action step; `logDiscrete` is not a step.

## Checks

Balanced scope, headless, `-Dallure.automaticallyOpen=false`:

```
mvn -pl shaft-engine "-Dtest=AllureActionStepReportingTest,ReportManagerHelperUnitTests" "-Dallure.automaticallyOpen=false" "-DheadlessExecution=true" test
```

- RED (F1): `failedNavigateAgainstInvalidUrlBodyWritesExactlyOneFailedAllureStep` found two identical FAIL steps (`expected [1] but found [2]`).
- GREEN: Surefire `TEST-TestSuite.xml` `tests="40"` `failures="0"`. JUnit `junitreports/TEST-com.shaft.tools.io.internal.AllureActionStepReportingTest.xml` `tests="7"` `failures="0"` at 2026-08-19T15:31:22 EEST. `junitreports/TEST-testPackage.unitTests.ReportManagerHelperUnitTests.xml` `tests="33"` `failures="0"`.

## Continuation

Head: fad1eca70f78fd5515abfb06eb49b1136a25ce05
State: Review F1 (no-throwable failAction duplicate FAIL step) committed and pushed. Hang-URL test unchanged. Independent review is a new instance.
Blockers: none
Next action: independent reviewer verifies F1. Do not merge from this implementer turn.