### PR TITLE
Fix ChaosEngine research, Plan Mode, and managed runtimes

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -72,6 +72,36 @@ macOS or Linux, using [install.sh](install.sh):
 url="$(printf 'https://raw.githubusercontent.com/S\150aftHQ/SHA\106T_ENGINE/main/chaos-engine/install.sh')"; curl -fsSL "$url" | bash -s -- "$url"
 ```
 
+Python is not required before either command. When no Python 3 executable is
+available, the wrapper downloads the pinned uv 0.11.29 standalone binary for
+Windows, Linux, or macOS on x64 or arm64, verifies its SHA-256, and uses its
+managed Python 3.10 to run the bootstrap. The installed generation owns pinned
+Node.js 24.19.0 for Memory; ambient Node and npm are not part of the runtime
+contract. Unsupported platforms and checksum failures stop before activation,
+leaving the prior generation active.
+
+Pass `--with-maven-tools` to install the optional Maven Tools MCP together with
+the project tools. It cannot be combined with `--skip-tools`. Java resolution
+prefers `CHAOSENGINE_JAVA`, then `JAVA_HOME`, then `PATH`; an unsuitable or
+missing Java triggers the verified Temurin 25.0.4+7 cache flow. Windows arm64
+uses the official Windows x64 Temurin artifact through Windows 11 x64
+emulation and fails closed if the Java 25 probe cannot execute. Project
+uninstall removes project-owned Python and Node generations but retains the
+shared Maven Tools cache; `cache purge --component maven-tools-mcp --version
+3.2.0` removes only exact receipt-verified cache content.
+
+POSIX:
+
+```bash
+url="https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"; curl -fsSL "$url" | bash -s -- "$url" --with-maven-tools
+```
+
+PowerShell:
+
+```powershell
+$installer = irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1"; & ([scriptblock]::Create($installer)) -WithMavenTools
+```
+
 Inspect the linked installer and [bootstrap.py](bootstrap.py) first when policy
 requires review before execution. The bootstrap resolves the default branch to
 an immutable commit and downloads only its validated `chaos-engine/` subtree;
@@ -131,7 +161,7 @@ upstream from the consumer repository.
 `status` and `doctor` report every component with its `owner`, `scope`,
 `lifecycle`, and `taskImpact`. Memory, MemPalace, and Graphify are advisory to
 ordinary tasks but remain strict in `doctor`; an unhealthy selected store still
-returns `recovery-required`. The optional Maven Tools MCP cache is user-owned
+returns `recovery-required`. The optional Maven Tools MCP cache is installer-owned
 and does not make project health fail.
 
 ## Optional native Maven Tools MCP
@@ -140,17 +170,14 @@ Do not put `docker run -i --rm` in a default stdio MCP configuration. Each
 active client owns its own stdio server process, so a Docker-backed declaration
 creates one container per client and keeps Docker Desktop and its VM resident.
 
-When Maven Tools MCP is wanted, the installing agent must use the upstream
-native JAR flow instead:
+`--with-maven-tools` performs the pinned native JAR flow:
 
-1. Resolve a real Java 25 executable from `CHAOSENGINE_JAVA`, `JAVA_HOME`, or
-   `PATH`; never write a copied example path.
-2. Clone `https://github.com/arvindand/maven-tools-mcp.git`, check out detached
-   commit `4475ff6c61f23ea9a93cb6d5665a63235ef2ef36`, and run `mvnw.cmd clean
-   verify -Pfull` on Windows or `./mvnw clean verify -Pfull` elsewhere. The
-   wrapper supplies Maven; Java 25 and Git are prerequisites. Upstream does not
-   publish a JAR release asset, so do not invent a download URL or silently
-   fall back to Docker.
+1. Resolve Java 25 from `CHAOSENGINE_JAVA`, `JAVA_HOME`, or `PATH`, otherwise
+   download and checksum-verify the selected Temurin 25.0.4+7 artifact.
+2. Prefer host Git for `arvindand/maven-tools-mcp` commit
+   `4475ff6c61f23ea9a93cb6d5665a63235ef2ef36`. Without Git, download the
+   checksum-pinned exact-commit archive. Build through the upstream Maven
+   wrapper with its `full` profile; Docker itself is not required at runtime.
 3. Stage `maven-tools-mcp-3.2.0.jar` under a fresh unique directory on the same
    filesystem as the current user's data directory, then publish that directory
    with a no-overwrite rename to
@@ -162,10 +189,9 @@ native JAR flow instead:
    the installed filename, and `sha256` = the lowercase SHA-256 of its bytes.
    Discovery recomputes the digest and rejects a missing, malformed, stale, or
    differently pinned receipt. The version directory is an immutable,
-   user-managed cache: parallel projects may read the verified pair, while
+   receipt-owned shared cache: parallel projects may read the verified pair, while
    project uninstall never changes or removes it.
-4. Run the ChaosEngine bootstrap again. Host installation discovers both files
-   and atomically rewrites `.mcp.json`, `.gemini/settings.json`, and
+4. Host installation discovers both files and atomically rewrites `.mcp.json`, `.gemini/settings.json`, and
    `.codex/config.toml` with their resolved absolute paths. Upgrades repeat
    discovery, so another user's Java or data path is never inherited.
 5. Start a fresh client session and prove both the MCP initialize and tools/list

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -204,15 +204,14 @@ bootstrap, install, status, doctor, rollback, or uninstall.
 flowchart TD
     accTitle: Runtime dependency graph
     accDescr: Platform prerequisites feed the transactional installer and its pinned project-local runtime tools.
-    Shell["PowerShell 7+ or POSIX shell + curl"] --> Py["Python 3.10+"]
-    Py --> Installer["ChaosEngine bootstrap + transactional installer<br/>Python standard library only"]
-    Node["Node.js + npm"] --> Installer
-    Installer --> UV["uv 0.11.29"]
+    Shell["PowerShell or POSIX shell + downloader"] --> Installer["ChaosEngine bootstrap + transactional installer"]
+    Installer --> UV["verified uv 0.11.29"]
     UV --> ManagedPython["uv-managed Python 3.10"]
     ManagedPython --> MP["mempalace 3.7.1<br/>mempalace + mempalace-mcp"]
     ManagedPython --> GF["graphifyy 0.9.43<br/>tree-sitter-sql 0.3.11"]
+    Installer --> Node["verified Node.js 24.19.0 + npm"]
     Node --> MEM["@aictx/memory 0.2.1<br/>memory + memory-mcp"]
-    Git["Git + Java 25<br/>optional"] --> Maven["Maven Tools MCP 3.2.0<br/>optional user cache"]
+    Installer --> Maven["Maven Tools MCP 3.2.0<br/>optional receipt-owned shared cache"]
 ```
 
 Missing or damaged `uv`, Graphify, MemPalace, or Memory entries trigger an
@@ -238,11 +237,11 @@ flowchart LR
 
 Tracked prerequisites and optional boundaries:
 
-- Required: writable target directory, network for fresh install/upgrade,
-  Python 3.10+, Node.js with npm, and PowerShell or POSIX shell with `curl`.
-- Installed automatically: pinned uv; uv-managed Python 3.10; Graphify;
-  MemPalace; Memory; six stable tool entrypoints.
-- Optional: Git and Java 25 only for native Maven Tools MCP build/cache.
+- Required: writable target directory, network for fresh install/upgrade, and
+  PowerShell or POSIX shell with `curl` or `wget`.
+- Installed automatically: pinned uv; uv-managed Python 3.10; Node.js 24.19.0;
+  Graphify; MemPalace; Memory; six stable tool entrypoints.
+- Optional: `--with-maven-tools` manages Git/archive retrieval and Java 25.
 - Generated and never tracked: dependency generations, receipts, caches,
   Graphify output, MemPalace indexes, Memory runtime indexes, reports, secrets.
 - Canonical skills: `chaos-engine`, `caveman`, `ponytail`; project profiles and
@@ -259,12 +258,12 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 <!-- inventory:prerequisites:start -->
 | Item | Purpose | Source of truth | Status | Platforms | Provisioner | Owner | Failure behavior |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Python 3.10+ | Run bootstrap, installer, kernel, and tools. | install.ps1; install.sh | required | Windows, Linux, macOS | operator | consumer environment | install stops before mutation |
+| Python 3.10+ | Run bootstrap, installer, kernel, and tools. | install.ps1; install.sh; dependencies.json | managed | Windows, Linux, macOS | verified uv 0.11.29 | immutable dependency generation | install stops before activation |
 | PowerShell or POSIX shell | Launch the reviewed bootstrap wrapper. | install.ps1; install.sh | required | platform native | operating system | consumer environment | bootstrap does not start |
 | curl or wget | Download immutable source on POSIX. | install.sh | required on POSIX | Linux, macOS | operator | consumer environment | download fails closed |
-| Node.js and npm | Provision Memory and launch Gemini hooks. | dependencies.json; hooks/launch.js | required | Windows, Linux, macOS | operator | consumer environment | dependency generation is not published |
+| Node.js and npm | Provision Memory and launch JavaScript hooks. | dependencies.json; hooks/launch.js | managed | Windows, Linux, macOS | immutable generation installer | installer receipt | dependency generation is not published |
 | network | Resolve source and provision a fresh or upgraded generation. | bootstrap.py; dependencies.py | required for fresh install or upgrade | Windows, Linux, macOS | operator | prior verified generation remains active |
-| Git and Java 25 | Build optional Maven Tools MCP cache. | hosts.py | optional | Windows, Linux, macOS | operator | optional component reports absent |
+| Git and Java 25 | Build optional Maven Tools MCP cache. | dependencies.json; install.py; hosts.py | optional and managed with `--with-maven-tools` | Windows, Linux, macOS | installer | receipt-owned shared cache | optional component reports absent |
 <!-- inventory:prerequisites:end -->
 
 ### Python Libraries
@@ -290,8 +289,9 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 | msvcrt | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hooks/kernel.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | os | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/tool.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | pathlib | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/tool.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
-| platform | Portable runtime standard-library dependency. | chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
+| platform | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hosts.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | posixpath | Portable runtime standard-library dependency. | chaos-engine/hooks/guard.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
+| queue | Portable runtime standard-library dependency. | chaos-engine/hosts.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | re | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | runpy | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/install.py, chaos-engine/tool.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | secrets | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
@@ -299,15 +299,16 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 | shutil | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hosts.py, chaos-engine/install.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | sqlite3 | Portable runtime standard-library dependency. | chaos-engine/hosts.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | stat | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hosts.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
-| subprocess | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hosts.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/tool.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
+| subprocess | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/tool.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | sys | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/tool.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
+| tarfile | Portable runtime standard-library dependency. | chaos-engine/dependencies.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | tempfile | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/hooks/reflection.py, chaos-engine/install.py, chaos-engine/learning.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
-| threading | Portable runtime standard-library dependency. | chaos-engine/hooks/kernel.py, chaos-engine/learning.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
+| threading | Portable runtime standard-library dependency. | chaos-engine/hooks/kernel.py, chaos-engine/hosts.py, chaos-engine/learning.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | time | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/kernel.py, chaos-engine/learning.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | types | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/hooks/kernel.py, chaos-engine/install.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | typing | Portable runtime standard-library dependency. | chaos-engine/hooks/kernel.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
-| urllib | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
-| zipfile | Portable runtime standard-library dependency. | chaos-engine/install.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
+| urllib | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
+| zipfile | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/install.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 <!-- inventory:python-libraries:end -->
 
 ### Managed Dependencies

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -256,10 +256,13 @@ def install_latest(
     repository: str,
     branch: str | None = None,
     skip_tools: bool = False,
+    with_maven_tools: bool = False,
     distribution: str | None = None,
     opener=urllib.request.urlopen,
     provisioner=None,
 ) -> dict[str, object]:
+    if skip_tools and with_maven_tools:
+        raise ValueError("--with-maven-tools cannot be combined with --skip-tools")
     project = Path(project).resolve()
     if not project.is_dir():
         raise ValueError(f"project is not a directory: {project}")
@@ -295,6 +298,7 @@ def install_latest(
                 provisioner=provisioner,
                 source_record=provenance,
                 distribution=distribution,
+                with_maven_tools=with_maven_tools,
             )
     if skip_tools or provisioner is not None:
         return {"status": "installed", "root": str(target), "commit": commit}
@@ -327,6 +331,7 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--branch")
     result.add_argument("--distribution")
     result.add_argument("--skip-tools", action="store_true", help=argparse.SUPPRESS)
+    result.add_argument("--with-maven-tools", action="store_true")
     return result
 
 
@@ -338,6 +343,7 @@ def main() -> int:
             repository=args.repository,
             branch=args.branch,
             skip_tools=args.skip_tools,
+            with_maven_tools=args.with_maven_tools,
             distribution=args.distribution,
         )
     except (OSError, RuntimeError, ValueError) as error:

--- a/chaos-engine/dependencies.json
+++ b/chaos-engine/dependencies.json
@@ -1,5 +1,33 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
+  "runtimes": {
+    "uv": {"version": "0.11.29", "artifacts": {
+      "windows-x64": {"url": "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-x86_64-pc-windows-msvc.zip", "sha256": "a047d55651bc3e0ca24595b25ec4cfcb10f9dca9fb56514e661269b37d4fae68"},
+      "windows-arm64": {"url": "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-aarch64-pc-windows-msvc.zip", "sha256": "55b597ae81bc29531a7c352a1431a8a73cc2755d7a5b9ec454580cbe02e5154f"},
+      "linux-x64": {"url": "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-x86_64-unknown-linux-gnu.tar.gz", "sha256": "04f8b82f5d47f0512dcd32c67a4a6f16a0ea27c81537c338fd0ad6b23cebe829"},
+      "linux-arm64": {"url": "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-aarch64-unknown-linux-gnu.tar.gz", "sha256": "94500fb064ae3c971a873cba64d94694c50677e0a4dbf78735c80509e7429919"},
+      "macos-x64": {"url": "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-x86_64-apple-darwin.tar.gz", "sha256": "c4c4de482da9ccdd076dc4fb5cfe7b740609029385c72f58606be3153602387d"},
+      "macos-arm64": {"url": "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-aarch64-apple-darwin.tar.gz", "sha256": "61c04acc52a33ef0f331e494bdfbedcdb6c26c6970c022ed3699e5860f8930e3"}
+    }},
+    "python": {"version": "3.10", "provider": "uv-managed"},
+    "node": {"version": "24.19.0", "artifacts": {
+      "windows-x64": {"url": "https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-x64.zip", "sha256": "57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73"},
+      "windows-arm64": {"url": "https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-arm64.zip", "sha256": "8502f4a50b458d4cc38ed8f2001556c2cd239d464920f74017926ccb1e1c157f"},
+      "linux-x64": {"url": "https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-x64.tar.xz", "sha256": "14b342e71204f811bde6153be8e04b62aef63c236fef92b55f9c83154b409647"},
+      "linux-arm64": {"url": "https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-arm64.tar.xz", "sha256": "01443c1e1a29e531ccad5a46fefa6df490d2189c49f7955904aecdbb0fe86fdc"},
+      "macos-x64": {"url": "https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-x64.tar.gz", "sha256": "d1b5e999db158c62fe8f7267a4476b035d8bd93b1a605bac24a3f0dd166e3316"},
+      "macos-arm64": {"url": "https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz", "sha256": "8294b7aa9b03997481c06babf1e8b270c859358f27da57a11509afe537ac381d"}
+    }},
+    "maven-tools-source": {"version": "4475ff6c61f23ea9a93cb6d5665a63235ef2ef36", "url": "https://github.com/arvindand/maven-tools-mcp/archive/4475ff6c61f23ea9a93cb6d5665a63235ef2ef36.zip", "sha256": "ceba276c3bf90bafbb4d7f109006d0cffa640466f0146826ce749c77a033bef8"},
+    "temurin": {"version": "25.0.4+7", "artifacts": {
+      "windows-x64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_windows_hotspot_25.0.4_7.zip", "sha256": "7caab7db43bf4b94a2e6252c699e70d90084f9aa7c943cd3414761fd540937ae"},
+      "windows-arm64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_windows_hotspot_25.0.4_7.zip", "sha256": "7caab7db43bf4b94a2e6252c699e70d90084f9aa7c943cd3414761fd540937ae", "artifactArchitecture": "x64", "emulated": true},
+      "linux-x64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_linux_hotspot_25.0.4_7.tar.gz", "sha256": "e58fcdcd637b25c03ca84cbbcefc70d11efb8f4b4cbd05decc9f661769d77f94"},
+      "linux-arm64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.4_7.tar.gz", "sha256": "621f7196f0b682fb557da58bec89bd7dfe5419811fe1c0ba75c9cc8432f084c7"},
+      "macos-x64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_mac_hotspot_25.0.4_7.tar.gz", "sha256": "a5ac9c46dad47ac06df35e36d096913195d8da1f3f71918828bcc2cfe33869b7"},
+      "macos-arm64": {"url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.tar.gz", "sha256": "5a101c54abf5a9f16c0f70d8c38ba99e6567c1ba213378f0bb04497284f051bd"}
+    }}
+  },
   "tools": {
     "uv": {"package": "uv==0.11.29"},
     "mempalace": {"package": "mempalace==3.7.1", "commands": ["mempalace", "mempalace-mcp"]},
@@ -11,6 +39,6 @@
     "memory": {"owner": "project", "scope": "project", "lifecycle": "persistent-data", "taskImpact": "advisory"},
     "mempalace": {"owner": "project", "scope": "project", "lifecycle": "persistent-data", "taskImpact": "advisory"},
     "graphify": {"owner": "project", "scope": "repository", "lifecycle": "derived-single-writer", "taskImpact": "advisory"},
-    "maven-tools-mcp": {"owner": "user", "scope": "user", "lifecycle": "user-managed-cache", "taskImpact": "optional"}
+    "maven-tools-mcp": {"owner": "installer", "scope": "user", "lifecycle": "receipt-owned", "taskImpact": "optional"}
   }
 }

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -10,15 +10,19 @@ import errno
 import hashlib
 import json
 import os
+import platform
 import re
 import secrets
 import shutil
 import stat
 import subprocess  # nosec B404 - fixed list-form dependency commands from tracked spec.
 import sys
+import tarfile
 import time
+import urllib.request
+import zipfile
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 RECEIPT_SCHEMA = 1
@@ -37,6 +41,8 @@ MAX_CONTROL_BYTES = 4 * 1024 * 1024
 # Pinned uv 0.11.29 + Graphify/MemPalace ownership is ~6.74 MiB compact.
 MAX_RECEIPT_BYTES = 8 * 1024 * 1024
 MAX_EXECUTABLE_BYTES = 256 * 1024 * 1024
+MAX_RUNTIME_ARCHIVE_BYTES = 256 * 1024 * 1024
+MAX_RUNTIME_EXPANDED_BYTES = 1024 * 1024 * 1024
 HEX_ID = re.compile(r"[0-9a-f]{32}")
 HEX_DIGEST = re.compile(r"[0-9a-f]{64}")
 REQUIRED_DISPATCHES = {
@@ -62,6 +68,160 @@ PYTHON_DISPATCH = (
     "if e.group=='console_scripts' and e.name==sys.argv[2]);"
     "sys.argv=[sys.argv[2],*sys.argv[3:]];raise SystemExit(e.load()())"
 )
+SUPPORTED_PLATFORMS = (
+    "windows-x64", "windows-arm64", "linux-x64", "linux-arm64",
+    "macos-x64", "macos-arm64",
+)
+
+
+def platform_key(*, system: str | None = None, machine: str | None = None) -> str:
+    systems = {"windows": "windows", "linux": "linux", "darwin": "macos", "macos": "macos"}
+    machines = {"x86_64": "x64", "amd64": "x64", "x64": "x64", "aarch64": "arm64", "arm64": "arm64"}
+    system_name = systems.get((system or platform.system()).casefold())
+    machine_name = machines.get((machine or platform.machine()).casefold())
+    key = f"{system_name}-{machine_name}"
+    if system_name is None or machine_name is None or key not in SUPPORTED_PLATFORMS:
+        raise ValueError(f"unsupported platform: {system or platform.system()}/{machine or platform.machine()}")
+    return key
+
+
+def select_runtime_artifact(
+    specification: dict[str, object], runtime: str, *, system: str | None = None,
+    machine: str | None = None,
+) -> dict[str, object]:
+    runtimes = specification.get("runtimes")
+    selected = runtimes.get(runtime) if isinstance(runtimes, dict) else None
+    artifacts = selected.get("artifacts") if isinstance(selected, dict) else None
+    artifact = artifacts.get(platform_key(system=system, machine=machine)) if isinstance(artifacts, dict) else None
+    if not isinstance(artifact, dict):
+        raise ValueError(f"runtime artifact is missing: {runtime}")
+    url, digest = artifact.get("url"), artifact.get("sha256")
+    if not isinstance(url, str) or not url.startswith("https://") or not isinstance(digest, str) or HEX_DIGEST.fullmatch(digest) is None:
+        raise ValueError(f"runtime artifact is invalid: {runtime}")
+    return dict(artifact)
+
+
+def validate_runtime_specification(specification: dict[str, object]) -> None:
+    if specification.get("schemaVersion") != 2:
+        raise ValueError("dependency specification schema is unsupported")
+    runtimes = specification.get("runtimes")
+    if not isinstance(runtimes, dict):
+        raise ValueError("dependency runtime specification is invalid")
+    for name in ("uv", "node", "temurin"):
+        runtime = runtimes.get(name)
+        artifacts = runtime.get("artifacts") if isinstance(runtime, dict) else None
+        if not isinstance(artifacts, dict) or set(artifacts) != set(SUPPORTED_PLATFORMS):
+            raise ValueError(f"dependency runtime artifact matrix is invalid: {name}")
+        for key in SUPPORTED_PLATFORMS:
+            select_runtime_artifact(
+                specification, name, system=key.split("-")[0], machine=key.split("-")[1]
+            )
+    platform_key()
+
+
+def node_dispatch(generation: Path, script: Path) -> dict[str, object]:
+    node = generation / ("node/node.exe" if os.name == "nt" else "node/bin/node")
+    return {
+        "kind": "node",
+        "executable": node.relative_to(generation).as_posix(),
+        "executableSha256": sha256(node),
+        "executableSize": node.stat().st_size,
+        "script": script.relative_to(generation).as_posix(),
+        "scriptSha256": sha256(script),
+        "scriptSize": script.stat().st_size,
+    }
+
+
+def _download_artifact(url: str, destination: Path, expected: str, opener=urllib.request.urlopen) -> None:
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with opener(url, timeout=60) as response, destination.open("xb") as stream:
+            while chunk := response.read(1024 * 1024):
+                total += len(chunk)
+                if total > MAX_RUNTIME_ARCHIVE_BYTES:
+                    raise ValueError("runtime artifact exceeds the download limit")
+                digest.update(chunk)
+                stream.write(chunk)
+        if digest.hexdigest() != expected:
+            raise ValueError("runtime artifact checksum verification failed")
+    except BaseException:
+        destination.unlink(missing_ok=True)
+        raise
+
+
+def _safe_archive_members(archive: Path) -> list[tuple[str, bytes, int]]:
+    result: list[tuple[str, bytes, int]] = []
+    total = 0
+    if archive.suffix == ".zip":
+        with zipfile.ZipFile(archive) as bundle:
+            for member in bundle.infolist():
+                mode = member.external_attr >> 16
+                if stat.S_ISLNK(mode):
+                    raise ValueError("runtime archive contains a link")
+                if member.is_dir():
+                    continue
+                total += member.file_size
+                if total > MAX_RUNTIME_EXPANDED_BYTES:
+                    raise ValueError("runtime archive expands beyond the size limit")
+                result.append((member.filename, bundle.read(member), mode))
+    else:
+        with tarfile.open(archive, "r:*") as bundle:
+            for member in bundle.getmembers():
+                if member.issym() or member.islnk():
+                    base = PurePosixPath(member.name).parent if member.issym() else PurePosixPath()
+                    target = PurePosixPath(os.path.normpath(str(base / member.linkname)).replace("\\", "/"))
+                    if target.is_absolute() or not target.parts or ".." in target.parts:
+                        raise ValueError("runtime archive contains an unsafe link")
+                    continue
+                if not (member.isfile() or member.isdir()):
+                    raise ValueError("runtime archive contains an unsafe entry")
+                if member.isdir():
+                    continue
+                total += member.size
+                if total > MAX_RUNTIME_EXPANDED_BYTES:
+                    raise ValueError("runtime archive expands beyond the size limit")
+                stream = bundle.extractfile(member)
+                if stream is None:
+                    raise ValueError("runtime archive entry is unreadable")
+                result.append((member.name, stream.read(), member.mode))
+    return result
+
+
+def _extract_runtime_archive(archive: Path, destination: Path) -> None:
+    members = _safe_archive_members(archive)
+    if not members:
+        raise ValueError("runtime archive is empty")
+    split = [Path(name.replace("\\", "/")).parts for name, _, _ in members]
+    if any(not parts or Path(*parts).is_absolute() or ".." in parts for parts in split):
+        raise ValueError("runtime archive contains an unsafe path")
+    strip = 1 if len({parts[0] for parts in split}) == 1 and all(len(parts) > 1 for parts in split) else 0
+    destination.mkdir(parents=True)
+    for (name, payload, mode), parts in zip(members, split):
+        relative = Path(*parts[strip:])
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+        if os.name != "nt" and mode & stat.S_IXUSR:
+            target.chmod(target.stat().st_mode | stat.S_IXUSR)
+
+
+def provision_generation_runtimes(
+    generation: Path, transaction: Path, specification: dict[str, object], *, opener=urllib.request.urlopen
+) -> None:
+    platform_key()
+    for name in ("uv", "node"):
+        artifact = select_runtime_artifact(specification, name)
+        suffix = ".zip" if str(artifact["url"]).endswith(".zip") else (
+            ".tar.xz" if str(artifact["url"]).endswith(".tar.xz") else ".tar.gz"
+        )
+        archive = transaction / f"{name}{suffix}"
+        _download_artifact(str(artifact["url"]), archive, str(artifact["sha256"]), opener)
+        destination = (
+            generation / "bootstrap" / ("Scripts" if os.name == "nt" else "bin")
+            if name == "uv" else generation / "node"
+        )
+        _extract_runtime_archive(archive, destination)
 
 
 class DanglingRuntimeLink(ValueError):
@@ -706,9 +866,11 @@ def _validate_generation_receipt(receipt: dict[str, object]) -> None:
         "ownership",
         "receiptIntegritySha256",
     }
+    modern = receipt.get("schemaVersion") == 3 and receipt.get("runtimeContractVersion") == 4
+    if modern:
+        required.add("runtimes")
     if (
-        receipt.get("schemaVersion") != 2
-        or receipt.get("runtimeContractVersion") != 3
+        not (modern or (receipt.get("schemaVersion") == 2 and receipt.get("runtimeContractVersion") == 3))
         or set(receipt) != required
         or HEX_DIGEST.fullmatch(str(receipt.get("specificationSha256", ""))) is None
         or HEX_DIGEST.fullmatch(str(receipt.get("coreSha256", ""))) is None
@@ -717,6 +879,8 @@ def _validate_generation_receipt(receipt: dict[str, object]) -> None:
         or not isinstance(receipt.get("ownership"), dict)
     ):
         raise ValueError("dependency generation receipt schema is invalid")
+    if modern and not isinstance(receipt.get("runtimes"), dict):
+        raise ValueError("dependency generation runtime metadata is invalid")
     ownership = receipt["ownership"]
     if (
         set(ownership) != {"directories", "files", "links", "sha256", "identities"}
@@ -779,15 +943,28 @@ def _validate_dispatch_metadata(name: str, value: object) -> dict[str, object]:
         digest, size = value.get("interpreterSha256"), value.get("interpreterSize")
     elif name in {"memory", "memory-mcp"}:
         suffix = "dist/cli/main.js" if name == "memory" else "dist/mcp/server.js"
+        if value.get("kind") == "npm":
+            expected = {
+                "kind": "npm", "script": f"npm/node_modules/@aictx/memory/{suffix}",
+                "entrypoint": name,
+            }
+            required = set(expected) | {"scriptSha256", "scriptSize"}
+            if set(value) != required or any(value.get(key) != item for key, item in expected.items()):
+                raise ValueError(f"dependency generation tool metadata is invalid: {name}")
+            digest, size = value.get("scriptSha256"), value.get("scriptSize")
+            if not isinstance(digest, str) or HEX_DIGEST.fullmatch(digest) is None or not isinstance(size, int) or not 0 < size <= MAX_EXECUTABLE_BYTES:
+                raise ValueError(f"dependency generation tool metadata is invalid: {name}")
+            return value
         expected = {
-            "kind": "npm",
+            "kind": "node",
+            "executable": "node/node.exe" if os.name == "nt" else "node/bin/node",
             "script": f"npm/node_modules/@aictx/memory/{suffix}",
             "entrypoint": name,
         }
-        required = set(expected) | {"scriptSha256", "scriptSize"}
+        required = set(expected) | {"executableSha256", "executableSize", "scriptSha256", "scriptSize"}
         if set(value) != required or any(value.get(key) != item for key, item in expected.items()):
             raise ValueError(f"dependency generation tool metadata is invalid: {name}")
-        digest, size = value.get("scriptSha256"), value.get("scriptSize")
+        digest, size = value.get("executableSha256"), value.get("executableSize")
     else:
         raise ValueError(f"dependency generation tool metadata is invalid: {name}")
     if (
@@ -1061,7 +1238,13 @@ def dispatch_command(
         if digest != dispatch["sha256"]:
             raise ValueError(f"dependency executable drift detected: {tool}")
         return [str(generation / relative), *arguments]
-    if dispatch.get("kind") == "npm":
+    if dispatch.get("kind") == "node":
+        executable_relative = str(dispatch["executable"])
+        executable_digest = _digest_regular_relative(
+            generation, executable_relative, f"Node executable for {tool}", dispatch["executableSize"]  # type: ignore[arg-type]
+        )
+        if executable_digest != dispatch["executableSha256"]:
+            raise ValueError(f"dependency Node executable drift detected: {tool}")
         relative = str(dispatch["script"])
         digest = _digest_regular_relative(
             generation,
@@ -1071,8 +1254,15 @@ def dispatch_command(
         )
         if digest != dispatch["scriptSha256"]:
             raise ValueError(f"dependency npm script drift detected: {tool}")
-        node = shutil.which("node") or "node"
-        return [node, str(generation / relative), *arguments]
+        return [str(generation / executable_relative), str(generation / relative), *arguments]
+    if dispatch.get("kind") == "npm":
+        relative = str(dispatch["script"])
+        digest = _digest_regular_relative(
+            generation, relative, f"npm script for {tool}", dispatch["scriptSize"]  # type: ignore[arg-type]
+        )
+        if digest != dispatch["scriptSha256"]:
+            raise ValueError(f"dependency npm script drift detected: {tool}")
+        return [shutil.which("node") or "node", str(generation / relative), *arguments]
     raise ValueError(f"dependency tool dispatch kind is unsupported: {tool}")
 
 
@@ -1095,23 +1285,25 @@ def generation_install_plan(
     generation: Path, specification: dict[str, object]
 ) -> dict[str, list[list[str]]]:
     tools = specification.get("tools")
-    if specification.get("schemaVersion") != 1 or not isinstance(tools, dict):
+    if specification.get("schemaVersion") != 2 or not isinstance(tools, dict):
         raise ValueError("dependency specification schema is unsupported")
     scripts = "Scripts" if os.name == "nt" else "bin"
     bootstrap = generation / "bootstrap"
-    python = executable(bootstrap / scripts, "python")
     uv = executable(bootstrap / scripts, "uv")
-    npm = shutil.which("npm")
-    if npm is None:
-        raise ValueError("Node.js npm is required to install the Memory tool")
+    node = executable(generation / ("node" if os.name == "nt" else "node/bin"), "node")
+    npm_cli = generation / (
+        "node/node_modules/npm/bin/npm-cli.js" if os.name == "nt"
+        else "node/lib/node_modules/npm/bin/npm-cli.js"
+    )
     graphify = tools.get("graphify")
     if not isinstance(graphify, dict):
         raise ValueError("graphify dependency specification is invalid")
+    uv_commands = [[uv, "--version"]] if Path(uv).is_file() else [
+        [sys.executable, "-m", "venv", "--copies", str(bootstrap)],
+        [executable(bootstrap / scripts, "python"), "-m", "pip", "install", "--no-cache-dir", "--upgrade", str(tools["uv"]["package"])],  # type: ignore[index]
+    ]
     return {
-        "uv": [
-            [sys.executable, "-m", "venv", "--copies", str(bootstrap)],
-            [python, "-m", "pip", "install", "--no-cache-dir", "--upgrade", str(tools["uv"]["package"])],  # type: ignore[index]
-        ],
+        "uv": uv_commands,
         "mempalace": [[
             uv,
             "tool",
@@ -1139,7 +1331,8 @@ def generation_install_plan(
             str(graphify["package"]),
         ]],
         "memory": [[
-            npm,
+            node,
+            str(npm_cli),
             "install",
             "--ignore-scripts",
             "--prefix",
@@ -1198,13 +1391,14 @@ def _generation_dispatches(generation: Path) -> dict[str, dict[str, object]]:
     ):
         script = generation / f"npm/node_modules/@aictx/memory/{suffix}"
         digest, size = file_record(script)
-        records[name] = {"dispatch": {
-            "kind": "npm",
-            "script": script.relative_to(generation).as_posix(),
-            "scriptSha256": digest,
-            "scriptSize": size,
-            "entrypoint": name,
-        }}
+        node = generation / ("node/node.exe" if os.name == "nt" else "node/bin/node")
+        records[name] = {"dispatch": (
+            {**node_dispatch(generation, script), "entrypoint": name}
+            if node.is_file() else {
+                "kind": "npm", "script": script.relative_to(generation).as_posix(),
+                "scriptSha256": digest, "scriptSize": size, "entrypoint": name,
+            }
+        )}
     return records
 
 
@@ -1219,12 +1413,14 @@ def _verify_dispatch_set(
                 dispatch["interpreterSha256"],
                 dispatch["interpreterSize"],
             )
-        elif dispatch["kind"] == "npm":
+        elif dispatch["kind"] == "node":
             path, digest, size = (
-                dispatch["script"],
-                dispatch["scriptSha256"],
-                dispatch["scriptSize"],
+                dispatch["executable"],
+                dispatch["executableSha256"],
+                dispatch["executableSize"],
             )
+        elif dispatch["kind"] == "npm":
+            path, digest, size = dispatch["script"], dispatch["scriptSha256"], dispatch["scriptSize"]
         else:
             path, digest, size = dispatch["path"], dispatch["sha256"], dispatch["size"]
         actual = _digest_regular_relative(
@@ -1256,6 +1452,8 @@ def _crosscheck_dispatch_ownership(
                 for link in links
             ):
                 raise ValueError(f"dependency dispatch ownership link drift detected: {name}")
+        elif kind == "node":
+            path, digest = dispatch["executable"], dispatch["executableSha256"]
         elif kind == "npm":
             path, digest = dispatch["script"], dispatch["scriptSha256"]
         else:
@@ -1311,8 +1509,8 @@ def _install_candidate_payload(
     ownership = sealed_ownership_record(generation)
     _crosscheck_dispatch_ownership(ownership, records)
     receipt: dict[str, object] = {
-        "schemaVersion": 2,
-        "runtimeContractVersion": 3,
+        "schemaVersion": 3,
+        "runtimeContractVersion": 4,
         "checkedAt": checked_at.isoformat(),
         "specificationSha256": specification_digest(specification),
         "coreSha256": core_sha256,
@@ -1327,6 +1525,14 @@ def _install_candidate_payload(
             not in {"UV_CACHE_DIR", "UV_TOOL_BIN_DIR", "UV_PYTHON_BIN_DIR", "NPM_CONFIG_CACHE"}
         },
         "installed": completed,
+        "runtimes": {
+            name: {
+                "version": specification["runtimes"][name]["version"],  # type: ignore[index]
+                "platform": platform_key(),
+                **select_runtime_artifact(specification, name),
+            }
+            for name in ("uv", "node")
+        },
         "tools": records,
         "ownership": ownership,
     }
@@ -1483,6 +1689,10 @@ def prepare_candidate(
         def validate_holds() -> None:
             for path, held, label in held_paths:
                 _assert_held_directory(path, held, label)
+
+        if runner is None:
+            provision_generation_runtimes(generation, transaction, specification)
+            validate_holds()
 
         result = _install_candidate_payload(
             project,
@@ -2125,15 +2335,13 @@ def finalize_generation_remove(project: Path) -> None:
 
 def install_plan(runtime: Path, specification: dict[str, object]) -> dict[str, list[list[str]]]:
     tools = specification.get("tools")
-    if specification.get("schemaVersion") != 1 or not isinstance(tools, dict):
+    if specification.get("schemaVersion") != 2 or not isinstance(tools, dict):
         raise ValueError("dependency specification schema is unsupported")
     environment = runtime / "bootstrap"
     scripts = environment / ("Scripts" if os.name == "nt" else "bin")
     uv = executable(scripts, "uv")
     npm_prefix = runtime / "npm"
-    npm = shutil.which("npm")
-    if npm is None:
-        raise ValueError("Node.js npm is required to install the Memory tool")
+    npm = npm_executable(runtime / ("node" if os.name == "nt" else "node/bin"), "npm")
     graphify = tools["graphify"]
     if not isinstance(graphify, dict):
         raise ValueError("graphify dependency specification is invalid")
@@ -2184,6 +2392,7 @@ def load_specification(path: Path) -> dict[str, object]:
     value = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(value, dict):
         raise ValueError("dependency specification must be an object")
+    validate_runtime_specification(value)
     return value
 
 

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -11,6 +11,8 @@ import hashlib
 import hmac
 import json
 import os
+import platform
+import queue
 import re
 import secrets
 import shutil
@@ -18,6 +20,7 @@ import sqlite3
 import stat
 import subprocess  # nosec B404 - probes a resolved local Java executable.
 import sys
+import threading
 from pathlib import Path, PurePosixPath
 
 
@@ -1399,6 +1402,7 @@ MAVEN_TOOLS_MCP_RECEIPT = "install-receipt.json"
 MAVEN_TOOLS_MCP_PROFILE = "docker,no-context7"
 MAVEN_TOOLS_CACHE_LOCK = ".cache.lock"
 MAVEN_TOOLS_CACHE_LOCK_MAGIC = b"chaos-engine-maven-tools-cache-lock-v1\n"
+TEMURIN_RECEIPT = "runtime-receipt.json"
 LEGACY_MAVEN_TOOLS_SERVER = {
     "command": "docker",
     "args": ["run", "-i", "--rm", "arvindand/maven-tools-mcp:3.2.0"],
@@ -1784,12 +1788,21 @@ def discover_maven_tools_runtime() -> tuple[Path, Path] | None:
     configured_java = os.environ.get("CHAOSENGINE_JAVA")
     java_home = os.environ.get("JAVA_HOME")
     path_java = shutil.which("java")
+    system = "windows" if os.name == "nt" else "macos" if sys.platform == "darwin" else "linux"
+    machine = platform.machine().lower()
+    architecture = "arm64" if machine in {"arm64", "aarch64"} else "x64"
+    managed_root = maven_tools_cache_root().parent / "temurin" / "25.0.4+7" / f"{system}-{architecture}"
+    managed_java = managed_root / (
+        "bin/java.exe" if os.name == "nt" else
+        "Contents/Home/bin/java" if sys.platform == "darwin" else "bin/java"
+    )
     java_candidates = [
         Path(configured_java).expanduser() if configured_java else None,
         Path(java_home) / "bin" / ("java.exe" if os.name == "nt" else "java")
         if java_home
         else None,
         Path(path_java) if path_java else None,
+        verified_managed_temurin(managed_java, f"{system}-{architecture}"),
     ]
     for candidate in java_candidates:
         if candidate is None or not candidate.is_file():
@@ -1805,16 +1818,99 @@ def discover_maven_tools_runtime() -> tuple[Path, Path] | None:
     return None
 
 
+def verified_managed_temurin(candidate: Path, host_platform: str) -> Path | None:
+    if not candidate.is_file() or is_link_or_reparse(candidate):
+        return None
+    receipt_path = candidate.parents[3 if sys.platform == "darwin" else 1] / TEMURIN_RECEIPT
+    if not receipt_path.is_file() or is_link_or_reparse(receipt_path):
+        return None
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    expected_architecture = "x64" if host_platform == "windows-arm64" else host_platform.split("-", 1)[1]
+    expected = {
+        "schemaVersion": 1,
+        "runtime": "temurin",
+        "version": "25.0.4+7",
+        "hostPlatform": host_platform,
+        "artifactArchitecture": expected_architecture,
+        "emulated": host_platform == "windows-arm64",
+        "java": candidate.relative_to(receipt_path.parent).as_posix(),
+        "javaSha256": digest,
+    }
+    return candidate.resolve() if receipt == expected and java_major(candidate) == 25 else None
+
+
+def probe_maven_tools_runtime(
+    java: Path,
+    jar: Path,
+    *,
+    popen=subprocess.Popen,
+    timeout: float = 30.0,
+) -> bool:
+    """Require a real MCP initialize and non-empty tools/list exchange."""
+    process = None
+    try:
+        process = popen(  # nosec B603 - both executables are receipt-verified owned paths.
+            [str(java), "-jar", str(jar), f"--spring.profiles.active={MAVEN_TOOLS_MCP_PROFILE}"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+        )
+        if process.stdin is None or process.stdout is None:
+            return False
+
+        def exchange(requests: list[dict[str, object]]) -> dict[str, object]:
+            for request in requests:
+                process.stdin.write(json.dumps(request, separators=(",", ":")) + "\n")
+            process.stdin.flush()
+            received: queue.Queue[str] = queue.Queue(maxsize=1)
+            threading.Thread(
+                target=lambda: received.put(process.stdout.readline()), daemon=True
+            ).start()
+            response = json.loads(received.get(timeout=timeout))
+            return response if isinstance(response, dict) else {}
+
+        initialized = exchange([{
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2025-03-26", "capabilities": {},
+                       "clientInfo": {"name": "chaosengine-installer", "version": "1"}},
+        }])
+        if initialized.get("id") != 1 or not isinstance(initialized.get("result"), dict):
+            return False
+        listed = exchange([
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        ])
+        result = listed.get("result")
+        return listed.get("id") == 2 and isinstance(result, dict) and bool(result.get("tools"))
+    except (OSError, ValueError, json.JSONDecodeError, queue.Empty):
+        return False
+    finally:
+        if process is not None and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
+
 def portable_python_server(
-    script_args: list[str], extra: dict[str, object] | None = None
+    script_args: list[str], extra: dict[str, object] | None = None,
+    managed_python: Path | None = None,
 ) -> dict[str, object]:
     posix_command, posix_prefix = interpreter("posix")
     windows_command, windows_prefix = interpreter("nt")
     server: dict[str, object] = {
-        "command": posix_command,
-        "args": [*posix_prefix, *script_args],
-        "commandWindows": windows_command,
-        "argsWindows": [*windows_prefix, *script_args],
+        "command": str(managed_python) if managed_python else posix_command,
+        "args": script_args if managed_python else [*posix_prefix, *script_args],
+        "commandWindows": str(managed_python) if managed_python else windows_command,
+        "argsWindows": script_args if managed_python else [*windows_prefix, *script_args],
         "cwd": ".",
     }
     if extra:
@@ -1825,11 +1921,12 @@ def portable_python_server(
 def owned_servers(
     platform_name: str | None = None,
     maven_runtime: tuple[Path, Path] | None = None,
+    managed_python: Path | None = None,
 ) -> dict[str, dict[str, object]]:
     del platform_name
     servers: dict[str, dict[str, object]] = {
         "chaosengine-memory": portable_python_server(
-            [".chaos-engine/tool.py", "memory-mcp"]
+            [".chaos-engine/tool.py", "memory-mcp"], managed_python=managed_python
         ),
         "chaosengine-mempalace": portable_python_server(
             [
@@ -1841,6 +1938,7 @@ def owned_servers(
                 "sqlite_exact",
             ],
             extra={"env": dict(MEMPALACE_MCP_ENV)},
+            managed_python=managed_python,
         ),
     }
     if maven_runtime is not None:
@@ -2190,7 +2288,8 @@ def legacy_codex_python_block(platform_name: str) -> str:
 
 
 def json_content(
-    before: bytes | None, maven_runtime: tuple[Path, Path] | None = None
+    before: bytes | None, maven_runtime: tuple[Path, Path] | None = None,
+    managed_python: Path | None = None,
 ) -> bytes:
     try:
         value = json.loads(before.decode("utf-8")) if before is not None else {}
@@ -2203,7 +2302,7 @@ def json_content(
         raise ValueError("invalid MCP server configuration")
     if servers.get("maven-tools-mcp") == LEGACY_MAVEN_TOOLS_SERVER:
         del servers["maven-tools-mcp"]
-    for name, desired in owned_servers(maven_runtime=maven_runtime).items():
+    for name, desired in owned_servers(maven_runtime=maven_runtime, managed_python=managed_python).items():
         if name in servers and not replaceable_owned_server(name, servers[name], desired):
             raise ValueError(f"ChaosEngine MCP server collision: {name}")
         servers[name] = desired
@@ -2214,6 +2313,7 @@ def codex_content(
     before: bytes | None,
     platform_name: str | None = None,
     maven_runtime: tuple[Path, Path] | None = None,
+    managed_python: Path | None = None,
 ) -> bytes:
     try:
         existing = before.decode("utf-8") if before is not None else ""
@@ -2233,6 +2333,9 @@ def codex_content(
     del platform_name
     posix_command, _posix_prefix = interpreter("posix")
     windows_command, _windows_prefix = interpreter("nt")
+    if managed_python is not None:
+        posix_command = windows_command = str(managed_python).replace("\\", "\\\\")
+    windows_prefix = "" if managed_python is not None else '"-3", '
     memory_args = '".chaos-engine/tool.py", "memory-mcp"'
     mempalace_args = (
         '".chaos-engine/tool.py", "mempalace-mcp", "--palace", '
@@ -2243,12 +2346,12 @@ def codex_content(
         f'[mcp_servers."chaosengine-memory"]\ncommand = "{posix_command}"\n'
         f"args = [{memory_args}]\n"
         f'commandWindows = "{windows_command}"\n'
-        f'argsWindows = ["-3", {memory_args}]\n'
+        f'argsWindows = [{windows_prefix}{memory_args}]\n'
         'cwd = ".."\n\n'
         f'[mcp_servers."chaosengine-mempalace"]\ncommand = "{posix_command}"\n'
         f"args = [{mempalace_args}]\n"
         f'commandWindows = "{windows_command}"\n'
-        f'argsWindows = ["-3", {mempalace_args}]\n'
+        f'argsWindows = [{windows_prefix}{mempalace_args}]\n'
         'cwd = ".."\n'
         f"{MEMPALACE_MCP_ENV_TOML}# CHAOSENGINE:END\n"
     )
@@ -2272,7 +2375,7 @@ def codex_content(
                 if candidate in existing:
                     return existing.replace(candidate, block).encode()
         raise ValueError("ChaosEngine Codex configuration collision")
-    for name in owned_servers(maven_runtime=maven_runtime):
+    for name in owned_servers(maven_runtime=maven_runtime, managed_python=managed_python):
         if f'mcp_servers."{name}"' in existing or f"mcp_servers.{name}" in existing:
             raise ValueError(f"ChaosEngine Codex server collision: {name}")
     separator = "\n" if existing and not existing.endswith("\n") else ""
@@ -2321,8 +2424,8 @@ def _tool_matchers() -> tuple[str, str]:
 PRE_TOOL_MATCHER, POST_TOOL_MATCHER = _tool_matchers()
 
 
-def chaos_guard_locator_command(*, windows: bool, host: str) -> str:
-    interpreter = "py -3" if windows else "python3"
+def chaos_guard_locator_command(*, windows: bool, host: str, managed_python: Path | None = None) -> str:
+    interpreter = json.dumps(str(managed_python)) if managed_python else ("py -3" if windows else "python3")
     return (
         f'{interpreter} -c "import os,pathlib,runpy;'
         f"os.environ['CHAOS_ENGINE_HOST']='{host}';"
@@ -2333,11 +2436,11 @@ def chaos_guard_locator_command(*, windows: bool, host: str) -> str:
     )
 
 
-def lifecycle_hooks_document(host: str, events: dict[str, str] | None = None) -> bytes:
+def lifecycle_hooks_document(host: str, events: dict[str, str] | None = None, managed_python: Path | None = None) -> bytes:
     handler = {
         "type": "command",
-        "command": chaos_guard_locator_command(windows=False, host=host),
-        "commandWindows": chaos_guard_locator_command(windows=True, host=host),
+        "command": chaos_guard_locator_command(windows=False, host=host, managed_python=managed_python),
+        "commandWindows": chaos_guard_locator_command(windows=True, host=host, managed_python=managed_python),
         "timeout": 30,
     }
     defaults = CLAUDE_HOOK_EVENTS if host == "claude" else REQUIRED_HOOK_EVENTS
@@ -2353,11 +2456,12 @@ def lifecycle_hooks_document(host: str, events: dict[str, str] | None = None) ->
     return (json.dumps({"hooks": hooks}, indent=2, sort_keys=True) + "\n").encode()
 
 
-def copilot_hooks_document() -> bytes:
+def copilot_hooks_document(managed_node: Path | None = None) -> bytes:
+    node = json.dumps(str(managed_node)) if managed_node else "node"
     handler = {
         "type": "command",
-        "bash": "node .chaos-engine/hooks/launch.js copilot",
-        "powershell": "node .chaos-engine/hooks/launch.js copilot",
+        "bash": f"{node} .chaos-engine/hooks/launch.js copilot",
+        "powershell": f"{node} .chaos-engine/hooks/launch.js copilot",
         "timeoutSec": 30,
     }
     hooks = {
@@ -2377,10 +2481,11 @@ def copilot_hooks_document() -> bytes:
     return (json.dumps({"version": 1, "hooks": hooks}, indent=2, sort_keys=True) + "\n").encode()
 
 
-def gemini_hooks_document() -> bytes:
+def gemini_hooks_document(managed_node: Path | None = None) -> bytes:
+    node = json.dumps(str(managed_node)) if managed_node else "node"
     handler = {
         "type": "command",
-        "command": "node .chaos-engine/hooks/launch.js gemini",
+        "command": f"{node} .chaos-engine/hooks/launch.js gemini",
         "name": "ChaosEngine lifecycle",
         "timeout": 30000,
     }
@@ -2403,8 +2508,8 @@ def gemini_hooks_document() -> bytes:
     return (json.dumps({"hooks": hooks}, indent=2, sort_keys=True) + "\n").encode()
 
 
-def copilot_hook_content(before: bytes | None) -> bytes:
-    desired = json.loads(copilot_hooks_document())
+def copilot_hook_content(before: bytes | None, managed_node: Path | None = None) -> bytes:
+    desired = json.loads(copilot_hooks_document(managed_node))
     if before is None:
         return (json.dumps(desired, indent=2, sort_keys=True) + "\n").encode()
     try:
@@ -2600,9 +2705,16 @@ def desired_content(
     maven_runtime: tuple[Path, Path] | None | bool = False,
     project_name: str = "project",
     plugin_version: str = "1.0.0",
+    dependency_runtime: Path | None = None,
 ) -> dict[str, bytes]:
     if maven_runtime is False:
         maven_runtime = discover_maven_tools_runtime()
+    managed_python = None
+    managed_node = None
+    if dependency_runtime is not None:
+        scripts = "Scripts" if os.name == "nt" else "bin"
+        managed_python = dependency_runtime / "uv-tools/mempalace" / scripts / ("python.exe" if os.name == "nt" else "python")
+        managed_node = dependency_runtime / ("node/node.exe" if os.name == "nt" else "node/bin/node")
     adapters = managed_paths()[:4]
     skill = (
         "---\nname: chaos-engine\ndescription: Load the canonical installed ChaosEngine before every task.\n---\n\n"
@@ -2801,7 +2913,7 @@ def desired_content(
         )
         + "\n"
     ).encode()
-    desired_hooks = lifecycle_hooks_document("codex")
+    desired_hooks = lifecycle_hooks_document("codex", managed_python=managed_python)
     after["plugins/chaos-engine/hooks/hooks.json"] = (
         json.dumps({"hooks": {}}, indent=2, sort_keys=True) + "\n"
     ).encode()
@@ -2812,11 +2924,11 @@ def desired_content(
     )
     after[".grok/hooks/lifecycle.json"] = hook_content(
         without_chaos_hooks(before[".grok/hooks/lifecycle.json"], "Grok"),
-        lifecycle_hooks_document("grok"),
+        lifecycle_hooks_document("grok", managed_python=managed_python),
         "Grok",
     )
     after[".github/hooks/chaos-engine.json"] = copilot_hook_content(
-        before[".github/hooks/chaos-engine.json"]
+        before[".github/hooks/chaos-engine.json"], managed_node
     )
     after["plugins/chaos-engine/hooks/guard.py"] = (
         Path(__file__).resolve().parent / "hooks/guard.py"
@@ -2843,7 +2955,7 @@ def desired_content(
     ).encode()
     claude_settings = hook_content(
         without_chaos_hooks(before[".claude/settings.json"], "Claude"),
-        lifecycle_hooks_document("claude"),
+        lifecycle_hooks_document("claude", managed_python=managed_python),
         "Claude",
     )
     try:
@@ -3066,15 +3178,15 @@ def desired_content(
         before[".github/copilot-instructions.md"],
         INSTRUCTION.replace(".chaos-engine/", "../.chaos-engine/"),
     )
-    after[".mcp.json"] = json_content(before[".mcp.json"], maven_runtime)
-    gemini_settings = json_content(before[".gemini/settings.json"], maven_runtime)
+    after[".mcp.json"] = json_content(before[".mcp.json"], maven_runtime, managed_python)
+    gemini_settings = json_content(before[".gemini/settings.json"], maven_runtime, managed_python)
     after[".gemini/settings.json"] = hook_content(
         without_chaos_hooks(gemini_settings, "Gemini"),
-        gemini_hooks_document(),
+        gemini_hooks_document(managed_node),
         "Gemini",
     )
     after[".codex/config.toml"] = codex_content(
-        before[".codex/config.toml"], maven_runtime=maven_runtime
+        before[".codex/config.toml"], maven_runtime=maven_runtime, managed_python=managed_python
     )
     after[".gitattributes"] = gitattributes_content(before[".gitattributes"])
     return after
@@ -3496,6 +3608,7 @@ def install(
     project: Path,
     core_commit: str | None = None,
     capability_policy_digest: str | None = None,
+    dependency_runtime: Path | None = None,
 ) -> dict[str, object]:
     project = project.resolve()
     if capability_policy_digest is not None and re.fullmatch(r"[0-9a-f]{64}", capability_policy_digest) is None:
@@ -3521,6 +3634,7 @@ def install(
                 before,
                 project_name=project_identity_name(project),
                 plugin_version=version,
+                dependency_runtime=dependency_runtime,
             )
             if (
                 after == wanted
@@ -3566,6 +3680,7 @@ def install(
         before,
         project_name=project_identity_name(project),
         plugin_version=version,
+        dependency_runtime=dependency_runtime,
     )
     if existing_anchors and existing_anchors[0].name.startswith(REMOVING_ANCHOR_PREFIX):
         raise ValueError("ChaosEngine host removal recovery is required")

--- a/chaos-engine/install.ps1
+++ b/chaos-engine/install.ps1
@@ -3,7 +3,8 @@
 #   irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex
 [CmdletBinding()]
 param(
-    [switch]$ParseOnly
+    [switch]$ParseOnly,
+    [switch]$WithMavenTools
 )
 
 Set-StrictMode -Version Latest
@@ -21,7 +22,28 @@ function Get-ChaosEnginePython {
             return @($found.Source)
         }
     }
-    throw "Python 3 is required (py -3, python3, or python)."
+    return $null
+}
+
+function Install-ChaosEngineUv([string]$Work) {
+    $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+    if ($architecture -eq "X64") {
+        $target = "x86_64-pc-windows-msvc"
+        $digest = "a047d55651bc3e0ca24595b25ec4cfcb10f9dca9fb56514e661269b37d4fae68"
+    }
+    elseif ($architecture -eq "Arm64") {
+        $target = "aarch64-pc-windows-msvc"
+        $digest = "55b597ae81bc29531a7c352a1431a8a73cc2755d7a5b9ec454580cbe02e5154f"
+    }
+    else { throw "Unsupported ChaosEngine platform: Windows/$architecture" }
+    $archive = Join-Path $Work "uv.zip"
+    Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-$target.zip" -OutFile $archive
+    $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $archive).Hash.ToLowerInvariant()
+    if ($actual -ne $digest) { throw "uv download checksum verification failed" }
+    Expand-Archive -LiteralPath $archive -DestinationPath $Work
+    $uv = Join-Path $Work "uv.exe"
+    if (-not (Test-Path -LiteralPath $uv -PathType Leaf)) { throw "uv archive is missing its executable" }
+    return $uv
 }
 
 function Get-ChaosEngineHeader([object]$Headers, [string]$Name) {
@@ -263,15 +285,16 @@ try {
         $response = Read-ChaosEngineUrl $bootstrapUrl
         [System.IO.File]::WriteAllText($bootstrap, [string]$response.Content)
     }
-    $invoke = @($python) + @(
-        $bootstrap,
-        "--project",
-        $project,
-        "--repository",
-        $repository,
-        "--branch",
-        $branch
-    )
+    $arguments = @($bootstrap, "--project", $project, "--repository", $repository, "--branch", $branch)
+    if ($WithMavenTools) { $arguments += "--with-maven-tools" }
+    if ($null -eq $python) {
+        $uv = Install-ChaosEngineUv $work
+        $env:UV_PYTHON_INSTALL_DIR = Join-Path $work "python"
+        & $uv python install 3.10 --no-progress
+        if ($LASTEXITCODE -ne 0) { throw "uv-managed Python installation failed" }
+        $invoke = @($uv, "run", "--no-project", "--managed-python", "--python", "3.10") + $arguments
+    }
+    else { $invoke = @($python) + $arguments }
     & $invoke[0] @($invoke[1..($invoke.Length - 1)])
     if ($LASTEXITCODE -ne 0) {
         throw "ChaosEngine bootstrap failed with exit $LASTEXITCODE"

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -12,6 +12,7 @@ import re
 import runpy
 import secrets
 import shutil
+import subprocess  # nosec B404 - fixed list-form Maven build commands.
 import sys
 import tempfile
 import types
@@ -74,7 +75,7 @@ def legacy_capability_policy() -> dict[str, dict[str, str]]:
         owner="project", scope="repository", lifecycle="derived-single-writer", taskImpact="advisory"
     )
     result["maven-tools-mcp"].update(
-        owner="user", scope="user", lifecycle="user-managed-cache", taskImpact="optional"
+        owner="installer", scope="user", lifecycle="receipt-owned", taskImpact="optional"
     )
     return _validated_capabilities(result)
 
@@ -1181,6 +1182,10 @@ def rollback(  # noqa: MC0001 - cross-resource rollback is one journaled state m
                     project,
                     core_commit=desired_commit,
                     capability_policy_digest=desired_manifest.get("capabilityPolicySha256"),
+                    dependency_runtime=(
+                        project / getattr(previous_dependencies, "GENERATIONS_NAME", ".chaos-engine-runtime-generations") / generation_previous["generationId"]
+                        if generation_previous is not None else None
+                    ),
                 )
                 restored_host_receipt, _ = previous_hosts.read_receipt(project)
                 if isinstance(restored_host_receipt.get("clientActivation"), dict):
@@ -1337,6 +1342,116 @@ def load_dependency_controller(installed_root: Path):
     return load_installed_controller(installed_root, "dependencies")
 
 
+def ensure_maven_tools(
+    target: Path, specification: dict[str, object], *, runner=subprocess.run
+) -> tuple[Path, Path]:
+    hosts = load_installed_controller(target, "hosts")
+    existing = hosts.discover_maven_tools_runtime()
+    if existing is not None:
+        if not hosts.probe_maven_tools_runtime(*existing):
+            raise ValueError("Maven Tools MCP initialization/tools-list probe failed")
+        return existing
+    dependencies = load_dependency_controller(target)
+    java_candidates = []
+    configured = os.environ.get("CHAOSENGINE_JAVA")
+    java_home = os.environ.get("JAVA_HOME")
+    path_java = shutil.which("java")
+    if configured:
+        java_candidates.append(Path(configured).expanduser())
+    if java_home:
+        java_candidates.append(Path(java_home) / "bin" / ("java.exe" if os.name == "nt" else "java"))
+    if path_java:
+        java_candidates.append(Path(path_java))
+    java = next((item.resolve() for item in java_candidates if item.is_file() and hosts.java_major(item.resolve()) == 25), None)
+    if java is None:
+        artifact = dependencies.select_runtime_artifact(specification, "temurin")
+        cache = hosts.maven_tools_cache_root().parent / "temurin" / "25.0.4+7" / dependencies.platform_key()
+        java_relative = Path(
+            "bin/java.exe" if os.name == "nt" else
+            "Contents/Home/bin/java" if sys.platform == "darwin" else "bin/java"
+        )
+        java = cache / java_relative
+        if not java.is_file():
+            cache.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.TemporaryDirectory(prefix=".temurin-", dir=cache.parent) as scratch_name:
+                scratch = Path(scratch_name)
+                url = str(artifact["url"])
+                archive = scratch / ("temurin.zip" if url.endswith(".zip") else "temurin.tar.gz")
+                dependencies._download_artifact(url, archive, str(artifact["sha256"]))
+                staged = scratch / "runtime"
+                dependencies._extract_runtime_archive(archive, staged)
+                candidate_java = staged / java_relative
+                if not candidate_java.is_file() or hosts.java_major(candidate_java) != 25:
+                    raise ValueError("managed Temurin Java 25 probe failed")
+                host_platform = dependencies.platform_key()
+                runtime_receipt = {
+                    "schemaVersion": 1,
+                    "runtime": "temurin",
+                    "version": "25.0.4+7",
+                    "hostPlatform": host_platform,
+                    "artifactArchitecture": str(artifact.get("artifactArchitecture", host_platform.split("-", 1)[1])),
+                    "emulated": bool(artifact.get("emulated", False)),
+                    "java": java_relative.as_posix(),
+                    "javaSha256": file_sha256(candidate_java),
+                }
+                (staged / hosts.TEMURIN_RECEIPT).write_text(
+                    json.dumps(runtime_receipt, sort_keys=True) + "\n", encoding="utf-8"
+                )
+                try:
+                    staged.replace(cache)
+                except OSError:
+                    if not cache.is_dir():
+                        raise
+            java = cache / java_relative
+        if hosts.verified_managed_temurin(java, dependencies.platform_key()) is None:
+            raise ValueError("managed Temurin Java 25 probe failed")
+    cache_status = hosts.maven_tools_cache_status()
+    if cache_status["status"] == "healthy":
+        runtime = hosts.discover_maven_tools_runtime()
+        if runtime is None:
+            raise ValueError("Maven Tools MCP cache Java probe failed")
+        return runtime
+    if cache_status["status"] != "absent":
+        raise ValueError("Maven Tools MCP cache is invalid")
+    cache_root = hosts.maven_tools_cache_root()
+    cache_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".maven-tools-source-") as source_name:
+        source = Path(source_name) / "source"
+        git = shutil.which("git")
+        if git:
+            runner([git, "clone", "--filter=blob:none", "--no-checkout", "https://github.com/arvindand/maven-tools-mcp.git", str(source)], check=True, timeout=300)
+            runner([git, "-C", str(source), "checkout", "--detach", hosts.MAVEN_TOOLS_MCP_COMMIT], check=True, timeout=120)
+        else:
+            source.mkdir()
+            archive = Path(source_name) / "source.zip"
+            source_artifact = specification["runtimes"]["maven-tools-source"]  # type: ignore[index]
+            dependencies._download_artifact(
+                str(source_artifact["url"]), archive, str(source_artifact["sha256"]),  # type: ignore[index]
+            )
+            source.rmdir()
+            dependencies._extract_runtime_archive(archive, source)
+        wrapper = source / ("mvnw.cmd" if os.name == "nt" else "mvnw")
+        if not wrapper.is_file():
+            raise ValueError("Maven Tools upstream wrapper is missing")
+        environment = os.environ.copy()
+        environment["JAVA_HOME"] = str(java.parent.parent)
+        runner([str(wrapper), "-B", "clean", "verify", "-Pfull"], cwd=source, env=environment, check=True, timeout=900)
+        built = source / f"target/maven-tools-mcp-{hosts.MAVEN_TOOLS_MCP_VERSION}.jar"
+        if not built.is_file() or built.stat().st_size == 0:
+            raise ValueError("Maven Tools build did not produce the pinned JAR")
+        with tempfile.TemporaryDirectory(prefix=".publishing-", dir=cache_root) as staging_name:
+            staging = Path(staging_name)
+            jar = staging / built.name
+            shutil.copyfile(built, jar)
+            receipt = {"version": hosts.MAVEN_TOOLS_MCP_VERSION, "commit": hosts.MAVEN_TOOLS_MCP_COMMIT, "jar": jar.name, "sha256": file_sha256(jar)}
+            (staging / hosts.MAVEN_TOOLS_MCP_RECEIPT).write_text(json.dumps(receipt, sort_keys=True) + "\n", encoding="utf-8")
+            hosts.publish_maven_tools_cache(staging)
+    runtime = hosts.discover_maven_tools_runtime()
+    if runtime is None or not hosts.probe_maven_tools_runtime(*runtime):
+        raise ValueError("Maven Tools MCP publication probe failed")
+    return runtime
+
+
 def installed_kernel_status(installed_root: Path) -> dict[str, object]:
     """Report canonical kernel health and declared host coverage."""
     try:
@@ -1375,6 +1490,7 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
     provisioner=None,
     source_record: dict[str, str] | None = None,
     distribution: str = DEFAULT_DISTRIBUTION,
+    with_maven_tools: bool = False,
 ) -> Path:
     project = project.resolve()
     generation_mode = provisioner is None
@@ -1445,6 +1561,8 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
         try:
             controller = load_dependency_controller(target)
             specification = controller.load_specification(target / "dependencies.json")
+            if with_maven_tools:
+                ensure_maven_tools(target, specification)
             if generation_mode:
                 specification_sha256 = controller.specification_digest(specification)
                 core_sha256 = file_sha256(target / MANIFEST_NAME)
@@ -1458,10 +1576,23 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
                     candidate = controller.prepare_candidate(
                         project, specification, core_sha256
                     )
+                if candidate is not None:
+                    dependency_generation = project / getattr(
+                        controller, "GENERATIONS_NAME", ".chaos-engine-runtime-generations"
+                    ) / candidate["generationId"]
+                else:
+                    dependency_generation = controller.active_generation(
+                        project,
+                        expected_specification_sha256=specification_sha256,
+                        expected_core_sha256=core_sha256,
+                    )[0]
+            else:
+                dependency_generation = None
             host_controller.install(
                 project,
                 core_commit=commit,
                 capability_policy_digest=installed_manifest.get("capabilityPolicySha256"),
+                dependency_runtime=dependency_generation,
             )
             host_created = not host_existed
             if not generation_mode:
@@ -1719,6 +1850,9 @@ def status_with_dependencies(project: Path, *, active_probes: bool = False) -> d
                     "generationId": pointer["active"]["generationId"],
                     "path": str(generation),
                 }
+                receipt = json.loads((generation / getattr(controller, "RECEIPT_NAME", "receipt.json")).read_text(encoding="utf-8"))
+                if isinstance(receipt.get("runtimes"), dict):
+                    result["dependencies"]["runtimes"] = receipt["runtimes"]
                 attach_component_status(
                     result, project, target, "healthy", host_controller
                 )
@@ -2078,6 +2212,7 @@ def parser() -> argparse.ArgumentParser:
     install_command.add_argument("--commit", required=True)
     install_command.add_argument("--distribution", default=DEFAULT_DISTRIBUTION)
     install_command.add_argument("--skip-tools", action="store_true")
+    install_command.add_argument("--with-maven-tools", action="store_true")
     for name in ("status", "doctor", "rollback", "uninstall"):
         command = commands.add_parser(name)
         command.add_argument("--project", required=True, type=Path)
@@ -2105,9 +2240,15 @@ def parser() -> argparse.ArgumentParser:
     return result
 
 
+def validate_install_options(args: argparse.Namespace) -> None:
+    if getattr(args, "skip_tools", False) and getattr(args, "with_maven_tools", False):
+        raise ValueError("--with-maven-tools cannot be combined with --skip-tools")
+
+
 def main() -> int:
     args = parser().parse_args()
     try:
+        validate_install_options(args)
         if args.command == "install":
             target = (
                 install(
@@ -2122,6 +2263,7 @@ def main() -> int:
                     args.source,
                     args.commit,
                     distribution=args.distribution,
+                    with_maven_tools=args.with_maven_tools,
                 )
             )
             result: object = {"status": "installed", "root": str(target)}

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -1342,7 +1342,7 @@ def load_dependency_controller(installed_root: Path):
     return load_installed_controller(installed_root, "dependencies")
 
 
-def ensure_maven_tools(
+def ensure_maven_tools(  # noqa: MC0001 - cross-resource provisioning is one transaction.
     target: Path, specification: dict[str, object], *, runner=subprocess.run
 ) -> tuple[Path, Path]:
     hosts = load_installed_controller(target, "hosts")

--- a/chaos-engine/install.sh
+++ b/chaos-engine/install.sh
@@ -87,12 +87,17 @@ EOF
   fail "Put owner/repository in the install URL (or set CHAOS_ENGINE_REPOSITORY for a local file run)."
 }
 
+with_maven_tools=
+for argument in "$@"; do
+  [ "$argument" = "--with-maven-tools" ] && with_maven_tools=1
+done
+
 if command -v python3 >/dev/null 2>&1; then
   python="python3"
 elif command -v python >/dev/null 2>&1; then
   python="python"
 else
-  fail "Python 3 is required (python3 or python)."
+  python=
 fi
 
 if command -v curl >/dev/null 2>&1; then
@@ -147,4 +152,32 @@ case "$0" in
     fetch "$bootstrap" "$bootstrap_url"
     ;;
 esac
-"$python" "$bootstrap" --project "$project" --repository "$repository" --branch "$branch"
+if [ -z "$python" ]; then
+  system=$(uname -s)
+  machine=$(uname -m)
+  case "$system:$machine" in
+    Linux:x86_64) uv_target=x86_64-unknown-linux-gnu; uv_sha=04f8b82f5d47f0512dcd32c67a4a6f16a0ea27c81537c338fd0ad6b23cebe829 ;;
+    Linux:aarch64|Linux:arm64) uv_target=aarch64-unknown-linux-gnu; uv_sha=94500fb064ae3c971a873cba64d94694c50677e0a4dbf78735c80509e7429919 ;;
+    Darwin:x86_64) uv_target=x86_64-apple-darwin; uv_sha=c4c4de482da9ccdd076dc4fb5cfe7b740609029385c72f58606be3153602387d ;;
+    Darwin:arm64) uv_target=aarch64-apple-darwin; uv_sha=61c04acc52a33ef0f331e494bdfbedcdb6c26c6970c022ed3699e5860f8930e3 ;;
+    *) fail "Unsupported ChaosEngine platform: $system/$machine" ;;
+  esac
+  uv_archive="$work/uv.tar.gz"
+  fetch "$uv_archive" "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-${uv_target}.tar.gz"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$uv_archive" | cut -d' ' -f1)
+  else
+    actual=$(shasum -a 256 "$uv_archive" | cut -d' ' -f1)
+  fi
+  [ "$actual" = "$uv_sha" ] || fail "uv download checksum verification failed"
+  tar -xzf "$uv_archive" -C "$work"
+  uv="$work/uv-${uv_target}/uv"
+  [ -x "$uv" ] || fail "uv archive is missing its executable"
+  export UV_PYTHON_INSTALL_DIR="$work/python"
+  "$uv" python install 3.10 --no-progress
+  set -- "$uv" run --no-project --managed-python --python 3.10 "$bootstrap" --project "$project" --repository "$repository" --branch "$branch"
+else
+  set -- "$python" "$bootstrap" --project "$project" --repository "$repository" --branch "$branch"
+fi
+[ -n "$with_maven_tools" ] && set -- "$@" --with-maven-tools
+"$@"

--- a/chaos-engine/references/lifecycle-hooks.md
+++ b/chaos-engine/references/lifecycle-hooks.md
@@ -24,7 +24,7 @@ events and point them at the installed ChaosEngine guard:
 | `PreToolUse` | Deny catastrophic or out-of-contract tool use. Hold work that owes a reflection receipt. |
 | `PostToolUse` | Record mutation, delivery, and outcome for reflection. |
 | `PostToolUseFailure` | Record the failure and inject a pending reflection checkpoint when one is owed. |
-| `Stop` | Collect incomplete delivery duties once without manufacturing work. Never start learning before delivery. After delivery, require exactly one root-owned terminal Learning Session completion immediately before the final report. `stop_hook_active` lets the retry proceed. |
+| `Stop` | Collect incomplete delivery duties once without manufacturing work. Plan Mode stays read-only: it may finish in a pre-dirty or unverifiable checkout without inheriting unrelated delivery, synchronization, tracking, cleanup, or Learning Session duties; confirmed NUL corruption still blocks with preservation guidance. Normal completion ownership applies to task-created mutation. Never start learning before delivery. After delivery, require exactly one root-owned terminal Learning Session completion immediately before the final report. `stop_hook_active` lets the retry proceed. |
 | `SubagentStop` | Apply delegate-owned completion duties only. Never start or inherit the root terminal Learning Session. A delegate that missed SessionStart still owes the entrypoint through its role adapter. |
 
 A host with no hook primitive cannot enforce this table. Say so in the install

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -2566,8 +2566,10 @@ def _research_preflight_events(
         if tool_name == "web__run"
         else tool_result
     )
-    if tool_name in {"WebSearch", "WebFetch", "web__run"} and _has_primary_source_url(
-        web_evidence
+    if (
+        tool_name in {"WebSearch", "WebFetch", "web__run"}
+        and (tool_name != "web__run" or _wrapped_web_result_successful(tool_result))
+        and _has_primary_source_url(web_evidence)
     ):
         events.append("authoritative-online-research")
     if tool_name == "update_plan":

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1966,6 +1966,7 @@ _PRIMARY_SOURCE_HOSTS = frozenset(
     {
         "docs.github.com",
         "github.com",
+        "raw.githubusercontent.com",
         "learn.microsoft.com",
         "docs.python.org",
         "docs.oracle.com",
@@ -2545,7 +2546,7 @@ def _research_preflight_events(
         events.extend(_functions_exec_plan_events(source))
         if (
             _wrapped_web_result_is_forwarded(source)
-            and _tool_result_explicitly_successful(tool_result)
+            and _wrapped_web_result_successful(tool_result)
             and _has_primary_source_url(tool_result)
         ):
             events.append("authoritative-online-research")
@@ -4066,6 +4067,23 @@ def _tool_result_explicitly_successful(tool_result: object) -> bool:
     )
 
 
+def _wrapped_web_result_successful(tool_result: object) -> bool:
+    """Accept normal web results while rejecting every explicit failure signal."""
+    if not isinstance(tool_result, dict) or tool_result.get("isError") is True:
+        return False
+    status = str(tool_result.get("status", "")).strip().lower()
+    if status and status not in {"ok", "success", "succeeded", "completed"}:
+        return False
+    if (
+        "exit_code" in tool_result or "exitCode" in tool_result
+    ) and tool_result.get("exit_code", tool_result.get("exitCode")) != 0:
+        return False
+    return not any(
+        tool_result.get(field) is not None and tool_result.get(field) != ""
+        for field in ("stderr", "error")
+    )
+
+
 def _tracked_issue_reference_event(
     command: str, tool_result: object, cwd: object = None
 ) -> str | None:
@@ -5564,6 +5582,26 @@ def run_stop(hook_input: dict) -> int:
         )
         if elapsed is None or elapsed <= 60 * 60:
             return 0
+    permission_mode = str(
+        hook_input.get("permission_mode", hook_input.get("permissionMode", ""))
+    ).strip().lower()
+    if permission_mode == "plan":
+        report = _worktree_report(_hook_working_directory(hook_input))
+        current = next(
+            (
+                item
+                for item in (report or {}).get("worktrees", [])
+                if item.get("is_current")
+            ),
+            None,
+        )
+        if current is not None and current.get("state") == "corrupt":
+            reason = (
+                "Current worktree contains NUL-corrupt files. Preserve healthy work and "
+                "restore only confirmed corrupt paths before continuing."
+            )
+            print(json.dumps({"decision": "block", "reason": reason}))
+        return 0
     reflection_reason = _terminal_reflection_reason(hook_input)
     if reflection_reason is not None:
         print(json.dumps({"decision": "block", "reason": reflection_reason}))

--- a/scripts/ci/validate_chaos_engine_readme.py
+++ b/scripts/ci/validate_chaos_engine_readme.py
@@ -195,12 +195,12 @@ def _events(root: Path) -> list[tuple[object, ...]]:
 def inventory_sections(root: Path = ROOT) -> dict[str, str]:
     static: dict[str, list[tuple[object, ...]]] = {
         "prerequisites": [
-            ("Python 3.10+", "Run bootstrap, installer, kernel, and tools.", "install.ps1; install.sh", "required", "Windows, Linux, macOS", "operator", "consumer environment", "install stops before mutation"),
+            ("Python 3.10+", "Run bootstrap, installer, kernel, and tools.", "install.ps1; install.sh; dependencies.json", "managed", "Windows, Linux, macOS", "verified uv 0.11.29", "immutable dependency generation", "install stops before activation"),
             ("PowerShell or POSIX shell", "Launch the reviewed bootstrap wrapper.", "install.ps1; install.sh", "required", "platform native", "operating system", "consumer environment", "bootstrap does not start"),
             ("curl or wget", "Download immutable source on POSIX.", "install.sh", "required on POSIX", "Linux, macOS", "operator", "consumer environment", "download fails closed"),
-            ("Node.js and npm", "Provision Memory and launch Gemini hooks.", "dependencies.json; hooks/launch.js", "required", "Windows, Linux, macOS", "operator", "consumer environment", "dependency generation is not published"),
+            ("Node.js and npm", "Provision Memory and launch JavaScript hooks.", "dependencies.json; hooks/launch.js", "managed", "Windows, Linux, macOS", "immutable generation installer", "installer receipt", "dependency generation is not published"),
             ("network", "Resolve source and provision a fresh or upgraded generation.", "bootstrap.py; dependencies.py", "required for fresh install or upgrade", "Windows, Linux, macOS", "operator", "prior verified generation remains active"),
-            ("Git and Java 25", "Build optional Maven Tools MCP cache.", "hosts.py", "optional", "Windows, Linux, macOS", "operator", "optional component reports absent"),
+            ("Git and Java 25", "Build optional Maven Tools MCP cache.", "dependencies.json; install.py; hosts.py", "optional and managed with `--with-maven-tools`", "Windows, Linux, macOS", "installer", "receipt-owned shared cache", "optional component reports absent"),
         ],
         "external-services": [
             ("GitHub API and raw content", "Resolve immutable source and deliver pull requests.", "bootstrap.py; work-github-playbook.md", "required for remote install and delivery", "network", "operator credentials", "GitHub and repository owner", "install or delivery blocks"),

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -167,7 +167,7 @@ def mempalace_runtime_status(project: Path):
             runtime = Path(temporary) / ".chaos-engine-runtime"
             plan = module.install_plan(runtime, specification)
 
-        self.assertEqual(1, specification["schemaVersion"])
+            self.assertEqual(2, specification["schemaVersion"])
         self.assertEqual({"uv", "mempalace", "graphify", "memory"}, set(plan))
         self.assertEqual("uv==0.11.29", plan["uv"][1][-1])
         self.assertIn("mempalace==3.7.1", plan["mempalace"][0])

--- a/tests/scripts/test_chaos_engine_generation_runtime.py
+++ b/tests/scripts/test_chaos_engine_generation_runtime.py
@@ -1663,7 +1663,7 @@ class GenerationRuntimeTests(unittest.TestCase):
                     python = generation / f"uv-tools/{environment_name}/{scripts}/{python_name}"
                     python.parent.mkdir(parents=True, exist_ok=True)
                     python.write_bytes(f"python-{environment_name}".encode())
-                if "npm" in Path(command[0]).name and "install" in command:
+                if any("npm" in Path(part).name for part in command[:2]) and "install" in command:
                     for name, suffix in (
                         ("memory", "dist/cli/main.js"),
                         ("memory-mcp", "dist/mcp/server.js"),
@@ -1781,7 +1781,7 @@ class GenerationRuntimeTests(unittest.TestCase):
                     path = generation / f"uv-tools/{name}/{scripts}/{python_name}"
                     path.parent.mkdir(parents=True, exist_ok=True)
                     path.write_bytes(f"python-{name}".encode())
-                elif "npm" in Path(command[0]).name and "install" in command:
+                elif any("npm" in Path(part).name for part in command[:2]) and "install" in command:
                     for suffix in ("dist/cli/main.js", "dist/mcp/server.js"):
                         path = generation / f"npm/node_modules/@aictx/memory/{suffix}"
                         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -261,7 +261,7 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             for name in ("memory", "mempalace", "graphify"):
                 self.assertEqual("advisory", result["components"][name]["taskImpact"])
             self.assertEqual("optional", result["components"]["maven-tools-mcp"]["taskImpact"])
-            self.assertEqual("user-managed-cache", result["components"]["maven-tools-mcp"]["lifecycle"])
+            self.assertEqual("receipt-owned", result["components"]["maven-tools-mcp"]["lifecycle"])
             self.assertEqual("recovery-required", result["status"])
             self.assertEqual(manifest["capabilityPolicySha256"], host_receipt["capabilityPolicySha256"])
             self.assertEqual(manifest["capabilities"], MODULE.legacy_capability_policy())

--- a/tests/scripts/test_chaos_engine_managed_runtimes.py
+++ b/tests/scripts/test_chaos_engine_managed_runtimes.py
@@ -1,0 +1,312 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+import io
+import zipfile
+import tarfile
+from unittest import mock
+from types import SimpleNamespace
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load(name: str):
+    path = ROOT / "chaos-engine" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"chaos_engine_{name}_managed", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+DEPENDENCIES = load("dependencies")
+INSTALLER = load("install")
+HOSTS = load("hosts")
+
+
+class ManagedRuntimeManifestTest(unittest.TestCase):
+    def setUp(self):
+        self.specification = json.loads(
+            (ROOT / "chaos-engine/dependencies.json").read_text(encoding="utf-8")
+        )
+
+    def test_manifest_pins_all_supported_runtime_artifacts(self):
+        self.assertEqual(2, self.specification["schemaVersion"])
+        self.assertEqual("0.11.29", self.specification["runtimes"]["uv"]["version"])
+        self.assertEqual("3.10", self.specification["runtimes"]["python"]["version"])
+        self.assertEqual("24.19.0", self.specification["runtimes"]["node"]["version"])
+        self.assertEqual("25.0.4+7", self.specification["runtimes"]["temurin"]["version"])
+        for runtime in ("uv", "node"):
+            self.assertEqual(
+                set(DEPENDENCIES.SUPPORTED_PLATFORMS),
+                set(self.specification["runtimes"][runtime]["artifacts"]),
+            )
+        for runtime in ("uv", "node", "temurin"):
+            for artifact in self.specification["runtimes"][runtime]["artifacts"].values():
+                self.assertRegex(artifact["sha256"], r"^[0-9a-f]{64}$")
+                self.assertTrue(artifact["url"].startswith("https://"))
+        emulated = self.specification["runtimes"]["temurin"]["artifacts"]["windows-arm64"]
+        self.assertTrue(emulated["emulated"])
+        self.assertEqual("x64", emulated["artifactArchitecture"])
+
+    def test_platform_selector_rejects_unsupported_before_returning_artifact(self):
+        with self.assertRaisesRegex(ValueError, "unsupported platform"):
+            DEPENDENCIES.select_runtime_artifact(
+                self.specification, "node", system="freebsd", machine="x86_64"
+            )
+
+    def test_node_dispatch_binds_owned_executable_and_digest(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            generation = Path(temporary)
+            node = generation / "node/bin/node"
+            script = generation / "npm/node_modules/@aictx/memory/dist/cli/main.js"
+            node.parent.mkdir(parents=True)
+            script.parent.mkdir(parents=True)
+            node.write_bytes(b"owned-node")
+            script.write_bytes(b"owned-memory")
+            dispatch = DEPENDENCIES.node_dispatch(generation, script)
+            self.assertEqual("node", dispatch["kind"])
+            self.assertEqual("node/bin/node", dispatch["executable"])
+            self.assertEqual(DEPENDENCIES.sha256(node), dispatch["executableSha256"])
+            self.assertEqual("npm/node_modules/@aictx/memory/dist/cli/main.js", dispatch["script"])
+
+    def test_safe_extraction_rejects_parent_traversal(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            archive = root / "bad.zip"
+            with zipfile.ZipFile(archive, "w") as bundle:
+                bundle.writestr("runtime/../../outside", b"bad")
+            with self.assertRaisesRegex(ValueError, "unsafe path"):
+                DEPENDENCIES._extract_runtime_archive(archive, root / "runtime")
+            self.assertFalse((root / "outside").exists())
+
+    def test_safe_extraction_omits_in_archive_relative_symlink(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            archive = root / "node.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                payload = b"npm-cli"
+                target = tarfile.TarInfo("node/lib/npm-cli.js")
+                target.size = len(payload)
+                bundle.addfile(target, io.BytesIO(payload))
+                link = tarfile.TarInfo("node/bin/npm")
+                link.type = tarfile.SYMTYPE
+                link.linkname = "../lib/npm-cli.js"
+                bundle.addfile(link)
+            DEPENDENCIES._extract_runtime_archive(archive, root / "runtime")
+            self.assertEqual(b"npm-cli", (root / "runtime/lib/npm-cli.js").read_bytes())
+            self.assertFalse((root / "runtime/bin/npm").exists())
+
+    def test_download_rejects_checksum_and_removes_partial(self):
+        class Response(io.BytesIO):
+            def __enter__(self): return self
+            def __exit__(self, *_args): self.close()
+        with tempfile.TemporaryDirectory() as temporary:
+            destination = Path(temporary) / "runtime.zip"
+            with self.assertRaisesRegex(ValueError, "checksum"):
+                DEPENDENCIES._download_artifact(
+                    "https://example.invalid/runtime.zip", destination, "0" * 64,
+                    opener=lambda *_args, **_kwargs: Response(b"wrong"),
+                )
+            self.assertFalse(destination.exists())
+
+    def test_download_limit_removes_partial(self):
+        class Response(io.BytesIO):
+            def __enter__(self): return self
+            def __exit__(self, *_args): self.close()
+        with tempfile.TemporaryDirectory() as temporary, \
+             mock.patch.object(DEPENDENCIES, "MAX_RUNTIME_ARCHIVE_BYTES", 4):
+            destination = Path(temporary) / "runtime.zip"
+            with self.assertRaisesRegex(ValueError, "download limit"):
+                DEPENDENCIES._download_artifact(
+                    "https://example.invalid/runtime.zip", destination, "0" * 64,
+                    opener=lambda *_args, **_kwargs: Response(b"too-large"),
+                )
+            self.assertFalse(destination.exists())
+
+    def test_generation_provisions_uv_and_node_from_verified_archives(self):
+        def archive(mode, entries):
+            output = io.BytesIO()
+            with tarfile.open(fileobj=output, mode=mode) as bundle:
+                for name, payload in entries.items():
+                    member = tarfile.TarInfo(name)
+                    member.size = len(payload)
+                    member.mode = 0o755
+                    bundle.addfile(member, io.BytesIO(payload))
+            return output.getvalue()
+
+        uv = archive("w:gz", {"uv-x86_64-unknown-linux-gnu/uv": b"uv"})
+        node = archive("w:xz", {
+            "node-v24.19.0-linux-x64/bin/node": b"node",
+            "node-v24.19.0-linux-x64/bin/npm": b"npm",
+        })
+        specification = json.loads(json.dumps(self.specification))
+        key = DEPENDENCIES.platform_key()
+        if key != "linux-x64":
+            self.skipTest("fixture targets Linux x64")
+        specification["runtimes"]["uv"]["artifacts"][key]["sha256"] = DEPENDENCIES.hashlib.sha256(uv).hexdigest()
+        specification["runtimes"]["node"]["artifacts"][key]["sha256"] = DEPENDENCIES.hashlib.sha256(node).hexdigest()
+
+        class Response(io.BytesIO):
+            def __enter__(self): return self
+            def __exit__(self, *_args): self.close()
+
+        def opener(url, **_kwargs):
+            return Response(node if "nodejs.org" in url else uv)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            generation, transaction = root / "generation", root / "transaction"
+            generation.mkdir(); transaction.mkdir()
+            DEPENDENCIES.provision_generation_runtimes(
+                generation, transaction, specification, opener=opener
+            )
+            self.assertEqual(b"uv", (generation / "bootstrap/bin/uv").read_bytes())
+            self.assertEqual(b"node", (generation / "node/bin/node").read_bytes())
+            memory = DEPENDENCIES.generation_install_plan(generation, specification)["memory"][0]
+            self.assertEqual(str(generation / "node/bin/node"), memory[0])
+            self.assertEqual(str(generation / "node/lib/node_modules/npm/bin/npm-cli.js"), memory[1])
+
+
+class ManagedRuntimeCliTest(unittest.TestCase):
+    def test_wrappers_bootstrap_uv_and_forward_maven_tools(self):
+        shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
+        powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
+        for document in (shell, powershell):
+            self.assertIn("0.11.29", document)
+            self.assertIn("3.10", document)
+        self.assertIn("--with-maven-tools", shell)
+        self.assertIn("WithMavenTools", powershell)
+
+    def test_maven_tools_conflicts_with_skip_tools(self):
+        parser = INSTALLER.parser()
+        args = parser.parse_args(
+            ["install", "--project", ".", "--source", ".", "--commit", "0" * 40,
+             "--skip-tools", "--with-maven-tools"]
+        )
+        with self.assertRaisesRegex(ValueError, "cannot be combined"):
+            INSTALLER.validate_install_options(args)
+
+    def test_install_forwards_maven_tools_request(self):
+        parser = INSTALLER.parser()
+        args = parser.parse_args(
+            ["install", "--project", ".", "--source", ".", "--commit", "0" * 40,
+             "--with-maven-tools"]
+        )
+        self.assertTrue(args.with_maven_tools)
+
+    def test_owned_mcp_servers_bind_managed_python(self):
+        managed = Path("/owned/python")
+        servers = HOSTS.owned_servers(managed_python=managed)
+        self.assertEqual(str(managed), servers["chaosengine-memory"]["command"])
+        self.assertEqual(str(managed), servers["chaosengine-mempalace"]["command"])
+
+    def test_hook_documents_bind_managed_python_and_node(self):
+        python = Path("/owned/python")
+        node = Path("/owned/node")
+        lifecycle = json.loads(HOSTS.lifecycle_hooks_document("codex", managed_python=python))
+        self.assertIn(str(python), lifecycle["hooks"]["SessionStart"][0]["hooks"][0]["command"])
+        copilot = json.loads(HOSTS.copilot_hooks_document(node))
+        self.assertIn(str(node), copilot["hooks"]["sessionStart"][0]["bash"])
+
+    def test_maven_tools_reuses_verified_existing_runtime(self):
+        expected = (Path("/java25"), Path("/maven-tools.jar"))
+        hosts = mock.Mock()
+        hosts.discover_maven_tools_runtime.return_value = expected
+        hosts.probe_maven_tools_runtime.return_value = True
+        with mock.patch.object(INSTALLER, "load_installed_controller", return_value=hosts):
+            self.assertEqual(expected, INSTALLER.ensure_maven_tools(Path("/core"), {}))
+        hosts.discover_maven_tools_runtime.assert_called_once_with()
+
+    def test_maven_tools_discovers_owned_temurin_without_ambient_java(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            data_root = Path(temporary)
+            java = data_root / "ChaosEngine/tools/temurin/25.0.4+7/linux-x64/bin/java"
+            java.parent.mkdir(parents=True)
+            java.write_bytes(b"java")
+            jar = data_root / "ChaosEngine/tools/maven-tools-mcp/3.2.0/maven-tools-mcp-3.2.0.jar"
+            jar.parent.mkdir(parents=True)
+            jar.write_bytes(b"jar")
+            with mock.patch.dict("os.environ", {"XDG_DATA_HOME": str(data_root)}, clear=True), \
+                 mock.patch.object(HOSTS.sys, "platform", "linux"), \
+                 mock.patch.object(HOSTS, "verified_maven_tools_jar", return_value=jar), \
+                 mock.patch.object(HOSTS, "verified_managed_temurin", return_value=java), \
+                 mock.patch.object(HOSTS, "java_major", return_value=25), \
+                 mock.patch.object(HOSTS.shutil, "which", return_value=None):
+                self.assertEqual((java, jar), HOSTS.discover_maven_tools_runtime())
+
+    def test_maven_tools_probe_requires_initialize_and_nonempty_tools_list(self):
+        process = mock.Mock()
+        process.stdin = io.StringIO()
+        process.stdout = io.StringIO(
+            '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"maven-tools-mcp"}}}\n'
+            '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"latest-version"}]}}\n'
+        )
+        process.stderr = io.StringIO()
+        process.poll.return_value = None
+        process.wait.return_value = 0
+        self.assertTrue(HOSTS.probe_maven_tools_runtime(Path("/java"), Path("/tools.jar"), popen=lambda *_args, **_kwargs: process))
+        requests = [json.loads(line) for line in process.stdin.getvalue().splitlines()]
+        self.assertEqual(["initialize", "notifications/initialized", "tools/list"], [item["method"] for item in requests])
+
+    def test_maven_tools_probe_rejects_empty_tools(self):
+        process = mock.Mock()
+        process.stdin = io.StringIO()
+        process.stdout = io.StringIO(
+            '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"maven-tools-mcp"}}}\n'
+            '{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}\n'
+        )
+        process.stderr = io.StringIO()
+        process.poll.return_value = None
+        process.wait.return_value = 0
+        self.assertFalse(HOSTS.probe_maven_tools_runtime(Path("/java"), Path("/tools.jar"), popen=lambda *_args, **_kwargs: process))
+
+    def test_maven_tools_archive_fallback_builds_and_publishes(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            java = root / "java"
+            java.write_bytes(b"java")
+            cache = root / "cache"
+            final = (java, cache / "3.2.0/maven-tools-mcp-3.2.0.jar")
+            hosts = SimpleNamespace(
+                discover_maven_tools_runtime=mock.Mock(side_effect=[None, final]),
+                java_major=lambda _path: 25,
+                maven_tools_cache_status=lambda: {"status": "absent"},
+                maven_tools_cache_root=lambda: cache,
+                MAVEN_TOOLS_MCP_VERSION="3.2.0",
+                MAVEN_TOOLS_MCP_COMMIT="4475ff6c61f23ea9a93cb6d5665a63235ef2ef36",
+                MAVEN_TOOLS_MCP_RECEIPT="install-receipt.json",
+                publish_maven_tools_cache=mock.Mock(),
+                probe_maven_tools_runtime=mock.Mock(return_value=True),
+            )
+            dependencies = SimpleNamespace(
+                _download_artifact=lambda _url, path, _sha: path.write_bytes(b"archive"),
+                _extract_runtime_archive=lambda _archive, source: (
+                    source.mkdir(),
+                    (source / "mvnw").write_bytes(b"wrapper"),
+                ),
+            )
+            specification = {"runtimes": {"maven-tools-source": {
+                "url": "https://example.invalid/source.zip", "sha256": "0" * 64,
+            }}}
+
+            def runner(command, **kwargs):
+                if Path(command[0]).name == "mvnw":
+                    output = Path(kwargs["cwd"]) / "target/maven-tools-mcp-3.2.0.jar"
+                    output.parent.mkdir()
+                    output.write_bytes(b"jar")
+                return SimpleNamespace(returncode=0)
+
+            with mock.patch.dict("os.environ", {"CHAOSENGINE_JAVA": str(java)}, clear=False), \
+                 mock.patch.object(INSTALLER, "load_installed_controller", return_value=hosts), \
+                 mock.patch.object(INSTALLER, "load_dependency_controller", return_value=dependencies), \
+                 mock.patch.object(INSTALLER.shutil, "which", return_value=None):
+                self.assertEqual(final, INSTALLER.ensure_maven_tools(Path("/core"), specification, runner=runner))
+            hosts.publish_maven_tools_cache.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_chaos_engine_managed_runtimes.py
+++ b/tests/scripts/test_chaos_engine_managed_runtimes.py
@@ -1,11 +1,10 @@
 import importlib.util
 import json
 import tempfile
-import unittest
 import io
 import zipfile
 import tarfile
-from unittest import mock
+from unittest import TestCase, main, mock
 from types import SimpleNamespace
 from pathlib import Path
 
@@ -17,7 +16,8 @@ def load(name: str):
     path = ROOT / "chaos-engine" / f"{name}.py"
     spec = importlib.util.spec_from_file_location(f"chaos_engine_{name}_managed", path)
     module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
+    if spec.loader is None:
+        raise RuntimeError(f"no module loader for {path}")
     spec.loader.exec_module(module)
     return module
 
@@ -27,7 +27,7 @@ INSTALLER = load("install")
 HOSTS = load("hosts")
 
 
-class ManagedRuntimeManifestTest(unittest.TestCase):
+class ManagedRuntimeManifestTest(TestCase):
     def setUp(self):
         self.specification = json.loads(
             (ROOT / "chaos-engine/dependencies.json").read_text(encoding="utf-8")
@@ -171,7 +171,7 @@ class ManagedRuntimeManifestTest(unittest.TestCase):
             self.assertEqual(str(generation / "node/lib/node_modules/npm/bin/npm-cli.js"), memory[1])
 
 
-class ManagedRuntimeCliTest(unittest.TestCase):
+class ManagedRuntimeCliTest(TestCase):
     def test_wrappers_bootstrap_uv_and_forward_maven_tools(self):
         shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
         powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
@@ -309,4 +309,4 @@ class ManagedRuntimeCliTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1802,6 +1802,38 @@ class GuardLifecycleTest(unittest.TestCase):
                     guard._research_preflight_events("functions.exec", source, failed),
                 )
 
+    def test_direct_web_accepts_only_successful_content_primary_result(self):
+        tool_input = {
+            "open": [
+                {
+                    "ref_id":
+                    "https://raw.githubusercontent.com/openai/codex/main/README.md"
+                }
+            ]
+        }
+        result = {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "https://raw.githubusercontent.com/openai/codex/main/README.md",
+                }
+            ]
+        }
+        self.assertIn(
+            "authoritative-online-research",
+            guard._research_preflight_events("web__run", tool_input, result),
+        )
+        for failed in (
+            {**result, "isError": True},
+            {**result, "status": "failed"},
+            {**result, "exit_code": 1},
+        ):
+            with self.subTest(failed=failed):
+                self.assertNotIn(
+                    "authoritative-online-research",
+                    guard._research_preflight_events("web__run", tool_input, failed),
+                )
+
     def test_raw_github_host_is_exact_not_suffix_spoofable(self):
         self.assertTrue(
             guard._has_primary_source_url(

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -1772,6 +1772,48 @@ class GuardLifecycleTest(unittest.TestCase):
             ),
         )
 
+    def test_wrapped_web_accepts_content_only_primary_result(self):
+        source = (
+            "const result = await tools.web__run({open:[{ref_id:"
+            "'https://raw.githubusercontent.com/openai/codex/main/README.md'}]}); "
+            "text(result);"
+        )
+        result = {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "https://raw.githubusercontent.com/openai/codex/main/README.md",
+                }
+            ]
+        }
+        self.assertIn(
+            "authoritative-online-research",
+            guard._research_preflight_events("functions.exec", source, result),
+        )
+        for failed in (
+            {**result, "isError": True},
+            {**result, "status": "failed"},
+            {**result, "exit_code": 1},
+            {**result, "error": "network failed"},
+        ):
+            with self.subTest(failed=failed):
+                self.assertNotIn(
+                    "authoritative-online-research",
+                    guard._research_preflight_events("functions.exec", source, failed),
+                )
+
+    def test_raw_github_host_is_exact_not_suffix_spoofable(self):
+        self.assertTrue(
+            guard._has_primary_source_url(
+                {"url": "https://raw.githubusercontent.com/openai/codex/main/README.md"}
+            )
+        )
+        self.assertFalse(
+            guard._has_primary_source_url(
+                {"url": "https://raw.githubusercontent.com.evil.invalid/openai/codex"}
+            )
+        )
+
     def test_shell_file_targets_share_main_and_outside_scoping(self):
         inside = {"cwd": ".", "tool_input": {"command": "Set-Content scripts/x.py x"}}
         outside_path = os.path.join(tempfile.gettempdir(), "research-scratch.txt")
@@ -2011,6 +2053,61 @@ class SessionStartRetrievalIsolationTest(unittest.TestCase):
         self.assertEqual(0, completed.returncode, completed.stderr)
         self.assertEqual(["False", "False"], completed.stdout.splitlines())
 
+class PlanModeStopTests(unittest.TestCase):
+    """#5315 keeps read-only Plan Mode outside mutation-owned Stop duties."""
+
+    def stop_output(self, state):
+        report = (
+            None
+            if state is None
+            else {"worktrees": [{"is_current": True, "state": state}]}
+        )
+        stream = io.StringIO()
+        with patch(
+            "scripts.agents.guard._worktree_report", return_value=report
+        ), redirect_stdout(stream):
+            self.assertEqual(0, guard.run_stop({"cwd": ".", "permission_mode": "plan"}))
+        return stream.getvalue()
+
+    def test_plan_mode_ignores_completion_states_and_unverifiable_report(self):
+        for state in ("clean", "uncommitted", "pending", "abandoned", "unknown", None):
+            with self.subTest(state=state):
+                self.assertEqual("", self.stop_output(state))
+
+    def test_plan_mode_blocks_confirmed_nul_corruption_only(self):
+        rendered = self.stop_output("corrupt")
+        self.assertIn("NUL-corrupt", rendered)
+        self.assertNotIn("Learning Session", rendered)
+        self.assertNotIn("pull request", rendered)
+
+    def test_non_plan_permission_modes_keep_completion_checks(self):
+        report = {"worktrees": [{"is_current": True, "state": "uncommitted"}]}
+        for mode in (None, "acceptEdits", "dontAsk"):
+            payload = {"cwd": "."}
+            if mode is not None:
+                payload["permission_mode"] = mode
+            with self.subTest(mode=mode), patch(
+                "scripts.agents.guard._worktree_report", return_value=report
+            ), patch(
+                "scripts.agents.guard.check_r16_learning_session", return_value=None
+            ), patch(
+                "scripts.agents.guard.check_r18_unpushed_work", return_value=None
+            ), patch(
+                "scripts.agents.guard.check_r20_user_harness_drift", return_value=None
+            ), patch(
+                "scripts.agents.guard.check_r21_run_state_not_recorded", return_value=None
+            ), patch(
+                "scripts.agents.guard.check_r24_foreign_worktree_left_behind",
+                return_value=None,
+            ), patch(
+                "scripts.agents.guard.check_r29_delivery_complete", return_value=None
+            ), patch(
+                "scripts.agents.guard._terminal_reflection_reason", return_value=None
+            ):
+                stream = io.StringIO()
+                with redirect_stdout(stream):
+                    guard.run_stop(payload)
+                self.assertIn("uncommitted work", stream.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- recognize successful forwarded authoritative web research without weakening generic receipt checks
- let read-only Plan Mode finish while retaining confirmed NUL-corruption protection
- provision verified managed uv, Python, and Node runtimes across supported platforms
- add optional --with-maven-tools with verified Temurin/source/build/cache ownership
- expose managed runtime health and preserve rollback/uninstall ownership

Closes #5312
Closes #5314
Closes #5315

## Checks

- 341 focused Python tests passed; 8 expected skips
- validate_agent_setup.py --skip-external
- validate_chaos_engine_readme.py
- shell syntax, Python compilation, and git diff checks
- live Linux stripped-PATH Node/npm verification
- live Linux Maven Tools build: 310 unit + 37 integration tests, MCP initialize and nonempty tools/list

## Continuation

Companion public documentation: ShaftHQ/shafthq.github.io branch ChaosEngine/docs-5314-5315. Screenshot follow-up: ShaftHQ/shafthq.github.io#1003. Terminal adversarial review and exact-head CI acceptance remain pending.