### PR TITLE
fix: gate ChaosEngine local bootstrap on a source-tree marker

### DIFF
--- a/chaos-engine/install.ps1
+++ b/chaos-engine/install.ps1
@@ -124,6 +124,17 @@ function Get-ChaosEngineInvocationText {
     return $chunks
 }
 
+function Test-ChaosEngineSourceTree([string]$ScriptDirectory) {
+    if ([string]::IsNullOrWhiteSpace($ScriptDirectory)) {
+        return $false
+    }
+    $skill = $ScriptDirectory
+    foreach ($part in "skills/chaos-engine/SKILL.md".Split("/")) {
+        $skill = Join-Path $skill $part
+    }
+    return Test-Path -LiteralPath $skill
+}
+
 function Test-ChaosEngineRepository([string]$Repository) {
     if ([string]::IsNullOrWhiteSpace($Repository)) {
         return $false
@@ -225,7 +236,7 @@ if (-not [string]::IsNullOrWhiteSpace($env:CHAOS_ENGINE_BRANCH)) {
 }
 $project = (Get-Location).Path
 $localBootstrap = $null
-if (-not [string]::IsNullOrWhiteSpace($PSScriptRoot)) {
+if ((-not [string]::IsNullOrWhiteSpace($PSScriptRoot)) -and (Test-ChaosEngineSourceTree $PSScriptRoot)) {
     $candidate = Join-Path $PSScriptRoot "bootstrap.py"
     if (Test-Path -LiteralPath $candidate) {
         $localBootstrap = $candidate

--- a/chaos-engine/install.sh
+++ b/chaos-engine/install.sh
@@ -19,6 +19,12 @@ valid_repository() {
   printf '%s\n' "$1" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
 }
 
+is_chaos_engine_source_tree() {
+  script_dir="$1"
+  [ -n "$script_dir" ] || return 1
+  [ -f "$script_dir/skills/chaos-engine/SKILL.md" ]
+}
+
 parse_chaos_engine_raw_url() {
   rest=$(printf '%s\n' "$1" | sed -n 's#.*https://raw.githubusercontent.com/\([A-Za-z0-9_.-]*\)/\([A-Za-z0-9_.-]*\)/\(.*\)/install\.sh.*#\1/\2|\3#p' | head -n 1)
   if [ -z "$rest" ]; then
@@ -131,7 +137,7 @@ echo "Installing ChaosEngine into ${project} from ${repository}@${branch}"
 case "$0" in
   */install.sh|install.sh)
     script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-    if [ -f "$script_dir/bootstrap.py" ]; then
+    if [ -f "$script_dir/bootstrap.py" ] && is_chaos_engine_source_tree "$script_dir"; then
       cp "$script_dir/bootstrap.py" "$bootstrap"
     else
       fetch "$bootstrap" "$bootstrap_url"

--- a/tests/scripts/test_chaos_engine_install_wrappers.py
+++ b/tests/scripts/test_chaos_engine_install_wrappers.py
@@ -111,6 +111,10 @@ class ChaosEngineInstallWrapperTest(unittest.TestCase):
         self.assertIn(PLACEHOLDER, shell)
         self.assertIn("Get-PSCallStack", powershell)
         self.assertIn("TryGetValues", powershell)
+        self.assertIn("Test-ChaosEngineSourceTree", powershell)
+        self.assertIn("is_chaos_engine_source_tree", shell)
+        self.assertIn("skills/chaos-engine/SKILL.md", powershell)
+        self.assertIn("skills/chaos-engine/SKILL.md", shell)
         self.assertNotIn('$response.Headers["Retry-After"]', powershell)
         self.assertNotIn("$response.Headers['Retry-After']", powershell)
         self.assertNotIn("shaft", powershell.casefold())
@@ -299,6 +303,9 @@ Write-Output (Get-ChaosEngineHeader $message.Headers 'X-Missing')
             wrapper = Path(temporary) / "install.ps1"
             wrapper.write_text(POWERSHELL.read_text(encoding="utf-8"), encoding="utf-8")
             (Path(temporary) / "bootstrap.py").write_text("marker = 1\n", encoding="utf-8")
+            skill = Path(temporary) / "skills" / "chaos-engine" / "SKILL.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text("# ChaosEngine\n", encoding="utf-8")
             completed = subprocess.run(
                 [
                     pwsh,
@@ -317,6 +324,35 @@ Write-Output (Get-ChaosEngineHeader $message.Headers 'X-Missing')
             )
         self.assertEqual(0, completed.returncode, completed.stderr + completed.stdout)
         self.assertIn("Example/Project|main|local|", completed.stdout)
+
+
+    def test_powershell_scratch_directory_with_stale_sibling_bootstrap_is_rejected(self):
+        pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if pwsh is None:
+            self.skipTest("pwsh is not on PATH")
+        with tempfile.TemporaryDirectory() as temporary:
+            wrapper = Path(temporary) / "install.ps1"
+            wrapper.write_text(POWERSHELL.read_text(encoding="utf-8"), encoding="utf-8")
+            (Path(temporary) / "bootstrap.py").write_text("marker = 1\n", encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    pwsh,
+                    "-NoProfile",
+                    "-File",
+                    str(wrapper),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "CHAOS_ENGINE_RESOLVE_ONLY": "1",
+                    "CHAOS_ENGINE_REPOSITORY": "Example/Project",
+                },
+            )
+        self.assertEqual(0, completed.returncode, completed.stderr + completed.stdout)
+        self.assertIn("Example/Project|main|remote|", completed.stdout)
+        self.assertNotIn("|local|", completed.stdout)
 
     def test_shell_wrapper_uses_positional_url_over_env(self):
         shell = shutil.which("bash") or shutil.which("sh")


### PR DESCRIPTION
Closes #5229

Related to #5224 and #5228.

## Summary

Local sibling bootstrap.py is reused only when skills/chaos-engine/SKILL.md exists next to the wrapper. Scratch leftover files download instead. Portable wrappers still contain no shaft token.

## Checks

- py -3 -m unittest tests.scripts.test_chaos_engine_install_wrappers
- py -3 scripts/ci/validate_documentation_boundaries.py

## Continuation

- Head: 1d5301f2b65edd6d5ee80db3d525da19fce99616
- State: safety-net commit on top of merged #5228; origin/main merged
- Blockers: none
- Next action: independent review, then arm auto-merge and watch checks