### PR TITLE
docs(chaos-engine): auto-inspect live writers every five minutes

### DIFF
--- a/chaos-engine/references/delegation.md
+++ b/chaos-engine/references/delegation.md
@@ -39,10 +39,10 @@ request, parallelize only independent file scopes. Each writer owns an isolated
 worktree. Hard cap four concurrent writing agents; the owner may set a cap of
 1–4. Refuse a requested cap above 4. File-overlapping writers never run in
 parallel even when parallel is requested. A read-only reviewer does not
-consume a slot. Check real progress for any agent or
-command at most every five minutes while a writer or required check is live,
-and supply a decision, a solved subproblem, or a re-spec — never a heartbeat.
-Follow [orchestrator follow-through](orchestrator-follow-through.md).
+consume a slot. While a writer, subagent, or required check is live,
+automatically follow the floor-and-ceiling inspection cadence in
+[orchestrator follow-through](orchestrator-follow-through.md); never a
+heartbeat.
 
 Treat agent lifetime as part of the assignment. Collect the writer's bounded
 failures, findings, and durable-learning candidates for the root session; a

--- a/chaos-engine/references/orchestrator-follow-through.md
+++ b/chaos-engine/references/orchestrator-follow-through.md
@@ -5,13 +5,19 @@ impediments, and continue delivery. Assignment alone is not progress.
 
 ## Cadence and inspection
 
-While any writer or required check is live, inspect at most every five minutes.
+While any writer or required check is live, including a live subagent,
+automatically inspect on a five-minute cadence. Floor: inspect at least every
+five minutes, without the owner asking. Ceiling: do not inspect more often than
+every five minutes except on dispatch, completion, failure, or owner/delegate
+interrupt. First inspect as soon as dispatch yields a live handle. Use the host
+timer or scheduler when it has one; otherwise the next main-thread wake still
+owes the inspection.
 No live writers or required checks: no scheduler.
 
-Each inspection must produce a decision, solved subproblem, re-spec, consult
-queue, upgrade, or explicit keep. Never a heartbeat. Validate errors and
-progress before the next handoff; bound retries and escalate instead of waiting
-indefinitely.
+Each inspection is a scrum: establish blocked or unblocked state and evidence
+of progress, then keep / re-spec / upgrade / kill. Never a heartbeat. Validate
+errors and progress before the next handoff; bound retries and escalate instead
+of waiting indefinitely.
 
 ## Consult and impediments
 

--- a/chaos-engine/references/roles.md
+++ b/chaos-engine/references/roles.md
@@ -19,6 +19,8 @@ external lifecycle only within granted authority. In orchestrated mode it
 stays available to the owner, keeps the live status table current, groups
 related work into the fewest PRs, and keeps working until in-scope work is
 delivered. Follow [orchestrator follow-through](orchestrator-follow-through.md).
+Its standing duty is to automatically inspect and adapt live work on that
+policy's floor-and-ceiling cadence.
 In orchestrated mode it does no task work itself.
 
 ## Implementer

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -226,7 +226,7 @@ you make no edits, run no long job, and install nothing;
 [delegation](../../references/delegation.md) lists what stays yours, including the
 live status table, fewest-PR grouping, keep-working-until-delivered loop, and
 delegate finding handoff before kill. Follow [orchestrator follow-through](../../references/orchestrator-follow-through.md)
-while work is live. The root owns the sole terminal Learning Session.
+automatically while work is live. The root owns the sole terminal Learning Session.
 
 **Default serial, optional parallel.** One writer at a time, ordered by
 dependency then priority. On owner request, parallelize independent writers up to

--- a/tests/scripts/test_chaos_engine_portable_core.py
+++ b/tests/scripts/test_chaos_engine_portable_core.py
@@ -886,7 +886,7 @@ class ChaosEnginePortableCoreTest(unittest.TestCase):
         self.assertIn("consultant agent", compact_skill)
 
 
-class ChaosEngineOrchestratorModeTest(unittest.TestCase):
+class OrchestratorModeContractTest(unittest.TestCase):
     """Portable orchestrator-mode pins (#5210, #5246, #5249)."""
 
     def _skill(self) -> str:
@@ -912,10 +912,13 @@ class ChaosEngineOrchestratorModeTest(unittest.TestCase):
         follow_through = CORE / "references/orchestrator-follow-through.md"
         self.assertTrue(follow_through.is_file())
         policy = re.sub(r"\s+", " ", follow_through.read_text(encoding="utf-8"))
-        self.assertIn("at most every five minutes", policy)
+        self.assertIn("Floor: inspect at least every five minutes", policy)
+        self.assertIn("without the owner asking", policy)
+        self.assertIn("Ceiling: do not inspect more often than every five minutes", policy)
         self.assertIn("While any writer or required check is live", policy)
         self.assertIn("No live writers or required checks: no scheduler", policy)
         self.assertIn("ask what is blocked and what would unblock", policy.lower())
+        self.assertIn("keep / re-spec / upgrade / kill", policy)
         self.assertIn("Never a heartbeat", policy)
         self.assertIn("Opening a PR does not complete follow-through", policy)
 


### PR DESCRIPTION
## Summary

Makes orchestrator live-writer inspection automatic. Owner never asks.

Canonical policy in `orchestrator-follow-through.md`: five-minute floor and ceiling, first inspect on dispatch, host scheduler when available, scrum decision `keep / re-spec / upgrade / kill`. Stop when nothing is live.

Thin pointers in delegation, roles, and the ChaosEngine skill. Host adapters unchanged.

Closes #5360

## Checks

- `python3 -m unittest tests.scripts.test_chaos_engine_portable_core.OrchestratorModeContractTest.test_orchestrator_follow_through_is_inspect_and_adapt_not_waiting` and sibling orchestrator-mode pins

## Continuation

Independent review of this head, then arm merge.