### PR TITLE
fix: escape RFC 8259 control chars in trace JSON

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java
+++ b/shaft-engine/src/main/java/com/shaft/tools/io/internal/FailureTraceReporter.java
@@ -3092,12 +3092,26 @@ public final class FailureTraceReporter {
     }
 
     private static String escapeJson(String value) {
-        return value(value)
-                .replace("\\", "\\\\")
-                .replace("\"", "\\\"")
-                .replace("\n", "\\n")
-                .replace("\r", "\\r")
-                .replace("\t", "\\t");
+        String source = value(value);
+        StringBuilder escaped = new StringBuilder(source.length());
+        for (int i = 0; i < source.length(); i++) {
+            char c = source.charAt(i);
+            switch (c) {
+                case '\\' -> escaped.append("\\\\");
+                case '"' -> escaped.append("\\\"");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        escaped.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        escaped.append(c);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
     }
 
     private static String escapeHtml(String value) {

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/FailureTraceReporterTest.java
@@ -193,6 +193,41 @@ public class FailureTraceReporterTest {
         }
     }
 
+    @Test(description = "ANSI ESC in a timeline log line must be RFC 8259-escaped so strict JSON.parse can load the payload")
+    public void ansiEscapeInTimelineMustProduceStrictlyValidJson() throws Exception {
+        TestExecutionInfo failingInfo = info("ansiTimelineScenario", failure());
+        Path traceDirectory = FailureTraceReporter.traceDirectory(failingInfo);
+        try {
+            deleteDirectory(traceDirectory);
+            SHAFT.Properties.reporting.set().traceEnabled(true).traceMode("failure");
+            String ansiBanner = "\u001B[1;36m=============== Starting execution... ===============\u001B[0m";
+            FailureTraceReporter.attachOnFailure(failingInfo, ansiBanner, List.of());
+
+            try (ZipFile zip = new ZipFile(traceDirectory.resolve("shaft-trace.zip").toFile())) {
+                String json = readZipEntry(zip, "shaft-trace.json");
+                assertRfc8259ControlCharsEscaped(json);
+                JsonNode root = JSON.readTree(json);
+                Assert.assertEquals(root.path("timeline").path(0).asText(), ansiBanner, json);
+                Assert.assertTrue(json.contains("\\u001b") || json.contains("\\u001B"), json);
+
+                String html = readZipEntry(zip, "SHAFT Trace Report.html");
+                String marker = "<pre hidden id=\"trace-data\">";
+                int payloadStart = html.indexOf(marker);
+                Assert.assertTrue(payloadStart >= 0, html);
+                payloadStart += marker.length();
+                int payloadEnd = html.indexOf("</pre>", payloadStart);
+                String encoded = html.substring(payloadStart, payloadEnd);
+                String decoded = encoded.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&");
+                assertRfc8259ControlCharsEscaped(decoded);
+                Assert.assertEquals(JSON.readTree(decoded).path("timeline").path(0).asText(), ansiBanner);
+            }
+        } finally {
+            TraceEventRecorder.clear();
+            deleteDirectory(traceDirectory);
+            Properties.clearForCurrentThread();
+        }
+    }
+
     @Test(description = "Rendered trace JSON should redact sensitive values and keep source fallback frame")
     public void traceJsonShouldRedactSecretsAndKeepFallbackFrame() throws Exception {
         RuntimeException throwable = failure();
@@ -2597,6 +2632,16 @@ public class FailureTraceReporterTest {
     private static String readZipEntry(ZipFile zip, String entryName) throws Exception {
         try (var input = zip.getInputStream(zip.getEntry(entryName))) {
             return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static void assertRfc8259ControlCharsEscaped(String json) {
+        for (int i = 0; i < json.length(); i++) {
+            char c = json.charAt(i);
+            if (c < 0x20 && c != '\n' && c != '\r' && c != '\t') {
+                Assert.fail("Unescaped RFC 8259 control character U+" + String.format("%04X", (int) c)
+                        + " at index " + i);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`FailureTraceReporter.escapeJson` now emits `\u00xx` for remaining RFC 8259 control characters (U+0000–U+001F), including ANSI ESC (`\u001b`). Timeline log lines with SHAFT color banners no longer make `shaft-trace.json` or the embedded `#trace-data` payload invalid for strict `JSON.parse`.

This is the same root as the blank/dead-click viewer: `JSON.parse` was the first statement of the inline script, so a throw skipped handler binding. No viewer rewrite.

Closes #5213
Closes #5209

Related to #5204
Related to #5212
Related to #5240 (sibling private `escapeJson` copies left in place)

## Checks

RED (before the `escapeJson` change):

```
mvn -pl shaft-engine "-Dtest=FailureTraceReporterTest#ansiEscapeInTimelineMustProduceStrictlyValidJson" test "-DheadlessExecution=true" "-Dallure.automaticallyOpen=false"
```

Surefire: 1 test, 1 failure: `Unescaped RFC 8259 control character U+001B at index 2387`

GREEN (after the change): same command. Surefire `TEST-com.shaft.tools.io.internal.FailureTraceReporterTest.xml`: tests=1 failures=0.

Nearest regression:

```
mvn -pl shaft-engine "-Dtest=FailureTraceReporterTest" test "-DheadlessExecution=true" "-Dallure.automaticallyOpen=false"
```

Surefire: tests=72 failures=0 errors=0 skipped=0. Did not run `TraceViewerBrowserAcceptanceTest` (no click/DOM/viewer JS change).

## Continuation

Head: `b86eb97358cce7a2e94b2bbbf06aee8b2108fe95`
State: implementation committed and pushed; awaiting independent review and PR-gate.
Blockers: none for this chunk. Native Memory `remember` degraded (`MemoryInvalidJsonl` blank `.memory/events.jsonl:1176`, already #5214, out of scope).
Next action: independent adversarial review, then arm auto-merge after the review/comment gate. Sibling serializers tracked as #5240.