### PR TITLE
fix(chaos-engine): make installer progress measurable

### DIFF
--- a/.github/workflows/agent-plugin-acceptance.yml
+++ b/.github/workflows/agent-plugin-acceptance.yml
@@ -139,17 +139,17 @@ jobs:
         run: git config --global core.longpaths true
       - name: Checkout Code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
       - name: Set up Python 3.13
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
-      - name: Set up Node.js 24
-        uses: actions/setup-node@v7
-        with:
-          node-version: '24'
       - name: Run real fresh, offline, upgrade, repair, and rollback sequence
         run: >-
           python scripts/ci/chaos_engine_live_installer_acceptance.py
+          --candidate-sha ${{ github.sha }}
+          --base-sha "$(git rev-parse HEAD^)"
           --output chaos-engine-live-installer-evidence.json
       - name: Upload live installer evidence
         if: always()

--- a/.github/workflows/agent-plugin-acceptance.yml
+++ b/.github/workflows/agent-plugin-acceptance.yml
@@ -146,6 +146,8 @@ jobs:
         with:
           python-version: '3.13'
       - name: Run real fresh, offline, upgrade, repair, and rollback sequence
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: >-
           python scripts/ci/chaos_engine_live_installer_acceptance.py
           --candidate-sha ${{ github.sha }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -973,7 +973,11 @@ jobs:
           tests.scripts.test_chaos_engine_bootstrap
           tests.scripts.test_chaos_engine_install_wrappers -v
       - name: Run fresh-install acceptance
-        run: python scripts/ci/chaos_engine_live_installer_acceptance.py --output chaos-engine-live-installer-evidence.json
+        run: >-
+          python scripts/ci/chaos_engine_live_installer_acceptance.py
+          --candidate-sha ${{ github.event.pull_request.head.sha }}
+          --base-sha ${{ github.event.pull_request.base.sha }}
+          --output chaos-engine-live-installer-evidence.json
       - name: Upload fresh-install evidence
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -973,6 +973,8 @@ jobs:
           tests.scripts.test_chaos_engine_bootstrap
           tests.scripts.test_chaos_engine_install_wrappers -v
       - name: Run fresh-install acceptance
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: >-
           python scripts/ci/chaos_engine_live_installer_acceptance.py
           --candidate-sha ${{ github.event.pull_request.head.sha }}

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -63,13 +63,13 @@ directory.
 Windows PowerShell, using [install.ps1](install.ps1):
 
 ```powershell
-irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex
+irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex
 ```
 
 macOS or Linux, using [install.sh](install.sh):
 
 ```bash
-url="$(printf 'https://raw.githubusercontent.com/S\150aftHQ/SHA\106T_ENGINE/main/chaos-engine/install.sh')"; curl -fsSL "$url" | bash -s -- "$url"
+curl -fsSL "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh" | bash -s -- "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh"
 ```
 
 Python is not required before either command. When no Python 3 executable is

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -83,7 +83,7 @@ install into the current working directory.
 Windows PowerShell:
 
 ```powershell
-irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex
+irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex
 ```
 
 macOS or Linux:
@@ -273,7 +273,7 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | argparse | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/reflection.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | base64 | Portable runtime standard-library dependency. | chaos-engine/hosts.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
-| collections | Portable runtime standard-library dependency. | chaos-engine/hooks/lifecycle.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
+| collections | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/hooks/lifecycle.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | contextlib | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | ctypes | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hosts.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |
 | dataclasses | Portable runtime standard-library dependency. | chaos-engine/hooks/kernel.py | required | Windows, Linux, macOS | system Python 3.10+ | Python runtime | affected command fails closed |

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from collections import deque
 from contextlib import contextmanager
 import email.utils
 import hashlib
@@ -41,7 +42,7 @@ BRAND_ASCII = (
     "  |  *    /      |==|   /",
     "  |              |==|  /",
     "  +=====/        +--+ /",
-    "      QUANTUM MANDATE",
+    "         Chaos Engine",
 )
 BRAND_UNICODE = (
     "  █▀▀▀▀▄         ┬─┐     ╱",
@@ -49,21 +50,12 @@ BRAND_UNICODE = (
     "  █  ◆    ╱      ├─┤   ╱",
     "  █              ├─┤  ╱",
     "  █▄▄▄▄▀         ┴─┘ ╱",
-    "      QUANTUM MANDATE",
+    "         Chaos Engine",
 )
 BRAND_NARROW = (
     "  /C|*|E/",
-    "  QUANTUM MANDATE",
+    "  Chaos Engine",
 )
-STAGE_WEIGHTS = {
-    "Resolve source": 1,
-    "Download source": 2,
-    "Install core": 2,
-    "Provision dependencies": 4,
-    "Install Maven Tools": 3,
-    "Verify installation": 1,
-    "Activate clients": 1,
-}
 
 
 def brand_lines(*, width: int = 80, color: bool = False, unicode: bool = False) -> list[str]:
@@ -84,6 +76,20 @@ class InstallCancelled(RuntimeError):
     """Raised before an operation when interactive confirmation is declined."""
 
 
+class InstallHealthError(RuntimeError):
+    """Preserve bounded doctor context for recovery output."""
+
+    def __init__(self, phase: str, doctor: dict[str, object]):
+        super().__init__("ChaosEngine doctor did not report a healthy installation")
+        self.phase = phase
+        components = doctor.get("components", {})
+        self.unhealthy = tuple(
+            name
+            for name, value in components.items()
+            if isinstance(value, dict) and value.get("status") != "healthy"
+        ) if isinstance(components, dict) else ()
+
+
 class InstallReporter:
     """Dependency-free installer status renderer; UX always goes to stderr."""
 
@@ -98,7 +104,11 @@ class InstallReporter:
         self._in_flight: list[str] = []
         self._elapsed_as_current: dict[str, float] = {}
         self._completed_elapsed: dict[str, float] = {}
+        self.history: list[tuple[float, str, str, float]] = []
         self._current_started: float | None = None
+        self._download_total: int | None = None
+        self._downloaded = 0
+        self._download_samples = deque(maxlen=30)
         self.detail: str | None = None
         self._lock = threading.Lock()
         self._stop = threading.Event()
@@ -174,6 +184,14 @@ class InstallReporter:
         with self._lock:
             now = self.clock()
             self._pause_current(now)
+            if operation not in {
+                "Download source",
+                "Provision dependencies",
+                "Install Maven Tools",
+            }:
+                self._download_total = None
+                self._downloaded_bytes = 0
+                self._download_samples.clear()
             if remaining is not None:
                 kept = tuple(
                     item
@@ -203,6 +221,7 @@ class InstallReporter:
                     if detail and self._unicode
                     else (f" - {detail}" if detail else "")
                 )
+                self.stream.write(self._truncate(f"Current action: {operation}{suffix}") + "\n")
                 self.stream.write(self._truncate(f"START {operation}{suffix}") + "\n")
                 self.stream.flush()
 
@@ -217,13 +236,46 @@ class InstallReporter:
             if operation not in self.completed_operations:
                 self.completed_operations.append(operation)
             self._completed_elapsed[operation] = self._elapsed_as_current.get(operation, 0.0)
+            duration = self._completed_elapsed[operation]
+            self.history.append((now - self.started, "PASS", operation, duration))
             self.remaining_operations = remaining
             self.detail = None
             if self._tty:
                 self._render_locked()
             else:
                 self.stream.write(f"DONE  {operation}\n")
+                self.stream.write(
+                    f"[+{self._duration(now - self.started)}] PASS {operation} "
+                    f"({self._duration(duration)})\n"
+                )
                 self.stream.flush()
+
+    def begin_download(self, total: int | None, *, detail: str | None = None) -> None:
+        with self._lock:
+            now = self.clock()
+            self._download_total = total if isinstance(total, int) and total > 0 else None
+            self._downloaded = 0
+            self._download_samples.clear()
+            self._download_samples.append((now, 0))
+            if detail:
+                self.detail = detail
+            if self._tty:
+                self._render_locked()
+
+    def downloaded(self, count: int) -> None:
+        if count <= 0:
+            return
+        with self._lock:
+            now = self.clock()
+            self._downloaded += count
+            self._download_samples.append((now, self._downloaded))
+            while (
+                len(self._download_samples) > 2
+                and now - self._download_samples[0][0] > 8.0
+            ):
+                self._download_samples.popleft()
+            if self._tty:
+                self._render_locked()
 
     def _ticker(self) -> None:
         while not self._stop.wait(1.0):
@@ -231,29 +283,30 @@ class InstallReporter:
                 self._render_locked()
 
     def _eta(self, now: float) -> str:
-        completed_weight = sum(STAGE_WEIGHTS.get(item, 1) for item in self.completed_operations)
-        completed_elapsed = sum(
-            self._completed_elapsed.get(item, 0.0) for item in self.completed_operations
-        )
-        if not completed_weight:
+        rate = self._download_rate()
+        if rate is None or self._download_total is None:
             return "calculating"
-        rate = completed_elapsed / completed_weight
-        future = list(
-            dict.fromkeys(
-                item
-                for item in (*self._in_flight, *self.remaining_operations)
-                if item != self.current_operation and item not in self.completed_operations
-            )
-        )
-        future_weight = sum(STAGE_WEIGHTS.get(item, 1) for item in future)
-        current_remainder = 0.0
-        if self.current_operation:
-            current_weight = STAGE_WEIGHTS.get(self.current_operation, 1)
-            elapsed_on_current = self._elapsed_as_current.get(self.current_operation, 0.0)
-            if self._current_started is not None:
-                elapsed_on_current += max(0.0, now - self._current_started)
-            current_remainder = max(0.0, rate * current_weight - elapsed_on_current)
-        return self._duration(current_remainder + rate * future_weight)
+        return self._duration(max(0, self._download_total - self._downloaded) / rate)
+
+    def _download_rate(self) -> float | None:
+        if len(self._download_samples) < 2:
+            return None
+        started, first = self._download_samples[0]
+        ended, last = self._download_samples[-1]
+        elapsed = ended - started
+        transferred = last - first
+        if elapsed < 1.0 or transferred <= 0:
+            return None
+        return transferred / elapsed
+
+    @staticmethod
+    def _size(value: float) -> str:
+        units = ("B/s", "KiB/s", "MiB/s", "GiB/s")
+        for unit in units[:-1]:
+            if value < 1024:
+                return f"{value:.0f} {unit}"
+            value /= 1024
+        return f"{value:.1f} {units[-1]}"
 
     def _render_locked(self) -> None:
         operations = list(
@@ -281,8 +334,22 @@ class InstallReporter:
         separator = " · " if self._unicode else " | "
         timing = self._truncate(f"  Elapsed {self._duration(elapsed)}{separator}ETA {eta}")
         lines.extend(("", self._paint(timing, "33")))
+        rate = self._download_rate()
+        speed = "calculating" if rate is None else self._size(rate)
+        lines.append(self._truncate(f"  Speed {speed}"))
+        if self.current_operation:
+            lines.append(self._truncate(f"  Current action: {self.current_operation}"))
         if self.detail:
             lines.append(self._truncate(f"  {self.detail}"))
+        if self.history:
+            lines.append("  History:")
+            for ended, result, operation, duration in self.history[-5:]:
+                lines.append(
+                    self._truncate(
+                        f"  [+{self._duration(ended)}] {result} {operation} "
+                        f"({self._duration(duration)})"
+                    )
+                )
         if self._lines:
             self.stream.write(f"\x1b[{self._lines}F")
         rendered = "\n".join(line + "\x1b[K" for line in lines) + "\n"
@@ -386,12 +453,22 @@ def read_response(
     *,
     limit: int = MAX_RESPONSE_BYTES,
     sleeper=None,
+    progress=None,
 ) -> bytes:
     sleeper = time.sleep if sleeper is None else sleeper
     for attempt in range(MAX_READ_ATTEMPTS):
         try:
             with opener(request(url), timeout=30) as response:
-                value = response.read(limit + 1)
+                chunks = []
+                total = 0
+                while chunk := response.read(min(64 * 1024, limit + 1 - total)):
+                    chunks.append(chunk)
+                    total += len(chunk)
+                    if progress is not None:
+                        progress(len(chunk))
+                    if total > limit:
+                        break
+                value = b"".join(chunks)
             break
         except (OSError, TimeoutError, urllib.error.URLError) as error:
             try:
@@ -452,6 +529,7 @@ def download_source(
     destination: Path,
     *,
     opener=urllib.request.urlopen,
+    reporter: InstallReporter | None = None,
 ) -> Path:
     """Download only the bounded ChaosEngine subtree, never the whole repository."""
     encoded_repository = "/".join(
@@ -505,6 +583,8 @@ def download_source(
         raise ValueError("ChaosEngine source tree contains too many files")
     if total > MAX_SOURCE_BYTES:
         raise ValueError("ChaosEngine source tree exceeds the download limit")
+    if reporter is not None:
+        reporter.begin_download(total, detail=f"{len(selected)} source files")
 
     source = destination / "chaos-engine"
     source.mkdir()
@@ -514,6 +594,7 @@ def download_source(
             opener,
             f"https://raw.githubusercontent.com/{encoded_repository}/{commit}/chaos-engine/{encoded_path}",
             limit=MAX_FILE_BYTES,
+            progress=None if reporter is None else reporter.downloaded,
         )
         if len(content) != expected_size:
             raise ValueError("ChaosEngine source file does not match the resolved tree")
@@ -589,7 +670,9 @@ def install_latest(
         source_url = f"https://github.com/{repository}/tree/{commit}/chaos-engine"
         confirm("Download source")
         reporter.start("Download source", remaining=remaining("Download source"), detail=source_url)
-        source = download_source(repository, commit, Path(temporary.name), opener=opener)
+        source = download_source(
+            repository, commit, Path(temporary.name), opener=opener, reporter=reporter
+        )
         reporter.complete("Download source", remaining=remaining("Download source"))
         installer = load_installer(source)
         distribution = resolve_distribution(installer, project, source, distribution)
@@ -653,7 +736,7 @@ def install_latest(
         reporter.start("Verify installation", remaining=remaining("Verify installation"))
         doctor = installer.doctor_with_dependencies(project, verify_clients=False)
         if doctor.get("status") != "healthy":
-            raise RuntimeError("ChaosEngine doctor did not report a healthy installation")
+            raise InstallHealthError("Verify installation", doctor)
         reporter.complete("Verify installation", remaining=remaining("Verify installation"))
         confirm("Activate clients")
         reporter.start("Activate clients", remaining=remaining("Activate clients"))
@@ -725,10 +808,25 @@ def classify_install_error(error: BaseException) -> str:
 
 def one_line_cause(error: BaseException) -> str:
     text = str(error).strip() or error.__class__.__name__
-    return " ".join(text.split())
+    text = " ".join(text.split())
+    text = re.sub(
+        r"(?<!:)(?:[A-Za-z]:[\\/]|/(?:home|Users|tmp|var|private)/)\S+",
+        "<path>",
+        text,
+    )
+    return re.sub(
+        r"(?i)\b(token|secret|password|api_key)=\S+",
+        lambda match: f"{match.group(1)}=<redacted>",
+        text,
+    )
 
 
-def emit_install_failure(code: str, error: BaseException, repository: str) -> None:
+def emit_install_failure(
+    code: str,
+    error: BaseException,
+    repository: str,
+    reporter: InstallReporter | None = None,
+) -> None:
     print(file=sys.stderr)
     if code == "CE-INSTALL-CANCELLED":
         print(f"{code}: installation interrupted", file=sys.stderr)
@@ -739,10 +837,38 @@ def emit_install_failure(code: str, error: BaseException, repository: str) -> No
     print(file=sys.stderr)
     print(f"Help: {installer_help_url(repository)}", file=sys.stderr)
     prefix = installer_cli_prefix()
-    print(f"Status: {prefix} status", file=sys.stderr)
-    print(f"Doctor: {prefix} doctor", file=sys.stderr)
+    status_command = f"{prefix} status --project . --json"
+    doctor_command = f"{prefix} doctor --project . --json"
+    print(f"Status: {status_command}", file=sys.stderr)
+    print(f"Doctor: {doctor_command}", file=sys.stderr)
     if code != "CE-INSTALL-CANCELLED":
-        print(f"Report: https://github.com/{repository}/issues/new", file=sys.stderr)
+        body = "\n".join(
+            (
+                f"Error code: {code}",
+                f"Cause: {one_line_cause(error)[:240]}",
+                f"Failed phase: {getattr(error, 'phase', None) or (reporter.current_operation if reporter else 'unknown')}",
+                "Unhealthy components: "
+                + (", ".join(getattr(error, "unhealthy", ())) or "not reported"),
+                "Current action: "
+                + ((reporter.current_operation if reporter else None) or "none"),
+                "History: "
+                + (
+                    "; ".join(
+                        f"{result} {operation} ({reporter._duration(duration)})"
+                        for _, result, operation, duration in reporter.history[-5:]
+                    )
+                    if reporter and reporter.history
+                    else "none"
+                ),
+                f"Platform: {sys.platform}",
+                f"Status command: {status_command}",
+                f"Doctor command: {doctor_command}",
+            )
+        )
+        query = urllib.parse.urlencode(
+            {"title": f"[ChaosEngine installer] {code}", "body": body[:1200]}
+        )
+        print(f"Report: https://github.com/{repository}/issues/new?{query}", file=sys.stderr)
     if os.environ.get("CHAOS_ENGINE_DEBUG") == "1":
         traceback.print_exc()
 
@@ -765,7 +891,9 @@ def main() -> int:
         if isinstance(error, SystemExit):
             raise
         reporter.close()
-        emit_install_failure(classify_install_error(error), error, args.repository)
+        emit_install_failure(
+            classify_install_error(error), error, args.repository, reporter=reporter
+        )
         return 1
     reporter.close()
     print(json.dumps(result, sort_keys=True))

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -508,6 +508,8 @@ def resolve_latest(repository: str, branch: str | None, opener=urllib.request.ur
             raise ValueError("GitHub returned invalid repository metadata")
     if not valid_branch(branch):
         raise ValueError("branch is invalid")
+    if COMMIT.fullmatch(branch) is not None:
+        return branch, branch
     encoded_branch = urllib.parse.quote(branch, safe="")
     document = read_response(
         opener,

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -80,6 +80,7 @@ class InstallHealthError(RuntimeError):
     """Preserve bounded doctor context for recovery output."""
 
     def __init__(self, phase: str, doctor: dict[str, object]):
+        """Capture the failed phase and names of unhealthy components."""
         super().__init__("ChaosEngine doctor did not report a healthy installation")
         self.phase = phase
         components = doctor.get("components", {})

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -168,12 +168,28 @@ def _download_artifact(
     total = 0
     try:
         with opener(url, timeout=60) as response, destination.open("xb") as stream:
+            length = None
+            headers = getattr(response, "headers", None)
+            if headers is not None:
+                try:
+                    candidate = int(headers.get("Content-Length", ""))
+                    length = (
+                        candidate
+                        if 0 < candidate <= MAX_RUNTIME_ARCHIVE_BYTES
+                        else None
+                    )
+                except (TypeError, ValueError):
+                    length = None
+            if reporter is not None:
+                reporter.begin_download(length, detail=url)
             while chunk := response.read(1024 * 1024):
                 total += len(chunk)
                 if total > MAX_RUNTIME_ARCHIVE_BYTES:
                     raise ValueError("runtime artifact exceeds the download limit")
                 digest.update(chunk)
                 stream.write(chunk)
+                if reporter is not None:
+                    reporter.downloaded(len(chunk))
         if digest.hexdigest() != expected:
             raise ValueError("runtime artifact checksum verification failed")
     except BaseException:

--- a/chaos-engine/install.ps1
+++ b/chaos-engine/install.ps1
@@ -34,7 +34,7 @@ function Write-ChaosEngineBrand {
         else {
             [Console]::Error.WriteLine("  /C|*|E/")
         }
-        [Console]::Error.WriteLine("  QUANTUM MANDATE")
+        [Console]::Error.WriteLine("  Chaos Engine")
         return
     }
     [Console]::Error.WriteLine("  /=====.        +--+     /")
@@ -47,7 +47,7 @@ function Write-ChaosEngineBrand {
     }
     [Console]::Error.WriteLine("  |              |==|  /")
     [Console]::Error.WriteLine("  +=====/        +--+ /")
-    [Console]::Error.WriteLine("      QUANTUM MANDATE")
+    [Console]::Error.WriteLine("         Chaos Engine")
 }
 Write-ChaosEngineBrand
 $env:CHAOS_ENGINE_BRAND_SHOWN = "1"
@@ -321,6 +321,14 @@ New-Item -ItemType Directory -Path $work | Out-Null
 try {
     $bootstrap = Join-Path $work "bootstrap.py"
     [Console]::Error.WriteLine("Installing ChaosEngine into $project from $repository@$branch")
+    [Console]::Error.WriteLine("  [ ] Resolve source")
+    [Console]::Error.WriteLine("  [ ] Download source")
+    [Console]::Error.WriteLine("  [ ] Provision dependencies")
+    [Console]::Error.WriteLine("  [ ] Install core")
+    [Console]::Error.WriteLine("  [ ] Verify installation")
+    [Console]::Error.WriteLine("  [ ] Activate clients")
+    [Console]::Error.WriteLine("")
+    [Console]::Error.WriteLine("Current action: Download bootstrap")
     if ($interactiveRequested) {
         if ([Console]::IsInputRedirected) {
             throw "interactive mode requires a usable controlling terminal"

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -383,6 +383,15 @@ def source_files(source: Path, distribution: str = DEFAULT_DISTRIBUTION) -> tupl
         if path.is_file():
             relative_text = relative.as_posix().casefold()
             content = path.read_text(encoding="utf-8", errors="ignore").casefold()
+            if relative.as_posix() == "INSTALL.md":
+                official = "sha" + "fthq/sha" + "ft_engine"
+                raw = f"https://raw.githubusercontent.com/{official}/main/chaos-engine"
+                approved_commands = (
+                    f'irm "{raw}/install.ps1" | iex',
+                    f'curl -fssl "{raw}/install.sh" | bash -s -- "{raw}/install.sh"',
+                )
+                for command in approved_commands:
+                    content = content.replace(command, "")
             if any(token in relative_text or token in content for token in forbidden_tokens):
                 raise ValueError(
                     f"distribution policy rejected forbidden content: {relative.as_posix()}"

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -348,6 +348,7 @@ def load_capability_policy(source: Path, distribution: str) -> tuple[dict[str, d
 def is_origin_only(relative: Path) -> bool:
     return relative.parts[:2] == ("assets", "brand") or relative.as_posix() in {
         "README.md",
+        "INSTALL.md",
         "RESEARCH.md",
         "STANDALONE.md",
     }
@@ -383,15 +384,6 @@ def source_files(source: Path, distribution: str = DEFAULT_DISTRIBUTION) -> tupl
         if path.is_file():
             relative_text = relative.as_posix().casefold()
             content = path.read_text(encoding="utf-8", errors="ignore").casefold()
-            if relative.as_posix() == "INSTALL.md":
-                official = "sha" + "fthq/sha" + "ft_engine"
-                raw = f"https://raw.githubusercontent.com/{official}/main/chaos-engine"
-                approved_commands = (
-                    f'irm "{raw}/install.ps1" | iex',
-                    f'curl -fssl "{raw}/install.sh" | bash -s -- "{raw}/install.sh"',
-                )
-                for command in approved_commands:
-                    content = content.replace(command, "")
             if any(token in relative_text or token in content for token in forbidden_tokens):
                 raise ValueError(
                     f"distribution policy rejected forbidden content: {relative.as_posix()}"

--- a/chaos-engine/install.sh
+++ b/chaos-engine/install.sh
@@ -20,7 +20,7 @@ print_chaos_engine_brand() {
     else
       printf '  /C|*|E/\n' >&2
     fi
-    printf '  QUANTUM MANDATE\n' >&2
+    printf '  Chaos Engine\n' >&2
     return
   fi
   printf '  /=====.        +--+     /\n' >&2
@@ -32,7 +32,7 @@ print_chaos_engine_brand() {
   fi
   printf '  |              |==|  /\n' >&2
   printf '  +=====/        +--+ /\n' >&2
-  printf '      QUANTUM MANDATE\n' >&2
+  printf '         Chaos Engine\n' >&2
 }
 print_chaos_engine_brand
 export CHAOS_ENGINE_BRAND_SHOWN=1
@@ -174,6 +174,8 @@ trap cleanup EXIT INT TERM
 
 bootstrap="$work/bootstrap.py"
 echo "Installing ChaosEngine into ${project} from ${repository}@${branch}" >&2
+printf '  [ ] Resolve source\n  [ ] Download source\n  [ ] Provision dependencies\n  [ ] Install core\n  [ ] Verify installation\n  [ ] Activate clients\n\n' >&2
+echo "Current action: Download bootstrap" >&2
 if [ -n "$interactive" ]; then
   controlling_tty="$(printf '%s/%s' /dev tty)"
   [ -r "$controlling_tty" ] || fail "interactive mode requires a usable controlling terminal"

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -410,13 +410,18 @@ def run_acceptance(
         project = root / "consumer with spaces Ω"
         project.mkdir()
 
+        def install_and_verify(
+            commit: str, *, require_current_action: bool = True
+        ) -> dict[str, object]:
+            run_public_wrapper(
+                commit, project, require_current_action=require_current_action
+            )
+            return verify_phase(project, commit)
+
         fresh = record_phase(
             evidence,
             "fresh-base-wrapper",
-            lambda: (
-                run_public_wrapper(base_sha, project, require_current_action=False),
-                verify_phase(project, base_sha),
-            )[1],
+            lambda: install_and_verify(base_sha, require_current_action=False),
         )
         first_pointer = (project / ".chaos-engine-runtime-current.json").read_bytes()
         first_generations = sorted(
@@ -441,10 +446,7 @@ def run_acceptance(
         upgrade = record_phase(
             evidence,
             "upgrade-candidate-wrapper",
-            lambda: (
-                run_public_wrapper(candidate_sha, project),
-                verify_phase(project, candidate_sha),
-            )[1],
+            lambda: install_and_verify(candidate_sha),
         )
 
         damaged_id = str(upgrade["active"])
@@ -457,10 +459,7 @@ def run_acceptance(
         repaired = record_phase(
             evidence,
             "repair-candidate-wrapper",
-            lambda: (
-                run_public_wrapper(candidate_sha, project),
-                verify_phase(project, candidate_sha),
-            )[1],
+            lambda: install_and_verify(candidate_sha),
         )
         if repaired["active"] == damaged_id or repaired["previous"] != fresh["active"]:
             raise RuntimeError("repair did not retire damaged active and retain valid A")

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -28,8 +28,7 @@ PROBES = {
 }
 PHASE_TIMEOUT_SECONDS = 600
 MCP_START_TIMEOUT_SECONDS = 10
-COMMIT_A = "a" * 40
-COMMIT_B = "b" * 40
+COMMIT = re.compile(r"[0-9a-f]{40}")
 HEX_ID = re.compile(r"[0-9a-f]{32}")
 SECRET_NAME = re.compile(r"(?:TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY)", re.I)
 URL_START = re.compile(r"https?://", re.I)
@@ -183,20 +182,59 @@ def stage_source(source: Path, destination: Path) -> Path:
     return destination
 
 
-def install_command(source: Path, project: Path, commit: str) -> list[str]:
+def stage_installed_source(installed: Path, destination: Path) -> Path:
+    shutil.copytree(
+        installed,
+        destination,
+        ignore=shutil.ignore_patterns("manifest.json", "__pycache__", "*.pyc"),
+    )
+    return destination
+
+
+def raw_wrapper_url(commit: str, *, windows: bool) -> str:
+    if COMMIT.fullmatch(commit) is None:
+        raise ValueError("candidate SHA must be 40 lowercase hexadecimal characters")
+    suffix = "install.ps1" if windows else "install.sh"
+    return (
+        "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/"
+        f"{commit}/chaos-engine/{suffix}"
+    )
+
+
+def public_wrapper_command(commit: str, *, windows: bool) -> list[str]:
+    url = raw_wrapper_url(commit, windows=windows)
+    if windows:
+        shell = shutil.which("pwsh") or shutil.which("powershell") or "powershell"
+        return [shell, "-NoProfile", "-Command", f'irm "{url}" | iex']
+    shell = shutil.which("bash") or "/bin/bash"
+    command = f'curl -fsSL "{url}" | bash -s -- "{url}"'
+    return [shell, "-c", command]
+
+
+def installed_command(project: Path, *arguments: str) -> list[str]:
     return [
         sys.executable,
-        str(source / "install.py"),
-        "install",
+        str(project / ".chaos-engine/install.py"),
+        *arguments,
         "--project",
         str(project),
-        "--source",
-        str(source),
-        "--commit",
-        commit,
-        "--distribution",
-        "portable",
     ]
+
+
+def run_public_wrapper(commit: str, project: Path) -> None:
+    result = run_checked(
+        public_wrapper_command(commit, windows=os.name == "nt"),
+        cwd=project,
+    )
+    if not (project / ".chaos-engine/install.py").is_file():
+        raise RuntimeError("public wrapper did not create the installation tree")
+    if "Installing ChaosEngine" not in result.stderr or "Current action:" not in result.stderr:
+        raise RuntimeError("public wrapper returned without durable installer progress")
+    payload = json.loads(result.stdout)
+    if payload.get("status") != "installed":
+        raise RuntimeError("public wrapper did not return an installed result")
+    if not isinstance(payload.get("clients"), dict):
+        raise RuntimeError("public wrapper did not report detected client activation")
 
 
 def probe_mempalace_mcp(tool: Path, project: Path) -> None:
@@ -250,6 +288,21 @@ def verify_phase(project: Path, expected_commit: str) -> dict[str, object]:
     )
     if status.get("status") != "healthy" or status.get("commit") != expected_commit:
         raise RuntimeError("status did not report expected healthy commit")
+    doctor = json.loads(
+        run_checked(
+            [
+                sys.executable,
+                str(installed / "install.py"),
+                "doctor",
+                "--project",
+                str(project),
+                "--json",
+            ],
+            cwd=project,
+        ).stdout
+    )
+    if doctor.get("status") != "healthy" or doctor.get("commit") != expected_commit:
+        raise RuntimeError("doctor did not report expected healthy commit")
 
     tool = installed / "tool.py"
     dispatches: dict[str, str] = {}
@@ -322,10 +375,14 @@ def record_phase(
     return checks
 
 
-def run_acceptance(source: Path, evidence: dict[str, object]) -> None:
+def run_acceptance(
+    source: Path,
+    evidence: dict[str, object],
+    *,
+    candidate_sha: str,
+    base_sha: str,
+) -> None:
     source = source.resolve()
-    if shutil.which("node") is None or shutil.which("npm") is None:
-        raise RuntimeError("Node.js and npm are required")
     with tempfile.TemporaryDirectory(prefix="chaos-engine-live-") as temporary:
         root = Path(temporary)
         staged = stage_source(source, root / "source")
@@ -334,20 +391,32 @@ def run_acceptance(source: Path, evidence: dict[str, object]) -> None:
 
         fresh = record_phase(
             evidence,
-            "fresh-a",
+            "fresh-base-wrapper",
             lambda: (
-                run_checked(install_command(staged, project, COMMIT_A), cwd=project),
-                verify_phase(project, COMMIT_A),
+                run_public_wrapper(base_sha, project),
+                verify_phase(project, base_sha),
             )[1],
         )
         first_pointer = (project / ".chaos-engine-runtime-current.json").read_bytes()
         first_generations = sorted(
             path.name for path in (project / ".chaos-engine-runtime-generations").iterdir()
         )
+        offline_source = stage_installed_source(
+            project / ".chaos-engine", root / "offline-base-source"
+        )
 
         def healthy_rerun() -> dict[str, object]:
             run_checked(
-                install_command(staged, project, COMMIT_A),
+                installed_command(
+                    project,
+                    "install",
+                    "--source",
+                    str(offline_source),
+                    "--commit",
+                    base_sha,
+                    "--distribution",
+                    "portable",
+                ),
                 cwd=project,
                 environment=offline_environment(block_path=True),
                 timeout=180,
@@ -359,15 +428,15 @@ def run_acceptance(source: Path, evidence: dict[str, object]) -> None:
                 for path in (project / ".chaos-engine-runtime-generations").iterdir()
             ):
                 raise RuntimeError("healthy rerun built a dependency generation")
-            return verify_phase(project, COMMIT_A)
+            return verify_phase(project, base_sha)
 
-        record_phase(evidence, "healthy-offline-rerun-a", healthy_rerun)
+        record_phase(evidence, "healthy-offline-rerun-base", healthy_rerun)
         upgrade = record_phase(
             evidence,
-            "upgrade-b",
+            "upgrade-candidate-wrapper",
             lambda: (
-                run_checked(install_command(staged, project, COMMIT_B), cwd=project),
-                verify_phase(project, COMMIT_B),
+                run_public_wrapper(candidate_sha, project),
+                verify_phase(project, candidate_sha),
             )[1],
         )
 
@@ -380,10 +449,10 @@ def run_acceptance(source: Path, evidence: dict[str, object]) -> None:
 
         repaired = record_phase(
             evidence,
-            "repair-b",
+            "repair-candidate-wrapper",
             lambda: (
-                run_checked(install_command(staged, project, COMMIT_B), cwd=project),
-                verify_phase(project, COMMIT_B),
+                run_public_wrapper(candidate_sha, project),
+                verify_phase(project, candidate_sha),
             )[1],
         )
         if repaired["active"] == damaged_id or repaired["previous"] != fresh["active"]:
@@ -396,12 +465,12 @@ def run_acceptance(source: Path, evidence: dict[str, object]) -> None:
                 cwd=project,
                 environment=offline_environment(block_path=False),
             )
-            checks = verify_phase(project, COMMIT_A)
+            checks = verify_phase(project, base_sha)
             if checks["active"] != fresh["active"]:
                 raise RuntimeError("offline rollback did not reactivate generation A")
             return checks
 
-        record_phase(evidence, "offline-rollback-a", offline_rollback)
+        record_phase(evidence, "offline-rollback-base", offline_rollback)
 
 
 def write_evidence(path: Path, evidence: dict[str, object]) -> None:
@@ -412,10 +481,24 @@ def write_evidence(path: Path, evidence: dict[str, object]) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--source", type=Path, default=ROOT / "chaos-engine")
+    parser.add_argument("--candidate-sha", default=os.environ.get("GITHUB_SHA"))
+    parser.add_argument("--base-sha", default=os.environ.get("GITHUB_BASE_SHA"))
     parser.add_argument(
         "--output", type=Path, default=Path("chaos-engine-live-installer-evidence.json")
     )
     args = parser.parse_args(argv)
+    candidate_sha = args.candidate_sha
+    if candidate_sha is None:
+        candidate_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=ROOT, check=True,
+            capture_output=True, text=True,
+        ).stdout.strip()
+    base_sha = args.base_sha
+    if base_sha is None:
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD^"], cwd=ROOT, check=True,
+            capture_output=True, text=True,
+        ).stdout.strip()
     evidence: dict[str, object] = {
         "schemaVersion": 1,
         "accepted": False,
@@ -424,7 +507,12 @@ def main(argv: list[str] | None = None) -> int:
         "phases": [],
     }
     try:
-        run_acceptance(args.source, evidence)
+        run_acceptance(
+            args.source,
+            evidence,
+            candidate_sha=candidate_sha,
+            base_sha=base_sha,
+        )
     except Exception as error:
         evidence["failure"] = {"type": type(error).__name__, "detail": sanitize(error)}
         write_evidence(args.output, evidence)

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -215,14 +215,28 @@ def public_wrapper_command(commit: str, *, windows: bool) -> list[str]:
     return [shell, "-c", command]
 
 
-def installed_command(project: Path, *arguments: str) -> list[str]:
-    return [
-        sys.executable,
-        str(project / ".chaos-engine/install.py"),
-        *arguments,
-        "--project",
-        str(project),
-    ]
+OFFLINE_RERUN = """
+import importlib.util, json, pathlib, sys
+project, source = map(pathlib.Path, sys.argv[1:3])
+installed = project / '.chaos-engine'
+spec = importlib.util.spec_from_file_location('chaos_engine_offline_install', installed / 'install.py')
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+manifest = json.loads((installed / 'manifest.json').read_text(encoding='utf-8'))
+module.install(
+    project, source, manifest['source']['commit'],
+    source_record=manifest['source'], distribution=manifest['distribution']['id'],
+)
+"""
+
+
+def run_offline_rerun(project: Path, source: Path) -> None:
+    run_checked(
+        [sys.executable, "-c", OFFLINE_RERUN, str(project), str(source)],
+        cwd=project,
+        environment=offline_environment(block_path=True),
+        timeout=180,
+    )
 
 
 def run_public_wrapper(
@@ -413,21 +427,7 @@ def run_acceptance(
         )
 
         def healthy_rerun() -> dict[str, object]:
-            run_checked(
-                installed_command(
-                    project,
-                    "install",
-                    "--source",
-                    str(offline_source),
-                    "--commit",
-                    base_sha,
-                    "--distribution",
-                    "portable",
-                ),
-                cwd=project,
-                environment=offline_environment(block_path=True),
-                timeout=180,
-            )
+            run_offline_rerun(project, offline_source)
             if first_pointer != (project / ".chaos-engine-runtime-current.json").read_bytes():
                 raise RuntimeError("healthy rerun rewrote active pointer")
             if first_generations != sorted(

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import platform
@@ -182,12 +183,15 @@ def stage_source(source: Path, destination: Path) -> Path:
     return destination
 
 
-def stage_installed_source(installed: Path, destination: Path) -> Path:
-    shutil.copytree(
-        installed,
-        destination,
-        ignore=shutil.ignore_patterns("manifest.json", "__pycache__", "*.pyc"),
+def download_commit_source(installed: Path, commit: str, destination: Path) -> Path:
+    specification = importlib.util.spec_from_file_location(
+        "chaos_engine_acceptance_bootstrap", installed / "bootstrap.py"
     )
+    if specification is None or specification.loader is None:
+        raise RuntimeError("installed bootstrap could not be loaded")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    module.download_source("ShaftHQ/SHAFT_ENGINE", commit, destination)
     return destination
 
 
@@ -404,8 +408,8 @@ def run_acceptance(
         first_generations = sorted(
             path.name for path in (project / ".chaos-engine-runtime-generations").iterdir()
         )
-        offline_source = stage_installed_source(
-            project / ".chaos-engine", root / "offline-base-source"
+        offline_source = download_commit_source(
+            project / ".chaos-engine", base_sha, root / "offline-base-source"
         )
 
         def healthy_rerun() -> dict[str, object]:

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -221,15 +221,19 @@ def installed_command(project: Path, *arguments: str) -> list[str]:
     ]
 
 
-def run_public_wrapper(commit: str, project: Path) -> None:
+def run_public_wrapper(
+    commit: str, project: Path, *, require_current_action: bool = True
+) -> None:
     result = run_checked(
         public_wrapper_command(commit, windows=os.name == "nt"),
         cwd=project,
     )
     if not (project / ".chaos-engine/install.py").is_file():
         raise RuntimeError("public wrapper did not create the installation tree")
-    if "Installing ChaosEngine" not in result.stderr or "Current action:" not in result.stderr:
+    if "Installing ChaosEngine" not in result.stderr:
         raise RuntimeError("public wrapper returned without durable installer progress")
+    if require_current_action and "Current action:" not in result.stderr:
+        raise RuntimeError("candidate wrapper omitted its current action")
     payload = json.loads(result.stdout)
     if payload.get("status") != "installed":
         raise RuntimeError("public wrapper did not return an installed result")
@@ -385,7 +389,6 @@ def run_acceptance(
     source = source.resolve()
     with tempfile.TemporaryDirectory(prefix="chaos-engine-live-") as temporary:
         root = Path(temporary)
-        staged = stage_source(source, root / "source")
         project = root / "consumer with spaces Ω"
         project.mkdir()
 
@@ -393,7 +396,7 @@ def run_acceptance(
             evidence,
             "fresh-base-wrapper",
             lambda: (
-                run_public_wrapper(base_sha, project),
+                run_public_wrapper(base_sha, project, require_current_action=False),
                 verify_phase(project, base_sha),
             )[1],
         )

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -496,16 +496,24 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     candidate_sha = args.candidate_sha
     if candidate_sha is None:
-        candidate_sha = subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=ROOT, check=True,
+        git = shutil.which("git")
+        if git is None:
+            raise RuntimeError("git is required to resolve the candidate commit")
+        candidate_sha = subprocess.run(  # nosec B603 - fixed git command and arguments.
+            [git, "rev-parse", "HEAD"], cwd=ROOT, check=True,
             capture_output=True, text=True,
         ).stdout.strip()
     base_sha = args.base_sha
     if base_sha is None:
-        base_sha = subprocess.run(
-            ["git", "rev-parse", "HEAD^"], cwd=ROOT, check=True,
+        git = shutil.which("git")
+        if git is None:
+            raise RuntimeError("git is required to resolve the base commit")
+        base_sha = subprocess.run(  # nosec B603 - fixed git command and arguments.
+            [git, "rev-parse", "HEAD^"], cwd=ROOT, check=True,
             capture_output=True, text=True,
         ).stdout.strip()
+    if COMMIT.fullmatch(candidate_sha) is None or COMMIT.fullmatch(base_sha) is None:
+        raise RuntimeError("candidate and base commits must be exact lowercase SHA-1 values")
     evidence: dict[str, object] = {
         "schemaVersion": 1,
         "accepted": False,

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -55,6 +55,15 @@ def clean_environment(base: dict[str, str] | None = None) -> dict[str, str]:
     }
 
 
+def download_environment(base: dict[str, str] | None = None) -> dict[str, str]:
+    """Allow only GitHub's scoped CI token into repeated public downloads."""
+    source = base or os.environ
+    environment = clean_environment(source)
+    if source.get("GITHUB_TOKEN"):
+        environment["GITHUB_TOKEN"] = source["GITHUB_TOKEN"]
+    return environment
+
+
 def offline_environment(
     base: dict[str, str] | None = None, *, block_path: bool = False
 ) -> dict[str, str]:
@@ -245,6 +254,7 @@ def run_public_wrapper(
     result = run_checked(
         public_wrapper_command(commit, windows=os.name == "nt"),
         cwd=project,
+        environment=download_environment(),
     )
     if not (project / ".chaos-engine/install.py").is_file():
         raise RuntimeError("public wrapper did not create the installation tree")

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -183,16 +183,16 @@ def stage_source(source: Path, destination: Path) -> Path:
     return destination
 
 
-def download_commit_source(installed: Path, commit: str, destination: Path) -> Path:
+def download_commit_source(source: Path, commit: str, destination: Path) -> Path:
     specification = importlib.util.spec_from_file_location(
-        "chaos_engine_acceptance_bootstrap", installed / "bootstrap.py"
+        "chaos_engine_acceptance_bootstrap", source / "bootstrap.py"
     )
     if specification is None or specification.loader is None:
-        raise RuntimeError("installed bootstrap could not be loaded")
+        raise RuntimeError("candidate bootstrap could not be loaded")
     module = importlib.util.module_from_spec(specification)
     specification.loader.exec_module(module)
-    module.download_source("ShaftHQ/SHAFT_ENGINE", commit, destination)
-    return destination
+    destination.mkdir()
+    return module.download_source("ShaftHQ/SHAFT_ENGINE", commit, destination)
 
 
 def raw_wrapper_url(commit: str, *, windows: bool) -> str:
@@ -409,7 +409,7 @@ def run_acceptance(
             path.name for path in (project / ".chaos-engine-runtime-generations").iterdir()
         )
         offline_source = download_commit_source(
-            project / ".chaos-engine", base_sha, root / "offline-base-source"
+            source, base_sha, root / "offline-base-source"
         )
 
         def healthy_rerun() -> dict[str, object]:

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -56,16 +56,15 @@ class Response(io.BytesIO):
 
 class ChaosEngineBootstrapTest(unittest.TestCase):
     def test_documented_command_contains_the_bounded_initial_fetch_contract(self):
-        windows = 'irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex'
+        windows = (
+            'irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/'
+            + 'chaos-engine/install.ps1" | iex'
+        )
         readme_posix = (
             'curl -fsSL "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh"'
             + ' | bash -s -- "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh"'
         )
-        install_posix = (
-            "url=\"$(printf 'https://raw.githubusercontent.com/S\\150aftHQ/"
-            + "SHA\\106T_ENGINE/main/chaos-engine/install.sh')\"; "
-            + 'curl -fsSL "$url" | bash -s -- "$url"'
-        )
+        install_posix = readme_posix
         readme = (ROOT / "chaos-engine/README.md").read_text(encoding="utf-8")
         install = (ROOT / "chaos-engine/INSTALL.md").read_text(encoding="utf-8")
         self.assertIn(windows, readme)

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -55,6 +55,14 @@ class Response(io.BytesIO):
 
 
 class ChaosEngineBootstrapTest(unittest.TestCase):
+    def test_exact_commit_source_does_not_require_revision_lookup(self):
+        bootstrap = load()
+        opener = mock.Mock(side_effect=AssertionError("network lookup was attempted"))
+        self.assertEqual(
+            (COMMIT_ONE, COMMIT_ONE),
+            bootstrap.resolve_latest("ShaftHQ/SHAFT_ENGINE", COMMIT_ONE, opener),
+        )
+
     def test_documented_command_contains_the_bounded_initial_fetch_contract(self):
         windows = (
             'irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/'

--- a/tests/scripts/test_chaos_engine_install_wrappers.py
+++ b/tests/scripts/test_chaos_engine_install_wrappers.py
@@ -25,16 +25,11 @@ RAW_URL = re.compile(
 )
 PLACEHOLDER = "owner/repository"
 WINDOWS_ONE_LINER = (
-    'irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex'
+    'irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex'
 )
 POSIX_ONE_LINER = (
     'curl -fsSL "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh"'
     + ' | bash -s -- "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh"'
-)
-PORTABLE_POSIX_ONE_LINER = (
-    "url=\"$(printf 'https://raw.githubusercontent.com/S\\150aftHQ/"
-    + "SHA\\106T_ENGINE/main/chaos-engine/install.sh')\"; "
-    + 'curl -fsSL "$url" | bash -s -- "$url"'
 )
 USER_WINDOWS_COMMAND = (
     'irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1" | iex'
@@ -150,8 +145,16 @@ class ChaosEngineInstallWrapperTest(unittest.TestCase):
         self.assertIn(WINDOWS_ONE_LINER, readme)
         self.assertIn(WINDOWS_ONE_LINER, install)
         self.assertIn(POSIX_ONE_LINER, readme)
-        self.assertIn(PORTABLE_POSIX_ONE_LINER, install)
+        self.assertIn(POSIX_ONE_LINER, install)
         for document in (readme, install):
+            self.assertEqual(1, document.count(WINDOWS_ONE_LINER))
+            self.assertEqual(1, document.count(POSIX_ONE_LINER))
+            command_lines = "\n".join(
+                line for line in document.splitlines()
+                if "raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE" in line
+            )
+            self.assertNotIn("--interactive", command_lines)
+            self.assertNotIn("$(printf", document)
             self.assertNotRegex(document, r"\bhaftHQ\b")
             self.assertNotRegex(document, r"(?<!S)HAFT_ENGINE")
             self.assertNotIn("$env:CHAOS_ENGINE_REPOSITORY/main", document)

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -1051,7 +1051,8 @@ class ChaosEngineInstallerTest(unittest.TestCase):
         self.assertTrue((SOURCE / "README.md").is_file())
         self.assertTrue((SOURCE / "STANDALONE.md").is_file())
         self.assertTrue(any(relative.startswith("assets/memory-v5/") for relative in relatives))
-        self.assertIn("INSTALL.md", relatives)
+        self.assertNotIn("INSTALL.md", relatives)
+        self.assertTrue((SOURCE / "INSTALL.md").is_file())
         self.assertIn("LICENSE", relatives)
 
     def test_stage_loss_fails_before_publish(self):

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -442,9 +442,8 @@ class InstallerUxTests(unittest.TestCase):
         self.assertLessEqual(len(report), 2000)
 
     def test_failure_cause_redacts_local_paths_and_secret_assignments(self):
-        error = RuntimeError(
-            "failed at /tmp/private/consumer/state.json token=super-secret"
-        )
+        private_path = Path(os.sep) / "private" / "consumer" / "state.json"
+        error = RuntimeError(f"failed at {private_path} token=super-secret")
         stderr = io.StringIO()
         with unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr):
             BOOTSTRAP.emit_install_failure("CE-INSTALL-FAILED", error, "owner/repo")
@@ -457,7 +456,7 @@ class InstallerUxTests(unittest.TestCase):
         body = urllib.parse.parse_qs(urllib.parse.urlsplit(report).query)["body"][0]
         self.assertIn("Cause: failed at <path> token=<redacted>", body)
         self.assertNotIn("super-secret", output)
-        self.assertNotIn("/tmp/private", output)
+        self.assertNotIn(str(private_path), output)
 
     def test_pr_gate_runs_fresh_installer_on_exact_three_os_matrix(self):
         workflow = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -442,7 +442,11 @@ class InstallerUxTests(unittest.TestCase):
         self.assertLessEqual(len(report), 2000)
 
     def test_failure_cause_redacts_local_paths_and_secret_assignments(self):
-        private_path = Path(os.sep) / "private" / "consumer" / "state.json"
+        private_path = Path(
+            "C:/private/consumer/state.json"
+            if os.name == "nt"
+            else "/private/consumer/state.json"
+        )
         error = RuntimeError(f"failed at {private_path} token=super-secret")
         stderr = io.StringIO()
         with unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr):

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -471,6 +471,7 @@ class InstallerUxTests(unittest.TestCase):
         block = workflow[workflow.index("  chaos-installer-acceptance:"):workflow.index("  summary:")]
         self.assertIn("needs.changes.outputs.chaos_installer == 'true'", block)
         self.assertIn("os: [ubuntu-22.04, macos-15, windows-2025]", block)
+        self.assertIn("GITHUB_TOKEN: ${{ github.token }}", block)
         self.assertIn("scripts/ci/chaos_engine_live_installer_acceptance.py", block)
         self.assertIn("--candidate-sha ${{ github.event.pull_request.head.sha }}", block)
         self.assertIn("--base-sha ${{ github.event.pull_request.base.sha }}", block)

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -469,6 +469,8 @@ class InstallerUxTests(unittest.TestCase):
         self.assertIn("needs.changes.outputs.chaos_installer == 'true'", block)
         self.assertIn("os: [ubuntu-22.04, macos-15, windows-2025]", block)
         self.assertIn("scripts/ci/chaos_engine_live_installer_acceptance.py", block)
+        self.assertIn("--candidate-sha ${{ github.event.pull_request.head.sha }}", block)
+        self.assertIn("--base-sha ${{ github.event.pull_request.base.sha }}", block)
         self.assertIn("tests.scripts.test_chaos_engine_bootstrap", block)
         self.assertIn("tests.scripts.test_chaos_engine_install_wrappers", block)
         self.assertNotIn("tests.scripts.test_chaos_engine_live_installer_acceptance", block)

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -7,6 +7,8 @@ import json
 import os
 import tempfile
 import threading
+import time
+import urllib.parse
 import unittest
 import unittest.mock
 from pathlib import Path
@@ -37,7 +39,8 @@ class InstallerUxTests(unittest.TestCase):
         output = stream.getvalue()
         self.assertNotIn("transparent automation", output)
         self.assertNotIn("AUTONOMOUS INSTALL", output)
-        self.assertIn("QUANTUM MANDATE", output)
+        self.assertIn("Chaos Engine", output)
+        self.assertNotIn("QUANTUM MANDATE", output)
         self.assertGreaterEqual(output.split("START", 1)[0].count("\n"), 3)
         self.assertIn("START Resolve source", output)
         self.assertIn("DONE  Resolve source", output)
@@ -64,7 +67,7 @@ class InstallerUxTests(unittest.TestCase):
                 output = stream.getvalue()
                 self.assertNotIn("transparent automation", output)
                 self.assertNotIn("AUTONOMOUS INSTALL", output)
-                self.assertIn("QUANTUM MANDATE", output)
+                self.assertIn("Chaos Engine", output)
                 self.assertIn("\x1b[38;2;255;59;77m", output)
                 self.assertIn("[", output)
                 self.assertIn("Download source", output)
@@ -76,6 +79,21 @@ class InstallerUxTests(unittest.TestCase):
             finally:
                 reporter.close()
         self.assertFalse(any(thread.name == "chaos-engine-installer" for thread in threading.enumerate()))
+
+    def test_ticker_updates_elapsed_each_second_during_blocking_work(self):
+        class Tty(io.StringIO):
+            def isatty(self):
+                return True
+
+        stream = Tty()
+        with unittest.mock.patch.dict(os.environ, {"TERM": "xterm", "NO_COLOR": "1"}):
+            reporter = BOOTSTRAP.InstallReporter(stream=stream)
+            reporter.start("Verify installation")
+            time.sleep(2.2)
+            reporter.close()
+        output = stream.getvalue()
+        self.assertIn("Elapsed 00:01", output)
+        self.assertIn("Elapsed 00:02", output)
 
     def test_tty_reporter_honors_plain_and_ascii_fallbacks_and_width(self):
         class NarrowAsciiTty(io.StringIO):
@@ -96,7 +114,7 @@ class InstallerUxTests(unittest.TestCase):
         self.assertNotIn("✓", output)
         self.assertNotIn("transparent automation", output)
         self.assertNotIn("AUTONOMOUS INSTALL", output)
-        self.assertIn("QUANTUM MANDATE", output)
+        self.assertIn("Chaos Engine", output)
         self.assertTrue(all(len(line) <= 38 for line in output.splitlines()))
 
     def test_narrow_width_uses_brand_narrow(self):
@@ -123,9 +141,9 @@ class InstallerUxTests(unittest.TestCase):
             reporter.close()
         output = stream.getvalue()
         self.assertIn("/C|*|E/", output)
-        self.assertIn("QUANTUM MANDATE", output)
+        self.assertIn("Chaos Engine", output)
 
-    def test_eta_does_not_grow_while_current_stage_overruns(self):
+    def test_download_progress_uses_measured_bytes_and_rolling_rate(self):
         class Tty(io.StringIO):
             def isatty(self):
                 return True
@@ -137,12 +155,6 @@ class InstallerUxTests(unittest.TestCase):
             def __call__(self):
                 return self.now
 
-        def eta_seconds(text: str) -> int:
-            line = [item for item in text.splitlines() if "ETA " in item][-1]
-            stamp = line.split("ETA ", 1)[1].split("\x1b", 1)[0].strip()
-            minutes, seconds = stamp.split(":")
-            return int(minutes) * 60 + int(seconds)
-
         clock = Clock()
         stream = Tty()
         with unittest.mock.patch.dict(os.environ, {"TERM": "xterm"}), unittest.mock.patch.object(
@@ -150,31 +162,23 @@ class InstallerUxTests(unittest.TestCase):
         ):
             reporter = BOOTSTRAP.InstallReporter(stream=stream, clock=clock)
             try:
-                reporter.start("Resolve source", remaining=("Download source", "Install core"))
-                clock.now = 2.0
-                reporter.complete("Resolve source", remaining=("Download source", "Install core"))
                 reporter.start("Download source", remaining=("Install core",))
-                previous = None
-                completed_weight = BOOTSTRAP.STAGE_WEIGHTS["Resolve source"]
-                remaining_weight = BOOTSTRAP.STAGE_WEIGHTS["Install core"]
-                for tick in (5.0, 10.0, 20.0):
-                    clock.now = tick
-                    reporter._render_locked()
-                    current = eta_seconds(stream.getvalue())
-                    if previous is None:
-                        self.assertGreater(current, 0)
-                    else:
-                        self.assertLessEqual(
-                            current, previous, f"ETA grew {previous} -> {current} at t={tick}"
-                        )
-                    previous = current
-                    old = tick * remaining_weight / completed_weight
-                    self.assertGreater(old, current)
+                reporter.begin_download(1000, detail="source files")
+                self.assertIn("Speed calculating", stream.getvalue())
+                clock.now = 1.0
+                reporter.downloaded(250)
+                clock.now = 2.0
+                reporter.downloaded(250)
+                reporter._render_locked()
+                output = stream.getvalue()
+                self.assertIn("250 B/s", output)
+                self.assertIn("ETA 00:02", output)
+                self.assertIn("Current action: Download source", output)
             finally:
                 reporter._stop.set()
                 reporter._thread = None
 
-    def test_nested_start_keeps_inflight_stage_in_remaining_weight(self):
+    def test_nested_start_keeps_inflight_stage_visible_without_fabricated_eta(self):
         class Clock:
             def __init__(self):
                 self.now = 0.0
@@ -200,33 +204,25 @@ class InstallerUxTests(unittest.TestCase):
         )
         reporter.start("Provision dependencies", remaining=("Verify installation",))
         self.assertIn("Install core", getattr(reporter, "_in_flight", ()))
-        future = sum(
-            BOOTSTRAP.STAGE_WEIGHTS.get(item, 1)
-            for item in reporter.remaining_operations
-        )
-        inflight = sum(
-            BOOTSTRAP.STAGE_WEIGHTS.get(item, 1)
-            for item in reporter._in_flight
-            if item != reporter.current_operation
-        )
-        self.assertEqual(BOOTSTRAP.STAGE_WEIGHTS["Install core"], inflight)
-        self.assertGreaterEqual(
-            future + inflight,
-            BOOTSTRAP.STAGE_WEIGHTS["Install core"] + BOOTSTRAP.STAGE_WEIGHTS["Verify installation"],
-        )
-        rate = 4.0 / BOOTSTRAP.STAGE_WEIGHTS["Resolve source"]
-        with_core = rate * (
-            BOOTSTRAP.STAGE_WEIGHTS["Provision dependencies"]
-            + BOOTSTRAP.STAGE_WEIGHTS["Install core"]
-            + BOOTSTRAP.STAGE_WEIGHTS["Verify installation"]
-        )
-        without_core = rate * (
-            BOOTSTRAP.STAGE_WEIGHTS["Provision dependencies"]
-            + BOOTSTRAP.STAGE_WEIGHTS["Verify installation"]
-        )
-        eta = reporter._eta(clock.now)
-        self.assertEqual(BOOTSTRAP.InstallReporter._duration(reporter, with_core), eta)
-        self.assertNotEqual(BOOTSTRAP.InstallReporter._duration(reporter, without_core), eta)
+        self.assertIn("Install core", getattr(reporter, "_in_flight", ()))
+        self.assertEqual("calculating", reporter._eta(clock.now))
+
+    def test_non_tty_history_has_timestamp_result_duration_and_current_action(self):
+        class Clock:
+            now = 0.0
+
+            def __call__(self):
+                return self.now
+
+        clock = Clock()
+        stream = io.StringIO()
+        reporter = BOOTSTRAP.InstallReporter(stream=stream, clock=clock)
+        reporter.start("Resolve source", remaining=("Download source",), detail="main")
+        clock.now = 2.25
+        reporter.complete("Resolve source", remaining=("Download source",))
+        output = stream.getvalue()
+        self.assertIn("Current action: Resolve source", output)
+        self.assertRegex(output, r"\[\+00:02\] PASS Resolve source \(00:02\)")
 
     def test_interactive_confirmation_accepts_only_y_or_yes(self):
         for answer in ("y\n", "YES\n"):
@@ -268,7 +264,7 @@ class InstallerUxTests(unittest.TestCase):
         self.assertEqual(result, json.loads(stdout.getvalue()))
         self.assertNotIn("transparent automation", stderr.getvalue())
         self.assertNotIn("AUTONOMOUS INSTALL", stderr.getvalue())
-        self.assertIn("QUANTUM MANDATE", stderr.getvalue())
+        self.assertIn("Chaos Engine", stderr.getvalue())
 
     def test_wrappers_expose_and_forward_interactive_mode(self):
         shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
@@ -278,13 +274,14 @@ class InstallerUxTests(unittest.TestCase):
         self.assertNotIn("CHAOS_ENGINE_INTERACTIVE", powershell)
         self.assertIn('arguments += "--interactive"', powershell)
 
-    def test_wrappers_print_the_same_quantum_mandate_mark(self):
+    def test_wrappers_print_the_same_chaos_engine_mark(self):
         shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
         powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
         for document in (shell, powershell):
             self.assertNotIn("transparent automation", document)
             self.assertNotIn("AUTONOMOUS INSTALL", document)
-            self.assertIn("QUANTUM MANDATE", document)
+            self.assertIn("Chaos Engine", document)
+            self.assertNotIn("QUANTUM MANDATE", document)
         for line in BOOTSTRAP.brand_lines(width=80, color=False, unicode=False):
             if not line.strip():
                 continue
@@ -297,6 +294,16 @@ class InstallerUxTests(unittest.TestCase):
         self.assertIn("$cols -lt 28", powershell)
         self.assertIn("/C|*|E/", shell)
         self.assertIn("/C|*|E/", powershell)
+
+    def test_wrappers_put_checklist_then_current_action_below_heading(self):
+        shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
+        powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
+        for document in (shell, powershell):
+            heading = document.index("Installing ChaosEngine into")
+            checklist = document.index("[ ] Resolve source", heading)
+            current = document.index("Current action: Download bootstrap", checklist)
+            self.assertLess(heading, checklist)
+            self.assertLess(checklist, current)
 
     def test_main_emits_stable_actionable_error_codes(self):
         cases = (
@@ -322,8 +329,15 @@ class InstallerUxTests(unittest.TestCase):
                 self.assertIn(code, stderr.getvalue())
                 self.assertIn("#installer-errors", stderr.getvalue())
                 self.assertIn(".chaos-engine/install.py doctor", stderr.getvalue())
+                self.assertIn("doctor --project . --json", stderr.getvalue())
+                self.assertIn("status --project . --json", stderr.getvalue())
                 if code == "CE-INSTALL-FAILED":
-                    self.assertIn("https://github.com/owner/repo/issues/new", stderr.getvalue())
+                    report = [
+                        line for line in stderr.getvalue().splitlines()
+                        if line.startswith("Report: ")
+                    ][0]
+                    self.assertIn("https://github.com/owner/repo/issues/new?", report)
+                    self.assertLessEqual(len(report.removeprefix("Report: ")), 2000)
 
     def test_keyboard_interrupt_emits_cancelled_without_traceback(self):
         stdout = io.StringIO()
@@ -406,6 +420,44 @@ class InstallerUxTests(unittest.TestCase):
         self.assertIn("https://github.com/owner/repo/issues/new", err)
         self.assertIn(".chaos-engine/install.py status", err)
         self.assertNotIn("Traceback", err)
+
+    def test_prefilled_report_is_bounded_sanitized_and_names_failed_health(self):
+        error = BOOTSTRAP.InstallHealthError(
+            "Verify installation",
+            {"components": {"memory": {"status": "recovery-required"}}},
+        )
+        stderr = io.StringIO()
+        with unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr):
+            BOOTSTRAP.emit_install_failure("CE-INSTALL-FAILED", error, "owner/repo")
+        report = [
+            line.removeprefix("Report: ")
+            for line in stderr.getvalue().splitlines()
+            if line.startswith("Report: ")
+        ][0]
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(report).query)
+        body = query["body"][0]
+        self.assertIn("Failed phase: Verify installation", body)
+        self.assertIn("Unhealthy components: memory", body)
+        self.assertIn("doctor --project . --json", body)
+        self.assertLessEqual(len(report), 2000)
+
+    def test_failure_cause_redacts_local_paths_and_secret_assignments(self):
+        error = RuntimeError(
+            "failed at /tmp/private/consumer/state.json token=super-secret"
+        )
+        stderr = io.StringIO()
+        with unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr):
+            BOOTSTRAP.emit_install_failure("CE-INSTALL-FAILED", error, "owner/repo")
+        output = stderr.getvalue()
+        report = next(
+            line.removeprefix("Report: ")
+            for line in output.splitlines()
+            if line.startswith("Report: ")
+        )
+        body = urllib.parse.parse_qs(urllib.parse.urlsplit(report).query)["body"][0]
+        self.assertIn("Cause: failed at <path> token=<redacted>", body)
+        self.assertNotIn("super-secret", output)
+        self.assertNotIn("/tmp/private", output)
 
     def test_pr_gate_runs_fresh_installer_on_exact_three_os_matrix(self):
         workflow = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -89,6 +89,50 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
         if isinstance(child_environment, dict):
             self.assertNotIn("OPENAI_API_KEY", child_environment)
 
+    def test_download_environment_allows_only_scoped_github_token(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module, "live installer acceptance runner is missing")
+        if module is None:
+            return
+        environment = module.download_environment(
+            {
+                "PATH": "trusted-tools",
+                "GITHUB_TOKEN": "scoped-token",
+                "OPENAI_API_KEY": "forbidden",
+                "PRIVATE_KEY": "forbidden",
+                "UNRELATED_SECRET": "forbidden",
+            }
+        )
+        self.assertEqual("trusted-tools", environment["PATH"])
+        self.assertEqual("scoped-token", environment["GITHUB_TOKEN"])
+        self.assertNotIn("OPENAI_API_KEY", environment)
+        self.assertNotIn("PRIVATE_KEY", environment)
+        self.assertNotIn("UNRELATED_SECRET", environment)
+
+    def test_public_wrapper_child_receives_only_scoped_github_token(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module, "live installer acceptance runner is missing")
+        if module is None:
+            return
+        project = ROOT
+        installed = project / ".chaos-engine" / "install.py"
+        with mock.patch.dict(
+            os.environ,
+            {"GITHUB_TOKEN": "scoped-token", "OPENAI_API_KEY": "forbidden"},
+        ), mock.patch.object(module, "run_checked") as runner, mock.patch.object(
+            module.Path, "is_file", return_value=True
+        ):
+            runner.return_value = CompletedProcess(
+                ["wrapper"], 0,
+                stdout='{"status":"installed","clients":{}}',
+                stderr="Installing ChaosEngine\nCurrent action:",
+            )
+            module.run_public_wrapper("a" * 40, project)
+        self.assertTrue(installed.is_absolute())
+        child_environment = runner.call_args.kwargs["environment"]
+        self.assertEqual("scoped-token", child_environment["GITHUB_TOKEN"])
+        self.assertNotIn("OPENAI_API_KEY", child_environment)
+
     def test_failure_still_writes_sanitized_json_evidence(self):
         module = load_acceptance()
         self.assertIsNotNone(module, "live installer acceptance runner is missing")
@@ -231,6 +275,12 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
         self.assertIn("scripts/ci/chaos_engine_live_installer_acceptance.py", commands)
         self.assertIn("--candidate-sha", commands)
         self.assertIn("--base-sha", commands)
+        acceptance = next(
+            step
+            for step in job["steps"]
+            if "chaos_engine_live_installer_acceptance.py" in str(step.get("run", ""))
+        )
+        self.assertEqual("${{ github.token }}", acceptance["env"]["GITHUB_TOKEN"])
         checkout = next(step for step in job["steps"] if step.get("uses") == "actions/checkout@v7")
         self.assertEqual(2, checkout["with"]["fetch-depth"])
         uploads = [step for step in job["steps"] if step.get("uses") == "actions/upload-artifact@v7"]

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -192,21 +192,6 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
                 staged.joinpath("hooks/kernel.py").read_text(encoding="utf-8"),
             )
 
-    def test_installed_source_stage_excludes_reserved_manifest(self):
-        module = load_acceptance()
-        self.assertIsNotNone(module)
-        if module is None:
-            return
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            installed = root / ".chaos-engine"
-            installed.joinpath("hooks").mkdir(parents=True)
-            installed.joinpath("hooks/kernel.py").write_text("owned = True\n", encoding="utf-8")
-            installed.joinpath("manifest.json").write_text("{}\n", encoding="utf-8")
-            staged = module.stage_installed_source(installed, root / "offline-source")
-            self.assertTrue(staged.joinpath("hooks/kernel.py").is_file())
-            self.assertFalse(staged.joinpath("manifest.json").exists())
-
     def test_candidate_install_uses_public_wrapper_not_install_py(self):
         module = load_acceptance()
         self.assertIsNotNone(module)

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -94,17 +94,19 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
         self.assertIsNotNone(module, "live installer acceptance runner is missing")
         if module is None:
             return
+        allowed = os.pathsep.join(("scoped", "fixture"))
+        blocked = os.pathsep.join(("blocked", "fixture"))
         environment = module.download_environment(
             {
                 "PATH": "trusted-tools",
-                "GITHUB_TOKEN": "scoped-token",
-                "OPENAI_API_KEY": "forbidden",
-                "PRIVATE_KEY": "forbidden",
-                "UNRELATED_SECRET": "forbidden",
+                "GITHUB_TOKEN": allowed,
+                "OPENAI_API_KEY": blocked,
+                "PRIVATE_KEY": blocked,
+                "UNRELATED_SECRET": blocked,
             }
         )
         self.assertEqual("trusted-tools", environment["PATH"])
-        self.assertEqual("scoped-token", environment["GITHUB_TOKEN"])
+        self.assertEqual(allowed, environment["GITHUB_TOKEN"])
         self.assertNotIn("OPENAI_API_KEY", environment)
         self.assertNotIn("PRIVATE_KEY", environment)
         self.assertNotIn("UNRELATED_SECRET", environment)
@@ -116,9 +118,11 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
             return
         project = ROOT
         installed = project / ".chaos-engine" / "install.py"
+        allowed = os.pathsep.join(("scoped", "fixture"))
+        blocked = os.pathsep.join(("blocked", "fixture"))
         with mock.patch.dict(
             os.environ,
-            {"GITHUB_TOKEN": "scoped-token", "OPENAI_API_KEY": "forbidden"},
+            {"GITHUB_TOKEN": allowed, "OPENAI_API_KEY": blocked},
         ), mock.patch.object(module, "run_checked") as runner, mock.patch.object(
             module.Path, "is_file", return_value=True
         ):
@@ -130,7 +134,7 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
             module.run_public_wrapper("a" * 40, project)
         self.assertTrue(installed.is_absolute())
         child_environment = runner.call_args.kwargs["environment"]
-        self.assertEqual("scoped-token", child_environment["GITHUB_TOKEN"])
+        self.assertEqual(allowed, child_environment["GITHUB_TOKEN"])
         self.assertNotIn("OPENAI_API_KEY", child_environment)
 
     def test_failure_still_writes_sanitized_json_evidence(self):

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -192,6 +192,42 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
                 staged.joinpath("hooks/kernel.py").read_text(encoding="utf-8"),
             )
 
+    def test_installed_source_stage_excludes_reserved_manifest(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module)
+        if module is None:
+            return
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            installed = root / ".chaos-engine"
+            installed.joinpath("hooks").mkdir(parents=True)
+            installed.joinpath("hooks/kernel.py").write_text("owned = True\n", encoding="utf-8")
+            installed.joinpath("manifest.json").write_text("{}\n", encoding="utf-8")
+            staged = module.stage_installed_source(installed, root / "offline-source")
+            self.assertTrue(staged.joinpath("hooks/kernel.py").is_file())
+            self.assertFalse(staged.joinpath("manifest.json").exists())
+
+    def test_candidate_install_uses_public_wrapper_not_install_py(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module)
+        if module is None:
+            return
+        sha = "1" * 40
+        posix = module.public_wrapper_command(sha, windows=False)
+        windows = module.public_wrapper_command(sha, windows=True)
+        self.assertIn("install.sh", " ".join(posix))
+        self.assertEqual(2, " ".join(posix).count(module.raw_wrapper_url(sha, windows=False)))
+        self.assertIn("install.ps1", " ".join(windows))
+        self.assertIn("irm", " ".join(windows))
+        self.assertNotIn("install.py", " ".join(posix + windows))
+
+    def test_acceptance_source_has_no_ambient_node_or_direct_installer_shortcut(self):
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertNotIn('shutil.which("node")', source)
+        self.assertNotIn('shutil.which("npm")', source)
+        self.assertNotIn("def install_command(", source)
+        self.assertIn("--candidate-sha", source)
+
     def test_weekly_manual_three_os_job_is_bounded_and_uploads_evidence(self):
         workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
         self.assertIn("schedule", workflow[True])

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -212,6 +212,8 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
         self.assertNotIn('shutil.which("npm")', source)
         self.assertNotIn("def install_command(", source)
         self.assertIn("--candidate-sha", source)
+        self.assertIn("source_record=manifest['source']", source)
+        self.assertIn("offline_environment(block_path=True)", source)
 
     def test_weekly_manual_three_os_job_is_bounded_and_uploads_evidence(self):
         workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -242,6 +242,10 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
         )
         commands = "\n".join(str(step.get("run", "")) for step in job["steps"])
         self.assertIn("scripts/ci/chaos_engine_live_installer_acceptance.py", commands)
+        self.assertIn("--candidate-sha", commands)
+        self.assertIn("--base-sha", commands)
+        checkout = next(step for step in job["steps"] if step.get("uses") == "actions/checkout@v7")
+        self.assertEqual(2, checkout["with"]["fetch-depth"])
         uploads = [step for step in job["steps"] if step.get("uses") == "actions/upload-artifact@v7"]
         self.assertEqual(1, len(uploads))
         self.assertEqual("always()", uploads[0]["if"])


### PR DESCRIPTION
## Summary

- replace fabricated stage-weight ETA with measured byte progress, rolling speed, and credible download ETA
- unify durable/TTY installer reporting with current action, checklist, timestamped history, and clean ticker lifecycle
- surface Chaos Engine branding and sanitized doctor recovery details with bounded prefilled issue reports
- publish and contract-test exact unattended commands across README and INSTALL
- exercise candidate-SHA public wrappers, independent doctor checks, tool probes, offline rerun, upgrade, repair, and rollback in live acceptance

## Verification

- `python3 -m unittest tests.scripts.test_chaos_engine_installer_ux tests.scripts.test_chaos_engine_install_wrappers tests.scripts.test_chaos_engine_live_installer_acceptance tests.scripts.test_chaos_engine_bootstrap tests.scripts.test_chaos_engine_dependencies` (126 passed, 6 skipped: PowerShell unavailable locally)
- `python3 scripts/ci/validate_chaos_engine_readme.py`
- `python3 scripts/ci/validate_documentation_boundaries.py`
- `python3 scripts/ci/validate_agent_setup.py --skip-external`
- `python3 -m py_compile chaos-engine/bootstrap.py chaos-engine/dependencies.py chaos-engine/install.py scripts/ci/chaos_engine_live_installer_acceptance.py`
- `git diff --check`

Closes #5336
Closes #5337
Closes #5338
Closes #5339
Closes #5340
