### PR TITLE
fix(intellij): unselected agent uses Select an option instead of null CLI

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/settings/ShaftSettingsConfigurable.java
@@ -1565,8 +1565,8 @@ public final class ShaftSettingsConfigurable implements SearchableConfigurable {
             String model = state.cloudModel == null || state.cloudModel.isBlank() ? "" : " / " + state.cloudModel.trim();
             return "Agent: Cloud / " + ShaftUiLabels.friendly(normalizeLower(state.cloudProvider, "gemini")) + model;
         }
-        return "Agent: Local / " + ShaftUiLabels.friendly(resolveFamily(state))
-                + " / " + ShaftUiLabels.friendly(normalize(state.assistantRuntime, "CLI"));
+        return ShaftUiLabels.localAgentSummary(resolveFamily(state),
+                normalize(state.assistantRuntime, "CLI"));
     }
 
     interface CredentialAccess {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -5634,11 +5634,10 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
     }
 
     private void updateRunSettingsSummary() {
-        String selectedMode = ShaftUiLabels.friendly(String.valueOf(mode.getSelectedItem()));
+        String selectedMode = ShaftUiLabels.friendly(mode.getSelectedItem());
         String route = usesCloud()
                 ? providerRouteLabel(String.valueOf(cloudProvider.getSelectedItem()))
-                : ShaftUiLabels.friendly(String.valueOf(assistantFamily.getSelectedItem())) + " "
-                + ShaftUiLabels.friendly(String.valueOf(assistantRuntime.getSelectedItem()));
+                : ShaftUiLabels.localAgentRoute(assistantFamily.getSelectedItem(), assistantRuntime.getSelectedItem());
         runSettingsToggle.setText("Run settings · " + selectedMode + " · " + route + " · Effort: "
                 + String.valueOf(effort.getSelectedItem()));
     }
@@ -5739,8 +5738,8 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
             String model = selectedModel.isBlank() ? "" : " " + selectedModel;
             return providerRouteLabel(settings.cloudProvider) + model;
         }
-        return ShaftUiLabels.friendly(resolveFamily(settings)) + " "
-                + ShaftUiLabels.friendly(normalize(settings.assistantRuntime, "CLI"));
+        return ShaftUiLabels.localAgentRoute(resolveFamily(settings),
+                normalize(settings.assistantRuntime, "CLI"));
     }
 
     private String currentAgentConfigurationTooltip() {
@@ -5749,8 +5748,8 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
             String model = selectedModel.isBlank() ? "" : " / " + selectedModel;
             return "Agent: " + providerRouteLabel(settings.cloudProvider) + model;
         }
-        return "Agent: Local / " + ShaftUiLabels.friendly(resolveFamily(settings))
-                + " / " + ShaftUiLabels.friendly(normalize(settings.assistantRuntime, "CLI"));
+        return ShaftUiLabels.localAgentSummary(resolveFamily(settings),
+                normalize(settings.assistantRuntime, "CLI"));
     }
 
     private static String providerKeyName(String provider) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftUiLabels.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftUiLabels.java
@@ -11,6 +11,8 @@ import java.util.Locale;
  * Human-friendly labels for persisted Assistant option tokens.
  */
 public final class ShaftUiLabels {
+    private static final String UNSELECTED_OPTION = "Select an option";
+
     private ShaftUiLabels() {
         throw new IllegalStateException("Utility class");
     }
@@ -37,13 +39,42 @@ public final class ShaftUiLabels {
     }
 
     /**
+     * Compact local-agent route, or setup's unselected wording when no family is chosen.
+     *
+     * @param family persisted family token or combo selection
+     * @param runtime persisted runtime token or combo selection
+     * @return {@code Codex CLI}-style label, or {@code Select an option}
+     */
+    public static String localAgentRoute(Object family, Object runtime) {
+        if (unselected(family)) {
+            return UNSELECTED_OPTION;
+        }
+        String runtimeLabel = friendly(runtime);
+        return runtimeLabel.isBlank() ? friendly(family) : friendly(family) + " " + runtimeLabel;
+    }
+
+    /**
+     * Settings/tooltip current-agent row, or setup's unselected wording when no family is chosen.
+     *
+     * @param family persisted family token or combo selection
+     * @param runtime persisted runtime token or combo selection
+     * @return {@code Agent: Local / Codex / CLI}, or {@code Agent: Select an option}
+     */
+    public static String localAgentSummary(Object family, Object runtime) {
+        if (unselected(family)) {
+            return "Agent: " + UNSELECTED_OPTION;
+        }
+        return "Agent: Local / " + friendly(family) + " / " + friendly(runtime);
+    }
+
+    /**
      * Returns display text for known Assistant option tokens.
      *
      * @param value token
      * @return readable label
      */
     public static String friendly(Object value) {
-        if (value == null) {
+        if (unselected(value)) {
             return "";
         }
         String text = value.toString();
@@ -78,6 +109,10 @@ public final class ShaftUiLabels {
             case "HIGH" -> "High effort";
             default -> text;
         };
+    }
+
+    private static boolean unselected(Object value) {
+        return value == null || value.toString().isBlank();
     }
 
     private static String normalize(String value) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/settings/ShaftSettingsConfigurableTest.java
@@ -346,6 +346,26 @@ class ShaftSettingsConfigurableTest {
     }
 
     @Test
+    void currentAgentRowUsesUnselectedWordingWhenNoAgentIsSelected() {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        settings.mcpCommand = "\"java\" \"@target/shaft-mcp.args\"";
+        settings.mcpSetupComplete = true;
+        settings.assistantFamily = "";
+        settings.defaultAutobotClient = "";
+        ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(settings, new InMemoryCredentials());
+        JComponent panel = (JComponent) configurable.createComponent();
+        JLabel currentAgent = findByAccessibleName(panel, "Current agent configuration", JLabel.class);
+
+        assertNotNull(currentAgent);
+        String text = currentAgent.getText();
+        assertAll(
+                () -> assertFalse(text.contains("null"), text),
+                () -> assertFalse(text.matches("(?s).*Local\\s*/\\s*/\\s*CLI.*"), text),
+                () -> assertTrue(text.contains("Select an option"), text),
+                () -> assertEquals(text, currentAgent.getAccessibleContext().getAccessibleDescription()));
+    }
+
+    @Test
     void advancedUiFlagIsPersistedBySettingsPanel() throws Exception {
         ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
         ShaftSettingsConfigurable configurable = new ShaftSettingsConfigurable(settings, new InMemoryCredentials());

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLayoutTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftAssistantPanelLayoutTest.java
@@ -691,8 +691,10 @@ class ShaftAssistantPanelLayoutTest {
                 () -> assertFalse(toggle.isSelected(), "the everyday composer must start compact"),
                 () -> assertFalse(settings.isVisible(), "route and configuration controls belong behind Run settings"),
                 () -> assertTrue(containsDescendant(settings, mode), "mode must remain in the settings disclosure"),
-                () -> assertTrue(toggle.getText().contains("CLI"),
-                        "the collapsed summary must name the effective agent/runtime"),
+                () -> assertTrue(toggle.getText().contains("Select an option"),
+                        "the collapsed summary must name the unselected agent: " + toggle.getText()),
+                () -> assertFalse(toggle.getText().contains("null"),
+                        "the collapsed summary must not stringify a missing family: " + toggle.getText()),
                 () -> assertTrue(toggle.getText().toLowerCase(java.util.Locale.ROOT).contains("effort"),
                         "the collapsed summary must name the selected effort"));
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/ShaftPanelSetupTest.java
@@ -37,6 +37,7 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JProgressBar;
 import javax.swing.JScrollPane;
+import javax.swing.JToggleButton;
 import javax.swing.JViewport;
 import javax.swing.RepaintManager;
 import javax.swing.SwingUtilities;
@@ -1909,6 +1910,30 @@ class ShaftPanelSetupTest {
                 () -> assertTrue(settings.defaultAutobotClient == null || settings.defaultAutobotClient.isBlank(),
                         settings.defaultAutobotClient),
                 () -> assertFalse(String.valueOf(selection).contains("CODEX"), String.valueOf(selection)));
+    }
+
+    @Test
+    void compactRunSettingsAndCurrentAgentUseUnselectedWordingWhenNoAgentIsSelected() {
+        ShaftAssistantPanel firstRun = new ShaftAssistantPanel(null, blankMcpSettings());
+        JToggleButton firstRunChip = findByAccessibleName(firstRun, "Run settings", JToggleButton.class);
+
+        ShaftSettingsState.Settings connectedEmpty = connectedMcpSettings();
+        connectedEmpty.assistantFamily = "";
+        connectedEmpty.defaultAutobotClient = "";
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, connectedEmpty, new ShaftAssistantChatState(),
+                () -> {
+                });
+        JToggleButton compactChip = findByAccessibleName(panel, "Run settings", JToggleButton.class);
+        JLabel currentAgent = findByAccessibleName(panel, "Current agent configuration", JLabel.class);
+        assertNotNull(firstRunChip);
+        assertNotNull(compactChip);
+        assertNotNull(currentAgent);
+
+        assertAll(
+                () -> assertUnselectedAgentWording("first-run compact chip", firstRunChip.getText()),
+                () -> assertUnselectedAgentWording("connected empty compact chip", compactChip.getText()),
+                () -> assertUnselectedAgentWording("current-agent text", currentAgent.getText()),
+                () -> assertUnselectedAgentWording("current-agent tooltip", currentAgent.getToolTipText()));
     }
 
     @Test
@@ -8446,6 +8471,15 @@ class ShaftPanelSetupTest {
 
     private static ShaftMcpSetupPanel.AgentReadinessProbe readyProbe() {
         return (client, runtime) -> ShaftMcpToolResult.success("Codex CLI executable is available on PATH.");
+    }
+
+    private static void assertUnselectedAgentWording(String surface, String wording) {
+        assertNotNull(wording, surface + " must have wording");
+        assertFalse(wording.contains("null"), surface + " leaked literal null: " + wording);
+        assertFalse(wording.matches("(?s).*Local\\s*/\\s*/\\s*CLI.*"),
+                surface + " leaked empty Local / / CLI gap: " + wording);
+        assertTrue(wording.contains("Select an option"),
+                surface + " must use setup unselected wording: " + wording);
     }
 
     private static boolean containsText(Component component, String expected) {


### PR DESCRIPTION
Closes #5263
Related to #5212

## Summary
After #5247/#5251, first-run Assistant starts with no selected agent. Compact Run settings used `String.valueOf(combo.getSelectedItem())`, which paints the literal `null` (`Run settings · Agent · null CLI · Effort: DEFAULT`). Settings current-agent used `Agent: Local / {empty family} / CLI`.

Setup already shows **Select an option**. Compact Run settings, the current-agent chip, and the Settings current-agent row now share `ShaftUiLabels.localAgentRoute` / `localAgentSummary` and use that same unselected wording. Selected-agent labels stay `Codex CLI` / `Agent: Local / Codex / CLI`. Setup step titles and #5151 screenshots are unchanged.

## Checks
RED from `shaft-intellij/` (expected assertion failures on `null` / `Local / / CLI`):

`.\gradlew.bat test --tests com.shaft.intellij.ui.ShaftPanelSetupTest.compactRunSettingsAndCurrentAgentUseUnselectedWordingWhenNoAgentIsSelected --tests com.shaft.intellij.settings.ShaftSettingsConfigurableTest.currentAgentRowUsesUnselectedWordingWhenNoAgentIsSelected "-Dallure.automaticallyOpen=false"`

Observed: compact chip `Run settings · Agent · null CLI · Effort: DEFAULT`; current-agent tooltip/Settings `Agent: Local /  / CLI`.

GREEN: the same two tests plus nearest current-agent / empty-family regressions (`assistantPanelShowsConfigureButtonWhenSetupCallbackIsConfigured`, `settingsShowsConnectedAgentConfigurationReadOnlyUntilConfigureIsClicked`, `runSettingsDisclosureStartsCollapsedAndKeepsRouteControlsTogether`, `lockedCloudRouteRefreshesItsCurrentConfigurationWhenDiscoveryOrSelectionChanges`, `setupPanelStartsWithUnselectedAgentAndNoRecommendedLabel`, `localProvidersHaveUnambiguousProviderLabelsAndNoCloudSummary`, `emptyFamilyAndClientDoNotCoerceToCodex`, `emptySetupFamilyAndClientDoNotCoerceToCodex`, `currentAgentConfigurationAccessibleDescriptionTracksLiveConfigurationAcrossUpdates`, `currentAgentChipGroupsLabelAndConfigureButtonWhenSummaryIsShown`, `currentAgentChipGroupsLabelAndGearButtonWhenRouteIsLocked`, `blankAssistantFamilyComboDoesNotStayOnCodexOrPersistIt`) with `"-Dallure.automaticallyOpen=false"`. BUILD SUCCESSFUL. Headless only; GUI was not launched. Screenshot refresh remains on PR #5262.

## Continuation
Head: 8ccb6fb58eb43079dc6649c46594d5099ee1d00f
State: pushed, ready for independent review. Merge not armed.
Blockers: none.
Next action: orchestrator-owned independent review, then merge if accepted.
