### PR TITLE
fix: wait out Marketplace listing lag after publishPlugin

### DIFF
--- a/scripts/ci/assert_intellij_marketplace_receipt.py
+++ b/scripts/ci/assert_intellij_marketplace_receipt.py
@@ -4,6 +4,11 @@
 Issue #5221: a cancelled verify+publish composite looked partly healthy because
 coverage uploaded `if: always()`. A successful Marketplace publish must leave a
 Gradle `BUILD SUCCESSFUL` receipt and the version must appear on plugin 32529.
+
+Issue #5227: Marketplace listing can lag the upload by more than the original
+5x15s budget. Wait long enough for a valid public listing, and if the version
+is still absent after a Gradle success, say listing is lagging rather than
+treating the landed upload as a miss that invites another dispatch.
 """
 
 from __future__ import annotations
@@ -52,12 +57,23 @@ def marketplace_versions(updates_json: str) -> list[str]:
     return versions
 
 
-def marketplace_receipt_errors(updates_json: str, version: str) -> list[str]:
+def marketplace_receipt_errors(
+    updates_json: str,
+    version: str,
+    *,
+    gradle_succeeded: bool = False,
+) -> list[str]:
     try:
         versions = marketplace_versions(updates_json)
     except (ValueError, json.JSONDecodeError) as error:
         return [f"Marketplace updates JSON is unreadable: {error}"]
     if version not in versions:
+        if gradle_succeeded:
+            return [
+                f"Marketplace plugin {MARKETPLACE_PLUGIN_ID} does not list version {version} "
+                "after a successful Gradle publishPlugin; listing still lagging. "
+                "Do not re-dispatch this single-use version."
+            ]
         return [
             f"Marketplace plugin {MARKETPLACE_PLUGIN_ID} does not list version {version}"
         ]
@@ -66,11 +82,16 @@ def marketplace_receipt_errors(updates_json: str, version: str) -> list[str]:
 
 def receipt_errors(log_text: str, properties_text: str, updates_json: str) -> list[str]:
     errors = gradle_receipt_errors(log_text)
+    gradle_succeeded = not errors
     try:
         version = plugin_version_from_properties(properties_text)
     except ValueError as error:
         return errors + [str(error)]
-    errors.extend(marketplace_receipt_errors(updates_json, version))
+    errors.extend(
+        marketplace_receipt_errors(
+            updates_json, version, gradle_succeeded=gradle_succeeded
+        )
+    )
     return errors
 
 
@@ -82,7 +103,7 @@ def fetch_updates(url: str = MARKETPLACE_UPDATES_URL, timeout: int = 30) -> str:
 
 def fetch_updates_with_retry(
     url: str = MARKETPLACE_UPDATES_URL,
-    attempts: int = 5,
+    attempts: int = 12,
     delay_seconds: float = 15,
     sleeper=time.sleep,
     fetcher=fetch_updates,

--- a/tests/scripts/test_assert_intellij_marketplace_receipt.py
+++ b/tests/scripts/test_assert_intellij_marketplace_receipt.py
@@ -1,4 +1,5 @@
 import importlib.util
+import inspect
 import tempfile
 import unittest
 from pathlib import Path
@@ -186,6 +187,33 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
         self.assertEqual([0.01, 0.01], sleeps)
         errors = MODULE.marketplace_receipt_errors(body, "10.3.20260818")
         self.assertTrue(any("10.3.20260818" in error for error in errors), errors)
+
+    def test_default_retry_budget_covers_observed_marketplace_listing_lag(self):
+        # Run 32247439124: BUILD SUCCESSFUL at 11:35:30Z, receipt miss at 11:36:32Z (~62s).
+        parameters = inspect.signature(MODULE.fetch_updates_with_retry).parameters
+        attempts = parameters["attempts"].default
+        delay_seconds = parameters["delay_seconds"].default
+        wait_seconds = (attempts - 1) * delay_seconds
+        self.assertGreaterEqual(
+            wait_seconds,
+            90,
+            f"default listing-lag wait is {wait_seconds}s; observed miss was ~62s",
+        )
+
+    def test_gradle_success_with_omitted_version_names_listing_lag(self):
+        errors = MODULE.receipt_errors(SUCCESS_LOG, PROPERTIES, MISSING)
+        blob = "\n".join(errors)
+        self.assertTrue(any("10.3.20260818" in error for error in errors), errors)
+        self.assertIn("listing still lagging", blob)
+        self.assertIn("Do not re-dispatch", blob)
+        self.assertNotIn("Gradle publish log is missing BUILD SUCCESSFUL", blob)
+
+    def test_missing_gradle_receipt_does_not_claim_listing_lag(self):
+        errors = MODULE.receipt_errors("", PROPERTIES, MISSING)
+        blob = "\n".join(errors)
+        self.assertTrue(any("BUILD SUCCESSFUL" in error for error in errors), errors)
+        self.assertNotIn("listing still lagging", blob)
+        self.assertNotIn("Do not re-dispatch", blob)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #5227
Related to #5221
Related to #5212

## Summary

After a successful `publishPlugin`, Marketplace listing can lag the upload. Run 32247439124 signed `10.3.20260818` (`BUILD SUCCESSFUL` at 11:35:30Z) then failed closed at 11:36:32Z because plugin 32529 omitted the version inside the 5x15s budget. The version later listed as public. Do not re-dispatch `10.3.20260818`.

This PR raises the live receipt retry default from 5x15s (60s wait) to 12x15s (165s wait) and, when Gradle `BUILD SUCCESSFUL` is present but the version is still absent, names listing lag and forbids re-dispatch. A missing Gradle receipt still fail-closes on `BUILD SUCCESSFUL` and does not claim the upload landed. `--updates-json` stays a no-retry unit-test path. Gradle publish is unchanged.

## Checks

RED (current 5x15s defaults, before the production change):

```
py -3 tests/scripts/test_assert_intellij_marketplace_receipt.py
```

Failures:

- `test_default_retry_budget_covers_observed_marketplace_listing_lag`: `AssertionError: 60 not greater than or equal to 90`
- `test_gradle_success_with_omitted_version_names_listing_lag`: `'listing still lagging' not found in 'Marketplace plugin 32529 does not list version 10.3.20260818'`

GREEN after the production change:

```
py -3 tests/scripts/test_assert_intellij_marketplace_receipt.py
```

Ran 15 tests in 0.009s. OK.

Did not run `test_intellij_verify_retry.py` or `test_validate_shaft_pilot_release.py`: this diff does not touch workflow wiring or that validator.

## Continuation

Head: f441567923
State: first retained checkpoint. Receipt retry budget and lag-vs-miss error text landed. Independent review is a new instance.
Blockers: none for this slice. Do not re-dispatch `10.3.20260818`. Keep #5221 and tracker #5212 in their current states.
Next action: independent review of this HEAD, then CI babysit. Do not merge in this instance.
