### PR TITLE
fix(chaos-engine): provision Python 3.11 and durable marketplace

### DIFF
--- a/chaos-engine/dependencies.json
+++ b/chaos-engine/dependencies.json
@@ -9,7 +9,7 @@
       "macos-x64": {"url": "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-x86_64-apple-darwin.tar.gz", "sha256": "c4c4de482da9ccdd076dc4fb5cfe7b740609029385c72f58606be3153602387d"},
       "macos-arm64": {"url": "https://github.com/astral-sh/uv/releases/download/0.11.29/uv-aarch64-apple-darwin.tar.gz", "sha256": "61c04acc52a33ef0f331e494bdfbedcdb6c26c6970c022ed3699e5860f8930e3"}
     }},
-    "python": {"version": "3.10", "provider": "uv-managed"},
+    "python": {"version": "3.11", "provider": "uv-managed"},
     "node": {"version": "24.19.0", "artifacts": {
       "windows-x64": {"url": "https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-x64.zip", "sha256": "57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73"},
       "windows-arm64": {"url": "https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-arm64.zip", "sha256": "8502f4a50b458d4cc38ed8f2001556c2cd239d464920f74017926ccb1e1c157f"},

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -1356,6 +1356,10 @@ def generation_install_plan(
         else "node/lib/node_modules/npm/bin/npm-cli.js"
     )
     graphify = tools.get("graphify")
+    python_runtime = specification.get("runtimes", {}).get("python", {})
+    python_version = python_runtime.get("version") if isinstance(python_runtime, dict) else None
+    if not isinstance(python_version, str) or re.fullmatch(r"3\.\d+", python_version) is None:
+        raise ValueError("Python runtime specification is invalid")
     if not isinstance(graphify, dict):
         raise ValueError("graphify dependency specification is invalid")
     uv_commands = [[uv, "--version"]] if Path(uv).is_file() else [
@@ -1371,7 +1375,7 @@ def generation_install_plan(
             "--no-cache",
             "--managed-python",
             "--python",
-            "3.10",
+            python_version,
             "--link-mode",
             "copy",
             str(tools["mempalace"]["package"]),  # type: ignore[index]
@@ -1383,7 +1387,7 @@ def generation_install_plan(
             "--no-cache",
             "--managed-python",
             "--python",
-            "3.10",
+            python_version,
             "--link-mode",
             "copy",
             "--with",

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -55,7 +55,7 @@ REQUIRED_DISPATCHES = {
 }
 WINDOWS_UV_JUNCTION_TAG = 0xA0000003
 WINDOWS_UV_ALIAS = re.compile(
-    r"uv-python/cpython-3\.10-windows-(?P<arch>x86_64|aarch64)-none"
+    r"uv-python/cpython-(?P<version>3\.\d+)-windows-(?P<arch>x86_64|aarch64)-none"
 )
 CANDIDATE_TRUST_BOUNDARY = (
     "A same-user trusted subprocess has ambient write authority and this stdlib "
@@ -1906,7 +1906,8 @@ def _windows_uv_junction_record(runtime: Path, path: Path) -> dict[str, str]:
     if not target.is_relative_to(root) or target.parent != _lexical_path(path.parent):
         raise ValueError(f"dependency runtime junction escapes the runtime: {relative}")
     expected = re.fullmatch(
-        rf"cpython-3\.10\.\d+-windows-{re.escape(alias.group('arch'))}-none",
+        rf"cpython-{re.escape(alias.group('version'))}\.\d+-windows-"
+        rf"{re.escape(alias.group('arch'))}-none",
         target.name,
     )
     if expected is None or is_link_or_reparse(target) or not target.is_dir():

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -854,6 +854,86 @@ def client_json(
         raise RuntimeError("client plugin command returned invalid JSON") from error
 
 
+_STALE_MARKETPLACE_ERROR = re.compile(
+    r"^(?:client plugin command failed:\s*)?(?:Error:\s*)?"
+    r"failed to load (?:configured )?marketplace(?: snapshot)?\(s\):\s*-\s*"
+    r"`(?P<name>chaos-engine-[0-9a-f]{12})`\s+at\s+(?P<root>.+?)"
+    r"(?::\s*|\s+)marketplace root does not contain a supported manifest\.?\s*$",
+    re.DOTALL,
+)
+_SUPPORTED_MARKETPLACE_MANIFESTS = (
+    ".agents/plugins/marketplace.json",
+    ".agents/plugins/api_marketplace.json",
+    ".claude-plugin/marketplace.json",
+    ".cursor-plugin/marketplace.json",
+)
+
+
+def stale_owned_marketplace(error: RuntimeError) -> str | None:
+    match = _STALE_MARKETPLACE_ERROR.fullmatch(str(error))
+    if match is None:
+        return None
+    name = match.group("name")
+    root = Path(match.group("root").strip())
+    if not root.is_absolute():
+        return None
+    try:
+        if any(is_link_or_reparse(path) for path in (root, *root.parents)):
+            return None
+    except OSError:
+        return None
+    parts = tuple(os.path.normcase(part) for part in root.parts)
+    durable = parts[-3:] == (
+        os.path.normcase("ChaosEngine"),
+        os.path.normcase("client-marketplaces"),
+        os.path.normcase(name),
+    )
+    legacy = parts[-2:] == (
+        os.path.normcase(".chaos-engine-state"),
+        os.path.normcase("client-marketplace"),
+    )
+    if legacy:
+        try:
+            project = root.parent.parent.resolve()
+        except OSError:
+            return None
+        digest = hashlib.sha256(os.path.normcase(str(project)).encode()).hexdigest()[:12]
+        legacy = name == f"chaos-engine-{digest}"
+    if not durable and not legacy:
+        return None
+    try:
+        supported_manifest = any(
+            (root / relative).exists() or is_link_or_reparse(root / relative)
+            for relative in _SUPPORTED_MARKETPLACE_MANIFESTS
+        )
+    except OSError:
+        return None
+    if supported_manifest:
+        return None
+    return name
+
+
+def remove_stale_marketplace_before_activation(
+    client: str,
+    executable: str,
+    project: Path,
+    *,
+    runner=subprocess.run,
+) -> None:
+    arguments = ["plugin", "marketplace", "list", "--json"]
+    try:
+        client_json(executable, arguments, project, runner=runner)
+    except RuntimeError as error:
+        marketplace_name = stale_owned_marketplace(error)
+        if marketplace_name is None:
+            raise
+        remove = ["plugin", "marketplace", "remove", marketplace_name]
+        if client == "claude":
+            remove.extend(["--scope", "local"])
+        client_command(executable, remove, project, runner=runner)
+        client_json(executable, arguments, project, runner=runner)
+
+
 def same_path(left: object, right: Path) -> bool:
     if not isinstance(left, str):
         return False
@@ -1378,9 +1458,12 @@ def activate_detected_plugins(
             executable = which(client)
             if executable is None:
                 continue
-            touched_clients.append(client)
             selected_client = lambda name, selected=client, path=executable: path if name == selected else None
+            remove_stale_marketplace_before_activation(
+                client, executable, project, runner=runner
+            )
             current = detected_plugin_status(project, runner=runner, which=selected_client)[client]
+            touched_clients.append(client)
             if current["marketplace"] != "healthy":
                 if confirmer is not None:
                     confirmer(f"Register {client} plugin marketplace")

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -683,7 +683,7 @@ def initialize_mempalace_runtime(project: Path) -> None:
         raise
 
 
-def mcp_runtime_healthy(project: Path) -> bool:
+def mcp_runtime_healthy(project: Path, managed_python: Path | None = None) -> bool:
     if mempalace_runtime_status(project)["status"] != "healthy":
         return False
     skip_checkout_mempalace = (
@@ -722,10 +722,11 @@ def mcp_runtime_healthy(project: Path) -> bool:
     environment = os.environ.copy()
     environment["PYTHONDONTWRITEBYTECODE"] = "1"
     environment.update(MEMPALACE_MCP_ENV)
+    python = str(managed_python) if managed_python is not None else sys.executable
     commands = (
-        [sys.executable, str(tool), "memory-mcp"],
+        [python, str(tool), "memory-mcp"],
         [
-            sys.executable,
+            python,
             str(tool),
             "mempalace-mcp",
             "--palace",
@@ -797,6 +798,28 @@ def mcp_runtime_healthy(project: Path) -> bool:
     return True
 
 
+def hook_runtime_healthy(project: Path, managed_python: Path) -> bool:
+    """Run changed-sensitive hook events through generated managed Python."""
+    guard = project / ".chaos-engine/hooks/guard.py"
+    if not managed_python.is_file() or not guard.is_file():
+        return False
+    for event in ("UserPromptSubmit", "PreToolUse", "PostToolUse"):
+        payload = {"hook_event_name": event, "session_id": "chaos-engine-doctor"}
+        if event != "UserPromptSubmit":
+            payload.update({"tool_name": "Bash", "tool_input": {"command": "true"}})
+        try:
+            result = subprocess.run(  # nosec B603 - receipt-owned interpreter and hook.
+                [str(managed_python), str(guard)], cwd=project, input=json.dumps(payload),
+                capture_output=True, text=True, check=False, timeout=30,
+                env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+            )
+            if result.returncode or not isinstance(json.loads(result.stdout or "{}"), dict):
+                return False
+        except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError):
+            return False
+    return True
+
+
 def client_command(
     executable: str,
     arguments: list[str],
@@ -844,7 +867,7 @@ def activation_contract(project: Path) -> tuple[Path, str, str, str]:
     project = project.resolve()
     digest = hashlib.sha256(os.path.normcase(str(project)).encode()).hexdigest()[:12]
     marketplace_name = f"chaos-engine-{digest}"
-    root = project / ".chaos-engine-state/client-marketplace"
+    root = maven_tools_data_root() / "ChaosEngine/client-marketplaces" / marketplace_name
     manifest_path = project / "plugins/chaos-engine/.codex-plugin/plugin.json"
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -854,6 +877,20 @@ def activation_contract(project: Path) -> tuple[Path, str, str, str]:
     if not isinstance(version, str) or re.fullmatch(r"\d+\.\d+\.\d+", version) is None:
         raise ValueError("ChaosEngine plugin version is invalid")
     return root, marketplace_name, f"{PLUGIN_NAME}@{marketplace_name}", version
+
+
+def activation_bundle_root(activation: dict[str, object]) -> Path:
+    """Return the exact receipt-owned durable marketplace path."""
+    name = activation.get("marketplaceName")
+    encoded_root = activation.get("bundleRoot")
+    if not isinstance(name, str) or re.fullmatch(r"chaos-engine-[0-9a-f]{12}", name) is None:
+        raise ValueError("ChaosEngine client activation receipt is invalid")
+    if not isinstance(encoded_root, str):
+        raise ValueError("ChaosEngine client activation receipt has no bundle root")
+    root = Path(encoded_root)
+    if not root.is_absolute() or root.name != name or root.parent.name != "client-marketplaces":
+        raise ValueError("ChaosEngine client activation receipt bundle root is invalid")
+    return root
 
 
 def activation_plugins(project: Path, marketplace_name: str) -> dict[str, dict[str, object]]:
@@ -1219,6 +1256,7 @@ def record_client_activation(project: Path, activation: dict[str, object]) -> No
         raise ValueError("ChaosEngine host activation requires an installed receipt")
     receipt["clientActivation"] = {
         "marketplaceName": activation["marketplaceName"],
+        "bundleRoot": activation["bundleRoot"],
         "ownedClients": activation["ownedClients"],
         "pluginVersion": activation["pluginVersion"],
         "claudeLocalBefore": activation["claudeLocalBefore"],
@@ -1333,6 +1371,7 @@ def activate_detected_plugins(
         "createdMarketplaces": created_marketplaces,
         "createdPlugins": created_plugins,
         "marketplaceName": marketplace_name,
+        "bundleRoot": str(root),
     }
     try:
         for client in ("codex", "claude"):
@@ -2390,12 +2429,12 @@ def codex_content(
         f"args = [{memory_args}]\n"
         f'commandWindows = "{windows_command}"\n'
         f'argsWindows = [{windows_prefix}{memory_args}]\n'
-        'cwd = ".."\n\n'
+        'cwd = "."\n\n'
         f'[mcp_servers."chaosengine-mempalace"]\ncommand = "{posix_command}"\n'
         f"args = [{mempalace_args}]\n"
         f'commandWindows = "{windows_command}"\n'
         f'argsWindows = [{windows_prefix}{mempalace_args}]\n'
-        'cwd = ".."\n'
+        'cwd = "."\n'
         f"{MEMPALACE_MCP_ENV_TOML}# CHAOSENGINE:END\n"
     )
     if maven_runtime is not None:
@@ -3987,10 +4026,12 @@ def finalize_uninstall(project: Path) -> None:
     anchor = host_anchor_path(project)
     if anchor.name.startswith(ACTIVE_ANCHOR_PREFIX):
         anchor = move_anchor(project, anchor, REMOVING_ANCHOR_PREFIX)
-    activation_root = project / ".chaos-engine-state/client-marketplace"
-    if activation_root.exists():
+    activation = receipt.get("clientActivation")
+    activation_root = activation_bundle_root(activation) if isinstance(activation, dict) else None
+    if activation_root is not None and activation_root.exists():
         if is_link_or_reparse(activation_root) or not activation_root.is_dir():
             raise ValueError("ChaosEngine activation marketplace collision")
+        activation_plugins_from_root(activation_root, str(activation["marketplaceName"]))
         shutil.rmtree(activation_root)
     receipt_path.unlink()
     anchor.unlink()

--- a/chaos-engine/install.ps1
+++ b/chaos-engine/install.ps1
@@ -304,9 +304,9 @@ try {
     if ($null -eq $python) {
         $uv = Install-ChaosEngineUv $work
         $env:UV_PYTHON_INSTALL_DIR = Join-Path $work "python"
-        & $uv python install 3.10 --no-progress
+        & $uv python install 3.11 --no-progress
         if ($LASTEXITCODE -ne 0) { throw "uv-managed Python installation failed" }
-        $invoke = @($uv, "run", "--no-project", "--managed-python", "--python", "3.10") + $arguments
+        $invoke = @($uv, "run", "--no-project", "--managed-python", "--python", "3.11") + $arguments
     }
     else { $invoke = @($python) + $arguments }
     & $invoke[0] @($invoke[1..($invoke.Length - 1)])

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -1930,11 +1930,24 @@ def doctor_with_dependencies(
             components["memory"]["status"] = "recovery-required"
             if retrieval.get("reason"):
                 components["memory"]["reason"] = retrieval["reason"]
-    if not host_controller.mcp_runtime_healthy(project.resolve()):
+    dependency = result.get("dependencies")
+    generation_path = dependency.get("path") if isinstance(dependency, dict) else None
+    scripts = "Scripts" if os.name == "nt" else "bin"
+    python_name = "python.exe" if os.name == "nt" else "python"
+    managed_python = (
+        Path(generation_path) / "uv-tools/mempalace" / scripts / python_name
+        if isinstance(generation_path, str) else None
+    )
+    if managed_python is None or not host_controller.mcp_runtime_healthy(project.resolve(), managed_python):
         result["status"] = "recovery-required"
         components = result.get("components")
         if isinstance(components, dict) and isinstance(components.get("mcps"), dict):
             components["mcps"]["status"] = "recovery-required"
+    if managed_python is None or not host_controller.hook_runtime_healthy(project.resolve(), managed_python):
+        result["status"] = "recovery-required"
+        components = result.get("components")
+        if isinstance(components, dict) and isinstance(components.get("hooks"), dict):
+            components["hooks"]["status"] = "recovery-required"
     if not verify_clients:
         return result
     clients = host_controller.detected_plugin_status(project.resolve())

--- a/chaos-engine/install.sh
+++ b/chaos-engine/install.sh
@@ -186,8 +186,8 @@ if [ -z "$python" ]; then
   uv="$work/uv-${uv_target}/uv"
   [ -x "$uv" ] || fail "uv archive is missing its executable"
   export UV_PYTHON_INSTALL_DIR="$work/python"
-  "$uv" python install 3.10 --no-progress
-  set -- "$uv" run --no-project --managed-python --python 3.10 "$bootstrap" --project "$project" --repository "$repository" --branch "$branch"
+  "$uv" python install 3.11 --no-progress
+  set -- "$uv" run --no-project --managed-python --python 3.11 "$bootstrap" --project "$project" --repository "$repository" --branch "$branch"
 else
   set -- "$python" "$bootstrap" --project "$project" --repository "$repository" --branch "$branch"
 fi

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -183,6 +183,16 @@ def read_json(path: Path) -> dict[str, object]:
     return value
 
 
+def managed_python_version(installed: Path) -> str:
+    dependencies = read_json(installed / "dependencies.json")
+    runtimes = dependencies.get("runtimes")
+    python = runtimes.get("python") if isinstance(runtimes, dict) else None
+    version = python.get("version") if isinstance(python, dict) else None
+    if not isinstance(version, str) or re.fullmatch(r"\d+\.\d+", version) is None:
+        raise RuntimeError("installed managed Python version is invalid")
+    return version
+
+
 def stage_source(source: Path, destination: Path) -> Path:
     shutil.copytree(
         source,
@@ -305,6 +315,7 @@ def probe_mempalace_mcp(tool: Path, project: Path) -> None:
 
 def verify_phase(project: Path, expected_commit: str) -> dict[str, object]:
     installed = project / ".chaos-engine"
+    python_version = managed_python_version(installed)
     status = json.loads(
         run_checked(
             [
@@ -374,8 +385,8 @@ def verify_phase(project: Path, expected_commit: str) -> dict[str, object]:
             timeout=60,
         )
         output = f"{version.stdout}\n{version.stderr}"
-        if "Python 3.10." not in output:
-            raise RuntimeError(f"{name} is not using managed Python 3.10")
+        if f"Python {python_version}." not in output:
+            raise RuntimeError(f"{name} is not using managed Python {python_version}")
     if any((active_root / name).exists() for name in ("uv-cache", "npm-cache", ".cache")):
         raise RuntimeError("transaction cache leaked into immutable generation")
     transactions = project / ".chaos-engine-runtime-transactions"
@@ -387,7 +398,7 @@ def verify_phase(project: Path, expected_commit: str) -> dict[str, object]:
         "active": str(active["generationId"]),
         "previous": None if previous is None else str(previous["generationId"]),
         "generationCount": len(generation_names),
-        "managedPython": "3.10",
+        "managedPython": python_version,
         "cacheState": "absent",
     }
 

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -153,6 +153,25 @@ def sanitize(value: object) -> str:
     return text[:head_size] + SANITIZER_TRUNCATION_MARKER + text[-tail_size:]
 
 
+def installer_failure_detail(value: str) -> str:
+    headline = next(
+        (line.strip() for line in value.splitlines() if "CE-INSTALL-" in line),
+        None,
+    )
+    if headline is None:
+        return value
+    fields: list[str] = []
+    for token in value.split():
+        if "/issues/new?" not in token:
+            continue
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(token).query)
+        for key, label in (("failed_phase", "failed phase"), ("unhealthy", "unhealthy")):
+            if query.get(key):
+                fields.append(f"{label}: {query[key][0]}")
+        break
+    return "; ".join((headline, *fields))
+
+
 def run_checked(
     command: list[str],
     *,
@@ -172,6 +191,7 @@ def run_checked(
     )
     if result.returncode:
         detail = result.stderr.strip() or result.stdout.strip() or "no process output"
+        detail = installer_failure_detail(detail)
         raise RuntimeError(f"command failed ({result.returncode}): {sanitize(detail)}")
     return result
 

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -637,7 +637,7 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
             project = Path(temporary) / "project"
             project.mkdir()
             opener, _ = self.opener([(COMMIT_ONE, "full")])
-            data_root = Path(temporary) / "user-data"
+            data_root = Path(temporary).resolve() / "user-data"
             data_variable = "LOCALAPPDATA" if os.name == "nt" else "XDG_DATA_HOME"
 
             def provisioner(runtime, specification):

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import os
 import subprocess  # nosec B404 - tests run fixed local Git commands only.
 import tempfile
 import unittest
@@ -636,6 +637,8 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
             project = Path(temporary) / "project"
             project.mkdir()
             opener, _ = self.opener([(COMMIT_ONE, "full")])
+            data_root = Path(temporary) / "user-data"
+            data_variable = "LOCALAPPDATA" if os.name == "nt" else "XDG_DATA_HOME"
 
             def provisioner(runtime, specification):
                 def runner(command, environment):
@@ -648,16 +651,17 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
 
                 return dependency_module.repair(runtime, specification, runner=runner)
 
-            result = module.install_latest(
-                project,
-                repository="Example/Project",
-                branch="main",
-                opener=opener,
-                provisioner=provisioner,
-            )
+            with mock.patch.dict(os.environ, {data_variable: str(data_root)}, clear=False):
+                result = module.install_latest(
+                    project,
+                    repository="Example/Project",
+                    branch="main",
+                    opener=opener,
+                    provisioner=provisioner,
+                )
 
-            installed = module.load_installer(project / ".chaos-engine")
-            status = installed.status_with_dependencies(project)
+                installed = module.load_installer(project / ".chaos-engine")
+                status = installed.status_with_dependencies(project)
             self.assertEqual(COMMIT_ONE, result["commit"])
             self.assertEqual("healthy", status["status"])
             self.assertEqual("healthy", status["hosts"]["status"])
@@ -692,13 +696,14 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
             self.assertTrue(project.joinpath(".mcp.json").is_file())
 
             same, _ = self.opener([(COMMIT_ONE, "full")])
-            repeated = module.install_latest(
-                project,
-                repository="example/project",
-                branch="main",
-                opener=same,
-                provisioner=provisioner,
-            )
+            with mock.patch.dict(os.environ, {data_variable: str(data_root)}, clear=False):
+                repeated = module.install_latest(
+                    project,
+                    repository="example/project",
+                    branch="main",
+                    opener=same,
+                    provisioner=provisioner,
+                )
             self.assertEqual(COMMIT_ONE, repeated["commit"])
 
     def test_public_bootstrap_upgrade_repairs_missing_mempalace(self):

--- a/tests/scripts/test_chaos_engine_generation_runtime.py
+++ b/tests/scripts/test_chaos_engine_generation_runtime.py
@@ -1487,7 +1487,7 @@ class GenerationRuntimeTests(unittest.TestCase):
             generation = Path(temporary)
             target = (
                 generation
-                / "uv-python/cpython-3.10.18-linux-x86_64-gnu/bin/python3.10"
+                / "uv-python/cpython-3.11.0-linux-x86_64-gnu/bin/python3.11"
             )
             target.parent.mkdir(parents=True)
             target.write_bytes(b"managed-python")
@@ -1512,11 +1512,11 @@ class GenerationRuntimeTests(unittest.TestCase):
             module._crosscheck_dispatch_ownership(ownership, records)
 
             self.assertEqual(
-                "../../../uv-python/cpython-3.10.18-linux-x86_64-gnu/bin/python3.10",
+                "../../../uv-python/cpython-3.11.0-linux-x86_64-gnu/bin/python3.11",
                 dispatch["interpreterLinkTarget"],
             )
             self.assertEqual(
-                "uv-python/cpython-3.10.18-linux-x86_64-gnu/bin/python3.10",
+                "uv-python/cpython-3.11.0-linux-x86_64-gnu/bin/python3.11",
                 dispatch["interpreterTarget"],
             )
             self.assertEqual(str(interpreter), module.dispatch_command(
@@ -1536,10 +1536,10 @@ class GenerationRuntimeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             generation = root / "generation"
-            exact = generation / "uv-python/cpython-3.10.18-windows-x86_64-none"
+            exact = generation / "uv-python/cpython-3.11.0-windows-x86_64-none"
             exact.mkdir(parents=True)
             (exact / "python.exe").write_bytes(b"managed-python")
-            alias = generation / "uv-python/cpython-3.10-windows-x86_64-none"
+            alias = generation / "uv-python/cpython-3.11-windows-x86_64-none"
             command = shutil.which("cmd.exe")
             self.assertIsNotNone(command)
             result = subprocess.run(  # nosec B603 - resolved cmd creates a fixture junction.
@@ -1555,8 +1555,8 @@ class GenerationRuntimeTests(unittest.TestCase):
             ownership = module.sealed_ownership_record(generation)
             self.assertIn(
                 {
-                    "path": "uv-python/cpython-3.10-windows-x86_64-none",
-                    "target": "uv-python/cpython-3.10.18-windows-x86_64-none",
+                    "path": "uv-python/cpython-3.11-windows-x86_64-none",
+                    "target": "uv-python/cpython-3.11.0-windows-x86_64-none",
                     "type": "junction",
                     "tag": "0xa0000003",
                 },
@@ -1692,7 +1692,7 @@ class GenerationRuntimeTests(unittest.TestCase):
             self.assertEqual([], list(transaction_root.iterdir()))
             self.assertTrue(any("--no-cache" in command for command in commands))
             self.assertTrue(
-                any("--python" in command and "3.10" in command for command in commands)
+                any("--python" in command and "3.11" in command for command in commands)
             )
             self.assertTrue(
                 all(

--- a/tests/scripts/test_chaos_engine_generation_runtime.py
+++ b/tests/scripts/test_chaos_engine_generation_runtime.py
@@ -1570,6 +1570,16 @@ class GenerationRuntimeTests(unittest.TestCase):
             self.assertFalse(generation.exists())
             self.assertFalse(exact.exists())
 
+    def test_windows_uv_python_alias_accepts_configured_minor_version(self):
+        module = load_controller()
+
+        match = module.WINDOWS_UV_ALIAS.fullmatch(
+            "uv-python/cpython-3.11-windows-x86_64-none"
+        )
+
+        self.assertIsNotNone(match)
+        self.assertEqual("3.11", match.group("version"))
+
     def test_candidate_cleanup_preserves_primary_install_error(self):
         module = load_controller()
         specification = json.loads(

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -297,6 +297,143 @@ class ChaosEngineHostsTest(unittest.TestCase):
             )
             self.assertNotIn(".chaos-engine-state", str(root))
 
+    def test_activation_removes_only_proven_stale_owned_marketplace(self):
+        module = load(HOSTS, "chaos_engine_stale_owned_marketplace")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            canonical = project / ".chaos-engine/skills/chaos-engine/SKILL.md"
+            canonical.parent.mkdir(parents=True)
+            canonical.write_text("# ChaosEngine\n", encoding="utf-8")
+            module.install(project, core_commit="1" * 40)
+            root, marketplace_name, _, _ = module.activation_contract(project)
+            stale_root = project / ".chaos-engine-state/client-marketplace"
+            state = {"stale": True, "marketplace": False, "plugins": set()}
+            calls = []
+
+            def runner(command, **_options):
+                calls.append(command)
+                joined = " ".join(command[1:])
+                if "marketplace list" in joined and state["stale"]:
+                    return mock.Mock(
+                        returncode=1,
+                        stdout="",
+                        stderr=(
+                            "Error: failed to load marketplace(s): "
+                            f"- `{marketplace_name}` at {stale_root} "
+                            "marketplace root does not contain a supported manifest"
+                        ),
+                    )
+                if "marketplace list" in joined:
+                    value = {
+                        "marketplaces": [
+                            {"name": marketplace_name, "root": str(root)}
+                        ]
+                        if state["marketplace"]
+                        else []
+                    }
+                elif "marketplace remove" in joined:
+                    state["stale"] = False
+                    value = {}
+                elif "marketplace add" in joined:
+                    state["marketplace"] = True
+                    value = {}
+                elif "plugin list" in joined:
+                    contracts = module.activation_plugins(project, marketplace_name)
+                    value = {
+                        "installed": [
+                            {
+                                "pluginId": contracts[name]["id"],
+                                "version": contracts[name]["version"],
+                                "installed": True,
+                                "enabled": True,
+                                "source": {"path": str(root / f"plugins/{name}")},
+                            }
+                            for name in state["plugins"]
+                        ],
+                        "available": [],
+                    }
+                elif "plugin add" in joined:
+                    plugin_id = next(item for item in command if "@" in item)
+                    state["plugins"].add(plugin_id.split("@", 1)[0])
+                    value = {}
+                else:
+                    raise AssertionError(command)
+                return mock.Mock(returncode=0, stdout=json.dumps(value), stderr="")
+
+            receipt = module.activate_detected_plugins(
+                project,
+                runner=runner,
+                which=lambda name: name if name == "codex" else None,
+            )
+
+            self.assertEqual("healthy", receipt["clients"]["codex"]["status"])
+            self.assertEqual(
+                1,
+                sum(
+                    command[1:] == ["plugin", "marketplace", "remove", marketplace_name]
+                    for command in calls
+                ),
+            )
+
+    def test_activation_preserves_unclassified_broken_marketplace(self):
+        module = load(HOSTS, "chaos_engine_unclassified_broken_marketplace")
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            cases = []
+            for label in ("foreign", "unknown", "valid", "linked"):
+                project = base / label / "consumer"
+                canonical = project / ".chaos-engine/skills/chaos-engine/SKILL.md"
+                canonical.parent.mkdir(parents=True)
+                canonical.write_text("# ChaosEngine\n", encoding="utf-8")
+                module.install(project, core_commit="1" * 40)
+                _, marketplace_name, _, _ = module.activation_contract(project)
+                stale_root = project / ".chaos-engine-state/client-marketplace"
+                reported_name = marketplace_name
+                reported_root = stale_root
+                if label == "foreign":
+                    reported_name = "foreign-marketplace"
+                elif label == "unknown":
+                    reported_root = base / "unknown-marketplace-root"
+                elif label == "valid":
+                    manifest = stale_root / ".agents/plugins/marketplace.json"
+                    manifest.parent.mkdir(parents=True)
+                    manifest.write_text("{}\n", encoding="utf-8")
+                cases.append((label, project, reported_name, reported_root))
+
+            for label, project, reported_name, reported_root in cases:
+                calls = []
+
+                def runner(command, **_options):
+                    calls.append(command)
+                    return mock.Mock(
+                        returncode=1,
+                        stdout="",
+                        stderr=(
+                            "Error: failed to load marketplace(s): "
+                            f"- `{reported_name}` at {reported_root} "
+                            "marketplace root does not contain a supported manifest"
+                        ),
+                    )
+
+                real_link_check = module.is_link_or_reparse
+                with self.subTest(case=label), mock.patch.object(
+                    module,
+                    "is_link_or_reparse",
+                    side_effect=lambda path: (
+                        label == "linked" and Path(path) == reported_root
+                    ) or real_link_check(path),
+                ), self.assertRaisesRegex(
+                    RuntimeError, "marketplace root does not contain a supported manifest"
+                ):
+                    module.activate_detected_plugins(
+                        project,
+                        runner=runner,
+                        which=lambda name: name if name == "codex" else None,
+                    )
+                self.assertFalse(
+                    any("marketplace remove" in " ".join(command[1:]) for command in calls)
+                )
+
     def test_failed_plugin_upgrade_restores_prior_bundle_and_activation_receipt(self):
         module = load(HOSTS, "chaos_engine_plugin_upgrade_rollback")
         with tempfile.TemporaryDirectory() as temporary:
@@ -1494,6 +1631,77 @@ class ChaosEngineHostsTest(unittest.TestCase):
             invalid = mock.Mock(returncode=0, stdout="not-json\n")
             with mock.patch.object(module.subprocess, "run", return_value=invalid):
                 self.assertFalse(module.mcp_runtime_healthy(project))
+
+    def test_doctor_mcp_probe_uses_configured_cwd_and_managed_python(self):
+        module = load(HOSTS, "chaos_engine_doctor_configured_mcp")
+        response = mock.Mock(
+            returncode=0,
+            stdout=json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}) + "\n",
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            tool = project / ".chaos-engine/tool.py"
+            tool.parent.mkdir()
+            tool.write_text("# owned\n", encoding="utf-8")
+            module.initialize_mempalace_runtime(project)
+            managed_python = project / "managed/python"
+            managed_python.parent.mkdir()
+            managed_python.write_bytes(b"python")
+            with mock.patch.object(
+                module.subprocess,
+                "run",
+                side_effect=[response, mock.Mock(
+                    returncode=0,
+                    stdout="\n".join((
+                        response.stdout.strip(),
+                        json.dumps({
+                            "jsonrpc": "2.0",
+                            "id": 2,
+                            "result": {"content": [{
+                                "type": "text",
+                                "text": json.dumps({
+                                    "backend": "sqlite_exact",
+                                    "total_drawers": 0,
+                                }),
+                            }]},
+                        }),
+                    )) + "\n",
+                )],
+            ) as run:
+                self.assertTrue(module.mcp_runtime_healthy(project, managed_python))
+
+            self.assertEqual(2, run.call_count)
+            for call in run.call_args_list:
+                self.assertEqual(managed_python, Path(call.args[0][0]))
+                self.assertEqual(project, call.kwargs["cwd"])
+            self.assertEqual(str(tool), run.call_args_list[0].args[0][1])
+
+    def test_hook_runtime_probe_executes_prompt_pre_and_post_with_managed_python(self):
+        module = load(HOSTS, "chaos_engine_doctor_hook_events")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            guard = project / ".chaos-engine/hooks/guard.py"
+            guard.parent.mkdir(parents=True)
+            guard.write_text("# owned\n", encoding="utf-8")
+            managed_python = project / "managed/python"
+            managed_python.parent.mkdir()
+            managed_python.write_bytes(b"python")
+            result = mock.Mock(returncode=0, stdout="{}\n")
+            with mock.patch.object(module.subprocess, "run", return_value=result) as run:
+                self.assertTrue(module.hook_runtime_healthy(project, managed_python))
+
+            self.assertEqual(3, run.call_count)
+            payloads = [json.loads(call.kwargs["input"]) for call in run.call_args_list]
+            self.assertEqual(
+                ["UserPromptSubmit", "PreToolUse", "PostToolUse"],
+                [payload["hook_event_name"] for payload in payloads],
+            )
+            self.assertNotIn("tool_name", payloads[0])
+            for call, payload in zip(run.call_args_list, payloads):
+                self.assertEqual([str(managed_python), str(guard)], call.args[0])
+                self.assertEqual(project, call.kwargs["cwd"])
+                if payload["hook_event_name"] != "UserPromptSubmit":
+                    self.assertEqual("Bash", payload["tool_name"])
 
     def test_mempalace_runtime_state_is_fail_closed_before_native_launch(self):
         module = load(HOSTS, "chaos_engine_mempalace_runtime_state")

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -229,6 +229,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
             activation = {
                 "marketplaceName": marketplace_name,
+                "bundleRoot": str(root),
                 "ownedClients": ["codex"],
                 "pluginVersion": "1.0.0",
                 "claudeLocalBefore": None,
@@ -276,6 +277,26 @@ class ChaosEngineHostsTest(unittest.TestCase):
                 module.activation_contract(second)[1],
             )
 
+    def test_activation_bundle_uses_durable_user_data_root(self):
+        module = load(HOSTS, "chaos_engine_durable_activation_root")
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            manifest = project / "plugins/chaos-engine/.codex-plugin/plugin.json"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({"name": "chaos-engine", "version": "1.0.7"}),
+                encoding="utf-8",
+            )
+            data_root = Path(temporary) / "user-data"
+            with mock.patch.dict(module.os.environ, {"XDG_DATA_HOME": str(data_root)}):
+                root, marketplace_name, _, _ = module.activation_contract(project)
+
+            self.assertEqual(
+                data_root / "ChaosEngine/client-marketplaces" / marketplace_name,
+                root,
+            )
+            self.assertNotIn(".chaos-engine-state", str(root))
+
     def test_failed_plugin_upgrade_restores_prior_bundle_and_activation_receipt(self):
         module = load(HOSTS, "chaos_engine_plugin_upgrade_rollback")
         with tempfile.TemporaryDirectory() as temporary:
@@ -287,6 +308,7 @@ class ChaosEngineHostsTest(unittest.TestCase):
             root, marketplace_name, plugin_id, old_version = module.prepare_activation_bundle(project)
             prior = {
                 "marketplaceName": marketplace_name,
+                "bundleRoot": str(root),
                 "ownedClients": [],
                 "pluginVersion": old_version,
                 "claudeLocalBefore": None,
@@ -1933,6 +1955,8 @@ class ChaosEngineHostsTest(unittest.TestCase):
         self.assertNotIn('command = "py"', windows_codex)
         self.assertIn('commandWindows = "py"', windows_codex)
         self.assertIn('"-3", ".chaos-engine/tool.py"', windows_codex)
+        self.assertIn('cwd = "."', windows_codex)
+        self.assertNotIn('cwd = ".."', windows_codex)
 
     def test_legacy_os_baked_mcp_servers_are_replaced_not_collided(self):
         module = load(HOSTS, "chaos_engine_hosts_legacy_mcp_launch")

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -89,9 +89,16 @@ class InstallerUxTests(unittest.TestCase):
         stream = Tty()
         with unittest.mock.patch.dict(os.environ, {"TERM": "xterm", "NO_COLOR": "1"}):
             reporter = BOOTSTRAP.InstallReporter(stream=stream)
-            reporter.start("Verify installation")
-            time.sleep(2.2)
-            reporter.close()
+            try:
+                reporter.start("Verify installation")
+                deadline = time.monotonic() + 5
+                while (
+                    "Elapsed 00:02" not in stream.getvalue()
+                    and time.monotonic() < deadline
+                ):
+                    time.sleep(0.05)
+            finally:
+                reporter.close()
         output = stream.getvalue()
         self.assertIn("Elapsed 00:01", output)
         self.assertIn("Elapsed 00:02", output)

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -35,6 +35,21 @@ def load_acceptance():
 
 
 class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
+    def test_managed_python_version_comes_from_installed_contract(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module)
+        if module is None:
+            return
+        with tempfile.TemporaryDirectory() as temporary:
+            installed = Path(temporary) / ".chaos-engine"
+            installed.mkdir()
+            installed.joinpath("dependencies.json").write_text(
+                json.dumps({"runtimes": {"python": {"version": "3.11"}}}),
+                encoding="utf-8",
+            )
+
+            self.assertEqual("3.11", module.managed_python_version(installed))
+
     def test_runner_contract_is_bounded_and_standard_library_only(self):
         module = load_acceptance()
         self.assertIsNotNone(module, "live installer acceptance runner is missing")

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -35,6 +35,25 @@ def load_acceptance():
 
 
 class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
+    def test_wrapper_failure_keeps_installer_phase_and_component(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module)
+        if module is None:
+            return
+        diagnostic = "\n".join((
+            "long progress output",
+            "CE-INSTALL-FAILED: ChaosEngine doctor did not report a healthy installation",
+            "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/new?"
+            "failed_phase=Verify+installation&unhealthy=hooks&cause=doctor+failed",
+            "PowerShell invocation error",
+        ))
+
+        self.assertEqual(
+            "CE-INSTALL-FAILED: ChaosEngine doctor did not report a healthy installation; "
+            "failed phase: Verify installation; unhealthy: hooks",
+            module.installer_failure_detail(diagnostic),
+        )
+
     def test_managed_python_version_comes_from_installed_contract(self):
         module = load_acceptance()
         self.assertIsNotNone(module)

--- a/tests/scripts/test_chaos_engine_managed_runtimes.py
+++ b/tests/scripts/test_chaos_engine_managed_runtimes.py
@@ -37,7 +37,7 @@ class ManagedRuntimeManifestTest(TestCase):
     def test_manifest_pins_all_supported_runtime_artifacts(self):
         self.assertEqual(2, self.specification["schemaVersion"])
         self.assertEqual("0.11.29", self.specification["runtimes"]["uv"]["version"])
-        self.assertEqual("3.10", self.specification["runtimes"]["python"]["version"])
+        self.assertEqual("3.11", self.specification["runtimes"]["python"]["version"])
         self.assertEqual("24.19.0", self.specification["runtimes"]["node"]["version"])
         self.assertEqual("25.0.4+7", self.specification["runtimes"]["temurin"]["version"])
         for runtime in ("uv", "node"):
@@ -248,7 +248,7 @@ class ManagedRuntimeCliTest(TestCase):
         powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
         for document in (shell, powershell):
             self.assertIn("0.11.29", document)
-            self.assertIn("3.10", document)
+            self.assertIn("3.11", document)
         self.assertIn("--with-maven-tools", shell)
         self.assertIn("WithMavenTools", powershell)
 


### PR DESCRIPTION
## Summary

- Provision managed Python 3.11 for generated tools, hooks, MCP adapters, and live installer acceptance.
- Run Codex MCP servers from the project root and publish marketplace bundles in durable user data.
- Remove only provably stale ChaosEngine marketplace registrations; preserve foreign, unknown, valid, linked, and ambiguous registrations.
- Bind active doctor MCP and hook probes to managed Python and verify configured cwd plus prompt/pre/post hook events.
- Accept `uv`'s same-runtime Windows Python minor-version junction while retaining target, tag, containment, and reparse checks.
- Isolate installer user-data fixtures across platforms, make elapsed-time UX proof scheduler-safe, and retain bounded nested-installer failure context.

Closes #5352
Related to #5354

## Checks

- `python3 -m unittest tests.scripts.test_chaos_engine_hosts.ChaosEngineHostsTest.test_activation_removes_only_proven_stale_owned_marketplace tests.scripts.test_chaos_engine_hosts.ChaosEngineHostsTest.test_activation_preserves_unclassified_broken_marketplace` — RED: 1 error from the unhandled stale marketplace load; preservation passed. GREEN: 2 tests passed.
- `python3 -m unittest tests.scripts.test_chaos_engine_hosts.ChaosEngineHostsTest.test_doctor_mcp_probe_uses_configured_cwd_and_managed_python tests.scripts.test_chaos_engine_hosts.ChaosEngineHostsTest.test_hook_runtime_probe_executes_prompt_pre_and_post_with_managed_python` — 2 tests passed.
- `python3 -m unittest tests.scripts.test_chaos_engine_live_installer_acceptance.ChaosEngineLiveInstallerAcceptanceTest.test_managed_python_version_comes_from_installed_contract` — RED: `AttributeError` because the acceptance runner had no contract reader. GREEN: 1 test passed.
- `python3 -m unittest tests.scripts.test_chaos_engine_live_installer_acceptance.ChaosEngineLiveInstallerAcceptanceTest.test_wrapper_failure_keeps_installer_phase_and_component` — RED: `AttributeError` because nested installer context was discarded. GREEN: 1 test passed.
- `python3 -m unittest tests.scripts.test_chaos_engine_generation_runtime.GenerationRuntimeTests.test_windows_uv_python_alias_accepts_configured_minor_version` — RED: assertion failure because the ownership regex accepted only Python 3.10. GREEN: 1 test passed.
- `python3 -m unittest tests.scripts.test_chaos_engine_generation_runtime.GenerationRuntimeTests.test_posix_uv_interpreter_link_is_canonicalized_bound_and_dispatched` — 1 sibling topology test passed.
- `python3 -m unittest tests.scripts.test_chaos_engine_live_installer_acceptance` — 15 tests passed.
- `python3 -m unittest tests.scripts.test_chaos_engine_managed_runtimes tests.scripts.test_chaos_engine_generation_runtime tests.scripts.test_chaos_engine_hosts tests.scripts.test_chaos_engine_installer tests.scripts.test_chaos_engine_bootstrap tests.scripts.test_chaos_engine_dependencies tests.scripts.test_chaos_engine_hook` — 357 tests passed, 2 skipped on `069608a0c897e3a7a382fd0424892b35eec983d0`.
- `python3 scripts/ci/validate_agent_setup.py --skip-external` — passed; 222931 guidance bytes and 438 memory objects validated. It reported unrelated worktree advisories without changing those worktrees.
- `python3 -m unittest tests.scripts.test_validate_release_notes` — 4 tests passed.
- `git diff --name-only origin/main...HEAD` — 13 expected installer/runtime/host source and test paths; no `chaos-engine/hooks/**` paths.
- `git diff --check origin/main...HEAD` — passed.
- `gh pr checks 5355 --repo ShaftHQ/SHAFT_ENGINE --watch --fail-fast` — passed on the exact head. Fresh installer acceptance passed on Ubuntu 22.04, macOS 15, and Windows 2025; PR Gate Summary, CodeQL, release-note governance, guidance, and body/autoclose gates passed.

## Continuation

- Completed every #5352 implementation and validation gap, including the Windows real-upgrade failure exposed after local checks.
- Branch remains open for review; this continuation does not merge it.
