### PR TITLE
fix(ci): consolidate IntelliJ Marketplace publishing

### DIFF
--- a/.github/actions/notify-intellij-marketplace-publish/action.yml
+++ b/.github/actions/notify-intellij-marketplace-publish/action.yml
@@ -1,7 +1,7 @@
 name: 'Notify IntelliJ Marketplace Publish Miss'
 description: >-
   Fail closed when a Publish IntelliJ Plugin run does not complete publishPlugin.
-  A release cancelled/timeout/failure files or keeps a dedicated tracking issue.
+  An automatic release failure files or keeps a dedicated tracking issue.
   Nightly cancelled=skip must not own this path.
 inputs:
   verify-result:
@@ -10,9 +10,14 @@ inputs:
   publish-result:
     description: 'needs.publish.result'
     required: true
-  event-name:
-    description: 'github.event_name'
-    required: true
+  manage-tracker:
+    description: 'When true, file, update, or close the automatic release tracker.'
+    required: false
+    default: 'false'
+  publish-required:
+    description: 'When false, prerequisite release gates prevented an expected publish.'
+    required: false
+    default: 'true'
   plugin-version:
     description: 'Plugin version. Falls back to shaft-intellij/gradle.properties.'
     required: false
@@ -34,7 +39,8 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         VERIFY_RESULT: ${{ inputs.verify-result }}
         PUBLISH_RESULT: ${{ inputs.publish-result }}
-        EVENT_NAME: ${{ inputs.event-name }}
+        MANAGE_TRACKER: ${{ inputs.manage-tracker }}
+        PUBLISH_REQUIRED: ${{ inputs.publish-required }}
         PLUGIN_VERSION: ${{ inputs.plugin-version }}
         LABEL: ${{ inputs.label }}
         REPO: ${{ github.repository }}
@@ -50,8 +56,13 @@ runs:
           version="unknown"
         fi
 
+        if [ "$PUBLISH_REQUIRED" != "true" ]; then
+          echo "Marketplace publish was not required because prerequisite release gates did not pass."
+          exit 0
+        fi
+
         if [ "$PUBLISH_RESULT" = "success" ]; then
-          if [ "$EVENT_NAME" = "release" ]; then
+          if [ "$MANAGE_TRACKER" = "true" ]; then
             existing=$(gh issue list --repo "$REPO" --state open --label "$LABEL" \
               --json number --jq '.[0].number // empty')
             if [ -n "$existing" ]; then
@@ -67,7 +78,7 @@ runs:
 
         echo "::error::IntelliJ Marketplace publish did not succeed (verify=$VERIFY_RESULT publish=$PUBLISH_RESULT version=$version). Coverage success must not hide this miss."
 
-        if [ "$EVENT_NAME" = "release" ]; then
+        if [ "$MANAGE_TRACKER" = "true" ]; then
           gh label create "$LABEL" --repo "$REPO" --color B60205 \
             --description "Dedicated tracker for a missed IntelliJ Marketplace publish" --force >/dev/null 2>&1 || true
           existing=$(gh issue list --repo "$REPO" --state open --label "$LABEL" \
@@ -78,7 +89,7 @@ runs:
             echo "Updated existing tracking issue #$existing."
           else
             BODY=$(printf '%s\n' \
-              "A **release-triggered** IntelliJ Marketplace publish did not complete \`publishPlugin\`." \
+              "An **automatic release** IntelliJ Marketplace publish did not complete \`publishPlugin\`." \
               "" \
               "- Version: \`$version\`" \
               "- Verify job: \`$VERIFY_RESULT\`" \

--- a/.github/workflows/mavenCentral_cd.yml
+++ b/.github/workflows/mavenCentral_cd.yml
@@ -5,6 +5,8 @@ name: Maven Central Continuous Delivery
 # build_release_and_deliver stays sequential so deploy cannot run after a failed test.
 # Named checks stay mirrored with shaft-pilot-release.yml's isolated jobs. Keep the
 # named checks in sync; do not re-serialize the PR gate to match this deploy path.
+# Marketplace publish and release announcement run in parallel after delivery and
+# public-installer verification; the standalone plugin workflow is manual recovery only.
 
 on:
   push:
@@ -260,6 +262,50 @@ jobs:
       - name: Run the public LATEST installer twice
         run: python scripts/ci/verify_shaft_mcp_installer_release.py
 
+  publish_intellij_plugin:
+    name: Publish IntelliJ plugin
+    needs: [build_release_and_deliver, verify_public_shaft_mcp_installer]
+    if: needs.build_release_and_deliver.result == 'success'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    concurrency:
+      group: publish-intellij-plugin
+      cancel-in-progress: false
+    steps:
+      - name: Checkout released source
+        uses: actions/checkout@v7
+      - name: Publish to JetBrains Marketplace
+        uses: ./.github/actions/intellij-verify
+        with:
+          publish: 'true'
+          verify: 'false'
+          marketplace-token: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+          certificate-chain: ${{ secrets.JETBRAINS_PLUGIN_CERTIFICATE_CHAIN }}
+          private-key: ${{ secrets.JETBRAINS_PLUGIN_PRIVATE_KEY }}
+          private-key-password: ${{ secrets.JETBRAINS_PLUGIN_PRIVATE_KEY_PASSWORD }}
+
+  notify_intellij_marketplace_publish:
+    name: Fail closed on missed Marketplace publish
+    needs: [build_release_and_deliver, verify_public_shaft_mcp_installer, publish_intellij_plugin]
+    if: always()
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout released source
+        uses: actions/checkout@v7
+      - name: File, keep, or close the Marketplace publish tracker
+        uses: ./.github/actions/notify-intellij-marketplace-publish
+        with:
+          verify-result: ${{ needs.build_release_and_deliver.result }}
+          publish-result: ${{ needs.publish_intellij_plugin.result }}
+          manage-tracker: 'true'
+          publish-required: ${{ needs.build_release_and_deliver.result == 'success' && needs.verify_public_shaft_mcp_installer.result == 'success' }}
+          plugin-version: ${{ needs.build_release_and_deliver.outputs.release_version }}
+          label: intellij-marketplace-publish-miss
+
   announce_release:
     name: Announce verified release
     needs: [build_release_and_deliver, verify_public_shaft_mcp_installer]
@@ -286,9 +332,8 @@ jobs:
         uses: ncipollo/release-action@v1.21.0
         with:
           # A release created with the default GITHUB_TOKEN does not emit a `release`
-          # event (GitHub's anti-recursion rule), so publish-intellij-plugin.yml and
-          # publish-shaft-mcp.yml — which both listen for `release: published` — would
-          # never fire. BOT_TOKEN is a PAT, so its release does trigger those workflows.
+          # event (GitHub's anti-recursion rule), so publish-shaft-mcp.yml would never
+          # fire. BOT_TOKEN is a PAT, so its release triggers that workflow.
           token: ${{ secrets.BOT_TOKEN }}
           allowUpdates: false
           generateReleaseNotes: true

--- a/.github/workflows/publish-intellij-plugin.yml
+++ b/.github/workflows/publish-intellij-plugin.yml
@@ -1,8 +1,6 @@
 name: Publish IntelliJ Plugin
 
 on:
-  release:
-    types: [ published ]
   workflow_dispatch:
 
 permissions:
@@ -14,11 +12,6 @@ concurrency:
 
 jobs:
   verify:
-    # Runs only for an actual published SHAFT release (created by mavenCentral_cd.yml's
-    # announce_release job), not merely because that workflow's run concluded successfully -
-    # its build_release_and_deliver job now also concludes successfully when it skips a
-    # no-op delivery for an already-published version, which must not re-publish here.
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: ubuntu-22.04
     # Room for the one retry the verification half of intellij-verify now takes
     # when the JetBrains host refuses a connect (issue #4494). Publish is a
@@ -27,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       - name: Validate release metadata
         run: python3 scripts/ci/validate_shaft_pilot_release.py
       - name: Verify IntelliJ plugin
@@ -44,7 +35,6 @@ jobs:
 
   publish:
     needs: verify
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: ubuntu-22.04
     # Own budget for sign and Marketplace upload. Never wrap that upload in
     # the verify retry helper: a Marketplace version number is single-use.
@@ -52,8 +42,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       - name: Publish to JetBrains Marketplace
         uses: ./.github/actions/intellij-verify
         with:
@@ -76,13 +64,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       - name: File a dedicated miss issue when a release does not publish
         uses: ./.github/actions/notify-intellij-marketplace-publish
         with:
           verify-result: ${{ needs.verify.result }}
           publish-result: ${{ needs.publish.result }}
-          event-name: ${{ github.event_name }}
-          plugin-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+          manage-tracker: 'false'
           label: intellij-marketplace-publish-miss

--- a/scripts/ci/assert_intellij_marketplace_receipt.py
+++ b/scripts/ci/assert_intellij_marketplace_receipt.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""Fail if publishPlugin left no Gradle or Marketplace receipt for this version.
+"""Fail if publishPlugin left no successful Gradle upload receipt.
 
 Issue #5221: a cancelled verify+publish composite looked partly healthy because
 coverage uploaded `if: always()`. A successful Marketplace publish must leave a
-Gradle `BUILD SUCCESSFUL` receipt and the version must appear on plugin 32529.
+Gradle `BUILD SUCCESSFUL` receipt. The version listing on plugin 32529 is advisory.
 
-Issue #5227: Marketplace listing can lag the upload by more than the original
-5x15s budget. Wait long enough for a valid public listing, and if the version
-is still absent after a Gradle success, say listing is lagging rather than
-treating the landed upload as a miss that invites another dispatch.
+Issues #5227 and #5344: Marketplace listing is eventually consistent and can
+lag an accepted upload beyond any short CI polling budget. A successful
+publishPlugin is the upload receipt; public listing remains an advisory check
+that must never invite another dispatch of the single-use version.
 """
 
 from __future__ import annotations
@@ -82,16 +82,10 @@ def marketplace_receipt_errors(
 
 def receipt_errors(log_text: str, properties_text: str, updates_json: str) -> list[str]:
     errors = gradle_receipt_errors(log_text)
-    gradle_succeeded = not errors
     try:
-        version = plugin_version_from_properties(properties_text)
+        plugin_version_from_properties(properties_text)
     except ValueError as error:
         return errors + [str(error)]
-    errors.extend(
-        marketplace_receipt_errors(
-            updates_json, version, gradle_succeeded=gradle_succeeded
-        )
-    )
     return errors
 
 
@@ -103,7 +97,7 @@ def fetch_updates(url: str = MARKETPLACE_UPDATES_URL, timeout: int = 30) -> str:
 
 def fetch_updates_with_retry(
     url: str = MARKETPLACE_UPDATES_URL,
-    attempts: int = 12,
+    attempts: int = 1,
     delay_seconds: float = 15,
     sleeper=time.sleep,
     fetcher=fetch_updates,
@@ -149,32 +143,46 @@ def main(argv: list[str] | None = None) -> int:
     log_text = args.log.read_text(encoding="utf-8")
     properties_text = args.properties.read_text(encoding="utf-8")
     gradle_errors = gradle_receipt_errors(log_text)
-    if gradle_errors and args.updates_json is None:
+    if gradle_errors:
         print("\n".join(gradle_errors), file=sys.stderr)
+        return 1
+    try:
+        version = plugin_version_from_properties(properties_text)
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
         return 1
     if args.updates_json is not None:
         updates_json = args.updates_json.read_text(encoding="utf-8")
     else:
-        try:
-            version = plugin_version_from_properties(properties_text)
-        except ValueError as error:
-            print(str(error), file=sys.stderr)
-            return 1
         try:
             updates_json = fetch_updates_with_retry(
                 url=args.updates_url,
                 version=version,
             )
         except RuntimeError as error:
-            print(str(error), file=sys.stderr)
-            return 1
-    errors = receipt_errors(log_text, properties_text, updates_json)
-    if errors:
-        print("\n".join(errors), file=sys.stderr)
-        return 1
-    version = plugin_version_from_properties(properties_text)
+            print(
+                f"Marketplace visibility check unavailable after accepted upload: {error}",
+                file=sys.stderr,
+            )
+            return 0
+    try:
+        versions = marketplace_versions(updates_json)
+    except (ValueError, json.JSONDecodeError) as error:
+        print(
+            f"Marketplace visibility check unreadable after accepted upload: {error}",
+            file=sys.stderr,
+        )
+        return 0
+    if version not in versions:
+        print(
+            f"Marketplace accepted plugin {MARKETPLACE_PLUGIN_ID} version {version}; "
+            "public listing is still pending. Do not re-dispatch this single-use version.",
+            file=sys.stderr,
+        )
+        return 0
     print(
-        f"Marketplace receipt confirmed for plugin {MARKETPLACE_PLUGIN_ID} version {version}."
+        f"Marketplace listing confirmed for plugin {MARKETPLACE_PLUGIN_ID} "
+        f"version {version}."
     )
     return 0
 

--- a/tests/scripts/test_assert_intellij_marketplace_receipt.py
+++ b/tests/scripts/test_assert_intellij_marketplace_receipt.py
@@ -1,7 +1,9 @@
 import importlib.util
 import inspect
+import io
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from urllib.error import URLError
 
@@ -33,12 +35,9 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
         )
         self.assertTrue(any("BUILD SUCCESSFUL" in error for error in errors), errors)
 
-    def test_marketplace_without_the_version_fails(self):
+    def test_marketplace_without_the_version_is_advisory_after_gradle_success(self):
         errors = MODULE.receipt_errors(SUCCESS_LOG, PROPERTIES, MISSING)
-        self.assertTrue(
-            any("10.3.20260818" in error for error in errors),
-            errors,
-        )
+        self.assertEqual([], errors)
 
     def test_empty_log_fails_even_if_marketplace_lists_the_version(self):
         errors = MODULE.receipt_errors("", PROPERTIES, LISTED)
@@ -106,7 +105,7 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
             MODULE.fetch_updates_with_retry = original
         self.assertEqual("10.3.20260818", seen.get("version"))
 
-    def test_cli_fails_when_marketplace_omits_the_version(self):
+    def test_cli_accepts_upload_when_marketplace_listing_lags(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             log = root / "publish.log"
@@ -115,9 +114,9 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
             log.write_text(SUCCESS_LOG, encoding="utf-8")
             properties.write_text(PROPERTIES, encoding="utf-8")
             updates.write_text(MISSING, encoding="utf-8")
-            self.assertEqual(
-                1,
-                MODULE.main(
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                result = MODULE.main(
                     [
                         "--log",
                         str(log),
@@ -126,8 +125,10 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
                         "--updates-json",
                         str(updates),
                     ]
-                ),
-            )
+                )
+            self.assertEqual(0, result)
+            self.assertIn("listing is still pending", stderr.getvalue())
+            self.assertIn("Do not re-dispatch", stderr.getvalue())
 
     def test_fetch_retries_then_raises(self):
         attempts = {"n": 0}
@@ -188,25 +189,20 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
         errors = MODULE.marketplace_receipt_errors(body, "10.3.20260818")
         self.assertTrue(any("10.3.20260818" in error for error in errors), errors)
 
-    def test_default_retry_budget_covers_observed_marketplace_listing_lag(self):
-        # Run 32247439124: BUILD SUCCESSFUL at 11:35:30Z, receipt miss at 11:36:32Z (~62s).
+    def test_default_visibility_probe_does_not_poll_after_accepted_upload(self):
         parameters = inspect.signature(MODULE.fetch_updates_with_retry).parameters
         attempts = parameters["attempts"].default
         delay_seconds = parameters["delay_seconds"].default
         wait_seconds = (attempts - 1) * delay_seconds
-        self.assertGreaterEqual(
+        self.assertEqual(
+            0,
             wait_seconds,
-            90,
-            f"default listing-lag wait is {wait_seconds}s; observed miss was ~62s",
+            f"accepted upload still waits {wait_seconds}s for an eventually consistent listing",
         )
 
-    def test_gradle_success_with_omitted_version_names_listing_lag(self):
+    def test_gradle_success_with_omitted_version_is_not_a_receipt_error(self):
         errors = MODULE.receipt_errors(SUCCESS_LOG, PROPERTIES, MISSING)
-        blob = "\n".join(errors)
-        self.assertTrue(any("10.3.20260818" in error for error in errors), errors)
-        self.assertIn("listing still lagging", blob)
-        self.assertIn("Do not re-dispatch", blob)
-        self.assertNotIn("Gradle publish log is missing BUILD SUCCESSFUL", blob)
+        self.assertEqual([], errors)
 
     def test_missing_gradle_receipt_does_not_claim_listing_lag(self):
         errors = MODULE.receipt_errors("", PROPERTIES, MISSING)

--- a/tests/scripts/test_assert_intellij_marketplace_receipt.py
+++ b/tests/scripts/test_assert_intellij_marketplace_receipt.py
@@ -47,9 +47,9 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
         errors = MODULE.receipt_errors(SUCCESS_LOG, "pluginSinceBuild=243\n", LISTED)
         self.assertTrue(any("pluginVersion" in error for error in errors), errors)
 
-    def test_unreadable_updates_json_fails(self):
+    def test_unreadable_updates_json_is_advisory_after_gradle_success(self):
         errors = MODULE.receipt_errors(SUCCESS_LOG, PROPERTIES, "not-json")
-        self.assertTrue(any("unreadable" in error for error in errors), errors)
+        self.assertEqual([], errors)
 
     def test_cli_accepts_fixture_updates_json(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -129,6 +129,30 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
             self.assertEqual(0, result)
             self.assertIn("listing is still pending", stderr.getvalue())
             self.assertIn("Do not re-dispatch", stderr.getvalue())
+
+    def test_cli_accepts_upload_when_marketplace_lookup_is_unavailable(self):
+        original = MODULE.fetch_updates_with_retry
+
+        def unavailable(*_args, **_kwargs):
+            raise RuntimeError("Marketplace updates fetch failed: timed out")
+
+        MODULE.fetch_updates_with_retry = unavailable
+        try:
+            with tempfile.TemporaryDirectory() as temp:
+                root = Path(temp)
+                log = root / "publish.log"
+                properties = root / "gradle.properties"
+                log.write_text(SUCCESS_LOG, encoding="utf-8")
+                properties.write_text(PROPERTIES, encoding="utf-8")
+                stderr = io.StringIO()
+                with redirect_stderr(stderr):
+                    result = MODULE.main(
+                        ["--log", str(log), "--properties", str(properties)]
+                    )
+            self.assertEqual(0, result)
+            self.assertIn("Marketplace visibility check unavailable", stderr.getvalue())
+        finally:
+            MODULE.fetch_updates_with_retry = original
 
     def test_fetch_retries_then_raises(self):
         attempts = {"n": 0}
@@ -242,7 +266,7 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
             MODULE.fetch_updates_with_retry = original
         self.assertEqual(0, calls["n"])
 
-    def test_cli_retries_listing_when_gradle_succeeded_and_version_is_omitted(self):
+    def test_cli_checks_listing_once_when_gradle_succeeded_and_version_is_omitted(self):
         calls = {"n": 0}
         original = MODULE.fetch_updates_with_retry
 
@@ -259,7 +283,7 @@ class IntellijMarketplaceReceiptTest(unittest.TestCase):
                 log.write_text(SUCCESS_LOG, encoding="utf-8")
                 properties.write_text(PROPERTIES, encoding="utf-8")
                 self.assertEqual(
-                    1,
+                    0,
                     MODULE.main(
                         [
                             "--log",

--- a/tests/scripts/test_intellij_verify_retry.py
+++ b/tests/scripts/test_intellij_verify_retry.py
@@ -24,6 +24,7 @@ ACTION = REPO_ROOT / ".github/actions/intellij-verify/action.yml"
 RETRY_SCRIPT = REPO_ROOT / "scripts/ci/build_retry.sh"
 WORKFLOWS = REPO_ROOT / ".github/workflows"
 PUBLISH_WORKFLOW = WORKFLOWS / "publish-intellij-plugin.yml"
+CENTRAL_WORKFLOW = WORKFLOWS / "mavenCentral_cd.yml"
 BUILD_FILE = REPO_ROOT / "shaft-intellij/build.gradle.kts"
 MARKETPLACE_RECEIPT_MARKERS = (
     "assert_intellij_marketplace_receipt",
@@ -48,6 +49,10 @@ def _run_steps() -> list[dict]:
 
 def _publish_workflow() -> dict:
     return yaml.safe_load(PUBLISH_WORKFLOW.read_text(encoding="utf-8")) or {}
+
+
+def _central_workflow() -> dict:
+    return yaml.safe_load(CENTRAL_WORKFLOW.read_text(encoding="utf-8")) or {}
 
 
 def _intellij_verify_with(step: dict) -> dict:
@@ -196,6 +201,38 @@ class IntellijMarketplacePublishSplitTest(unittest.TestCase):
         for name, timeout in publish_jobs:
             self.assertIsNotNone(timeout, f"{name} declares no timeout")
             self.assertGreater(timeout, 0, f"{name} timeout must be a real bound")
+
+    def test_standalone_publish_workflow_is_manual_only(self):
+        document = yaml.load(
+            PUBLISH_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader
+        )
+        self.assertEqual({"workflow_dispatch": ""}, document["on"])
+
+    def test_full_release_owns_publish_only_job_after_public_installer_gate(self):
+        jobs = _central_workflow()["jobs"]
+        publish = jobs.get("publish_intellij_plugin")
+        self.assertIsNotNone(publish, "mavenCentral_cd.yml has no automatic IntelliJ publish job")
+        self.assertEqual(
+            {"build_release_and_deliver", "verify_public_shaft_mcp_installer"},
+            set(publish.get("needs") or []),
+        )
+        publish_steps = [
+            step
+            for step in publish.get("steps") or []
+            if "intellij-verify" in str(step.get("uses", ""))
+        ]
+        self.assertEqual(1, len(publish_steps))
+        self.assertTrue(_truthy(_intellij_verify_with(publish_steps[0]).get("publish")))
+        self.assertFalse(_truthy(_intellij_verify_with(publish_steps[0]).get("verify")))
+
+    def test_announcement_and_intellij_publish_share_prerequisites(self):
+        jobs = _central_workflow()["jobs"]
+        publish = jobs.get("publish_intellij_plugin") or {}
+        self.assertEqual(
+            set(jobs["announce_release"].get("needs") or []),
+            set(publish.get("needs") or []),
+        )
+        self.assertNotIn("publish_intellij_plugin", jobs["announce_release"].get("needs") or [])
 
     def test_release_cancelled_or_timed_out_publish_is_a_failure_not_skip(self):
         text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #5344

## Summary

Consolidate automatic IntelliJ Marketplace publishing into the full Maven Central release workflow, retain the standalone workflow for manual recovery, and stop treating JetBrains Marketplace listing lag as a failed upload.

Root-cause evidence: run 32760666698 completed `publishPlugin` successfully. Marketplace update 1149677 records version `10.3.20260824` as approved and listed with a creation timestamp matching that upload. The workflow failed only because the public updates list remained eventually inconsistent beyond the fixed 165-second poll.

## Tracking

- [x] Ground #5344 against run logs, current workflows, and Marketplace state
- [x] Record approved design and proof matrices on #5344
- [x] Add and verify RED contract tests
- [x] Move automatic publish ownership into `mavenCentral_cd.yml`
- [x] Keep `publish-intellij-plugin.yml` manual-only
- [x] Make accepted Gradle upload authoritative; Marketplace listing advisory
- [x] Preserve dedicated automatic publish failure tracking
- [x] Run focused GREEN validation and YAML parsing
- [x] Inspect final diff and push implementation
- [x] Triage draft PR CI

## Implementation

- Full release publishes the IntelliJ plugin after Maven delivery and public installer verification.
- Marketplace publish and release announcement run in parallel from the same prerequisites.
- Existing full-release IntelliJ verification remains unchanged; publish job uses `publish: true` and `verify: false`.
- Standalone workflow retains verification, publish, and fail-closed behavior for manual recovery only.
- Shared concurrency prevents automatic and manual uploads from racing.
- Successful `publishPlugin` output is authoritative. One Marketplace lookup reports visibility but cannot turn an accepted single-use version into a retry invitation.
- Automatic release path alone manages the dedicated missed-publish tracker.

## Checks

RED on `1e60d1fb9e`:

```text
python3 -m unittest tests.scripts.test_assert_intellij_marketplace_receipt tests.scripts.test_intellij_verify_retry
Ran 31 tests
FAILED (failures=7)
```

GREEN on `4f34394a2c`:

```text
python3 -m unittest tests.scripts.test_assert_intellij_marketplace_receipt tests.scripts.test_intellij_verify_retry tests.scripts.test_validate_shaft_pilot_release
Ran 65 tests
OK

python3 scripts/ci/validate_shaft_pilot_release.py
SHAFT Pilot release contract is valid.
```

All changed workflow/action YAML files parse with `yaml.safe_load`; `git diff --check` passes.

Repository harness command was also attempted. `py` is unavailable on this Linux host, so the equivalent `python3 scripts/ci/validate_agent_setup.py --skip-external` ran. It reported pre-existing repository harness/reachability and unrelated worktree findings; none concern this five-file release workflow change.

No release, workflow dispatch, Marketplace upload, or deployment ran during local validation.

## Continuation

Head: `4f34394a2c`
State: implementation complete. Replacement release-note governance passes after adding the required `bug` label. Documentation Boundary still fails on unchanged `origin/main` `.chaos-engine/**` Markdown; this PR does not modify that surface. Remaining matrix jobs are running. Work remained single-threaded with no delegation.