### PR TITLE
fix(chaos-engine): keep failed installs and modernize installer UX

### DIFF
--- a/.github/ISSUE_TEMPLATE/chaos-engine-installer.yml
+++ b/.github/ISSUE_TEMPLATE/chaos-engine-installer.yml
@@ -1,0 +1,50 @@
+name: ChaosEngine installer
+description: Report a failed ChaosEngine installation with the fields the installer prefills.
+title: "[ChaosEngine installer] "
+labels: [bug, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form is opened by the ChaosEngine installer when install verification fails.
+        Keep the prefilled fields and add anything that is missing.
+  - type: input
+    id: error_code
+    attributes:
+      label: Error code
+      placeholder: CE-INSTALL-FAILED
+    validations:
+      required: true
+  - type: textarea
+    id: cause
+    attributes:
+      label: Cause
+    validations:
+      required: true
+  - type: input
+    id: failed_phase
+    attributes:
+      label: Failed phase
+    validations:
+      required: true
+  - type: input
+    id: unhealthy
+    attributes:
+      label: Unhealthy components
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+  - type: input
+    id: status_command
+    attributes:
+      label: Status command
+  - type: input
+    id: doctor_command
+    attributes:
+      label: Doctor command
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Terminal emulator, whether Java/Node were already installed, and anything else maintainers should know.

--- a/.memory/config.json
+++ b/.memory/config.json
@@ -1,15 +1,11 @@
 {
-  "git": {
-    "trackContextPacks": false
-  },
   "memory": {
     "autoIndex": true,
-    "defaultTokenBudget": 600,
-    "saveContextPacks": false
+    "defaultTokenBudget": 600
   },
   "project": {
     "id": "project.shaft-engine",
     "name": "Shaft Engine"
   },
-  "version": 4
+  "version": 5
 }

--- a/.memory/schema/config.schema.json
+++ b/.memory/schema/config.schema.json
@@ -1,74 +1,42 @@
 {
-  "$id": "https://aictx.dev/schemas/v4/config.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aictx.dev/schemas/v5/config.schema.json",
+  "type": "object",
   "additionalProperties": false,
+  "required": ["version", "project", "memory"],
   "properties": {
-    "git": {
-      "additionalProperties": false,
-      "properties": {
-        "trackContextPacks": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "trackContextPacks"
-      ],
-      "type": "object"
-    },
-    "memory": {
-      "additionalProperties": false,
-      "properties": {
-        "autoIndex": {
-          "type": "boolean"
-        },
-        "defaultTokenBudget": {
-          "maximum": 50000,
-          "minimum": 501,
-          "type": "integer"
-        },
-        "saveContextPacks": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "defaultTokenBudget",
-        "autoIndex",
-        "saveContextPacks"
-      ],
-      "type": "object"
+    "version": {
+      "enum": [5]
     },
     "project": {
+      "type": "object",
       "additionalProperties": false,
+      "required": ["id", "name"],
       "properties": {
         "id": {
-          "pattern": "^project\\.[a-z0-9][a-z0-9-]*$",
-          "type": "string"
+          "type": "string",
+          "pattern": "^project\\.[a-z0-9][a-z0-9-]*$"
         },
         "name": {
-          "minLength": 1,
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         }
-      },
-      "required": [
-        "id",
-        "name"
-      ],
-      "type": "object"
+      }
     },
-    "version": {
-      "enum": [
-        1,
-        2,
-        3,
-        4
-      ]
+    "memory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["defaultTokenBudget", "autoIndex"],
+      "properties": {
+        "defaultTokenBudget": {
+          "type": "integer",
+          "minimum": 501,
+          "maximum": 50000
+        },
+        "autoIndex": {
+          "type": "boolean"
+        }
+      }
     }
-  },
-  "required": [
-    "version",
-    "project",
-    "memory",
-    "git"
-  ],
-  "type": "object"
+  }
 }

--- a/.memory/schema/event.schema.json
+++ b/.memory/schema/event.schema.json
@@ -1,7 +1,45 @@
 {
-  "$id": "https://aictx.dev/schemas/v4/event.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aictx.dev/schemas/v5/event.schema.json",
+  "type": "object",
   "additionalProperties": false,
+  "required": ["event", "actor", "timestamp"],
+  "properties": {
+    "event": {
+      "enum": [
+        "memory.created",
+        "memory.updated",
+        "memory.marked_stale",
+        "memory.superseded",
+        "memory.deleted",
+        "relation.created",
+        "relation.updated",
+        "relation.deleted",
+        "index.rebuilt"
+      ]
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "relation_id": {
+      "type": "string",
+      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "actor": {
+      "enum": ["agent", "user", "cli", "mcp", "system"]
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+    },
+    "reason": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
   "allOf": [
     {
       "if": {
@@ -12,9 +50,7 @@
         }
       },
       "then": {
-        "required": [
-          "id"
-        ]
+        "required": ["id"]
       }
     },
     {
@@ -26,59 +62,8 @@
         }
       },
       "then": {
-        "required": [
-          "relation_id"
-        ]
+        "required": ["relation_id"]
       }
     }
-  ],
-  "properties": {
-    "actor": {
-      "enum": [
-        "agent",
-        "user",
-        "cli",
-        "mcp",
-        "system"
-      ]
-    },
-    "event": {
-      "enum": [
-        "memory.created",
-        "memory.updated",
-        "memory.marked_stale",
-        "memory.superseded",
-        "memory.deleted",
-        "relation.created",
-        "relation.updated",
-        "relation.deleted",
-        "index.rebuilt",
-        "context.generated"
-      ]
-    },
-    "id": {
-      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
-      "type": "string"
-    },
-    "payload": {
-      "type": "object"
-    },
-    "reason": {
-      "type": "string"
-    },
-    "relation_id": {
-      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$",
-      "type": "string"
-    },
-    "timestamp": {
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
-      "type": "string"
-    }
-  },
-  "required": [
-    "event",
-    "actor",
-    "timestamp"
-  ],
-  "type": "object"
+  ]
 }

--- a/.memory/schema/object.schema.json
+++ b/.memory/schema/object.schema.json
@@ -1,20 +1,135 @@
 {
-  "$id": "https://aictx.dev/schemas/v4/object.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aictx.dev/schemas/v5/object.schema.json",
+  "type": "object",
   "additionalProperties": false,
-  "allOf": [
-    {
-      "else": {
+  "required": [
+    "id",
+    "type",
+    "status",
+    "title",
+    "body_path",
+    "content_hash",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "type": {
+      "enum": ["project", "feature", "decision", "gotcha", "question"]
+    },
+    "status": {
+      "enum": ["active", "stale", "superseded", "open", "closed"]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "body_path": {
+      "type": "string",
+      "pattern": "^memory\\/.+\\.md$"
+    },
+    "stage": {
+      "enum": ["idea", "building", "shipped", "paused", "dead"]
+    },
+    "anchors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$"
+      },
+      "uniqueItems": true
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "id"],
         "properties": {
-          "status": {
-            "enum": [
-              "active",
-              "stale",
-              "superseded"
-            ]
+          "kind": {
+            "enum": ["memory", "relation", "file", "commit", "task", "source"]
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1
           }
         }
-      },
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "enum": ["agent", "user", "cli", "mcp", "system"]
+        },
+        "task": {
+          "type": "string"
+        },
+        "commit": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "origin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "locator"],
+      "properties": {
+        "kind": {
+          "enum": ["file", "url", "user", "external"]
+        },
+        "locator": {
+          "type": "string",
+          "minLength": 1
+        },
+        "captured_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "media_type": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "superseded_by": {
+      "type": ["string", "null"],
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "content_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "created_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+    },
+    "updated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+    }
+  },
+  "allOf": [
+    {
       "if": {
         "properties": {
           "type": {
@@ -25,272 +140,32 @@
       "then": {
         "properties": {
           "status": {
-            "enum": [
-              "stale",
-              "superseded",
-              "open",
-              "closed"
-            ]
+            "enum": ["stale", "superseded", "open", "closed"]
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "status": {
+            "enum": ["active", "stale", "superseded"]
           }
         }
       }
-    }
-  ],
-  "properties": {
-    "body_path": {
-      "pattern": "^memory\\/.+\\.md$",
-      "type": "string"
     },
-    "content_hash": {
-      "pattern": "^sha256:[a-f0-9]{64}$",
-      "type": "string"
-    },
-    "created_at": {
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
-      "type": "string"
-    },
-    "evidence": {
-      "items": {
-        "additionalProperties": false,
+    {
+      "if": {
         "properties": {
-          "id": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "kind": {
-            "enum": [
-              "memory",
-              "relation",
-              "file",
-              "commit",
-              "task",
-              "source"
-            ]
+          "type": {
+            "const": "feature"
           }
-        },
-        "required": [
-          "kind",
-          "id"
-        ],
-        "type": "object"
-      },
-      "type": "array"
-    },
-    "facets": {
-      "additionalProperties": false,
-      "properties": {
-        "applies_to": {
-          "items": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "type": "array",
-          "uniqueItems": true
-        },
-        "category": {
-          "enum": [
-            "project-description",
-            "architecture",
-            "stack",
-            "convention",
-            "file-layout",
-            "product-feature",
-            "testing",
-            "decision-rationale",
-            "abandoned-attempt",
-            "workflow",
-            "gotcha",
-            "debugging-fact",
-            "source",
-            "product-intent",
-            "feature-map",
-            "roadmap",
-            "agent-guidance",
-            "concept",
-            "open-question",
-            "domain",
-            "bounded-context",
-            "capability",
-            "business-rule",
-            "unresolved-conflict"
-          ]
-        },
-        "load_modes": {
-          "items": {
-            "enum": [
-              "coding",
-              "debugging",
-              "review",
-              "architecture",
-              "onboarding"
-            ]
-          },
-          "type": "array",
-          "uniqueItems": true
         }
       },
-      "required": [
-        "category"
-      ],
-      "type": "object"
-    },
-    "id": {
-      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
-      "type": "string"
-    },
-    "origin": {
-      "additionalProperties": false,
-      "properties": {
-        "captured_at": {
-          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
-          "type": "string"
-        },
-        "digest": {
-          "pattern": "^sha256:[a-f0-9]{64}$",
-          "type": "string"
-        },
-        "kind": {
-          "enum": [
-            "file",
-            "url",
-            "user",
-            "external"
-          ]
-        },
-        "locator": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "media_type": {
-          "minLength": 1,
-          "type": "string"
+      "then": {},
+      "else": {
+        "not": {
+          "required": ["stage"]
         }
-      },
-      "required": [
-        "kind",
-        "locator"
-      ],
-      "type": "object"
-    },
-    "scope": {
-      "additionalProperties": false,
-      "properties": {
-        "branch": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "kind": {
-          "enum": [
-            "project",
-            "branch",
-            "task"
-          ]
-        },
-        "project": {
-          "pattern": "^project\\.[a-z0-9][a-z0-9-]*$",
-          "type": "string"
-        },
-        "task": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "kind",
-        "project",
-        "branch",
-        "task"
-      ],
-      "type": "object"
-    },
-    "source": {
-      "additionalProperties": false,
-      "properties": {
-        "commit": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "kind": {
-          "enum": [
-            "agent",
-            "user",
-            "cli",
-            "mcp",
-            "system"
-          ]
-        },
-        "task": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "kind"
-      ],
-      "type": "object"
-    },
-    "status": {
-      "enum": [
-        "active",
-        "stale",
-        "superseded",
-        "open",
-        "closed"
-      ]
-    },
-    "superseded_by": {
-      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "tags": {
-      "items": {
-        "pattern": "^[a-z0-9][a-z0-9-]*$",
-        "type": "string"
-      },
-      "type": "array",
-      "uniqueItems": true
-    },
-    "title": {
-      "minLength": 1,
-      "type": "string"
-    },
-    "type": {
-      "enum": [
-        "project",
-        "architecture",
-        "source",
-        "synthesis",
-        "decision",
-        "constraint",
-        "question",
-        "fact",
-        "gotcha",
-        "workflow",
-        "note",
-        "concept"
-      ]
-    },
-    "updated_at": {
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
-      "type": "string"
+      }
     }
-  },
-  "required": [
-    "id",
-    "type",
-    "status",
-    "title",
-    "body_path",
-    "scope",
-    "content_hash",
-    "created_at",
-    "updated_at"
-  ],
-  "type": "object"
+  ]
 }

--- a/.memory/schema/patch.schema.json
+++ b/.memory/schema/patch.schema.json
@@ -1,498 +1,30 @@
 {
-  "$defs": {
-    "createObject": {
-      "additionalProperties": false,
-      "properties": {
-        "body": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "evidence": {
-          "$ref": "#/$defs/evidence"
-        },
-        "facets": {
-          "$ref": "#/$defs/facets"
-        },
-        "id": {
-          "$ref": "#/$defs/objectId"
-        },
-        "op": {
-          "const": "create_object"
-        },
-        "origin": {
-          "$ref": "#/$defs/origin"
-        },
-        "scope": {
-          "$ref": "#/$defs/scope"
-        },
-        "source": {
-          "$ref": "#/$defs/source"
-        },
-        "status": {
-          "enum": [
-            "active",
-            "stale",
-            "superseded",
-            "open",
-            "closed"
-          ]
-        },
-        "tags": {
-          "$ref": "#/$defs/tags"
-        },
-        "title": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "project",
-            "architecture",
-            "source",
-            "synthesis",
-            "decision",
-            "constraint",
-            "question",
-            "fact",
-            "gotcha",
-            "workflow",
-            "note",
-            "concept"
-          ]
-        }
-      },
-      "required": [
-        "op",
-        "type",
-        "title",
-        "body"
-      ],
-      "type": "object"
-    },
-    "createRelation": {
-      "additionalProperties": false,
-      "properties": {
-        "confidence": {
-          "enum": [
-            "low",
-            "medium",
-            "high"
-          ]
-        },
-        "evidence": {
-          "$ref": "#/$defs/evidence"
-        },
-        "from": {
-          "$ref": "#/$defs/objectId"
-        },
-        "id": {
-          "$ref": "#/$defs/relationId"
-        },
-        "op": {
-          "const": "create_relation"
-        },
-        "predicate": {
-          "enum": [
-            "affects",
-            "requires",
-            "depends_on",
-            "supersedes",
-            "conflicts_with",
-            "supports",
-            "challenges",
-            "derived_from",
-            "summarizes",
-            "documents",
-            "mentions",
-            "implements",
-            "related_to"
-          ]
-        },
-        "status": {
-          "enum": [
-            "active",
-            "stale",
-            "rejected"
-          ]
-        },
-        "to": {
-          "$ref": "#/$defs/objectId"
-        }
-      },
-      "required": [
-        "op",
-        "from",
-        "predicate",
-        "to"
-      ],
-      "type": "object"
-    },
-    "deleteObject": {
-      "additionalProperties": false,
-      "properties": {
-        "id": {
-          "$ref": "#/$defs/objectId"
-        },
-        "op": {
-          "const": "delete_object"
-        }
-      },
-      "required": [
-        "op",
-        "id"
-      ],
-      "type": "object"
-    },
-    "deleteRelation": {
-      "additionalProperties": false,
-      "properties": {
-        "id": {
-          "$ref": "#/$defs/relationId"
-        },
-        "op": {
-          "const": "delete_relation"
-        }
-      },
-      "required": [
-        "op",
-        "id"
-      ],
-      "type": "object"
-    },
-    "evidence": {
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "id": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "kind": {
-            "enum": [
-              "memory",
-              "relation",
-              "file",
-              "commit",
-              "task",
-              "source"
-            ]
-          }
-        },
-        "required": [
-          "kind",
-          "id"
-        ],
-        "type": "object"
-      },
-      "type": "array"
-    },
-    "facets": {
-      "additionalProperties": false,
-      "properties": {
-        "applies_to": {
-          "items": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "type": "array",
-          "uniqueItems": true
-        },
-        "category": {
-          "enum": [
-            "project-description",
-            "architecture",
-            "stack",
-            "convention",
-            "file-layout",
-            "product-feature",
-            "testing",
-            "decision-rationale",
-            "abandoned-attempt",
-            "workflow",
-            "gotcha",
-            "debugging-fact",
-            "source",
-            "product-intent",
-            "feature-map",
-            "roadmap",
-            "agent-guidance",
-            "concept",
-            "open-question",
-            "domain",
-            "bounded-context",
-            "capability",
-            "business-rule",
-            "unresolved-conflict"
-          ]
-        },
-        "load_modes": {
-          "items": {
-            "enum": [
-              "coding",
-              "debugging",
-              "review",
-              "architecture",
-              "onboarding"
-            ]
-          },
-          "type": "array",
-          "uniqueItems": true
-        }
-      },
-      "required": [
-        "category"
-      ],
-      "type": "object"
-    },
-    "markStale": {
-      "additionalProperties": false,
-      "properties": {
-        "id": {
-          "$ref": "#/$defs/objectId"
-        },
-        "op": {
-          "const": "mark_stale"
-        },
-        "reason": {
-          "minLength": 1,
-          "type": "string"
-        }
-      },
-      "required": [
-        "op",
-        "id",
-        "reason"
-      ],
-      "type": "object"
-    },
-    "objectId": {
-      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
-      "type": "string"
-    },
-    "origin": {
-      "additionalProperties": false,
-      "properties": {
-        "captured_at": {
-          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
-          "type": "string"
-        },
-        "digest": {
-          "pattern": "^sha256:[a-f0-9]{64}$",
-          "type": "string"
-        },
-        "kind": {
-          "enum": [
-            "file",
-            "url",
-            "user",
-            "external"
-          ]
-        },
-        "locator": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "media_type": {
-          "minLength": 1,
-          "type": "string"
-        }
-      },
-      "required": [
-        "kind",
-        "locator"
-      ],
-      "type": "object"
-    },
-    "relationId": {
-      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$",
-      "type": "string"
-    },
-    "scope": {
-      "additionalProperties": false,
-      "properties": {
-        "branch": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "kind": {
-          "enum": [
-            "project",
-            "branch",
-            "task"
-          ]
-        },
-        "project": {
-          "pattern": "^project\\.[a-z0-9][a-z0-9-]*$",
-          "type": "string"
-        },
-        "task": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "kind",
-        "project",
-        "branch",
-        "task"
-      ],
-      "type": "object"
-    },
-    "source": {
-      "additionalProperties": false,
-      "properties": {
-        "commit": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "kind": {
-          "enum": [
-            "agent",
-            "user",
-            "cli",
-            "mcp",
-            "system"
-          ]
-        },
-        "task": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "kind"
-      ],
-      "type": "object"
-    },
-    "supersedeObject": {
-      "additionalProperties": false,
-      "properties": {
-        "id": {
-          "$ref": "#/$defs/objectId"
-        },
-        "op": {
-          "const": "supersede_object"
-        },
-        "reason": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "superseded_by": {
-          "$ref": "#/$defs/objectId"
-        }
-      },
-      "required": [
-        "op",
-        "id",
-        "superseded_by",
-        "reason"
-      ],
-      "type": "object"
-    },
-    "tags": {
-      "items": {
-        "pattern": "^[a-z0-9][a-z0-9-]*$",
-        "type": "string"
-      },
-      "type": "array",
-      "uniqueItems": true
-    },
-    "updateObject": {
-      "additionalProperties": false,
-      "properties": {
-        "body": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "evidence": {
-          "$ref": "#/$defs/evidence"
-        },
-        "facets": {
-          "$ref": "#/$defs/facets"
-        },
-        "id": {
-          "$ref": "#/$defs/objectId"
-        },
-        "op": {
-          "const": "update_object"
-        },
-        "origin": {
-          "$ref": "#/$defs/origin"
-        },
-        "scope": {
-          "$ref": "#/$defs/scope"
-        },
-        "source": {
-          "$ref": "#/$defs/source"
-        },
-        "status": {
-          "enum": [
-            "active",
-            "stale",
-            "superseded",
-            "open",
-            "closed"
-          ]
-        },
-        "superseded_by": {
-          "$ref": "#/$defs/objectId"
-        },
-        "tags": {
-          "$ref": "#/$defs/tags"
-        },
-        "title": {
-          "minLength": 1,
-          "type": "string"
-        }
-      },
-      "required": [
-        "op",
-        "id"
-      ],
-      "type": "object"
-    },
-    "updateRelation": {
-      "additionalProperties": false,
-      "properties": {
-        "confidence": {
-          "enum": [
-            "low",
-            "medium",
-            "high"
-          ]
-        },
-        "evidence": {
-          "$ref": "#/$defs/evidence"
-        },
-        "id": {
-          "$ref": "#/$defs/relationId"
-        },
-        "op": {
-          "const": "update_relation"
-        },
-        "status": {
-          "enum": [
-            "active",
-            "stale",
-            "rejected"
-          ]
-        }
-      },
-      "required": [
-        "op",
-        "id"
-      ],
-      "type": "object"
-    }
-  },
-  "$id": "https://aictx.dev/schemas/v4/patch.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aictx.dev/schemas/v5/patch.schema.json",
+  "type": "object",
   "additionalProperties": false,
+  "required": ["source", "changes"],
   "properties": {
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "enum": ["agent", "user", "cli", "mcp", "system"]
+        },
+        "task": {
+          "type": "string"
+        },
+        "commit": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
     "changes": {
+      "type": "array",
+      "minItems": 1,
       "items": {
         "oneOf": [
           {
@@ -520,39 +52,302 @@
             "$ref": "#/$defs/deleteRelation"
           }
         ]
+      }
+    }
+  },
+  "$defs": {
+    "objectId": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "relationId": {
+      "type": "string",
+      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "stage": {
+      "enum": ["idea", "building", "shipped", "paused", "dead"]
+    },
+    "anchors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
       },
-      "minItems": 1,
-      "type": "array"
+      "uniqueItems": true
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$"
+      },
+      "uniqueItems": true
     },
     "source": {
+      "type": "object",
       "additionalProperties": false,
+      "required": ["kind"],
       "properties": {
-        "commit": {
-          "minLength": 1,
-          "type": "string"
-        },
         "kind": {
-          "enum": [
-            "agent",
-            "user",
-            "cli",
-            "mcp",
-            "system"
-          ]
+          "enum": ["agent", "user", "cli", "mcp", "system"]
         },
         "task": {
           "type": "string"
+        },
+        "commit": {
+          "type": "string",
+          "minLength": 1
         }
-      },
-      "required": [
-        "kind"
-      ],
-      "type": "object"
+      }
+    },
+    "origin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "locator"],
+      "properties": {
+        "kind": {
+          "enum": ["file", "url", "user", "external"]
+        },
+        "locator": {
+          "type": "string",
+          "minLength": 1
+        },
+        "captured_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "media_type": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "id"],
+        "properties": {
+          "kind": {
+            "enum": ["memory", "relation", "file", "commit", "task", "source"]
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "createObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "type", "title", "body"],
+      "properties": {
+        "op": {
+          "const": "create_object"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "type": {
+          "enum": ["project", "feature", "decision", "gotcha", "question"]
+        },
+        "status": {
+          "enum": ["active", "stale", "superseded", "open", "closed"]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "body": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stage": {
+          "$ref": "#/$defs/stage"
+        },
+        "anchors": {
+          "$ref": "#/$defs/anchors"
+        },
+        "tags": {
+          "$ref": "#/$defs/tags"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "origin": {
+          "$ref": "#/$defs/origin"
+        }
+      }
+    },
+    "updateObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id"],
+      "properties": {
+        "op": {
+          "const": "update_object"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "status": {
+          "enum": ["active", "stale", "superseded", "open", "closed"]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "body": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stage": {
+          "$ref": "#/$defs/stage"
+        },
+        "anchors": {
+          "$ref": "#/$defs/anchors"
+        },
+        "tags": {
+          "$ref": "#/$defs/tags"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "origin": {
+          "$ref": "#/$defs/origin"
+        },
+        "superseded_by": {
+          "$ref": "#/$defs/objectId"
+        }
+      }
+    },
+    "markStale": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id", "reason"],
+      "properties": {
+        "op": {
+          "const": "mark_stale"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "supersedeObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id", "superseded_by", "reason"],
+      "properties": {
+        "op": {
+          "const": "supersede_object"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        },
+        "superseded_by": {
+          "$ref": "#/$defs/objectId"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "deleteObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id"],
+      "properties": {
+        "op": {
+          "const": "delete_object"
+        },
+        "id": {
+          "$ref": "#/$defs/objectId"
+        }
+      }
+    },
+    "createRelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "from", "predicate", "to"],
+      "properties": {
+        "op": {
+          "const": "create_relation"
+        },
+        "id": {
+          "$ref": "#/$defs/relationId"
+        },
+        "from": {
+          "$ref": "#/$defs/objectId"
+        },
+        "predicate": {
+          "enum": ["affects", "depends_on", "supersedes", "related_to"]
+        },
+        "to": {
+          "$ref": "#/$defs/objectId"
+        },
+        "status": {
+          "enum": ["active", "stale", "rejected"]
+        },
+        "confidence": {
+          "enum": ["low", "medium", "high"]
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        }
+      }
+    },
+    "updateRelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id"],
+      "properties": {
+        "op": {
+          "const": "update_relation"
+        },
+        "id": {
+          "$ref": "#/$defs/relationId"
+        },
+        "status": {
+          "enum": ["active", "stale", "rejected"]
+        },
+        "confidence": {
+          "enum": ["low", "medium", "high"]
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        }
+      }
+    },
+    "deleteRelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["op", "id"],
+      "properties": {
+        "op": {
+          "const": "delete_relation"
+        },
+        "id": {
+          "$ref": "#/$defs/relationId"
+        }
+      }
     }
-  },
-  "required": [
-    "source",
-    "changes"
-  ],
-  "type": "object"
+  }
 }

--- a/.memory/schema/relation.schema.json
+++ b/.memory/schema/relation.schema.json
@@ -1,99 +1,59 @@
 {
-  "$id": "https://aictx.dev/schemas/v4/relation.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aictx.dev/schemas/v5/relation.schema.json",
+  "type": "object",
   "additionalProperties": false,
+  "required": ["id", "from", "predicate", "to", "status", "created_at", "updated_at"],
   "properties": {
-    "confidence": {
-      "enum": [
-        "low",
-        "medium",
-        "high"
-      ]
-    },
-    "content_hash": {
-      "pattern": "^sha256:[a-f0-9]{64}$",
-      "type": "string"
-    },
-    "created_at": {
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
-      "type": "string"
-    },
-    "evidence": {
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "id": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "kind": {
-            "enum": [
-              "memory",
-              "relation",
-              "file",
-              "commit",
-              "task",
-              "source"
-            ]
-          }
-        },
-        "required": [
-          "kind",
-          "id"
-        ],
-        "type": "object"
-      },
-      "type": "array"
+    "id": {
+      "type": "string",
+      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$"
     },
     "from": {
-      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
-      "type": "string"
-    },
-    "id": {
-      "pattern": "^rel\\.[a-z0-9][a-z0-9-]*$",
-      "type": "string"
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
     },
     "predicate": {
-      "enum": [
-        "affects",
-        "requires",
-        "depends_on",
-        "supersedes",
-        "conflicts_with",
-        "supports",
-        "challenges",
-        "derived_from",
-        "summarizes",
-        "documents",
-        "mentions",
-        "implements",
-        "related_to"
-      ]
-    },
-    "status": {
-      "enum": [
-        "active",
-        "stale",
-        "rejected"
-      ]
+      "enum": ["affects", "depends_on", "supersedes", "related_to"]
     },
     "to": {
-      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$",
-      "type": "string"
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*\\.[a-z0-9][a-z0-9-]*$"
+    },
+    "status": {
+      "enum": ["active", "stale", "rejected"]
+    },
+    "confidence": {
+      "enum": ["low", "medium", "high"]
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "id"],
+        "properties": {
+          "kind": {
+            "enum": ["memory", "relation", "file", "commit", "task", "source"]
+          },
+          "id": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "content_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "created_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
     },
     "updated_at": {
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$",
-      "type": "string"
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,9})?(Z|[+-]\\d{2}:\\d{2})$"
     }
-  },
-  "required": [
-    "id",
-    "from",
-    "predicate",
-    "to",
-    "status",
-    "created_at",
-    "updated_at"
-  ],
-  "type": "object"
+  }
 }

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -80,15 +80,16 @@ Node.js 24.19.0 for Memory; ambient Node and npm are not part of the runtime
 contract. Unsupported platforms and checksum failures stop before activation,
 leaving the prior generation active.
 
-Pass `--with-maven-tools` to install the optional Maven Tools MCP together with
-the project tools. It cannot be combined with `--skip-tools`. Java resolution
-prefers `CHAOSENGINE_JAVA`, then `JAVA_HOME`, then `PATH`; an unsuitable or
-missing Java triggers the verified Temurin 25.0.4+7 cache flow. Windows arm64
-uses the official Windows x64 Temurin artifact through Windows 11 x64
-emulation and fails closed if the Java 25 probe cannot execute. Project
-uninstall removes project-owned Python and Node generations but retains the
-shared Maven Tools cache; `cache purge --component maven-tools-mcp --version
-3.2.0` removes only exact receipt-verified cache content.
+A root `pom.xml` enables Maven Tools MCP automatically. Pass `--with-maven-tools`
+to force it on a non-Maven project. `--skip-tools` still skips it. Java
+resolution prefers `CHAOSENGINE_JAVA`, then `JAVA_HOME`, then `PATH` when the
+major version is 17 or newer; otherwise the installer downloads checksummed
+Temurin 25.0.4+7. If an ambient JDK cannot probe the JAR, the pin is used.
+Windows arm64 uses the official Windows x64 Temurin artifact through Windows 11
+x64 emulation and fails closed if that probe cannot execute. Project uninstall
+removes project-owned Python and Node generations but retains the shared Maven
+Tools cache; `cache purge --component maven-tools-mcp --version 3.2.0` removes
+only exact receipt-verified cache content.
 
 POSIX:
 
@@ -161,8 +162,9 @@ upstream from the consumer repository.
 `status` and `doctor` report every component with its `owner`, `scope`,
 `lifecycle`, and `taskImpact`. Memory, MemPalace, and Graphify are advisory to
 ordinary tasks but remain strict in `doctor`; an unhealthy selected store still
-returns `recovery-required`. The optional Maven Tools MCP cache is installer-owned
-and does not make project health fail.
+returns `recovery-required`. Maven Tools MCP is auto-installed when the project
+has a root `pom.xml`. On non-Maven projects it stays optional and absent does
+not make project health fail.
 
 ## Optional native Maven Tools MCP
 
@@ -170,9 +172,9 @@ Do not put `docker run -i --rm` in a default stdio MCP configuration. Each
 active client owns its own stdio server process, so a Docker-backed declaration
 creates one container per client and keeps Docker Desktop and its VM resident.
 
-`--with-maven-tools` performs the pinned native JAR flow:
+A root `pom.xml`, or `--with-maven-tools`, performs the pinned native JAR flow:
 
-1. Resolve Java 25 from `CHAOSENGINE_JAVA`, `JAVA_HOME`, or `PATH`, otherwise
+1. Resolve Java 17+ from `CHAOSENGINE_JAVA`, `JAVA_HOME`, or `PATH`, otherwise
    download and checksum-verify the selected Temurin 25.0.4+7 artifact.
 2. Prefer host Git for `arvindand/maven-tools-mcp` commit
    `4475ff6c61f23ea9a93cb6d5665a63235ef2ef36`. Without Git, download the
@@ -201,9 +203,10 @@ creates one container per client and keeps Docker Desktop and its VM resident.
    `no-context7` keeps the receipt-pinned server's native tool surface independent
    of a live downstream Context7 connection.
 
-If Java 25 or the verified JAR is absent, installation leaves this optional MCP
-server out of every host configuration. Maven CLI, repository files, Context7,
-and authoritative Maven Central sources remain the no-Docker fallback.
+If neither an ambient Java 17+ runtime nor the Temurin pin can run the JAR,
+installation fails closed on a Maven project and omits the server on a
+non-Maven project. Maven CLI, repository files, Context7, and authoritative
+Maven Central sources remain the no-Docker fallback.
 
 Inspect or remove the exact supported cache version with:
 

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -36,26 +36,29 @@ MAX_RETRY_AFTER_SECONDS = 60.0
 RETRY_BASE_SECONDS = 1.0
 TRANSIENT_HTTP_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
 CYBERNETIC_RED = "\x1b[38;2;255;59;77m"
+ION_BLUE = "\x1b[38;2;47;125;255m"
+OPTICAL_WHITE = "\x1b[38;2;242;247;255m"
 BRAND_ASCII = (
-    "  /=====.        +--+     /",
-    "  |              |==|    /",
-    "  |  *    /      |==|   /",
-    "  |              |==|  /",
-    "  +=====/        +--+ /",
-    "         Chaos Engine",
+    "  ,-----.          +--+       /",
+    "  |                |==|      /",
+    "  |  *      /      |==|     /",
+    "  |                |==|    /",
+    "  `-----'          +--+   /",
+    "         ChaosEngine",
 )
 BRAND_UNICODE = (
-    "  █▀▀▀▀▄         ┬─┐     ╱",
-    "  █              ├─┤    ╱",
-    "  █  ◆    ╱      ├─┤   ╱",
-    "  █              ├─┤  ╱",
-    "  █▄▄▄▄▀         ┴─┘ ╱",
-    "         Chaos Engine",
+    "  █▀▀▀▀▀▄           ┬──┐        ╱",
+    "  █                 ├──┤       ╱",
+    "  █   ◆      ╱      ├──┤      ╱",
+    "  █                 ├──┤     ╱",
+    "  █▄▄▄▄▄▀           ┴──┘    ╱",
+    "          ChaosEngine",
 )
 BRAND_NARROW = (
     "  /C|*|E/",
-    "  Chaos Engine",
+    "  ChaosEngine",
 )
+TRACE_LIMIT = 12
 
 
 def brand_lines(*, width: int = 80, color: bool = False, unicode: bool = False) -> list[str]:
@@ -68,8 +71,33 @@ def brand_lines(*, width: int = 80, color: bool = False, unicode: bool = False) 
     else:
         templates = BRAND_ASCII
         glyph = "*"
-    painted = f"{CYBERNETIC_RED}{glyph}\x1b[0m" if color else glyph
-    return [template.replace(glyph, painted, 1) if glyph in template else template for template in templates]
+    core = f"{CYBERNETIC_RED}{glyph}\x1b[0m" if color else glyph
+    painted = []
+    for template in templates:
+        line = template.replace(glyph, core, 1) if glyph in template else template
+        if color and "ChaosEngine" in line:
+            line = line.replace(
+                "ChaosEngine",
+                f"{OPTICAL_WHITE}ChaosEngine\x1b[0m",
+                1,
+            )
+        painted.append(line)
+    return painted
+
+
+def _component_blocks_health(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    status = value.get("status")
+    if status == "healthy":
+        return False
+    return not (value.get("taskImpact") == "optional" and status == "absent")
+
+
+def wants_maven_tools(project: Path, *, skip_tools: bool, requested: bool) -> bool:
+    if skip_tools:
+        return False
+    return requested or (Path(project) / "pom.xml").is_file()
 
 
 class InstallCancelled(RuntimeError):
@@ -87,7 +115,7 @@ class InstallHealthError(RuntimeError):
         self.unhealthy = tuple(
             name
             for name, value in components.items()
-            if isinstance(value, dict) and value.get("status") != "healthy"
+            if _component_blocks_health(value)
         ) if isinstance(components, dict) else ()
 
 
@@ -106,7 +134,10 @@ class InstallReporter:
         self._elapsed_as_current: dict[str, float] = {}
         self._completed_elapsed: dict[str, float] = {}
         self.history: list[tuple[float, str, str, float]] = []
+        self.traces: list[tuple[float, str]] = []
         self._current_started: float | None = None
+        self.project_root: str | None = None
+        self.source_label: str | None = None
         self._download_total: int | None = None
         self._downloaded = 0
         self._download_samples = deque(maxlen=30)
@@ -115,10 +146,7 @@ class InstallReporter:
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._lines = 0
-        self._tty = (
-            bool(getattr(self.stream, "isatty", lambda: False)())
-            and os.environ.get("TERM") != "dumb"
-        )
+        self._tty = self._stderr_is_tty()
         self._color = self._tty and "NO_COLOR" not in os.environ
         self._unicode = self._encodable("✓◉·…█▀▄┬├┴╱◆")
         if self._tty and os.name == "nt" and not self._enable_windows_vt():
@@ -131,6 +159,38 @@ class InstallReporter:
             ):
                 self.stream.write(line + "\n")
             self.stream.flush()
+
+    def _stderr_is_tty(self) -> bool:
+        if os.environ.get("TERM") == "dumb":
+            return False
+        isatty = getattr(self.stream, "isatty", None)
+        if callable(isatty):
+            return bool(isatty())
+        try:
+            return self.stream is sys.stderr and os.isatty(2)
+        except (AttributeError, OSError, ValueError):
+            return False
+
+    def announce(self, project: Path, repository: str, branch: str) -> None:
+        self.project_root = str(Path(project).resolve())
+        self.source_label = f"{repository}@{branch}"
+        if self._tty:
+            with self._lock:
+                self._render_locked()
+        else:
+            self.stream.write(self._truncate(f"Install root: {self.project_root}") + "\n")
+            self.stream.write(self._truncate(f"Source: {self.source_label}") + "\n")
+            self.stream.flush()
+
+    def trace(self, message: str) -> None:
+        with self._lock:
+            self.traces.append((self.clock() - self.started, message))
+            del self.traces[:-TRACE_LIMIT]
+            if self._tty:
+                self._render_locked()
+            else:
+                self.stream.write(self._truncate(f"  {message}") + "\n")
+                self.stream.flush()
 
     def _enable_windows_vt(self) -> bool:
         try:
@@ -191,7 +251,7 @@ class InstallReporter:
                 "Install Maven Tools",
             }:
                 self._download_total = None
-                self._downloaded_bytes = 0
+                self._downloaded = 0
                 self._download_samples.clear()
             if remaining is not None:
                 kept = tuple(
@@ -222,7 +282,6 @@ class InstallReporter:
                     if detail and self._unicode
                     else (f" - {detail}" if detail else "")
                 )
-                self.stream.write(self._truncate(f"Current action: {operation}{suffix}") + "\n")
                 self.stream.write(self._truncate(f"START {operation}{suffix}") + "\n")
                 self.stream.flush()
 
@@ -239,6 +298,8 @@ class InstallReporter:
             self._completed_elapsed[operation] = self._elapsed_as_current.get(operation, 0.0)
             duration = self._completed_elapsed[operation]
             self.history.append((now - self.started, "PASS", operation, duration))
+            self.traces.append((now - self.started, f"PASS {operation} ({self._duration(duration)})"))
+            del self.traces[:-TRACE_LIMIT]
             self.remaining_operations = remaining
             self.detail = None
             if self._tty:
@@ -283,10 +344,11 @@ class InstallReporter:
             with self._lock:
                 self._render_locked()
 
-    def _eta(self, now: float) -> str:
+    def _remaining(self, now: float) -> str | None:
+        del now
         rate = self._download_rate()
         if rate is None or self._download_total is None:
-            return "calculating"
+            return None
         return self._duration(max(0, self._download_total - self._downloaded) / rate)
 
     def _download_rate(self) -> float | None:
@@ -322,35 +384,41 @@ class InstallReporter:
         )
         now = self.clock()
         elapsed = max(0.0, now - self.started)
-        eta = self._eta(now)
         check, active, empty = (("✓", "◉", " ") if self._unicode else ("x", "*", " "))
         lines = [""]
+        if self.project_root:
+            lines.append(self._truncate(f"  Install root: {self.project_root}"))
+        if self.source_label:
+            lines.append(self._truncate(f"  Source: {self.source_label}"))
+        if self.project_root or self.source_label:
+            lines.append("")
         for item in operations:
             if item in self.completed_operations:
-                lines.append(self._paint(self._truncate(f"  [{check}] {item}"), "32"))
+                duration = self._duration(self._completed_elapsed.get(item, 0.0))
+                lines.append(self._paint(self._truncate(f"  [{check}] {item}  {duration}"), "32"))
             elif item == self.current_operation or item in self._in_flight:
                 lines.append(self._paint(self._truncate(f"  [{active}] {item}  running"), "36"))
             else:
                 lines.append(self._truncate(f"  [{empty}] {item}"))
         separator = " · " if self._unicode else " | "
-        timing = self._truncate(f"  Elapsed {self._duration(elapsed)}{separator}ETA {eta}")
-        lines.extend(("", self._paint(timing, "33")))
+        metrics = [f"Elapsed {self._duration(elapsed)}"]
         rate = self._download_rate()
-        speed = "calculating" if rate is None else self._size(rate)
-        lines.append(self._truncate(f"  Speed {speed}"))
-        if self.current_operation:
-            lines.append(self._truncate(f"  Current action: {self.current_operation}"))
+        if rate is not None:
+            metrics.append(self._size(rate))
+        remaining = self._remaining(now)
+        if remaining is not None:
+            metrics.append(f"remaining {remaining}")
+        lines.extend(("", self._paint(self._truncate("  " + separator.join(metrics)), "36")))
         if self.detail:
-            lines.append(self._truncate(f"  {self.detail}"))
-        if self.history:
-            lines.append("  History:")
-            for ended, result, operation, duration in self.history[-5:]:
-                lines.append(
-                    self._truncate(
-                        f"  [+{self._duration(ended)}] {result} {operation} "
-                        f"({self._duration(duration)})"
-                    )
-                )
+            lines.append(self._paint(self._truncate(f"  {self.detail}"), "36"))
+        log = self.traces[-TRACE_LIMIT:] or [
+            (ended, f"{result} {operation} ({self._duration(duration)})")
+            for ended, result, operation, duration in self.history[-TRACE_LIMIT:]
+        ]
+        if log:
+            lines.append(self._paint("  Trace", "36"))
+            for ended, message in log:
+                lines.append(self._truncate(f"  [+{self._duration(ended)}] {message}"))
         if self._lines:
             self.stream.write(f"\x1b[{self._lines}F")
         rendered = "\n".join(line + "\x1b[K" for line in lines) + "\n"
@@ -588,6 +656,7 @@ def download_source(
         raise ValueError("ChaosEngine source tree exceeds the download limit")
     if reporter is not None:
         reporter.begin_download(total, detail=f"{len(selected)} source files")
+        reporter.trace(f"download {len(selected)} files ({total} bytes)")
 
     source = destination / "chaos-engine"
     source.mkdir()
@@ -644,7 +713,11 @@ def install_latest(
     project = Path(project).resolve()
     if not project.is_dir():
         raise ValueError(f"project is not a directory: {project}")
+    with_maven_tools = wants_maven_tools(
+        project, skip_tools=skip_tools, requested=with_maven_tools
+    )
     reporter = reporter or InstallReporter()
+    reporter.announce(project, repository, branch or "default")
     try:
         terminal_context = terminal_factory() if interactive else None
         if terminal_context is not None:
@@ -754,8 +827,6 @@ def install_latest(
         if not isinstance(error, (KeyboardInterrupt, InstallCancelled)):
             if prior_install and (project / ".chaos-engine.backup").exists():
                 installer.rollback(project)
-            else:
-                installer.uninstall_with_dependencies(project)
         if terminal_context is not None:
             terminal_context.__exit__(*sys.exc_info())
         raise
@@ -788,8 +859,13 @@ def installer_help_url(repository: str) -> str:
     return f"https://{owner}.github.io/docs/agentic/chaos-engine#installer-errors"
 
 
-def installer_cli_prefix() -> str:
-    return "py -3 .chaos-engine/install.py" if os.name == "nt" else "python3 .chaos-engine/install.py"
+def installer_cli_prefix(project: Path | None = None) -> str | None:
+    root = Path(project) if project is not None else Path.cwd()
+    cli = root / ".chaos-engine" / "install.py"
+    if not cli.is_file():
+        return None
+    command = "py -3" if os.name == "nt" else "python3"
+    return f"{command} .chaos-engine/install.py"
 
 
 def classify_install_error(error: BaseException) -> str:
@@ -829,6 +905,7 @@ def emit_install_failure(
     error: BaseException,
     repository: str,
     reporter: InstallReporter | None = None,
+    project: Path | None = None,
 ) -> None:
     print(file=sys.stderr)
     if code == "CE-INSTALL-CANCELLED":
@@ -839,11 +916,17 @@ def emit_install_failure(
         print(f"{code}: {one_line_cause(error)}", file=sys.stderr)
     print(file=sys.stderr)
     print(f"Help: {installer_help_url(repository)}", file=sys.stderr)
-    prefix = installer_cli_prefix()
-    status_command = f"{prefix} status --project . --json"
-    doctor_command = f"{prefix} doctor --project . --json"
-    print(f"Status: {status_command}", file=sys.stderr)
-    print(f"Doctor: {doctor_command}", file=sys.stderr)
+    prefix = installer_cli_prefix(project)
+    status_command = f"{prefix} status --project . --json" if prefix else None
+    doctor_command = f"{prefix} doctor --project . --json" if prefix else None
+    if prefix:
+        print(f"Status: {status_command}", file=sys.stderr)
+        print(f"Doctor: {doctor_command}", file=sys.stderr)
+    else:
+        print("Installer CLI is not on disk.", file=sys.stderr)
+        print("Rerun the same install command to continue.", file=sys.stderr)
+        status_command = "not available; .chaos-engine/install.py is not on disk"
+        doctor_command = status_command
     if code != "CE-INSTALL-CANCELLED":
         body = "\n".join(
             (
@@ -869,9 +952,24 @@ def emit_install_failure(
             )
         )
         query = urllib.parse.urlencode(
-            {"title": f"[ChaosEngine installer] {code}", "body": body[:1200]}
+            {
+                "template": "chaos-engine-installer.yml",
+                "title": f"[ChaosEngine installer] {code}",
+                "error_code": code,
+                "cause": one_line_cause(error)[:240],
+                "failed_phase": getattr(error, "phase", None)
+                or (reporter.current_operation if reporter else "unknown"),
+                "unhealthy": ", ".join(getattr(error, "unhealthy", ())) or "not reported",
+                "platform": sys.platform,
+                "status_command": status_command or "",
+                "doctor_command": doctor_command or "",
+            }
         )
-        print(f"Report: https://github.com/{repository}/issues/new?{query}", file=sys.stderr)
+        print(
+            "Next step: click this link to open a GitHub issue with this report:",
+            file=sys.stderr,
+        )
+        print(f"https://github.com/{repository}/issues/new?{query}", file=sys.stderr)
     if os.environ.get("CHAOS_ENGINE_DEBUG") == "1":
         traceback.print_exc()
 
@@ -895,7 +993,11 @@ def main() -> int:
             raise
         reporter.close()
         emit_install_failure(
-            classify_install_error(error), error, args.repository, reporter=reporter
+            classify_install_error(error),
+            error,
+            args.repository,
+            reporter=reporter,
+            project=Path(args.project).resolve(),
         )
         return 1
     reporter.close()

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -91,7 +91,22 @@ def _component_blocks_health(value: object) -> bool:
     status = value.get("status")
     if status == "healthy":
         return False
-    return not (value.get("taskImpact") == "optional" and status == "absent")
+    if value.get("taskImpact") == "optional" and status == "absent":
+        return False
+    return value.get("taskImpact") == "required"
+
+
+def _required_install_unhealthy(doctor: dict[str, object]) -> bool:
+    components = doctor.get("components")
+    if isinstance(components, dict) and any(
+        _component_blocks_health(value) for value in components.values()
+    ):
+        return True
+    for key in ("kernel", "hosts", "dependencies"):
+        item = doctor.get(key)
+        if isinstance(item, dict) and item.get("status") not in {None, "healthy", "absent"}:
+            return True
+    return False
 
 
 def wants_maven_tools(project: Path, *, skip_tools: bool, requested: bool) -> bool:
@@ -811,7 +826,7 @@ def install_latest(
     try:
         reporter.start("Verify installation", remaining=remaining("Verify installation"))
         doctor = installer.doctor_with_dependencies(project, verify_clients=False)
-        if doctor.get("status") != "healthy":
+        if _required_install_unhealthy(doctor):
             raise InstallHealthError("Verify installation", doctor)
         reporter.complete("Verify installation", remaining=remaining("Verify installation"))
         confirm("Activate clients")

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -3184,17 +3184,7 @@ def desired_content(
     schema_assets = memory_schema_assets()
     for name in MEMORY_SCHEMA_FILES:
         relative = f".memory/schema/{name}"
-        existing = before[relative]
-        if existing is None:
-            after[relative] = (schema_assets / name).read_bytes()
-        else:
-            try:
-                schema = json.loads(existing)
-            except (UnicodeDecodeError, json.JSONDecodeError) as error:
-                raise ValueError("invalid Memory storage") from error
-            if not isinstance(schema, (dict, bool)):
-                raise ValueError("invalid Memory storage")
-            after[relative] = existing
+        after[relative] = (schema_assets / name).read_bytes()
     events = before[".memory/events.jsonl"]
     if events is None:
         after[".memory/events.jsonl"] = b""

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -196,6 +196,25 @@ def validate_memory_config(content: bytes) -> None:
         raise ValueError("invalid Memory configuration")
 
 
+def migrate_memory_config(content: bytes) -> bytes:
+    validate_memory_config(content)
+    config = json.loads(content)
+    if config.get("version") == 5:
+        return content if content.endswith(b"\n") else content + b"\n"
+    memory = config["memory"]
+    migrated = {
+        "version": 5,
+        "project": config["project"],
+        "memory": {
+            "autoIndex": memory["autoIndex"],
+            "defaultTokenBudget": memory["defaultTokenBudget"],
+        },
+    }
+    payload = (json.dumps(migrated, indent=2, sort_keys=True) + "\n").encode()
+    validate_memory_config(payload)
+    return payload
+
+
 def memory_schema_assets() -> Path:
     return Path(__file__).resolve().parent / "assets/memory-v5"
 
@@ -3161,8 +3180,7 @@ def desired_content(
             json.dumps(memory_config, indent=2, sort_keys=True) + "\n"
         ).encode()
     else:
-        validate_memory_config(memory_before)
-        after[".memory/config.json"] = memory_before
+        after[".memory/config.json"] = migrate_memory_config(memory_before)
     schema_assets = memory_schema_assets()
     for name in MEMORY_SCHEMA_FILES:
         relative = f".memory/schema/{name}"

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -3826,7 +3826,6 @@ def grok_runtime_status(
 def snapshot(project: Path) -> dict[str, object]:
     project = project.resolve()
     receipt, raw = read_receipt(project)
-    verify(project, receipt)
     return {"receipt": receipt, "raw": raw}
 
 

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -256,7 +256,7 @@ def retrieval_configs_healthy(project: Path) -> bool:
     return True
 
 
-def retrieval_runtime_healthy(project: Path) -> bool:
+def retrieval_runtime_status(project: Path) -> dict[str, str]:
     tool = project / ".chaos-engine/tool.py"
     for arguments in (("status", "--json"), ("check", "--json")):
         result = subprocess.run(  # nosec B603 - fixed owned launcher and arguments.
@@ -268,16 +268,33 @@ def retrieval_runtime_healthy(project: Path) -> bool:
             timeout=30,
         )
         if result.returncode != 0:
-            return False
+            detail = (result.stderr or result.stdout or "memory tool exited non-zero").strip()
+            return {
+                "status": "recovery-required",
+                "reason": f"memory {' '.join(arguments)} failed: {detail[:240]}",
+            }
         try:
             payload = json.loads(result.stdout)
         except json.JSONDecodeError:
-            return False
+            return {
+                "status": "recovery-required",
+                "reason": f"memory {' '.join(arguments)} did not return JSON",
+            }
         if not isinstance(payload, dict) or payload.get("ok") is not True:
-            return False
+            return {
+                "status": "recovery-required",
+                "reason": f"memory {' '.join(arguments)} reported not ok",
+            }
         if arguments[0] == "check" and payload.get("data", {}).get("valid") is not True:
-            return False
-    return True
+            return {
+                "status": "recovery-required",
+                "reason": "memory check reported invalid store",
+            }
+    return {"status": "healthy"}
+
+
+def retrieval_runtime_healthy(project: Path) -> bool:
+    return retrieval_runtime_status(project).get("status") == "healthy"
 
 
 def _sqlite_runtime_valid(
@@ -1820,7 +1837,7 @@ def discover_maven_tools_runtime() -> tuple[Path, Path] | None:
             continue
         if is_link_or_reparse(resolved):
             continue
-        if java_major(resolved) == 25:
+        if (java_major(resolved) or 0) >= 17:
             return resolved, jar
     return None
 

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -3669,7 +3669,6 @@ def install(
         before = decode_images(receipt["before"], nullable=True)
         after = decode_images(receipt["after"], nullable=False)
         if receipt["phase"] == "installed":
-            verify(project, receipt)
             desired_capability_digest = capability_policy_digest or receipt.get("capabilityPolicySha256")
             version = plugin_cache_version(core_commit)
             wanted = desired_content(
@@ -3678,6 +3677,12 @@ def install(
                 plugin_version=version,
                 dependency_runtime=dependency_runtime,
             )
+            current = current_images(project)
+            for relative in managed_paths():
+                if current[relative] not in (after[relative], wanted[relative]):
+                    raise ValueError(
+                        f"ChaosEngine host adapter drift detected: {project / relative}"
+                    )
             if (
                 after == wanted
                 and receipt.get("coreCommit") == core_commit

--- a/chaos-engine/install.ps1
+++ b/chaos-engine/install.ps1
@@ -11,46 +11,6 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $script:ChaosEngineInvocationLine = [string]$MyInvocation.Line
-function Write-ChaosEngineBrand {
-    $cols = 80
-    if (-not [string]::IsNullOrWhiteSpace($env:COLUMNS)) {
-        $parsed = 0
-        if ([int]::TryParse($env:COLUMNS, [ref]$parsed)) {
-            $cols = $parsed
-        }
-    }
-    $color = $false
-    try {
-        $color = (-not [Console]::IsErrorRedirected) -and [string]::IsNullOrWhiteSpace($env:NO_COLOR) -and $env:TERM -ne "dumb"
-    }
-    catch {
-        $color = [string]::IsNullOrWhiteSpace($env:NO_COLOR) -and $env:TERM -ne "dumb"
-    }
-    $esc = [char]27
-    if ($cols -lt 28) {
-        if ($color) {
-            [Console]::Error.WriteLine("  /C|$esc[38;2;255;59;77m*$esc[0m|E/")
-        }
-        else {
-            [Console]::Error.WriteLine("  /C|*|E/")
-        }
-        [Console]::Error.WriteLine("  Chaos Engine")
-        return
-    }
-    [Console]::Error.WriteLine("  /=====.        +--+     /")
-    [Console]::Error.WriteLine("  |              |==|    /")
-    if ($color) {
-        [Console]::Error.WriteLine("  |  $esc[38;2;255;59;77m*$esc[0m    /      |==|   /")
-    }
-    else {
-        [Console]::Error.WriteLine("  |  *    /      |==|   /")
-    }
-    [Console]::Error.WriteLine("  |              |==|  /")
-    [Console]::Error.WriteLine("  +=====/        +--+ /")
-    [Console]::Error.WriteLine("         Chaos Engine")
-}
-Write-ChaosEngineBrand
-$env:CHAOS_ENGINE_BRAND_SHOWN = "1"
 
 function Get-ChaosEnginePython {
     $py = Get-Command py -ErrorAction SilentlyContinue
@@ -321,14 +281,6 @@ New-Item -ItemType Directory -Path $work | Out-Null
 try {
     $bootstrap = Join-Path $work "bootstrap.py"
     [Console]::Error.WriteLine("Installing ChaosEngine into $project from $repository@$branch")
-    [Console]::Error.WriteLine("  [ ] Resolve source")
-    [Console]::Error.WriteLine("  [ ] Download source")
-    [Console]::Error.WriteLine("  [ ] Provision dependencies")
-    [Console]::Error.WriteLine("  [ ] Install core")
-    [Console]::Error.WriteLine("  [ ] Verify installation")
-    [Console]::Error.WriteLine("  [ ] Activate clients")
-    [Console]::Error.WriteLine("")
-    [Console]::Error.WriteLine("Current action: Download bootstrap")
     if ($interactiveRequested) {
         if ([Console]::IsInputRedirected) {
             throw "interactive mode requires a usable controlling terminal"

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -1349,10 +1349,9 @@ def ensure_maven_tools(  # noqa: MC0001 - cross-resource provisioning is one tra
 ) -> tuple[Path, Path]:
     hosts = load_installed_controller(target, "hosts")
     existing = hosts.discover_maven_tools_runtime()
-    if existing is not None:
-        if not hosts.probe_maven_tools_runtime(*existing):
-            raise ValueError("Maven Tools MCP initialization/tools-list probe failed")
+    if existing is not None and hosts.probe_maven_tools_runtime(*existing):
         return existing
+    ambient_unusable = existing is not None
     dependencies = load_dependency_controller(target)
     java_candidates = []
     configured = os.environ.get("CHAOSENGINE_JAVA")
@@ -1364,7 +1363,17 @@ def ensure_maven_tools(  # noqa: MC0001 - cross-resource provisioning is one tra
         java_candidates.append(Path(java_home) / "bin" / ("java.exe" if os.name == "nt" else "java"))
     if path_java:
         java_candidates.append(Path(path_java))
-    java = next((item.resolve() for item in java_candidates if item.is_file() and hosts.java_major(item.resolve()) == 25), None)
+    java = None
+    if not ambient_unusable:
+        java = next(
+            (
+                item.resolve()
+                for item in java_candidates
+                if item.is_file()
+                and (hosts.java_major(item.resolve()) or 0) >= 17
+            ),
+            None,
+        )
     if java is None:
         artifact = dependencies.select_runtime_artifact(specification, "temurin")
         cache = hosts.maven_tools_cache_root().parent / "temurin" / "25.0.4+7" / dependencies.platform_key()
@@ -1509,6 +1518,7 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
     confirmer=None,
 ) -> Path:
     project = project.resolve()
+    with_maven_tools = with_maven_tools or (project / "pom.xml").is_file()
     generation_mode = provisioner is None
     with project_lock(project):
         if read_cross_rollback_journal(project) is not None:
@@ -1911,13 +1921,16 @@ def doctor_with_dependencies(
     result = status_with_dependencies(project, active_probes=True)
     target = project.resolve() / INSTALL_DIRECTORY
     host_controller = load_installed_controller(target, "hosts")
-    if not host_controller.retrieval_runtime_healthy(project.resolve()):
+    retrieval = host_controller.retrieval_runtime_status(project.resolve())
+    if retrieval.get("status") != "healthy":
         result["status"] = "recovery-required"
         components = result.get("components")
         if isinstance(components, dict) and isinstance(
             components.get("retrieval-config"), dict
         ):
             components["retrieval-config"]["status"] = "recovery-required"
+            if retrieval.get("reason"):
+                components["retrieval-config"]["reason"] = retrieval["reason"]
     if not host_controller.mcp_runtime_healthy(project.resolve()):
         result["status"] = "recovery-required"
         components = result.get("components")

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -1536,7 +1536,8 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
                 old_host_controller = load_installed_controller(current, "hosts")
                 host_receipt_path = project / old_host_controller.RECEIPT_NAME
                 if host_receipt_path.exists() or is_link_or_reparse(host_receipt_path):
-                    host_snapshot = old_host_controller.snapshot(project)
+                    receipt, raw = old_host_controller.read_receipt(project)
+                    host_snapshot = {"receipt": receipt, "raw": raw}
                 if generation_mode:
                     try:
                         old_dependencies = load_dependency_controller(current)
@@ -1925,12 +1926,10 @@ def doctor_with_dependencies(
     if retrieval.get("status") != "healthy":
         result["status"] = "recovery-required"
         components = result.get("components")
-        if isinstance(components, dict) and isinstance(
-            components.get("retrieval-config"), dict
-        ):
-            components["retrieval-config"]["status"] = "recovery-required"
+        if isinstance(components, dict) and isinstance(components.get("memory"), dict):
+            components["memory"]["status"] = "recovery-required"
             if retrieval.get("reason"):
-                components["retrieval-config"]["reason"] = retrieval["reason"]
+                components["memory"]["reason"] = retrieval["reason"]
     if not host_controller.mcp_runtime_healthy(project.resolve()):
         result["status"] = "recovery-required"
         components = result.get("components")

--- a/chaos-engine/install.sh
+++ b/chaos-engine/install.sh
@@ -4,38 +4,7 @@
 #   curl -fsSL "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh" | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"
 set -eu
 
-print_chaos_engine_brand() {
-  cols=${COLUMNS:-}
-  if [ -z "$cols" ] && command -v tput >/dev/null 2>&1; then
-    cols=$(tput cols 2>/dev/null || true)
-  fi
-  cols=${cols:-80}
-  color=0
-  if [ -t 2 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
-    color=1
-  fi
-  if [ "$cols" -lt 28 ] 2>/dev/null; then
-    if [ "$color" -eq 1 ]; then
-      printf '  /C|\033[38;2;255;59;77m*\033[0m|E/\n' >&2
-    else
-      printf '  /C|*|E/\n' >&2
-    fi
-    printf '  Chaos Engine\n' >&2
-    return
-  fi
-  printf '  /=====.        +--+     /\n' >&2
-  printf '  |              |==|    /\n' >&2
-  if [ "$color" -eq 1 ]; then
-    printf '  |  \033[38;2;255;59;77m*\033[0m    /      |==|   /\n' >&2
-  else
-    printf '  |  *    /      |==|   /\n' >&2
-  fi
-  printf '  |              |==|  /\n' >&2
-  printf '  +=====/        +--+ /\n' >&2
-  printf '         Chaos Engine\n' >&2
-}
-print_chaos_engine_brand
-export CHAOS_ENGINE_BRAND_SHOWN=1
+# Brand and live progress belong to bootstrap.py so curl|bash cannot double-paint.
 
 fail() {
   echo "$1" >&2
@@ -174,8 +143,6 @@ trap cleanup EXIT INT TERM
 
 bootstrap="$work/bootstrap.py"
 echo "Installing ChaosEngine into ${project} from ${repository}@${branch}" >&2
-printf '  [ ] Resolve source\n  [ ] Download source\n  [ ] Provision dependencies\n  [ ] Install core\n  [ ] Verify installation\n  [ ] Activate clients\n\n' >&2
-echo "Current action: Download bootstrap" >&2
 if [ -n "$interactive" ]; then
   controlling_tty="$(printf '%s/%s' /dev tty)"
   [ -r "$controlling_tty" ] || fail "interactive mode requires a usable controlling terminal"

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -260,8 +260,8 @@ def run_public_wrapper(
         raise RuntimeError("public wrapper did not create the installation tree")
     if "Installing ChaosEngine" not in result.stderr:
         raise RuntimeError("public wrapper returned without durable installer progress")
-    if require_current_action and "Current action:" not in result.stderr:
-        raise RuntimeError("candidate wrapper omitted its current action")
+    if require_current_action and "START " not in result.stderr and "Elapsed " not in result.stderr:
+        raise RuntimeError("candidate wrapper omitted installer progress")
     payload = json.loads(result.stdout)
     if payload.get("status") != "installed":
         raise RuntimeError("public wrapper did not return an installed result")

--- a/scripts/ci/validate_agent_setup.py
+++ b/scripts/ci/validate_agent_setup.py
@@ -161,21 +161,19 @@ def validate_memory_setup(root: Path = ROOT) -> list[dict[str, str]]:
         return [issue("memory-config", ".memory/config.json", str(error))]
 
     expected_config = {
-        "version": 4,
+        "version": 5,
         "project": {"id": "project.shaft-engine", "name": "Shaft Engine"},
         "memory": {
             "autoIndex": True,
             "defaultTokenBudget": 600,
-            "saveContextPacks": False,
         },
-        "git": {"trackContextPacks": False},
     }
     if config != expected_config:
         errors.append(
             issue(
                 "memory-config",
                 ".memory/config.json",
-                "configuration must use schema v4, project.shaft-engine, and a 600-token budget",
+                "configuration must use schema v5, project.shaft-engine, and a 600-token budget",
             )
         )
 

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -332,7 +332,13 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
             installer.load_installed_controller.return_value.activate_detected_plugins.return_value = {
                 "createdPlugins": ["codex"]
             }
-            installer.doctor_with_dependencies.return_value = {"status": "healthy"}
+            installer.doctor_with_dependencies.return_value = {
+                "status": "healthy",
+                "components": {},
+                "kernel": {"status": "healthy"},
+                "hosts": {"status": "healthy"},
+                "dependencies": {"status": "healthy"},
+            }
 
             with mock.patch.object(module, "load_installer", return_value=installer):
                 result = module.install_latest(
@@ -362,7 +368,13 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
             opener, _ = self.opener([(COMMIT_ONE, "full")])
             installer = mock.Mock()
             installer.install_with_dependencies.return_value = project / ".chaos-engine"
-            installer.doctor_with_dependencies.return_value = {"status": "healthy"}
+            installer.doctor_with_dependencies.return_value = {
+                "status": "healthy",
+                "components": {},
+                "kernel": {"status": "healthy"},
+                "hosts": {"status": "healthy"},
+                "dependencies": {"status": "healthy"},
+            }
             installer.load_installed_controller.return_value.activate_detected_plugins.return_value = {
                 "createdPlugins": []
             }
@@ -376,6 +388,37 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
             self.assertTrue(
                 installer.install_with_dependencies.call_args.kwargs["with_maven_tools"]
             )
+
+    def test_advisory_memory_probe_does_not_fail_verify(self):
+        module = load()
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "project"
+            project.mkdir()
+            opener, _ = self.opener([(COMMIT_ONE, "full")])
+            installer = mock.Mock()
+            installer.install_with_dependencies.return_value = project / ".chaos-engine"
+            installer.doctor_with_dependencies.return_value = {
+                "status": "recovery-required",
+                "components": {
+                    "memory": {"status": "recovery-required", "taskImpact": "advisory"},
+                    "retrieval-config": {"status": "healthy", "taskImpact": "required"},
+                },
+                "kernel": {"status": "healthy"},
+                "hosts": {"status": "healthy"},
+                "dependencies": {"status": "healthy"},
+            }
+            installer.load_installed_controller.return_value.activate_detected_plugins.return_value = {
+                "createdPlugins": []
+            }
+            with mock.patch.object(module, "load_installer", return_value=installer):
+                result = module.install_latest(
+                    project,
+                    repository="Example/Project",
+                    branch="main",
+                    opener=opener,
+                )
+            self.assertEqual("recovery-required", result["doctor"]["status"])
+            installer.uninstall_with_dependencies.assert_not_called()
 
     def test_failed_post_install_doctor_keeps_new_install_for_doctor_commands(self):
         module = load()

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -353,7 +353,31 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
             )
             self.assertEqual("healthy", result["doctor"]["status"])
 
-    def test_failed_post_install_doctor_removes_new_activation_and_install(self):
+    def test_root_pom_xml_enables_maven_tools_without_flag(self):
+        module = load()
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "project"
+            project.mkdir()
+            (project / "pom.xml").write_text("<project/>\n", encoding="utf-8")
+            opener, _ = self.opener([(COMMIT_ONE, "full")])
+            installer = mock.Mock()
+            installer.install_with_dependencies.return_value = project / ".chaos-engine"
+            installer.doctor_with_dependencies.return_value = {"status": "healthy"}
+            installer.load_installed_controller.return_value.activate_detected_plugins.return_value = {
+                "createdPlugins": []
+            }
+            with mock.patch.object(module, "load_installer", return_value=installer):
+                module.install_latest(
+                    project,
+                    repository="Example/Project",
+                    branch="main",
+                    opener=opener,
+                )
+            self.assertTrue(
+                installer.install_with_dependencies.call_args.kwargs["with_maven_tools"]
+            )
+
+    def test_failed_post_install_doctor_keeps_new_install_for_doctor_commands(self):
         module = load()
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "project"
@@ -375,10 +399,10 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
                     )
 
             host.activate_detected_plugins.assert_not_called()
-            installer.uninstall_with_dependencies.assert_called_once_with(project.resolve())
+            installer.uninstall_with_dependencies.assert_not_called()
             installer.rollback.assert_not_called()
 
-    def test_failed_doctor_after_unverified_prior_tree_uninstalls_instead_of_rollback(self):
+    def test_failed_doctor_after_unverified_prior_tree_keeps_current_generation(self):
         module = load()
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "project"
@@ -398,7 +422,7 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
                         opener=opener,
                     )
 
-            installer.uninstall_with_dependencies.assert_called_once_with(project.resolve())
+            installer.uninstall_with_dependencies.assert_not_called()
             installer.rollback.assert_not_called()
 
     def test_failed_doctor_after_prior_install_with_backup_rolls_back(self):
@@ -615,6 +639,7 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
                 set(status["components"]),
             )
             self.assertEqual("absent", status["components"]["maven-tools-mcp"]["status"])
+            self.assertEqual("optional", status["components"]["maven-tools-mcp"]["taskImpact"])
             self.assertTrue(all(
                 component["status"] == "healthy"
                 for name, component in status["components"].items()

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -1285,17 +1285,22 @@ class ChaosEngineHostsTest(unittest.TestCase):
             self.assertEqual("installed", receipt["phase"])
             self.assertEqual("installed", second["phase"])
             self.assertTrue(module.retrieval_configs_healthy(project))
-            self.assertEqual(before_config, project.joinpath(".memory/config.json").read_bytes())
+            migrated = json.loads(project.joinpath(".memory/config.json").read_text(encoding="utf-8"))
+            self.assertEqual(5, migrated["version"])
+            self.assertEqual(v4_config["project"], migrated["project"])
+            self.assertEqual(v4_config["memory"]["autoIndex"], migrated["memory"]["autoIndex"])
+            self.assertEqual(
+                v4_config["memory"]["defaultTokenBudget"],
+                migrated["memory"]["defaultTokenBudget"],
+            )
+            self.assertNotIn("git", migrated)
+            self.assertNotIn("saveContextPacks", migrated["memory"])
             for name, payload in before_schemas.items():
                 self.assertEqual(payload, project.joinpath(".memory/schema", name).read_bytes())
-                self.assertNotIn(b"/v5/", payload)
             self.assertEqual(object_bytes, object_path.read_bytes())
             self.assertEqual(before_yaml, project.joinpath("mempalace.yaml").read_bytes())
             self.assertTrue(before_yaml.startswith(b"wing: itestflow_agent\nexclude_patterns:\n"))
-            kept = json.loads(before_config)
-            self.assertEqual(4, kept["version"])
-            self.assertIn("git", kept)
-            self.assertIn("saveContextPacks", kept["memory"])
+            self.assertEqual(4, json.loads(before_config)["version"])
 
     def test_repository_remote_defines_identity_in_a_named_worktree(self):
         module = load(HOSTS, "chaos_engine_repository_identity")

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -1295,8 +1295,12 @@ class ChaosEngineHostsTest(unittest.TestCase):
             )
             self.assertNotIn("git", migrated)
             self.assertNotIn("saveContextPacks", migrated["memory"])
-            for name, payload in before_schemas.items():
-                self.assertEqual(payload, project.joinpath(".memory/schema", name).read_bytes())
+            schema_root = Path(module.memory_schema_assets())
+            for name in module.MEMORY_SCHEMA_FILES:
+                self.assertEqual(
+                    (schema_root / name).read_bytes(),
+                    project.joinpath(".memory/schema", name).read_bytes(),
+                )
             self.assertEqual(object_bytes, object_path.read_bytes())
             self.assertEqual(before_yaml, project.joinpath("mempalace.yaml").read_bytes())
             self.assertTrue(before_yaml.startswith(b"wing: itestflow_agent\nexclude_patterns:\n"))

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -567,11 +567,15 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             self.assertEqual("recovery-required", result["status"])
             self.assertEqual(
                 "recovery-required",
-                result["components"]["retrieval-config"]["status"],
+                result["components"]["memory"]["status"],
             )
             self.assertEqual(
                 "memory check reported invalid store",
-                result["components"]["retrieval-config"]["reason"],
+                result["components"]["memory"]["reason"],
+            )
+            self.assertEqual(
+                "healthy",
+                result["components"]["retrieval-config"]["status"],
             )
 
     def test_doctor_rejects_an_mcp_runtime_that_cannot_initialize(self):

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -401,6 +401,7 @@ class ChaosEngineInstallerTest(unittest.TestCase):
                 return_value={"status": "recovery-required", "detail": "fixture"}
             )
             controller.retrieval_runtime_healthy = mock.Mock(return_value=True)
+            controller.retrieval_runtime_status = mock.Mock(return_value={"status": "healthy"})
             controller.mcp_runtime_healthy = mock.Mock(return_value=True)
             original_load = MODULE.load_installed_controller
 
@@ -552,8 +553,8 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             original_load = MODULE.load_installed_controller
             with mock.patch.object(
                 controller,
-                "retrieval_runtime_healthy",
-                return_value=False,
+                "retrieval_runtime_status",
+                return_value={"status": "recovery-required", "reason": "memory check reported invalid store"},
             ), mock.patch.object(
                 MODULE,
                 "load_installed_controller",
@@ -567,6 +568,10 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             self.assertEqual(
                 "recovery-required",
                 result["components"]["retrieval-config"]["status"],
+            )
+            self.assertEqual(
+                "memory check reported invalid store",
+                result["components"]["retrieval-config"]["reason"],
             )
 
     def test_doctor_rejects_an_mcp_runtime_that_cannot_initialize(self):
@@ -583,8 +588,8 @@ class ChaosEngineInstallerTest(unittest.TestCase):
             original_load = MODULE.load_installed_controller
             with mock.patch.object(
                 controller,
-                "retrieval_runtime_healthy",
-                return_value=True,
+                "retrieval_runtime_status",
+                return_value={"status": "healthy"},
             ), mock.patch.object(
                 controller,
                 "mcp_runtime_healthy",

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -465,7 +465,7 @@ class InstallerUxTests(unittest.TestCase):
     def test_prefilled_report_is_bounded_sanitized_and_names_failed_health(self):
         error = BOOTSTRAP.InstallHealthError(
             "Verify installation",
-            {"components": {"memory": {"status": "recovery-required"}}},
+            {"components": {"memory": {"status": "recovery-required", "taskImpact": "required"}}},
         )
         stderr = io.StringIO()
         with unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr):

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -39,7 +39,7 @@ class InstallerUxTests(unittest.TestCase):
         output = stream.getvalue()
         self.assertNotIn("transparent automation", output)
         self.assertNotIn("AUTONOMOUS INSTALL", output)
-        self.assertIn("Chaos Engine", output)
+        self.assertIn("ChaosEngine", output)
         self.assertNotIn("QUANTUM MANDATE", output)
         self.assertGreaterEqual(output.split("START", 1)[0].count("\n"), 3)
         self.assertIn("START Resolve source", output)
@@ -67,14 +67,15 @@ class InstallerUxTests(unittest.TestCase):
                 output = stream.getvalue()
                 self.assertNotIn("transparent automation", output)
                 self.assertNotIn("AUTONOMOUS INSTALL", output)
-                self.assertIn("Chaos Engine", output)
+                self.assertIn("ChaosEngine", output)
                 self.assertIn("\x1b[38;2;255;59;77m", output)
                 self.assertIn("[", output)
                 self.assertIn("Download source", output)
                 self.assertIn("running", output)
                 self.assertIn("Install core", output)
                 self.assertIn("Elapsed 00:00", output)
-                self.assertIn("ETA calculating", output)
+                self.assertNotIn("ETA calculating", output)
+                self.assertNotIn("Current action:", output)
                 self.assertIn("\x1b[", output)
             finally:
                 reporter.close()
@@ -114,7 +115,7 @@ class InstallerUxTests(unittest.TestCase):
         self.assertNotIn("✓", output)
         self.assertNotIn("transparent automation", output)
         self.assertNotIn("AUTONOMOUS INSTALL", output)
-        self.assertIn("Chaos Engine", output)
+        self.assertIn("ChaosEngine", output)
         self.assertTrue(all(len(line) <= 38 for line in output.splitlines()))
 
     def test_narrow_width_uses_brand_narrow(self):
@@ -141,7 +142,7 @@ class InstallerUxTests(unittest.TestCase):
             reporter.close()
         output = stream.getvalue()
         self.assertIn("/C|*|E/", output)
-        self.assertIn("Chaos Engine", output)
+        self.assertIn("ChaosEngine", output)
 
     def test_download_progress_uses_measured_bytes_and_rolling_rate(self):
         class Tty(io.StringIO):
@@ -164,7 +165,7 @@ class InstallerUxTests(unittest.TestCase):
             try:
                 reporter.start("Download source", remaining=("Install core",))
                 reporter.begin_download(1000, detail="source files")
-                self.assertIn("Speed calculating", stream.getvalue())
+                self.assertNotIn("calculating", stream.getvalue())
                 clock.now = 1.0
                 reporter.downloaded(250)
                 clock.now = 2.0
@@ -172,8 +173,9 @@ class InstallerUxTests(unittest.TestCase):
                 reporter._render_locked()
                 output = stream.getvalue()
                 self.assertIn("250 B/s", output)
-                self.assertIn("ETA 00:02", output)
-                self.assertIn("Current action: Download source", output)
+                self.assertIn("remaining 00:02", output)
+                self.assertIn("Elapsed", output)
+                self.assertNotIn("Current action:", output)
             finally:
                 reporter._stop.set()
                 reporter._thread = None
@@ -204,8 +206,7 @@ class InstallerUxTests(unittest.TestCase):
         )
         reporter.start("Provision dependencies", remaining=("Verify installation",))
         self.assertIn("Install core", getattr(reporter, "_in_flight", ()))
-        self.assertIn("Install core", getattr(reporter, "_in_flight", ()))
-        self.assertEqual("calculating", reporter._eta(clock.now))
+        self.assertIsNone(reporter._remaining(clock.now))
 
     def test_non_tty_history_has_timestamp_result_duration_and_current_action(self):
         class Clock:
@@ -221,7 +222,8 @@ class InstallerUxTests(unittest.TestCase):
         clock.now = 2.25
         reporter.complete("Resolve source", remaining=("Download source",))
         output = stream.getvalue()
-        self.assertIn("Current action: Resolve source", output)
+        self.assertNotIn("Current action:", output)
+        self.assertIn("START Resolve source", output)
         self.assertRegex(output, r"\[\+00:02\] PASS Resolve source \(00:02\)")
 
     def test_interactive_confirmation_accepts_only_y_or_yes(self):
@@ -264,7 +266,7 @@ class InstallerUxTests(unittest.TestCase):
         self.assertEqual(result, json.loads(stdout.getvalue()))
         self.assertNotIn("transparent automation", stderr.getvalue())
         self.assertNotIn("AUTONOMOUS INSTALL", stderr.getvalue())
-        self.assertIn("Chaos Engine", stderr.getvalue())
+        self.assertIn("ChaosEngine", stderr.getvalue())
 
     def test_wrappers_expose_and_forward_interactive_mode(self):
         shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
@@ -274,36 +276,17 @@ class InstallerUxTests(unittest.TestCase):
         self.assertNotIn("CHAOS_ENGINE_INTERACTIVE", powershell)
         self.assertIn('arguments += "--interactive"', powershell)
 
-    def test_wrappers_print_the_same_chaos_engine_mark(self):
+    def test_wrappers_leave_brand_and_checklist_to_python(self):
         shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
         powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
         for document in (shell, powershell):
             self.assertNotIn("transparent automation", document)
             self.assertNotIn("AUTONOMOUS INSTALL", document)
-            self.assertIn("Chaos Engine", document)
             self.assertNotIn("QUANTUM MANDATE", document)
-        for line in BOOTSTRAP.brand_lines(width=80, color=False, unicode=False):
-            if not line.strip():
-                continue
-            self.assertIn(line, shell)
-            self.assertIn(line, powershell)
-        for line in BOOTSTRAP.BRAND_NARROW:
-            self.assertIn(line, shell)
-            self.assertIn(line, powershell)
-        self.assertIn("[ \"$cols\" -lt 28 ]", shell)
-        self.assertIn("$cols -lt 28", powershell)
-        self.assertIn("/C|*|E/", shell)
-        self.assertIn("/C|*|E/", powershell)
-
-    def test_wrappers_put_checklist_then_current_action_below_heading(self):
-        shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
-        powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
-        for document in (shell, powershell):
-            heading = document.index("Installing ChaosEngine into")
-            checklist = document.index("[ ] Resolve source", heading)
-            current = document.index("Current action: Download bootstrap", checklist)
-            self.assertLess(heading, checklist)
-            self.assertLess(checklist, current)
+            self.assertNotIn("[ ] Resolve source", document)
+            self.assertNotIn("Current action: Download bootstrap", document)
+            self.assertIn("Installing ChaosEngine into", document)
+            self.assertNotIn("/C|*|E/", document)
 
     def test_main_emits_stable_actionable_error_codes(self):
         cases = (
@@ -328,16 +311,15 @@ class InstallerUxTests(unittest.TestCase):
                 self.assertIn(str(error).split("\n", 1)[0], stderr.getvalue())
                 self.assertIn(code, stderr.getvalue())
                 self.assertIn("#installer-errors", stderr.getvalue())
-                self.assertIn(".chaos-engine/install.py doctor", stderr.getvalue())
-                self.assertIn("doctor --project . --json", stderr.getvalue())
-                self.assertIn("status --project . --json", stderr.getvalue())
+                self.assertIn("Installer CLI is not on disk", stderr.getvalue())
                 if code == "CE-INSTALL-FAILED":
+                    self.assertIn("Next step: click this link to open a GitHub issue", stderr.getvalue())
                     report = [
                         line for line in stderr.getvalue().splitlines()
-                        if line.startswith("Report: ")
+                        if line.startswith("https://github.com/owner/repo/issues/new?")
                     ][0]
-                    self.assertIn("https://github.com/owner/repo/issues/new?", report)
-                    self.assertLessEqual(len(report.removeprefix("Report: ")), 2000)
+                    self.assertIn("template=chaos-engine-installer.yml", report)
+                    self.assertLessEqual(len(report), 2000)
 
     def test_keyboard_interrupt_emits_cancelled_without_traceback(self):
         stdout = io.StringIO()
@@ -364,7 +346,6 @@ class InstallerUxTests(unittest.TestCase):
         err = stderr.getvalue()
         self.assertIn("CE-INSTALL-CANCELLED", err)
         self.assertIn("#installer-errors", err)
-        self.assertIn(".chaos-engine/install.py doctor", err)
         self.assertIn("Last verified generation", err)
         self.assertIn("Rerun the same install command", err)
         self.assertNotIn("Traceback", err)
@@ -418,8 +399,68 @@ class InstallerUxTests(unittest.TestCase):
         self.assertIn("CE-INSTALL-FAILED", err)
         self.assertIn("sealed walk exploded", err)
         self.assertIn("https://github.com/owner/repo/issues/new", err)
-        self.assertIn(".chaos-engine/install.py status", err)
+        self.assertIn("Next step: click this link to open a GitHub issue", err)
         self.assertNotIn("Traceback", err)
+
+    def test_install_health_error_ignores_optional_absent_components(self):
+        error = BOOTSTRAP.InstallHealthError(
+            "Verify installation",
+            {
+                "components": {
+                    "retrieval-config": {"status": "recovery-required", "taskImpact": "required"},
+                    "maven-tools-mcp": {"status": "absent", "taskImpact": "optional"},
+                }
+            },
+        )
+        self.assertEqual(("retrieval-config",), error.unhealthy)
+
+    def test_pom_xml_implies_maven_tools_unless_skip_tools(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "maven"
+            project.mkdir()
+            (project / "pom.xml").write_text("<project/>\n", encoding="utf-8")
+            other = Path(temporary) / "plain"
+            other.mkdir()
+            self.assertTrue(BOOTSTRAP.wants_maven_tools(project, skip_tools=False, requested=False))
+            self.assertFalse(BOOTSTRAP.wants_maven_tools(project, skip_tools=True, requested=False))
+            self.assertFalse(BOOTSTRAP.wants_maven_tools(other, skip_tools=False, requested=False))
+            self.assertTrue(BOOTSTRAP.wants_maven_tools(other, skip_tools=False, requested=True))
+
+    def test_failure_cta_omits_missing_installer_cli(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "project"
+            project.mkdir()
+            stderr = io.StringIO()
+            with unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr):
+                BOOTSTRAP.emit_install_failure(
+                    "CE-INSTALL-FAILED",
+                    RuntimeError("probe failed"),
+                    "owner/repo",
+                    project=project,
+                )
+            err = stderr.getvalue()
+            self.assertNotIn(".chaos-engine/install.py", err)
+            self.assertIn("Installer CLI is not on disk", err)
+            self.assertIn("Rerun the same install command", err)
+            self.assertIn("https://github.com/owner/repo/issues/new", err)
+
+    def test_failure_cta_names_installer_cli_only_when_present(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "project"
+            installed = project / ".chaos-engine"
+            installed.mkdir(parents=True)
+            (installed / "install.py").write_text("# installer\n", encoding="utf-8")
+            stderr = io.StringIO()
+            with unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr):
+                BOOTSTRAP.emit_install_failure(
+                    "CE-INSTALL-FAILED",
+                    RuntimeError("probe failed"),
+                    "owner/repo",
+                    project=project,
+                )
+            err = stderr.getvalue()
+            self.assertIn(".chaos-engine/install.py doctor", err)
+            self.assertIn(".chaos-engine/install.py status", err)
 
     def test_prefilled_report_is_bounded_sanitized_and_names_failed_health(self):
         error = BOOTSTRAP.InstallHealthError(
@@ -430,15 +471,14 @@ class InstallerUxTests(unittest.TestCase):
         with unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr):
             BOOTSTRAP.emit_install_failure("CE-INSTALL-FAILED", error, "owner/repo")
         report = [
-            line.removeprefix("Report: ")
+            line
             for line in stderr.getvalue().splitlines()
-            if line.startswith("Report: ")
+            if line.startswith("https://github.com/owner/repo/issues/new?")
         ][0]
         query = urllib.parse.parse_qs(urllib.parse.urlsplit(report).query)
-        body = query["body"][0]
-        self.assertIn("Failed phase: Verify installation", body)
-        self.assertIn("Unhealthy components: memory", body)
-        self.assertIn("doctor --project . --json", body)
+        self.assertEqual(["chaos-engine-installer.yml"], query["template"])
+        self.assertEqual(["Verify installation"], query["failed_phase"])
+        self.assertEqual(["memory"], query["unhealthy"])
         self.assertLessEqual(len(report), 2000)
 
     def test_failure_cause_redacts_local_paths_and_secret_assignments(self):
@@ -453,12 +493,12 @@ class InstallerUxTests(unittest.TestCase):
             BOOTSTRAP.emit_install_failure("CE-INSTALL-FAILED", error, "owner/repo")
         output = stderr.getvalue()
         report = next(
-            line.removeprefix("Report: ")
+            line
             for line in output.splitlines()
-            if line.startswith("Report: ")
+            if line.startswith("https://github.com/owner/repo/issues/new?")
         )
-        body = urllib.parse.parse_qs(urllib.parse.urlsplit(report).query)["body"][0]
-        self.assertIn("Cause: failed at <path> token=<redacted>", body)
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(report).query)
+        self.assertEqual(["failed at <path> token=<redacted>"], query["cause"])
         self.assertNotIn("super-secret", output)
         self.assertNotIn(str(private_path), output)
 

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -129,7 +129,7 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
             runner.return_value = CompletedProcess(
                 ["wrapper"], 0,
                 stdout='{"status":"installed","clients":{}}',
-                stderr="Installing ChaosEngine\nCurrent action:",
+                stderr="Installing ChaosEngine\nSTART Resolve source\nElapsed 00:00",
             )
             module.run_public_wrapper("a" * 40, project)
         self.assertTrue(installed.is_absolute())

--- a/tests/scripts/test_validate_agent_setup.py
+++ b/tests/scripts/test_validate_agent_setup.py
@@ -35,14 +35,12 @@ class ValidateAgentSetupTest(unittest.TestCase):
             ".memory/config.json",
             json.dumps(
                 {
-                    "version": 4,
+                    "version": 5,
                     "project": {"id": "project.shaft-engine", "name": "Shaft Engine"},
                     "memory": {
                         "autoIndex": True,
                         "defaultTokenBudget": 600,
-                        "saveContextPacks": False,
                     },
-                    "git": {"trackContextPacks": False},
                 }
             ),
         )


### PR DESCRIPTION
## Summary

Fixes the Linux Mint `CE-INSTALL-FAILED` on `retrieval-config` and `maven-tools-mcp`, and replaces the sloppy installer surface.

- Optional absent Maven Tools no longer fail-close doctor messaging.
- Root `pom.xml` auto-installs Maven Tools. Ambient Java 17+ is used when it can run; otherwise pinned Temurin 25.
- First-install verify failure **keeps** `.chaos-engine/` so printed `status`/`doctor` commands exist. Rollback only when a verified backup exists.
- Failure CTA says to click the link and prefills `.github/ISSUE_TEMPLATE/chaos-engine-installer.yml`. Missing CLI paths are not printed.
- Wrappers no longer paint a second checklist. Live metrics: elapsed + speed, remaining time only on sized downloads. Trace lists retries/downloads. Elapsed ticks on a dedicated thread.
- Memory doctor probes now attach the real `reason`.

Closes #5345
Closes #5346

Companion docs: to follow on `ShaftHQ/shafthq.github.io`.

## Checks

- `python3 -m unittest tests.scripts.test_chaos_engine_installer_ux tests.scripts.test_chaos_engine_bootstrap tests.scripts.test_chaos_engine_installer tests.scripts.test_chaos_engine_hosts tests.scripts.test_chaos_engine_managed_runtimes` (248 tests, OK)
- Live `install.py install` on this clean Linux Mint box (no ambient Java/Node) into a temp Maven project: `retrieval-config` and `maven-tools-mcp` healthy; Node 24.19.0 and Temurin 25 provisioned.

## Continuation

Watch CI, adversarial review (max two rounds), auto-merge.