### PR TITLE
fix(agent): record wrapped plan receipt events

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Task|Agent|Read|Grep|Bash|PowerShell|shell_command|exec_command|functions[.]exec|Write|Edit|NotebookEdit|apply_patch|WebSearch|WebFetch|web__run|update_plan|enter_plan_mode|EnterPlanMode|exit_plan_mode|ExitPlanMode|todo_write|TodoWrite|mcp__shaft[-_]memory__(?:remember_memory|save_memory_patch)|mcp__mempalace__.*|mcp__graphify__.*",
+        "matcher": "Task|Agent|spawn_agent|collaboration[.]spawn_agent|Read|Grep|Bash|PowerShell|shell_command|exec_command|functions[.]exec|Write|Edit|NotebookEdit|apply_patch|WebSearch|WebFetch|web__run|update_plan|enter_plan_mode|EnterPlanMode|exit_plan_mode|ExitPlanMode|todo_write|TodoWrite|mcp__shaft[-_]memory__(?:remember_memory|save_memory_patch)|mcp__mempalace__.*|mcp__graphify__.*",
         "hooks": [
           {
             "type": "command",

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -2018,6 +2018,49 @@ def _functions_exec_commands(tool_input: object) -> tuple[str, ...]:
     return _wrapped_exec_commands(_functions_exec_source(tool_input))
 
 
+def _functions_exec_plan_events(source: str) -> tuple[str, ...]:
+    """Map one literal wrapped update_plan call without executing JavaScript."""
+    wrapper = re.fullmatch(
+        r"\s*(?:// @exec:[^\r\n]*\r?\n\s*)?"
+        r"(?:const\s+[A-Za-z_$][\w$]*\s*=\s*)?await\s+tools\.update_plan\s*"
+        r"\(\s*(?P<details>\{.*\})\s*\)\s*;\s*"
+        r"(?:text\s*\(\s*[A-Za-z_$][\w$]*\s*\)\s*;?\s*)?",
+        source,
+        re.DOTALL,
+    )
+    if wrapper is None:
+        return ()
+    details = wrapper.group("details")
+    string_literal = r'(?:"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\')'
+    step = (
+        r"\{\s*(?:step|\"step\"|'step')\s*:\s*" + string_literal
+        + r"\s*,\s*(?:status|\"status\"|'status')\s*:\s*"
+        + r'(?:"(?:pending|in_progress|completed)"|\'(?:pending|in_progress|completed)\')'
+        + r"\s*\}"
+    )
+    plan = r"\[\s*" + step + r"(?:\s*,\s*" + step + r")*\s*\]"
+    explanation_key = r'(?:explanation|"explanation"|\'explanation\')'
+    plan_key = r'(?:plan|"plan"|\'plan\')'
+    shapes = (
+        r"\{\s*" + explanation_key + r"\s*:\s*(?P<explanation>" + string_literal
+        + r")\s*,\s*" + plan_key + r"\s*:\s*" + plan + r"\s*\}",
+        r"\{\s*" + plan_key + r"\s*:\s*" + plan + r"\s*,\s*"
+        + explanation_key + r"\s*:\s*(?P<explanation>" + string_literal + r")\s*\}",
+        r"\{\s*" + plan_key + r"\s*:\s*" + plan + r"\s*\}",
+    )
+    literal = next(
+        (candidate for shape in shapes if (candidate := re.fullmatch(shape, details, re.DOTALL))),
+        None,
+    )
+    if literal is None:
+        return ()
+    explanation = literal.groupdict().get("explanation") or ""
+    events: list[str] = ["record-plan"]
+    if "compare proven approaches" in explanation[1:-1].lower():
+        events.insert(0, "compare-proven-approaches")
+    return tuple(events)
+
+
 def _wrapped_exec_call_count(source: str) -> int:
     return len(re.findall(r"\btools\.exec_command\s*\(", source))
 
@@ -2131,6 +2174,7 @@ def _research_preflight_events(
                     "exec_command", {"cmd": command}, tool_result
                 )
             )
+        events.extend(_functions_exec_plan_events(source))
     lowered_name = tool_name.lower()
     if ("shaft-memory" in lowered_name or "shaft_memory" in lowered_name) and any(
         verb in lowered_name for verb in ("search", "load", "inspect")

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -3115,7 +3115,9 @@ def check_r30_merge_authority_before_arming(command: str, tool_name: str, hook_i
 # finds something requests changes. Neither is a comment.
 REVIEW_VERDICTS = frozenset({"APPROVED", "CHANGES_REQUESTED"})
 
-DISPATCH_TOOLS = frozenset({"Task", "Agent"})
+DISPATCH_TOOLS = frozenset(
+    {"Task", "Agent", "spawn_agent", "collaboration.spawn_agent"}
+)
 REVIEWER_SUBAGENT_TYPES = frozenset({"reviewer"})
 ADAPTED_SUBAGENT_TYPES = frozenset({"chaos-engine", "coder", "helper", "reviewer", "tester"})
 
@@ -3136,13 +3138,18 @@ def check_r22_dispatch_adapter(hook_input: dict, tool_name: str) -> str | None:
     if not isinstance(tool_input, dict):
         subagent = ""
     else:
-        subagent = tool_input.get("subagent_type") or tool_input.get("subagent") or ""
+        subagent = (
+            tool_input.get("subagent_type")
+            or tool_input.get("agent_type")
+            or tool_input.get("subagent")
+            or ""
+        )
     if isinstance(subagent, str) and subagent.strip().lower() in ADAPTED_SUBAGENT_TYPES:
         return None
     legal = " | ".join(sorted(ADAPTED_SUBAGENT_TYPES))
     return (
         "R22 blocked: this dispatch has no role adapter, so it cannot receive the "
-        "mandatory entrypoint. Re-dispatch with subagent_type: " + legal + "."
+        "mandatory entrypoint. Re-dispatch with subagent_type/agent_type: " + legal + "."
     )
 
 
@@ -3507,7 +3514,12 @@ def _reviewer_dispatch_event(hook_input: dict, tool_name: str) -> str | None:
     tool_input = hook_input.get("tool_input")
     if not isinstance(tool_input, dict):
         return None
-    subagent = tool_input.get("subagent_type") or tool_input.get("subagent") or ""
+    subagent = (
+        tool_input.get("subagent_type")
+        or tool_input.get("agent_type")
+        or tool_input.get("subagent")
+        or ""
+    )
     if not isinstance(subagent, str):
         return None
     if subagent.strip().lower() not in REVIEWER_SUBAGENT_TYPES:

--- a/tests/scripts/test_agent_harness_portability.py
+++ b/tests/scripts/test_agent_harness_portability.py
@@ -708,6 +708,13 @@ class AgentHarnessPortabilityTest(unittest.TestCase):
         for path in (ROOT / ".claude/settings.json", ROOT / ".codex/hooks.json"):
             self.assertNotIn("bypass-hook-trust", path.read_text(encoding="utf-8"))
 
+    def test_codex_intercepts_collaboration_dispatches(self):
+        config = json.loads((ROOT / ".codex/hooks.json").read_text(encoding="utf-8"))
+        matcher = config["hooks"]["PreToolUse"][0]["matcher"]
+        for tool_name in ("collaboration.spawn_agent", "spawn_agent"):
+            with self.subTest(tool_name=tool_name):
+                self.assertIsNotNone(re.fullmatch(matcher, tool_name))
+
     def test_equivalent_host_hook_events_produce_equivalent_outcomes(self):
         fixtures = {
             "claude": {

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -4552,6 +4552,19 @@ class ObservedReviewDispatchTest(unittest.TestCase):
                 "review:feature",
             )
 
+    def test_a_collaboration_reviewer_dispatch_produces_a_review_event(self):
+        payload = {
+            "tool_name": "collaboration.spawn_agent",
+            "tool_input": {"agent_type": "reviewer"},
+            "session_id": "s",
+            "cwd": ".",
+        }
+        with patch("scripts.agents.guard._current_branch", return_value="feature"):
+            self.assertEqual(
+                guard._reviewer_dispatch_event(payload, "collaboration.spawn_agent"),
+                "review:feature",
+            )
+
     def test_any_other_subagent_produces_nothing(self):
         for subagent in ("coder", "tester", "general-purpose", ""):
             with self.subTest(subagent=subagent):
@@ -4651,6 +4664,21 @@ class DispatchAdapterGateTest(unittest.TestCase):
                     with redirect_stdout(output):
                         self.assertEqual(guard.run_pretooluse(self.payload(subagent)), 0)
                 self.assertNotIn("R22 blocked", output.getvalue())
+
+    def test_collaboration_dispatch_reads_the_agent_type_adapter(self):
+        payload = {
+            "tool_name": "collaboration.spawn_agent",
+            "tool_input": {"agent_type": "reviewer"},
+            "session_id": "r22",
+            "cwd": ".",
+        }
+        self.assertIsNone(
+            guard.check_r22_dispatch_adapter(payload, "collaboration.spawn_agent")
+        )
+        payload["tool_input"]["agent_type"] = "general-purpose"
+        self.assertIsNotNone(
+            guard.check_r22_dispatch_adapter(payload, "collaboration.spawn_agent")
+        )
 
     def test_r22_records_the_learning_loop_arming_escape(self):
         source = inspect.getsource(guard.check_r22_dispatch_adapter).lower()

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -4717,17 +4717,6 @@ class DispatchAdapterGateTest(unittest.TestCase):
                 text = open(os.path.join(root, name), encoding="utf-8").read()
                 self.assertIn("Task|Agent", text)
 
-    def test_codex_intercepts_collaboration_dispatches(self):
-        root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        config = json.loads(
-            Path(root, ".codex", "hooks.json").read_text(encoding="utf-8")
-        )
-        matcher = config["hooks"]["PreToolUse"][0]["matcher"]
-        for tool_name in ("collaboration.spawn_agent", "spawn_agent"):
-            with self.subTest(tool_name=tool_name):
-                self.assertIsNotNone(re.fullmatch(matcher, tool_name))
-
-
 class HistoricalDispatchReplayTest(unittest.TestCase):
     """R22 / #4570 A12: replay the 18-dispatch audit without local transcript state."""
 

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1426,6 +1426,47 @@ class GuardLifecycleTest(unittest.TestCase):
         self.assertEqual(guard._research_preflight_events("todo_write", {"todos": []}), ())
         self.assertEqual(guard._research_preflight_events("todo_write", {}), ())
 
+    def test_wrapped_update_plan_maps_plan_receipt_events(self):
+        source = (
+            'const result = await tools.update_plan({explanation:"Compare proven approaches",'
+            'plan:[{step:"Implement",status:"in_progress"}]}); text(result);'
+        )
+
+        self.assertEqual(
+            guard._research_preflight_events("functions.exec", source, {}),
+            ("compare-proven-approaches", "record-plan"),
+        )
+        self.assertEqual(
+            guard._research_preflight_events(
+                "functions.exec", f'const example = {json.dumps(source)}; text(example);', {}
+            ),
+            (),
+        )
+        invalid_sources = (
+            'await tools.update_plan({/* explanation:"Compare proven approaches" */'
+            'plan:[{step:"Implement",status:"in_progress"}]});',
+            'await tools.update_plan({explanation:"Compare proven approaches",'
+            'plan:[buildStep()]});',
+            'await tools.update_plan({...payload,explanation:"Compare proven approaches",'
+            'plan:[{step:"Implement",status:"in_progress"}]});',
+            'await tools.update_plan({metadata:{explanation:"Compare proven approaches"},'
+            'plan:[{step:"Implement",status:"in_progress"}]});',
+        )
+        required_prefix = list(guard.IMPLEMENTATION_PREFLIGHT_EVENTS[:3])
+        for invalid_source in invalid_sources:
+            with self.subTest(invalid_source=invalid_source):
+                events = guard._research_preflight_events("functions.exec", invalid_source, {})
+                self.assertEqual(events, ())
+                with patch(
+                    "scripts.agents.guard.ledger_events",
+                    return_value=[*required_prefix, *events],
+                ):
+                    self.assertIsNotNone(
+                        guard.check_r25_research_before_implementation(
+                            self.payload(), "Write"
+                        )
+                    )
+
     def test_shell_command_maps_research_clis_in_command_order(self):
         self.assertEqual(
             guard._research_preflight_events(

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -4565,6 +4565,23 @@ class ObservedReviewDispatchTest(unittest.TestCase):
                 "review:feature",
             )
 
+    def test_collaboration_reviewer_dispatch_is_recorded_by_the_hook(self):
+        payload = {
+            "tool_name": "collaboration.spawn_agent",
+            "tool_input": {"agent_type": "reviewer"},
+            "session_id": "s",
+            "cwd": ".",
+        }
+        events: list[str] = []
+        with patch("scripts.agents.guard._current_branch", return_value="feature"):
+            with patch(
+                "scripts.agents.guard.ledger_record",
+                side_effect=lambda _payload, event: events.append(event) or True,
+            ):
+                with redirect_stdout(io.StringIO()):
+                    guard.run_pretooluse(payload)
+        self.assertIn("review:feature", events)
+
     def test_any_other_subagent_produces_nothing(self):
         for subagent in ("coder", "tester", "general-purpose", ""):
             with self.subTest(subagent=subagent):
@@ -4699,6 +4716,16 @@ class DispatchAdapterGateTest(unittest.TestCase):
             with self.subTest(host=name):
                 text = open(os.path.join(root, name), encoding="utf-8").read()
                 self.assertIn("Task|Agent", text)
+
+    def test_codex_intercepts_collaboration_dispatches(self):
+        root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        config = json.loads(
+            Path(root, ".codex", "hooks.json").read_text(encoding="utf-8")
+        )
+        matcher = config["hooks"]["PreToolUse"][0]["matcher"]
+        for tool_name in ("collaboration.spawn_agent", "spawn_agent"):
+            with self.subTest(tool_name=tool_name):
+                self.assertIsNotNone(re.fullmatch(matcher, tool_name))
 
 
 class HistoricalDispatchReplayTest(unittest.TestCase):

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1461,7 +1461,9 @@ class GuardLifecycleTest(unittest.TestCase):
                     guard,
                     "ledger_events",
                     return_value=[*required_prefix, *events],
-                ):
+                ), patch.object(
+                    guard, "_act_as_mohab_root", return_value=str(Path.cwd())
+                ), patch.object(guard, "_path_is_inside", return_value=True):
                     self.assertIsNotNone(
                         guard.check_r25_research_before_implementation(
                             self.payload(), "Write"

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1457,8 +1457,9 @@ class GuardLifecycleTest(unittest.TestCase):
             with self.subTest(invalid_source=invalid_source):
                 events = guard._research_preflight_events("functions.exec", invalid_source, {})
                 self.assertEqual(events, ())
-                with patch(
-                    "scripts.agents.guard.ledger_events",
+                with patch.object(
+                    guard,
+                    "ledger_events",
                     return_value=[*required_prefix, *events],
                 ):
                     self.assertIsNotNone(


### PR DESCRIPTION
## Summary

- Record R25 comparison and plan receipt events from one literal wrapped `tools.update_plan(...)` call inside `functions.exec`.
- Fail closed for comments, dynamic expressions, object spreads, nested markers, invalid statuses, and quoted fake source.
- Add RED/GREEN regression coverage for valid and adversarial wrapper shapes.

Closes #5271

## Checks

- `py -3 -m unittest tests.scripts.test_guard_lifecycle` - 287 tests passed.
- `py -3 scripts/ci/validate_agent_setup.py --skip-external` - passed.
- Independent adversarial review - zero Critical, Important, or Minor findings after fix round.

## Continuation

Head: `e640562e4edd2b3f0569aa205fbeaea8fdc3253a`

State: Verified, independently reviewed, committed, and pushed.

Blockers: None.

Next action: Audit PR comments and checks, arm merge-commit auto-merge, watch to confirmed merge, then normalize local repository to one clean `main` worktree at `origin/main`.
