### PR TITLE
fix: repair drifted ChaosEngine installs on upgrade

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -87,7 +87,14 @@ repository profile is installed only when the target project's root `pom.xml`
 matches that profile's declared Maven artifact ids. Pass `--distribution` to
 the bootstrap if you need to override the detected choice. Re-running the
 same command upgrades to the latest resolved commit; an offline or invalid
-download leaves the last verified installation unchanged. The bootstrap retries
+download leaves the last verified installation unchanged. A drifted, CRLF-converted,
+extra-file, or otherwise broken `.chaos-engine` directory is replaced with a
+fresh verified payload. Controllers from that broken tree are not executed, and
+the broken tree is not kept as a rollback backup. A leftover install journal
+in front of a still-broken tree is dropped so the next run can retry. Link or
+reparse trees stay fail-closed. Uninstall and rollback of a still-drifted tree
+also stay fail-closed. Generated `__pycache__` files are not treated as
+ownership drift. The bootstrap retries
 transient timeout, connection, rate-limit, and server responses with bounded
 backoff, while permanent client errors fail immediately.
 

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -306,7 +306,7 @@ def install_latest(
         clients = host_controller.activate_detected_plugins(project)
         doctor["clients"] = clients.get("clients", {})
     except BaseException:
-        if prior_install:
+        if prior_install and (project / ".chaos-engine.backup").exists():
             installer.rollback(project)
         else:
             installer.uninstall_with_dependencies(project)

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -338,7 +338,7 @@ def source_files(source: Path, distribution: str = DEFAULT_DISTRIBUTION) -> tupl
     files: list[Path] = []
     for path in sorted(source.rglob("*")):
         relative = path.relative_to(source)
-        if "__pycache__" in relative.parts or path.suffix == ".pyc":
+        if is_generated_python_cache(relative):
             continue
         if relative.as_posix() == DISTRIBUTIONS_NAME:
             continue
@@ -417,14 +417,20 @@ def load_manifest(target: Path) -> dict[str, object]:
     return manifest
 
 
+def is_generated_python_cache(relative: Path) -> bool:
+    return "__pycache__" in relative.parts or relative.suffix == ".pyc"
+
+
 def installed_payload(target: Path) -> dict[str, str]:
     reject_link_or_reparse(target)
     payload: dict[str, str] = {}
     for path in sorted(target.rglob("*")):
         reject_link_or_reparse(path)
-        relative = path.relative_to(target).as_posix()
-        if path.is_file() and relative != MANIFEST_NAME:
-            payload[relative] = file_sha256(path)
+        relative = path.relative_to(target)
+        if is_generated_python_cache(relative):
+            continue
+        if path.is_file() and relative.as_posix() != MANIFEST_NAME:
+            payload[relative.as_posix()] = file_sha256(path)
     return payload
 
 
@@ -433,6 +439,44 @@ def verify_install(target: Path) -> dict[str, object]:
     if installed_payload(target) != manifest["files"]:
         raise ValueError(f"ChaosEngine ownership drift detected: {target}")
     return manifest
+
+
+def _is_link_or_reparse_error(error: BaseException) -> bool:
+    return str(error).startswith("path is a link or reparse point:")
+
+
+def try_verify_install(target: Path) -> dict[str, object] | None:
+    try:
+        return verify_install(target)
+    except ValueError as error:
+        if _is_link_or_reparse_error(error):
+            raise
+        return None
+
+
+def inspect_current_install(target: Path) -> dict[str, object] | None:
+    reject_link_or_reparse(target)
+    if not target.is_dir():
+        raise ValueError(f"ChaosEngine install path is not a directory: {target}")
+    return try_verify_install(target)
+
+
+def peek_host_token(target: Path) -> str | None:
+    try:
+        manifest = load_manifest(target)
+    except ValueError:
+        return None
+    token = manifest.get("hostToken")
+    if isinstance(token, str) and re.fullmatch(r"[0-9a-f]{64}", token) is not None:
+        return token
+    return None
+
+
+def remove_repairable_tree(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists():
+        path.unlink()
 
 
 @contextmanager
@@ -759,24 +803,36 @@ def _recover_transaction(  # noqa: MC0001 - one auditable recovery state machine
         reject_link_or_reparse(path)
     if operation in ("install", "update"):
         if not target.exists() and displaced.exists():
-            verify_install(displaced)
-            displaced.replace(target)
-        elif not target.exists() and backup.exists() and not displaced.exists():
+            if try_verify_install(displaced) is None:
+                remove_repairable_tree(displaced)
+            else:
+                displaced.replace(target)
+        if not target.exists() and backup.exists() and not displaced.exists():
             verify_install(backup)
             backup.replace(target)
-        elif not target.exists() and not backup.exists() and not displaced.exists():
+        if not target.exists() and not backup.exists() and not displaced.exists():
             journal.unlink()
             return
-        verify_install(target)
+        if try_verify_install(target) is None:
+            if displaced.exists() and try_verify_install(displaced) is not None:
+                remove_repairable_tree(target)
+                displaced.replace(target)
+            else:
+                if displaced.exists():
+                    remove_repairable_tree(displaced)
+                journal.unlink()
+                return
         if backup.exists():
             verify_install(backup)
         if displaced.exists():
-            verify_install(displaced)
-            if backup.exists():
-                require_absent(old_backup, "obsolete backup path")
-                backup.replace(old_backup)
-            displaced.replace(backup)
-            verify_install(backup)
+            if try_verify_install(displaced) is None:
+                remove_repairable_tree(displaced)
+            else:
+                if backup.exists():
+                    require_absent(old_backup, "obsolete backup path")
+                    backup.replace(old_backup)
+                displaced.replace(backup)
+                verify_install(backup)
         if old_backup.exists():
             shutil.rmtree(old_backup)
     elif operation == "rollback":
@@ -867,8 +923,8 @@ def install(  # noqa: MC0001 - publication and compensation form one transaction
         _recover_transaction(project)
         if read_cross_rollback_journal(project) is not None:
             raise ValueError("rollback recovery is required before install")
-        if target.exists():
-            current = verify_install(target)
+        current = inspect_current_install(target) if target.exists() else None
+        if current is not None:
             current_commit = current["source"]["commit"]  # type: ignore[index]
             current_distribution = current.get("distribution")
             legacy_distribution = (
@@ -946,7 +1002,10 @@ def install(  # noqa: MC0001 - publication and compensation form one transaction
                 "source": desired_source,
                 "files": ownership,
                 "hostToken": (
-                    str(current["hostToken"]) if target.exists() else secrets.token_hex(32)
+                    str(current["hostToken"])
+                    if current is not None
+                    else (peek_host_token(target) if target.exists() else None)
+                    or secrets.token_hex(32)
                 ),
             }
             (stage / MANIFEST_NAME).write_text(
@@ -956,13 +1015,15 @@ def install(  # noqa: MC0001 - publication and compensation form one transaction
             publish_staged_tree(stage, target, displaced)
             verify_install(target)
             if displaced.exists():
-                verify_install(displaced)
-                if backup.exists():
+                if try_verify_install(displaced) is None:
+                    remove_repairable_tree(displaced)
+                else:
+                    if backup.exists():
+                        verify_install(backup)
+                        require_absent(old_backup, "obsolete backup path")
+                        backup.replace(old_backup)
+                    displaced.replace(backup)
                     verify_install(backup)
-                    require_absent(old_backup, "obsolete backup path")
-                    backup.replace(old_backup)
-                displaced.replace(backup)
-                verify_install(backup)
             if old_backup.exists():
                 shutil.rmtree(old_backup)
             journal.unlink()
@@ -998,6 +1059,7 @@ def rollback(  # noqa: MC0001 - cross-resource rollback is one journaled state m
             receipt_controller = None
             receipt_value = None
             if target.exists():
+                verify_install(target)
                 receipt_controller = load_installed_controller(target, "hosts")
                 host_receipt_path = project / ".chaos-engine-hosts.json"
                 if host_receipt_path.exists() or is_link_or_reparse(host_receipt_path):
@@ -1188,12 +1250,13 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
         old_manifest = None
         host_snapshot = None
         if current.exists():
-            old_manifest = verify_install(current)
-            old_commit = str(old_manifest["source"]["commit"])
-            old_host_controller = load_installed_controller(current, "hosts")
-            host_receipt_path = project / old_host_controller.RECEIPT_NAME
-            if host_receipt_path.exists() or is_link_or_reparse(host_receipt_path):
-                host_snapshot = old_host_controller.snapshot(project)
+            old_manifest = inspect_current_install(current)
+            if old_manifest is not None:
+                old_commit = str(old_manifest["source"]["commit"])
+                old_host_controller = load_installed_controller(current, "hosts")
+                host_receipt_path = project / old_host_controller.RECEIPT_NAME
+                if host_receipt_path.exists() or is_link_or_reparse(host_receipt_path):
+                    host_snapshot = old_host_controller.snapshot(project)
         target = install(
             project,
             source,
@@ -1255,9 +1318,12 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
                 except BaseException as cleanup_error:
                     compensation_errors.append(cleanup_error)
             try:
-                if old_commit is None:
+                backup_path = project / BACKUP_NAME
+                if old_commit is None and try_verify_install(backup_path) is not None:
+                    rollback(project, _locked=True)
+                elif old_commit is None:
                     uninstall(project, expected_commit=commit, _locked=True)
-                elif core_changed and (project / BACKUP_NAME).exists():
+                elif core_changed and backup_path.exists():
                     rollback(project, _locked=True)
             except BaseException as cleanup_error:
                 compensation_errors.append(cleanup_error)

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -336,7 +336,6 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
             opener, _ = self.opener([(COMMIT_ONE, "full")])
             installer = mock.Mock()
             installer.install_with_dependencies.return_value = project / ".chaos-engine"
-            host = installer.load_installed_controller.return_value
             installer.doctor_with_dependencies.side_effect = RuntimeError("probe failed")
 
             with mock.patch.object(module, "load_installer", return_value=installer):

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -325,6 +325,55 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
 
             host.activate_detected_plugins.assert_not_called()
             installer.uninstall_with_dependencies.assert_called_once_with(project.resolve())
+            installer.rollback.assert_not_called()
+
+    def test_failed_doctor_after_unverified_prior_tree_uninstalls_instead_of_rollback(self):
+        module = load()
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "project"
+            project.mkdir()
+            (project / ".chaos-engine").mkdir()
+            opener, _ = self.opener([(COMMIT_ONE, "full")])
+            installer = mock.Mock()
+            installer.install_with_dependencies.return_value = project / ".chaos-engine"
+            host = installer.load_installed_controller.return_value
+            installer.doctor_with_dependencies.side_effect = RuntimeError("probe failed")
+
+            with mock.patch.object(module, "load_installer", return_value=installer):
+                with self.assertRaisesRegex(RuntimeError, "probe failed"):
+                    module.install_latest(
+                        project,
+                        repository="Example/Project",
+                        branch="main",
+                        opener=opener,
+                    )
+
+            installer.uninstall_with_dependencies.assert_called_once_with(project.resolve())
+            installer.rollback.assert_not_called()
+
+    def test_failed_doctor_after_prior_install_with_backup_rolls_back(self):
+        module = load()
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "project"
+            project.mkdir()
+            (project / ".chaos-engine").mkdir()
+            (project / ".chaos-engine.backup").mkdir()
+            opener, _ = self.opener([(COMMIT_ONE, "full")])
+            installer = mock.Mock()
+            installer.install_with_dependencies.return_value = project / ".chaos-engine"
+            installer.doctor_with_dependencies.side_effect = RuntimeError("probe failed")
+
+            with mock.patch.object(module, "load_installer", return_value=installer):
+                with self.assertRaisesRegex(RuntimeError, "probe failed"):
+                    module.install_latest(
+                        project,
+                        repository="Example/Project",
+                        branch="main",
+                        opener=opener,
+                    )
+
+            installer.rollback.assert_called_once_with(project.resolve())
+            installer.uninstall_with_dependencies.assert_not_called()
 
     def opener(self, commits: list[tuple[str, str]]):
         calls: list[str] = []

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -1569,7 +1569,7 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             self.assertEqual(old_digest, tree_digest(project / ".chaos-engine"))
             self.assertEqual(TEST_COMMIT, MODULE.status(project)["commit"])
 
-    def test_drift_rejects_update_and_uninstall(self):
+    def test_content_drift_repairs_on_update_and_still_rejects_uninstall(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             project = root / "consumer"
@@ -1579,11 +1579,206 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             installed.joinpath("profiles/README.md").write_text("user edit\n", encoding="utf-8")
 
             with self.assertRaisesRegex(ValueError, "drift"):
-                MODULE.install(project, source, "2" * 40)
-            with self.assertRaisesRegex(ValueError, "drift"):
                 MODULE.uninstall(project)
 
+            MODULE.install(project, source, "2" * 40)
+
+            repaired = project / ".chaos-engine"
+            self.assertNotEqual("user edit\n", (repaired / "profiles/README.md").read_text(encoding="utf-8"))
+            MODULE.verify_install(repaired)
+            self.assertEqual("2" * 40, MODULE.status(project)["commit"])
+            self.assertFalse(project.joinpath(".chaos-engine.backup").exists())
+            self.assertFalse(project.joinpath(".chaos-engine.backup.next").exists())
             self.assertTrue(installed.exists())
+
+    def test_crlf_drifted_install_upgrades_to_clean_payload(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            project = root / "consumer"
+            project.mkdir()
+            source = copy_source(root / "source")
+            installed = MODULE.install(project, source, TEST_COMMIT)
+            host_token = json.loads((installed / "manifest.json").read_text(encoding="utf-8"))["hostToken"]
+            for path in installed.rglob("*"):
+                if path.is_file():
+                    data = path.read_bytes()
+                    path.write_bytes(data.replace(b"\n", b"\r\n"))
+
+            with self.assertRaisesRegex(ValueError, "ownership drift"):
+                MODULE.verify_install(installed)
+
+            MODULE.install(project, source, "2" * 40)
+
+            repaired = project / ".chaos-engine"
+            MODULE.verify_install(repaired)
+            manifest = json.loads((repaired / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(host_token, manifest["hostToken"])
+            self.assertEqual("2" * 40, manifest["source"]["commit"])
+            self.assertNotIn(b"\r\n", (repaired / "README.md").read_bytes())
+            self.assertFalse(project.joinpath(".chaos-engine.backup").exists())
+            self.assertFalse(project.joinpath(".chaos-engine.backup.next").exists())
+
+    def test_generated_python_cache_is_not_ownership_drift(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            installed = MODULE.install(project, SOURCE, TEST_COMMIT)
+            cache = installed / "__pycache__"
+            cache.mkdir()
+            (cache / "hosts.cpython-314.pyc").write_bytes(b"generated")
+            before = tree_digest(project)
+
+            MODULE.verify_install(installed)
+            same = MODULE.install(project, SOURCE, TEST_COMMIT)
+
+            self.assertEqual(installed, same)
+            self.assertEqual(before, tree_digest(project))
+            self.assertTrue((cache / "hosts.cpython-314.pyc").is_file())
+
+    def test_repair_install_never_executes_a_drifted_controller(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            installed = MODULE.install(project, SOURCE, TEST_COMMIT)
+            sentinel = project / "executed.txt"
+            for name in ("hosts.py", "dependencies.py"):
+                controller = installed / name
+                controller.write_text(
+                    controller.read_text(encoding="utf-8")
+                    + f"\nfrom pathlib import Path\nPath({str(sentinel)!r}).write_text('executed')\n",
+                    encoding="utf-8",
+                )
+
+            MODULE.install_with_dependencies(
+                project, SOURCE, "2" * 40, provisioner=lambda *_args, **_kwargs: None
+            )
+
+            self.assertFalse(sentinel.exists())
+            MODULE.verify_install(project / ".chaos-engine")
+            self.assertEqual("2" * 40, MODULE.status(project)["commit"])
+            self.assertFalse(project.joinpath(".chaos-engine.backup").exists())
+            self.assertFalse(project.joinpath(".chaos-engine.backup.next").exists())
+
+    def test_invalid_manifest_tree_is_replaced_on_install(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            leftover = project / ".chaos-engine"
+            leftover.mkdir()
+            leftover.joinpath("leftover.txt").write_text("junk\n", encoding="utf-8")
+
+            MODULE.install(project, SOURCE, TEST_COMMIT)
+
+            repaired = project / ".chaos-engine"
+            self.assertFalse((repaired / "leftover.txt").exists())
+            MODULE.verify_install(repaired)
+            self.assertEqual(TEST_COMMIT, MODULE.status(project)["commit"])
+            self.assertFalse(project.joinpath(".chaos-engine.backup").exists())
+            self.assertFalse(project.joinpath(".chaos-engine.backup.next").exists())
+
+    def test_content_drift_repair_ignores_link_in_the_project_path(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "linkage-app"
+            project.mkdir()
+            installed = MODULE.install(project, SOURCE, TEST_COMMIT)
+            installed.joinpath("profiles/README.md").write_text("user edit\n", encoding="utf-8")
+
+            MODULE.install(project, SOURCE, "2" * 40)
+
+            MODULE.verify_install(project / ".chaos-engine")
+            self.assertEqual("2" * 40, MODULE.status(project)["commit"])
+            self.assertFalse(project.joinpath(".chaos-engine.backup").exists())
+            self.assertFalse(project.joinpath(".chaos-engine.backup.next").exists())
+
+    def test_rollback_never_executes_a_drifted_controller(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            installed = MODULE.install(project, SOURCE, TEST_COMMIT)
+            sentinel = project / "executed.txt"
+            controller = installed / "hosts.py"
+            controller.write_text(
+                controller.read_text(encoding="utf-8")
+                + f"\nfrom pathlib import Path\nPath({str(sentinel)!r}).write_text('executed')\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "ownership drift"):
+                MODULE.rollback(project)
+
+            self.assertFalse(sentinel.exists())
+            self.assertTrue(installed.exists())
+
+    def test_failed_repair_publish_is_retryable(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            project = root / "consumer"
+            project.mkdir()
+            source = copy_source(root / "source")
+            installed = MODULE.install(project, source, TEST_COMMIT)
+            installed.joinpath("profiles/README.md").write_text("user edit\n", encoding="utf-8")
+            source.joinpath("profiles/README.md").write_text("updated\n", encoding="utf-8")
+            real_replace = Path.replace
+
+            def fail_stage_publish(path, destination):
+                if path.name.startswith(".chaos-engine-stage-") and destination == installed:
+                    raise OSError("injected")
+                return real_replace(path, destination)
+
+            with mock.patch.object(Path, "replace", autospec=True, side_effect=fail_stage_publish):
+                with self.assertRaisesRegex(OSError, "injected"):
+                    MODULE.install(project, source, "2" * 40)
+
+            MODULE.install(project, source, "2" * 40)
+
+            repaired = project / ".chaos-engine"
+            MODULE.verify_install(repaired)
+            self.assertEqual("2" * 40, MODULE.status(project)["commit"])
+            self.assertFalse(project.joinpath(".chaos-engine.transaction.json").exists())
+            self.assertFalse(project.joinpath(".chaos-engine.backup").exists())
+            self.assertFalse(project.joinpath(".chaos-engine.backup.next").exists())
+
+    def test_update_recovery_discards_a_drifted_displaced_tree(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            project = root / "consumer"
+            other = root / "other"
+            project.mkdir()
+            other.mkdir()
+            MODULE.install(project, SOURCE, TEST_COMMIT)
+            MODULE.install(other, SOURCE, TEST_COMMIT)
+            drifted = other / ".chaos-engine"
+            drifted.joinpath("profiles/README.md").write_text("user edit\n", encoding="utf-8")
+            MODULE.write_journal(project, "update", "2" * 40)
+            drifted.replace(project / MODULE.NEXT_BACKUP_NAME)
+
+            MODULE.recover_transaction(project)
+
+            MODULE.verify_install(project / ".chaos-engine")
+            self.assertFalse((project / MODULE.NEXT_BACKUP_NAME).exists())
+            self.assertFalse((project / MODULE.BACKUP_NAME).exists())
+            self.assertEqual(TEST_COMMIT, MODULE.status(project)["commit"])
+
+    def test_update_recovery_restores_verified_displaced_over_drifted_target(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            project = root / "consumer"
+            other = root / "other"
+            project.mkdir()
+            other.mkdir()
+            MODULE.install(project, SOURCE, TEST_COMMIT)
+            MODULE.install(other, SOURCE, TEST_COMMIT)
+            (project / ".chaos-engine" / "profiles/README.md").write_text(
+                "user edit\n", encoding="utf-8"
+            )
+            MODULE.write_journal(project, "update", "2" * 40)
+            (other / ".chaos-engine").replace(project / MODULE.NEXT_BACKUP_NAME)
+
+            MODULE.recover_transaction(project)
+
+            MODULE.verify_install(project / ".chaos-engine")
+            self.assertFalse((project / MODULE.NEXT_BACKUP_NAME).exists())
+            self.assertEqual(TEST_COMMIT, MODULE.status(project)["commit"])
 
     def test_failed_publish_restores_last_known_good(self):
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

Re-running the ChaosEngine installer now upgrades a healthy tree and replaces a drifted or broken `.chaos-engine` directory with a fresh verified payload. Windows adopter checkouts with `core.autocrlf=true` were failing closed on ownership drift because every owned file became CRLF.

Repair does not execute controllers from the broken tree and does not keep that tree as a rollback backup. Uninstall and rollback of a still-drifted tree stay fail-closed. Generated `__pycache__` is ignored in ownership hashes. Leftover install journals in front of a broken tree are dropped so retry works.

Closes #5237

## Checks

- `py -3 -B -m unittest tests.scripts.test_chaos_engine_installer tests.scripts.test_chaos_engine_bootstrap` — 119 tests, OK
- ChaosEngine acceptance passed on ubuntu/macOS/Windows for the previous head; unused-variable Codacy finding removed

## Continuation

- Head: `64aa55691b234d94e796b1fd598ea2f0763d925d`
- State: implementation pushed on `ChaosEngine/5237-repair-drifted-install`
- Blockers: none
- Next action: CI, independent GitHub review, arm auto-merge
