### PR TITLE
feat(intellij): orchestrate AutoBot codegen

### DIFF
--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinator.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinator.java
@@ -65,9 +65,6 @@ public final class AssistantCodegenWorkflowCoordinator implements Disposable {
             "element_upload_file");
     private final Map<String, Workflow> workflows = new ConcurrentHashMap<>();
 
-    public AssistantCodegenWorkflowCoordinator() {
-    }
-
     static AssistantCodegenWorkflowCoordinator getInstance(Project project) {
         if (project == null) {
             return new AssistantCodegenWorkflowCoordinator();
@@ -84,21 +81,9 @@ public final class AssistantCodegenWorkflowCoordinator implements Disposable {
         String key = sessionKey(sessionId);
         Workflow current = workflows.get(key);
         if (current != null) {
-            if (current.phase == Phase.AWAITING_URL) {
-                return acceptUrl(current, userText);
-            }
-            if (current.phase == Phase.AWAITING_EDIT_CONFIRMATION) {
-                return acceptConsent(current, userText);
-            }
-            if (current.phase.terminal()) {
-                if (baseInvocation == null) {
-                    return AssistantCommand.Invocation.local("This AutoBot codegen workflow already ended with "
-                            + current.phase.name().toLowerCase(Locale.ROOT) + ". Start a new `/codegen` request.");
-                }
-                workflows.remove(key);
-            } else {
-                return AssistantCommand.Invocation.local("AutoBot codegen is already running in phase "
-                        + current.phase + ". Cancel it before starting another workflow.");
+            AssistantCommand.Invocation currentRoute = routeCurrentWorkflow(key, current, userText, baseInvocation);
+            if (currentRoute != null) {
+                return currentRoute;
             }
         }
         if (!scenarioCodegen(baseInvocation, userText)) {
@@ -126,6 +111,29 @@ public final class AssistantCodegenWorkflowCoordinator implements Disposable {
             return AssistantCommand.Invocation.local(URL_QUESTION);
         }
         return recordInvocation(workflow);
+    }
+
+    private AssistantCommand.Invocation routeCurrentWorkflow(
+            String key,
+            Workflow current,
+            String userText,
+            AssistantCommand.Invocation baseInvocation) {
+        if (current.phase == Phase.AWAITING_URL) {
+            return acceptUrl(current, userText);
+        }
+        if (current.phase == Phase.AWAITING_EDIT_CONFIRMATION) {
+            return acceptConsent(current, userText);
+        }
+        if (!current.phase.terminal()) {
+            return AssistantCommand.Invocation.local("AutoBot codegen is already running in phase "
+                    + current.phase + ". Cancel it before starting another workflow.");
+        }
+        if (baseInvocation == null) {
+            return AssistantCommand.Invocation.local("This AutoBot codegen workflow already ended with "
+                    + current.phase.name().toLowerCase(Locale.ROOT) + ". Start a new `/codegen` request.");
+        }
+        workflows.remove(key);
+        return null;
     }
 
     ShaftMcpToolResult complete(String sessionId, ShaftMcpToolResult result, String workingDirectory) {
@@ -403,30 +411,41 @@ public final class AssistantCodegenWorkflowCoordinator implements Disposable {
     }
 
     private static boolean validTerminal(JsonObject terminal) {
-        if (terminal == null
-                || !nonBlankString(terminal, "status")
-                || !terminal.has("phaseOutcomes")
-                || !terminal.get("phaseOutcomes").isJsonObject()
-                || !terminal.has("changedClasses")
-                || !terminal.get("changedClasses").isJsonArray()
-                || !terminal.has("createdClasses")
-                || !terminal.get("createdClasses").isJsonArray()
-                || !optionalString(terminal, "reportPath")) {
+        if (!validTerminalShape(terminal)) {
             return false;
         }
         String status = terminal.get("status").getAsString().trim().toLowerCase(Locale.ROOT);
         JsonArray changedClasses = terminal.getAsJsonArray("changedClasses");
         JsonArray createdClasses = terminal.getAsJsonArray("createdClasses");
         JsonObject phaseOutcomes = terminal.getAsJsonObject("phaseOutcomes");
-        if (!("passed".equals(status) || "failed".equals(status))
-                || !validClassNames(changedClasses)
-                || !validClassNames(createdClasses)
-                || !validPhaseOutcomes(phaseOutcomes)) {
+        if (!validTerminalValues(status, changedClasses, createdClasses, phaseOutcomes)) {
             return false;
         }
-        if (!"passed".equals(status)) {
-            return true;
-        }
+        return !"passed".equals(status) || validPassedTerminal(changedClasses, createdClasses, phaseOutcomes);
+    }
+
+    private static boolean validTerminalShape(JsonObject terminal) {
+        return terminal != null
+                && nonBlankString(terminal, "status")
+                && terminal.has("phaseOutcomes")
+                && terminal.get("phaseOutcomes").isJsonObject()
+                && terminal.has("changedClasses")
+                && terminal.get("changedClasses").isJsonArray()
+                && terminal.has("createdClasses")
+                && terminal.get("createdClasses").isJsonArray()
+                && optionalString(terminal, "reportPath");
+    }
+
+    private static boolean validTerminalValues(
+            String status, JsonArray changedClasses, JsonArray createdClasses, JsonObject phaseOutcomes) {
+        return ("passed".equals(status) || "failed".equals(status))
+                && validClassNames(changedClasses)
+                && validClassNames(createdClasses)
+                && validPhaseOutcomes(phaseOutcomes);
+    }
+
+    private static boolean validPassedTerminal(
+            JsonArray changedClasses, JsonArray createdClasses, JsonObject phaseOutcomes) {
         return nonBlankOutcome(phaseOutcomes, "GENERATE")
                 && nonBlankOutcome(phaseOutcomes, "REPLAY")
                 && nonBlankOutcome(phaseOutcomes, "HEAL")

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinator.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinator.java
@@ -165,11 +165,25 @@ public final class AssistantCodegenWorkflowCoordinator implements Disposable {
         } catch (IllegalArgumentException | UnsupportedOperationException error) {
             return workflow.phase;
         }
-        if ((reported == Phase.GENERATE || reported == Phase.REPLAY || reported == Phase.HEAL)
-                && workflow.phase.mutableOrder() <= reported.mutableOrder()) {
+        if (allowedProgressTransition(workflow, reported)) {
+            if (reported == Phase.HEAL && workflow.phase != Phase.HEAL) {
+                workflow.healAttempts++;
+            }
             workflow.phase = reported;
         }
         return workflow.phase;
+    }
+
+    private static boolean allowedProgressTransition(Workflow workflow, Phase reported) {
+        if (!(reported == Phase.GENERATE || reported == Phase.REPLAY || reported == Phase.HEAL)) {
+            return false;
+        }
+        Phase current = workflow.phase;
+        if (reported == Phase.HEAL && current != Phase.HEAL) {
+            return workflow.healAttempts < workflow.healRetryAllowance;
+        }
+        return current.mutableOrder() <= reported.mutableOrder()
+                || (current == Phase.HEAL && reported == Phase.REPLAY);
     }
 
     Phase phase(String sessionId) {
@@ -335,7 +349,7 @@ public final class AssistantCodegenWorkflowCoordinator implements Disposable {
         state.addProperty("recordingPath", AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH);
         return """
                 AutoBot free-text codegen, read-only RECORD invocation. You own all browser and SHAFT MCP actions; the IntelliJ plugin coordinates state and presentation only.
-                Initialize negotiated SHAFT MCP capabilities, call capture_start with the exact state below, perform the requested browser journey, call capture_stop/save, then inspect existing test and page-object classes and propose reuse/new owners. Do not edit source. Do not generate, replay, or heal. Preserve MCP timeout, cancellation, shutdown, and client lifecycle.
+                Load and follow `$shaft-recording-codegen`, `$shaft-locator-design`, and `$shaft-web-actions` plus the repository's SHAFT recording guidance. Use negotiated SHAFT MCP/CLI capabilities to call capture_start with the exact state below, perform the requested browser journey, and call capture_stop/save. Then inspect existing test classes and page objects and propose which existing owners to reuse and which owners are genuinely missing. Do not edit source. Do not generate, replay, or heal. Preserve MCP timeout, cancellation, shutdown, and client lifecycle.
 
                 Workflow state:
                 %s
@@ -354,7 +368,9 @@ public final class AssistantCodegenWorkflowCoordinator implements Disposable {
         state.addProperty("healRetryAllowance", workflow.healRetryAllowance);
         return """
                 AutoBot free-text codegen, approved mutable invocation. Explicit edit consent was granted before this process launched. You own GENERATE, REPLAY, and HEAL through negotiated SHAFT MCP and local project tools; the IntelliJ plugin coordinates state and presentation only.
-                Reuse the approved proposal and saved recording. Make the smallest source change, reporting exact changed and created class names. Replay once. On failure, heal and replay no more than the exact healRetryAllowance in state; never inherit another default and never weaken assertions. Preserve MCP timeout, cancellation, shutdown, and client lifecycle.
+                Load and follow `$shaft-automated-test-authoring`, `$shaft-page-objects`, `$shaft-recording-codegen`, `$shaft-locator-design`, `$shaft-web-actions`, and `$shaft-change-verification` plus the repository's SHAFT test-generation guidance. Before any source edit, inspect existing test classes and page objects and call `shaft_coding_partner_plan` (or the negotiated equivalent owner/reuse planning capability). Reuse the approved proposal, saved recording, existing test classes, page objects, locator fields, and action methods. Create a new owner only when none fits.
+                Follow the Page Object Model and the project's existing package and class ownership. Keep locators and page actions in page objects, not test methods. Locator priority is stable author-written IDs first, then existing project locator conventions, then accessible semantic locators, with XPath only as a last fallback. Use SHAFT syntax and fluent action chaining.
+                Make the smallest source change, reporting exact changed and created class names. Replay once. On failure, heal and replay no more than the exact healRetryAllowance in state; never inherit another default and never weaken assertions. Preserve MCP timeout, cancellation, shutdown, and client lifecycle.
                 Emit a parseable progress line when each phase starts: SHAFT_CODEGEN_PROGRESS {"phase":"GENERATE|REPLAY|HEAL"}
 
                 Workflow state:
@@ -680,6 +696,7 @@ public final class AssistantCodegenWorkflowCoordinator implements Disposable {
         private String proposalMarkdown = "";
         private JsonObject proposal = new JsonObject();
         private Phase phase = Phase.IDLE;
+        private int healAttempts;
 
         private Workflow(
                 String scenario,

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinator.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinator.java
@@ -1,0 +1,676 @@
+package com.shaft.intellij.ui;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+import com.shaft.intellij.mcp.ShaftMcpToolResult;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Project-scoped state and consent boundary for free-text AutoBot code generation. */
+@Service(Service.Level.PROJECT)
+public final class AssistantCodegenWorkflowCoordinator implements Disposable {
+    static final String PROPOSAL_PREFIX = "SHAFT_CODEGEN_PROPOSAL ";
+    static final String PROGRESS_PREFIX = "SHAFT_CODEGEN_PROGRESS ";
+    static final String RESULT_PREFIX = "SHAFT_CODEGEN_RESULT ";
+    private static final String URL_QUESTION = "What URL should AutoBot record?";
+    private static final Pattern URL = Pattern.compile("(?i)\\b(?:https?://|file:/)[^\\s,;)}\\]]+");
+    private static final Pattern HEAL_RETRY_OVERRIDE = Pattern.compile(
+            "(?i)\\b(?:allow|use|try|perform|up\\s+to)\\s+(\\d{1,2})\\s+(?:heal|healing)\\s+retries\\b");
+    private static final Pattern CLASS_NAME = Pattern.compile("[A-Za-z_$][A-Za-z0-9_.$]*");
+    private static final String CUSTOM_PROPERTIES = "src/main/resources/properties/custom.properties";
+    private static final String SHAFT_MCP_TOOL_PREFIX = "mcp__shaft-mcp__";
+    private static final List<String> RECORD_MCP_TOOLS = List.of(
+            "capture_start",
+            "capture_status",
+            "capture_stop",
+            "browser_accessibility_audit",
+            "browser_aria_snapshot",
+            "browser_get_current_url",
+            "browser_get_page_dom",
+            "browser_get_title",
+            "browser_navigate",
+            "browser_navigate_back",
+            "browser_navigate_forward",
+            "browser_network_requests",
+            "browser_refresh",
+            "browser_set_window_size",
+            "browser_take_screenshot",
+            "element_clear",
+            "element_click",
+            "element_drag_and_drop",
+            "element_hover",
+            "element_is_displayed",
+            "element_is_enabled",
+            "element_is_selected",
+            "element_type",
+            "element_upload_file");
+    private final Map<String, Workflow> workflows = new ConcurrentHashMap<>();
+
+    public AssistantCodegenWorkflowCoordinator() {
+    }
+
+    static AssistantCodegenWorkflowCoordinator getInstance(Project project) {
+        if (project == null) {
+            return new AssistantCodegenWorkflowCoordinator();
+        }
+        AssistantCodegenWorkflowCoordinator service = project.getService(AssistantCodegenWorkflowCoordinator.class);
+        return service == null ? new AssistantCodegenWorkflowCoordinator() : service;
+    }
+
+    AssistantCommand.Invocation route(
+            String sessionId,
+            String userText,
+            AssistantCommand.Invocation baseInvocation,
+            String workingDirectory) {
+        String key = sessionKey(sessionId);
+        Workflow current = workflows.get(key);
+        if (current != null) {
+            if (current.phase == Phase.AWAITING_URL) {
+                return acceptUrl(current, userText);
+            }
+            if (current.phase == Phase.AWAITING_EDIT_CONFIRMATION) {
+                return acceptConsent(current, userText);
+            }
+            if (current.phase.terminal()) {
+                if (baseInvocation == null) {
+                    return AssistantCommand.Invocation.local("This AutoBot codegen workflow already ended with "
+                            + current.phase.name().toLowerCase(Locale.ROOT) + ". Start a new `/codegen` request.");
+                }
+                workflows.remove(key);
+            } else {
+                return AssistantCommand.Invocation.local("AutoBot codegen is already running in phase "
+                        + current.phase + ". Cancel it before starting another workflow.");
+            }
+        }
+        if (!scenarioCodegen(baseInvocation, userText)) {
+            return baseInvocation == null
+                    ? AssistantCommand.Invocation.local("No AutoBot codegen workflow is awaiting input.")
+                    : baseInvocation;
+        }
+        if (!supportsRecordToolSandbox(baseInvocation)) {
+            return AssistantCommand.Invocation.local(
+                    "AutoBot scenario codegen requires Codex CLI. The selected client cannot enforce "
+                            + "the browser/capture-only RECORD tool boundary before edit consent.");
+        }
+        if (hasCustomCommand(baseInvocation)) {
+            return AssistantCommand.Invocation.local(
+                    "AutoBot scenario codegen requires a supported built-in Local / CLI client. "
+                            + "Custom Agent commands cannot enforce the read-only RECORD boundary.");
+        }
+        Workflow workflow = new Workflow(scenario(userText), baseInvocation, workingDirectory);
+        workflows.put(key, workflow);
+        String scenarioUrl = firstUrl(workflow.scenario);
+        String configuredUrl = configuredBaseUrl(workingDirectory);
+        workflow.targetUrl = scenarioUrl.isBlank() ? configuredUrl : scenarioUrl;
+        if (workflow.targetUrl.isBlank()) {
+            workflow.phase = Phase.AWAITING_URL;
+            return AssistantCommand.Invocation.local(URL_QUESTION);
+        }
+        return recordInvocation(workflow);
+    }
+
+    ShaftMcpToolResult complete(String sessionId, ShaftMcpToolResult result, String workingDirectory) {
+        Workflow workflow = workflows.get(sessionKey(sessionId));
+        if (workflow == null || workflow.phase.terminal()) {
+            return result;
+        }
+        if (workflow.phase == Phase.RECORD) {
+            return completeRecord(workflow, result, workingDirectory);
+        }
+        if (workflow.phase == Phase.GENERATE || workflow.phase == Phase.REPLAY || workflow.phase == Phase.HEAL) {
+            return completeMutable(workflow, result, workingDirectory);
+        }
+        return result;
+    }
+
+    Phase progress(String sessionId, String line) {
+        Workflow workflow = workflows.get(sessionKey(sessionId));
+        if (workflow == null || workflow.phase.terminal()) {
+            return workflow == null ? Phase.IDLE : workflow.phase;
+        }
+        JsonObject progress = structuredObject(line, PROGRESS_PREFIX);
+        if (progress == null || !progress.has("phase")) {
+            return workflow.phase;
+        }
+        Phase reported;
+        try {
+            reported = Phase.valueOf(progress.get("phase").getAsString().trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException | UnsupportedOperationException error) {
+            return workflow.phase;
+        }
+        if ((reported == Phase.GENERATE || reported == Phase.REPLAY || reported == Phase.HEAL)
+                && workflow.phase.mutableOrder() <= reported.mutableOrder()) {
+            workflow.phase = reported;
+        }
+        return workflow.phase;
+    }
+
+    Phase phase(String sessionId) {
+        Workflow workflow = workflows.get(sessionKey(sessionId));
+        return workflow == null ? Phase.IDLE : workflow.phase;
+    }
+
+    String status(String sessionId) {
+        Phase phase = phase(sessionId);
+        return switch (phase) {
+            case AWAITING_URL -> "AutoBot awaiting target URL";
+            case RECORD -> "AutoBot recording";
+            case AWAITING_EDIT_CONFIRMATION -> "AutoBot awaiting edit confirmation";
+            case GENERATE -> "AutoBot generating";
+            case REPLAY -> "AutoBot replaying";
+            case HEAL -> "AutoBot healing";
+            case SUCCEEDED -> "AutoBot codegen passed";
+            case DENIED -> "AutoBot codegen denied";
+            case CANCELLED -> "AutoBot codegen cancelled";
+            case DISPOSED -> "AutoBot codegen disposed";
+            case FAILED -> "AutoBot codegen failed";
+            case IDLE -> "";
+        };
+    }
+
+    void cancel(String sessionId) {
+        terminate(sessionId, Phase.CANCELLED);
+    }
+
+    void disposeSession(String sessionId) {
+        terminate(sessionId, Phase.DISPOSED);
+    }
+
+    @Override
+    public void dispose() {
+        workflows.values().stream()
+                .filter(workflow -> !workflow.phase.terminal())
+                .forEach(workflow -> workflow.phase = Phase.DISPOSED);
+    }
+
+    private AssistantCommand.Invocation acceptUrl(Workflow workflow, String response) {
+        String supplied = firstUrl(response);
+        if (supplied.isBlank()) {
+            workflow.phase = Phase.FAILED;
+            return AssistantCommand.Invocation.local(
+                    "A target URL was not supplied after the single URL question. AutoBot codegen cancelled.");
+        }
+        workflow.targetUrl = supplied;
+        return recordInvocation(workflow);
+    }
+
+    private AssistantCommand.Invocation acceptConsent(Workflow workflow, String response) {
+        String decision = normalizeDecision(response);
+        if (explicitDenial(decision)) {
+            workflow.phase = Phase.DENIED;
+            return AssistantCommand.Invocation.local(
+                    "AutoBot codegen stopped at the proposal. No mutable invocation was launched.");
+        }
+        if (!explicitApproval(decision)) {
+            return AssistantCommand.Invocation.local(
+                    workflow.proposalMarkdown
+                            + "\n\nNo source files or replay have run. Send `approve edits` to continue or `deny` to stop.");
+        }
+        workflow.phase = Phase.GENERATE;
+        JsonObject arguments = workflow.baseArguments.deepCopy();
+        arguments.addProperty("mode", "AGENT");
+        arguments.addProperty("allowSourceMutation", true);
+        arguments.remove("readOnlyCodegenRecording");
+        arguments.addProperty("healRetryAllowance", workflow.healRetryAllowance);
+        arguments.addProperty("prompt", mutablePrompt(workflow));
+        return AssistantCommand.Invocation.tool("autobot_local_agent_run", arguments)
+                .routedVia(workflow.routedVia);
+    }
+
+    private static AssistantCommand.Invocation recordInvocation(Workflow workflow) {
+        workflow.phase = Phase.RECORD;
+        JsonObject arguments = workflow.baseArguments.deepCopy();
+        arguments.addProperty("mode", "AGENT");
+        arguments.addProperty("allowSourceMutation", false);
+        arguments.addProperty("readOnlyCodegenRecording", true);
+        arguments.remove("healRetryAllowance");
+        arguments.addProperty("prompt", recordPrompt(workflow));
+        return AssistantCommand.Invocation.tool("autobot_local_agent_run", arguments)
+                .routedVia(workflow.routedVia);
+    }
+
+    static List<String> recordMcpTools() {
+        return RECORD_MCP_TOOLS;
+    }
+
+    boolean allowsRecordMcpTool(String sessionId, String toolName) {
+        Workflow workflow = workflows.get(sessionKey(sessionId));
+        if (workflow == null || workflow.phase != Phase.RECORD || toolName == null) {
+            return false;
+        }
+        String normalized = toolName.startsWith(SHAFT_MCP_TOOL_PREFIX)
+                ? toolName.substring(SHAFT_MCP_TOOL_PREFIX.length())
+                : toolName;
+        return RECORD_MCP_TOOLS.contains(normalized);
+    }
+
+    private static ShaftMcpToolResult completeRecord(
+            Workflow workflow, ShaftMcpToolResult result, String workingDirectory) {
+        if (result == null || !result.success()) {
+            workflow.phase = Phase.FAILED;
+            return result == null ? ShaftMcpToolResult.failure("AutoBot recording returned no result.") : result;
+        }
+        JsonObject proposal = structuredObject(
+                AssistantLocalAgentRunner.StructuredStreamParser.modelOutput(result.output()), PROPOSAL_PREFIX);
+        if (!validProposal(proposal)) {
+            workflow.phase = Phase.FAILED;
+            return ShaftMcpToolResult.failure(
+                    "AutoBot recording ended without a valid structured proposal. No source mutation was launched.");
+        }
+        String recordingPath = proposal.get("recordingPath").getAsString().trim();
+        if (!AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH.equals(recordingPath)) {
+            workflow.phase = Phase.FAILED;
+            return ShaftMcpToolResult.failure("AutoBot returned recording path `" + recordingPath
+                    + "`; expected unchanged route `" + AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH + "`.");
+        }
+        if (!realCanonicalRecording(workingDirectory)) {
+            workflow.phase = Phase.FAILED;
+            return ShaftMcpToolResult.failure(
+                    "AutoBot did not save a regular recording file at the canonical project path `"
+                            + AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH + "`.");
+        }
+        workflow.recordingPath = recordingPath;
+        workflow.proposal = proposal.deepCopy();
+        workflow.proposalMarkdown = proposal.get("proposalMarkdown").getAsString().trim();
+        workflow.phase = Phase.AWAITING_EDIT_CONFIRMATION;
+        return ShaftMcpToolResult.success("**AutoBot recording and reuse proposal**\n\n"
+                + workflow.proposalMarkdown
+                + "\n\nRecording: `" + workflow.recordingPath + "`"
+                + "\n\nNo source files or replay have run. Send `approve edits` to continue or `deny` to stop.");
+    }
+
+    private static ShaftMcpToolResult completeMutable(
+            Workflow workflow,
+            ShaftMcpToolResult result,
+            String workingDirectory) {
+        if (result == null || !result.success()) {
+            workflow.phase = Phase.FAILED;
+            return result == null ? ShaftMcpToolResult.failure("AutoBot mutable run returned no result.") : result;
+        }
+        JsonObject terminal = structuredObject(
+                AssistantLocalAgentRunner.StructuredStreamParser.modelOutput(result.output()), RESULT_PREFIX);
+        if (!validTerminal(terminal)) {
+            workflow.phase = Phase.FAILED;
+            return ShaftMcpToolResult.failure(
+                    "AutoBot mutable run ended without a valid structured terminal summary.");
+        }
+        String status = terminal.get("status").getAsString().trim().toLowerCase(Locale.ROOT);
+        workflow.phase = "passed".equals(status) ? Phase.SUCCEEDED : Phase.FAILED;
+        return "passed".equals(status)
+                ? ShaftMcpToolResult.success(terminalMarkdown(terminal, workingDirectory))
+                : ShaftMcpToolResult.failure(terminalMarkdown(terminal, workingDirectory));
+    }
+
+    private static String recordPrompt(Workflow workflow) {
+        JsonObject state = new JsonObject();
+        state.addProperty("scenario", workflow.scenario);
+        state.addProperty("targetUrl", workflow.targetUrl);
+        state.addProperty("recordingPath", AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH);
+        return """
+                AutoBot free-text codegen, read-only RECORD invocation. You own all browser and SHAFT MCP actions; the IntelliJ plugin coordinates state and presentation only.
+                Initialize negotiated SHAFT MCP capabilities, call capture_start with the exact state below, perform the requested browser journey, call capture_stop/save, then inspect existing test and page-object classes and propose reuse/new owners. Do not edit source. Do not generate, replay, or heal. Preserve MCP timeout, cancellation, shutdown, and client lifecycle.
+
+                Workflow state:
+                %s
+
+                End with exactly one parseable line:
+                SHAFT_CODEGEN_PROPOSAL {"recordingPath":"recordings/intellij-capture.json","proposalMarkdown":"...","phaseOutcomes":{"RECORD":"passed"}}
+                """.formatted(state).stripIndent().trim();
+    }
+
+    private static String mutablePrompt(Workflow workflow) {
+        JsonObject state = new JsonObject();
+        state.addProperty("scenario", workflow.scenario);
+        state.addProperty("targetUrl", workflow.targetUrl);
+        state.addProperty("recordingPath", workflow.recordingPath);
+        state.add("proposal", workflow.proposal.deepCopy());
+        state.addProperty("healRetryAllowance", workflow.healRetryAllowance);
+        return """
+                AutoBot free-text codegen, approved mutable invocation. Explicit edit consent was granted before this process launched. You own GENERATE, REPLAY, and HEAL through negotiated SHAFT MCP and local project tools; the IntelliJ plugin coordinates state and presentation only.
+                Reuse the approved proposal and saved recording. Make the smallest source change, reporting exact changed and created class names. Replay once. On failure, heal and replay no more than the exact healRetryAllowance in state; never inherit another default and never weaken assertions. Preserve MCP timeout, cancellation, shutdown, and client lifecycle.
+                Emit a parseable progress line when each phase starts: SHAFT_CODEGEN_PROGRESS {"phase":"GENERATE|REPLAY|HEAL"}
+
+                Workflow state:
+                %s
+
+                End with exactly one parseable line:
+                SHAFT_CODEGEN_RESULT {"status":"passed|failed","phaseOutcomes":{"RECORD":"...","GENERATE":"...","REPLAY":"...","HEAL":"..."},"changedClasses":[],"createdClasses":[],"reportPath":"allure-report/AllureReport.html or blank"}
+                """.formatted(state).stripIndent().trim();
+    }
+
+    private static String terminalMarkdown(JsonObject terminal, String workingDirectory) {
+        String status = terminal.get("status").getAsString().trim().toLowerCase(Locale.ROOT);
+        StringBuilder markdown = new StringBuilder("**AutoBot codegen terminal summary**\n\nStatus: **")
+                .append(status).append("**\n\nPhase outcomes:\n");
+        for (Map.Entry<String, JsonElement> entry : terminal.getAsJsonObject("phaseOutcomes").entrySet()) {
+            markdown.append("- ").append(entry.getKey()).append(": ")
+                    .append(entry.getValue().getAsString()).append('\n');
+        }
+        markdown.append("\nChanged classes: ").append(classList(terminal.getAsJsonArray("changedClasses")))
+                .append("\n\nCreated classes: ").append(classList(terminal.getAsJsonArray("createdClasses")));
+        if (realAllureReport(terminal, workingDirectory)) {
+            markdown.append("\n\n[Allure report](allure-report/AllureReport.html)");
+        }
+        return markdown.toString();
+    }
+
+    private static boolean realAllureReport(JsonObject terminal, String workingDirectory) {
+        if (!terminal.has("reportPath")
+                || !"allure-report/AllureReport.html".equals(terminal.get("reportPath").getAsString().trim())
+                || workingDirectory == null
+                || workingDirectory.isBlank()) {
+            return false;
+        }
+        Path root = Path.of(workingDirectory).toAbsolutePath().normalize();
+        Path report = root.resolve("allure-report/AllureReport.html").normalize();
+        return report.startsWith(root) && Files.isRegularFile(report);
+    }
+
+    private static String classList(JsonArray values) {
+        List<String> names = new ArrayList<>();
+        values.forEach(value -> names.add("`" + value.getAsString() + "`"));
+        return names.isEmpty() ? "none" : String.join(", ", names);
+    }
+
+    private static boolean validProposal(JsonObject proposal) {
+        if (proposal == null) {
+            return false;
+        }
+        return nonBlankString(proposal, "recordingPath")
+                && nonBlankString(proposal, "proposalMarkdown")
+                && proposal.has("phaseOutcomes")
+                && proposal.get("phaseOutcomes").isJsonObject()
+                && nonBlankOutcome(proposal.getAsJsonObject("phaseOutcomes"), "RECORD");
+    }
+
+    private static boolean validTerminal(JsonObject terminal) {
+        if (terminal == null
+                || !nonBlankString(terminal, "status")
+                || !terminal.has("phaseOutcomes")
+                || !terminal.get("phaseOutcomes").isJsonObject()
+                || !terminal.has("changedClasses")
+                || !terminal.get("changedClasses").isJsonArray()
+                || !terminal.has("createdClasses")
+                || !terminal.get("createdClasses").isJsonArray()
+                || !optionalString(terminal, "reportPath")) {
+            return false;
+        }
+        String status = terminal.get("status").getAsString().trim().toLowerCase(Locale.ROOT);
+        JsonArray changedClasses = terminal.getAsJsonArray("changedClasses");
+        JsonArray createdClasses = terminal.getAsJsonArray("createdClasses");
+        JsonObject phaseOutcomes = terminal.getAsJsonObject("phaseOutcomes");
+        if (!("passed".equals(status) || "failed".equals(status))
+                || !validClassNames(changedClasses)
+                || !validClassNames(createdClasses)
+                || !validPhaseOutcomes(phaseOutcomes)) {
+            return false;
+        }
+        if (!"passed".equals(status)) {
+            return true;
+        }
+        return nonBlankOutcome(phaseOutcomes, "GENERATE")
+                && nonBlankOutcome(phaseOutcomes, "REPLAY")
+                && nonBlankOutcome(phaseOutcomes, "HEAL")
+                && (!changedClasses.isEmpty() || !createdClasses.isEmpty());
+    }
+
+    private static boolean validPhaseOutcomes(JsonObject outcomes) {
+        if (outcomes.entrySet().isEmpty()) {
+            return false;
+        }
+        for (Map.Entry<String, JsonElement> outcome : outcomes.entrySet()) {
+            String phase = outcome.getKey();
+            if (!("RECORD".equals(phase) || "GENERATE".equals(phase)
+                    || "REPLAY".equals(phase) || "HEAL".equals(phase))
+                    || !nonBlankOutcome(outcomes, phase)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean nonBlankOutcome(JsonObject outcomes, String phase) {
+        return outcomes.has(phase)
+                && outcomes.get(phase).isJsonPrimitive()
+                && outcomes.get(phase).getAsJsonPrimitive().isString()
+                && !outcomes.get(phase).getAsString().isBlank();
+    }
+
+    private static boolean realCanonicalRecording(String workingDirectory) {
+        if (workingDirectory == null || workingDirectory.isBlank()) {
+            return false;
+        }
+        Path root = Path.of(workingDirectory).toAbsolutePath().normalize();
+        Path recording = root.resolve(AssistantCommand.DEFAULT_CAPTURE_RECORDING_PATH).normalize();
+        if (!recording.startsWith(root)
+                || !Files.isRegularFile(recording, LinkOption.NOFOLLOW_LINKS)
+                || Files.isSymbolicLink(recording)) {
+            return false;
+        }
+        try {
+            return recording.toRealPath().startsWith(root.toRealPath());
+        } catch (IOException | RuntimeException error) {
+            return false;
+        }
+    }
+
+    private static boolean validClassNames(JsonArray values) {
+        for (JsonElement value : values) {
+            if (!value.isJsonPrimitive()
+                    || !value.getAsJsonPrimitive().isString()
+                    || !CLASS_NAME.matcher(value.getAsString()).matches()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean nonBlankString(JsonObject object, String key) {
+        return object.has(key)
+                && object.get(key).isJsonPrimitive()
+                && object.get(key).getAsJsonPrimitive().isString()
+                && !object.get(key).getAsString().isBlank();
+    }
+
+    private static boolean optionalString(JsonObject object, String key) {
+        return !object.has(key)
+                || (object.get(key).isJsonPrimitive() && object.get(key).getAsJsonPrimitive().isString());
+    }
+
+    private static JsonObject structuredObject(String output, String prefix) {
+        if (output == null || output.isBlank()) {
+            return null;
+        }
+        String[] lines = output.split("\\R");
+        for (int index = lines.length - 1; index >= 0; index--) {
+            String line = lines[index].trim();
+            if (line.isBlank()) {
+                continue;
+            }
+            if (!line.startsWith(prefix)) {
+                return null;
+            }
+            try {
+                JsonElement parsed = JsonParser.parseString(line.substring(prefix.length()).trim());
+                return parsed.isJsonObject() ? parsed.getAsJsonObject() : null;
+            } catch (RuntimeException error) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static String configuredBaseUrl(String workingDirectory) {
+        if (workingDirectory == null || workingDirectory.isBlank()) {
+            return "";
+        }
+        Path file = Path.of(workingDirectory).resolve(CUSTOM_PROPERTIES);
+        if (!Files.isRegularFile(file)) {
+            return "";
+        }
+        Properties properties = new Properties();
+        try (Reader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        } catch (IOException | RuntimeException error) {
+            return "";
+        }
+        String candidate = properties.getProperty("baseURL", "").trim();
+        return validUrl(candidate) ? candidate : "";
+    }
+
+    private static String firstUrl(String text) {
+        Matcher matcher = URL.matcher(text == null ? "" : text);
+        if (!matcher.find()) {
+            return "";
+        }
+        String candidate = matcher.group();
+        return validUrl(candidate) ? candidate : "";
+    }
+
+    private static boolean validUrl(String candidate) {
+        if (candidate == null || candidate.isBlank()) {
+            return false;
+        }
+        try {
+            URI uri = URI.create(candidate);
+            return "file".equalsIgnoreCase(uri.getScheme())
+                    ? uri.getPath() != null && !uri.getPath().isBlank()
+                    : ("http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme()))
+                    && uri.getHost() != null;
+        } catch (IllegalArgumentException error) {
+            return false;
+        }
+    }
+
+    private static int healRetryAllowance(String scenario) {
+        Matcher matcher = HEAL_RETRY_OVERRIDE.matcher(scenario == null ? "" : scenario);
+        if (!matcher.find()) {
+            return 1;
+        }
+        int requested = Integer.parseInt(matcher.group(1));
+        return requested > 1 ? requested : 1;
+    }
+
+    private static boolean scenarioCodegen(AssistantCommand.Invocation invocation, String userText) {
+        if (invocation == null
+                || !"autobot_local_agent_run".equals(invocation.toolName())
+                || userText == null) {
+            return false;
+        }
+        return userText.stripLeading().toLowerCase(Locale.ROOT).startsWith("/codegen");
+    }
+
+    private static boolean hasCustomCommand(AssistantCommand.Invocation invocation) {
+        JsonElement command = invocation.arguments().get("command");
+        return command != null && command.isJsonArray() && !command.getAsJsonArray().isEmpty();
+    }
+
+    private static boolean supportsRecordToolSandbox(AssistantCommand.Invocation invocation) {
+        JsonElement client = invocation.arguments().get("client");
+        if (client == null || !client.isJsonPrimitive() || !client.getAsJsonPrimitive().isString()) {
+            return false;
+        }
+        String normalized = client.getAsString().trim().toUpperCase(Locale.ROOT);
+        return "CODEX".equals(normalized);
+    }
+
+    private static String scenario(String userText) {
+        String trimmed = userText == null ? "" : userText.trim();
+        return trimmed.replaceFirst("(?is)^/codegen(?:\\s+|$)", "").trim();
+    }
+
+    private static String normalizeDecision(String response) {
+        return response == null ? "" : response.trim().toLowerCase(Locale.ROOT)
+                .replaceAll("[.!]+$", "")
+                .trim();
+    }
+
+    private static boolean explicitApproval(String decision) {
+        return decision.matches("approve(?: edits)?|approved|yes(?:,? proceed)?|proceed|continue");
+    }
+
+    private static boolean explicitDenial(String decision) {
+        return decision.matches("deny|denied|no|cancel|stop");
+    }
+
+    private void terminate(String sessionId, Phase terminal) {
+        Workflow workflow = workflows.get(sessionKey(sessionId));
+        if (workflow != null && !workflow.phase.terminal()) {
+            workflow.phase = terminal;
+        }
+    }
+
+    private static String sessionKey(String sessionId) {
+        return sessionId == null || sessionId.isBlank() ? "default" : sessionId;
+    }
+
+    enum Phase {
+        IDLE,
+        AWAITING_URL,
+        RECORD,
+        AWAITING_EDIT_CONFIRMATION,
+        GENERATE,
+        REPLAY,
+        HEAL,
+        SUCCEEDED,
+        FAILED,
+        DENIED,
+        CANCELLED,
+        DISPOSED;
+
+        boolean terminal() {
+            return this == SUCCEEDED || this == FAILED || this == DENIED || this == CANCELLED || this == DISPOSED;
+        }
+
+        int mutableOrder() {
+            return switch (this) {
+                case GENERATE -> 0;
+                case REPLAY -> 1;
+                case HEAL -> 2;
+                default -> Integer.MAX_VALUE;
+            };
+        }
+    }
+
+    private static final class Workflow {
+        private final String scenario;
+        private final JsonObject baseArguments;
+        private final String routedVia;
+        private final int healRetryAllowance;
+        private String targetUrl = "";
+        private String recordingPath = "";
+        private String proposalMarkdown = "";
+        private JsonObject proposal = new JsonObject();
+        private Phase phase = Phase.IDLE;
+
+        private Workflow(
+                String scenario,
+                AssistantCommand.Invocation baseInvocation,
+                String workingDirectory) {
+            this.scenario = scenario;
+            this.baseArguments = baseInvocation.arguments().deepCopy();
+            this.baseArguments.addProperty("workingDirectory", workingDirectory == null ? "" : workingDirectory);
+            this.routedVia = baseInvocation.routedVia();
+            this.healRetryAllowance = healRetryAllowance(scenario);
+        }
+    }
+}

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantCommand.java
@@ -75,6 +75,17 @@ final class AssistantCommand {
                     Source edits are approved for this session.
                     You may apply patches, write files, and run filesystem commands needed to make the requested source changes.
                     """.stripIndent().trim();
+    private static final String AUTOBOT_SCENARIO_CODEGEN_WORKFLOW =
+            """
+                    This is an AutoBot scenario-to-recording code-generation workflow. You own every workflow action; the IntelliJ plugin only presents progress, cancellation, disposal, confirmations, and your final result.
+                    Use only negotiated SHAFT MCP capabilities. Initialize before use and shut down cleanly when this run ends. Cloud routes are forbidden; fail closed if this is not a local CLI run.
+
+                    1. Resolve target URL from the scenario first, then existing project configuration. If still absent, ask exactly one URL question before recording and do not start recording.
+                    2. Own capture_start, browser actions, capture_stop/save, project inspection, reuse planning, generation, replay, healing, and final summary. Do not ask the plugin to perform any browser, capture, generation, replay, or healing action.
+                    3. Before edits, inspect existing tests and page objects. Propose reused and new owners, preserve Page Object Model and locator guidance, and prefer stable author IDs before project conventions. Require explicit approval before any source edit or replay. Until that approval, do not write files or replay.
+                    4. After approval, make the smallest change using existing owners where possible; create a class only when required. Replay once. If it fails, analyze and make at most one heal retry unless the scenario explicitly requests more. Never weaken an assertion to heal it.
+                    5. End with a concise terminal summary: phase outcomes, changed/created classes, final status, and `allure-report/AllureReport.html` only if it exists. State absent report links honestly.
+                    """.stripIndent().trim();
     // Split out so cloudPrompt's non-code-generation branch (which has no other reason to mention
     // shaft-mcp -- cloud providers don't have it) can still ask cloud models to emit the structured
     // line (or, failing that, the fence) that AssistantQuestion looks for, without pulling in the
@@ -785,7 +796,8 @@ final class AssistantCommand {
         String liveCodegen = liveCodegenSlashPrompt(text);
         boolean upgradeAgentRequest = false;
         if (!liveCodegen.isBlank()) {
-            return Invocation.tool("capture_start", captureStart(liveCodegen))
+            return autobotScenarioCodegen(liveCodegen, selection, mode, workingDirectory, customCommand,
+                    conversationContext, attachmentsContext)
                     .withDefaultRoutedVia("slash command");
         } else if (isUpgradeSlashCommand(text) || isNaturalUpgradeIntent(text)) {
             // Upgrading is an action, not a recipe: the local agent performs the upgrade itself
@@ -865,6 +877,37 @@ final class AssistantCommand {
         arguments.add("environment", new JsonObject());
         arguments.addProperty("timeoutSeconds", DEFAULT_TIMEOUT_SECONDS);
         arguments.addProperty("allowSourceMutation", "AGENT".equals(mode) && allowSourceMutation);
+        return Invocation.tool("autobot_local_agent_run", arguments);
+    }
+
+    private static Invocation autobotScenarioCodegen(
+            String scenario,
+            Selection selection,
+            String mode,
+            String workingDirectory,
+            String customCommand,
+            String conversationContext,
+            String attachmentsContext) {
+        if (selection.cloud() || !"CLI".equals(selection.runtime())) {
+            return Invocation.local("AutoBot scenario codegen requires a Local / CLI route; cloud and non-CLI routes are unavailable.");
+        }
+        JsonObject arguments = new JsonObject();
+        arguments.addProperty("client", selection.client());
+        arguments.addProperty("mode", mode);
+        arguments.addProperty("model", selection.localModel());
+        arguments.addProperty("effort", selection.effort());
+        String prompt = AUTOBOT_SCENARIO_CODEGEN_WORKFLOW + "\n\nScenario:\n" + scenario;
+        prompt = withConversationContext(prompt, conversationContext);
+        prompt = withAttachments(prompt, attachmentsContext);
+        arguments.addProperty("prompt", "CODEX".equals(selection.family())
+                ? prompt
+                : withEffortHint(prompt, selection.effort()));
+        arguments.addProperty("workingDirectory", workingDirectory == null ? "" : workingDirectory);
+        arguments.add("command", commandArray(customCommand));
+        arguments.add("environment", new JsonObject());
+        arguments.addProperty("timeoutSeconds", DEFAULT_TIMEOUT_SECONDS);
+        // The workflow itself obtains a visible, per-change consent after it has presented reuse.
+        arguments.addProperty("allowSourceMutation", false);
         return Invocation.tool("autobot_local_agent_run", arguments);
     }
 

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -541,15 +541,20 @@ final class AssistantLocalAgentRunner {
             return custom;
         }
         boolean allowSourceMutation = allowSourceMutation(arguments);
+        boolean readOnlyCodegenRecording = booleanValue(arguments, "readOnlyCodegenRecording");
         boolean unrestrictedLocalAgentAccess = booleanValue(arguments, "unrestrictedLocalAgentAccess");
         String mode = normalize(string(arguments, "mode", "ASK"));
         String model = string(arguments, "model", "").trim();
         String effort = normalize(string(arguments, "effort", ""));
         return switch (normalize(string(arguments, "client", ""))) {
-            case "CLAUDE_CODE" -> claudeCommand(mode, allowSourceMutation, model, bridge);
+            case "CLAUDE_CODE" -> readOnlyCodegenRecording
+                    ? List.of()
+                    : claudeCommand(mode, allowSourceMutation, model, bridge);
             case "COPILOT_CLI" -> copilotCommand(mode, allowSourceMutation, model);
             case "GROK" -> grokCommand(mode, allowSourceMutation, string(arguments, "prompt", ""));
-            case "CODEX" -> codexCommand(mode, allowSourceMutation, unrestrictedLocalAgentAccess, model, effort);
+            case "CODEX" -> codexCommand(
+                    mode, allowSourceMutation, readOnlyCodegenRecording,
+                    unrestrictedLocalAgentAccess, model, effort);
             default -> List.of();
         };
     }
@@ -1131,13 +1136,36 @@ final class AssistantLocalAgentRunner {
             if (!activity.isBlank()) {
                 output.append("\n\n").append(activity);
             }
-            return output + "\n\n" + usageHolder();
+            return output + "\n\n" + usageHolder(core);
+        }
+
+        static String modelOutput(String composedOutput) {
+            if (composedOutput == null || composedOutput.isBlank()) {
+                return composedOutput;
+            }
+            int end = composedOutput.length();
+            while (end > 0 && Character.isWhitespace(composedOutput.charAt(end - 1))) {
+                end--;
+            }
+            int lineStart = composedOutput.lastIndexOf('\n', end - 1) + 1;
+            JsonObject metadata = StreamJson.parseObject(composedOutput.substring(lineStart, end).trim());
+            if (!validRunnerMetadata(metadata)) {
+                return composedOutput;
+            }
+            int modelOutputCharacters = metadata.getAsJsonObject("shaft_runner")
+                    .get("model_output_characters").getAsInt();
+            if (modelOutputCharacters < 0
+                    || modelOutputCharacters > lineStart
+                    || !composedOutput.substring(modelOutputCharacters, lineStart).startsWith("\n\n")) {
+                return composedOutput;
+            }
+            return composedOutput.substring(0, modelOutputCharacters);
         }
 
         /**
          * Detects the structured question protocol (issue #3719) in a just-captured terminal
          * answer, via {@link AssistantQuestion#detectStructuredLine}, stashing it in {@link
-         * #structuredQuestion} for {@link #usageHolder()} and returning the answer text with the
+         * #structuredQuestion} for {@link #usageHolder(String)} and returning the answer text with the
          * marker line removed. Detecting here -- at the moment the terminal event's raw text is
          * captured, before {@link #activitySummary()} or the usage/plan metadata line are appended
          * after it -- is what keeps this reliable: those later append their own trailing lines,
@@ -1156,7 +1184,7 @@ final class AssistantLocalAgentRunner {
             return detected.promptMarkdown();
         }
 
-        private JsonObject usageHolder() {
+        private JsonObject usageHolder(String core) {
             JsonObject usage = new JsonObject();
             usage.addProperty("input_tokens", StreamJson.orZero(inputTokens));
             usage.addProperty("output_tokens", StreamJson.orZero(outputTokens));
@@ -1175,7 +1203,53 @@ final class AssistantLocalAgentRunner {
                 question.add("options", options);
                 usageHolder.add("question", question);
             }
+            if (endsWithCodegenMarker(core)) {
+                JsonObject runner = new JsonObject();
+                runner.addProperty("model_output_characters", core.length());
+                usageHolder.add("shaft_runner", runner);
+            }
             return usageHolder;
+        }
+
+        private static boolean endsWithCodegenMarker(String core) {
+            String[] lines = core.split("\\R");
+            for (int index = lines.length - 1; index >= 0; index--) {
+                String line = lines[index].trim();
+                if (!line.isBlank()) {
+                    return line.startsWith(AssistantCodegenWorkflowCoordinator.PROPOSAL_PREFIX)
+                            || line.startsWith(AssistantCodegenWorkflowCoordinator.RESULT_PREFIX);
+                }
+            }
+            return false;
+        }
+
+        private static boolean validRunnerMetadata(JsonObject metadata) {
+            if (metadata == null
+                    || !metadata.has("usage")
+                    || !metadata.get("usage").isJsonObject()
+                    || !metadata.has("shaft_runner")
+                    || !metadata.get("shaft_runner").isJsonObject()) {
+                return false;
+            }
+            for (String key : metadata.keySet()) {
+                if (!"usage".equals(key) && !"plan".equals(key)
+                        && !"question".equals(key) && !"shaft_runner".equals(key)) {
+                    return false;
+                }
+            }
+            JsonObject usage = metadata.getAsJsonObject("usage");
+            JsonObject runner = metadata.getAsJsonObject("shaft_runner");
+            return usage.size() == 2
+                    && usage.has("input_tokens")
+                    && usage.get("input_tokens").isJsonPrimitive()
+                    && usage.get("input_tokens").getAsJsonPrimitive().isNumber()
+                    && usage.has("output_tokens")
+                    && usage.get("output_tokens").isJsonPrimitive()
+                    && usage.get("output_tokens").getAsJsonPrimitive().isNumber()
+                    && runner.size() == 1
+                    && runner.has("model_output_characters")
+                    && runner.get("model_output_characters").isJsonPrimitive()
+                    && runner.get("model_output_characters").getAsJsonPrimitive().isNumber();
         }
 
         /**
@@ -1293,7 +1367,7 @@ final class AssistantLocalAgentRunner {
         /**
          * Sets the terminal answer text, running it through {@link #captureStructuredQuestion} so the
          * structured-question protocol (issue #3719) is detected and stripped at the moment the raw
-         * text is captured, before {@link #activitySummary()}/{@link #usageHolder()} append their own
+         * text is captured, before {@link #activitySummary(boolean)}/{@link #usageHolder(String)} append their own
          * trailing content.
          */
         void setAnswer(String rawAnswer) {
@@ -1366,7 +1440,8 @@ final class AssistantLocalAgentRunner {
      * unrestricted recovery option; ungranted runs retain the read-only sandbox.
      */
     private static List<String> codexCommand(
-            String mode, boolean allowSourceMutation, boolean unrestrictedLocalAgentAccess,
+            String mode, boolean allowSourceMutation, boolean readOnlyCodegenRecording,
+            boolean unrestrictedLocalAgentAccess,
             String model, String effort) {
         boolean unrestrictedAgent = "AGENT".equals(mode) && allowSourceMutation && unrestrictedLocalAgentAccess;
         List<String> command = new ArrayList<>(unrestrictedAgent
@@ -1386,9 +1461,14 @@ final class AssistantLocalAgentRunner {
             command.add("AGENT".equals(mode) && allowSourceMutation ? "workspace-write" : "read-only");
         }
         if ("AGENT".equals(mode)) {
-            if (AgentApprovalCapability.CODEX.isAutoApproveGranted(allowSourceMutation)) {
+            if (AgentApprovalCapability.CODEX.isAutoApproveGranted(allowSourceMutation)
+                    || readOnlyCodegenRecording) {
                 command.add("-c");
                 command.add("mcp_servers.shaft-mcp.default_tools_approval_mode=\"approve\"");
+            }
+            if (readOnlyCodegenRecording) {
+                command.add("-c");
+                command.add("mcp_servers.shaft-mcp.enabled_tools=" + recordMcpToolsToml());
             }
             command.add("-c");
             command.add("mcp_servers.shaft-mcp.tool_timeout_sec=600");
@@ -1480,6 +1560,12 @@ final class AssistantLocalAgentRunner {
     private static void addShaftMcpAllowedTools(List<String> command) {
         command.add("--allowedTools");
         command.add("mcp__shaft-mcp");
+    }
+
+    private static String recordMcpToolsToml() {
+        return AssistantCodegenWorkflowCoordinator.recordMcpTools().stream()
+                .map(tool -> "\"" + tool + "\"")
+                .collect(java.util.stream.Collectors.joining(",", "[", "]"));
     }
 
     private static List<String> copilotCommand(String mode, boolean allowSourceMutation, String model) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/AssistantLocalAgentRunner.java
@@ -1224,29 +1224,41 @@ final class AssistantLocalAgentRunner {
         }
 
         private static boolean validRunnerMetadata(JsonObject metadata) {
-            if (metadata == null
-                    || !metadata.has("usage")
-                    || !metadata.get("usage").isJsonObject()
-                    || !metadata.has("shaft_runner")
-                    || !metadata.get("shaft_runner").isJsonObject()) {
+            if (!validRunnerMetadataShape(metadata) || !validRunnerMetadataKeys(metadata)) {
                 return false;
-            }
-            for (String key : metadata.keySet()) {
-                if (!"usage".equals(key) && !"plan".equals(key)
-                        && !"question".equals(key) && !"shaft_runner".equals(key)) {
-                    return false;
-                }
             }
             JsonObject usage = metadata.getAsJsonObject("usage");
             JsonObject runner = metadata.getAsJsonObject("shaft_runner");
+            return validUsageMetadata(usage) && validModelOutputMetadata(runner);
+        }
+
+        private static boolean validRunnerMetadataShape(JsonObject metadata) {
+            return metadata != null
+                    && metadata.has("usage")
+                    && metadata.get("usage").isJsonObject()
+                    && metadata.has("shaft_runner")
+                    && metadata.get("shaft_runner").isJsonObject();
+        }
+
+        private static boolean validRunnerMetadataKeys(JsonObject metadata) {
+            return metadata.keySet().stream().allMatch(key -> "usage".equals(key)
+                    || "plan".equals(key)
+                    || "question".equals(key)
+                    || "shaft_runner".equals(key));
+        }
+
+        private static boolean validUsageMetadata(JsonObject usage) {
             return usage.size() == 2
                     && usage.has("input_tokens")
                     && usage.get("input_tokens").isJsonPrimitive()
                     && usage.get("input_tokens").getAsJsonPrimitive().isNumber()
                     && usage.has("output_tokens")
                     && usage.get("output_tokens").isJsonPrimitive()
-                    && usage.get("output_tokens").getAsJsonPrimitive().isNumber()
-                    && runner.size() == 1
+                    && usage.get("output_tokens").getAsJsonPrimitive().isNumber();
+        }
+
+        private static boolean validModelOutputMetadata(JsonObject runner) {
+            return runner.size() == 1
                     && runner.has("model_output_characters")
                     && runner.get("model_output_characters").isJsonPrimitive()
                     && runner.get("model_output_characters").getAsJsonPrimitive().isNumber();
@@ -1565,7 +1577,7 @@ final class AssistantLocalAgentRunner {
     private static String recordMcpToolsToml() {
         return AssistantCodegenWorkflowCoordinator.recordMcpTools().stream()
                 .map(tool -> "\"" + tool + "\"")
-                .collect(java.util.stream.Collectors.joining(",", "[", "]"));
+                .collect(Collectors.joining(",", "[", "]"));
     }
 
     private static List<String> copilotCommand(String mode, boolean allowSourceMutation, String model) {

--- a/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
+++ b/shaft-intellij/src/main/java/com/shaft/intellij/ui/ShaftAssistantPanel.java
@@ -170,6 +170,8 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
     // one process-wide flag (issue #3591 item 3).
     private final String recordingKey = "assistant#" + Integer.toHexString(System.identityHashCode(this));
     private final ShaftAssistantChatState chatState;
+    private final AssistantCodegenWorkflowCoordinator codegenCoordinator;
+    private String activeCodegenSessionId = "";
     private final JComboBox<ShaftAssistantChatState.Session> chatSelector;
     private final JButton newChat;
     private final JComboBox<String> mode;
@@ -447,6 +449,7 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
         this.project = project;
         this.settings = settings;
         this.chatState = chatState;
+        this.codegenCoordinator = AssistantCodegenWorkflowCoordinator.getInstance(project);
         this.configureFlow = setupFlow;
         this.apiKeySaver = apiKeySaver;
         setBorder(JBUI.Borders.empty(12));
@@ -1581,6 +1584,21 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
                 openFileContext(project),
                 conversationContext,
                 attachmentsContext);
+        String codegenSessionId = chatState.activeSession().id;
+        AssistantCodegenWorkflowCoordinator.Phase codegenPhase = codegenCoordinator.phase(codegenSessionId);
+        boolean continuingCodegen = codegenPhase == AssistantCodegenWorkflowCoordinator.Phase.AWAITING_URL
+                || codegenPhase == AssistantCodegenWorkflowCoordinator.Phase.AWAITING_EDIT_CONFIRMATION;
+        boolean startingCodegen = "autobot_local_agent_run".equals(invocation.toolName())
+                && text.stripLeading().toLowerCase(Locale.ROOT).startsWith("/codegen");
+        boolean codegenWorkflowInvocation = continuingCodegen || startingCodegen;
+        if (codegenWorkflowInvocation) {
+            invocation = codegenCoordinator.route(
+                    codegenSessionId,
+                    text,
+                    continuingCodegen ? null : invocation,
+                    workingDirectory);
+            activeCodegenSessionId = codegenSessionId;
+        }
         if ("autobot_local_agent_run".equals(invocation.toolName())) {
             invocation.arguments().addProperty("unrestrictedLocalAgentAccess",
                     unrestrictedLocalAgentAccess.isSelected());
@@ -1604,7 +1622,10 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
         // rendered/persisted, never the actual invocation (built from `text` directly at
         // AssistantCommand.fromPrompt() above), so this never changes agent behavior.
         append("user", text, "");
-        if (!approvingCaptureReview && AssistantCommand.requiresAgentModeForMcp(text, selectedMode, invocation)) {
+        String invocationMode = invocation.arguments().has("mode")
+                ? invocation.arguments().get("mode").getAsString()
+                : selectedMode;
+        if (!approvingCaptureReview && AssistantCommand.requiresAgentModeForMcp(text, invocationMode, invocation)) {
             setRunning(false, "Switch to Agent mode");
             showGateConfirmation(
                     project,
@@ -1616,6 +1637,7 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
         }
         if (agentMode
                 && !approvingCaptureReview
+                && !codegenWorkflowInvocation
                 && requiresSourceEditApprovalBeforeSend(
                         agentMode,
                         route.cloud(),
@@ -1652,6 +1674,9 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
         }
         if (invocation.isLocal()) {
             showLocalResponse(invocation.localResponse());
+            if (codegenWorkflowInvocation) {
+                setStatus(codegenCoordinator.status(codegenSessionId));
+            }
             return;
         }
         if (requiresMcpSetup(invocation, mcpConfigured())) {
@@ -2353,6 +2378,20 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
             localAgentOutputCoalescer.flush();
         }
         boolean cancelled = error instanceof CancellationException;
+        AssistantCodegenWorkflowCoordinator.Phase completingCodegenPhase =
+                codegenCoordinator.phase(activeCodegenSessionId);
+        boolean completingCodegen = completingCodegenPhase == AssistantCodegenWorkflowCoordinator.Phase.RECORD
+                || completingCodegenPhase == AssistantCodegenWorkflowCoordinator.Phase.GENERATE
+                || completingCodegenPhase == AssistantCodegenWorkflowCoordinator.Phase.REPLAY
+                || completingCodegenPhase == AssistantCodegenWorkflowCoordinator.Phase.HEAL;
+        if (cancelled && completingCodegen) {
+            codegenCoordinator.cancel(activeCodegenSessionId);
+        } else if (completingCodegen) {
+            result = codegenCoordinator.complete(
+                    activeCodegenSessionId,
+                    result,
+                    project == null || project.getBasePath() == null ? "" : project.getBasePath());
+        }
         // Snapshot before setRunning(false, ...) clears killRequested for the next run.
         boolean killed = cancelled && killRequested;
         boolean success = error == null && result != null && result.success();
@@ -2405,6 +2444,10 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
             return;
         }
         showAgentToolResult(streamToken, currentStream, success, result, error, captureIntegrationRun, partialOutput);
+        String codegenStatus = completingCodegen ? codegenCoordinator.status(activeCodegenSessionId) : "";
+        if (!codegenStatus.isBlank()) {
+            setStatus(codegenStatus);
+        }
     }
 
     private boolean handleKilledOrStaleAgentStream(int streamToken) {
@@ -2687,6 +2730,13 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
         // never reach localAgentOutput (the Verbose/Killed raw-buffer source) or a transcript bubble.
         boolean rawPassthrough = line != null && line.startsWith(AssistantLocalAgentRunner.RAW_STDOUT_MARKER);
         String content = rawPassthrough ? line.substring(AssistantLocalAgentRunner.RAW_STDOUT_MARKER.length()) : line;
+        AssistantCodegenWorkflowCoordinator.Phase codegenPhase =
+                codegenCoordinator.progress(activeCodegenSessionId, content);
+        if (codegenPhase == AssistantCodegenWorkflowCoordinator.Phase.GENERATE
+                || codegenPhase == AssistantCodegenWorkflowCoordinator.Phase.REPLAY
+                || codegenPhase == AssistantCodegenWorkflowCoordinator.Phase.HEAL) {
+            setStatus(codegenCoordinator.status(activeCodegenSessionId));
+        }
         if (localAgentOutput.length() > 0) {
             localAgentOutput.append("\n");
         }
@@ -3164,10 +3214,17 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
             future.complete(LocalAgentApprovalBridge.Decision.deny("The Assistant run has ended."));
             return;
         }
-        // SHAFT's own MCP tools are first-party Assistant capabilities and are always allowed.
-        // The command line already pre-approves them via --allowedTools, so this is defense in
-        // depth for CLI versions or configurations where that flag does not take effect.
+        // The read-only AutoBot RECORD invocation gets only browser/capture tools. In particular,
+        // generate/replay/heal stay unavailable until the user approves the mutable invocation.
         if (isShaftMcpTool(toolName)) {
+            if (codegenCoordinator.phase(activeCodegenSessionId)
+                    == AssistantCodegenWorkflowCoordinator.Phase.RECORD
+                    && !codegenCoordinator.allowsRecordMcpTool(activeCodegenSessionId, toolName)) {
+                appendAgentMilestone("Blocked SHAFT tool before edit confirmation: " + toolName);
+                future.complete(LocalAgentApprovalBridge.Decision.deny(
+                        "This SHAFT tool is unavailable until AutoBot edit confirmation."));
+                return;
+            }
             appendAgentMilestone("Auto-approved SHAFT tool: " + toolName);
             future.complete(LocalAgentApprovalBridge.Decision.allow());
             return;
@@ -3604,6 +3661,7 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
         if (invocation != null) {
             invocation.kill();
         }
+        codegenCoordinator.disposeSession(activeCodegenSessionId);
     }
 
     /**
@@ -5118,6 +5176,7 @@ final class ShaftAssistantPanel extends JPanel implements Disposable {
 
     private void cancelOrKillCurrent() {
         if (currentInvocation != null) {
+            codegenCoordinator.cancel(activeCodegenSessionId);
             if (cancelRequested) {
                 killRequested = true;
                 stopLocalAgentStreaming();

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinatorTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinatorTest.java
@@ -117,7 +117,7 @@ class AssistantCodegenWorkflowCoordinatorTest {
                 .setText("/codegen visit https://example.com");
 
         Method send = ShaftAssistantPanel.class.getDeclaredMethod("send", com.intellij.openapi.project.Project.class);
-        send.setAccessible(true);
+        send.setAccessible(true); // NOPMD - invokes the real panel send path for this integration test
         send.invoke(panel, new Object[]{null});
 
         Object panelCoordinator = fieldValue(panel, "codegenCoordinator");
@@ -341,13 +341,13 @@ class AssistantCodegenWorkflowCoordinatorTest {
         ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
         Field coordinatorField = findField(ShaftAssistantPanel.class, "codegenCoordinator");
         assertNotNull(coordinatorField, "panel must retain its workflow coordinator");
-        coordinatorField.setAccessible(true);
+        coordinatorField.setAccessible(true); // NOPMD - test-only inspection of the panel-owned coordinator
         Object panelCoordinator = coordinatorField.get(panel);
         route(panelCoordinator, "panel-session", "/codegen visit https://example.com",
                 codegen("/codegen visit https://example.com"));
         Field sessionField = findField(ShaftAssistantPanel.class, "activeCodegenSessionId");
         assertNotNull(sessionField, "panel must identify the workflow session it owns");
-        sessionField.setAccessible(true);
+        sessionField.setAccessible(true); // NOPMD - test-only setup of the panel-owned workflow session
         sessionField.set(panel, "panel-session");
         panel.dispose();
 
@@ -668,7 +668,7 @@ class AssistantCodegenWorkflowCoordinatorTest {
     private static void showAgentResult(ShaftAssistantPanel panel, ShaftMcpToolResult result) throws Exception {
         Method method = ShaftAssistantPanel.class.getDeclaredMethod(
                 "showAgentResult", ShaftMcpToolResult.class, Throwable.class);
-        method.setAccessible(true);
+        method.setAccessible(true); // NOPMD - invokes the real asynchronous completion target in this integration test
         method.invoke(panel, result, null);
     }
 
@@ -737,14 +737,14 @@ class AssistantCodegenWorkflowCoordinatorTest {
             return null;
         }
         Constructor<?> constructor = type.getDeclaredConstructor();
-        constructor.setAccessible(true);
+        constructor.setAccessible(true); // NOPMD - test-only construction of the package-private coordinator seam
         return constructor.newInstance();
     }
 
     private static Object invoke(Object target, String name, Class<?>[] parameterTypes, Object... arguments)
             throws Exception {
         Method method = target.getClass().getDeclaredMethod(name, parameterTypes);
-        method.setAccessible(true);
+        method.setAccessible(true); // NOPMD - test-only invocation of package-private coordinator behavior
         return method.invoke(target, arguments);
     }
 
@@ -758,13 +758,13 @@ class AssistantCodegenWorkflowCoordinatorTest {
 
     private static Object fieldValue(Object target, String name) throws Exception {
         Field field = target.getClass().getDeclaredField(name);
-        field.setAccessible(true);
+        field.setAccessible(true); // NOPMD - test-only field inspection through the established helper
         return field.get(target);
     }
 
     private static void setField(Object target, String name, Object value) throws Exception {
         Field field = target.getClass().getDeclaredField(name);
-        field.setAccessible(true);
+        field.setAccessible(true); // NOPMD - test-only field injection through the established helper
         field.set(target, value);
     }
 

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinatorTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinatorTest.java
@@ -1,0 +1,811 @@
+package com.shaft.intellij.ui;
+
+import com.google.gson.JsonObject;
+import com.shaft.intellij.mcp.ShaftMcpToolResult;
+import com.shaft.intellij.settings.ShaftSettingsState;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class AssistantCodegenWorkflowCoordinatorTest {
+    private static final String COORDINATOR =
+            "com.shaft.intellij.ui.AssistantCodegenWorkflowCoordinator";
+
+    @TempDir
+    Path projectRoot;
+
+    @Test
+    void scenarioUrlWinsOverConfiguredBaseUrlAndStartsReadOnlyRecord() throws Exception {
+        writeConfiguredBaseUrl("https://configured.example");
+        Object coordinator = coordinator();
+        AssistantCommand.Invocation invocation = route(
+                coordinator,
+                "url-precedence",
+                "/codegen visit https://scenario.example/login and sign in",
+                codegen("/codegen visit https://scenario.example/login and sign in"));
+
+        assertAll(
+                () -> assertEquals("RECORD", phase(coordinator, "url-precedence")),
+                () -> assertEquals("autobot_local_agent_run", invocation.toolName()),
+                () -> assertFalse(invocation.arguments().get("allowSourceMutation").getAsBoolean()),
+                () -> assertFalse(invocation.arguments().has("targetUrl"),
+                        "plugin must pass the URL in AutoBot state, not own browser orchestration"),
+                () -> assertTrue(invocation.arguments().get("prompt").getAsString()
+                        .contains("\"targetUrl\":\"https://scenario.example/login\"")),
+                () -> assertFalse(invocation.arguments().get("prompt").getAsString()
+                        .contains("\"targetUrl\":\"https://configured.example\"")),
+                () -> assertTrue(invocation.arguments().get("prompt").getAsString()
+                        .contains("SHAFT_CODEGEN_PROPOSAL")));
+    }
+
+    @Test
+    void codexRecordLaunchAllowsOnlyBrowserCaptureMcpToolsInReadOnlySandbox() throws Exception {
+        Object coordinator = coordinator();
+        AssistantCommand.Invocation invocation = route(
+                coordinator,
+                "codex-record-tools",
+                "/codegen visit https://example.com and submit the form",
+                codegen("/codegen visit https://example.com and submit the form"));
+
+        List<String> command = AssistantLocalAgentRunner.commandFor(invocation.arguments());
+        String enabledTools = command.stream()
+                .filter(value -> value.startsWith("mcp_servers.shaft-mcp.enabled_tools="))
+                .findFirst()
+                .orElse("");
+
+        assertAll(
+                () -> assertTrue(command.contains("read-only"), command.toString()),
+                () -> assertTrue(command.contains("mcp_servers.shaft-mcp.default_tools_approval_mode=\"approve\""),
+                        command.toString()),
+                () -> assertTrue(enabledTools.contains("capture_start"), enabledTools),
+                () -> assertTrue(enabledTools.contains("capture_stop"), enabledTools),
+                () -> assertTrue(enabledTools.contains("element_click"), enabledTools),
+                () -> assertFalse(enabledTools.contains("capture_generate_replay"), enabledTools));
+    }
+
+    @Test
+    void recordForcesAgentModeEvenWhenPanelWasInAskMode() throws Exception {
+        String request = "/codegen visit https://example.com";
+        AssistantCommand.Invocation askMode = AssistantCommand.fromPrompt(
+                request,
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "ASK",
+                projectRoot.toString(),
+                "",
+                false);
+
+        AssistantCommand.Invocation invocation = route(
+                coordinator(), "ask-mode-record", request, askMode);
+
+        assertAll(
+                () -> assertEquals("AGENT", invocation.arguments().get("mode").getAsString()),
+                () -> assertFalse(invocation.arguments().get("allowSourceMutation").getAsBoolean()),
+                () -> assertTrue(AssistantLocalAgentRunner.commandFor(invocation.arguments()).contains("read-only")));
+    }
+
+    @Test
+    void panelAskSelectionLaunchesCoordinatorForcedAgentInvocationWithoutOrphaningRecord() throws Exception {
+        ShaftSettingsState.Settings settings = blankMcpSettings();
+        settings.assistantFamily = "CODEX";
+        settings.defaultAutobotClient = "CODEX";
+        settings.defaultAutobotMode = "ASK";
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, settings);
+        CountDownLatch launchAttempted = new CountDownLatch(1);
+        setField(panel, "localAgentProcessLauncher",
+                (AssistantLocalAgentRunner.ProcessLauncher) (command, directory, environment) -> {
+                    launchAttempted.countDown();
+                    throw new java.io.IOException("test launcher");
+                });
+        setField(panel, "requireLocalAgentCommandAvailable", false);
+        ((javax.swing.JTextArea) fieldValue(panel, "prompt"))
+                .setText("/codegen visit https://example.com");
+
+        Method send = ShaftAssistantPanel.class.getDeclaredMethod("send", com.intellij.openapi.project.Project.class);
+        send.setAccessible(true);
+        send.invoke(panel, new Object[]{null});
+
+        Object panelCoordinator = fieldValue(panel, "codegenCoordinator");
+        String sessionId = ((ShaftAssistantChatState) fieldValue(panel, "chatState")).activeSession().id;
+        assertAll(
+                () -> assertTrue(launchAttempted.await(2, TimeUnit.SECONDS),
+                        "the coordinator-forced AGENT invocation must pass the panel's MCP preflight"),
+                () -> assertEquals("ASK", ((javax.swing.JComboBox<?>) fieldValue(panel, "mode")).getSelectedItem()),
+                () -> assertEquals("RECORD", phase(panelCoordinator, sessionId)),
+                () -> assertNotNull(fieldValue(panel, "currentInvocation"),
+                        "accepted RECORD work must retain a cancellable invocation"));
+        panel.dispose();
+    }
+
+    @Test
+    void clientWithoutEnforceableRecordToolSandboxFailsClosed() throws Exception {
+        String request = "/codegen visit https://example.com";
+        AssistantCommand.Invocation unsupported = AssistantCommand.fromPrompt(
+                request,
+                AssistantCommand.Selection.local("GROK", "CLI"),
+                "AGENT",
+                projectRoot.toString(),
+                "",
+                false);
+        Object coordinator = coordinator();
+
+        AssistantCommand.Invocation invocation = route(
+                coordinator, "unsupported-record-client", request, unsupported);
+
+        assertAll(
+                () -> assertTrue(invocation.isLocal()),
+                () -> assertTrue(invocation.localResponse().contains("cannot enforce")),
+                () -> assertEquals("IDLE", phase(coordinator, "unsupported-record-client")));
+    }
+
+    @Test
+    void claudeRecordClientFailsClosedWithActionableCodexGuidance() throws Exception {
+        String request = "/codegen visit https://example.com";
+        AssistantCommand.Invocation claude = AssistantCommand.fromPrompt(
+                request, "CLAUDE_CODE", "AGENT", projectRoot.toString(), "", false);
+        Object coordinator = coordinator();
+
+        AssistantCommand.Invocation invocation = route(
+                coordinator, "claude-record-client", request, claude);
+
+        assertAll(
+                () -> assertTrue(invocation.isLocal()),
+                () -> assertTrue(invocation.localResponse().contains("Codex CLI"), invocation.localResponse()),
+                () -> assertTrue(invocation.localResponse().contains("cannot enforce"), invocation.localResponse()),
+                () -> assertEquals("IDLE", phase(coordinator, "claude-record-client")));
+    }
+
+    @Test
+    void recordToolPolicyBlocksGenerationAndReplayBeforeConsent() throws Exception {
+        Object coordinator = coordinator();
+        route(coordinator, "record-tool-policy", "/codegen visit https://example.com",
+                codegen("/codegen visit https://example.com"));
+
+        boolean captureAllowed = (boolean) invoke(
+                coordinator,
+                "allowsRecordMcpTool",
+                new Class<?>[]{String.class, String.class},
+                "record-tool-policy",
+                "mcp__shaft-mcp__capture_start");
+        boolean clickAllowed = (boolean) invoke(
+                coordinator,
+                "allowsRecordMcpTool",
+                new Class<?>[]{String.class, String.class},
+                "record-tool-policy",
+                "mcp__shaft-mcp__element_click");
+        boolean generateAllowed = (boolean) invoke(
+                coordinator,
+                "allowsRecordMcpTool",
+                new Class<?>[]{String.class, String.class},
+                "record-tool-policy",
+                "mcp__shaft-mcp__capture_generate_replay");
+
+        assertAll(
+                () -> assertTrue(captureAllowed),
+                () -> assertTrue(clickAllowed),
+                () -> assertFalse(generateAllowed));
+    }
+
+    @Test
+    void configuredBaseUrlStartsRecordWhenScenarioHasNoUrl() throws Exception {
+        writeConfiguredBaseUrl("https://configured.example/base");
+        Object coordinator = coordinator();
+        AssistantCommand.Invocation invocation = route(
+                coordinator,
+                "configured-url",
+                "/codegen sign in and verify the dashboard",
+                codegen("/codegen sign in and verify the dashboard"));
+
+        assertAll(
+                () -> assertEquals("RECORD", phase(coordinator, "configured-url")),
+                () -> assertTrue(invocation.arguments().get("prompt").getAsString()
+                        .contains("\"targetUrl\":\"https://configured.example/base\"")),
+                () -> assertFalse(invocation.arguments().get("allowSourceMutation").getAsBoolean()));
+    }
+
+    @Test
+    void missingUrlAsksOnceThenEitherStartsOrTerminates() throws Exception {
+        Object startsAfterAnswer = coordinator();
+        AssistantCommand.Invocation question = route(
+                startsAfterAnswer,
+                "url-answer",
+                "/codegen sign in and verify the dashboard",
+                codegen("/codegen sign in and verify the dashboard"));
+        AssistantCommand.Invocation record = route(
+                startsAfterAnswer,
+                "url-answer",
+                "https://answer.example/login",
+                null);
+
+        Object rejectsRepeatedMissing = coordinator();
+        route(rejectsRepeatedMissing, "url-missing", "/codegen verify dashboard",
+                codegen("/codegen verify dashboard"));
+        AssistantCommand.Invocation terminal = route(
+                rejectsRepeatedMissing,
+                "url-missing",
+                "use the normal environment",
+                null);
+        AssistantCommand.Invocation lateAnswer = route(
+                rejectsRepeatedMissing,
+                "url-missing",
+                "https://too-late.example",
+                null);
+
+        assertAll(
+                () -> assertEquals("What URL should AutoBot record?", question.localResponse()),
+                () -> assertEquals("RECORD", phase(startsAfterAnswer, "url-answer")),
+                () -> assertEquals("autobot_local_agent_run", record.toolName()),
+                () -> assertTrue(record.arguments().get("prompt").getAsString()
+                        .contains("\"targetUrl\":\"https://answer.example/login\"")),
+                () -> assertEquals("FAILED", phase(rejectsRepeatedMissing, "url-missing")),
+                () -> assertTrue(terminal.isLocal()),
+                () -> assertFalse(terminal.localResponse().contains("What URL"),
+                        "the second missing answer must terminate instead of asking indefinitely"),
+                () -> assertTrue(lateAnswer.isLocal()),
+                () -> assertFalse(lateAnswer.arguments().has("allowSourceMutation")));
+    }
+
+    @Test
+    void proposalRequiresExplicitApprovalBeforeMutableSecondRun() throws Exception {
+        Object coordinator = coordinator();
+        startAndCompleteProposal(coordinator, "approval", "/codegen visit https://example.com and log in");
+
+        AssistantCommand.Invocation unrelated = route(coordinator, "approval", "looks reasonable", null);
+        AssistantCommand.Invocation approved = route(coordinator, "approval", "approve edits", null);
+
+        assertAll(
+                () -> assertTrue(unrelated.isLocal(), "non-explicit consent must not launch a process"),
+                () -> assertEquals("GENERATE", phase(coordinator, "approval")),
+                () -> assertEquals("autobot_local_agent_run", approved.toolName()),
+                () -> assertTrue(approved.arguments().get("allowSourceMutation").getAsBoolean()),
+                () -> assertEquals(1, approved.arguments().get("healRetryAllowance").getAsInt()),
+                () -> assertTrue(approved.arguments().get("prompt").getAsString()
+                        .contains("\"recordingPath\":\"recordings/intellij-capture.json\"")),
+                () -> assertTrue(approved.arguments().get("prompt").getAsString()
+                        .contains("\"healRetryAllowance\":1")));
+    }
+
+    @Test
+    void mutableRunProgressUpdatesGenerateReplayAndHealState() throws Exception {
+        Object coordinator = coordinator();
+        startAndCompleteProposal(coordinator, "progress", "/codegen visit https://example.com");
+        route(coordinator, "progress", "approve", null);
+
+        invoke(coordinator, "progress", new Class<?>[]{String.class, String.class},
+                "progress", "SHAFT_CODEGEN_PROGRESS {\"phase\":\"REPLAY\"}");
+        String replay = phase(coordinator, "progress");
+        invoke(coordinator, "progress", new Class<?>[]{String.class, String.class},
+                "progress", "SHAFT_CODEGEN_PROGRESS {\"phase\":\"HEAL\"}");
+
+        assertAll(
+                () -> assertEquals("REPLAY", replay),
+                () -> assertEquals("HEAL", phase(coordinator, "progress")));
+    }
+
+    @Test
+    void denialEndsAtProposalWithoutMutableInvocation() throws Exception {
+        Object coordinator = coordinator();
+        startAndCompleteProposal(coordinator, "denial", "/codegen visit https://example.com");
+
+        AssistantCommand.Invocation denied = route(coordinator, "denial", "deny", null);
+        AssistantCommand.Invocation laterApproval = route(coordinator, "denial", "approve", null);
+
+        assertAll(
+                () -> assertEquals("DENIED", phase(coordinator, "denial")),
+                () -> assertTrue(denied.isLocal()),
+                () -> assertFalse(denied.arguments().has("allowSourceMutation")),
+                () -> assertTrue(laterApproval.isLocal()),
+                () -> assertFalse(laterApproval.arguments().has("allowSourceMutation")));
+    }
+
+    @Test
+    void explicitHealOverrideIsNarrowAndDoesNotInheritHealerDefault() throws Exception {
+        Object defaultCoordinator = coordinator();
+        startAndCompleteProposal(defaultCoordinator, "default-retry",
+                "/codegen visit https://example.com and retry failed steps");
+        AssistantCommand.Invocation defaultMutable = route(defaultCoordinator, "default-retry", "approve", null);
+
+        Object overrideCoordinator = coordinator();
+        startAndCompleteProposal(overrideCoordinator, "override-retry",
+                "/codegen visit https://example.com; allow 3 heal retries");
+        AssistantCommand.Invocation overrideMutable = route(overrideCoordinator, "override-retry", "approve", null);
+
+        assertAll(
+                () -> assertEquals(1, defaultMutable.arguments().get("healRetryAllowance").getAsInt()),
+                () -> assertEquals(3, overrideMutable.arguments().get("healRetryAllowance").getAsInt()));
+    }
+
+    @Test
+    void cancelAndPanelDisposalMakeWorkflowTerminal() throws Exception {
+        Object cancelledCoordinator = coordinator();
+        route(cancelledCoordinator, "cancelled", "/codegen visit https://example.com",
+                codegen("/codegen visit https://example.com"));
+        invoke(cancelledCoordinator, "cancel", new Class<?>[]{String.class}, "cancelled");
+        AssistantCommand.Invocation afterCancel = route(cancelledCoordinator, "cancelled", "approve", null);
+
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        Field coordinatorField = findField(ShaftAssistantPanel.class, "codegenCoordinator");
+        assertNotNull(coordinatorField, "panel must retain its workflow coordinator");
+        coordinatorField.setAccessible(true);
+        Object panelCoordinator = coordinatorField.get(panel);
+        route(panelCoordinator, "panel-session", "/codegen visit https://example.com",
+                codegen("/codegen visit https://example.com"));
+        Field sessionField = findField(ShaftAssistantPanel.class, "activeCodegenSessionId");
+        assertNotNull(sessionField, "panel must identify the workflow session it owns");
+        sessionField.setAccessible(true);
+        sessionField.set(panel, "panel-session");
+        panel.dispose();
+
+        assertAll(
+                () -> assertEquals("CANCELLED", phase(cancelledCoordinator, "cancelled")),
+                () -> assertTrue(afterCancel.isLocal()),
+                () -> assertFalse(afterCancel.arguments().has("allowSourceMutation")),
+                () -> assertEquals("DISPOSED", phase(panelCoordinator, "panel-session")));
+    }
+
+    @Test
+    void terminalSummaryUsesStructuredOutcomesAndOnlyLinksARealReport() throws Exception {
+        Object withReport = coordinator();
+        startAndCompleteProposal(withReport, "with-report", "/codegen visit https://example.com");
+        route(withReport, "with-report", "approve", null);
+        Path report = projectRoot.resolve("allure-report/AllureReport.html");
+        Files.createDirectories(report.getParent());
+        Files.writeString(report, "report");
+        ShaftMcpToolResult linked = complete(withReport, "with-report", terminalResult(true));
+
+        Files.delete(report);
+        Object withoutReport = coordinator();
+        startAndCompleteProposal(withoutReport, "without-report", "/codegen visit https://example.com");
+        route(withoutReport, "without-report", "approve", null);
+        ShaftMcpToolResult unlinked = complete(withoutReport, "without-report", terminalResult(true));
+
+        assertAll(
+                () -> assertEquals("SUCCEEDED", phase(withReport, "with-report")),
+                () -> assertTrue(linked.output().contains("RECORD: passed")),
+                () -> assertTrue(linked.output().contains("Changed classes: `LoginPage`")),
+                () -> assertTrue(linked.output().contains("Created classes: `LoginTest`")),
+                () -> assertTrue(linked.output().contains("allure-report/AllureReport.html")),
+                () -> assertEquals("SUCCEEDED", phase(withoutReport, "without-report")),
+                () -> assertFalse(unlinked.output().contains("AllureReport.html"),
+                        "a model claim must never fabricate a report link when the file is absent"));
+    }
+
+    @Test
+    void malformedProposalFailsClosedAtStructuredBoundary() throws Exception {
+        Object coordinator = coordinator();
+        route(coordinator, "bad-proposal", "/codegen visit https://example.com",
+                codegen("/codegen visit https://example.com"));
+
+        ShaftMcpToolResult completed = complete(
+                coordinator,
+                "bad-proposal",
+                ShaftMcpToolResult.success("recorded, trust me"));
+
+        assertAll(
+                () -> assertEquals("FAILED", phase(coordinator, "bad-proposal")),
+                () -> assertFalse(completed.success()),
+                () -> assertTrue(completed.output().contains("structured proposal")));
+    }
+
+    @Test
+    void proposalBoundaryMustBeTheFinalNonBlankLine() throws Exception {
+        Object coordinator = coordinator();
+        String request = "/codegen visit https://example.com";
+        route(coordinator, "proposal-boundary", request, codegen(request));
+
+        ShaftMcpToolResult completed = complete(
+                coordinator,
+                "proposal-boundary",
+                ShaftMcpToolResult.success("SHAFT_CODEGEN_PROPOSAL " + proposalJson() + "\nmore prose"));
+
+        assertAll(
+                () -> assertFalse(completed.success()),
+                () -> assertEquals("FAILED", phase(coordinator, "proposal-boundary")));
+    }
+
+    @Test
+    void runnerComposedProposalMetadataStillReachesEditConfirmation() throws Exception {
+        Object coordinator = coordinator();
+        String sessionId = "runner-composed-proposal";
+        String request = "/codegen visit https://example.com";
+        route(coordinator, sessionId, request, codegen(request));
+
+        Path recording = projectRoot.resolve("recordings/intellij-capture.json");
+        Files.createDirectories(recording.getParent());
+        Files.writeString(recording, "{}");
+        AssistantLocalAgentRunner.StructuredStreamParser parser =
+                new AssistantLocalAgentRunner.StructuredStreamParser(
+                        AssistantLocalAgentRunner.StructuredStreamParser.Format.CODEX);
+        JsonObject usage = new JsonObject();
+        usage.addProperty("input_tokens", 7);
+        usage.addProperty("output_tokens", 3);
+        JsonObject terminalEvent = new JsonObject();
+        terminalEvent.addProperty("type", "turn.completed");
+        terminalEvent.addProperty("last_agent_message",
+                "Recording saved.\nSHAFT_CODEGEN_PROPOSAL " + proposalJson());
+        terminalEvent.add("usage", usage);
+        parser.accept(terminalEvent.toString(), ignored -> { });
+
+        ShaftMcpToolResult completed = complete(
+                coordinator, sessionId, ShaftMcpToolResult.success(parser.finalOutput()));
+
+        assertAll(
+                () -> assertTrue(completed.success(), completed.output()),
+                () -> assertEquals("AWAITING_EDIT_CONFIRMATION", phase(coordinator, sessionId)),
+                () -> assertTrue(completed.output().contains("Reuse `LoginPage`")));
+    }
+
+    @Test
+    void runnerComposedTerminalResultWithActivityReachesSucceeded() throws Exception {
+        Object coordinator = coordinator();
+        String sessionId = "runner-composed-result";
+        String request = "/codegen visit https://example.com";
+        startAndCompleteProposal(coordinator, sessionId, request);
+        route(coordinator, sessionId, "approve", null);
+
+        AssistantLocalAgentRunner.StructuredStreamParser parser =
+                new AssistantLocalAgentRunner.StructuredStreamParser(
+                        AssistantLocalAgentRunner.StructuredStreamParser.Format.CODEX);
+        parser.accept("{\"type\":\"item.completed\",\"item\":{\"type\":\"file_change\","
+                        + "\"status\":\"completed\",\"changes\":[{\"path\":\"src/test/java/LoginTest.java\","
+                        + "\"kind\":\"add\"}]}}",
+                ignored -> { });
+        JsonObject usage = new JsonObject();
+        usage.addProperty("input_tokens", 11);
+        usage.addProperty("output_tokens", 5);
+        JsonObject terminalEvent = new JsonObject();
+        terminalEvent.addProperty("type", "turn.completed");
+        terminalEvent.addProperty("last_agent_message", terminalResult(true).output());
+        terminalEvent.add("usage", usage);
+        parser.accept(terminalEvent.toString(), ignored -> { });
+
+        ShaftMcpToolResult completed = complete(
+                coordinator, sessionId, ShaftMcpToolResult.success(parser.finalOutput()));
+
+        assertAll(
+                () -> assertTrue(completed.success(), completed.output()),
+                () -> assertEquals("SUCCEEDED", phase(coordinator, sessionId)),
+                () -> assertTrue(completed.output().contains("Created classes: `LoginTest`")));
+    }
+
+    @Test
+    void proposalRejectsCanonicalPathWhenRecordingFileIsMissing() throws Exception {
+        Object coordinator = coordinator();
+        String sessionId = "missing-recording-file";
+        String request = "/codegen visit https://example.com";
+        route(coordinator, sessionId, request, codegen(request));
+
+        ShaftMcpToolResult completed = complete(coordinator, sessionId, ShaftMcpToolResult.success(
+                "SHAFT_CODEGEN_PROPOSAL " + proposalJson()));
+
+        assertAll(
+                () -> assertFalse(completed.success()),
+                () -> assertEquals("FAILED", phase(coordinator, sessionId)),
+                () -> assertTrue(completed.output().contains("recording file"), completed.output()));
+    }
+
+    @Test
+    void proposalAndPassedResultRequireMandatoryPhaseEvidence() throws Exception {
+        writeRecording();
+        Object proposalCoordinator = coordinator();
+        String request = "/codegen visit https://example.com";
+        route(proposalCoordinator, "empty-record-phase", request, codegen(request));
+        ShaftMcpToolResult emptyRecordPhase = complete(
+                proposalCoordinator,
+                "empty-record-phase",
+                ShaftMcpToolResult.success("SHAFT_CODEGEN_PROPOSAL "
+                        + "{\"recordingPath\":\"recordings/intellij-capture.json\","
+                        + "\"proposalMarkdown\":\"Reuse LoginPage\",\"phaseOutcomes\":{}}"));
+
+        Object terminalCoordinator = coordinator();
+        startAndCompleteProposal(terminalCoordinator, "missing-mutable-phases", request);
+        route(terminalCoordinator, "missing-mutable-phases", "approve", null);
+        ShaftMcpToolResult missingMutablePhases = complete(
+                terminalCoordinator,
+                "missing-mutable-phases",
+                terminalResult("passed", "{\"GENERATE\":\"passed\"}", "[\"LoginPage\"]", "[]"));
+
+        assertAll(
+                () -> assertFalse(emptyRecordPhase.success()),
+                () -> assertEquals("FAILED", phase(proposalCoordinator, "empty-record-phase")),
+                () -> assertFalse(missingMutablePhases.success()),
+                () -> assertEquals("FAILED", phase(terminalCoordinator, "missing-mutable-phases")));
+    }
+
+    @Test
+    void passedResultRequiresAtLeastOneChangedOrCreatedClass() throws Exception {
+        Object coordinator = coordinator();
+        String sessionId = "empty-class-evidence";
+        String request = "/codegen visit https://example.com";
+        startAndCompleteProposal(coordinator, sessionId, request);
+        route(coordinator, sessionId, "approve", null);
+
+        ShaftMcpToolResult completed = complete(
+                coordinator,
+                sessionId,
+                terminalResult(
+                        "passed",
+                        "{\"GENERATE\":\"passed\",\"REPLAY\":\"passed\",\"HEAL\":\"not needed\"}",
+                        "[]",
+                        "[]"));
+
+        assertAll(
+                () -> assertFalse(completed.success()),
+                () -> assertEquals("FAILED", phase(coordinator, sessionId)));
+    }
+
+    @Test
+    void forgedRecordingPathAndTerminalStatusFailClosed() throws Exception {
+        writeRecording();
+        Object pathCoordinator = coordinator();
+        String request = "/codegen visit https://example.com";
+        route(pathCoordinator, "forged-path", request, codegen(request));
+        ShaftMcpToolResult forgedPath = complete(
+                pathCoordinator,
+                "forged-path",
+                ShaftMcpToolResult.success("SHAFT_CODEGEN_PROPOSAL "
+                        + proposalJson().replace("recordings/intellij-capture.json", "../outside.json")));
+
+        Object statusCoordinator = coordinator();
+        startAndCompleteProposal(statusCoordinator, "forged-status", request);
+        route(statusCoordinator, "forged-status", "approve", null);
+        ShaftMcpToolResult forgedStatus = complete(
+                statusCoordinator,
+                "forged-status",
+                terminalResult(
+                        "success",
+                        "{\"GENERATE\":\"passed\",\"REPLAY\":\"passed\",\"HEAL\":\"not needed\"}",
+                        "[\"LoginPage\"]",
+                        "[]"));
+
+        assertAll(
+                () -> assertFalse(forgedPath.success()),
+                () -> assertEquals("FAILED", phase(pathCoordinator, "forged-path")),
+                () -> assertFalse(forgedStatus.success()),
+                () -> assertEquals("FAILED", phase(statusCoordinator, "forged-status")));
+    }
+
+    @Test
+    void failedTerminalRejectsEveryMalformedOrUnknownPhaseOutcome() {
+        assertAll(
+                () -> assertInvalidTerminal("failed-object-phase", "failed",
+                        "{\"RECORD\":{\"detail\":\"saved\"}}", "[]", "[]"),
+                () -> assertInvalidTerminal("failed-null-phase", "failed",
+                        "{\"RECORD\":null}", "[]", "[]"),
+                () -> assertInvalidTerminal("failed-blank-phase", "failed",
+                        "{\"RECORD\":\"   \"}", "[]", "[]"),
+                () -> assertInvalidTerminal("failed-unknown-phase", "failed",
+                        "{\"UNKNOWN\":\"failed\"}", "[]", "[]"));
+    }
+
+    @Test
+    void passedTerminalRejectsExtraMalformedOrUnknownPhaseOutcome() {
+        assertAll(
+                () -> assertInvalidTerminal("passed-object-phase", "passed",
+                        "{\"GENERATE\":\"passed\",\"REPLAY\":\"passed\",\"HEAL\":\"not needed\","
+                                + "\"RECORD\":{\"detail\":\"saved\"}}",
+                        "[\"LoginPage\"]", "[]"),
+                () -> assertInvalidTerminal("passed-unknown-phase", "passed",
+                        "{\"GENERATE\":\"passed\",\"REPLAY\":\"passed\",\"HEAL\":\"not needed\","
+                                + "\"UNKNOWN\":\"passed\"}",
+                        "[\"LoginPage\"]", "[]"));
+    }
+
+    @Test
+    void validPartialFailedTerminalStillRendersItsAvailablePhaseOutcome() throws Exception {
+        Object coordinator = mutableCoordinator("partial-failed-terminal");
+
+        ShaftMcpToolResult completed = complete(
+                coordinator,
+                "partial-failed-terminal",
+                terminalResult("failed", "{\"RECORD\":\"recorded\"}", "[]", "[]"));
+
+        assertAll(
+                () -> assertFalse(completed.success(), completed.output()),
+                () -> assertEquals("FAILED", phase(coordinator, "partial-failed-terminal")),
+                () -> assertTrue(completed.output().contains("Status: **failed**"), completed.output()),
+                () -> assertTrue(completed.output().contains("- RECORD: recorded"), completed.output()));
+    }
+
+    @Test
+    void malformedTerminalCompletesPanelWithoutLeavingRunningState() throws Exception {
+        ShaftAssistantPanel panel = new ShaftAssistantPanel(null, blankMcpSettings());
+        String sessionId = "panel-malformed-terminal";
+        try {
+            Object coordinator = fieldValue(panel, "codegenCoordinator");
+            startAndCompleteProposal(coordinator, sessionId, "/codegen visit https://example.com");
+            route(coordinator, sessionId, "approve", null);
+            setField(panel, "activeCodegenSessionId", sessionId);
+            panel.setRunning(true, "Running AutoBot codegen");
+
+            assertAll(
+                    () -> assertDoesNotThrow(() -> showAgentResult(
+                            panel,
+                            terminalResult("failed", "{\"RECORD\":{\"detail\":\"saved\"}}", "[]", "[]"))),
+                    () -> assertFalse((boolean) fieldValue(panel, "running")),
+                    () -> assertEquals("FAILED", phase(coordinator, sessionId)));
+        } finally {
+            panel.dispose();
+        }
+    }
+
+    private void assertInvalidTerminal(
+            String sessionId, String status, String phaseOutcomes, String changedClasses, String createdClasses)
+            throws Exception {
+        Object coordinator = mutableCoordinator(sessionId);
+        ShaftMcpToolResult completed = complete(
+                coordinator, sessionId, terminalResult(status, phaseOutcomes, changedClasses, createdClasses));
+
+        assertAll(
+                () -> assertFalse(completed.success(), completed.output()),
+                () -> assertEquals("FAILED", phase(coordinator, sessionId)),
+                () -> assertTrue(completed.output().contains("valid structured terminal summary"), completed.output()));
+    }
+
+    private Object mutableCoordinator(String sessionId) throws Exception {
+        Object coordinator = coordinator();
+        String request = "/codegen visit https://example.com";
+        startAndCompleteProposal(coordinator, sessionId, request);
+        route(coordinator, sessionId, "approve", null);
+        return coordinator;
+    }
+
+    private static void showAgentResult(ShaftAssistantPanel panel, ShaftMcpToolResult result) throws Exception {
+        Method method = ShaftAssistantPanel.class.getDeclaredMethod(
+                "showAgentResult", ShaftMcpToolResult.class, Throwable.class);
+        method.setAccessible(true);
+        method.invoke(panel, result, null);
+    }
+
+    private void startAndCompleteProposal(Object coordinator, String sessionId, String request) throws Exception {
+        writeRecording();
+        AssistantCommand.Invocation first = route(coordinator, sessionId, request, codegen(request));
+        assertFalse(first.arguments().get("allowSourceMutation").getAsBoolean());
+        ShaftMcpToolResult proposal = complete(coordinator, sessionId, ShaftMcpToolResult.success(
+                "Recording saved.\nSHAFT_CODEGEN_PROPOSAL " + proposalJson()));
+        assertAll(
+                () -> assertTrue(proposal.success()),
+                () -> assertEquals("AWAITING_EDIT_CONFIRMATION", phase(coordinator, sessionId)),
+                () -> assertTrue(proposal.output().contains("Reuse `LoginPage`")));
+    }
+
+    private AssistantCommand.Invocation codegen(String prompt) {
+        return AssistantCommand.fromPrompt(
+                prompt,
+                AssistantCommand.Selection.local("CODEX", "CLI"),
+                "AGENT",
+                projectRoot.toString(),
+                "",
+                false);
+    }
+
+    private AssistantCommand.Invocation route(
+            Object coordinator,
+            String sessionId,
+            String userText,
+            AssistantCommand.Invocation baseInvocation) throws Exception {
+        return (AssistantCommand.Invocation) invoke(
+                coordinator,
+                "route",
+                new Class<?>[]{String.class, String.class, AssistantCommand.Invocation.class, String.class},
+                sessionId,
+                userText,
+                baseInvocation,
+                projectRoot.toString());
+    }
+
+    private ShaftMcpToolResult complete(Object coordinator, String sessionId, ShaftMcpToolResult result)
+            throws Exception {
+        return (ShaftMcpToolResult) invoke(
+                coordinator,
+                "complete",
+                new Class<?>[]{String.class, ShaftMcpToolResult.class, String.class},
+                sessionId,
+                result,
+                projectRoot.toString());
+    }
+
+    private String phase(Object coordinator, String sessionId) throws Exception {
+        return String.valueOf(invoke(
+                coordinator,
+                "phase",
+                new Class<?>[]{String.class},
+                sessionId));
+    }
+
+    private static Object coordinator() throws Exception {
+        Class<?> type;
+        try {
+            type = Class.forName(COORDINATOR);
+        } catch (ClassNotFoundException error) {
+            fail("Observable codegen coordinator is missing", error);
+            return null;
+        }
+        Constructor<?> constructor = type.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        return constructor.newInstance();
+    }
+
+    private static Object invoke(Object target, String name, Class<?>[] parameterTypes, Object... arguments)
+            throws Exception {
+        Method method = target.getClass().getDeclaredMethod(name, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(target, arguments);
+    }
+
+    private static Field findField(Class<?> type, String name) {
+        try {
+            return type.getDeclaredField(name);
+        } catch (NoSuchFieldException error) {
+            return null;
+        }
+    }
+
+    private static Object fieldValue(Object target, String name) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private void writeConfiguredBaseUrl(String value) throws Exception {
+        Path properties = projectRoot.resolve("src/main/resources/properties/custom.properties");
+        Files.createDirectories(properties.getParent());
+        Files.writeString(properties, "baseURL=" + value + System.lineSeparator());
+    }
+
+    private void writeRecording() throws Exception {
+        Path recording = projectRoot.resolve("recordings/intellij-capture.json");
+        Files.createDirectories(recording.getParent());
+        Files.writeString(recording, "{}");
+    }
+
+    private static String proposalJson() {
+        return "{\"recordingPath\":\"recordings/intellij-capture.json\","
+                + "\"proposalMarkdown\":\"Reuse `LoginPage`; create `LoginTest`.\","
+                + "\"phaseOutcomes\":{\"RECORD\":\"passed\"}}";
+    }
+
+    private static ShaftMcpToolResult terminalResult(boolean success) {
+        String json = "{\"status\":\"" + (success ? "passed" : "failed") + "\","
+                + "\"phaseOutcomes\":{\"RECORD\":\"passed\",\"GENERATE\":\"passed\","
+                + "\"REPLAY\":\"passed\",\"HEAL\":\"not needed\"},"
+                + "\"changedClasses\":[\"LoginPage\"],\"createdClasses\":[\"LoginTest\"],"
+                + "\"reportPath\":\"allure-report/AllureReport.html\"}";
+        return ShaftMcpToolResult.success("Finished.\nSHAFT_CODEGEN_RESULT " + json);
+    }
+
+    private static ShaftMcpToolResult terminalResult(
+            String status, String phaseOutcomes, String changedClasses, String createdClasses) {
+        String json = "{\"status\":\"" + status + "\",\"phaseOutcomes\":" + phaseOutcomes
+                + ",\"changedClasses\":" + changedClasses + ",\"createdClasses\":" + createdClasses
+                + ",\"reportPath\":\"\"}";
+        return ShaftMcpToolResult.success("SHAFT_CODEGEN_RESULT " + json);
+    }
+
+    private static ShaftSettingsState.Settings blankMcpSettings() {
+        ShaftSettingsState.Settings settings = new ShaftSettingsState.Settings();
+        settings.mcpCommand = "";
+        return settings;
+    }
+}

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinatorTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCodegenWorkflowCoordinatorTest.java
@@ -281,7 +281,36 @@ class AssistantCodegenWorkflowCoordinatorTest {
     }
 
     @Test
-    void mutableRunProgressUpdatesGenerateReplayAndHealState() throws Exception {
+    void launchedRecordAndMutablePromptsRetainTheShaftCodeGenerationContract() throws Exception {
+        Object coordinator = coordinator();
+        String sessionId = "launched-prompt-contract";
+        String request = "/codegen visit https://example.com and log in";
+
+        AssistantCommand.Invocation record = route(coordinator, sessionId, request, codegen(request));
+        writeRecording();
+        complete(coordinator, sessionId, ShaftMcpToolResult.success(
+                "SHAFT_CODEGEN_PROPOSAL " + proposalJson()));
+        AssistantCommand.Invocation mutable = route(coordinator, sessionId, "approve edits", null);
+
+        String recordPrompt = record.arguments().get("prompt").getAsString();
+        String mutablePrompt = mutable.arguments().get("prompt").getAsString();
+        assertAll(
+                () -> assertTrue(recordPrompt.contains("$shaft-recording-codegen"), recordPrompt),
+                () -> assertTrue(recordPrompt.contains("SHAFT MCP/CLI"), recordPrompt),
+                () -> assertTrue(recordPrompt.contains("existing test classes and page objects"), recordPrompt),
+                () -> assertTrue(mutablePrompt.contains("$shaft-automated-test-authoring"), mutablePrompt),
+                () -> assertTrue(mutablePrompt.contains("$shaft-page-objects"), mutablePrompt),
+                () -> assertTrue(mutablePrompt.contains("shaft_coding_partner_plan"), mutablePrompt),
+                () -> assertTrue(mutablePrompt.contains("Page Object Model"), mutablePrompt),
+                () -> assertTrue(mutablePrompt.contains("stable author-written IDs first"), mutablePrompt),
+                () -> assertTrue(mutablePrompt.contains("existing project locator conventions"), mutablePrompt),
+                () -> assertTrue(mutablePrompt.contains("Create a new owner only when none fits"), mutablePrompt),
+                () -> assertTrue(mutablePrompt.contains("Replay once"), mutablePrompt),
+                () -> assertTrue(mutablePrompt.contains("healRetryAllowance"), mutablePrompt));
+    }
+
+    @Test
+    void mutableRunProgressAllowsTheSingleHealReplayLoopButRejectsOtherBacktracking() throws Exception {
         Object coordinator = coordinator();
         startAndCompleteProposal(coordinator, "progress", "/codegen visit https://example.com");
         route(coordinator, "progress", "approve", null);
@@ -291,10 +320,21 @@ class AssistantCodegenWorkflowCoordinatorTest {
         String replay = phase(coordinator, "progress");
         invoke(coordinator, "progress", new Class<?>[]{String.class, String.class},
                 "progress", "SHAFT_CODEGEN_PROGRESS {\"phase\":\"HEAL\"}");
+        String heal = phase(coordinator, "progress");
+        invoke(coordinator, "progress", new Class<?>[]{String.class, String.class},
+                "progress", "SHAFT_CODEGEN_PROGRESS {\"phase\":\"REPLAY\"}");
+        String replayAfterHeal = phase(coordinator, "progress");
+        invoke(coordinator, "progress", new Class<?>[]{String.class, String.class},
+                "progress", "SHAFT_CODEGEN_PROGRESS {\"phase\":\"GENERATE\"}");
+        invoke(coordinator, "progress", new Class<?>[]{String.class, String.class},
+                "progress", "SHAFT_CODEGEN_PROGRESS {\"phase\":\"HEAL\"}");
 
         assertAll(
                 () -> assertEquals("REPLAY", replay),
-                () -> assertEquals("HEAL", phase(coordinator, "progress")));
+                () -> assertEquals("HEAL", heal),
+                () -> assertEquals("REPLAY", replayAfterHeal),
+                () -> assertEquals("REPLAY", phase(coordinator, "progress"),
+                        "the default allowance must reject a second heal/replay loop"));
     }
 
     @Test
@@ -324,10 +364,20 @@ class AssistantCodegenWorkflowCoordinatorTest {
         startAndCompleteProposal(overrideCoordinator, "override-retry",
                 "/codegen visit https://example.com; allow 3 heal retries");
         AssistantCommand.Invocation overrideMutable = route(overrideCoordinator, "override-retry", "approve", null);
+        invoke(overrideCoordinator, "progress", new Class<?>[]{String.class, String.class},
+                "override-retry", "SHAFT_CODEGEN_PROGRESS {\"phase\":\"REPLAY\"}");
+        invoke(overrideCoordinator, "progress", new Class<?>[]{String.class, String.class},
+                "override-retry", "SHAFT_CODEGEN_PROGRESS {\"phase\":\"HEAL\"}");
+        invoke(overrideCoordinator, "progress", new Class<?>[]{String.class, String.class},
+                "override-retry", "SHAFT_CODEGEN_PROGRESS {\"phase\":\"REPLAY\"}");
+        invoke(overrideCoordinator, "progress", new Class<?>[]{String.class, String.class},
+                "override-retry", "SHAFT_CODEGEN_PROGRESS {\"phase\":\"HEAL\"}");
 
         assertAll(
                 () -> assertEquals(1, defaultMutable.arguments().get("healRetryAllowance").getAsInt()),
-                () -> assertEquals(3, overrideMutable.arguments().get("healRetryAllowance").getAsInt()));
+                () -> assertEquals(3, overrideMutable.arguments().get("healRetryAllowance").getAsInt()),
+                () -> assertEquals("HEAL", phase(overrideCoordinator, "override-retry"),
+                        "an explicit allowance must permit the requested additional loop"));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandTest.java
@@ -268,7 +268,7 @@ class AssistantCommandTest {
     }
 
     @Test
-    void slashCodegenScenarioStartsCaptureWithFullGoalAndTargetUrl() {
+    void slashCodegenScenarioRoutesToAutobotWithFullWorkflowContract() {
         String scenario = "navigate to https://duckduckgo.com, search for shaft_engine, "
                 + "open the first result and assert that the url is correct.";
 
@@ -281,14 +281,27 @@ class AssistantCommandTest {
                 true);
 
         assertAll(
-                () -> assertEquals("capture_start", invocation.toolName()),
-                () -> assertEquals(scenario, invocation.arguments().get("sessionGoal").getAsString()),
-                () -> assertEquals("https://duckduckgo.com", invocation.arguments().get("targetUrl").getAsString()),
-                () -> assertFalse(invocation.isSequence()));
+                () -> assertEquals("autobot_local_agent_run", invocation.toolName()),
+                () -> assertEquals("AGENT", invocation.arguments().get("mode").getAsString()),
+                () -> assertFalse(invocation.arguments().get("allowSourceMutation").getAsBoolean()),
+                () -> assertFalse(invocation.arguments().has("targetUrl"),
+                        "the plugin must not own browser orchestration"),
+                () -> assertFalse(invocation.isSequence()),
+                () -> assertTrue(invocation.arguments().get("prompt").getAsString().contains(scenario)),
+                () -> assertTrue(invocation.arguments().get("prompt").getAsString()
+                        .contains("capture_start, browser actions, capture_stop/save")),
+                () -> assertTrue(invocation.arguments().get("prompt").getAsString()
+                        .contains("exactly one URL question")),
+                () -> assertTrue(invocation.arguments().get("prompt").getAsString()
+                        .contains("explicit approval before any source edit or replay")),
+                () -> assertTrue(invocation.arguments().get("prompt").getAsString()
+                        .contains("one heal retry")),
+                () -> assertTrue(invocation.arguments().get("prompt").getAsString()
+                        .contains("allure-report/AllureReport.html")));
     }
 
     @Test
-    void multilineSlashCodegenScenarioStartsCapture() {
+    void multilineSlashCodegenScenarioRoutesToAutobot() {
         AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
                 "/codegen\nnavigate to https://example.com and click login",
                 AssistantCommand.Selection.local("CODEX", "CLI"),
@@ -298,9 +311,24 @@ class AssistantCommandTest {
                 true);
 
         assertAll(
-                () -> assertEquals("capture_start", invocation.toolName()),
-                () -> assertEquals("navigate to https://example.com and click login",
-                        invocation.arguments().get("sessionGoal").getAsString()));
+                () -> assertEquals("autobot_local_agent_run", invocation.toolName()),
+                () -> assertTrue(invocation.arguments().get("prompt").getAsString()
+                        .contains("navigate to https://example.com and click login")));
+    }
+
+    @Test
+    void slashCodegenScenarioFailsClosedForCloudRoute() {
+        AssistantCommand.Invocation invocation = AssistantCommand.fromPrompt(
+                "/codegen navigate to https://example.com and click login",
+                AssistantCommand.Selection.cloud("openai", "gpt-5"),
+                "AGENT",
+                ".",
+                "",
+                true);
+
+        assertAll(
+                () -> assertTrue(invocation.isLocal()),
+                () -> assertTrue(invocation.localResponse().contains("Local / CLI route")));
     }
 
     @Test

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandToolIndexRoutingTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantCommandToolIndexRoutingTest.java
@@ -249,10 +249,10 @@ class AssistantCommandToolIndexRoutingTest {
                 "an explicit recording path must still deterministically drive the replay generator");
         AssistantCommand.Invocation liveCodegen =
                 command("/codegen navigate to https://example.com and click login");
-        assertEquals("capture_start", liveCodegen.toolName(),
-                "a free-text /codegen flow description must start the plugin-owned recorder");
-        assertEquals("navigate to https://example.com and click login",
-                liveCodegen.arguments().get("sessionGoal").getAsString());
+        assertEquals("autobot_local_agent_run", liveCodegen.toolName(),
+                "a free-text /codegen flow description must route to the AutoBot local CLI");
+        assertFalse(liveCodegen.arguments().has("targetUrl"),
+                "the plugin must not drive capture_start for the AutoBot workflow");
     }
 
     private static AssistantCommand.Invocation command(String prompt) {

--- a/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerCommandTest.java
+++ b/shaft-intellij/src/test/java/com/shaft/intellij/ui/AssistantLocalAgentRunnerCommandTest.java
@@ -127,6 +127,29 @@ class AssistantLocalAgentRunnerCommandTest {
                 () -> assertTrue(process.stdinClosed(), "Buffered/custom command paths must close stdin immediately"));
     }
 
+    @Test
+    void customAgentCommandFailsClosedBecauseReadOnlyCodegenCannotSandboxIt() {
+        String request = "/codegen visit https://example.com and verify the title";
+        AssistantCommand.Invocation base = AssistantCommand.fromPrompt(
+                request, "CODEX", "AGENT", ".", "stub-agent --record", false);
+        AssistantCodegenWorkflowCoordinator coordinator = new AssistantCodegenWorkflowCoordinator();
+        AssistantCommand.Invocation record = coordinator.route("custom-record", request, base, ".");
+
+        assertAll(
+                () -> assertTrue(record.isLocal()),
+                () -> assertTrue(record.localResponse().contains("built-in Local / CLI")),
+                () -> assertFalse(record.arguments().has("allowSourceMutation")));
+    }
+
+    @Test
+    void claudeReadOnlyCodegenCommandHasNoBestEffortPermissionFallback() {
+        JsonObject readOnlyRecord = arguments("CLAUDE_CODE", "AGENT", false);
+        readOnlyRecord.addProperty("readOnlyCodegenRecording", true);
+
+        assertTrue(AssistantLocalAgentRunner.commandFor(readOnlyRecord).isEmpty(),
+                "Claude Code cannot enforce the browser/capture-only boundary, so RECORD must not launch");
+    }
+
     /**
      * Regression test for the bug behind #5/#6/#7: a prior approval-bridge implementation held
      * stdin open past the initial prompt write for every Claude Code invocation, but Claude's


### PR DESCRIPTION
## Summary

- route free-text `/codegen <scenario>` to a Codex AutoBot workflow instead of plugin-owned browser capture
- coordinate `RECORD`, URL fallback, edit confirmation, `GENERATE`, `REPLAY`, one default `HEAL` retry, and terminal status per chat session
- keep recording-JSON replay deterministic and preserve the plugin as a UI/lifecycle coordinator
- enforce a read-only browser/capture MCP allowlist before consent, then launch a separate source-mutable invocation only after explicit approval
- require the actual launched AutoBot prompts to use SHAFT authoring/page-object guidance, reuse existing owners, follow POM and locator priority, and report retry replay progress
- validate recording, phase, class, and optional Allure evidence before presenting success or failure

Closes #5275
Related to #5273

## Checks

- `shaft-intellij/gradlew.bat test --tests com.shaft.intellij.ui.AssistantCodegenWorkflowCoordinatorTest --tests com.shaft.intellij.ui.AssistantCommandTest --tests com.shaft.intellij.ui.AssistantCommandToolIndexRoutingTest --tests com.shaft.intellij.ui.AssistantCommandRoutingTest --tests com.shaft.intellij.ui.AssistantLocalAgentRunnerCommandTest --tests com.shaft.intellij.ui.AssistantLocalAgentRunnerVerboseStreamTest --tests com.shaft.intellij.ui.ShaftAssistantPanelDisposalTest --tests com.shaft.intellij.ui.ShaftPanelSetupTest -Djava.awt.headless=true -Dallure.automaticallyOpen=false --rerun-tasks` — 529 tests, 0 failures, 0 errors, 0 skipped
- focused Codacy cleanup run across coordinator, runner, routing, and panel disposal tests — 99 tests, 0 failures, 0 errors, 0 skipped
- focused launched-prompt and retry-progress run across five impacted suites — 101 tests, 0 failures, 0 errors, 0 skipped
- `shaft-intellij/gradlew.bat test --tests com.shaft.intellij.ui.ShaftPluginScreenshotRendererTest -Djava.awt.headless=true -Dallure.automaticallyOpen=false` — 8 tests, 0 failures, 0 errors, 1 expected skip; no component/layout change, so no screenshot artifact retained
- `git diff --check` — clean
- independent adversarial reviews for the workflow, static-analysis cleanup, and launched-prompt/retry contract — Spec PASS, Quality APPROVED, ZERO BLOCKING FINDINGS
- refreshed GitHub PR Gate, IntelliJ build, CodeQL, Codacy, dependency submission, and installer checks — terminal green or intentional skip

## Continuation

Head: `d13b83dcb3d0fb408eb5225d333cda72d05f10bf`

State: exact-head implementation, reviews, checks, merge authority, and feedback audit are complete. Companion documentation is green on ShaftHQ/shafthq.github.io#1001.

Blockers: none. A configured Codex plus SHAFT MCP/browser E2E was not run under the selected focused headless local scope.

Next action: merge this PR and verify the merged head, then merge the companion documentation PR.
