### PR TITLE
docs(chaos-engine): orchestrator inspect-and-adapt follow-through

### DIFF
--- a/chaos-engine/references/delegation.md
+++ b/chaos-engine/references/delegation.md
@@ -40,8 +40,9 @@ worktree. Hard cap four concurrent writing agents; the owner may set a cap of
 1–4. Refuse a requested cap above 4. File-overlapping writers never run in
 parallel even when parallel is requested. A read-only reviewer does not
 consume a slot. Check real progress for any agent or
-command unexamined for about twenty minutes, and supply a decision, a solved
-subproblem, or a re-spec — never a heartbeat.
+command at most every five minutes while a writer or required check is live,
+and supply a decision, a solved subproblem, or a re-spec — never a heartbeat.
+Follow [orchestrator follow-through](orchestrator-follow-through.md).
 
 Treat agent lifetime as part of the assignment. Collect the writer's bounded
 failures, findings, and durable-learning candidates for the root session; a

--- a/chaos-engine/references/orchestrator-bootstrap.md
+++ b/chaos-engine/references/orchestrator-bootstrap.md
@@ -25,8 +25,8 @@ does. A single stream skips this file and is worked solo, in sequence.
    deferred consolidated proof command. Select the most intelligent, default, or
    mechanical capability using [delegation](delegation.md), never provider
    identity. After every dispatch, update the live status table.
-8. Stay available for architecture and consult decisions, on the check-in
-   cadence in [delegation](delegation.md).
+8. Stay available for architecture and consult decisions; follow
+   [orchestrator follow-through](orchestrator-follow-through.md).
 9. Review the actual diff and tests as [delegation](delegation.md) defines.
    Main thread owns synthesis and final verification. Collect the writer's
    bounded learning handoff, then destroy the finished writer and continue.

--- a/chaos-engine/references/orchestrator-follow-through.md
+++ b/chaos-engine/references/orchestrator-follow-through.md
@@ -1,0 +1,29 @@
+# Orchestrator follow-through
+
+Orchestrators inspect live writers and required checks, consult, remove
+impediments, and continue delivery. Assignment alone is not progress.
+
+## Cadence and inspection
+
+While any writer or required check is live, inspect at most every five minutes.
+No live writers or required checks: no scheduler.
+
+Each inspection must produce a decision, solved subproblem, re-spec, consult
+queue, upgrade, or explicit keep. Never a heartbeat. Validate errors and
+progress before the next handoff; bound retries and escalate instead of waiting
+indefinitely.
+
+## Consult and impediments
+
+Ask what is blocked and what would unblock. Do not rewrite a healthy writer's
+task. Remove tooling, access, and environment impediments;
+coach the owner through how-to-work impediments; escalate owner-only decisions.
+
+## Delivery and escalation
+
+Opening a PR does not complete follow-through. Continue until the in-scope
+delivery condition is met.
+
+Escalate using portable capability levels: mechanical, default, and most
+intelligent. Host dispatch prompts may map those levels to their own capability
+labels; portable policy never binds them to a vendor.

--- a/chaos-engine/references/roles.md
+++ b/chaos-engine/references/roles.md
@@ -18,7 +18,8 @@ entrypoint's solo-or-orchestrate rule, never decided here. Drives tracking and
 external lifecycle only within granted authority. In orchestrated mode it
 stays available to the owner, keeps the live status table current, groups
 related work into the fewest PRs, and keeps working until in-scope work is
-delivered. In orchestrated mode it does no task work itself.
+delivered. Follow [orchestrator follow-through](orchestrator-follow-through.md).
+In orchestrated mode it does no task work itself.
 
 ## Implementer
 

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -225,7 +225,8 @@ Orchestrating keeps you reachable for owner or delegate decisions. In this mode
 you make no edits, run no long job, and install nothing;
 [delegation](../../references/delegation.md) lists what stays yours, including the
 live status table, fewest-PR grouping, keep-working-until-delivered loop, and
-delegate finding handoff before kill. The root owns the sole terminal Learning Session.
+delegate finding handoff before kill. Follow [orchestrator follow-through](../../references/orchestrator-follow-through.md)
+while work is live. The root owns the sole terminal Learning Session.
 
 **Default serial, optional parallel.** One writer at a time, ordered by
 dependency then priority. On owner request, parallelize independent writers up to

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -908,6 +908,17 @@ class ChaosEngineOrchestratorModeTest(unittest.TestCase):
         ]
         return re.sub(r"\s+", " ", "\n".join(texts))
 
+    def test_orchestrator_follow_through_is_inspect_and_adapt_not_waiting(self):
+        follow_through = CORE / "references/orchestrator-follow-through.md"
+        self.assertTrue(follow_through.is_file())
+        policy = re.sub(r"\s+", " ", follow_through.read_text(encoding="utf-8"))
+        self.assertIn("at most every five minutes", policy)
+        self.assertIn("While any writer or required check is live", policy)
+        self.assertIn("No live writers or required checks: no scheduler", policy)
+        self.assertIn("ask what is blocked and what would unblock", policy.lower())
+        self.assertIn("Never a heartbeat", policy)
+        self.assertIn("Opening a PR does not complete follow-through", policy)
+
     def test_entrypoint_auto_switches_and_forbids_self_work_with_serial_default(self):
         skill = self._skill()
         self.assertIn('Do not wait for the owner to say "orchestrate"', skill)


### PR DESCRIPTION
Closes #5356

Related to #5354 as incident context only.

## Summary

- Add one portable orchestrator follow-through policy with inspect-and-adapt cadence, consult, impediment ownership, and escalation rules.
- Point canonical orchestration guidance at that policy and pin its behavior.

Research:

- https://scrumguides.org/scrum-guide.html
- https://kindatechnical.com/agile-methodologies/scrum-master-servant-leader.html
- https://learn.microsoft.com/en-us/azure/architecture/ai-ml/guide/ai-agent-design-patterns
- https://agent.minimax.io/docs/techblog/agent-team

## Checks

- `python3 -m unittest tests.scripts.test_chaos_engine_portable_core tests.scripts.test_agent_harness_portability`

## Continuation

- Follow-through continues through review and merge; opening this PR is not completion.