### PR TITLE
fix: share one {repo}_main MemPalace wing across worktrees

### DIFF
--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -100,6 +100,12 @@ LEGACY_MANAGED_PATHS = (
 )
 
 
+def default_mempalace_wing(project_name: str) -> str:
+    """Return the shared `{repository}_main` wing for a new MemPalace config."""
+    safe = re.sub(r"[^a-z0-9]+", "_", project_name.casefold()).strip("_") or "project"
+    return f"{safe}_main"
+
+
 def project_identity_name(project: Path) -> str:
     """Return the repository identity, independent of a checkout/worktree folder name."""
     result = subprocess.run(  # nosec B603 B607 - fixed git query, no shell.
@@ -338,17 +344,37 @@ def centralized_mempalace_status() -> dict[str, str]:
     }
 
 
-def mempalace_runtime_status(project: Path) -> dict[str, str]:
-    """Classify project-local MemPalace state without importing its native backend."""
-    palace = project / ".chaos-engine-state/mempalace"
+def resolved_central_palace(project: Path) -> Path | None:
+    """Return the resolver palace path when it is absolute and printable."""
+    resolver = project / "tools/repository-map/resolve_mempalace.py"
+    if not resolver.is_file():
+        return None
+    try:
+        completed = subprocess.run(  # nosec B603 - owned resolver, no shell.
+            [sys.executable, str(resolver)],
+            cwd=project,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    palace = completed.stdout.strip()
+    if completed.returncode != 0 or not palace:
+        return None
+    path = Path(palace)
+    return path if path.is_absolute() else None
+
+
+def mempalace_directory_status(palace: Path) -> dict[str, str]:
+    """Classify one MemPalace directory without importing its native backend."""
     if is_link_or_reparse(palace):
         return {
             "status": "recovery-required",
             "detail": "MemPalace state is a link or reparse point",
         }
     if not palace.exists():
-        if repository_map_resolver_present(project):
-            return centralized_mempalace_status()
         return {"status": "initialization-required", "backend": "sqlite_exact"}
     if not palace.is_dir():
         return {
@@ -431,9 +457,38 @@ def mempalace_runtime_status(project: Path) -> dict[str, str]:
                 "detail": "SQLite-exact MemPalace state is unreadable or malformed",
             }
         return {"status": "healthy", "backend": "sqlite_exact"}
-    if repository_map_resolver_present(project):
-        return centralized_mempalace_status()
     return {"status": "initialization-required", "backend": "sqlite_exact"}
+
+
+def mempalace_runtime_status(project: Path) -> dict[str, str]:
+    """Classify project-local or centralized MemPalace state."""
+    palace = project / ".chaos-engine-state/mempalace"
+    if is_link_or_reparse(palace):
+        return {
+            "status": "recovery-required",
+            "detail": "MemPalace state is a link or reparse point",
+        }
+    if not palace.exists():
+        central = resolved_central_palace(project)
+        if central is not None and central.exists():
+            status = mempalace_directory_status(central)
+            if status.get("status") != "initialization-required":
+                return status
+        if repository_map_resolver_present(project):
+            return centralized_mempalace_status()
+        return {"status": "initialization-required", "backend": "sqlite_exact"}
+    status = mempalace_directory_status(palace)
+    if (
+        status.get("status") == "initialization-required"
+        and repository_map_resolver_present(project)
+    ):
+        central = resolved_central_palace(project)
+        if central is not None and central.exists():
+            central_status = mempalace_directory_status(central)
+            if central_status.get("status") != "initialization-required":
+                return central_status
+        return centralized_mempalace_status()
+    return status
 
 
 def _cleanup_failed_mempalace_initialization(
@@ -559,6 +614,10 @@ def initialize_mempalace_runtime(project: Path) -> None:
 def mcp_runtime_healthy(project: Path) -> bool:
     if mempalace_runtime_status(project)["status"] != "healthy":
         return False
+    skip_checkout_mempalace = (
+        repository_map_resolver_present(project)
+        and not (project / ".chaos-engine-state/mempalace/sqlite_exact.sqlite3").is_file()
+    )
     initialize = json.dumps(
         {
             "jsonrpc": "2.0",
@@ -604,6 +663,8 @@ def mcp_runtime_healthy(project: Path) -> bool:
         ],
     )
     for index, command in enumerate(commands):
+        if index == 1 and skip_checkout_mempalace:
+            continue
         result = subprocess.run(  # nosec B603 - fixed owned launcher and arguments.
             command,
             cwd=project,
@@ -2796,9 +2857,8 @@ def desired_content(
         after[relative] = b""
     mempalace_before = before["mempalace.yaml"]
     if mempalace_before is None:
-        safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "-", project_name).strip("-") or "project"
         after["mempalace.yaml"] = (
-            f"wing: {safe_name}\n"
+            f"wing: {default_mempalace_wing(project_name)}\n"
             "rooms:\n  - name: general\n    description: Project source and documentation\n"
             "    keywords: [project, source, documentation]\n"
             "exclude_patterns:\n  - mempalace.yaml\n  - .memory/**\n"

--- a/mempalace.yaml
+++ b/mempalace.yaml
@@ -1,4 +1,4 @@
-wing: shaft_engine
+wing: shaft_engine_main
 exclude_patterns:
 - .git/**
 - .idea/**

--- a/scripts/agents/knowledge_stores.py
+++ b/scripts/agents/knowledge_stores.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 # Fixed list-form calls to repository resolvers and the MemPalace CLI.
 import subprocess  # nosec B404
@@ -24,6 +25,21 @@ def run_python(script: Path, arguments: list[str], cwd: Path) -> subprocess.Comp
         text=True,
         check=False,
     )
+
+
+def configured_wing(cwd: Path) -> str | None:
+    """Return the checkout MemPalace wing when mempalace.yaml declares exactly one."""
+    path = cwd / "mempalace.yaml"
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    matches = re.findall(r"(?m)^wing:\s*([A-Za-z0-9_.-]+)\s*$", text)
+    if len(matches) != 1:
+        return None
+    return matches[0]
 
 
 def resolve_palace(cwd: Path) -> str:
@@ -70,8 +86,9 @@ def cmd_search(cwd: Path, query: str, wing: str | None, room: str | None, result
     """Search the resolved palace without creating a checkout-local copy."""
     palace = resolve_palace(cwd)
     arguments = ["search", query]
-    if wing:
-        arguments.extend(["--wing", wing])
+    selected_wing = wing or configured_wing(cwd)
+    if selected_wing:
+        arguments.extend(["--wing", selected_wing])
     if room:
         arguments.extend(["--room", room])
     if results is not None:

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -473,7 +473,9 @@ class ChaosEngineHostsTest(unittest.TestCase):
             self.assertEqual({"version", "project", "memory"}, set(memory_config))
             self.assertEqual("consumer", memory_config["project"]["name"])
             self.assertTrue(module.retrieval_configs_healthy(project))
-            self.assertIn("wing: consumer", project.joinpath("mempalace.yaml").read_text())
+            self.assertEqual("consumer_main", module.default_mempalace_wing("consumer"))
+            self.assertEqual("shaft_engine_main", module.default_mempalace_wing("SHAFT_ENGINE"))
+            self.assertIn("wing: consumer_main", project.joinpath("mempalace.yaml").read_text())
             ignores = project.joinpath(".gitignore").read_text()
             self.assertIn(".chaos-engine-runtime/", ignores)
             self.assertIn(".chaos-engine.lock", ignores)
@@ -970,7 +972,14 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
             memory = json.loads(project.joinpath(".memory/config.json").read_text())
             self.assertEqual("actual-project", memory["project"]["name"])
-            self.assertIn("wing: actual-project", project.joinpath("mempalace.yaml").read_text())
+            self.assertEqual(
+                "actual_project_main",
+                module.default_mempalace_wing("actual-project"),
+            )
+            self.assertIn(
+                "wing: actual_project_main",
+                project.joinpath("mempalace.yaml").read_text(),
+            )
 
     def test_retrieval_runtime_executes_memory_status_and_check(self):
         module = load(HOSTS, "chaos_engine_retrieval_runtime")
@@ -1352,6 +1361,72 @@ class ChaosEngineHostsTest(unittest.TestCase):
                     module.initialize_mempalace_runtime(project)
 
             self.assertFalse((palace / "sqlite_exact.sqlite3").exists())
+
+    def test_shaft_resolver_with_healthy_central_palace_is_healthy_and_skips_checkout_mcp(self):
+        module = load(HOSTS, "chaos_engine_mempalace_central_healthy")
+        with tempfile.TemporaryDirectory() as temporary:
+            shaft = Path(temporary) / "shaft"
+            palace = Path(temporary) / "shared-palace"
+            palace.mkdir(parents=True)
+            create_sqlite_exact_state(palace / "sqlite_exact.sqlite3")
+            resolver = shaft / "tools/repository-map/resolve_mempalace.py"
+            resolver.parent.mkdir(parents=True)
+            resolver.write_text(
+                "from pathlib import Path\nprint(Path(r'%s').resolve())\n"
+                % str(palace).replace("\\", "\\\\"),
+                encoding="utf-8",
+            )
+
+            state = module.mempalace_runtime_status(shaft)
+            self.assertEqual("healthy", state["status"])
+            self.assertEqual("sqlite_exact", state["backend"])
+
+            module.initialize_mempalace_runtime(shaft)
+            self.assertFalse((shaft / ".chaos-engine-state/mempalace").exists())
+            shaft.joinpath(".chaos-engine").mkdir()
+            shaft.joinpath(".chaos-engine/tool.py").write_text("# owned\n")
+            memory_ok = mock.Mock(
+                returncode=0,
+                stdout=json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}) + "\n",
+            )
+            real_run = module.subprocess.run
+
+            def runner(command, **kwargs):
+                if len(command) >= 2 and str(command[1]).endswith("resolve_mempalace.py"):
+                    return real_run(command, **kwargs)
+                return memory_ok
+
+            with mock.patch.object(module.subprocess, "run", side_effect=runner) as run:
+                self.assertTrue(module.mcp_runtime_healthy(shaft))
+            launched = [
+                call.args[0]
+                for call in run.call_args_list
+                if call.args and "memory-mcp" in call.args[0]
+            ]
+            self.assertEqual(1, len(launched))
+            self.assertTrue(
+                all("mempalace-mcp" not in call.args[0] for call in run.call_args_list)
+            )
+
+    def test_shaft_resolver_with_empty_central_palace_is_degraded_and_does_not_initialize(self):
+        module = load(HOSTS, "chaos_engine_mempalace_central_empty")
+        with tempfile.TemporaryDirectory() as temporary:
+            shaft = Path(temporary) / "shaft"
+            palace = Path(temporary) / "shared-palace"
+            palace.mkdir(parents=True)
+            resolver = shaft / "tools/repository-map/resolve_mempalace.py"
+            resolver.parent.mkdir(parents=True)
+            resolver.write_text(
+                "from pathlib import Path\nprint(Path(r'%s').resolve())\n"
+                % str(palace).replace("\\", "\\\\"),
+                encoding="utf-8",
+            )
+
+            state = module.mempalace_runtime_status(shaft)
+            self.assertEqual("degraded", state["status"])
+            module.initialize_mempalace_runtime(shaft)
+            self.assertFalse((shaft / ".chaos-engine-state/mempalace").exists())
+            self.assertEqual([], list(palace.iterdir()))
 
     def test_shaft_resolver_without_checkout_palace_is_degraded_and_does_not_initialize(self):
         module = load(HOSTS, "chaos_engine_mempalace_shaft_resolver")

--- a/tests/scripts/test_knowledge_stores.py
+++ b/tests/scripts/test_knowledge_stores.py
@@ -106,6 +106,38 @@ class KnowledgeStoresTest(unittest.TestCase):
         self.assertFalse(self.checkout_palace_created(self.linked))
         self.assertFalse(self.checkout_palace_created(self.primary))
 
+    def test_search_without_wing_uses_checkout_yaml_wing(self):
+        (self.linked / "mempalace.yaml").write_text(
+            "wing: checkout_main\n"
+            "rooms:\n- name: general\n  description: Checkout files\n"
+            "exclude_patterns:\n- .git/**\n",
+            encoding="utf-8",
+        )
+
+        completed = self.cli("search", "shared cache")
+        combined = completed.stdout + completed.stderr
+
+        self.assertEqual(0, completed.returncode, combined)
+        tokens = self.assert_global_flags_before("search")
+        self.assertIn("checkout_main", tokens)
+        self.assertFalse(self.checkout_palace_created(self.linked))
+
+    def test_search_explicit_wing_overrides_checkout_yaml_wing(self):
+        (self.linked / "mempalace.yaml").write_text(
+            "wing: checkout_main\n"
+            "rooms:\n- name: general\n  description: Checkout files\n"
+            "exclude_patterns:\n- .git/**\n",
+            encoding="utf-8",
+        )
+
+        completed = self.cli("search", "shared cache", "--wing", "explicit_main")
+        combined = completed.stdout + completed.stderr
+
+        self.assertEqual(0, completed.returncode, combined)
+        tokens = self.assert_global_flags_before("search")
+        self.assertIn("explicit_main", tokens)
+        self.assertNotIn("checkout_main", tokens)
+
     def test_search_from_linked_worktree_forwards_query_to_resolved_palace(self):
         completed = self.cli("search", "shared cache", "--wing", "shaft_engine_main")
         combined = completed.stdout + completed.stderr

--- a/tests/scripts/test_shaft_knowledge_refresh.py
+++ b/tests/scripts/test_shaft_knowledge_refresh.py
@@ -33,6 +33,13 @@ class ShaftKnowledgeRefreshTest(unittest.TestCase):
     def test_refresh_uses_approved_url_and_verified_sha_not_mutable_names(self):
         module = self.module()
         root = Path(tempfile.mkdtemp()) / "SHAFT_ENGINE-main"
+        root.mkdir(parents=True)
+        (root / "mempalace.yaml").write_text(
+            "wing: from_yaml_main\n"
+            "rooms:\n- name: general\n  description: SHAFT source\n"
+            "exclude_patterns:\n- .git/**\n",
+            encoding="utf-8",
+        )
         sentinel = root.parent / ".shaft-nightly-maintenance.json"
         commands = []
 
@@ -86,7 +93,7 @@ class ShaftKnowledgeRefreshTest(unittest.TestCase):
         self.assertIn(["git", "clean", "-ffd"], invoked)
         self.assertFalse(any("--dry-run" in command for command in invoked))
         self.assertIn(
-            ["mempalace", "sync", str(root.resolve()), "--wing", "shaft_engine_main", "--apply"],
+            ["mempalace", "sync", str(root.resolve()), "--wing", "from_yaml_main", "--apply"],
             invoked,
         )
         child_commands = [
@@ -109,6 +116,13 @@ class ShaftKnowledgeRefreshTest(unittest.TestCase):
     def test_store_maintenance_reports_both_outcomes_when_either_store_fails(self):
         module = self.module()
         root = Path(tempfile.mkdtemp()) / "SHAFT_ENGINE-main"
+        root.mkdir(parents=True)
+        (root / "mempalace.yaml").write_text(
+            "wing: from_yaml_main\n"
+            "rooms:\n- name: general\n  description: SHAFT source\n"
+            "exclude_patterns:\n- .git/**\n",
+            encoding="utf-8",
+        )
         sentinel = root.parent / ".shaft-nightly-maintenance.json"
         commands = []
 
@@ -143,6 +157,13 @@ class ShaftKnowledgeRefreshTest(unittest.TestCase):
     def test_refresh_force_includes_exact_promote_paths_on_mine(self):
         module = self.module()
         root = Path(tempfile.mkdtemp()) / "SHAFT_ENGINE-main"
+        root.mkdir(parents=True)
+        (root / "mempalace.yaml").write_text(
+            "wing: from_yaml_main\n"
+            "rooms:\n- name: general\n  description: SHAFT source\n"
+            "exclude_patterns:\n- .git/**\n",
+            encoding="utf-8",
+        )
         sentinel = root.parent / ".shaft-nightly-maintenance.json"
         commands = []
 
@@ -174,6 +195,7 @@ class ShaftKnowledgeRefreshTest(unittest.TestCase):
 
         mines = [command for command in commands if command[0:2] == ["mempalace", "mine"]]
         self.assertTrue(mines)
+        self.assertIn("from_yaml_main", mines[0])
         included = " ".join(" ".join(command) for command in mines)
         self.assertIn("--include-ignored", included)
         self.assertIn("src/custom.properties", included)
@@ -182,6 +204,13 @@ class ShaftKnowledgeRefreshTest(unittest.TestCase):
     def test_mempalace_failure_keeps_the_successful_graphify_outcome(self):
         module = self.module()
         root = Path(tempfile.mkdtemp()) / "SHAFT_ENGINE-main"
+        root.mkdir(parents=True)
+        (root / "mempalace.yaml").write_text(
+            "wing: from_yaml_main\n"
+            "rooms:\n- name: general\n  description: SHAFT source\n"
+            "exclude_patterns:\n- .git/**\n",
+            encoding="utf-8",
+        )
         sentinel = root.parent / ".shaft-nightly-maintenance.json"
         commands = []
 
@@ -217,6 +246,13 @@ class ShaftKnowledgeRefreshTest(unittest.TestCase):
     def test_local_url_rewrite_stops_before_fetch(self):
         module = self.module()
         root = Path(tempfile.mkdtemp()) / "SHAFT_ENGINE-main"
+        root.mkdir(parents=True)
+        (root / "mempalace.yaml").write_text(
+            "wing: from_yaml_main\n"
+            "rooms:\n- name: general\n  description: SHAFT source\n"
+            "exclude_patterns:\n- .git/**\n",
+            encoding="utf-8",
+        )
         sentinel = root.parent / ".shaft-nightly-maintenance.json"
         commands = []
 

--- a/tools/agent-infra/shaft_knowledge_refresh.py
+++ b/tools/agent-infra/shaft_knowledge_refresh.py
@@ -17,7 +17,6 @@ import sys
 from typing import Iterator
 
 ORIGIN = "https://github.com/ShaftHQ/SHAFT_ENGINE"
-WING = "shaft_engine_main"
 TRUST_MODEL = "exclusive-maintenance-home-v1"
 GIT_ROUTING_VARIABLES = (
     "GIT_DIR",
@@ -293,6 +292,17 @@ def validate_pending_receipt(pending: Path, requested_root: Path) -> dict[str, o
     return data
 
 
+def configured_wing(root: Path) -> str:
+    """Return the shared wing declared by this checkout's mempalace.yaml."""
+    matches = re.findall(
+        r"(?m)^wing:\s*([A-Za-z0-9_.-]+)\s*$",
+        (root / "mempalace.yaml").read_text(encoding="utf-8"),
+    )
+    if len(matches) != 1:
+        raise ValueError("mempalace.yaml must declare exactly one wing")
+    return matches[0]
+
+
 def refresh(requested_root: Path, requested_sentinel: Path) -> None:
     root, sentinel = validate_owned_clone(requested_root, requested_sentinel)
     git_exe, mempalace = required("git"), required("mempalace")
@@ -318,6 +328,7 @@ def refresh(requested_root: Path, requested_sentinel: Path) -> None:
         validate_owned_paths(requested_root, requested_sentinel)
         run([git_exe, "reset", "--hard", fetched], root, git_env)
         run([git_exe, "clean", "-ffd"], root, git_env)
+        wing = configured_wing(root)
         environment = git_env.copy()
         environment["SHAFT_GRAPHIFY_OUT"] = str(root / "graphify-out")
         outcomes: dict[str, str] = {}
@@ -331,13 +342,13 @@ def refresh(requested_root: Path, requested_sentinel: Path) -> None:
         else:
             outcomes["Graphify"] = "healthy"
         try:
-            run([mempalace, "sync", str(root), "--wing", WING, "--apply"], root, git_env)
+            run([mempalace, "sync", str(root), "--wing", wing, "--apply"], root, git_env)
             mine = [
                 mempalace,
                 "mine",
                 str(root),
                 "--wing",
-                WING,
+                wing,
                 "--agent",
                 "scheduled-refresh",
             ]


### PR DESCRIPTION
The portable installer now writes `wing: {sanitized_repo}_main` for new mempalace.yaml. This checkout declares shaft_engine_main. knowledge_stores search defaults to that yaml wing, and nightly mine/sync reads the yaml instead of a hardcoded name.

Doctor treats a valid git-common-dir sqlite_exact palace as healthy and does not create a checkout-local .chaos-engine-state/mempalace.