### PR TITLE
feat: portable orchestrator mode and planning follow-ups

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -47,9 +47,7 @@ then runs active `doctor` probes. Generated indexes, caches, receipts, and runti
 remain untracked; canonical configuration and adapters remain trackable.
 Origin identity masters under `assets/brand/`, the origin adoption matrix
 `RESEARCH.md`, and `STANDALONE.md` stay in the source tree and are not copied
-into the adopter payload. The
-
-installer also merges receipt-bound LF attributes for canonical harness paths,
+into the adopter payload. The installer also merges receipt-bound LF attributes for canonical harness paths,
 so Windows Git checkouts retain the exact owned bytes while unrelated
 `.gitattributes` rules remain untouched.
 

--- a/chaos-engine/references/consult-first.md
+++ b/chaos-engine/references/consult-first.md
@@ -7,6 +7,9 @@ before touching anything. No edits yet.
 Triage is unconditional and lives in the entrypoint, so a trivial task never
 loads this file. Arrive already knowing which points you owe. If triage and the
 user's framing disagree about size, say so in one line and work to the larger.
+During planning, keep asking material follow-ups until the plan is
+decision-ready. After owner approval, execution is unattended; dispatch a
+consultant agent for implementation ambiguity rather than asking the user.
 
 ## Full pass
 

--- a/chaos-engine/references/delegation.md
+++ b/chaos-engine/references/delegation.md
@@ -30,22 +30,60 @@ mechanical-helper role from [roles](roles.md) to both subagent hosts.
 ## Main-thread duties
 
 Orchestrator retains decomposition, architecture, consultation, assignment,
-synthesis, integration, and final verification, and stays available for owner
-realignment and delegate questions. The entrypoint's solo-or-orchestrate rule
+synthesis, integration, and final verification. Stay available to the owner
+for realignment and delegate questions. The entrypoint's solo-or-orchestrate rule
 decides whether it also implements; this file governs the orchestrated mode.
 
-Run only independent file scopes concurrently. Each writer owns an isolated
-worktree. Hard cap four concurrent writing agents; a read-only reviewer does not
+Default is one writer at a time, ordered by dependency then priority. On owner
+request, parallelize only independent file scopes. Each writer owns an isolated
+worktree. Hard cap four concurrent writing agents; the owner may set a cap of
+1–4. Refuse a requested cap above 4. File-overlapping writers never run in
+parallel even when parallel is requested. A read-only reviewer does not
 consume a slot. Check real progress for any agent or
 command unexamined for about twenty minutes, and supply a decision, a solved
 subproblem, or a re-spec — never a heartbeat.
 
-Treat agent lifetime as part of the assignment. Close every no-longer-needed
-agent and its descendants before moving to the next phase. Never use
-`followup_task` to reactivate a completed or finished assignment; a new review
-round gets a new reviewer instance. Preserve the closed relationship as
-history instead of deleting it. A final answer with an unneeded live agent is
-incomplete.
+Treat agent lifetime as part of the assignment. Verify that the writer's
+Learning Loop before kill actually landed in a source-controlled place
+(Memory, a GitHub issue after duplicate search, or an explicit nothing-durable
+result). Then close every no-longer-needed agent and its descendants before
+moving to the next phase. Never use `followup_task` to reactivate a completed
+or finished assignment; a new review round gets a new reviewer instance.
+Preserve the closed relationship as history instead of deleting it. A final
+answer with an unneeded live agent is incomplete.
+
+## Orchestrator mode
+
+Same class of standing duties: stay available, keep the live status table
+current after every dispatch and every finished agent, group related work into
+the fewest PRs that still keep one problem per issue (`Closes #N` per completed
+subtask), and keep working until every in-scope ticket is delivered. Do not
+treat planning, a status table, or one PR as session complete.
+
+After grouping, the done condition is: every in-scope ticket is merged or
+explicitly out of scope. After each chunk merges, destroy that writer, start
+the next from a fresh `ChaosEngine/*` branch off the fetched configured
+default branch, update the live status table, and continue. Stop only when
+the in-scope set is empty, the owner narrows scope, or a real blocker needs
+the owner.
+
+Same-subsystem leftovers share one PR. Split only when writers would collide on
+the same files and cannot be sequenced, or when the work truly belongs to
+different categories. If a delegate omitted an actionable leftover, file the
+missing issue or Memory as an owner-command; do not implement the leftover work.
+
+After every dispatch and after every subagent finishes, post or update a status
+table the owner can read without reconstructing the session. Include completed,
+in progress, planned, and out of scope rows so out of scope is not silently
+dropped. Enhance with blocker, PR/issue links, HEAD SHA, and Learning Loop
+result (`memory` / `issue` / `nothing durable`). Do not put secrets in the
+table.
+
+| ID / work item | Mode stream | Status | Owner / agent | Dependency | Last update | Details / evidence | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
+Status values at least: `planned`, `in progress`, `blocked`, `review`,
+`completed`, `out of scope`.
 
 ## Independent adversarial review
 

--- a/chaos-engine/references/orchestrator-bootstrap.md
+++ b/chaos-engine/references/orchestrator-bootstrap.md
@@ -14,17 +14,23 @@ does. A single stream skips this file and is worked solo, in sequence.
    owner asks, then backlog. Finish before opening new fronts.
 4. Compare file scopes. Sequence overlap; isolate independent writers in
    worktrees, within the concurrency cap in [delegation](delegation.md).
-5. Ticket substantial multi-part work before dispatch: tracker plus linked
-   subtask issues.
-6. Dispatch bounded specs: exact behavior, files, precedent, exclusions,
+   Default one writer at a time; parallel only on owner request.
+5. After loading every assigned ticket, group related work into the fewest PRs
+   that still keep one problem per issue. Ticket substantial multi-part work
+   before dispatch: tracker plus linked subtask issues.
+6. Create a delivery loop whose done condition is every in-scope ticket
+   delivered or explicitly out of scope. Do not stop after a plan, a status
+   table, or one PR.
+7. Dispatch bounded specs: exact behavior, files, precedent, exclusions,
    expected RED, and proof command. Select the most intelligent, default, or
    mechanical capability using [delegation](delegation.md), never provider
-   identity.
-7. Stay available for architecture and consult decisions, on the check-in
+   identity. After every dispatch, update the live status table.
+8. Stay available for architecture and consult decisions, on the check-in
    cadence in [delegation](delegation.md).
-8. Review the actual diff and tests as [delegation](delegation.md) defines.
-   Main thread owns synthesis and final verification.
-9. File adjacent findings and route durable Learning Loop output before close.
+9. Review the actual diff and tests as [delegation](delegation.md) defines.
+   Main thread owns synthesis and final verification. Verify Learning Loop
+   before kill, then destroy the finished writer and continue the delivery loop.
+10. File adjacent findings and route durable Learning Loop output before close.
 
 For branch, tracker, and PR mechanics use
 [work GitHub](work-github-playbook.md).

--- a/chaos-engine/references/research-receipt.md
+++ b/chaos-engine/references/research-receipt.md
@@ -41,9 +41,9 @@ objective and reasoning, success criteria, audience, included and excluded
 scope, constraints, current state, callers, assumptions, tradeoffs, risks, and
 proof before reducing the work to files or steps. Never ask a question the
 repository, retrieval stores, or authoritative sources can answer. Then ask
-every material question, and keep asking follow-ups until the plan is
-decision-ready. Record the answer, any remaining unknown, and the evidence
-behind the confidence level.
+every material question needed for high confidence in the user's intent, and
+keep asking follow-ups until the plan is decision-ready. Record the answer, any
+remaining unknown, and the evidence behind the confidence level.
 
 Every plan records each store as `used` (scoped query plus verified evidence),
 `skipped` (concrete irrelevance), or `degraded` (attempt plus sanitized reason),

--- a/chaos-engine/references/research-receipt.md
+++ b/chaos-engine/references/research-receipt.md
@@ -39,10 +39,11 @@ contract changes.
 Every substantive plan is thorough and decision-ready. Establish the main
 objective and reasoning, success criteria, audience, included and excluded
 scope, constraints, current state, callers, assumptions, tradeoffs, risks, and
-proof before reducing the work to files or steps. Ask every material question
-needed for high confidence in the user's intent, but never ask a question the
-repository, retrieval stores, or authoritative sources can answer. Record the
-answer, any remaining unknown, and the evidence behind the confidence level.
+proof before reducing the work to files or steps. Never ask a question the
+repository, retrieval stores, or authoritative sources can answer. Then ask
+every material question, and keep asking follow-ups until the plan is
+decision-ready. Record the answer, any remaining unknown, and the evidence
+behind the confidence level.
 
 Every plan records each store as `used` (scoped query plus verified evidence),
 `skipped` (concrete irrelevance), or `degraded` (attempt plus sanitized reason),
@@ -50,9 +51,11 @@ and includes dated online research. Legacy query/evidence means `used`. Compare
 two complete approaches and steelman the rejected option. Use Mermaid when
 dependencies, components, state, or workflows become materially clearer;
 otherwise record why a diagram would be decorative. Own implementation of the
-plan: after approval, carry it proactively through RED, implementation,
-independent review, PR delivery, authorized merge, and scoped cleanup. Re-ask
-only for a new HALT condition, not for approval already granted.
+plan: after approval, go completely unattended and carry it proactively through
+RED, implementation, independent review, PR delivery, authorized merge, and
+scoped cleanup. Do not ask the user for implementation clarifications; dispatch
+a consultant agent. HALT only when merge authority was never granted or a new
+request contradicts the approved plan, not for approval already granted.
 
 Install and learning contracts live in [dependencies.json](../dependencies.json)
 and are enforced by `tests/scripts/test_chaos_engine_installer.py`,

--- a/chaos-engine/references/roles.md
+++ b/chaos-engine/references/roles.md
@@ -15,7 +15,10 @@ role means adding both adapters.
 Main-thread owner. Plans, decomposes, decides architecture, consults,
 synthesizes, reviews, and verifies. Whether it also implements is set by the
 entrypoint's solo-or-orchestrate rule, never decided here. Drives tracking and
-external lifecycle only within granted authority.
+external lifecycle only within granted authority. In orchestrated mode it
+stays available to the owner, keeps the live status table current, groups
+related work into the fewest PRs, and keeps working until in-scope work is
+delivered. In orchestrated mode it does no task work itself.
 
 ## Implementer
 

--- a/chaos-engine/references/work-github-planning.md
+++ b/chaos-engine/references/work-github-planning.md
@@ -27,19 +27,29 @@ Issue-backed plans must be copied onto the GitHub issue before the first impleme
 
 Only then ask about a decision the user alone must make.
 
-## 1. Ask once, at the start, then go unattended
+## 1. Keep asking follow-ups until decision-ready; then go unattended
 
-Ground one batch of decisions: branch/PR shape, merge authority, and any truly
-ambiguous scope. The default is one branch/worktree, linked subtask issues, and
-one PR per related group; for genuinely disjoint work, offer a separate branch+PR per item looped sequentially. Do not ask piecemeal later unless a real HALT condition applies.
+During planning, ground first. Never ask what the repository, retrieval stores,
+or authoritative docs can answer. Then ask every material question, and keep
+asking follow-ups until the plan is decision-ready. A plan that skipped those
+questions is incomplete.
+
+Ground remaining owner-only decisions: branch/PR shape, merge authority, and any
+truly ambiguous scope. The default is one branch/worktree, linked subtask issues, and
+one PR per related group; for genuinely disjoint work, offer a separate branch+PR per item looped sequentially.
+
+After the owner approves the plan, go completely unattended. Do not ask the user
+for implementation clarifications or for permission already granted. If execution
+hits ambiguity, dispatch a consultant agent (read-only, independent) and take
+its guidance. Absorb owner-initiated mid-flight requests.
 
 ### Mid-session realignment: named HALT conditions
 
 HALT and ask when a new request changes the agreed branch, PR, or merge-authority
 shape; cannot be grounded in current code (say what you searched); conflicts
-with work in flight (surface the conflict and two options); or needs merge
-authority that was never granted. Otherwise absorb the request into the owned
-plan.
+with work in flight (surface the conflict and two options); needs merge
+authority that was never granted; or a new request contradicts the approved
+plan. Otherwise absorb the request into the owned plan.
 
 ## 2. Branch and track
 

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -115,7 +115,7 @@ ownership. Approval never crosses target classes.
 
 1. Orient on requested outcome and concrete proof of done.
 2. Read current instructions and live files before acting.
-3. Plan by uncertainty, blast radius, and reversibility; test riskiest premise first.
+3. Plan by uncertainty, blast radius, and reversibility; test riskiest premise first; keep asking follow-ups until the plan is decision-ready. After owner approval, go unattended and dispatch a consultant agent for execution ambiguity.
 4. Act in smallest verified increment. Fix root owner of an invariant, not each symptom.
 5. Verify affected behavior empirically, including nearest plausible regression.
 6. Report outcome, exact checks, failures, and Learning Loop result.
@@ -205,19 +205,27 @@ on each other.
 | Work streams | Mode |
 | --- | --- |
 | One | **Solo.** Do the work yourself, in sequence. Do not delegate it. |
-| Two or more | **Orchestrate.** One agent per stream, each in its own worktree, up to four. Do no task work yourself. |
+| Two or more | **Orchestrate.** Do not wait for the owner to say "orchestrate". Default one writer at a time, each in its own worktree. Do no task work yourself. |
 
 Orchestrating keeps you reachable for owner or delegate decisions. In this mode
 you make no edits, run no long job, and install nothing;
-[delegation](../../references/delegation.md) lists what stays yours.
+[delegation](../../references/delegation.md) lists what stays yours, including the
+live status table, fewest-PR grouping, keep-working-until-delivered loop, and
+Learning Loop before kill.
+
+**Default serial, optional parallel.** One writer at a time, ordered by
+dependency then priority. On owner request, parallelize independent writers up to
+a hard cap of four; the owner may set a cap of 1–4. Refuse a requested cap above
+4. File-overlapping writers never run in parallel.
 
 **Switching mode.** Finish or hand over what you hold before you switch. While
 any delegate still owns a stream you remain orchestrating, even if the count
 alone would say otherwise. Never start an edit in the same breath as adopting
-solo mode; land the transition first.
+solo mode or orchestrator mode; land the transition first.
 
 **A host with no subagent primitive cannot orchestrate.** It works solo at any
-count, sequentially, and still owes the review gate a separate instance.
+count, sequentially, still shows the live status table, and still owes the review
+gate a separate instance.
 
 **A reviewer is never a work stream.** Review does not turn a solo session into
 an orchestrated one, and a read-only reviewer does not consume one of the four

--- a/tests/scripts/test_agent_harness_portability.py
+++ b/tests/scripts/test_agent_harness_portability.py
@@ -504,6 +504,25 @@ class AgentHarnessPortabilityTest(unittest.TestCase):
         ):
             self.assertIn(required, compact)
 
+    def test_portable_orchestrator_mode_groups_fewest_prs_and_keeps_working(self):
+        """#5246 #5249: portable orchestrator mode, not only the SHAFT profile."""
+        delegation = (ROOT / "chaos-engine/references/delegation.md").read_text(
+            encoding="utf-8"
+        )
+        skill = (ROOT / "chaos-engine/skills/chaos-engine/SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        compact = re.sub(r"\s+", " ", "\n".join((delegation, skill)))
+        for required in (
+            "fewest PRs that still keep one problem per issue",
+            "stay available",
+            "live status table",
+            "keep working until every in-scope ticket is delivered",
+            "one writer at a time",
+            'Do not wait for the owner to say "orchestrate"',
+        ):
+            self.assertIn(required, compact)
+
     def test_host_token_budgets_include_mandatory_entrypoint(self):
         budget = json.loads(
             (ROOT / "scripts/ci/agent_guidance_budget.json").read_text(encoding="utf-8")

--- a/tests/scripts/test_agent_harness_reachability.py
+++ b/tests/scripts/test_agent_harness_reachability.py
@@ -725,7 +725,7 @@ class EntrypointDutyTest(unittest.TestCase):
         planning = self.PLANNING_PLAYBOOK.read_text(encoding="utf-8")
         for heading in (
             "## 0. Ground the scope before asking anything",
-            "## 1. Ask once, at the start, then go unattended",
+            "## 1. Keep asking follow-ups until decision-ready; then go unattended",
             "## 2. Branch and track",
             "## 3. Work items in dependency order, front-loading risk",
             "## 3b. Tracking issue + one-issue-per-subtask (mandatory default for new work)",

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -74,6 +74,23 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
         self.assertIn("for ($attempt = 0; $attempt -lt 4; $attempt++)", powershell)
         self.assertIn("curl -fsSL --retry 3", shell)
 
+    def test_posix_copy_gate_calls_source_tree_helper_after_resolve_only(self):
+        """#5232: a helper definition alone must not keep leftover-copy CI green."""
+        shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
+        self.assertIn("CHAOS_ENGINE_RESOLVE_ONLY", shell)
+        after_resolve = shell.split("CHAOS_ENGINE_RESOLVE_ONLY", 1)[1]
+        self.assertIn("is_chaos_engine_source_tree", after_resolve)
+        self.assertIn('cp "$script_dir/bootstrap.py"', after_resolve)
+
+    def test_install_md_joins_the_installer_lf_attributes_sentence(self):
+        """#5234: origin omit-list and LF-attributes stay one paragraph."""
+        document = (ROOT / "chaos-engine/INSTALL.md").read_text(encoding="utf-8")
+        self.assertIn(
+            "into the adopter payload. The installer also merges receipt-bound LF attributes",
+            document,
+        )
+        self.assertNotRegex(document, r"The\s*\n\s*\n\s*installer also merges")
+
     def test_read_response_retries_a_transient_http_failure(self):
         module = load()
         transient = urllib.error.HTTPError(

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -14,6 +14,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from urllib.parse import unquote, urlparse
 
+from tests.scripts.test_chaos_engine_install_wrappers import (
+    has_implicit_string_concat,
+    source_segment_for_function,
+)
+
 
 ROOT = Path(__file__).resolve().parents[2]
 BOOTSTRAP = ROOT / "chaos-engine/bootstrap.py"
@@ -54,7 +59,7 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
         windows = 'irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex'
         posix = (
             'curl -fsSL "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"'
-            ' | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"'
+            + ' | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"'
         )
         for relative in ("chaos-engine/README.md", "chaos-engine/INSTALL.md"):
             document = ROOT.joinpath(relative).read_text(encoding="utf-8")
@@ -73,6 +78,22 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
         self.assertIn("--project", shell)
         self.assertIn("for ($attempt = 0; $attempt -lt 4; $attempt++)", powershell)
         self.assertIn("curl -fsSL --retry 3", shell)
+
+    def test_documented_posix_one_liner_uses_explicit_concatenation(self):
+        """#5253: adjacent literals in the documented POSIX one-liner go red."""
+        source = Path(__file__).read_text(encoding="utf-8")
+        snippet = source_segment_for_function(
+            source, "test_documented_command_contains_the_bounded_initial_fetch_contract"
+        )
+        self.assertTrue(
+            has_implicit_string_concat("X = (\n    'a'\n    'b'\n)\n"),
+            "detector must catch adjacent literals",
+        )
+        self.assertFalse(has_implicit_string_concat("X = (\n    'a'\n    + 'b'\n)\n"))
+        self.assertFalse(
+            has_implicit_string_concat(snippet),
+            "documented POSIX one-liner must use explicit + or one line",
+        )
 
     def test_posix_copy_gate_calls_source_tree_helper_after_resolve_only(self):
         """#5232: a helper definition alone must not keep leftover-copy CI green."""

--- a/tests/scripts/test_chaos_engine_install_wrappers.py
+++ b/tests/scripts/test_chaos_engine_install_wrappers.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import ast
+import io
 import os
 import re
 import shutil
 import subprocess  # nosec B404 - tests invoke local pwsh/bash on repo wrappers only.
 import tempfile
+import tokenize
 import unittest
 from pathlib import Path
 
@@ -26,7 +29,7 @@ WINDOWS_ONE_LINER = (
 )
 POSIX_ONE_LINER = (
     'curl -fsSL "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"'
-    ' | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"'
+    + ' | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"'
 )
 USER_WINDOWS_COMMAND = (
     'irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex'
@@ -378,7 +381,7 @@ Write-Output (Get-ChaosEngineHeader $message.Headers 'X-Missing')
                     shell,
                     "-c",
                     "CHAOS_ENGINE_RESOLVE_ONLY=1 CHAOS_ENGINE_REPOSITORY=Evil/Repo "
-                    f"'{script}' '{url}'",
+                    + f"'{script}' '{url}'",
                 ],
                 check=False,
                 capture_output=True,
@@ -388,9 +391,211 @@ Write-Output (Get-ChaosEngineHeader $message.Headers 'X-Missing')
         self.assertEqual(0, completed.returncode, completed.stderr + completed.stdout)
         self.assertEqual(
             "ShaftHQ/SHAFT_ENGINE|main|chaos-engine|"
-            "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/bootstrap.py",
+            + "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/bootstrap.py",
             completed.stdout.strip().splitlines()[-1],
         )
+
+    def test_remaining_wrapper_strings_use_explicit_concatenation(self):
+        """#5233: adjacent literals in POSIX_ONE_LINER or the positional-url test go red."""
+        source = Path(__file__).read_text(encoding="utf-8")
+        self.assertTrue(
+            has_implicit_string_concat("X = (\n    'a'\n    'b'\n)\n"),
+            "detector must catch adjacent literals",
+        )
+        self.assertFalse(has_implicit_string_concat("X = (\n    'a'\n    + 'b'\n)\n"))
+        self.assertFalse(has_implicit_string_concat("X = 'ab'\n"))
+        posix = source_segment_for_assignment(source, "POSIX_ONE_LINER")
+        positional = source_segment_for_function(
+            source, "test_shell_wrapper_uses_positional_url_over_env"
+        )
+        self.assertFalse(
+            has_implicit_string_concat(posix),
+            "POSIX_ONE_LINER must use explicit + or one line",
+        )
+        self.assertFalse(
+            has_implicit_string_concat(positional),
+            "test_shell_wrapper_uses_positional_url_over_env must use explicit + or one line",
+        )
+
+    def test_install_md_joins_the_installer_lf_attributes_sentence(self):
+        """#5234: do not leave a one-word `The` paragraph."""
+        document = (ROOT / "chaos-engine/INSTALL.md").read_text(encoding="utf-8")
+        self.assertIn(
+            "into the adopter payload. The installer also merges receipt-bound LF attributes",
+            document,
+        )
+        self.assertNotRegex(document, r"The\s*\n\s*\n\s*installer also merges")
+
+    def test_posix_leftover_bootstrap_is_not_copied_without_source_tree_skill(self):
+        """#5232: leftover bootstrap.py without SKILL.md must take the fetch path."""
+        self._run_posix_bootstrap_copy_gate(source_tree=False)
+
+    def test_posix_source_tree_bootstrap_is_copied_when_skill_exists(self):
+        """#5232: a source-tree fixture with SKILL.md does copy sibling bootstrap.py."""
+        self._run_posix_bootstrap_copy_gate(source_tree=True)
+
+    def _run_posix_bootstrap_copy_gate(self, *, source_tree: bool) -> None:
+        shell = shutil.which("bash") or shutil.which("sh")
+        if shell is None:
+            self.skipTest("sh is not on PATH")
+        if shutil.which("python3") is None and shutil.which("python") is None:
+            self.skipTest("python3 is required")
+        url = (
+            "https://raw.githubusercontent.com/Example/Project/main/"
+            "chaos-engine/install.sh"
+        )
+        leftover = 'raise SystemExit("LEFTOVER_BOOTSTRAP")\n'
+        fetched = 'raise SystemExit("FETCHED_BOOTSTRAP")\n'
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temporary:
+            root = Path(temporary)
+            wrapper = root / "install.sh"
+            wrapper.write_bytes(
+                SHELL.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+            )
+            (root / "bootstrap.py").write_bytes(leftover.encode("utf-8"))
+            if source_tree:
+                skill = root / "skills" / "chaos-engine" / "SKILL.md"
+                skill.parent.mkdir(parents=True)
+                skill.write_text("# ChaosEngine\n", encoding="utf-8", newline="\n")
+            bindir = root / "bin"
+            bindir.mkdir()
+            write_posix_stub(
+                bindir / "curl",
+                "\n".join(
+                    (
+                        "#!/bin/sh",
+                        'out=""',
+                        'while [ "$#" -gt 0 ]; do',
+                        '  case "$1" in',
+                        '    -o) out="$2"; shift 2 ;;',
+                        "    --retry|--retry-delay) shift 2 ;;",
+                        '    -*) shift ;;',
+                        '    *) shift ;;',
+                        "  esac",
+                        "done",
+                        '[ -n "$out" ] || exit 1',
+                        f"printf '%s\\n' '{fetched.strip()}' > \"$out\"",
+                    )
+                ),
+            )
+            write_posix_stub(
+                bindir / "wget",
+                "\n".join(
+                    (
+                        "#!/bin/sh",
+                        'echo "wget must not run in leftover-bootstrap tests" >&2',
+                        "exit 1",
+                    )
+                ),
+            )
+            project = root / "project"
+            project.mkdir()
+            script = shell_visible_path(shell, wrapper)
+            unix_bin = shell_visible_path(shell, bindir)
+            unix_project = shell_visible_path(shell, project)
+            completed = subprocess.run(  # nosec B603 - local bash plus repo wrapper
+                [
+                    shell,
+                    "-c",
+                    f"PATH='{unix_bin}':\"$PATH\" && cd '{unix_project}' && "
+                    f"sh '{script}' '{url}'",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        output = completed.stdout + completed.stderr
+        if source_tree:
+            self.assertIn("LEFTOVER_BOOTSTRAP", output)
+            self.assertNotIn("FETCHED_BOOTSTRAP", output)
+        else:
+            self.assertIn("FETCHED_BOOTSTRAP", output)
+            self.assertNotIn("LEFTOVER_BOOTSTRAP", output)
+
+
+_STRINGY = {tokenize.STRING}
+if hasattr(tokenize, "FSTRING_START"):
+    _STRINGY.add(tokenize.FSTRING_START)
+
+
+def has_implicit_string_concat(source: str) -> bool:
+    pending = False
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type in _STRINGY:
+            if pending:
+                return True
+            pending = True
+        elif tok.type == tokenize.OP and tok.string == "+":
+            pending = False
+        elif tok.type in (
+            tokenize.NL,
+            tokenize.NEWLINE,
+            tokenize.INDENT,
+            tokenize.DEDENT,
+            tokenize.COMMENT,
+            tokenize.ENCODING,
+        ):
+            continue
+        else:
+            pending = False
+    return False
+
+
+def source_segment_for_assignment(source: str, name: str) -> str:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                segment = ast.get_source_segment(source, node)
+                if segment is None:
+                    raise AssertionError(f"could not read assignment {name}")
+                return segment
+    raise AssertionError(f"assignment {name} is missing")
+
+
+def source_segment_for_function(source: str, name: str) -> str:
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            segment = ast.get_source_segment(source, node)
+            if segment is None:
+                raise AssertionError(f"could not read function {name}")
+            return segment
+    raise AssertionError(f"function {name} is missing")
+
+
+def write_posix_stub(path: Path, body: str) -> None:
+    text = body.replace("\r\n", "\n").replace("\r", "\n").rstrip() + "\n"
+    path.write_bytes(text.encode("utf-8"))
+    path.chmod(0o755)
+
+
+def shell_visible_path(shell: str, path: Path) -> str:
+    script = path.resolve().as_posix()
+    if os.name != "nt" or script[1:3] != ":/":
+        return script
+    wsl = "/mnt/" + script[0].lower() + script[2:]
+    git_bash = "/" + script[0].lower() + script[2:]
+    probe = subprocess.run(  # nosec B603 - local bash path probe, no user input
+        [
+            shell,
+            "-c",
+            f"test -e '{wsl}' && echo wsl || test -e '{git_bash}' && echo git "
+            f"|| test -e '{script}' && echo win || echo missing",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if "wsl" in probe.stdout:
+        return wsl
+    if "git" in probe.stdout:
+        return git_bash
+    if "win" in probe.stdout:
+        return script
+    raise unittest.SkipTest(f"{shell} cannot see {path}")
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -833,6 +833,108 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
         workflow = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")
         self.assertIn("tests.scripts.test_chaos_engine_portable_core", workflow)
 
+    def test_planning_keeps_asking_follow_ups_then_runs_unattended(self):
+        """#5248: ask-once-then-unattended cannot silently return."""
+        planning = (CORE / "references/work-github-planning.md").read_text(encoding="utf-8")
+        receipt = (CORE / "references/research-receipt.md").read_text(encoding="utf-8")
+        consult = (CORE / "references/consult-first.md").read_text(encoding="utf-8")
+        skill = CANONICAL_SKILL.read_text(encoding="utf-8")
+        forbidden = "Ask once, at the start, then go unattended"
+        for text, name in (
+            (planning, "work-github-planning.md"),
+            (receipt, "research-receipt.md"),
+            (consult, "consult-first.md"),
+            (skill, "SKILL.md"),
+        ):
+            with self.subTest(file=name):
+                self.assertNotIn(forbidden, text)
+        compact_planning = re.sub(r"\s+", " ", planning)
+        compact_receipt = re.sub(r"\s+", " ", receipt)
+        compact_consult = re.sub(r"\s+", " ", consult)
+        compact_skill = re.sub(r"\s+", " ", skill)
+        self.assertIn("keep asking follow-ups until the plan is decision-ready", compact_planning)
+        self.assertIn("go completely unattended", compact_planning)
+        self.assertIn("consultant agent", compact_planning)
+        self.assertIn("keep asking follow-ups until the plan is decision-ready", compact_receipt)
+        self.assertIn("consultant agent", compact_receipt)
+        self.assertIn("consultant agent", compact_consult)
+        self.assertIn("keep asking follow-ups until the plan is decision-ready", compact_skill)
+        self.assertIn("consultant agent", compact_skill)
+
+
+class ChaosEngineOrchestratorModeTest(unittest.TestCase):
+    """Portable orchestrator-mode pins (#5210, #5246, #5249)."""
+
+    def _skill(self) -> str:
+        return re.sub(r"\s+", " ", CANONICAL_SKILL.read_text(encoding="utf-8"))
+
+    def _delegation(self) -> str:
+        return re.sub(
+            r"\s+",
+            " ",
+            (CORE / "references/delegation.md").read_text(encoding="utf-8"),
+        )
+
+    def _combined(self) -> str:
+        texts = [
+            CANONICAL_SKILL.read_text(encoding="utf-8"),
+            (CORE / "references/delegation.md").read_text(encoding="utf-8"),
+            (CORE / "references/roles.md").read_text(encoding="utf-8"),
+            (CORE / "references/orchestrator-bootstrap.md").read_text(encoding="utf-8"),
+        ]
+        return re.sub(r"\s+", " ", "\n".join(texts))
+
+    def test_entrypoint_auto_switches_and_forbids_self_work_with_serial_default(self):
+        skill = self._skill()
+        self.assertIn('Do not wait for the owner to say "orchestrate"', skill)
+        self.assertIn("do no task work yourself", skill.lower())
+        self.assertIn("one writer at a time", skill.lower())
+        self.assertIn("never start an edit in the same breath as adopting", skill.lower())
+
+    def test_delegation_pins_status_table_serial_cap_and_learning_loop_before_kill(self):
+        delegation = self._delegation()
+        for column in (
+            "ID / work item",
+            "Mode stream",
+            "Status",
+            "Owner / agent",
+            "Dependency",
+            "Last update",
+            "Details / evidence",
+            "Next action",
+        ):
+            with self.subTest(column=column):
+                self.assertIn(column, delegation)
+        for status in (
+            "planned",
+            "in progress",
+            "blocked",
+            "review",
+            "completed",
+            "out of scope",
+        ):
+            with self.subTest(status=status):
+                self.assertIn(status, delegation)
+        self.assertIn("Learning Loop before kill", delegation)
+        self.assertIn("Refuse a requested cap above 4", delegation)
+        self.assertIn("File-overlapping writers never run in parallel", delegation)
+        self.assertIn("one writer at a time", delegation.lower())
+
+    def test_portable_orchestrator_groups_fewest_prs_and_keeps_working(self):
+        delegation = self._delegation()
+        for phrase in (
+            "stay available",
+            "live status table",
+            "fewest PRs that still keep one problem per issue",
+            "keep working until every in-scope ticket is delivered",
+            "Do not treat planning, a status table, or one PR as session complete",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, delegation)
+        combined = self._combined()
+        self.assertIn("stay available", combined)
+        self.assertIn("live status table", combined)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -889,6 +889,8 @@ class ChaosEngineOrchestratorModeTest(unittest.TestCase):
         self.assertIn('Do not wait for the owner to say "orchestrate"', skill)
         self.assertIn("do no task work yourself", skill.lower())
         self.assertIn("one writer at a time", skill.lower())
+        self.assertRegex(skill, r"1[–-]4")
+        self.assertIn("still shows the live status table", skill)
         self.assertIn("never start an edit in the same breath as adopting", skill.lower())
 
     def test_delegation_pins_status_table_serial_cap_and_learning_loop_before_kill(self):
@@ -917,6 +919,7 @@ class ChaosEngineOrchestratorModeTest(unittest.TestCase):
                 self.assertIn(status, delegation)
         self.assertIn("Learning Loop before kill", delegation)
         self.assertIn("Refuse a requested cap above 4", delegation)
+        self.assertRegex(delegation, r"1[–-]4")
         self.assertIn("File-overlapping writers never run in parallel", delegation)
         self.assertIn("one writer at a time", delegation.lower())
 


### PR DESCRIPTION
## Summary

Portable ChaosEngine orchestrator-mode contract, planning follow-ups, and leftover harness pins.

Closes #5210
Closes #5246
Closes #5248
Closes #5249
Closes #5232
Closes #5233
Closes #5234
Closes #5253
Related to #5212

- Orchestrator mode auto-switches on two or more owner tasks, does no task work, stays available, defaults to one writer at a time, optional parallel cap 1–4, live status table, Learning Loop before kill.
- Fewest-PR grouping and keep-working-until-delivered are portable standing duties next to stay-available and the status table. SHAFT sequential multi-issue pin from #5160 is unchanged.
- Planning keeps asking follow-ups until decision-ready; after owner approval, run unattended and dispatch a consultant for execution ambiguity. Restores `high confidence` in the research-receipt planning-quality paragraph.
- POSIX leftover `bootstrap.py` without `skills/chaos-engine/SKILL.md` takes the fetch path; source-tree fixtures copy.
- Remaining wrapper and bootstrap POSIX one-liner test strings use explicit `+`.
- `INSTALL.md` joins the origin omit-list and LF-attributes sentence.

Session tracker #5212 stays open.

## Checks

RED (before GREEN; copy-gate mutation observed leftover `bootstrap.py` copied):

```
py -3 -m unittest tests.scripts.test_agent_harness_portability tests.scripts.test_chaos_engine_portable_core tests.scripts.test_chaos_engine_install_wrappers tests.scripts.test_chaos_engine_bootstrap -v
```

GREEN (128 tests including SoloOrOrchestrateTest and planning heading pin):

```
py -3 -m unittest tests.scripts.test_agent_harness_portability tests.scripts.test_chaos_engine_portable_core tests.scripts.test_chaos_engine_install_wrappers tests.scripts.test_chaos_engine_bootstrap tests.scripts.test_agent_router_contract.SoloOrOrchestrateTest tests.scripts.test_agent_harness_reachability.EntrypointDutyTest.test_the_github_playbook_links_its_planning_and_tracking_half -v
```

Result: `Ran 128 tests in 54.436s OK`

#5253 follow-up:

```
py -3 -m unittest tests.scripts.test_chaos_engine_bootstrap -v
```

Result: `Ran 29 tests in 36.279s OK`

Review fix (ConsultGate `high confidence` plus cap/status-table pins):

```
py -3 -m unittest tests.scripts.test_agent_router_contract.ConsultGateTest.test_planning_contract_requires_intent_confidence_detail_and_owned_delivery tests.scripts.test_chaos_engine_portable_core.ChaosEngineOrchestratorModeTest tests.scripts.test_chaos_engine_portable_core.ChaosEnginePortableCoreTest.test_planning_keeps_asking_follow_ups_then_runs_unattended -v
```

Result: `Ran 5 tests in 0.006s OK`

```
py -3 scripts/ci/validate_agent_setup.py --skip-external
```

Result: `Agent setup is valid: 215820 guidance bytes, 434 memory objects.`

## Continuation

- Head: 6af27c0823d89cc11d35f3aa503277bac9062423
- State: review finding restored `high confidence`; owner-settable cap and no-subagent status table pinned. Ready for independent review.
- Blockers: none. Native Memory remains degraded (blank `.memory/events.jsonl` line 1176; #5214).
- Next action: independent review, then orchestrator arms merge. This writer does not arm merge. Session tracker #5212 stays open.
