### PR TITLE
fix(chaos-engine): harden Grok lifecycle writes

### DIFF
--- a/chaos-engine/hooks/guard.py
+++ b/chaos-engine/hooks/guard.py
@@ -515,6 +515,8 @@ def _run_event(event: dict, _host: str) -> int:
     if event_name == "SessionStart":
         token = reflection.record_session_start(session_id)
     else:
+        if event_name not in {"SubagentStop", "SessionEnd"}:
+            reflection.record_session_start(session_id, estimated=True)
         token = None
     if _record_failed_result(event, event_name, commands, tool_name, session_id):
         return 0

--- a/chaos-engine/hooks/kernel.py
+++ b/chaos-engine/hooks/kernel.py
@@ -134,6 +134,14 @@ HOST_CAPABILITIES: Mapping[str, HostCapability] = {
             postToolUse="PostToolUse",
             agentStop="Stop",
             sessionEnd="SessionEnd",
+            session_start="SessionStart",
+            user_prompt_submit="UserPromptSubmit",
+            pre_tool_use="PreToolUse",
+            post_tool_use="PostToolUse",
+            post_tool_use_failure="PostToolUseFailure",
+            stop="Stop",
+            subagent_stop="SubagentStop",
+            session_end="SessionEnd",
         ),
         GROK_EVENTS,
     ),
@@ -276,8 +284,10 @@ def normalize_event(raw: Mapping[str, object], host: str | None = None) -> HookE
     for source, target in FIELD_ALIASES.items():
         if target not in normalized and source in normalized:
             normalized[target] = normalized[source]
-    if not normalized.get("hook_event_name") and os.environ.get("GROK_HOOK_EVENT"):
+    if selected == "grok" and not normalized.get("hook_event_name") and os.environ.get("GROK_HOOK_EVENT"):
         normalized["hook_event_name"] = os.environ["GROK_HOOK_EVENT"]
+    if selected == "grok" and not normalized.get("session_id") and os.environ.get("GROK_SESSION_ID"):
+        normalized["session_id"] = os.environ["GROK_SESSION_ID"]
     name = _event_name(normalized.get("hook_event_name"), selected)
     tool_input = normalized.get("tool_input")
     if isinstance(tool_input, str):

--- a/chaos-engine/hooks/reflection.py
+++ b/chaos-engine/hooks/reflection.py
@@ -179,7 +179,9 @@ def entries(session_id: str) -> list[dict]:
     return found
 
 
-def record_session_start(session_id: str, observed_at: str | None = None) -> str | None:
+def record_session_start(
+    session_id: str, observed_at: str | None = None, *, estimated: bool = False
+) -> str | None:
     token = _ensure_session_token(session_id)
     if token is None:
         return None
@@ -191,6 +193,7 @@ def record_session_start(session_id: str, observed_at: str | None = None) -> str
             "schemaVersion": SCHEMA_VERSION,
             "kind": "session-start",
             "observedAt": observed_at or datetime.now(UTC).isoformat(),
+            **({"estimated": True} if estimated else {}),
         },
     )
     return token if recorded else None

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -3752,6 +3752,47 @@ def verify(
     return {"status": "healthy"}
 
 
+def grok_runtime_status(
+    project: Path, *, executable: str | None = None, runner=None
+) -> dict[str, str]:
+    """Verify detected Grok project trust and loaded lifecycle hooks without mutation."""
+    command = executable or shutil.which("grok")
+    if not command:
+        return {"status": "not-detected"}
+    run = subprocess.run if runner is None else runner
+    try:
+        completed = run(
+            [command, "inspect", "--json"],
+            cwd=project.resolve(),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        payload = json.loads(completed.stdout or "{}") if completed.returncode == 0 else {}
+    except (OSError, subprocess.SubprocessError, ValueError):
+        payload = {}
+    recovery = (
+        "Run `grok inspect --json` from the project. If projectTrusted is false, "
+        "review the project then run `/hooks-trust`; reload hooks and rerun doctor."
+    )
+    if not isinstance(payload, dict) or payload.get("projectTrusted") is not True:
+        return {"status": "recovery-required", "detail": recovery}
+    hooks = payload.get("hooks")
+    loaded = {
+        str(item.get("event"))
+        for item in hooks if isinstance(item, dict)
+        if "guard.py" in str(item.get("target") or "")
+    } if isinstance(hooks, list) else set()
+    required = {
+        "session_start", "user_prompt_submit", "pre_tool_use", "post_tool_use",
+        "post_tool_use_failure", "stop", "subagent_stop", "session_end",
+    }
+    if not required.issubset(loaded):
+        return {"status": "recovery-required", "detail": recovery}
+    return {"status": "healthy"}
+
+
 def snapshot(project: Path) -> dict[str, object]:
     project = project.resolve()
     receipt, raw = read_receipt(project)

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -1838,6 +1838,11 @@ def status_with_dependencies(project: Path, *, active_probes: bool = False) -> d
                 )
             if result["hosts"]["status"] != "healthy":  # type: ignore[index]
                 result["status"] = "recovery-required"
+            if active_probes:
+                result["hosts"]["grok"] = host_controller.grok_runtime_status(project)  # type: ignore[index]
+                if result["hosts"]["grok"]["status"] == "recovery-required":  # type: ignore[index]
+                    result["hosts"]["status"] = "recovery-required"  # type: ignore[index]
+                    result["status"] = "recovery-required"
             removing = project / ".chaos-engine-runtime.removing"
             backup = project / ".chaos-engine-runtime.backup"
             building = project / ".chaos-engine-runtime.building"

--- a/scripts/agents/github_client.py
+++ b/scripts/agents/github_client.py
@@ -49,6 +49,58 @@ class GitHubClient:
             raise GitHubUnavailable("GitHub API returned an invalid object")
         return payload
 
+    def comment_once(self, issue: int, body_file: str) -> dict:
+        """Post one exact issue comment and prove its remote body and URL."""
+        if not isinstance(issue, int) or issue < 1:
+            raise ValueError("issue must be a positive integer")
+        path = Path(body_file)
+        try:
+            body = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            raise GitHubUnavailable(f"prepared comment body is unavailable: {error}") from error
+
+        def exact_comment() -> dict | None:
+            return next(
+                (
+                    item
+                    for item in self.rest_pages(f"issues/{issue}/comments")
+                    if item.get("body") == body and isinstance(item.get("html_url"), str)
+                ),
+                None,
+            )
+
+        existing = exact_comment()
+        if existing:
+            return {"created": False, "url": existing["html_url"], "body": body}
+        command = [
+            self.executable,
+            "issue",
+            "comment",
+            str(issue),
+            "--repo",
+            self.repository,
+            "--body-file",
+            str(path),
+        ]
+        try:
+            result = self.runner(
+                command, cwd=self.root, capture_output=True, text=True, timeout=30, check=False
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            raise GitHubUnavailable(f"GitHub comment failed: {error}; run `gh auth status`") from error
+        if result.returncode:
+            detail = result.stderr.strip() or "GitHub CLI returned an error"
+            raise GitHubUnavailable(
+                f"{detail}; run `gh auth status` and grant Issues or Pull requests write permission"
+            )
+        verified = exact_comment()
+        if not verified:
+            raise GitHubUnavailable(
+                "GitHub comment readback did not match the prepared body; content remains in "
+                + str(path)
+            )
+        return {"created": True, "url": verified["html_url"], "body": body}
+
     @staticmethod
     def _validate_endpoint(endpoint: str) -> None:
         if (

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1580,8 +1580,18 @@ def normalize_hook_input(raw: dict) -> dict:
     for source, target in _FIELD_ALIASES.items():
         if target not in normalized and source in raw:
             normalized[target] = raw[source]
-    if not normalized.get("hook_event_name") and os.environ.get("GROK_HOOK_EVENT"):
+    is_grok = hook_host(raw) == "grok"
+    if is_grok and not normalized.get("hook_event_name") and os.environ.get("GROK_HOOK_EVENT"):
         normalized["hook_event_name"] = os.environ["GROK_HOOK_EVENT"]
+    if is_grok and not normalized.get("session_id") and os.environ.get("GROK_SESSION_ID"):
+        normalized["session_id"] = os.environ["GROK_SESSION_ID"]
+    if is_grok:
+        normalized["hook_event_name"] = {
+            "session_start": "SessionStart", "user_prompt_submit": "UserPromptSubmit",
+            "pre_tool_use": "PreToolUse", "post_tool_use": "PostToolUse",
+            "post_tool_use_failure": "PostToolUseFailure", "stop": "Stop",
+            "subagent_stop": "SubagentStop", "session_end": "SessionEnd",
+        }.get(str(normalized.get("hook_event_name") or ""), normalized.get("hook_event_name"))
 
     tool_input = normalized.get("tool_input")
     if isinstance(tool_input, dict):
@@ -6760,6 +6770,8 @@ def _prepare_hook(hook_input: dict) -> None:
     """Apply source-only budget and ledger policy before shared dispatch."""
     start_hook_budget()
     _ledger_path(hook_input)
+    if hook_input.get("hook_event_name") not in {"SessionStart", "SubagentStop", "SessionEnd"}:
+        _reflection.record_session_start(_reflection_session_id(hook_input), estimated=True)
 
 
 def _evaluate_kernel_event(hook_input: dict, host: str):

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -92,6 +92,39 @@ def create_chroma_state(path: Path) -> None:
 
 
 class ChaosEngineHostsTest(unittest.TestCase):
+    def test_grok_runtime_requires_trust_and_complete_loaded_lifecycle(self):
+        module = load(HOSTS, "chaos_engine_grok_runtime")
+        events = (
+            "session_start", "user_prompt_submit", "pre_tool_use", "post_tool_use",
+            "post_tool_use_failure", "stop", "subagent_stop", "session_end",
+        )
+        healthy = {"projectTrusted": True, "hooks": [
+            {"event": event, "target": "python3 .chaos-engine/hooks/guard.py"}
+            for event in events
+        ]}
+        def result(payload, returncode=0):
+            return subprocess.CompletedProcess([], returncode, json.dumps(payload), "")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            for payload, expected in (
+                (healthy, "healthy"),
+                ({**healthy, "projectTrusted": False}, "recovery-required"),
+                ({**healthy, "hooks": healthy["hooks"][:-1]}, "recovery-required"),
+            ):
+                calls = []
+                state = module.grok_runtime_status(
+                    project, executable="grok",
+                    runner=lambda command, **kwargs: calls.append((command, kwargs)) or result(payload),
+                )
+                self.assertEqual(expected, state["status"])
+                self.assertEqual(["grok", "inspect", "--json"], calls[0][0])
+                self.assertNotIn("--trust", calls[0][0])
+            failed = module.grok_runtime_status(
+                project, executable="grok", runner=lambda *_a, **_k: result({}, 1)
+            )
+            self.assertEqual("recovery-required", failed["status"])
+            self.assertIn("/hooks-trust", failed["detail"])
+
     def test_detected_client_plugins_are_registered_installed_and_verified(self):
         module = load(HOSTS, "chaos_engine_plugin_activation")
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_chaos_engine_kernel.py
+++ b/tests/scripts/test_chaos_engine_kernel.py
@@ -74,6 +74,40 @@ class ChaosEngineKernelTest(TestCase):
             {"git status"},
         )
 
+    def test_grok_official_environment_fallback_normalizes_snake_case(self):
+        aliases = {
+            "session_start": "SessionStart",
+            "user_prompt_submit": "UserPromptSubmit",
+            "pre_tool_use": "PreToolUse",
+            "post_tool_use": "PostToolUse",
+            "post_tool_use_failure": "PostToolUseFailure",
+            "stop": "Stop",
+            "subagent_stop": "SubagentStop",
+            "session_end": "SessionEnd",
+        }
+        for native, canonical in aliases.items():
+            with self.subTest(native=native), mock.patch.dict(
+                os.environ,
+                {"GROK_HOOK_EVENT": native, "GROK_SESSION_ID": "grok-session"},
+                clear=False,
+            ):
+                event = self.kernel.normalize_event({}, "grok")
+                self.assertEqual(canonical, event.name)
+                self.assertEqual("grok-session", event.session_id)
+
+    def test_grok_payload_wins_and_environment_never_leaks_to_other_hosts(self):
+        with mock.patch.dict(
+            os.environ,
+            {"GROK_HOOK_EVENT": "stop", "GROK_SESSION_ID": "environment"},
+            clear=False,
+        ):
+            event = self.kernel.normalize_event(
+                {"hookEventName": "pre_tool_use", "sessionId": "payload"}, "grok"
+            )
+            other = self.kernel.normalize_event({}, "codex")
+        self.assertEqual(("PreToolUse", "payload"), (event.name, event.session_id))
+        self.assertEqual(("", ""), (other.name, other.session_id))
+
     def test_copilot_json_tool_args_preserve_mutation(self):
         event = self.kernel.normalize_event(
             {

--- a/tests/scripts/test_github_client.py
+++ b/tests/scripts/test_github_client.py
@@ -2,6 +2,7 @@
 
 import json
 import subprocess  # nosec B404 - subprocess objects are test fixtures only.
+import tempfile
 import unittest
 
 from scripts.agents.github_client import GitHubClient, GitHubUnavailable
@@ -53,6 +54,40 @@ class GitHubClientTest(unittest.TestCase):
         for repository, endpoint in (("bad", "issues/1/comments"), ("owner/repo", "https://evil.test"), ("owner/repo", "../users")):
             with self.subTest(repository=repository, endpoint=endpoint), self.assertRaises(ValueError):
                 GitHubClient(repository, runner=lambda *_a, **_k: None, executable="gh").rest_pages(endpoint)
+
+    def test_comment_once_checks_exact_body_posts_with_file_and_reads_back(self):
+        calls = []
+        responses = [
+            subprocess.CompletedProcess([], 0, "[]", ""),
+            subprocess.CompletedProcess([], 0, "https://github.com/consumer/project/issues/7#issuecomment-9\n", ""),
+            subprocess.CompletedProcess([], 0, json.dumps([[{"body": "proof", "html_url": "https://github.com/consumer/project/issues/7#issuecomment-9"}]]), ""),
+        ]
+        def runner(command, **_kwargs):
+            calls.append(command)
+            return responses.pop(0)
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as body_file:
+            body_file.write("proof")
+            body_file.flush()
+            result = GitHubClient("consumer/project", runner=runner, executable="gh").comment_once(7, body_file.name)
+        self.assertTrue(result["created"])
+        self.assertIn("--body-file", calls[1])
+        self.assertEqual("https://github.com/consumer/project/issues/7#issuecomment-9", result["url"])
+
+    def test_comment_once_reuses_exact_existing_body_and_fails_on_mismatch(self):
+        existing = [[{"body": "proof", "html_url": "https://github.com/consumer/project/issues/7#issuecomment-8"}]]
+        client = GitHubClient("consumer/project", runner=lambda *_a, **_k: subprocess.CompletedProcess([], 0, json.dumps(existing), ""), executable="gh")
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as body_file:
+            body_file.write("proof")
+            body_file.flush()
+            self.assertFalse(client.comment_once(7, body_file.name)["created"])
+
+        responses = [subprocess.CompletedProcess([], 0, "[]", ""), subprocess.CompletedProcess([], 0, "url", ""), subprocess.CompletedProcess([], 0, json.dumps([[{"body": "other", "html_url": "url"}]]), "")]
+        client = GitHubClient("consumer/project", runner=lambda *_a, **_k: responses.pop(0), executable="gh")
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as body_file:
+            body_file.write("proof")
+            body_file.flush()
+            with self.assertRaisesRegex(GitHubUnavailable, "readback"):
+                client.comment_once(7, body_file.name)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_learning_session.py
+++ b/tests/scripts/test_learning_session.py
@@ -317,7 +317,8 @@ class LearningWriteOutcomeTest(unittest.TestCase):
                 "--session-id inert-controller --operation-id inert-op"},
             "tool_response": "exit 0",
         }
-        with patch("scripts.agents.guard._learning_session.load_completion") as completion:
+        with patch("scripts.agents.guard._learning_session_core") as controller:
+            completion = controller.return_value.load_completion
             completion.return_value = {
                 "operation": "assess", "incident_hashes": ["a" * 64], "reason_code": None
             }


### PR DESCRIPTION
## Summary

Normalize official Grok lifecycle environment inputs, provide exact-readback idempotent GitHub issue comments, estimate missed session starts without fabricating elapsed time, and verify detected Grok installations through `grok inspect --json` without changing trust.

Closes #5333
Closes #5335

## Checks

- `python3 -m unittest tests.scripts.test_chaos_engine_kernel tests.scripts.test_github_client`
- `python3 -m unittest tests.scripts.test_chaos_engine_hosts tests.scripts.test_chaos_engine_installer` (195 passed)
- focused mandatory Learning Session / repeated Stop coverage and full learning-session suite (61 passed)
- live detected-host `grok inspect --json` verification returned healthy
- `python3 scripts/ci/validate_agent_setup.py --skip-external`
- `python3 scripts/ci/validate_documentation_boundaries.py`

## Continuation

No deferred PR 1 scope.
