### PR TITLE
fix: accept MemPalace origin sidecar and pin sqlite_exact MCP env

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -13,7 +13,7 @@ approval_mode = "prompt"
 
 [mcp_servers.mempalace]
 command = "mempalace-mcp"
-env = { MEMPALACE_EMBEDDING_MODEL = "minilm" }
+env = { MEMPALACE_EMBEDDING_MODEL = "minilm", MEMPALACE_BACKEND = "sqlite_exact" }
 required = false
 
 [mcp_servers.context7]

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,8 @@
     "mempalace": {
       "command": "mempalace-mcp",
       "env": {
-        "MEMPALACE_EMBEDDING_MODEL": "minilm"
+        "MEMPALACE_EMBEDDING_MODEL": "minilm",
+        "MEMPALACE_BACKEND": "sqlite_exact"
       }
     },
     "context7": {

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -447,11 +447,27 @@ def mempalace_directory_status(palace: Path) -> dict[str, str]:
             "status": "recovery-required",
             "detail": "MemPalace state contains unrecognized recoverable data",
         }
-    if sidecar.exists() and (not sidecar.is_dir() or is_link_or_reparse(sidecar)):
-        return {
-            "status": "recovery-required",
-            "detail": "MemPalace state contains unrecognized recoverable data",
-        }
+    if sidecar.exists():
+        if not sidecar.is_dir() or is_link_or_reparse(sidecar):
+            return {
+                "status": "recovery-required",
+                "detail": "MemPalace state contains unrecognized recoverable data",
+            }
+        try:
+            sidecar_children = list(sidecar.iterdir())
+        except OSError:
+            return {
+                "status": "recovery-required",
+                "detail": "MemPalace state is unreadable or contains a link or reparse point",
+            }
+        if any(
+            child.name != "origin.json" or is_link_or_reparse(child)
+            for child in sidecar_children
+        ):
+            return {
+                "status": "recovery-required",
+                "detail": "MemPalace state contains unrecognized recoverable data",
+            }
     wal_exists = wal.exists()
     shared_memory_exists = shared_memory.exists()
     if not exact.exists() and (wal_exists or shared_memory_exists):

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -68,6 +68,14 @@ SQLITE_EXACT_INDEXES = {
         (1, ("collection_id", "id")),
     },
 }
+MEMPALACE_MCP_ENV = {
+    "MEMPALACE_EMBEDDING_MODEL": "minilm",
+    "MEMPALACE_BACKEND": "sqlite_exact",
+}
+MEMPALACE_MCP_ENV_TOML = (
+    'env = { MEMPALACE_EMBEDDING_MODEL = "minilm", '
+    'MEMPALACE_BACKEND = "sqlite_exact" }\n'
+)
 CHROMA_SCHEMA = {
     "collections": {
         "id": ("TEXT", 0, 1), "name": ("TEXT", 1, 0),
@@ -432,8 +440,14 @@ def mempalace_directory_status(palace: Path) -> dict[str, str]:
 
     wal = Path(f"{exact}-wal")
     shared_memory = Path(f"{exact}-shm")
-    allowed_names = {path.name for path in (exact, wal, shared_memory)}
+    sidecar = palace / ".mempalace"
+    allowed_names = {path.name for path in (exact, wal, shared_memory, sidecar)}
     if any(child.name not in allowed_names for child in children):
+        return {
+            "status": "recovery-required",
+            "detail": "MemPalace state contains unrecognized recoverable data",
+        }
+    if sidecar.exists() and (not sidecar.is_dir() or is_link_or_reparse(sidecar)):
         return {
             "status": "recovery-required",
             "detail": "MemPalace state contains unrecognized recoverable data",
@@ -649,7 +663,7 @@ def mcp_runtime_healthy(project: Path) -> bool:
     tool = project / ".chaos-engine/tool.py"
     environment = os.environ.copy()
     environment["PYTHONDONTWRITEBYTECODE"] = "1"
-    environment["MEMPALACE_EMBEDDING_MODEL"] = "minilm"
+    environment.update(MEMPALACE_MCP_ENV)
     commands = (
         [sys.executable, str(tool), "memory-mcp"],
         [
@@ -1799,7 +1813,7 @@ def owned_servers(
                 "--backend",
                 "sqlite_exact",
             ],
-            extra={"env": {"MEMPALACE_EMBEDDING_MODEL": "minilm"}},
+            extra={"env": dict(MEMPALACE_MCP_ENV)},
         ),
     }
     if maven_runtime is not None:
@@ -2115,7 +2129,7 @@ def legacy_owned_python_server(name: str, platform_name: str) -> dict[str, objec
     }[name]
     server: dict[str, object] = {"command": command, "args": args, "cwd": "."}
     if name == "chaosengine-mempalace":
-        server["env"] = {"MEMPALACE_EMBEDDING_MODEL": "minilm"}
+        server["env"] = dict(MEMPALACE_MCP_ENV)
     return server
 
 
@@ -2140,7 +2154,7 @@ def legacy_codex_python_block(platform_name: str) -> str:
         f'[mcp_servers."chaosengine-mempalace"]\ncommand = "{command}"\n'
         f'args = [{prefix_text}".chaos-engine/tool.py", "mempalace-mcp", "--palace", '
         '".chaos-engine-state/mempalace", "--backend", "sqlite_exact"]\ncwd = ".."\n'
-        'env = { MEMPALACE_EMBEDDING_MODEL = "minilm" }\n# CHAOSENGINE:END\n'
+        f"{MEMPALACE_MCP_ENV_TOML}# CHAOSENGINE:END\n"
     )
 
 
@@ -2205,7 +2219,7 @@ def codex_content(
         f'commandWindows = "{windows_command}"\n'
         f'argsWindows = ["-3", {mempalace_args}]\n'
         'cwd = ".."\n'
-        'env = { MEMPALACE_EMBEDDING_MODEL = "minilm" }\n# CHAOSENGINE:END\n'
+        f"{MEMPALACE_MCP_ENV_TOML}# CHAOSENGINE:END\n"
     )
     if maven_runtime is not None:
         java, jar = maven_runtime

--- a/tests/scripts/test_agent_harness_portability.py
+++ b/tests/scripts/test_agent_harness_portability.py
@@ -879,15 +879,20 @@ class AgentHarnessPortabilityTest(unittest.TestCase):
             (ROOT / ".claude/user-harness/settings.json").read_text(encoding="utf-8")
         )
         self.assertIs(user_settings["enabledPlugins"]["mempalace@mempalace"], False)
+        expected_mempalace_env = {
+            "MEMPALACE_EMBEDDING_MODEL": "minilm",
+            "MEMPALACE_BACKEND": "sqlite_exact",
+        }
         self.assertEqual(
-            claude_mcp["mcpServers"]["mempalace"]["env"]["MEMPALACE_EMBEDDING_MODEL"],
-            "minilm",
+            claude_mcp["mcpServers"]["mempalace"]["env"],
+            expected_mempalace_env,
         )
         codex = tomllib.loads((ROOT / ".codex/config.toml").read_text(encoding="utf-8"))
         project_mcp = claude_mcp["mcpServers"]["mempalace"]
         codex_mcp = codex["mcp_servers"]["mempalace"]
         self.assertEqual(codex_mcp["command"], project_mcp["command"])
         self.assertEqual(codex_mcp["env"], project_mcp["env"])
+        self.assertEqual(codex_mcp["env"], expected_mempalace_env)
         ignore = (ROOT / ".gitignore").read_text(encoding="utf-8")
         self.assertNotRegex(ignore, r"(?m)^mempalace\.yaml$")
         for pattern in ("entities.json", "graphify-out/", "**/target/"):

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -397,10 +397,13 @@ class ChaosEngineHostsTest(unittest.TestCase):
                     ["--backend", "sqlite_exact"],
                     mempalace["args"][-2:],
                 )
+                self.assertEqual(module.MEMPALACE_MCP_ENV, mempalace["env"])
             self.assertIn('[mcp_servers."chaosengine-memory"]', codex)
             self.assertIn('".chaos-engine/tool.py", "memory-mcp"]', codex)
             self.assertIn(".chaos-engine-state/mempalace", str(claude))
             self.assertIn('"--backend", "sqlite_exact"', codex)
+            self.assertIn("MEMPALACE_BACKEND = \"sqlite_exact\"", codex)
+            self.assertIn("MEMPALACE_EMBEDDING_MODEL = \"minilm\"", codex)
 
     def test_complete_host_harness_installs_inventory_roles_hooks_and_plugin(self):
         module = load(HOSTS, "chaos_engine_complete_hosts")
@@ -1272,6 +1275,12 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 module.mempalace_runtime_status(project)["status"],
             )
 
+            (sidecar / "unknown.sqlite3").write_bytes(b"nope")
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+            (sidecar / "unknown.sqlite3").unlink()
             (palace / "unknown.sqlite3").write_bytes(b"nope")
             self.assertEqual(
                 "recovery-required",

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -1256,6 +1256,28 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 module.mempalace_runtime_status(project)["status"],
             )
 
+    def test_mempalace_runtime_accepts_sqlite_exact_origin_sidecar(self):
+        module = load(HOSTS, "chaos_engine_mempalace_origin_sidecar")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            palace = project / ".chaos-engine-state/mempalace"
+            palace.mkdir(parents=True)
+            create_sqlite_exact_state(palace / "sqlite_exact.sqlite3")
+            sidecar = palace / ".mempalace"
+            sidecar.mkdir()
+            (sidecar / "origin.json").write_text("{}", encoding="utf-8")
+
+            self.assertEqual(
+                "healthy",
+                module.mempalace_runtime_status(project)["status"],
+            )
+
+            (palace / "unknown.sqlite3").write_bytes(b"nope")
+            self.assertEqual(
+                "recovery-required",
+                module.mempalace_runtime_status(project)["status"],
+            )
+
     def test_mempalace_runtime_rejects_reparse_state_before_native_launch(self):
         module = load(HOSTS, "chaos_engine_mempalace_reparse_state")
         self.assertTrue(hasattr(module, "mempalace_runtime_status"))
@@ -1369,6 +1391,8 @@ class ChaosEngineHostsTest(unittest.TestCase):
             palace = Path(temporary) / "shared-palace"
             palace.mkdir(parents=True)
             create_sqlite_exact_state(palace / "sqlite_exact.sqlite3")
+            (palace / ".mempalace").mkdir()
+            (palace / ".mempalace" / "origin.json").write_text("{}", encoding="utf-8")
             resolver = shaft / "tools/repository-map/resolve_mempalace.py"
             resolver.parent.mkdir(parents=True)
             resolver.write_text(

--- a/tests/scripts/test_resolve_graph_out.py
+++ b/tests/scripts/test_resolve_graph_out.py
@@ -196,6 +196,7 @@ class ResolveGraphOutTest(unittest.TestCase):
         self.assertIn("'tools/repository-map/README.md'", workflow)
         self.assertIn("stale", guidance.lower())
         self.assertIn("graphify_maintenance.py refresh", readme)
+        self.assertIn("Do not run `graphify hook install`", readme)
         self.assertIn("before the marker", guidance)
         self.assertIn("primary checkout", readme)
         self.assertIn(

--- a/tests/scripts/test_resolve_mempalace.py
+++ b/tests/scripts/test_resolve_mempalace.py
@@ -108,7 +108,7 @@ class ResolveMempalaceTest(unittest.TestCase):
         self.assertIn("scripts/agents/knowledge_stores.py", entrypoint)
         self.assertIn("tools/repository-map/resolve_mempalace.py", entrypoint)
         self.assertIn("SHAFT-Nightly-Knowledge-Refresh", readme)
-        self.assertIn("MEMPAL_DIR", readme)
+        self.assertIn("Do not set `MEMPAL_DIR`", readme)
         self.assertIn("knowledge_stores.py", routing)
         self.assertNotIn("daydream", readme.lower())
         self.assertNotIn("daydream", entrypoint.lower())

--- a/tests/scripts/test_resolve_mempalace.py
+++ b/tests/scripts/test_resolve_mempalace.py
@@ -108,6 +108,7 @@ class ResolveMempalaceTest(unittest.TestCase):
         self.assertIn("scripts/agents/knowledge_stores.py", entrypoint)
         self.assertIn("tools/repository-map/resolve_mempalace.py", entrypoint)
         self.assertIn("SHAFT-Nightly-Knowledge-Refresh", readme)
+        self.assertIn("MEMPAL_DIR", readme)
         self.assertIn("knowledge_stores.py", routing)
         self.assertNotIn("daydream", readme.lower())
         self.assertNotIn("daydream", entrypoint.lower())

--- a/tools/repository-map/README.md
+++ b/tools/repository-map/README.md
@@ -70,6 +70,17 @@ The default `.graphifyignore` keeps semantic document/media formats out of the g
 
 `graphify-out/` is intentionally ignored (`.gitignore`). Do not commit generated graph reports, HTML, JSON, caches, or binary exports unless a maintainer explicitly asks for a reviewed snapshot.
 
+Do not run `graphify hook install` here. Git LFS already owns `post-commit`,
+`post-checkout`, and `pre-push`. Graphify's installer would replace those
+hooks. Per-commit rebuilds also violate the primary-only refresh owner
+(`graphify_maintenance.py`) and would race linked worktrees.
+
+Do not set `MEMPAL_DIR` to this checkout. Official MemPalace Stop/PreCompact
+hooks may live in a host user profile, but auto-mining the SHAFT tree on every
+save races `SHAFT-Nightly-Knowledge-Refresh` and duplicates `shaft_engine_main`.
+Conversation ingest stays `--mode convos` against transcript dirs, never the
+repository root.
+
 ## Shared cache across worktrees
 
 Because `graphify-out/` is gitignored, it never exists in a fresh `git worktree` clone. Rather than rebuilding per worktree, treat the **main checkout's** `graphify-out/` as one shared, read-only cache for all linked worktrees:


### PR DESCRIPTION
MemPalace 3.7 writes ``<palace>/.mempalace/origin.json``. Doctor treated that sidecar as unrecognized data and reported recovery-required on the shared git-common-dir palace. The classifier now allows that directory when it is a real directory, and still fails closed on any other extra file.

MCP env now sets ``MEMPALACE_BACKEND=sqlite_exact`` next to minilm in:
- ``.mcp.json`` (Claude, Grok, Copilot clients that read it)
- ``.codex/config.toml``
- ChaosEngine portable ``hosts.py`` launchers (Gemini and adopter hosts get the same env)

No Grok-only hook files. Graphify git hooks are not installed: Git LFS owns post-commit/post-checkout/pre-push, and per-commit rebuilds would race the primary-only refresh owner. ``MEMPAL_DIR`` must not point at this checkout.

Checked with focused unittest for sidecar health, portable forbidden tokens, MCP env parity, and README hook contracts.