### PR TITLE
fix(agent): make project hooks authoritative

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,8 @@ ChaosEngine entrypoint.
 - Fix small blockers in path. Search before filing every non-blocking adjacent
   finding as its own standalone issue; receipts and existing issue references
   are evidence, not substitutes for a new action ticket.
-- Preserve structured data with structured APIs. Keep prose natural; avoid
-  repetitive filler and stock AI wording.
+- Preserve structured data with structured APIs. Chat follows Caveman at
+  ChaosEngine ultra. Persisted artifacts stay ordinary prose.
 
 ## Windows and GUI safety
 

--- a/chaos-engine/RESEARCH.md
+++ b/chaos-engine/RESEARCH.md
@@ -42,7 +42,8 @@ preview runtime.
 Primary sources checked live: [Agent Skills specification](https://agentskills.io/specification),
 [Anthropic context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents),
 and DeepSeek Harness [compaction](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/compaction.md)
-plus code mode. Companion bodies stay MIT-pinned and optional at runtime.
+plus code mode. Companion bodies stay MIT-pinned. ChaosEngine selects ultra
+and loads them at task start on every host; they are not optional at runtime.
 
 | Pattern | Decision | ChaosEngine ownership |
 | --- | --- | --- |
@@ -50,7 +51,7 @@ plus code mode. Companion bodies stay MIT-pinned and optional at runtime.
 | Just-in-time retrieval | Adopted | Query a store only when it can shorten the task; one bounded attempt. |
 | Tool-result prune and spill | Adopted as guidance | [context-economy](references/context-economy.md) |
 | Script over long tool chains | Adopted as guidance | [script-first](references/script-first.md) |
-| Auto-load companion bodies every mutation | Rejected | Caveman and Ponytail load on invoke or when they change the next action. |
+| Auto-load companion bodies every mutation | Rejected | SessionStart injects each vendor `SKILL.md` once. Do not re-inject on every tool. Companions stay active at ultra until off. |
 
 ## Architecture decision
 

--- a/chaos-engine/hooks/guard.py
+++ b/chaos-engine/hooks/guard.py
@@ -303,6 +303,25 @@ def wrapped_exec_call_count(source: str) -> int:
     return len(re.findall(r"\btools\.exec_command\s*\(", source))
 
 
+def functions_exec_source(tool_input: object) -> str:
+    if isinstance(tool_input, str):
+        return tool_input
+    if isinstance(tool_input, dict):
+        for key in ("input", "source", "code"):
+            source = tool_input.get(key)
+            if isinstance(source, str):
+                return source
+    return ""
+
+
+def functions_exec_direct_command(tool_input: object) -> str:
+    if isinstance(tool_input, dict):
+        command = tool_input.get("cmd") or tool_input.get("command")
+        if isinstance(command, str):
+            return command
+    return ""
+
+
 def main() -> int:
     try:
         event = json.load(sys.stdin)
@@ -310,11 +329,15 @@ def main() -> int:
         event = {}
     tool_input = event.get("tool_input", {}) if isinstance(event, dict) else {}
     tool_name = str(event.get("tool_name", "")) if isinstance(event, dict) else ""
-    if isinstance(tool_input, dict):
+    functions_source = functions_exec_source(tool_input)
+    functions_direct = functions_exec_direct_command(tool_input)
+    if tool_name == "functions.exec" and functions_direct:
+        commands = (functions_direct,)
+    elif tool_name == "functions.exec" and functions_source:
+        commands = wrapped_exec_commands(functions_source)
+    elif isinstance(tool_input, dict):
         command = str(tool_input.get("command") or tool_input.get("cmd") or "")
         commands = (command,) if command else ()
-    elif tool_name == "functions.exec" and isinstance(tool_input, str):
-        commands = wrapped_exec_commands(tool_input)
     else:
         commands = ()
     event_name = (
@@ -377,8 +400,12 @@ def main() -> int:
         return 2
     uninspectable = (
         tool_name == "functions.exec"
-        and isinstance(tool_input, str)
-        and wrapped_exec_call_count(tool_input) != len(commands)
+        and not functions_direct
+        and (
+            not isinstance(tool_input, (str, dict))
+            or (isinstance(tool_input, dict) and not functions_source)
+            or wrapped_exec_call_count(functions_source) != len(commands)
+        )
     )
     destructive = uninspectable or any(
         catastrophic_posix(candidate)

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -2298,9 +2298,9 @@ def chaos_guard_locator_command(*, windows: bool) -> str:
     return (
         f'{interpreter} -c "import pathlib,runpy;'
         "cands=('.chaos-engine/hooks/guard.py','plugins/chaos-engine/hooks/guard.py');"
-        "p=next(root/rel for root in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) "
-        "for rel in cands if (root/rel).is_file());"
-        "runpy.run_path(str(p),run_name='__main__')\""
+        "p=next((root/rel for root in (pathlib.Path.cwd(),*pathlib.Path.cwd().parents) "
+        "for rel in cands if (root/rel).is_file()),None);"
+        "runpy.run_path(str(p),run_name='__main__') if p else print('{}')\""
     )
 
 
@@ -2657,7 +2657,9 @@ def desired_content(
         + "\n"
     ).encode()
     desired_hooks = lifecycle_hooks_document()
-    after["plugins/chaos-engine/hooks/hooks.json"] = desired_hooks
+    after["plugins/chaos-engine/hooks/hooks.json"] = (
+        json.dumps({"hooks": {}}, indent=2, sort_keys=True) + "\n"
+    ).encode()
     after[".codex/hooks.json"] = hook_content(
         without_chaos_hooks(before[".codex/hooks.json"], "Codex"),
         desired_hooks,

--- a/chaos-engine/references/lifecycle-hooks.md
+++ b/chaos-engine/references/lifecycle-hooks.md
@@ -30,14 +30,26 @@ A host with no hook primitive cannot enforce this table. Say so in the install
 receipt. Do not pretend a README sentence is a substitute. Grok currently
 ignores SessionStart and UserPromptSubmit stdout, so companion injection is
 host-capable on Claude and Codex; Grok still gets the same registration and
-the PreToolUse/Stop gates.
+the PreToolUse/Stop gates. Hosts that ignore SessionStart stdout still apply
+companions through the entrypoint load. ChaosEngine selects ultra through
+every supported host adapter.
 
 ## Registration
 
-`hosts.py` writes the same command groups into every generated hook document it
-owns: Codex `hooks.json`, Claude settings, the plugin hook pack, and Grok
-project hooks. Foreign handlers stay. Empty `{"hooks": {}}` after install is a
-defect.
+`hosts.py` writes the same command groups into the source-controlled,
+project-local hook document for each host with a hook primitive: Codex
+`hooks.json`, Claude settings, and Grok project hooks. Those direct provider
+documents are the only lifecycle-hook owners. The ChaosEngine plugin carries
+skills and portable hook code but does not register a second hook pack. Its
+legacy hook document is overwritten with an empty `hooks` mapping during
+install and upgrade so older active copies cannot survive. Hosts without a
+hook primitive receive their tracked guidance adapters and no unsupported hook
+configuration. Foreign handlers stay. An empty direct provider hook document
+after install is a defect.
+
+Machine-installed ChaosEngine copies are not persistence. Remove conflicting
+global copies and change the source-controlled harness so reinstalling or
+syncing cannot recreate duplicate lifecycle handlers.
 
 The command must be cwd-independent, contain a space so a host cannot treat it
 as a path relative to the settings file, and resolve `hooks/guard.py` from the
@@ -48,8 +60,9 @@ installed tree (`.chaos-engine/hooks/guard.py` or
 
 Caveman and Ponytail remain pinned vendor files. Do not rewrite, filter,
 summarize, or truncate them for injection. Intensity tables and examples stay.
-Default intensity is each companion's own default. Off only: `stop caveman`,
-`stop ponytail`, or `normal mode`.
+ChaosEngine selects **ultra** for both. Off only: `stop caveman`,
+`stop ponytail`, or `normal mode`. Host chat and formatting rules that fight
+those vendor files yield to them.
 
 Persisted artifacts (commits, issues, reviews, memory objects) stay in ordinary
 prose, as those files already require.

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -148,9 +148,27 @@ This file is the only router. It does not restate companion rules.
 Load both companion skills at the start of every task, on every host, in every
 main thread and delegate. [Lifecycle hooks](../../references/lifecycle-hooks.md)
 make that a SessionStart injection of each vendor `SKILL.md` verbatim, not a
-second optional read. Default intensity remains each companion's own
-default. Off only: `stop caveman`, `stop ponytail`, or `normal mode`.
-Once loaded, each companion's own text applies.
+second optional read. A host that ignores SessionStart stdout still owes this
+load through the entrypoint.
+
+ChaosEngine selects **ultra** for both companions. That intensity is mandated
+here, not a session preference. Vendor tables still define what ultra means.
+Off only: `stop caveman`, `stop ponytail`, or `normal mode`. Lite or full only
+when the user names that level.
+
+Once loaded, each companion's own text applies. Chat follows Caveman. What you
+build follows Ponytail. Host or adapter prose and formatting that demand
+complete sentences, restating tool work, decorative tables, essays, or
+natural-prose filler yield to the companions. Safety warnings, irreversible
+confirmations, ethical conduct, and persisted artifacts stay as those vendor
+files already carve out.
+
+### Harness portability
+
+Every ChaosEngine harness change — guidance, adapters, hooks, installer, or
+config — is provider-agnostic and works through every supported host adapter.
+A host-only file is a thin adapter and never owns policy. Refuse a change that
+works through one adapter and silently no-ops the others.
 
 - [Caveman skill](../../vendor/caveman/skills/caveman/SKILL.md) — [inventory](../../vendor/caveman/INVENTORY.md)
 - [Ponytail skill](../../vendor/ponytail/skills/ponytail/SKILL.md) — [inventory](../../vendor/ponytail/INVENTORY.md)
@@ -272,5 +290,4 @@ deterministic light, dark, monochrome, lockup, and small-size identity masters
 documented in the [ChaosEngine identity guide](../../assets/brand/BRAND.md).
 Those masters stay in the origin source tree and are not copied into adopter
 installs.
-
 

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1990,6 +1990,18 @@ def _wrapped_exec_commands(source: str) -> tuple[str, ...]:
     return tuple(commands)
 
 
+def _functions_exec_source(tool_input: object) -> str:
+    """Return the freeform JavaScript source from supported Codex wire shapes."""
+    if isinstance(tool_input, str):
+        return tool_input
+    if isinstance(tool_input, dict):
+        for key in ("input", "source", "code"):
+            source = tool_input.get(key)
+            if isinstance(source, str):
+                return source
+    return ""
+
+
 def _wrapped_exec_call_count(source: str) -> int:
     return len(re.findall(r"\btools\.exec_command\s*\(", source))
 
@@ -2056,7 +2068,11 @@ def _research_preflight_events(
 ) -> tuple[str, ...]:
     """Map one successful native-client tool call to receipt events in observed order."""
     details = tool_input if isinstance(tool_input, dict) else {}
-    source = tool_input if isinstance(tool_input, str) else json.dumps(details, sort_keys=True)
+    source = (
+        _functions_exec_source(tool_input)
+        if tool_name == "functions.exec"
+        else tool_input if isinstance(tool_input, str) else json.dumps(details, sort_keys=True)
+    )
     rendered = source.lower()
     events: list[str] = []
     if tool_name in {"Read", "Grep"}:
@@ -2213,7 +2229,7 @@ def _shell_is_mutation(command: str) -> bool:
 
 
 def _functions_exec_is_mutation(tool_input: object) -> bool:
-    source = tool_input if isinstance(tool_input, str) else ""
+    source = _functions_exec_source(tool_input)
     if re.search(r"\btools\.apply_patch\s*\(", source):
         return True
     if re.search(r"\btools\.exec_command\s*\(", source):
@@ -2229,7 +2245,9 @@ def _hook_commands(hook_input: dict, tool_name: str) -> tuple[str, ...]:
         command = _extract_command(hook_input)
         return (command,) if command else ()
     if tool_name == "functions.exec":
-        return _wrapped_exec_commands(hook_input.get("tool_input", ""))
+        return _wrapped_exec_commands(
+            _functions_exec_source(hook_input.get("tool_input", ""))
+        )
     return ()
 
 
@@ -4018,8 +4036,10 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
     commands = _hook_commands(hook_input, tool_name)
     if (
         tool_name == "functions.exec"
-        and isinstance(hook_input.get("tool_input"), str)
-        and _wrapped_exec_call_count(hook_input["tool_input"]) != len(commands)
+        and _wrapped_exec_call_count(
+            _functions_exec_source(hook_input.get("tool_input"))
+        )
+        != len(commands)
     ):
         _record_guard_block_and_deny(
             hook_input,

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -2002,6 +2002,22 @@ def _functions_exec_source(tool_input: object) -> str:
     return ""
 
 
+def _functions_exec_direct_command(tool_input: object) -> str:
+    """Return a shell command supplied directly by a wrapped Codex event."""
+    if isinstance(tool_input, dict):
+        command = tool_input.get("cmd") or tool_input.get("command")
+        if isinstance(command, str):
+            return command
+    return ""
+
+
+def _functions_exec_commands(tool_input: object) -> tuple[str, ...]:
+    direct = _functions_exec_direct_command(tool_input)
+    if direct:
+        return (direct,)
+    return _wrapped_exec_commands(_functions_exec_source(tool_input))
+
+
 def _wrapped_exec_call_count(source: str) -> int:
     return len(re.findall(r"\btools\.exec_command\s*\(", source))
 
@@ -2105,9 +2121,10 @@ def _research_preflight_events(
             if len(segments) == 1 and _shell_requests_primary_source(lowered):
                 events.append("authoritative-online-research")
     if tool_name == "functions.exec":
-        wrapped_commands = _wrapped_exec_commands(source)
+        wrapped_commands = _functions_exec_commands(tool_input)
         wrapped_call_count = _wrapped_exec_call_count(source)
-        if wrapped_call_count == 1 and len(wrapped_commands) == 1:
+        direct_command = _functions_exec_direct_command(tool_input)
+        if direct_command or (wrapped_call_count == 1 and len(wrapped_commands) == 1):
             command = wrapped_commands[0]
             events.extend(
                 _research_preflight_events(
@@ -2229,6 +2246,9 @@ def _shell_is_mutation(command: str) -> bool:
 
 
 def _functions_exec_is_mutation(tool_input: object) -> bool:
+    direct = _functions_exec_direct_command(tool_input)
+    if direct:
+        return _shell_is_mutation(direct)
     source = _functions_exec_source(tool_input)
     if re.search(r"\btools\.apply_patch\s*\(", source):
         return True
@@ -2245,9 +2265,7 @@ def _hook_commands(hook_input: dict, tool_name: str) -> tuple[str, ...]:
         command = _extract_command(hook_input)
         return (command,) if command else ()
     if tool_name == "functions.exec":
-        return _wrapped_exec_commands(
-            _functions_exec_source(hook_input.get("tool_input", ""))
-        )
+        return _functions_exec_commands(hook_input.get("tool_input", ""))
     return ()
 
 
@@ -4034,12 +4052,17 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
         return 0
 
     commands = _hook_commands(hook_input, tool_name)
+    functions_input = hook_input.get("tool_input")
+    functions_source = _functions_exec_source(functions_input)
+    functions_direct = _functions_exec_direct_command(functions_input)
     if (
         tool_name == "functions.exec"
-        and _wrapped_exec_call_count(
-            _functions_exec_source(hook_input.get("tool_input"))
+        and not functions_direct
+        and (
+            not isinstance(functions_input, (str, dict))
+            or (isinstance(functions_input, dict) and not functions_source)
+            or _wrapped_exec_call_count(functions_source) != len(commands)
         )
-        != len(commands)
     ):
         _record_guard_block_and_deny(
             hook_input,

--- a/tests/scripts/test_chaos_engine_hook.py
+++ b/tests/scripts/test_chaos_engine_hook.py
@@ -124,6 +124,18 @@ class ChaosEngineHookTest(unittest.TestCase):
             {
                 "hook_event_name": "PreToolUse",
                 "tool_name": "functions.exec",
+                "tool_input": {
+                    "input": 'await tools.exec_command({cmd:"git reset --hard HEAD~1"});'
+                },
+            },
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "functions.exec",
+                "tool_input": {"cmd": "git reset --hard HEAD~1"},
+            },
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "functions.exec",
                 "tool_input": "const bad = 'git reset --hard HEAD~1'; "
                 "await tools.exec_command({cmd: bad});",
             },
@@ -141,7 +153,14 @@ class ChaosEngineHookTest(unittest.TestCase):
                 (result.returncode, json.loads(result.stdout).get("decision"))
                 for result in results
             ],
-            [(2, "block"), (2, "block"), (2, "block"), (2, "block")],
+            [
+                (2, "block"),
+                (2, "block"),
+                (2, "block"),
+                (2, "block"),
+                (2, "block"),
+                (2, "block"),
+            ],
         )
 
     def test_first_stop_event_requires_completion_gate_then_avoids_a_loop(self):

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -582,9 +582,53 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 input=json.dumps(failure), capture_output=True, text=True,
                 env=hook_environment, check=False,
             )
+            wrapped_destruction = subprocess.run(  # nosec B603 - installed local hook.
+                [os.sys.executable, str(installed_hook)],
+                input=json.dumps(
+                    {
+                        "hook_event_name": "PreToolUse",
+                        "tool_name": "functions.exec",
+                        "tool_input": {"cmd": "git reset --hard HEAD~1"},
+                        "session_id": "installed-object-wrapper",
+                    }
+                ),
+                capture_output=True,
+                text=True,
+                env=hook_environment,
+                check=False,
+            )
+            wrapped_source_destruction = subprocess.run(  # nosec B603 - installed local hook.
+                [os.sys.executable, str(installed_hook)],
+                input=json.dumps(
+                    {
+                        "hook_event_name": "PreToolUse",
+                        "tool_name": "functions.exec",
+                        "tool_input": {
+                            "input": (
+                                'await tools.exec_command('
+                                '{cmd:"git reset --hard HEAD~1"});'
+                            )
+                        },
+                        "session_id": "installed-source-wrapper",
+                    }
+                ),
+                capture_output=True,
+                text=True,
+                env=hook_environment,
+                check=False,
+            )
             self.assertEqual(0, first.returncode, first.stderr)
             self.assertEqual(0, second.returncode, second.stderr)
             self.assertIn("Reflection required", second.stdout)
+            self.assertEqual(2, wrapped_destruction.returncode)
+            self.assertEqual(
+                "block", json.loads(wrapped_destruction.stdout)["decision"]
+            )
+            self.assertEqual(2, wrapped_source_destruction.returncode)
+            self.assertEqual(
+                "block",
+                json.loads(wrapped_source_destruction.stdout)["decision"],
+            )
 
     def test_lifecycle_hook_is_a_noop_outside_an_installed_project(self):
         module = load(HOSTS, "chaos_engine_hook_noop")

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -411,6 +411,9 @@ class ChaosEngineHostsTest(unittest.TestCase):
             project = Path(temporary) / "consumer"
             project.joinpath(".chaos-engine/skills/chaos-engine").mkdir(parents=True)
             project.joinpath(".chaos-engine/skills/chaos-engine/SKILL.md").write_text("# C\n")
+            legacy_plugin_hooks = project / "plugins/chaos-engine/hooks/hooks.json"
+            legacy_plugin_hooks.parent.mkdir(parents=True)
+            legacy_plugin_hooks.write_bytes(module.lifecycle_hooks_document())
 
             receipt = module.install(project)
 
@@ -458,6 +461,14 @@ class ChaosEngineHostsTest(unittest.TestCase):
             self.assertLessEqual(required, set(receipt["after"]))
             for relative in required:
                 self.assertTrue(project.joinpath(relative).is_file(), relative)
+            self.assertEqual(
+                {},
+                json.loads(
+                    project.joinpath(
+                        "plugins/chaos-engine/hooks/hooks.json"
+                    ).read_text()
+                )["hooks"],
+            )
             marketplace = json.loads(
                 project.joinpath(".agents/plugins/marketplace.json").read_text()
             )
@@ -524,18 +535,17 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 "SubagentStop",
             }
             lifecycle = json.loads(project.joinpath(".codex/hooks.json").read_text())["hooks"]
-            plugin_lifecycle = json.loads(
-                project.joinpath("plugins/chaos-engine/hooks/hooks.json").read_text()
-            )["hooks"]
             grok_lifecycle = json.loads(
                 project.joinpath(".grok/hooks/lifecycle.json").read_text()
             )["hooks"]
             claude_lifecycle = json.loads(
                 project.joinpath(".claude/settings.json").read_text()
             )["hooks"]
-            for document in (lifecycle, plugin_lifecycle, grok_lifecycle, claude_lifecycle):
+            for document in (lifecycle, grok_lifecycle, claude_lifecycle):
                 self.assertEqual(required_events, set(document))
                 for event in required_events:
+                    self.assertEqual(1, len(document[event]), event)
+                    self.assertEqual(1, len(document[event][0]["hooks"]), event)
                     command = document[event][0]["hooks"][0]["command"]
                     self.assertIn(" ", command, event)
                     self.assertTrue(
@@ -543,6 +553,17 @@ class ChaosEngineHostsTest(unittest.TestCase):
                         or "plugins/chaos-engine/hooks/guard.py" in command,
                         event,
                     )
+            for manifest_path in (
+                "plugins/chaos-engine/.codex-plugin/plugin.json",
+                "plugins/chaos-engine/.claude-plugin/plugin.json",
+            ):
+                manifest = json.loads(project.joinpath(manifest_path).read_text())
+                self.assertNotIn("hooks", manifest)
+            self.assertNotIn(
+                "hooks",
+                json.loads(project.joinpath(".gemini/settings.json").read_text()),
+            )
+            self.assertFalse(project.joinpath(".github/hooks.json").exists())
             installed_hook = project / "plugins/chaos-engine/hooks/guard.py"
             hook_environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}
             failure = {
@@ -564,6 +585,26 @@ class ChaosEngineHostsTest(unittest.TestCase):
             self.assertEqual(0, first.returncode, first.stderr)
             self.assertEqual(0, second.returncode, second.stderr)
             self.assertIn("Reflection required", second.stdout)
+
+    def test_lifecycle_hook_is_a_noop_outside_an_installed_project(self):
+        module = load(HOSTS, "chaos_engine_hook_noop")
+        document = json.loads(module.lifecycle_hooks_document())
+        handler = document["hooks"]["PreToolUse"][0]["hooks"][0]
+        command = handler["commandWindows"] if os.name == "nt" else handler["command"]
+
+        with tempfile.TemporaryDirectory() as temporary:
+            completed = subprocess.run(  # nosec B602 - generated fixed hook command.
+                command,
+                shell=True,
+                cwd=temporary,
+                input=json.dumps({"hook_event_name": "PreToolUse"}),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        self.assertEqual({}, json.loads(completed.stdout))
 
     def test_plugin_marketplace_preserves_unrelated_entries(self):
         module = load(HOSTS, "chaos_engine_marketplace_merge")

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -342,6 +342,32 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
             for relative in pin["files"]:
                 self.assertTrue((vendor / relative).is_file(), relative)
 
+    def test_companions_are_always_on_ultra_and_beat_host_prose(self):
+        skill = CANONICAL_SKILL.read_text(encoding="utf-8")
+        hooks = (CORE / "references/lifecycle-hooks.md").read_text(encoding="utf-8")
+        agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        lowered = skill.casefold()
+
+        self.assertIn("Load both companion skills at the start of every task", skill)
+        self.assertIn("selects **ultra**", lowered)
+        self.assertNotIn("Default intensity remains each companion's own", skill)
+        self.assertIn("yield to the companions", lowered)
+        compact_hooks = " ".join(hooks.casefold().split())
+        self.assertIn(
+            "still apply companions through the entrypoint load", compact_hooks
+        )
+        self.assertNotIn("load on invoke", lowered)
+        self.assertNotIn("Keep prose natural", agents)
+        self.assertIn("Caveman", agents)
+
+    def test_harness_changes_require_five_host_compatibility(self):
+        skill = CANONICAL_SKILL.read_text(encoding="utf-8")
+        lowered = skill.casefold()
+        self.assertIn("harness change", lowered)
+        self.assertIn("provider-agnostic", lowered)
+        self.assertIn("every supported host adapter", lowered)
+        self.assertIn("silently no-ops the others", lowered)
+
     def test_canonical_cleanup_policy_is_portable_and_has_three_scopes(self):
         canonical = CANONICAL_SKILL.read_text(encoding="utf-8")
         task_isolation_router = canonical.split("## Task isolation", 1)[1].split(

--- a/tests/scripts/test_chaos_engine_research.py
+++ b/tests/scripts/test_chaos_engine_research.py
@@ -37,11 +37,15 @@ class ChaosEngineResearchTest(unittest.TestCase):
 
     def test_token_first_adoption_is_dated_and_rejects_auto_loaded_companions(self):
         content = MATRIX.read_text(encoding="utf-8")
+        lowered = content.lower()
         self.assertIn("Accessed: 2026-08-17", content)
         self.assertIn("context-economy", content)
         self.assertIn("script-first", content)
-        self.assertIn("auto-load companion bodies every mutation", content.lower())
-        self.assertIn("rejected", content.lower())
+        self.assertIn("auto-load companion bodies every mutation", lowered)
+        self.assertIn("rejected", lowered)
+        self.assertNotIn("load on invoke", lowered)
+        self.assertIn("sessionstart", lowered)
+        self.assertIn("ultra", lowered)
 
     def test_top_ten_matrix_is_dated_primary_sourced_and_actionable(self):
         content = MATRIX.read_text(encoding="utf-8")

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -2440,6 +2440,25 @@ class HookJsonProtocolTest(unittest.TestCase):
                     return f"EXCEPTION:{type(error).__name__}\n"
         return output.getvalue()
 
+    def test_functions_exec_accepts_object_wrapped_freeform_input(self):
+        output = self.invoke(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "functions.exec",
+                "tool_input": {
+                    "input": (
+                        'const result = await tools.exec_command({cmd:"git status"}); '
+                        "text(result.output);"
+                    )
+                },
+                "cwd": str(Path(__file__).resolve().parents[2]),
+                "session_id": "object-wrapped-functions-exec",
+            }
+        )
+
+        self.assertNotIn("Lifecycle hook produced invalid JSON output", output)
+        self.assertIsInstance(json.loads(output), dict)
+
     def test_main_emits_one_json_object_for_every_lifecycle_event(self):
         callbacks = {
             "SessionStart": "run_session_start",

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -2459,6 +2459,24 @@ class HookJsonProtocolTest(unittest.TestCase):
         self.assertNotIn("Lifecycle hook produced invalid JSON output", output)
         self.assertIsInstance(json.loads(output), dict)
 
+    def test_functions_exec_cmd_wrapped_shell_is_inspected(self):
+        output = self.invoke(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "functions.exec",
+                "tool_input": {"cmd": "git reset --hard HEAD~1"},
+                "cwd": str(Path(__file__).resolve().parents[2]),
+                "session_id": "cmd-wrapped-functions-exec",
+            }
+        )
+
+        decision = json.loads(output)["hookSpecificOutput"]
+        self.assertEqual("deny", decision["permissionDecision"])
+        self.assertNotIn(
+            "Lifecycle hook produced invalid JSON output",
+            decision["permissionDecisionReason"],
+        )
+
     def test_main_emits_one_json_object_for_every_lifecycle_event(self):
         callbacks = {
             "SessionStart": "run_session_start",


### PR DESCRIPTION
## Summary

- make source-controlled direct provider hooks the sole active ChaosEngine lifecycle owners
- empty legacy plugin hook packs during install/upgrade so duplicate handlers cannot survive
- inspect raw, wrapped, and direct `functions.exec` command payloads fail-closed
- mandate provider-neutral harness changes across Claude, Codex, Grok, Gemini, and GitHub Copilot
- mandate source-controlled Caveman and Ponytail ultra selection at ChaosEngine level

## Validation

- `py -3 -m unittest tests.scripts.test_guard_lifecycle tests.scripts.test_chaos_engine_hook tests.scripts.test_chaos_engine_hosts tests.scripts.test_chaos_engine_portable_core tests.scripts.test_chaos_engine_research tests.scripts.test_agent_harness_portability tests.scripts.test_chaos_engine_installer` (560 passed)
- `py -3 scripts/ci/validate_agent_setup.py --skip-external`
- `py -3 scripts/agents/sync_user_harness.py` (in sync)
- all required GitHub checks passed
- exact-head feedback audit: allow, zero open findings
- independent adversarial re-review: zero blockers at `ba390660b93bea3bf2c1e435025a38e7fd1e1666`
