### PR TITLE
fix: derive ChaosEngine install source from the invocation URL

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -22,11 +22,11 @@ Give the following instruction to a coding agent while its working directory is
 the project you want to manage:
 
 > Install or upgrade ChaosEngine in this project from the latest commit of the
-> official upstream. Change into the target project first. Set
-> `CHAOS_ENGINE_REPOSITORY` to the upstream `owner/repository`, then run
+> official upstream. Change into the target project first. Run
 > `chaos-engine/install.ps1` on Windows (`irm ... | iex`) or
-> `chaos-engine/install.sh` on macOS/Linux (`curl -fsSL ... | bash`). Those
-> wrappers download `bootstrap.py` and run the full install: hooks, skills,
+> `chaos-engine/install.sh` on macOS/Linux (`curl -fsSL ... | bash -s -- <url>`).
+> Those wrappers read owner/repository from the invocation URL, then download
+> `bootstrap.py` and run the full install: hooks, skills,
 > companions, Memory, MemPalace, Graphify CLI, and doctor. Do not stop until
 > the active doctor reports the resolved 40-character commit and every
 > required component healthy. Treat the installed ChaosEngine skill as the
@@ -45,31 +45,30 @@ requires marketplace registration, the agent registers the project marketplace
 and installs `chaos-engine`, `caveman`, and `ponytail` at project local scope,
 then runs active `doctor` probes. Generated indexes, caches, receipts, and runtimes
 remain untracked; canonical configuration and adapters remain trackable.
-Origin identity masters under `assets/brand/` and the origin adoption matrix
-`RESEARCH.md` stay in the source tree and are not copied into the adopter
-payload. The
+Origin identity masters under `assets/brand/`, the origin adoption matrix
+`RESEARCH.md`, and `STANDALONE.md` stay in the source tree and are not copied
+into the adopter payload. The
 
 installer also merges receipt-bound LF attributes for canonical harness paths,
 so Windows Git checkouts retain the exact owned bytes while unrelated
 `.gitattributes` rules remain untouched.
 
-Configure `CHAOS_ENGINE_REPOSITORY` in the caller's host environment with the
-canonical `owner/repository` source. The installer reads it without copying the
-source identity into the adopter payload. Change into the target project or
-folder first; both scripts install into the current working directory.
+Replace `owner/repository` in the URL with the upstream that hosts the wrapper.
+The scripts parse that URL and do not copy the source identity into the adopter
+payload. `CHAOS_ENGINE_REPOSITORY` remains a local-file override when the
+invocation URL cannot be parsed. Change into the target project or folder first;
+both scripts install into the current working directory.
 
 Windows PowerShell, using [install.ps1](install.ps1):
 
 ```powershell
-$env:CHAOS_ENGINE_REPOSITORY = 'owner/repository'
-irm "https://raw.githubusercontent.com/$env:CHAOS_ENGINE_REPOSITORY/main/chaos-engine/install.ps1" | iex
+irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex
 ```
 
 macOS or Linux, using [install.sh](install.sh):
 
 ```bash
-export CHAOS_ENGINE_REPOSITORY=owner/repository
-curl -fsSL "https://raw.githubusercontent.com/${CHAOS_ENGINE_REPOSITORY}/main/chaos-engine/install.sh" | bash
+curl -fsSL "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh" | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"
 ```
 
 Inspect the linked installer and [bootstrap.py](bootstrap.py) first when policy

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -71,21 +71,22 @@ flow resolves a configured upstream branch to an immutable commit, downloads
 only that commit's validated `chaos-engine/` subtree, and installs ChaosEngine
 inside the target project.
 
-Configure `CHAOS_ENGINE_REPOSITORY` in the caller's host environment with the
-canonical `owner/repository` source; it is not copied into the adopter payload.
-Change into the target project or folder first; both scripts install into the
-current working directory.
+Replace `owner/repository` in the URL with the upstream that hosts the wrapper;
+it is not copied into the adopter payload. `CHAOS_ENGINE_REPOSITORY` remains a
+local-file override when the invocation URL cannot be parsed. Change into the
+target project or folder first; both scripts install into the current working
+directory.
 
 Windows PowerShell:
 
 ```powershell
-irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex
+irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex
 ```
 
 macOS or Linux:
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh" | bash
+curl -fsSL "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh" | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"
 ```
 
 Inspect [install.ps1](install.ps1), [install.sh](install.sh), and

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -159,6 +159,7 @@ default; repository-specific distributions require an explicit selection.
 | [`tool.py`](tool.py) | Relocatable launcher for ChaosEngine-owned local tools |
 | [`learning.py`](learning.py) | Privacy-gated queue for reusable improvement candidates |
 | [`RESEARCH.md`](RESEARCH.md) | Dated adoption decisions and their local proof owners |
+| [`STANDALONE.md`](STANDALONE.md) | Origin-only spec for a later standalone source repository |
 | [`assets/brand/`](assets/brand/) | Origin identity masters; not copied into adopter installs |
 
 The installer records provenance and per-file ownership in the consumer
@@ -235,6 +236,7 @@ reports, caches, runtime indexes, or `graphify-out/`.
 - [Lifecycle hooks](references/lifecycle-hooks.md)
 - <a href="profiles/README.md">Project profiles</a>
 - [Research and adoption matrix](RESEARCH.md)
+- [Standalone source-repository spec](STANDALONE.md)
 - [Identity and brand rules](assets/brand/BRAND.md)
 
 ChaosEngine supports rigorous, evidence-led software delivery. Gambaru.

--- a/chaos-engine/STANDALONE.md
+++ b/chaos-engine/STANDALONE.md
@@ -1,0 +1,135 @@
+# Spec: migrate ChaosEngine to ShaftHQ/chaos-engine
+
+Status: approved for later implementation. This file is origin-only and is not
+copied into adopter payloads. Tracker: ShaftHQ/SHAFT_ENGINE#5225 (parent #5223).
+Do not create the GitHub repository, rewrite history, or change bootstrap prefix
+selection in the same change that only records this spec.
+
+## Goal
+
+`ShaftHQ/chaos-engine` becomes the public source of the portable harness. The
+tree lives at repository root (`install.ps1`, `install.sh`, `bootstrap.py`,
+`install.py`, `skills/`, `profiles/portable/`, `references/`, `vendor/`, …).
+The public one-liner becomes:
+
+```powershell
+irm "https://raw.githubusercontent.com/ShaftHQ/chaos-engine/main/install.ps1" | iex
+```
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/ShaftHQ/chaos-engine/main/install.sh" | bash -s -- "https://raw.githubusercontent.com/ShaftHQ/chaos-engine/main/install.sh"
+```
+
+Wrappers already derive owner/repository and the sibling `bootstrap.py` from that
+URL (SHAFT_ENGINE#5224). The remaining gap is `bootstrap.py` still selecting
+GitHub tree entries whose first path part is `chaos-engine/`.
+
+## Current layout
+
+| Location | Role |
+| --- | --- |
+| `ShaftHQ/SHAFT_ENGINE/chaos-engine/` | Canonical source tree today |
+| GitHub tree prefix `chaos-engine/` | `bootstrap.py` download filter and raw path |
+| `profiles/portable/` | Public default distribution |
+| `profiles/shaft/` | SHAFT-only profile, selected via `installWhen.mavenArtifactIds` |
+| `tests/scripts/test_chaos_engine_*.py` | Proof in SHAFT_ENGINE |
+| `assets/brand/`, `RESEARCH.md`, this file | Origin-only; omitted from adopter payload |
+
+## Key decisions
+
+1. **End state is a real standalone repository, not a forever-mirror.** User
+   requested a direct migration to `ShaftHQ/chaos-engine`. A publish Action that
+   leaves SHAFT_ENGINE as the only writable source is rejected as the end state.
+2. **History is preserved** with `git filter-repo --path chaos-engine/ --path-rename chaos-engine/:`.
+   A fresh orphan branch would drop blame and review context.
+3. **SHAFT profile stays in SHAFT_ENGINE.** It is already excluded from the
+   portable payload. The public repo ships `profiles/portable/` only.
+4. **Shim the old nested URL** for a dated deprecation window so existing
+   `.../SHAFT_ENGINE/main/chaos-engine/install.ps1` one-liners keep working.
+5. **Bootstrap learns root-or-nested**, then the new one-liner works without a
+   second wrapper change.
+
+## Bootstrap prefix (later, PR 1)
+
+Today `download_source` skips every tree entry whose `path.parts[0] != "chaos-engine"`,
+then strips that prefix.
+
+Change:
+
+- If the recursive tree contains `skills/chaos-engine/SKILL.md` at repo root,
+  treat the repository as the source tree (standalone).
+- Else if it contains `chaos-engine/skills/chaos-engine/SKILL.md`, keep today’s
+  nested filter (SHAFT_ENGINE shim and any remaining nested hosts).
+- Else fail closed: unexpected layout.
+- Raw file URLs must use the same prefix the filter selected.
+- Origin-only omit list stays `assets/brand/**` plus `RESEARCH.md` and
+  `STANDALONE.md` (and later siblings in that omit set).
+- Proof: existing nested-tree bootstrap tests stay green; new tests feed a
+  root-tree fixture and assert `skills/chaos-engine/SKILL.md` is installed and
+  `chaos-engine/` is not required. A mutation that only understands nested
+  paths must fail the root fixture.
+
+## Cut over (later, PR 2)
+
+1. Create empty `ShaftHQ/chaos-engine` (MIT, public).
+2. From a throwaway clone of SHAFT_ENGINE:
+   `git filter-repo --path chaos-engine/ --path-rename chaos-engine/:`
+   then push the filtered history to `ShaftHQ/chaos-engine` `main`.
+3. Do not force-push SHAFT_ENGINE. Do not rewrite SHAFT_ENGINE history.
+4. Confirm HEAD of the new repo has `skills/chaos-engine/SKILL.md` at root and
+   no extra wrapping `chaos-engine/` directory.
+
+## Tests and CI (later, PR 3)
+
+Move `tests/scripts/test_chaos_engine_*.py` (and only their dedicated fixtures)
+with the project. SHAFT_ENGINE CI either:
+
+- calls the standalone repo’s workflow, or
+- vendors a subtree/submodule of the tests until SHAFT-only jobs no longer need
+  them.
+
+Do not leave two drifting copies of the same assertion. Portable forbidden-token
+tests stay with the portable tree.
+
+## SHAFT_ENGINE shim (later, PR 4)
+
+Keep `chaos-engine/install.ps1` and `install.sh` in SHAFT_ENGINE as wrappers that
+still parse the nested URL and still point bootstrap at the nested tree **or**
+redirect `--repository ShaftHQ/chaos-engine` once bootstrap understands root
+trees. Document a deprecation date. After that date, PR 5 removes the shim and
+leaves a short INSTALL note pointing at the standalone one-liner.
+
+SHAFT profile one-liners switch to `ShaftHQ/chaos-engine` when the shim is no
+longer the supported path.
+
+## Adopter upgrade
+
+Re-run the one-liner. Bootstrap already upgrades to the resolved commit and
+leaves the last verified install in place on a failed download. No silent
+conversion of legacy pre-distribution installs (existing rule unchanged).
+
+## Invariants that must survive
+
+- Portable payload still forbids `shaft` / `mohab` / `act-as-mohab` tokens.
+- `portable` remains the public default; repository profile install still
+  requires `installWhen.mavenArtifactIds` (or an explicit `--distribution`).
+- Install target remains the caller’s current working directory.
+- Doctor still reports the 40-character commit and required component health.
+- Brand masters and RESEARCH stay origin-only.
+- Vendor Caveman/Ponytail pins, licenses, and third-party notices move with the
+  tree.
+
+## Non-goals of the spec-only change
+
+Creating `ShaftHQ/chaos-engine`, running filter-repo, moving tests, changing
+`bootstrap.py` prefix selection, publishing, or rewriting SHAFT_ENGINE history.
+
+## Later PR plan
+
+| Order | Title | Depends on |
+| --- | --- | --- |
+| 1 | Bootstrap accepts a root source tree or the nested `chaos-engine/` prefix | this spec |
+| 2 | Create `ShaftHQ/chaos-engine` with filtered history | 1 |
+| 3 | Move ChaosEngine tests/CI to the standalone repo | 2 |
+| 4 | Point docs and SHAFT profile at the standalone one-liner; keep nested shim | 2 |
+| 5 | Remove the SHAFT_ENGINE nested shim after the deprecation date | 4 |

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -200,7 +200,10 @@ def download_source(
         relative = PurePosixPath(*path.parts[1:])
         if not relative.parts:
             raise ValueError("ChaosEngine source tree has an unexpected layout")
-        if relative.parts[:2] == ("assets", "brand") or relative.as_posix() == "RESEARCH.md":
+        if relative.parts[:2] == ("assets", "brand") or relative.as_posix() in {
+            "RESEARCH.md",
+            "STANDALONE.md",
+        }:
             continue
         selected.append((relative, size))
         total += size

--- a/chaos-engine/install.ps1
+++ b/chaos-engine/install.ps1
@@ -36,6 +36,7 @@ function Get-ChaosEngineHeader([object]$Headers, [string]$Name) {
         return $null
     }
     catch {
+        Write-Verbose "Retry-After lookup via header API failed"
     }
     try {
         $got = $Headers.GetValues($Name)
@@ -44,6 +45,7 @@ function Get-ChaosEngineHeader([object]$Headers, [string]$Name) {
         }
     }
     catch {
+        Write-Verbose "Retry-After lookup via header API failed"
     }
     try {
         $indexed = $Headers[$Name]
@@ -52,6 +54,7 @@ function Get-ChaosEngineHeader([object]$Headers, [string]$Name) {
         }
     }
     catch {
+        Write-Verbose "Retry-After lookup via header API failed"
     }
     return $null
 }

--- a/chaos-engine/install.ps1
+++ b/chaos-engine/install.ps1
@@ -1,12 +1,14 @@
 # Install or upgrade ChaosEngine into the current directory.
 # Run this from the target project folder:
-#   $env:CHAOS_ENGINE_REPOSITORY = 'owner/repository'
-#   irm "https://raw.githubusercontent.com/$env:CHAOS_ENGINE_REPOSITORY/main/chaos-engine/install.ps1" | iex
+#   irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex
 [CmdletBinding()]
-param()
+param(
+    [switch]$ParseOnly
+)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+$script:ChaosEngineInvocationLine = [string]$MyInvocation.Line
 
 function Get-ChaosEnginePython {
     $py = Get-Command py -ErrorAction SilentlyContinue
@@ -20,6 +22,140 @@ function Get-ChaosEnginePython {
         }
     }
     throw "Python 3 is required (py -3, python3, or python)."
+}
+
+function Get-ChaosEngineHeader([object]$Headers, [string]$Name) {
+    if ($null -eq $Headers) {
+        return $null
+    }
+    $values = $null
+    try {
+        if ($Headers.TryGetValues($Name, [ref]$values) -and $null -ne $values) {
+            return [string](@($values)[0])
+        }
+        return $null
+    }
+    catch {
+    }
+    try {
+        $got = $Headers.GetValues($Name)
+        if ($null -ne $got) {
+            return [string](@($got)[0])
+        }
+    }
+    catch {
+    }
+    try {
+        $indexed = $Headers[$Name]
+        if ($null -ne $indexed) {
+            return [string]$indexed
+        }
+    }
+    catch {
+    }
+    return $null
+}
+
+function ConvertFrom-ChaosEngineRawUrl([string]$Text) {
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return $null
+    }
+    $match = [regex]::Match(
+        $Text,
+        'https://raw\.githubusercontent\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/(.+?)/install\.(ps1|sh)\b',
+        [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+    )
+    if (-not $match.Success) {
+        return $null
+    }
+    $repository = $match.Groups[1].Value + "/" + $match.Groups[2].Value
+    if ($repository -eq "owner/repository") {
+        return $null
+    }
+    $rest = $match.Groups[3].Value
+    $parts = @($rest -split "/")
+    if ($parts.Length -ge 3 -and $parts[0] -eq "refs" -and $parts[1] -in @("heads", "tags")) {
+        $ref = ($parts[0..2] -join "/")
+        $prefixParts = @()
+        if ($parts.Length -gt 3) {
+            $prefixParts = $parts[3..($parts.Length - 1)]
+        }
+    }
+    else {
+        $ref = $parts[0]
+        $prefixParts = @()
+        if ($parts.Length -gt 1) {
+            $prefixParts = $parts[1..($parts.Length - 1)]
+        }
+    }
+    $prefix = $prefixParts -join "/"
+    $bootstrapPath = "bootstrap.py"
+    if (-not [string]::IsNullOrWhiteSpace($prefix)) {
+        $bootstrapPath = "$prefix/bootstrap.py"
+    }
+    return @{
+        Repository   = $repository
+        Ref          = $ref
+        Prefix       = $prefix
+        BootstrapUrl = "https://raw.githubusercontent.com/$repository/$ref/$bootstrapPath"
+    }
+}
+
+function Get-ChaosEngineInvocationText {
+    $chunks = New-Object System.Collections.Generic.List[string]
+    foreach ($frame in Get-PSCallStack) {
+        if ($null -ne $frame.Position -and -not [string]::IsNullOrWhiteSpace($frame.Position.Text)) {
+            $chunks.Add([string]$frame.Position.Text)
+        }
+        if ($null -ne $frame.InvocationInfo -and -not [string]::IsNullOrWhiteSpace($frame.InvocationInfo.Line)) {
+            $chunks.Add([string]$frame.InvocationInfo.Line)
+        }
+    }
+    if (-not [string]::IsNullOrWhiteSpace($script:ChaosEngineInvocationLine)) {
+        $chunks.Add($script:ChaosEngineInvocationLine)
+    }
+    $commandLine = [Environment]::CommandLine
+    if (-not [string]::IsNullOrWhiteSpace($commandLine)) {
+        $chunks.Add([string]$commandLine)
+    }
+    return $chunks
+}
+
+function Test-ChaosEngineRepository([string]$Repository) {
+    if ([string]::IsNullOrWhiteSpace($Repository)) {
+        return $false
+    }
+    if ($Repository -eq "owner/repository") {
+        return $false
+    }
+    return $Repository -match '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
+}
+
+function Resolve-ChaosEngineSource {
+    param([string[]]$Texts)
+    if ($null -eq $Texts -or $Texts.Count -eq 0) {
+        $Texts = @(Get-ChaosEngineInvocationText)
+    }
+    foreach ($text in $Texts) {
+        $parsed = ConvertFrom-ChaosEngineRawUrl $text
+        if ($null -ne $parsed) {
+            return $parsed
+        }
+    }
+    $envRepository = [string]$env:CHAOS_ENGINE_REPOSITORY
+    if (Test-ChaosEngineRepository $envRepository) {
+        $ref = [string]$env:CHAOS_ENGINE_BRANCH
+        if ([string]::IsNullOrWhiteSpace($ref)) {
+            $ref = "main"
+        }
+        return @{
+            Repository   = $envRepository
+            Ref          = $ref
+            Prefix       = "chaos-engine"
+            BootstrapUrl = "https://raw.githubusercontent.com/$envRepository/$ref/chaos-engine/bootstrap.py"
+        }
+    }
+    throw "Put owner/repository in the install URL (or set CHAOS_ENGINE_REPOSITORY for a local file run)."
 }
 
 function Read-ChaosEngineUrl([string]$Url) {
@@ -36,8 +172,8 @@ function Read-ChaosEngineUrl([string]$Url) {
                 $code = [int]$response.StatusCode
             }
             $retryAfter = $null
-            if ($null -ne $response -and $null -ne $response.Headers) {
-                $retryAfter = $response.Headers["Retry-After"]
+            if ($null -ne $response) {
+                $retryAfter = Get-ChaosEngineHeader $response.Headers "Retry-After"
             }
             $retryable = ($null -ne $code -and $transient -contains $code) -or
                 ($code -eq 403 -and -not [string]::IsNullOrWhiteSpace($retryAfter))
@@ -62,24 +198,57 @@ function Read-ChaosEngineUrl([string]$Url) {
     throw "unable to download ChaosEngine bootstrap"
 }
 
-$repository = [string]$env:CHAOS_ENGINE_REPOSITORY
-if ([string]::IsNullOrWhiteSpace($repository)) {
-    throw "Set CHAOS_ENGINE_REPOSITORY to the upstream owner/repository before running this installer."
+if ($ParseOnly) {
+    return
 }
+
+$source = Resolve-ChaosEngineSource
+$repository = [string]$source.Repository
 $branch = [string]$env:CHAOS_ENGINE_BRANCH
+if ([string]::IsNullOrWhiteSpace($branch)) {
+    $branch = [string]$source.Ref
+}
 if ([string]::IsNullOrWhiteSpace($branch)) {
     $branch = "main"
 }
+$bootstrapUrl = [string]$source.BootstrapUrl
+if (-not [string]::IsNullOrWhiteSpace($env:CHAOS_ENGINE_BRANCH)) {
+    $prefix = [string]$source.Prefix
+    $bootstrapPath = "bootstrap.py"
+    if (-not [string]::IsNullOrWhiteSpace($prefix)) {
+        $bootstrapPath = "$prefix/bootstrap.py"
+    }
+    $bootstrapUrl = "https://raw.githubusercontent.com/$repository/$branch/$bootstrapPath"
+}
 $project = (Get-Location).Path
+$localBootstrap = $null
+if (-not [string]::IsNullOrWhiteSpace($PSScriptRoot)) {
+    $candidate = Join-Path $PSScriptRoot "bootstrap.py"
+    if (Test-Path -LiteralPath $candidate) {
+        $localBootstrap = $candidate
+    }
+}
+if ($env:CHAOS_ENGINE_RESOLVE_ONLY -eq "1") {
+    $localFlag = "remote"
+    if ($null -ne $localBootstrap) {
+        $localFlag = "local"
+    }
+    Write-Output "$repository|$branch|$localFlag|$bootstrapUrl"
+    return
+}
 $python = Get-ChaosEnginePython
 $work = Join-Path ([System.IO.Path]::GetTempPath()) ("chaos-engine-bootstrap-" + [guid]::NewGuid().ToString("N"))
 New-Item -ItemType Directory -Path $work | Out-Null
 try {
     $bootstrap = Join-Path $work "bootstrap.py"
-    $url = "https://raw.githubusercontent.com/$repository/$branch/chaos-engine/bootstrap.py"
     Write-Output "Installing ChaosEngine into $project from $repository@$branch"
-    $response = Read-ChaosEngineUrl $url
-    [System.IO.File]::WriteAllText($bootstrap, [string]$response.Content)
+    if ($null -ne $localBootstrap) {
+        Copy-Item -LiteralPath $localBootstrap -Destination $bootstrap
+    }
+    else {
+        $response = Read-ChaosEngineUrl $bootstrapUrl
+        [System.IO.File]::WriteAllText($bootstrap, [string]$response.Content)
+    }
     $invoke = @($python) + @(
         $bootstrap,
         "--project",

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -319,6 +319,13 @@ def load_capability_policy(source: Path, distribution: str) -> tuple[dict[str, d
     return merged, hashlib.sha256(encoded).hexdigest()
 
 
+def is_origin_only(relative: Path) -> bool:
+    return relative.parts[:2] == ("assets", "brand") or relative.as_posix() in {
+        "RESEARCH.md",
+        "STANDALONE.md",
+    }
+
+
 def source_files(source: Path, distribution: str = DEFAULT_DISTRIBUTION) -> tuple[Path, ...]:
     reject_link_or_reparse(source)
     if not (source / "skills/chaos-engine/SKILL.md").is_file():
@@ -341,10 +348,7 @@ def source_files(source: Path, distribution: str = DEFAULT_DISTRIBUTION) -> tupl
             and relative.parts[1] != selected_profile
         ):
             continue
-        if relative.parts[:2] == ("assets", "brand") or relative.as_posix() in {
-            "RESEARCH.md",
-            "STANDALONE.md",
-        }:
+        if is_origin_only(relative):
             continue
         if is_link_or_reparse(path):
             raise ValueError(f"source contains a link or reparse point: {relative}")

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -341,7 +341,10 @@ def source_files(source: Path, distribution: str = DEFAULT_DISTRIBUTION) -> tupl
             and relative.parts[1] != selected_profile
         ):
             continue
-        if relative.parts[:2] == ("assets", "brand") or relative.as_posix() == "RESEARCH.md":
+        if relative.parts[:2] == ("assets", "brand") or relative.as_posix() in {
+            "RESEARCH.md",
+            "STANDALONE.md",
+        }:
             continue
         if is_link_or_reparse(path):
             raise ValueError(f"source contains a link or reparse point: {relative}")

--- a/chaos-engine/install.sh
+++ b/chaos-engine/install.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 # Install or upgrade ChaosEngine into the current directory.
 # Run this from the target project folder:
-#   export CHAOS_ENGINE_REPOSITORY=owner/repository
-#   curl -fsSL "https://raw.githubusercontent.com/${CHAOS_ENGINE_REPOSITORY}/main/chaos-engine/install.sh" | bash
+#   curl -fsSL "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh" | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"
 set -eu
 
 fail() {
@@ -10,12 +9,77 @@ fail() {
   exit 1
 }
 
-if [ -z "${CHAOS_ENGINE_REPOSITORY:-}" ]; then
-  fail "Set CHAOS_ENGINE_REPOSITORY to the upstream owner/repository before running this installer."
-fi
-repository="$CHAOS_ENGINE_REPOSITORY"
-branch="${CHAOS_ENGINE_BRANCH:-main}"
-project="$(pwd)"
+valid_repository() {
+  lowered=$(printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$lowered" in
+    ""|owner/repository) return 1 ;;
+    */*) ;;
+    *) return 1 ;;
+  esac
+  printf '%s\n' "$1" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
+}
+
+parse_chaos_engine_raw_url() {
+  rest=$(printf '%s\n' "$1" | sed -n 's#.*https://raw.githubusercontent.com/\([A-Za-z0-9_.-]*\)/\([A-Za-z0-9_.-]*\)/\(.*\)/install\.sh.*#\1/\2|\3#p' | head -n 1)
+  if [ -z "$rest" ]; then
+    rest=$(printf '%s\n' "$1" | sed -n 's#.*https://raw.githubusercontent.com/\([A-Za-z0-9_.-]*\)/\([A-Za-z0-9_.-]*\)/\(.*\)/install\.ps1.*#\1/\2|\3#p' | head -n 1)
+  fi
+  [ -n "$rest" ] || return 1
+  repository=${rest%%|*}
+  path=${rest#*|}
+  valid_repository "$repository" || return 1
+  case "$path" in
+    refs/heads/*|refs/tags/*)
+      ref=$(printf '%s\n' "$path" | cut -d/ -f1-3)
+      prefix=$(printf '%s\n' "$path" | cut -d/ -f4-)
+      ;;
+    *)
+      ref=${path%%/*}
+      if [ "$path" = "$ref" ]; then
+        prefix=
+      else
+        prefix=${path#*/}
+      fi
+      ;;
+  esac
+  if [ -n "$prefix" ]; then
+    bootstrap_path="$prefix/bootstrap.py"
+  else
+    bootstrap_path="bootstrap.py"
+  fi
+  printf '%s|%s|%s|%s\n' "$repository" "$ref" "$prefix" "https://raw.githubusercontent.com/${repository}/${ref}/${bootstrap_path}"
+}
+
+collect_source_text() {
+  printf '%s\n' "$1"
+  if [ -n "${CHAOS_ENGINE_INSTALL_URL:-}" ]; then
+    printf '%s\n' "$CHAOS_ENGINE_INSTALL_URL"
+  fi
+  if command -v ps >/dev/null 2>&1 && [ -n "${PPID:-}" ]; then
+    ps -o args= -p "$PPID" 2>/dev/null || true
+  fi
+}
+
+resolve_source() {
+  parsed=
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    parsed=$(parse_chaos_engine_raw_url "$line" || true)
+    if [ -n "$parsed" ]; then
+      printf '%s\n' "$parsed"
+      return 0
+    fi
+  done <<EOF
+$(collect_source_text "${1:-}")
+EOF
+  env_repository=${CHAOS_ENGINE_REPOSITORY:-}
+  if valid_repository "$env_repository"; then
+    ref=${CHAOS_ENGINE_BRANCH:-main}
+    printf '%s|%s|%s|%s\n' "$env_repository" "$ref" "chaos-engine" "https://raw.githubusercontent.com/${env_repository}/${ref}/chaos-engine/bootstrap.py"
+    return 0
+  fi
+  fail "Put owner/repository in the install URL (or set CHAOS_ENGINE_REPOSITORY for a local file run)."
+}
 
 if command -v python3 >/dev/null 2>&1; then
   python="python3"
@@ -37,6 +101,25 @@ else
   fail "curl or wget is required to download the ChaosEngine bootstrap."
 fi
 
+source_record=$(resolve_source "${1:-}")
+repository=$(printf '%s\n' "$source_record" | cut -d'|' -f1)
+ref=$(printf '%s\n' "$source_record" | cut -d'|' -f2)
+prefix=$(printf '%s\n' "$source_record" | cut -d'|' -f3)
+bootstrap_url=$(printf '%s\n' "$source_record" | cut -d'|' -f4-)
+branch=${CHAOS_ENGINE_BRANCH:-$ref}
+if [ -n "${CHAOS_ENGINE_BRANCH:-}" ]; then
+  if [ -n "$prefix" ]; then
+    bootstrap_url="https://raw.githubusercontent.com/${repository}/${branch}/${prefix}/bootstrap.py"
+  else
+    bootstrap_url="https://raw.githubusercontent.com/${repository}/${branch}/bootstrap.py"
+  fi
+fi
+project="$(pwd)"
+if [ "${CHAOS_ENGINE_RESOLVE_ONLY:-}" = 1 ]; then
+  printf '%s|%s|%s|%s\n' "$repository" "$branch" "$prefix" "$bootstrap_url"
+  exit 0
+fi
+
 work="$(mktemp -d "${TMPDIR:-/tmp}/chaos-engine-bootstrap-XXXXXX")"
 cleanup() {
   rm -rf "$work"
@@ -44,7 +127,18 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 bootstrap="$work/bootstrap.py"
-url="https://raw.githubusercontent.com/${repository}/${branch}/chaos-engine/bootstrap.py"
 echo "Installing ChaosEngine into ${project} from ${repository}@${branch}"
-fetch "$bootstrap" "$url"
+case "$0" in
+  */install.sh|install.sh)
+    script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+    if [ -f "$script_dir/bootstrap.py" ]; then
+      cp "$script_dir/bootstrap.py" "$bootstrap"
+    else
+      fetch "$bootstrap" "$bootstrap_url"
+    fi
+    ;;
+  *)
+    fetch "$bootstrap" "$bootstrap_url"
+    ;;
+esac
 "$python" "$bootstrap" --project "$project" --repository "$repository" --branch "$branch"

--- a/chaos-engine/profiles/shaft/entrypoint.md
+++ b/chaos-engine/profiles/shaft/entrypoint.md
@@ -33,8 +33,8 @@ apply unchanged to repository and portable installed hosts.
   one-liner in [INSTALL](../../INSTALL.md). From the target folder:
   `irm https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1 | iex`
   on Windows, or
-  `curl -fsSL https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh | bash`
-  on macOS/Linux, with `CHAOS_ENGINE_REPOSITORY=ShaftHQ/SHAFT_ENGINE`.
+  `curl -fsSL https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh | bash -s -- https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh`
+  on macOS/Linux.
 - Maven modules and SHAFT product behavior route through the playbooks and
   mastery chapters under [references](references/routing.md).
 - Cheap, bounded, already-specified local coding work uses the

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -45,6 +45,7 @@ ALLOWED_EXACT = {
     "chaos-engine/README.md",
     "chaos-engine/profiles/README.md",
     "chaos-engine/RESEARCH.md",
+    "chaos-engine/STANDALONE.md",
     "chaos-engine/INSTALL.md",
     "chaos-engine/THIRD_PARTY_NOTICES.md",
 }

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -51,8 +51,11 @@ class Response(io.BytesIO):
 
 class ChaosEngineBootstrapTest(unittest.TestCase):
     def test_documented_command_contains_the_bounded_initial_fetch_contract(self):
-        windows = 'irm "https://raw.githubusercontent.com/$env:CHAOS_ENGINE_REPOSITORY/main/chaos-engine/install.ps1" | iex'
-        posix = 'curl -fsSL "https://raw.githubusercontent.com/${CHAOS_ENGINE_REPOSITORY}/main/chaos-engine/install.sh" | bash'
+        windows = 'irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex'
+        posix = (
+            'curl -fsSL "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"'
+            ' | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"'
+        )
         for relative in ("chaos-engine/README.md", "chaos-engine/INSTALL.md"):
             document = ROOT.joinpath(relative).read_text(encoding="utf-8")
             self.assertIn(windows, document)
@@ -681,6 +684,7 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
                 {"path": "chaos-engine/skills/chaos-engine/SKILL.md", "type": "blob", "mode": "100644", "size": 5},
                 {"path": "chaos-engine/assets/brand/symbol-light.svg", "type": "blob", "mode": "100644", "size": 5},
                 {"path": "chaos-engine/RESEARCH.md", "type": "blob", "mode": "100644", "size": 8},
+                {"path": "chaos-engine/STANDALONE.md", "type": "blob", "mode": "100644", "size": 9},
                 {"path": "chaos-engine/assets/memory-v5/config.schema.json", "type": "blob", "mode": "100644", "size": 6},
             ],
         }
@@ -698,6 +702,8 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
                 return Response(b"brand")
             if str(url).endswith("RESEARCH.md"):
                 return Response(b"research")
+            if str(url).endswith("STANDALONE.md"):
+                return Response(b"standalone")
             if str(url).endswith("config.schema.json"):
                 return Response(b"schema")
             raise AssertionError(url)
@@ -709,7 +715,16 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
             self.assertTrue((source / "assets/memory-v5/config.schema.json").is_file())
             self.assertFalse((source / "assets/brand/symbol-light.svg").exists())
             self.assertFalse((source / "RESEARCH.md").exists())
-            self.assertFalse(any("symbol-light.svg" in url or url.endswith("RESEARCH.md") for url in requested if "git/trees" not in url))
+            self.assertFalse((source / "STANDALONE.md").exists())
+            self.assertFalse(
+                any(
+                    "symbol-light.svg" in url
+                    or url.endswith("RESEARCH.md")
+                    or url.endswith("STANDALONE.md")
+                    for url in requested
+                    if "git/trees" not in url
+                )
+            )
 
     def test_bootstrap_is_reachable_and_runs_in_three_os_ci(self):
         skill = (ROOT / "chaos-engine/skills/chaos-engine/SKILL.md").read_text(encoding="utf-8")

--- a/tests/scripts/test_chaos_engine_install_wrappers.py
+++ b/tests/scripts/test_chaos_engine_install_wrappers.py
@@ -1,0 +1,362 @@
+"""ChaosEngine one-liner wrappers derive source from the invocation URL (#5224)."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+POWERSHELL = ROOT / "chaos-engine/install.ps1"
+SHELL = ROOT / "chaos-engine/install.sh"
+RAW_URL = re.compile(
+    r"https://raw\.githubusercontent\.com/"
+    r"([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/"
+    r"(.+?)/install\.(ps1|sh)\b",
+    re.IGNORECASE,
+)
+PLACEHOLDER = "owner/repository"
+WINDOWS_ONE_LINER = (
+    'irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex'
+)
+POSIX_ONE_LINER = (
+    'curl -fsSL "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"'
+    ' | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"'
+)
+USER_WINDOWS_COMMAND = (
+    'irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex'
+)
+FORK_WINDOWS_COMMAND = (
+    'irm "https://raw.githubusercontent.com/Other/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex'
+)
+ROOT_WINDOWS_COMMAND = (
+    'irm "https://raw.githubusercontent.com/Example/chaos-engine/main/install.ps1" | iex'
+)
+
+
+def parse_raw_url(text: str) -> dict[str, str] | None:
+    match = RAW_URL.search(text)
+    if match is None:
+        return None
+    owner, repo, rest, script = match.groups()
+    repository = f"{owner}/{repo}"
+    if repository.casefold() == PLACEHOLDER:
+        return None
+    parts = rest.split("/")
+    if len(parts) >= 3 and parts[0] == "refs" and parts[1] in {"heads", "tags"}:
+        ref = "/".join(parts[:3])
+        prefix_parts = parts[3:]
+    else:
+        ref = parts[0]
+        prefix_parts = parts[1:]
+    prefix = "/".join(prefix_parts)
+    bootstrap_path = "bootstrap.py" if not prefix else f"{prefix}/bootstrap.py"
+    return {
+        "repository": repository,
+        "ref": ref,
+        "prefix": prefix,
+        "script": f"install.{script}",
+        "bootstrap_url": (
+            f"https://raw.githubusercontent.com/{repository}/{ref}/{bootstrap_path}"
+        ),
+    }
+
+
+class ChaosEngineInstallWrapperTest(unittest.TestCase):
+    def test_python_grammar_extracts_nested_fork_and_root_urls(self):
+        nested = parse_raw_url(USER_WINDOWS_COMMAND)
+        self.assertEqual(
+            {
+                "repository": "ShaftHQ/SHAFT_ENGINE",
+                "ref": "main",
+                "prefix": "chaos-engine",
+                "script": "install.ps1",
+                "bootstrap_url": (
+                    "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/"
+                    "main/chaos-engine/bootstrap.py"
+                ),
+            },
+            nested,
+        )
+        self.assertEqual(
+            "Other/SHAFT_ENGINE",
+            parse_raw_url(FORK_WINDOWS_COMMAND)["repository"],
+        )
+        root = parse_raw_url(ROOT_WINDOWS_COMMAND)
+        self.assertEqual("Example/chaos-engine", root["repository"])
+        self.assertEqual("", root["prefix"])
+        self.assertEqual(
+            "https://raw.githubusercontent.com/Example/chaos-engine/main/bootstrap.py",
+            root["bootstrap_url"],
+        )
+        self.assertIsNone(
+            parse_raw_url(
+                'irm "https://raw.githubusercontent.com/owner/repository/main/'
+                'chaos-engine/install.ps1" | iex'
+            )
+        )
+
+    def test_wrappers_contain_the_raw_url_grammar_and_reject_the_placeholder(self):
+        powershell = POWERSHELL.read_text(encoding="utf-8")
+        shell = SHELL.read_text(encoding="utf-8")
+        self.assertIn("ConvertFrom-ChaosEngineRawUrl", powershell)
+        self.assertIn("parse_chaos_engine_raw_url", shell)
+        self.assertIn("raw.githubusercontent.com", shell)
+        self.assertIn(PLACEHOLDER, powershell)
+        self.assertIn(PLACEHOLDER, shell)
+        self.assertIn("Get-PSCallStack", powershell)
+        self.assertIn("TryGetValues", powershell)
+        self.assertNotIn('$response.Headers["Retry-After"]', powershell)
+        self.assertNotIn("$response.Headers['Retry-After']", powershell)
+        self.assertNotIn("shaft", powershell.casefold())
+        self.assertNotIn("shaft", shell.casefold())
+
+    def test_wrappers_prefer_invocation_url_over_placeholder_env(self):
+        powershell = POWERSHELL.read_text(encoding="utf-8")
+        shell = SHELL.read_text(encoding="utf-8")
+        self.assertIn("CHAOS_ENGINE_REPOSITORY", powershell)
+        self.assertIn("CHAOS_ENGINE_REPOSITORY", shell)
+        self.assertRegex(powershell, r"ConvertFrom-ChaosEngineRawUrl")
+        self.assertNotRegex(
+            powershell,
+            r"if \(\[string\]::IsNullOrWhiteSpace\(\$repository\)\) \{\s*"
+            r'throw "Set CHAOS_ENGINE_REPOSITORY',
+        )
+        self.assertNotIn(
+            'fail "Set CHAOS_ENGINE_REPOSITORY to the upstream owner/repository',
+            shell,
+        )
+
+    def test_documented_one_liners_put_owner_repository_in_the_url(self):
+        for relative in ("chaos-engine/README.md", "chaos-engine/INSTALL.md"):
+            document = ROOT.joinpath(relative).read_text(encoding="utf-8")
+            self.assertIn(WINDOWS_ONE_LINER, document, relative)
+            self.assertIn(POSIX_ONE_LINER, document, relative)
+            self.assertNotIn("haftHQ", document)
+            self.assertNotIn("HAFT_ENGINE", document)
+            self.assertNotIn("$env:CHAOS_ENGINE_REPOSITORY/main", document)
+
+    def test_shaft_profile_keeps_the_real_url_without_an_env_preamble(self):
+        profile = (
+            ROOT / "chaos-engine/profiles/shaft/entrypoint.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/"
+            "chaos-engine/install.ps1",
+            profile,
+        )
+        self.assertNotIn("with `CHAOS_ENGINE_REPOSITORY=", profile)
+
+    def test_powershell_parser_matches_the_python_grammar_when_pwsh_exists(self):
+        powershell = POWERSHELL.read_text(encoding="utf-8")
+        self.assertIn("ConvertFrom-ChaosEngineRawUrl", powershell)
+        pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if pwsh is None:
+            self.skipTest("pwsh is not on PATH")
+        script = r"""
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. $args[0] -ParseOnly
+$samples = @(
+    'irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex',
+    'irm "https://raw.githubusercontent.com/Other/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex',
+    'irm "https://raw.githubusercontent.com/Example/chaos-engine/main/install.ps1" | iex',
+    'irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex'
+)
+foreach ($sample in $samples) {
+    $parsed = ConvertFrom-ChaosEngineRawUrl $sample
+    if ($null -eq $parsed) {
+        Write-Output 'NONE'
+        continue
+    }
+    Write-Output ($parsed.Repository + '|' + $parsed.Ref + '|' + $parsed.Prefix + '|' + $parsed.BootstrapUrl)
+}
+"""
+        with tempfile.NamedTemporaryFile("w", suffix=".ps1", delete=False, encoding="utf-8") as handle:
+            handle.write(script)
+            driver = handle.name
+        try:
+            completed = subprocess.run(
+                [pwsh, "-NoProfile", "-File", driver, str(POWERSHELL)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            Path(driver).unlink(missing_ok=True)
+        self.assertEqual(0, completed.returncode, completed.stderr + completed.stdout)
+        lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+        self.assertEqual(
+            [
+                "ShaftHQ/SHAFT_ENGINE|main|chaos-engine|"
+                "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/bootstrap.py",
+                "Other/SHAFT_ENGINE|main|chaos-engine|"
+                "https://raw.githubusercontent.com/Other/SHAFT_ENGINE/main/chaos-engine/bootstrap.py",
+                "Example/chaos-engine|main||"
+                "https://raw.githubusercontent.com/Example/chaos-engine/main/bootstrap.py",
+                "NONE",
+            ],
+            lines,
+        )
+
+    def test_powershell_resolver_prefers_invocation_url_over_placeholder_env(self):
+        powershell = POWERSHELL.read_text(encoding="utf-8")
+        self.assertIn("Resolve-ChaosEngineSource", powershell)
+        pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if pwsh is None:
+            self.skipTest("pwsh is not on PATH")
+        script = r"""
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. $args[0] -ParseOnly
+$env:CHAOS_ENGINE_REPOSITORY = 'owner/repository'
+$parsed = Resolve-ChaosEngineSource -Texts @(
+    'irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex'
+)
+Write-Output ($parsed.Repository + '|' + $parsed.Ref + '|' + $parsed.Prefix)
+"""
+        with tempfile.NamedTemporaryFile("w", suffix=".ps1", delete=False, encoding="utf-8") as handle:
+            handle.write(script)
+            driver = handle.name
+        try:
+            completed = subprocess.run(
+                [pwsh, "-NoProfile", "-File", driver, str(POWERSHELL)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            Path(driver).unlink(missing_ok=True)
+        self.assertEqual(0, completed.returncode, completed.stderr + completed.stdout)
+        self.assertEqual(
+            ["ShaftHQ/SHAFT_ENGINE|main|chaos-engine"],
+            [line.strip() for line in completed.stdout.splitlines() if line.strip()],
+        )
+
+    def test_powershell_irm_pipeline_uses_url_not_leftover_env(self):
+        pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if pwsh is None:
+            self.skipTest("pwsh is not on PATH")
+        script_path = str(POWERSHELL).replace("'", "''")
+        command = (
+            "$env:CHAOS_ENGINE_RESOLVE_ONLY='1'; "
+            "$env:CHAOS_ENGINE_REPOSITORY='Evil/Repo'; "
+            "$url = 'https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1'; "
+            f"Get-Content -Raw -LiteralPath '{script_path}' | iex"
+        )
+        completed = subprocess.run(
+            [pwsh, "-NoProfile", "-Command", command],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr + completed.stdout)
+        self.assertIn(
+            "ShaftHQ/SHAFT_ENGINE|main|remote|"
+            "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/bootstrap.py",
+            completed.stdout,
+        )
+        self.assertNotIn("Evil/Repo", completed.stdout)
+
+    def test_powershell_header_helper_reads_http_response_headers(self):
+        pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if pwsh is None:
+            self.skipTest("pwsh is not on PATH")
+        script = r"""
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. $args[0] -ParseOnly
+$message = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::TooManyRequests)
+[void]$message.Headers.TryAddWithoutValidation('Retry-After', '5')
+Write-Output (Get-ChaosEngineHeader $message.Headers 'Retry-After')
+Write-Output (Get-ChaosEngineHeader $message.Headers 'X-Missing')
+"""
+        with tempfile.NamedTemporaryFile("w", suffix=".ps1", delete=False, encoding="utf-8") as handle:
+            handle.write(script)
+            driver = handle.name
+        try:
+            completed = subprocess.run(
+                [pwsh, "-NoProfile", "-File", driver, str(POWERSHELL)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            Path(driver).unlink(missing_ok=True)
+        self.assertEqual(0, completed.returncode, completed.stderr + completed.stdout)
+        self.assertEqual(["5"], [line.strip() for line in completed.stdout.splitlines() if line.strip()])
+
+    def test_powershell_resolve_only_uses_sibling_bootstrap(self):
+        pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if pwsh is None:
+            self.skipTest("pwsh is not on PATH")
+        with tempfile.TemporaryDirectory() as temporary:
+            wrapper = Path(temporary) / "install.ps1"
+            wrapper.write_text(POWERSHELL.read_text(encoding="utf-8"), encoding="utf-8")
+            (Path(temporary) / "bootstrap.py").write_text("marker = 1\n", encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    pwsh,
+                    "-NoProfile",
+                    "-File",
+                    str(wrapper),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "CHAOS_ENGINE_RESOLVE_ONLY": "1",
+                    "CHAOS_ENGINE_REPOSITORY": "Example/Project",
+                },
+            )
+        self.assertEqual(0, completed.returncode, completed.stderr + completed.stdout)
+        self.assertIn("Example/Project|main|local|", completed.stdout)
+
+    def test_shell_wrapper_uses_positional_url_over_env(self):
+        shell = shutil.which("bash") or shutil.which("sh")
+        if shell is None:
+            self.skipTest("sh is not on PATH")
+        script = SHELL.as_posix()
+        if os.name == "nt" and script[1:3] == ":/":
+            wsl = "/mnt/" + script[0].lower() + script[2:]
+            probe = subprocess.run(
+                [shell, "-c", f"test -f '{wsl}' && echo wsl || test -f '{script}' && echo win || echo missing"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if "wsl" in probe.stdout:
+                script = wsl
+            elif "win" not in probe.stdout:
+                self.skipTest(f"{shell} cannot read {SHELL}")
+        url = "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh"
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temporary:
+            completed = subprocess.run(
+                [
+                    shell,
+                    "-c",
+                    "CHAOS_ENGINE_RESOLVE_ONLY=1 CHAOS_ENGINE_REPOSITORY=Evil/Repo "
+                    f"'{script}' '{url}'",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                cwd=temporary,
+            )
+        self.assertEqual(0, completed.returncode, completed.stderr + completed.stdout)
+        self.assertEqual(
+            "ShaftHQ/SHAFT_ENGINE|main|chaos-engine|"
+            "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/bootstrap.py",
+            completed.stdout.strip().splitlines()[-1],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/scripts/test_chaos_engine_install_wrappers.py
+++ b/tests/scripts/test_chaos_engine_install_wrappers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
-import subprocess
+import subprocess  # nosec B404 - tests invoke local pwsh/bash on repo wrappers only.
 import tempfile
 import unittest
 from pathlib import Path
@@ -181,7 +181,7 @@ foreach ($sample in $samples) {
             handle.write(script)
             driver = handle.name
         try:
-            completed = subprocess.run(
+            completed = subprocess.run(  # nosec B603 - local pwsh plus the repo wrapper
                 [pwsh, "-NoProfile", "-File", driver, str(POWERSHELL)],
                 check=False,
                 capture_output=True,
@@ -194,11 +194,11 @@ foreach ($sample in $samples) {
         self.assertEqual(
             [
                 "ShaftHQ/SHAFT_ENGINE|main|chaos-engine|"
-                "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/bootstrap.py",
+                + "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/bootstrap.py",
                 "Other/SHAFT_ENGINE|main|chaos-engine|"
-                "https://raw.githubusercontent.com/Other/SHAFT_ENGINE/main/chaos-engine/bootstrap.py",
+                + "https://raw.githubusercontent.com/Other/SHAFT_ENGINE/main/chaos-engine/bootstrap.py",
                 "Example/chaos-engine|main||"
-                "https://raw.githubusercontent.com/Example/chaos-engine/main/bootstrap.py",
+                + "https://raw.githubusercontent.com/Example/chaos-engine/main/bootstrap.py",
                 "NONE",
             ],
             lines,
@@ -325,7 +325,7 @@ Write-Output (Get-ChaosEngineHeader $message.Headers 'X-Missing')
         script = SHELL.as_posix()
         if os.name == "nt" and script[1:3] == ":/":
             wsl = "/mnt/" + script[0].lower() + script[2:]
-            probe = subprocess.run(
+            probe = subprocess.run(  # nosec B603 - local bash path probe, no user input
                 [shell, "-c", f"test -f '{wsl}' && echo wsl || test -f '{script}' && echo win || echo missing"],
                 check=False,
                 capture_output=True,

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -861,6 +861,8 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             )
         )
         self.assertNotIn("RESEARCH.md", relatives)
+        self.assertNotIn("STANDALONE.md", relatives)
+        self.assertTrue((SOURCE / "STANDALONE.md").is_file())
         self.assertTrue(any(relative.startswith("assets/memory-v5/") for relative in relatives))
         self.assertIn("INSTALL.md", relatives)
         self.assertIn("LICENSE", relatives)

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -1,5 +1,6 @@
 """Portable ChaosEngine core and project-profile contract tests (#4792)."""
 
+import importlib.util
 import json
 import re
 import unittest
@@ -9,6 +10,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CORE = ROOT / "chaos-engine"
+INSTALLER_SPEC = importlib.util.spec_from_file_location(
+    "chaos_engine_installer_portable_core", CORE / "install.py"
+)
+if INSTALLER_SPEC is None or INSTALLER_SPEC.loader is None:
+    raise RuntimeError("portable core tests could not load install.py")
+INSTALLER = importlib.util.module_from_spec(INSTALLER_SPEC)
+INSTALLER_SPEC.loader.exec_module(INSTALLER)
 CANONICAL_SKILL = CORE / "skills/chaos-engine/SKILL.md"
 CLEANUP_SCOPES = CORE / "references/cleanup-scopes.md"
 TASK_ISOLATION = CORE / "references/task-isolation.md"
@@ -305,6 +313,9 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             "POSIX absolute path": POSIX_ABSOLUTE_PATH,
             "hard-coded default branch": re.compile(r"origin/main", re.IGNORECASE),
         }
+        self.assertTrue((CORE / "STANDALONE.md").is_file())
+        self.assertTrue((CORE / "RESEARCH.md").is_file())
+        self.assertTrue(INSTALLER.is_origin_only(Path("STANDALONE.md")))
         sources = sorted(
             path
             for path in CORE.rglob("*")
@@ -313,6 +324,7 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             and "vendor" not in path.relative_to(CORE).parts
             and "__pycache__" not in path.relative_to(CORE).parts
             and path.suffix != ".pyc"
+            and not INSTALLER.is_origin_only(path.relative_to(CORE))
         )
         self.assertTrue(sources, "portable core sources must exist")
         for path in sources:

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -82,6 +82,7 @@ flowchart LR
         self.write("chaos-engine/skills/chaos-engine/SKILL.md", "# ChaosEngine\n")
         self.write("chaos-engine/profiles/README.md", "# Project profiles\n")
         self.write("chaos-engine/RESEARCH.md", "# Adoption matrix\n")
+        self.write("chaos-engine/STANDALONE.md", "# Spec\n")
         self.write("chaos-engine/INSTALL.md", "# Install\n")
         self.write("chaos-engine/THIRD_PARTY_NOTICES.md", "# Notices\n")
 


### PR DESCRIPTION
Closes #5224
Closes #5225

Related to #5223.

## Summary

The Windows one-liner `irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex` ignored that URL and read `$env:CHAOS_ENGINE_REPOSITORY`. A leftover placeholder `owner/repository` 404'd, then PowerShell 7 threw `Unable to index into an object of type "System.Net.Http.Headers.HttpResponseHeaders"` instead of the HTTP error.

Wrappers now parse owner/repository, ref, and sibling `bootstrap.py` from the raw GitHub URL (forks and a future repo-root `install.ps1` included). Invocation URL wins over env. Placeholder `owner/repository` is rejected. Retry-After is read with `TryGetValues` so a 404 is a 404. POSIX `curl | bash -s -- ` is the reliable form; `install.sh` is executed in tests.

Origin-only `chaos-engine/STANDALONE.md` specifies the later move to `ShaftHQ/chaos-engine` without implementing the split. It is classified the same way as `RESEARCH.md`: kept in the origin tree, omitted from the portable payload via `install.is_origin_only`, allowlisted in the documentation boundary, and linked from `chaos-engine/README.md` so it is not an unreachability orphan. The generic portable-core token scan uses that same origin-only helper, so the spec can name the future repo without being treated as shipped core.

Codacy on this diff: implicit string concat in the wrapper expected-output list is now explicit `+`. Empty `catch` blocks in `Get-ChaosEngineHeader` are fail-soft header-API probes (PS5 vs PS7 `HttpResponseHeaders`); they now `Write-Verbose` and still fall through instead of throwing. `subprocess` in `test_chaos_engine_install_wrappers.py` is local pwsh/bash on repo wrappers (`# nosec B404` / `B603`), not untrusted input.

## Checks

Local RED on merge HEAD (matched CI run 32253533783):

- `py -3 scripts/ci/validate_documentation_boundaries.py` → `ERROR: public or unapproved Markdown remains: chaos-engine/STANDALONE.md`
- `test_every_harness_element_is_reachable_or_exempt_with_a_reason` → `chaos-engine/STANDALONE.md (no markdown link reaches it)`
- `test_the_exemption_list_is_empty_so_the_headline_figure_is_not_bought` → `1 != 0`
- `test_generic_core_has_no_shaft_or_machine_specific_paths` → `ShaftHQ` and `SHAFT_ENGINE` in `STANDALONE.md`

Local GREEN after `b68842ea2b`:

- `py -3 scripts/ci/validate_documentation_boundaries.py` (618 tracked Markdown files)
- `py -3 -m unittest tests.scripts.test_validate_documentation_boundaries tests.scripts.test_agent_harness_reachability tests.scripts.test_chaos_engine_portable_core` (86 tests)
- `py -3 tests/scripts/test_chaos_engine_install_wrappers.py` (11 tests)
- `py -3 tests/scripts/test_chaos_engine_bootstrap.py` (24 tests)
- `py -3 tests/scripts/test_chaos_engine_installer.py ChaosEngineInstallerTest.test_portable_source_files_omit_origin_only_docs ChaosEngineInstallerTest.test_default_distribution_installs_only_neutral_portable_payload` (2 tests)

## Continuation

- Head: b68842ea2b303e147fb9257f9763a1f4d2fec5fc
- State: origin/main merged (merge commit, no rebase/force); STANDALONE.md is origin-only like RESEARCH.md; wrapper URL fix unchanged
- Blockers: none
- Next action: independent PR review, then arm auto-merge and watch checks
