### PR TITLE
fix(ci): allow iOS Safari nightly to finish

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -1074,7 +1074,7 @@ jobs:
   iOS_Web_SAFARI_BrowserStack:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',iOS_Web_SAFARI_BrowserStack,')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}

--- a/tests/scripts/test_validate_workflow_timeouts.py
+++ b/tests/scripts/test_validate_workflow_timeouts.py
@@ -118,6 +118,14 @@ jobs:
         timeout = workflow["jobs"]["capture-e2e"].get("timeout-minutes", 0)
         self.assertGreaterEqual(timeout, 15)
 
+    def test_ios_web_safari_job_allows_observed_nightly_runtime_headroom(self):
+        repository_root = Path(__file__).resolve().parents[2]
+        workflow = yaml.safe_load(
+            (repository_root / ".github/workflows/e2eTests.yml").read_text(encoding="utf-8")
+        )
+        timeout = workflow["jobs"]["iOS_Web_SAFARI_BrowserStack"].get("timeout-minutes", 0)
+        self.assertEqual(timeout, 15)
+
     def test_local_safari_job_allows_observed_nightly_runtime_headroom(self):
         repository_root = Path(__file__).resolve().parents[2]
         workflow = yaml.safe_load(


### PR DESCRIPTION
## Summary

- raise only the `iOS_Web_SAFARI_BrowserStack` scheduled E2E job timeout from 10 to 15 minutes
- preserve the existing BrowserStack scenario and all test assertions
- add a focused workflow regression that locks the job timeout at the observed-safe minimum

## Checks

- `py -3 -m unittest tests.scripts.test_validate_workflow_timeouts -v` — 15 tests passed
- `py -3 scripts/ci/validate_workflow_timeouts.py` — passed
- workflow YAML parse — exact iOS Safari job timeout is 15 minutes
- `git diff --check` — passed
- independent exact-patch review — zero blocking findings

## Continuation

Head: `2f59a386eafc9046077e8c90005993d878d1a978`

State: Focused local validation and independent review are complete; remote PR gates are pending.

Blockers: The replacement scheduled E2E run can only prove runtime after this PR merges.

Next action: Clear remote review and checks, merge, then require a later scheduled-event E2E success before closing #5266.

Closes #5284

Related to #5266 and #5273
