### PR TITLE
docs(harness): keep asking during planning, then go unattended (#5248)

### DIFF
--- a/chaos-engine/references/consult-first.md
+++ b/chaos-engine/references/consult-first.md
@@ -2,7 +2,8 @@
 
 You are here because the entrypoint's triage selected a depth beyond the
 trivial row. Decide what good looks like and how the change will be proved
-before touching anything. No edits yet.
+before touching anything. No edits yet. Planning that skipped the material
+owner-only questions is incomplete.
 
 Triage is unconditional and lives in the entrypoint, so a trivial task never
 loads this file. Arrive already knowing which points you owe. If triage and the

--- a/chaos-engine/references/research-receipt.md
+++ b/chaos-engine/references/research-receipt.md
@@ -41,8 +41,8 @@ objective and reasoning, success criteria, audience, included and excluded
 scope, constraints, current state, callers, assumptions, tradeoffs, risks, and
 proof before reducing the work to files or steps. Ground first: never ask a
 question the repository, retrieval stores, or authoritative sources can answer.
-Then ask every material question and keep asking follow-ups until the plan is
-decision-ready. A plan that skipped those questions is incomplete. Record the
+Then ask every material question needed for high confidence in the user's
+intent and keep asking follow-ups until the plan is decision-ready. A plan that skipped those questions is incomplete. Record the
 answer, any remaining unknown, and the evidence behind the confidence level.
 
 Every plan records each store as `used` (scoped query plus verified evidence),

--- a/chaos-engine/references/research-receipt.md
+++ b/chaos-engine/references/research-receipt.md
@@ -39,9 +39,10 @@ contract changes.
 Every substantive plan is thorough and decision-ready. Establish the main
 objective and reasoning, success criteria, audience, included and excluded
 scope, constraints, current state, callers, assumptions, tradeoffs, risks, and
-proof before reducing the work to files or steps. Ask every material question
-needed for high confidence in the user's intent, but never ask a question the
-repository, retrieval stores, or authoritative sources can answer. Record the
+proof before reducing the work to files or steps. Ground first: never ask a
+question the repository, retrieval stores, or authoritative sources can answer.
+Then ask every material question and keep asking follow-ups until the plan is
+decision-ready. A plan that skipped those questions is incomplete. Record the
 answer, any remaining unknown, and the evidence behind the confidence level.
 
 Every plan records each store as `used` (scoped query plus verified evidence),
@@ -50,9 +51,12 @@ and includes dated online research. Legacy query/evidence means `used`. Compare
 two complete approaches and steelman the rejected option. Use Mermaid when
 dependencies, components, state, or workflows become materially clearer;
 otherwise record why a diagram would be decorative. Own implementation of the
-plan: after approval, carry it proactively through RED, implementation,
-independent review, PR delivery, authorized merge, and scoped cleanup. Re-ask
-only for a new HALT condition, not for approval already granted.
+plan: after approval, go unattended and carry it proactively through RED,
+implementation, independent review, PR delivery, authorized merge, and scoped
+cleanup. Do not ask the user for implementation clarifications or permission
+already granted. If execution hits ambiguity, take a consultant agent's
+guidance. Re-ask the user only for a new HALT condition: merge authority that
+was never granted, or a request that contradicts the approved plan.
 
 Install and learning contracts live in [dependencies.json](../dependencies.json)
 and are enforced by `tests/scripts/test_chaos_engine_installer.py`,

--- a/chaos-engine/references/work-github-planning.md
+++ b/chaos-engine/references/work-github-planning.md
@@ -27,19 +27,29 @@ Issue-backed plans must be copied onto the GitHub issue before the first impleme
 
 Only then ask about a decision the user alone must make.
 
-## 1. Ask once, at the start, then go unattended
+## 1. Keep asking until the plan is decision-ready, then go unattended
 
-Ground one batch of decisions: branch/PR shape, merge authority, and any truly
-ambiguous scope. The default is one branch/worktree, linked subtask issues, and
-one PR per related group; for genuinely disjoint work, offer a separate branch+PR per item looped sequentially. Do not ask piecemeal later unless a real HALT condition applies.
+1. During planning: ground first. Never ask what the repository, retrieval
+   stores, or authoritative docs can answer. Then ask every material question
+   and keep asking follow-ups until the plan is decision-ready. Planning that
+   skips those questions is incomplete.
+2. After owner approval: go completely unattended. Do not ask the user for
+   implementation clarifications or permission already granted.
+3. If execution hits ambiguity: dispatch a consultant agent (read-only,
+   independent) and take its guidance. Do not ask the user. Absorb
+   owner-initiated mid-flight requests. HALT to the user only when merge
+   authority was never granted or the new request contradicts the approved
+   plan.
+
+The default is one branch/worktree, linked subtask issues, and one PR per related group; for genuinely disjoint work, offer a separate branch+PR per item looped sequentially.
 
 ### Mid-session realignment: named HALT conditions
 
-HALT and ask when a new request changes the agreed branch, PR, or merge-authority
-shape; cannot be grounded in current code (say what you searched); conflicts
-with work in flight (surface the conflict and two options); or needs merge
-authority that was never granted. Otherwise absorb the request into the owned
-plan.
+HALT and ask only when merge authority was never granted, or a new request
+contradicts the approved plan: it changes the agreed branch, PR, or
+merge-authority shape, or conflicts with work in flight (surface the conflict
+and two options). If execution cannot be grounded in current code, say what you searched to the consultant agent; do not ask the user. Otherwise absorb
+the request into the owned plan.
 
 ## 2. Branch and track
 

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -115,7 +115,7 @@ ownership. Approval never crosses target classes.
 
 1. Orient on requested outcome and concrete proof of done.
 2. Read current instructions and live files before acting.
-3. Plan by uncertainty, blast radius, and reversibility; test riskiest premise first.
+3. Plan by uncertainty, blast radius, and reversibility; ground first, keep asking material follow-ups until decision-ready, then go unattended after approval; test riskiest premise first.
 4. Act in smallest verified increment. Fix root owner of an invariant, not each symptom.
 5. Verify affected behavior empirically, including nearest plausible regression.
 6. Report outcome, exact checks, failures, and Learning Loop result.

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -725,7 +725,7 @@ class EntrypointDutyTest(unittest.TestCase):
         planning = self.PLANNING_PLAYBOOK.read_text(encoding="utf-8")
         for heading in (
             "## 0. Ground the scope before asking anything",
-            "## 1. Ask once, at the start, then go unattended",
+            "## 1. Keep asking until the plan is decision-ready, then go unattended",
             "## 2. Branch and track",
             "## 3. Work items in dependency order, front-loading risk",
             "## 3b. Tracking issue + one-issue-per-subtask (mandatory default for new work)",

--- a/tests/scripts/test_chaos_engine_planning.py
+++ b/tests/scripts/test_chaos_engine_planning.py
@@ -1,0 +1,81 @@
+"""Focused planning-contract tests for keep-asking-then-unattended (#5248)."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PLANNING = ROOT / "chaos-engine/references/work-github-planning.md"
+RECEIPT = ROOT / "chaos-engine/references/research-receipt.md"
+CONSULT = ROOT / "chaos-engine/references/consult-first.md"
+SKILL = ROOT / "chaos-engine/skills/chaos-engine/SKILL.md"
+FORBIDDEN = "Ask once, at the start, then go unattended"
+
+
+def contract_violations(planning: str, receipt: str, consult: str, skill: str) -> list[str]:
+    """Return violations of the #5248 planning contract for the given texts."""
+    violations: list[str] = []
+    if FORBIDDEN in planning:
+        violations.append(
+            "work-github-planning.md still says Ask once, at the start, then go unattended"
+        )
+    if FORBIDDEN in receipt or FORBIDDEN in consult or FORBIDDEN in skill:
+        violations.append("aligned guidance restored Ask once, at the start, then go unattended")
+    for required in (
+        "keep asking follow-ups",
+        "decision-ready",
+        "consultant agent",
+        "implementation clarifications",
+        "never granted",
+    ):
+        if required not in planning:
+            violations.append(f"work-github-planning.md missing {required!r}")
+    if "keep asking follow-ups" not in receipt:
+        violations.append("research-receipt.md missing keep-asking-during-planning rule")
+    if "incomplete" not in consult.lower():
+        violations.append("consult-first.md missing incomplete-without-those-questions sentence")
+    plan_step = next(
+        (line for line in skill.splitlines() if line.startswith("3. Plan by ")),
+        "",
+    )
+    if "decision-ready" not in plan_step or "unattended" not in plan_step:
+        violations.append("SKILL.md plan step missing decision-ready unattended contract")
+    return violations
+
+
+class ChaosEnginePlanningContractTest(unittest.TestCase):
+    def test_live_guidance_keeps_asking_then_goes_unattended(self):
+        violations = contract_violations(
+            PLANNING.read_text(encoding="utf-8"),
+            RECEIPT.read_text(encoding="utf-8"),
+            CONSULT.read_text(encoding="utf-8"),
+            SKILL.read_text(encoding="utf-8"),
+        )
+        self.assertEqual([], violations)
+
+    def test_restoring_ask_once_sentence_fails(self):
+        mutated = PLANNING.read_text(encoding="utf-8") + f"\n{FORBIDDEN}\n"
+        violations = contract_violations(
+            mutated,
+            RECEIPT.read_text(encoding="utf-8"),
+            CONSULT.read_text(encoding="utf-8"),
+            SKILL.read_text(encoding="utf-8"),
+        )
+        self.assertTrue(
+            any(FORBIDDEN in item for item in violations),
+            violations,
+        )
+
+    def test_chaos_engine_references_do_not_restore_ask_once(self):
+        hits = [
+            str(path.relative_to(ROOT)).replace("\\", "/")
+            for path in (ROOT / "chaos-engine").rglob("*.md")
+            if FORBIDDEN in path.read_text(encoding="utf-8")
+        ]
+        self.assertEqual([], hits)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #5248

## Summary

Replace the ChaosEngine planning rule **Ask once, at the start, then go unattended** with keep-asking until the plan is decision-ready, then unattended execution.

- Planning: ground first, ask every material question, keep asking follow-ups until decision-ready. A plan that skipped those questions is incomplete.
- After owner approval: go unattended. Do not ask the user for implementation clarifications or permission already granted.
- Execution ambiguity: dispatch a consultant agent. HALT only for never-granted merge authority or a request that contradicts the approved plan.

Aligned `research-receipt.md`, `consult-first.md`, and the portable SKILL.md plan step. Separate from #5247 product work.

## Checks

- RED: `py -3 -m unittest tests.scripts.test_chaos_engine_planning` failed while the old sentence remained (old heading plus missing new contract phrases).
- GREEN: same command passed after the guidance edit. Mutation that restores `Ask once, at the start, then go unattended` still fails.
- Sibling heading pin: `tests.scripts.test_agent_harness_reachability.EntrypointDutyTest.test_the_github_playbook_links_its_planning_and_tracking_half`
- SKILL line budget: `tests.scripts.test_chaos_engine_portable_core.ChaosEnginePortableCoreTest.test_validation_scope_recommends_balanced_and_ci_reruns_only_changed_tests`
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` passed (212361 guidance bytes).
- CI follow-up: `ConsultGateTest.test_planning_contract_requires_intent_confidence_detail_and_owned_delivery` failed on `3b670d0b21` because `high confidence` was dropped. Restored that phrase. Re-run passed.
- Review blockers: RED then GREEN for the Agent Guidance Gate run-list pin and the too-narrow HALT colon. `py -3 -m unittest tests.scripts.test_chaos_engine_planning tests.scripts.test_agent_router_contract.ConsultGateTest.test_planning_contract_requires_intent_confidence_detail_and_owned_delivery` passed, plus reachability CI-list and heading pins.

## Continuation

- Head: `a63b4e458c5b3a0812c021ee1cd476dff204f8e2`
- State: Review blockers addressed (PR Gate now runs `tests.scripts.test_chaos_engine_planning`; HALT covers any plan contradiction). Merge not armed. Independent local reviewer still cannot be spawned from this implementer subagent.
- Blockers: independent adversarial re-review of this revision. Orchestrator babysits review and merge.
- Next action: re-review HEAD; do not squash or merge until that gate passes.
