### PR TITLE
test(installer): verify MCP initialize handshakes

### DIFF
--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -338,12 +338,39 @@ def probe_mcp(command: list[str], project: Path, *, popen=subprocess.Popen) -> N
         raise RuntimeError(
             f"MCP connection closed during initialize: {sanitize(stderr or stdout)}"
         ) from error
-    if process.returncode or response.get("id") != 1 or not isinstance(
-        response.get("result"), dict
+    result = response.get("result")
+    server = result.get("serverInfo") if isinstance(result, dict) else None
+    if (
+        process.returncode
+        or response.get("jsonrpc") != "2.0"
+        or response.get("id") != 1
+        or not isinstance(result, dict)
+        or not isinstance(result.get("protocolVersion"), str)
+        or not isinstance(result.get("capabilities"), dict)
+        or not isinstance(server, dict)
+        or not isinstance(server.get("name"), str)
+        or not isinstance(server.get("version"), str)
     ):
         raise RuntimeError(
             f"MCP initialize failed: {sanitize(stderr or stdout)}"
         )
+
+
+def probe_project_mcps(tool: Path, project: Path) -> None:
+    commands = (
+        [sys.executable, str(tool), "memory-mcp"],
+        [
+            sys.executable,
+            str(tool),
+            "mempalace-mcp",
+            "--palace",
+            ".chaos-engine-state/mempalace",
+            "--backend",
+            "sqlite_exact",
+        ],
+    )
+    for command in commands:
+        probe_mcp(command, project)
 
 
 def verify_phase(project: Path, expected_commit: str) -> dict[str, object]:
@@ -385,21 +412,8 @@ def verify_phase(project: Path, expected_commit: str) -> dict[str, object]:
     for name, arguments in PROBES.items():
         run_checked([sys.executable, str(tool), name, *arguments], cwd=project, timeout=120)
         dispatches[name] = "pass"
-    mcp_commands = {
-        "memory-mcp": [sys.executable, str(tool), "memory-mcp"],
-        "mempalace-mcp": [
-            sys.executable,
-            str(tool),
-            "mempalace-mcp",
-            "--palace",
-            ".chaos-engine-state/mempalace",
-            "--backend",
-            "sqlite_exact",
-        ],
-    }
-    for name, command in mcp_commands.items():
-        probe_mcp(command, project)
-        dispatches[name] = "pass"
+    probe_project_mcps(tool, project)
+    dispatches.update({"memory-mcp": "pass", "mempalace-mcp": "pass"})
 
     pointer_path = project / ".chaos-engine-runtime-current.json"
     if pointer_path.stat().st_size > 16 * 1024:

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -28,6 +28,7 @@ PROBES = {
 }
 PHASE_TIMEOUT_SECONDS = 600
 MCP_START_TIMEOUT_SECONDS = 10
+MCP_PROTOCOL_VERSION = "2025-06-18"
 COMMIT = re.compile(r"[0-9a-f]{40}")
 HEX_ID = re.compile(r"[0-9a-f]{32}")
 SECRET_NAME = re.compile(r"(?:TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY)", re.I)
@@ -305,7 +306,7 @@ def probe_mcp(command: list[str], project: Path, *, popen=subprocess.Popen) -> N
             "id": 1,
             "method": "initialize",
             "params": {
-                "protocolVersion": "2025-06-18",
+                "protocolVersion": MCP_PROTOCOL_VERSION,
                 "capabilities": {},
                 "clientInfo": {"name": "chaos-engine-acceptance", "version": "1"},
             },
@@ -343,9 +344,10 @@ def probe_mcp(command: list[str], project: Path, *, popen=subprocess.Popen) -> N
     if (
         process.returncode
         or response.get("jsonrpc") != "2.0"
+        or type(response.get("id")) is not int
         or response.get("id") != 1
         or not isinstance(result, dict)
-        or not isinstance(result.get("protocolVersion"), str)
+        or result.get("protocolVersion") != MCP_PROTOCOL_VERSION
         or not isinstance(result.get("capabilities"), dict)
         or not isinstance(server, dict)
         or not isinstance(server.get("name"), str)

--- a/scripts/ci/chaos_engine_live_installer_acceptance.py
+++ b/scripts/ci/chaos_engine_live_installer_acceptance.py
@@ -25,7 +25,6 @@ PROBES = {
     "mempalace": ["--version"],
     "graphify": ["--version"],
     "memory": ["--help"],
-    "memory-mcp": ["--help"],
 }
 PHASE_TIMEOUT_SECONDS = 600
 MCP_START_TIMEOUT_SECONDS = 10
@@ -299,26 +298,32 @@ def run_public_wrapper(
         raise RuntimeError("public wrapper did not report detected client activation")
 
 
-def probe_mempalace_mcp(tool: Path, project: Path) -> None:
-    command = [
-        sys.executable,
-        str(tool),
-        "mempalace-mcp",
-        "--palace",
-        ".chaos-engine-state/mempalace",
-        "--backend",
-        "sqlite_exact",
-    ]
-    process = subprocess.Popen(  # nosec B603
+def probe_mcp(command: list[str], project: Path, *, popen=subprocess.Popen) -> None:
+    request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "chaos-engine-acceptance", "version": "1"},
+            },
+        }
+    ) + "\n"
+    process = popen(  # nosec B603
         command,
         cwd=project,
         env={**clean_environment(), "PYTHONDONTWRITEBYTECODE": "1"},
+        stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
     )
     try:
-        stdout, stderr = process.communicate(timeout=MCP_START_TIMEOUT_SECONDS)
+        stdout, stderr = process.communicate(
+            request, timeout=MCP_START_TIMEOUT_SECONDS
+        )
     except subprocess.TimeoutExpired:
         process.terminate()
         try:
@@ -326,10 +331,18 @@ def probe_mempalace_mcp(tool: Path, project: Path) -> None:
         except subprocess.TimeoutExpired:
             process.kill()
             process.communicate(timeout=5)
-        return
-    if process.returncode:
+        raise RuntimeError("MCP initialize timed out")
+    try:
+        response = json.loads(stdout.splitlines()[0])
+    except (IndexError, json.JSONDecodeError) as error:
         raise RuntimeError(
-            f"mempalace-mcp exited during startup: {sanitize(stderr or stdout)}"
+            f"MCP connection closed during initialize: {sanitize(stderr or stdout)}"
+        ) from error
+    if process.returncode or response.get("id") != 1 or not isinstance(
+        response.get("result"), dict
+    ):
+        raise RuntimeError(
+            f"MCP initialize failed: {sanitize(stderr or stdout)}"
         )
 
 
@@ -372,8 +385,21 @@ def verify_phase(project: Path, expected_commit: str) -> dict[str, object]:
     for name, arguments in PROBES.items():
         run_checked([sys.executable, str(tool), name, *arguments], cwd=project, timeout=120)
         dispatches[name] = "pass"
-    probe_mempalace_mcp(tool, project)
-    dispatches["mempalace-mcp"] = "pass"
+    mcp_commands = {
+        "memory-mcp": [sys.executable, str(tool), "memory-mcp"],
+        "mempalace-mcp": [
+            sys.executable,
+            str(tool),
+            "mempalace-mcp",
+            "--palace",
+            ".chaos-engine-state/mempalace",
+            "--backend",
+            "sqlite_exact",
+        ],
+    }
+    for name, command in mcp_commands.items():
+        probe_mcp(command, project)
+        dispatches[name] = "pass"
 
     pointer_path = project / ".chaos-engine-runtime-current.json"
     if pointer_path.stat().st_size > 16 * 1024:

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -545,29 +545,40 @@ class InstallerUxTests(unittest.TestCase):
             (ValueError("unsupported platform: solaris/sparc"), "CE-INSTALL-UNSUPPORTED-PLATFORM"),
             (RuntimeError("memory-mcp entrypoint probe failed"), "CE-INSTALL-PROBE-FAILED"),
         )
-        for error, code in cases:
-            with self.subTest(code=code):
-                stdout = io.StringIO()
-                stderr = io.StringIO()
-                with unittest.mock.patch.object(BOOTSTRAP, "install_latest", side_effect=error), unittest.mock.patch.object(
-                    BOOTSTRAP.sys, "stdout", stdout
-                ), unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr), unittest.mock.patch.object(
-                    BOOTSTRAP.sys, "argv", ["bootstrap.py", "--project", ".", "--repository", "owner/repo"]
-                ):
-                    self.assertEqual(1, BOOTSTRAP.main())
-                self.assertEqual("", stdout.getvalue())
-                self.assertIn(str(error).split("\n", 1)[0], stderr.getvalue())
-                self.assertIn(code, stderr.getvalue())
-                self.assertIn("#installer-errors", stderr.getvalue())
-                self.assertIn("Installer CLI is not on disk", stderr.getvalue())
-                if code == "CE-INSTALL-FAILED":
-                    self.assertIn("Next step: click this link to open a GitHub issue", stderr.getvalue())
-                    report = [
-                        line for line in stderr.getvalue().splitlines()
-                        if line.startswith("https://github.com/owner/repo/issues/new?")
-                    ][0]
-                    self.assertIn("template=chaos-engine-installer.yml", report)
-                    self.assertLessEqual(len(report), 2000)
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "project"
+            project.mkdir()
+            for error, code in cases:
+                with self.subTest(code=code):
+                    stdout = io.StringIO()
+                    stderr = io.StringIO()
+                    with unittest.mock.patch.object(BOOTSTRAP, "install_latest", side_effect=error), unittest.mock.patch.object(
+                        BOOTSTRAP.sys, "stdout", stdout
+                    ), unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr), unittest.mock.patch.object(
+                        BOOTSTRAP.sys,
+                        "argv",
+                        [
+                            "bootstrap.py",
+                            "--project",
+                            str(project),
+                            "--repository",
+                            "owner/repo",
+                        ],
+                    ):
+                        self.assertEqual(1, BOOTSTRAP.main())
+                    self.assertEqual("", stdout.getvalue())
+                    self.assertIn(str(error).split("\n", 1)[0], stderr.getvalue())
+                    self.assertIn(code, stderr.getvalue())
+                    self.assertIn("#installer-errors", stderr.getvalue())
+                    self.assertIn("Installer CLI is not on disk", stderr.getvalue())
+                    if code == "CE-INSTALL-FAILED":
+                        self.assertIn("Next step: click this link to open a GitHub issue", stderr.getvalue())
+                        report = [
+                            line for line in stderr.getvalue().splitlines()
+                            if line.startswith("https://github.com/owner/repo/issues/new?")
+                        ][0]
+                        self.assertIn("template=chaos-engine-installer.yml", report)
+                        self.assertLessEqual(len(report), 2000)
 
     def test_keyboard_interrupt_emits_cancelled_without_traceback(self):
         stdout = io.StringIO()

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -88,6 +88,38 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
                 imported.add(node.module.split(".", 1)[0])
         self.assertTrue(imported <= sys.stdlib_module_names, imported - sys.stdlib_module_names)
 
+    def test_mcp_probe_requires_successful_initialize_response(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module)
+        if module is None:
+            return
+        process = mock.Mock()
+        process.communicate.return_value = (
+            '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"fixture"}}}\n',
+            "",
+        )
+        process.returncode = 0
+
+        module.probe_mcp(["fixture-mcp"], ROOT, popen=lambda *_args, **_kwargs: process)
+
+        request = json.loads(process.communicate.call_args.args[0])
+        self.assertEqual("initialize", request["method"])
+        self.assertEqual(1, request["id"])
+
+    def test_mcp_probe_rejects_closed_initialize_handshake(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module)
+        if module is None:
+            return
+        process = mock.Mock()
+        process.communicate.return_value = ("", "server exited")
+        process.returncode = 1
+
+        with self.assertRaisesRegex(RuntimeError, "closed during initialize"):
+            module.probe_mcp(
+                ["fixture-mcp"], ROOT, popen=lambda *_args, **_kwargs: process
+            )
+
     def test_offline_environment_blocks_package_network_and_hides_secrets(self):
         module = load_acceptance()
         self.assertIsNotNone(module, "live installer acceptance runner is missing")

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -139,6 +139,29 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
                 ["fixture-mcp"], ROOT, popen=lambda *_args, **_kwargs: process
             )
 
+    def test_mcp_probe_rejects_wrong_protocol_and_boolean_id(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module)
+        if module is None:
+            return
+        responses = (
+            '{"jsonrpc":"2.0","id":true,"result":{"protocolVersion":"2025-06-18",'
+            '"capabilities":{},"serverInfo":{"name":"fixture","version":"1"}}}\n',
+            '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"garbage",'
+            '"capabilities":{},"serverInfo":{"name":"fixture","version":"1"}}}\n',
+        )
+        for response in responses:
+            with self.subTest(response=response):
+                process = mock.Mock()
+                process.communicate.return_value = (response, "")
+                process.returncode = 0
+                with self.assertRaisesRegex(RuntimeError, "initialize failed"):
+                    module.probe_mcp(
+                        ["fixture-mcp"],
+                        ROOT,
+                        popen=lambda *_args, **_kwargs: process,
+                    )
+
     def test_project_mcp_probe_covers_memory_and_mempalace(self):
         module = load_acceptance()
         self.assertIsNotNone(module)

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -95,7 +95,9 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
             return
         process = mock.Mock()
         process.communicate.return_value = (
-            '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"fixture"}}}\n',
+            '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18",'
+            '"capabilities":{"tools":{}},"serverInfo":{"name":"fixture",'
+            '"version":"1"}}}\n',
             "",
         )
         process.returncode = 0
@@ -119,6 +121,35 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
             module.probe_mcp(
                 ["fixture-mcp"], ROOT, popen=lambda *_args, **_kwargs: process
             )
+
+    def test_mcp_probe_rejects_incomplete_initialize_result(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module)
+        if module is None:
+            return
+        process = mock.Mock()
+        process.communicate.return_value = (
+            '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{}}}\n',
+            "",
+        )
+        process.returncode = 0
+
+        with self.assertRaisesRegex(RuntimeError, "initialize failed"):
+            module.probe_mcp(
+                ["fixture-mcp"], ROOT, popen=lambda *_args, **_kwargs: process
+            )
+
+    def test_project_mcp_probe_covers_memory_and_mempalace(self):
+        module = load_acceptance()
+        self.assertIsNotNone(module)
+        if module is None:
+            return
+        tool = ROOT / ".chaos-engine/tool.py"
+        with mock.patch.object(module, "probe_mcp") as probe:
+            module.probe_project_mcps(tool, ROOT)
+
+        commands = {call.args[0][2] for call in probe.call_args_list}
+        self.assertEqual({"memory-mcp", "mempalace-mcp"}, commands)
 
     def test_offline_environment_blocks_package_network_and_hides_secrets(self):
         module = load_acceptance()


### PR DESCRIPTION
## Summary
- replace shallow MCP startup checks with real JSON-RPC initialize handshakes
- validate exact protocol negotiation and server metadata
- cover both Memory and MemPalace launch contracts, including closed connections and malformed responses

## Validation
- `python3 -m unittest tests.scripts.test_chaos_engine_live_installer_acceptance`
- real fresh installation of the repository distribution
- real Memory and MemPalace initialize probes through the installed `.chaos-engine/tool.py`
- `git diff --check`

## Notes
A fresh installation succeeded before this change, confirming the reported local failure came from missing machine-local runtime state rather than the installer transaction. This change strengthens the live installer acceptance boundary so the same client-visible handshake failure cannot pass CI through `--help` probes.