### PR TITLE
Fix R25 research-first hook failures

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|PowerShell|shell_command|exec_command|functions[.]exec|run_shell_command|run_in_terminal|Write|Edit|NotebookEdit|apply_patch|write_file|create_file|edit_file|replace|replace_string_in_file|multi_replace_string_in_file|Read|Grep|Glob|Skill|read_file|read_many_files|list_directory|glob|grep_search|search_file_content|WebSearch|WebFetch|web__run|google_web_search|web_fetch|update_plan|enter_plan_mode|EnterPlanMode|exit_plan_mode|ExitPlanMode|todo_write|TodoWrite|mcp__[^|]*memory__.*|mcp__mempalace__.*|mcp__graphify__.*",
+        "matcher": "Bash|PowerShell|shell_command|exec_command|functions[.]exec|run_shell_command|run_in_terminal|Write|Edit|NotebookEdit|apply_patch|write_file|create_file|edit_file|replace|replace_string_in_file|multi_replace_string_in_file|mcp__[^|]*memory__(?:remember_memory|save_memory_patch)|mcp__mempalace__mempalace_(?:add_drawer|checkpoint|create_tunnel|delete_by_source|delete_drawer|delete_hallway|delete_tunnel|diary_write|kg_(?:add|invalidate|supersede)|mine|sync|update_drawer)",
         "hooks": [
           {
             "type": "command",
@@ -53,7 +53,7 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": "Bash|PowerShell|shell_command|exec_command|functions[.]exec|run_shell_command|run_in_terminal|Write|Edit|NotebookEdit|apply_patch|write_file|create_file|edit_file|replace|replace_string_in_file|multi_replace_string_in_file|Read|Grep|Glob|Skill|read_file|read_many_files|list_directory|glob|grep_search|search_file_content|WebSearch|WebFetch|web__run|google_web_search|web_fetch|update_plan|enter_plan_mode|EnterPlanMode|exit_plan_mode|ExitPlanMode|todo_write|TodoWrite|mcp__[^|]*memory__.*|mcp__mempalace__.*|mcp__graphify__.*",
+        "matcher": "Bash|PowerShell|shell_command|exec_command|functions[.]exec|run_shell_command|run_in_terminal|Write|Edit|NotebookEdit|apply_patch|write_file|create_file|edit_file|replace|replace_string_in_file|multi_replace_string_in_file|mcp__[^|]*memory__(?:remember_memory|save_memory_patch)|mcp__mempalace__mempalace_(?:add_drawer|checkpoint|create_tunnel|delete_by_source|delete_drawer|delete_hallway|delete_tunnel|diary_write|kg_(?:add|invalidate|supersede)|mine|sync|update_drawer)",
         "hooks": [
           {
             "type": "command",

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -16,7 +16,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|PowerShell|shell_command|exec_command|functions[.]exec|run_shell_command|run_in_terminal|Write|Edit|NotebookEdit|apply_patch|write_file|create_file|edit_file|replace|replace_string_in_file|multi_replace_string_in_file|Read|Grep|Glob|Skill|read_file|read_many_files|list_directory|glob|grep_search|search_file_content|WebSearch|WebFetch|web__run|google_web_search|web_fetch|update_plan|enter_plan_mode|EnterPlanMode|exit_plan_mode|ExitPlanMode|todo_write|TodoWrite|mcp__[^|]*memory__.*|mcp__mempalace__.*|mcp__graphify__.*",
+        "matcher": "Bash|PowerShell|shell_command|exec_command|functions[.]exec|run_shell_command|run_in_terminal|Write|Edit|NotebookEdit|apply_patch|write_file|create_file|edit_file|replace|replace_string_in_file|multi_replace_string_in_file|mcp__[^|]*memory__(?:remember_memory|save_memory_patch)|mcp__mempalace__mempalace_(?:add_drawer|checkpoint|create_tunnel|delete_by_source|delete_drawer|delete_hallway|delete_tunnel|diary_write|kg_(?:add|invalidate|supersede)|mine|sync|update_drawer)",
         "hooks": [
           {
             "type": "command",
@@ -29,7 +29,7 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": "Bash|PowerShell|shell_command|exec_command|functions[.]exec|run_shell_command|run_in_terminal|Write|Edit|NotebookEdit|apply_patch|write_file|create_file|edit_file|replace|replace_string_in_file|multi_replace_string_in_file|Read|Grep|Glob|Skill|read_file|read_many_files|list_directory|glob|grep_search|search_file_content|WebSearch|WebFetch|web__run|google_web_search|web_fetch|update_plan|enter_plan_mode|EnterPlanMode|exit_plan_mode|ExitPlanMode|todo_write|TodoWrite|mcp__[^|]*memory__.*|mcp__mempalace__.*|mcp__graphify__.*",
+        "matcher": "Bash|PowerShell|shell_command|exec_command|functions[.]exec|run_shell_command|run_in_terminal|Write|Edit|NotebookEdit|apply_patch|write_file|create_file|edit_file|replace|replace_string_in_file|multi_replace_string_in_file|mcp__[^|]*memory__(?:remember_memory|save_memory_patch)|mcp__mempalace__mempalace_(?:add_drawer|checkpoint|create_tunnel|delete_by_source|delete_drawer|delete_hallway|delete_tunnel|diary_write|kg_(?:add|invalidate|supersede)|mine|sync|update_drawer)",
         "hooks": [
           {
             "type": "command",

--- a/chaos-engine/hooks/matchers.json
+++ b/chaos-engine/hooks/matchers.json
@@ -10,9 +10,7 @@
   "observational": [
     "Bash", "PowerShell", "shell_command", "exec_command", "functions[.]exec", "run_shell_command", "run_in_terminal",
     "Write", "Edit", "NotebookEdit", "apply_patch", "write_file", "create_file", "edit_file", "replace", "replace_string_in_file", "multi_replace_string_in_file",
-    "Read", "Grep", "Glob", "Skill", "read_file", "read_many_files", "list_directory", "glob", "grep_search", "search_file_content",
-    "WebSearch", "WebFetch", "web__run", "google_web_search", "web_fetch",
-    "update_plan", "enter_plan_mode", "EnterPlanMode", "exit_plan_mode", "ExitPlanMode", "todo_write", "TodoWrite",
-    "mcp__[^|]*memory__.*", "mcp__mempalace__.*", "mcp__graphify__.*"
+    "mcp__[^|]*memory__(?:remember_memory|save_memory_patch)",
+    "mcp__mempalace__mempalace_(?:add_drawer|checkpoint|create_tunnel|delete_by_source|delete_drawer|delete_hallway|delete_tunnel|diary_write|kg_(?:add|invalidate|supersede)|mine|sync|update_drawer)"
   ]
 }

--- a/chaos-engine/references/lifecycle-hooks.md
+++ b/chaos-engine/references/lifecycle-hooks.md
@@ -55,14 +55,14 @@ as a path relative to the settings file, and resolve `hooks/guard.py` from the
 installed tree (`.chaos-engine/hooks/guard.py` or
 `plugins/chaos-engine/hooks/guard.py`).
 
-Tool matching is owned by [`hooks/matchers.json`](../hooks/matchers.json). Preventive matching includes
+Tool matching is owned by [`hooks/matchers.json`](../hooks/matchers.json). Preventive and observational matching include
 only surfaces that can be denied usefully: mutation-capable shell execution,
 file writes, dispatch, and memory/store writes. Read, search, web research, and
-plan/TODO tools do not start a PreToolUse process because no current rule can
-deny them successfully. Their PostToolUse and PostToolUseFailure events remain
-matched where the outcome supplies research, test, mutation, delivery, memory,
-or repeated-failure evidence. A future preventive rule for a read-only surface
-must restore that surface to the preventive matcher with a contract test.
+plan/TODO tools do not start a hook process because their outcomes own no safety
+decision or durable lifecycle state. Research-first remains one compact
+SessionStart instruction; it is not reconstructed from host-specific tool
+observations or enforced on every mutation. A future rule for a read-only
+surface must restore only the lifecycle events it needs with a contract test.
 Gemini, Claude, Codex, and Grok use native matcher fields. Copilot's workspace
 hook format has no matcher field, so `hooks/launch.js` applies the same policy
 before starting Python.

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -3067,55 +3067,6 @@ def _act_as_mohab_root(cwd: object) -> str | None:
         current = parent
 
 
-def check_r25_research_before_implementation(
-    hook_input: dict, tool_name: str, context: _InvocationContext | None = None
-) -> str | None:
-    """Fail closed when an implementation tool arrives before the ordered receipt."""
-    tool_input = hook_input.get("tool_input")
-    if context is None:
-        context = _invocation_context(hook_input, tool_name)
-    if not context.mutation:
-        return None
-    cwd = _hook_working_directory(hook_input)
-    root = _act_as_mohab_root(cwd)
-    if not root:
-        return None
-    if tool_name in _FILE_MUTATION_TOOLS or tool_name in _SHELL_TOOLS:
-        targets = context.targets
-        if targets and all(not _path_is_inside(path, root, cwd) for path in targets):
-            return None
-    events = ledger_events(hook_input)
-    if _is_plan_receipt_command(
-        str(
-            (tool_input if isinstance(tool_input, dict) else {}).get("command")
-            or (tool_input if isinstance(tool_input, dict) else {}).get("cmd")
-            or ""
-        )
-    ):
-        required_prefix = IMPLEMENTATION_PREFLIGHT_EVENTS[:-1]
-        cursor = -1
-        for required in required_prefix:
-            try:
-                cursor = events.index(required, cursor + 1)
-            except ValueError:
-                break
-        else:
-            return None
-    cursor = -1
-    for required in IMPLEMENTATION_PREFLIGHT_EVENTS:
-        try:
-            cursor = events.index(required, cursor + 1)
-        except ValueError:
-            return (
-                "R25 research-first blocked: implementation requires the ordered "
-                "session receipt before mutation. Missing or late event: "
-                f"{required}. Required order: "
-                + ", ".join(IMPLEMENTATION_PREFLIGHT_EVENTS)
-                + ". Complete the live query or plan action; do not forge the ledger."
-            )
-    return None
-
-
 def _unpushed_commit_count(branch: str, cwd: object = None) -> int | None:
     """Commits on `branch` that exist on no remote, or None if unanswerable.
 
@@ -4525,11 +4476,6 @@ def run_pretooluse(hook_input: dict, host: str = "portable") -> int:
         _record_guard_block_and_deny(hook_input, reason, host)
         return 0
 
-    reason = check_r25_research_before_implementation(hook_input, tool_name, context)
-    if reason is not None:
-        _record_guard_block_and_deny(hook_input, reason, host)
-        return 0
-
     if commands:
         command_tool = "PowerShell" if tool_name == "functions.exec" else tool_name
         for invocation in context.invocations:
@@ -4656,11 +4602,6 @@ def run_posttooluse(hook_input: dict) -> int:
             )
             if issue_reference:
                 ledger_record(hook_input, issue_reference)
-    if not result_failed:
-        for event in _research_preflight_events(
-            tool_name, hook_input.get("tool_input"), result, commands
-        ):
-            ledger_record(hook_input, event)
     return 0
 
 
@@ -5895,7 +5836,6 @@ _SELF_TEST_COVERAGE: dict[str, str] = {
     "check_r21_run_state_not_recorded": "run_required_action_self_test",
     "check_r22_dispatch_adapter": "run_required_action_self_test",
     "check_r24_foreign_worktree_left_behind": "run_required_action_self_test",
-    "check_r25_research_before_implementation": "run_required_action_self_test",
     "check_r28_pr_audit_before_arming": "run_required_action_self_test",
     "check_r29_delivery_complete": "run_required_action_self_test",
     "check_r30_merge_authority_before_arming": "run_required_action_self_test",
@@ -6043,24 +5983,6 @@ def run_required_action_self_test() -> int:
             failures.append(description)
 
     write = {"cwd": ".", "tool_input": {"file_path": "shaft-engine/src/main/java/A.java"}}
-
-    # R25: every implementation mutation needs the live ordered research receipt.
-    check(
-        "R25 blocks an implementation write with no research receipt",
-        _with_stubs(
-            {"ledger_events": lambda payload: []},
-            lambda: check_r25_research_before_implementation(write, "Write"),
-        )
-        is not None,
-    )
-    check(
-        "R25 allows an implementation write after the ordered research receipt",
-        _with_stubs(
-            {"ledger_events": lambda payload: list(RESEARCH_PREFLIGHT_EVENTS)},
-            lambda: check_r25_research_before_implementation(write, "Write"),
-        )
-        is None,
-    )
 
     # R22: only a host adapter can deliver the mandatory entrypoint to a delegate.
     check(

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -775,7 +775,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
         for tool in ("Read", "Grep", "WebSearch", "WebFetch", "web__run", "update_plan"):
             self.assertIsNone(re.fullmatch(preventive, tool), tool)
-            self.assertIsNotNone(re.fullmatch(observational, tool), tool)
+            self.assertIsNone(re.fullmatch(observational, tool), tool)
         for tool in ("Bash", "PowerShell", "apply_patch", "Write", "spawn_agent"):
             self.assertIsNotNone(re.fullmatch(preventive, tool), tool)
 

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -912,26 +912,6 @@ class CommitObservationTest(unittest.TestCase):
         self.assertEqual(runner.call_args.kwargs["timeout"], 0.125)
 
 
-class ResearchPreflightAdvisoryStoreTest(unittest.TestCase):
-    """R25 store policy is independent of the broad Stop-rule fixture."""
-
-    def test_store_events_are_advisory_for_a_complete_non_store_receipt(self):
-        advisory = {"query-native-memory", "query-mempalace", "query-graphify"}
-        required = [
-            event for event in guard.RESEARCH_PREFLIGHT_EVENTS if event not in advisory
-        ]
-        payload = {
-            "cwd": ".",
-            "session_id": "research-first-test",
-            "tool_name": "Write",
-            "tool_input": {},
-        }
-        with patch("scripts.agents.guard.ledger_events", return_value=required):
-            self.assertIsNone(
-                guard.check_r25_research_before_implementation(payload, "Write")
-            )
-
-
 class DelegatePreflightRedTest(unittest.TestCase):
     """#4570's missing delegate and learning-session behavior."""
 
@@ -1083,50 +1063,6 @@ class GuardLifecycleTest(unittest.TestCase):
         ):
             self.assertIn(required, context)
 
-    def payload(self) -> dict:
-        return {
-            "cwd": ".",
-            "session_id": "research-first-test",
-            "tool_name": "Write",
-            "tool_input": {"file_path": ".agents/skills/act-as-mohab/SKILL.md"},
-        }
-
-    def test_write_without_a_receipt_is_blocked(self):
-        with patch("scripts.agents.guard.ledger_events", return_value=[]):
-            reason = guard.check_r25_research_before_implementation(self.payload(), "Write")
-        self.assertIn("research-first", reason.lower())
-        self.assertIn("read-live-files", reason)
-
-    def test_each_missing_or_late_receipt_event_blocks_the_mutation(self):
-        required = guard.IMPLEMENTATION_PREFLIGHT_EVENTS
-        for missing in required:
-            with self.subTest(missing=missing):
-                events = [event for event in required if event != missing]
-                with patch("scripts.agents.guard.ledger_events", return_value=events):
-                    self.assertIsNotNone(
-                        guard.check_r25_research_before_implementation(self.payload(), "Write")
-                    )
-        late = [*required[1:], required[0]]
-        with patch("scripts.agents.guard.ledger_events", return_value=late):
-            self.assertIsNotNone(
-                guard.check_r25_research_before_implementation(self.payload(), "Write")
-            )
-
-    def test_complete_ordered_receipt_allows_the_mutation(self):
-        with patch(
-            "scripts.agents.guard.ledger_events",
-            return_value=list(guard.RESEARCH_PREFLIGHT_EVENTS),
-        ):
-            self.assertIsNone(
-                guard.check_r25_research_before_implementation(self.payload(), "Write")
-            )
-
-    def test_analysis_tools_are_not_blocked(self):
-        with patch("scripts.agents.guard.ledger_events", return_value=[]):
-            self.assertIsNone(
-                guard.check_r25_research_before_implementation(self.payload(), "Read")
-            )
-
     def test_live_tool_events_map_to_the_receipt_vocabulary(self):
         fixtures = (
             ("Read", {"file_path": "src/Main.java"}, None, "read-live-files"),
@@ -1227,23 +1163,10 @@ class GuardLifecycleTest(unittest.TestCase):
             'await tools.update_plan({metadata:{explanation:"Compare proven approaches"},'
             'plan:[{step:"Implement",status:"in_progress"}]});',
         )
-        required_prefix = list(guard.IMPLEMENTATION_PREFLIGHT_EVENTS[:3])
         for invalid_source in invalid_sources:
             with self.subTest(invalid_source=invalid_source):
                 events = guard._research_preflight_events("functions.exec", invalid_source, {})
                 self.assertEqual(events, ())
-                with patch.object(
-                    guard,
-                    "ledger_events",
-                    return_value=[*required_prefix, *events],
-                ), patch.object(
-                    guard, "_act_as_mohab_root", return_value=str(Path.cwd())
-                ), patch.object(guard, "_path_is_inside", return_value=True):
-                    self.assertIsNotNone(
-                        guard.check_r25_research_before_implementation(
-                            self.payload(), "Write"
-                        )
-                    )
 
     def test_shell_command_maps_research_clis_in_command_order(self):
         self.assertEqual(
@@ -1454,7 +1377,7 @@ class GuardLifecycleTest(unittest.TestCase):
                 )
         self.assertEqual(observed, [])
 
-    def test_portable_hook_matchers_skip_read_only_pre_calls_but_observe_outcomes(self):
+    def test_portable_hook_matchers_skip_research_only_calls(self):
         plan_surfaces = (
             "update_plan",
             "enter_plan_mode",
@@ -1474,12 +1397,17 @@ class GuardLifecycleTest(unittest.TestCase):
                 post = hooks["PostToolUse"][0]["matcher"]
                 for tool in read_only_surfaces:
                     self.assertIsNone(re.fullmatch(pre, tool), tool)
-                    self.assertIsNotNone(re.fullmatch(post, tool), tool)
+                    self.assertIsNone(re.fullmatch(post, tool), tool)
                 for tool in ("apply_patch", "PowerShell"):
                     self.assertIsNotNone(re.fullmatch(pre, tool), tool)
                 for tool in ("Task", "Agent", "spawn_agent"):
                     self.assertIsNotNone(re.fullmatch(pre, tool), tool)
                     self.assertIsNone(re.fullmatch(post, tool), tool)
+
+    def test_pretooluse_does_not_dispatch_research_preflight(self):
+        source = inspect.getsource(guard.run_pretooluse)
+
+        self.assertNotIn("check_r25_research_before_implementation", source)
 
     def test_redirect_detection_is_quote_aware(self):
         quoted = 'rg -n "Map<String, List<Integer>>" shaft-engine'
@@ -1569,37 +1497,6 @@ class GuardLifecycleTest(unittest.TestCase):
             guard._implementation_targets("apply_patch", patch_input),
         )
 
-    def test_every_live_mutation_lane_requires_the_receipt(self):
-        fixtures = (
-            ("PowerShell", {"command": "Set-Content scripts/x.py changed"}),
-            ("exec_command", {"cmd": "Set-Content scripts/x.py changed"}),
-            ("functions.exec", 'const p = "x"; await tools.apply_patch(p);'),
-            (
-                "functions.exec",
-                'await tools.exec_command({cmd:"echo safe"}); '
-                "const bad = 'git reset --hard HEAD~1'; "
-                "await tools.exec_command({cmd: bad});",
-            ),
-            (
-                "mcp__shaft_memory__remember_memory",
-                {"content": "durable"},
-            ),
-            ("PowerShell", {"command": "Clear-Content scripts/x.py"}),
-            ("PowerShell", {"command": "Copy-Item source.txt scripts/x.py"}),
-            ("PowerShell", {"command": "Rename-Item old.txt scripts/x.py"}),
-            ("Bash", {"command": "printf changed > scripts/x.py"}),
-            ("mcp__shaft-memory__remember_memory", {"content": "durable"}),
-            ("mcp__mempalace__mempalace_delete_drawer", {"drawer_id": "x"}),
-            ("PowerShell", {"command": "gh api --method PATCH repos/o/r -f x=y"}),
-        )
-        for tool_name, tool_input in fixtures:
-            with self.subTest(tool_name=tool_name, tool_input=tool_input):
-                payload = {"cwd": ".", "tool_input": tool_input}
-                with patch("scripts.agents.guard.ledger_events", return_value=[]):
-                    self.assertIsNotNone(
-                        guard.check_r25_research_before_implementation(payload, tool_name)
-                    )
-
     def test_apply_patch_shares_default_branch_and_outside_target_scoping(self):
         inside = {
             "cwd": ".",
@@ -1616,10 +1513,6 @@ class GuardLifecycleTest(unittest.TestCase):
             ):
                 self.assertIsNotNone(guard.check_r19_fresh_base(inside, "apply_patch"))
                 self.assertIsNone(guard.check_r19_fresh_base(outside, "apply_patch"))
-        with patch("scripts.agents.guard.ledger_events", return_value=[]):
-            self.assertIsNone(
-                guard.check_r25_research_before_implementation(outside, "apply_patch")
-            )
         wrapped = {
             "cwd": ".",
             "tool_input": 'const p = "patch"; await tools.apply_patch(p);',
@@ -1633,7 +1526,7 @@ class GuardLifecycleTest(unittest.TestCase):
                     guard.check_r19_fresh_base(wrapped, "functions.exec")
                 )
 
-    def test_only_successful_post_tool_events_certify_research(self):
+    def test_post_tool_events_do_not_build_a_research_receipt(self):
         payload = {
             "cwd": ".",
             "session_id": "post-tool-receipt",
@@ -1647,9 +1540,9 @@ class GuardLifecycleTest(unittest.TestCase):
 
         with patch("scripts.agents.guard.ledger_record", side_effect=lambda _payload, event: observed.append(event)):
             self.assertEqual(guard.run_posttooluse(payload), 0)
-        self.assertEqual(observed, ["read-live-files", "load-routed-skill"])
+        self.assertEqual(observed, [])
 
-    def test_successful_shell_research_is_recorded_in_command_order(self):
+    def test_successful_shell_research_is_not_recorded(self):
         payload = {
             "cwd": ".",
             "session_id": "ordered-shell-receipt",
@@ -1662,16 +1555,7 @@ class GuardLifecycleTest(unittest.TestCase):
         observed = []
         with patch("scripts.agents.guard.ledger_record", side_effect=lambda _payload, event: observed.append(event)):
             guard.run_posttooluse(payload)
-        self.assertEqual(
-            observed,
-            [
-                "query-graphify",
-                "query-mempalace",
-                "query-native-memory",
-                "read-live-files",
-                "load-routed-skill",
-            ],
-        )
+        self.assertEqual(observed, [])
 
     def test_only_explicit_primary_source_research_counts_as_authoritative(self):
         generic = guard._research_preflight_events(
@@ -1858,38 +1742,6 @@ class GuardLifecycleTest(unittest.TestCase):
             with patch("scripts.agents.guard._repository_root", return_value=root):
                 self.assertIsNotNone(guard.check_r19_fresh_base(inside, "PowerShell"))
                 self.assertIsNone(guard.check_r19_fresh_base(outside, "PowerShell"))
-        with patch("scripts.agents.guard.ledger_events", return_value=[]):
-            self.assertIsNone(
-                guard.check_r25_research_before_implementation(outside, "PowerShell")
-            )
-
-    def test_issue_backed_plan_comment_completes_its_own_receipt_after_success(self):
-        command = (
-            "gh issue comment 4666 --body 'Implementation plan and executable specification'"
-        )
-        payload = {"cwd": ".", "tool_input": {"command": command}}
-        first_seven = list(guard.RESEARCH_PREFLIGHT_EVENTS[:-1])
-        with patch("scripts.agents.guard.ledger_events", return_value=first_seven):
-            self.assertIsNone(
-                guard.check_r25_research_before_implementation(payload, "PowerShell")
-            )
-        observed = []
-        with patch(
-            "scripts.agents.guard.ledger_record",
-            side_effect=lambda _payload, event: observed.append(event),
-        ):
-            guard.run_posttooluse(
-                {**payload, "tool_name": "PowerShell", "session_id": "issue-plan"}
-            )
-        self.assertIn("record-plan", observed)
-
-        unrelated = {"cwd": ".", "tool_input": {"command": "gh issue comment 4666 --body status"}}
-        with patch("scripts.agents.guard.ledger_events", return_value=first_seven):
-            self.assertIsNotNone(
-                guard.check_r25_research_before_implementation(unrelated, "PowerShell")
-            )
-
-
     @patch("scripts.agents.guard._open_pull_request_count", return_value=1)
     @patch(
         "scripts.agents.guard._worktree_report",
@@ -2724,7 +2576,6 @@ class PullRequestAuditBeforeArmingGateTest(unittest.TestCase):
             mock.patch.object(guard, "_checkpoint_identity", side_effect=identity),
             mock.patch.object(guard, "_validated_pr_audit_receipt", return_value=True),
             mock.patch.object(guard, "check_r19_fresh_base", return_value=None),
-            mock.patch.object(guard, "check_r25_research_before_implementation", return_value=None),
             mock.patch.object(guard, "check_r30_merge_authority_before_arming", return_value=None),
             redirect_stdout(stream),
         ):
@@ -2748,7 +2599,6 @@ class PullRequestAuditBeforeArmingGateTest(unittest.TestCase):
                     mock.patch.object(guard, "_checkpoint_identity", side_effect=identity),
                     mock.patch.object(guard, "_validated_pr_audit_receipt", return_value=True),
                     mock.patch.object(guard, "check_r19_fresh_base", return_value=None),
-                    mock.patch.object(guard, "check_r25_research_before_implementation", return_value=None),
                     mock.patch.object(guard, "check_r30_merge_authority_before_arming", return_value=None),
                     redirect_stdout(stream),
                 ):


### PR DESCRIPTION
## Summary

- Closes #5318.
- Keeps research-first preflight in existing SessionStart context instead of denying every mutation from a heuristic ledger.
- Removes research-only read, search, web, plan, and store-read PostToolUse processes while retaining mutation, delivery, failure, and safety hooks.
- Preserves provider-neutral generated matcher parity.

## Checks

- Focused RED: 2 tests failed for existing R25 dispatch and research-only PostToolUse matchers.
- Focused GREEN: 6 lifecycle/host matcher tests passed.
- python3 scripts/agents/guard.py --self-test (99 command cases; R9/R10/R11/required-action/rule coverage passed).
- python3 scripts/ci/validate_agent_setup.py --skip-external (passed: 221702 guidance bytes, 438 memory objects).
- Balanced modules: 354/358 passed; 4 pre-existing Windows-literal-path tests fail on Linux by resolving C:/task beneath POSIX cwd. No changed code owns that path behavior.

## Continuation

- Root reviewer should run terminal adversarial review, audit CI/comments, and decide merge.
- Native Memory, MemPalace, and Graphify were degraded because their CLIs are unavailable; live files and targeted rg supplied structural evidence.