### PR TITLE
fix(ci): bound release version gate checkout

### DIFF
--- a/.github/workflows/shaft-pilot-release.yml
+++ b/.github/workflows/shaft-pilot-release.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
       - name: Detect SHAFT version change
         id: version-diff
         shell: bash
@@ -43,6 +44,8 @@ jobs:
             echo "changed=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
+
+          git fetch --no-tags --depth=1 origin "${BASE_SHA}"
 
           # Release-candidate infra (this workflow's own file or the composite actions
           # it depends on) must be exercised on its own PR, not only on the next real

--- a/tests/scripts/test_validate_shaft_pilot_release.py
+++ b/tests/scripts/test_validate_shaft_pilot_release.py
@@ -628,6 +628,22 @@ jobs:
 
 
 class ShaftPilotReleaseIsolationTest(unittest.TestCase):
+    def test_detect_fetches_only_exact_pull_request_commits(self):
+        workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+        detect_job = workflow["jobs"]["detect-shaft-version-change"]
+        checkout = detect_job["steps"][0]
+        detect = _step_blob(detect_job)
+
+        self.assertEqual(1, checkout.get("with", {}).get("fetch-depth"))
+        self.assertEqual(
+            "ref: ${{ github.event.pull_request.head.sha || github.sha }}",
+            "ref: " + checkout.get("with", {}).get("ref", ""),
+        )
+        self.assertIn(
+            'git fetch --no-tags --depth=1 origin "${BASE_SHA}"',
+            detect,
+        )
+
     def test_isolated_slices_run_in_parallel_after_detect_only(self):
         workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
         jobs = workflow["jobs"]


### PR DESCRIPTION
## Summary

Make the release-version detection checkout bounded: check out the exact pull-request head shallowly and fetch only the exact base SHA.

Closes #5279.

## Checks

- `py -3 -m unittest tests.scripts.test_validate_shaft_pilot_release` — 33 passed.
- `py -3 scripts/ci/validate_shaft_pilot_release.py` — passed.
- `git diff --check` — clean.
- Independent adversarial review — zero blocking findings.

## Continuation

- Head: `6ff1f2dce57e459584ecf9a66cc80e82997ecfae`.
- State: ready for remote PR gates.
- Blockers: none.
- Next action: review remote comments, watch checks, then merge when green.
