### PR TITLE
fix: Stop idempotence, quote-safe pick-locator snippets, live /codegen replay

### DIFF
--- a/.chaos-engine/hooks/guard.py
+++ b/.chaos-engine/hooks/guard.py
@@ -380,20 +380,27 @@ def _stop_block_reason(event: dict, session_id: str) -> str:
     ):
         return ""
     elapsed = reflection.session_elapsed_seconds(session_id)
-    if elapsed is not None and elapsed > 3600 and not reflection.has_valid_terminal_receipt(session_id):
-        return "Terminal reflection required before this session can stop."
     if elapsed is not None and elapsed > 3600:
-        raw_message = event.get("last_assistant_message", event.get("lastAssistantMessage"))
-        if raw_message is None:
+        if reflection.has_valid_terminal_receipt(session_id) or _learning_session_completed(session_id):
             return ""
-        message = str(raw_message).casefold()
-        missing = [label for label in TERMINAL_LABELS if label not in message]
-        if missing:
-            return "Terminal reflection summary is missing: " + ", ".join(missing) + "."
+        return "Terminal reflection required before this session can stop."
     loop_reason = learning_session_reason(session_id, event)
     if loop_reason:
         return loop_reason
     return ""
+
+
+def _learning_session_completed(session_id: str) -> bool:
+    """Whether the terminal Learning Session remains current for this session."""
+    completed = False
+    for item in reflection.entries(session_id):
+        if item.get("kind") != "task-activity":
+            continue
+        if item.get("activity") == "learning-session-complete":
+            completed = True
+        elif item.get("activity") in {"mutation", "delivery-complete"}:
+            completed = False
+    return completed
 
 
 def _record_failed_result(

--- a/.chaos-engine/hooks/guard.py
+++ b/.chaos-engine/hooks/guard.py
@@ -379,6 +379,11 @@ def _stop_block_reason(event: dict, session_id: str) -> str:
         event.get("stop_hook_active") or event.get("stopHookActive")
     ):
         return ""
+    permission_mode = str(
+        event.get("permission_mode", event.get("permissionMode", ""))
+    ).strip().lower()
+    if permission_mode == "plan":
+        return ""
     elapsed = reflection.session_elapsed_seconds(session_id)
     if elapsed is not None and elapsed > 3600:
         if reflection.has_valid_terminal_receipt(session_id) or _learning_session_completed(session_id):
@@ -398,7 +403,7 @@ def _learning_session_completed(session_id: str) -> bool:
             continue
         if item.get("activity") == "learning-session-complete":
             completed = True
-        elif item.get("activity") in {"mutation", "delivery-complete"}:
+        elif item.get("activity") == "mutation":
             completed = False
     return completed
 

--- a/chaos-engine/hooks/guard.py
+++ b/chaos-engine/hooks/guard.py
@@ -380,20 +380,27 @@ def _stop_block_reason(event: dict, session_id: str) -> str:
     ):
         return ""
     elapsed = reflection.session_elapsed_seconds(session_id)
-    if elapsed is not None and elapsed > 3600 and not reflection.has_valid_terminal_receipt(session_id):
-        return "Terminal reflection required before this session can stop."
     if elapsed is not None and elapsed > 3600:
-        raw_message = event.get("last_assistant_message", event.get("lastAssistantMessage"))
-        if raw_message is None:
+        if reflection.has_valid_terminal_receipt(session_id) or _learning_session_completed(session_id):
             return ""
-        message = str(raw_message).casefold()
-        missing = [label for label in TERMINAL_LABELS if label not in message]
-        if missing:
-            return "Terminal reflection summary is missing: " + ", ".join(missing) + "."
+        return "Terminal reflection required before this session can stop."
     loop_reason = learning_session_reason(session_id, event)
     if loop_reason:
         return loop_reason
     return ""
+
+
+def _learning_session_completed(session_id: str) -> bool:
+    """Whether the terminal Learning Session remains current for this session."""
+    completed = False
+    for item in reflection.entries(session_id):
+        if item.get("kind") != "task-activity":
+            continue
+        if item.get("activity") == "learning-session-complete":
+            completed = True
+        elif item.get("activity") in {"mutation", "delivery-complete"}:
+            completed = False
+    return completed
 
 
 def _record_failed_result(

--- a/chaos-engine/hooks/guard.py
+++ b/chaos-engine/hooks/guard.py
@@ -379,6 +379,11 @@ def _stop_block_reason(event: dict, session_id: str) -> str:
         event.get("stop_hook_active") or event.get("stopHookActive")
     ):
         return ""
+    permission_mode = str(
+        event.get("permission_mode", event.get("permissionMode", ""))
+    ).strip().lower()
+    if permission_mode == "plan":
+        return ""
     elapsed = reflection.session_elapsed_seconds(session_id)
     if elapsed is not None and elapsed > 3600:
         if reflection.has_valid_terminal_receipt(session_id) or _learning_session_completed(session_id):
@@ -398,7 +403,7 @@ def _learning_session_completed(session_id: str) -> bool:
             continue
         if item.get("activity") == "learning-session-complete":
             completed = True
-        elif item.get("activity") in {"mutation", "delivery-complete"}:
+        elif item.get("activity") == "mutation":
             completed = False
     return completed
 

--- a/plugins/chaos-engine/hooks/guard.py
+++ b/plugins/chaos-engine/hooks/guard.py
@@ -380,17 +380,27 @@ def _stop_block_reason(event: dict, session_id: str) -> str:
     ):
         return ""
     elapsed = reflection.session_elapsed_seconds(session_id)
-    if elapsed is not None and elapsed > 3600 and not reflection.has_valid_terminal_receipt(session_id):
-        return "Terminal reflection required before this session can stop."
     if elapsed is not None and elapsed > 3600:
-        message = str(event.get("last_assistant_message") or event.get("lastAssistantMessage") or "").casefold()
-        missing = [label for label in TERMINAL_LABELS if label not in message]
-        if missing:
-            return "Terminal reflection summary is missing: " + ", ".join(missing) + "."
+        if reflection.has_valid_terminal_receipt(session_id) or _learning_session_completed(session_id):
+            return ""
+        return "Terminal reflection required before this session can stop."
     loop_reason = learning_session_reason(session_id, event)
     if loop_reason:
         return loop_reason
     return ""
+
+
+def _learning_session_completed(session_id: str) -> bool:
+    """Whether the terminal Learning Session remains current for this session."""
+    completed = False
+    for item in reflection.entries(session_id):
+        if item.get("kind") != "task-activity":
+            continue
+        if item.get("activity") == "learning-session-complete":
+            completed = True
+        elif item.get("activity") in {"mutation", "delivery-complete"}:
+            completed = False
+    return completed
 
 
 def _record_failed_result(

--- a/plugins/chaos-engine/hooks/guard.py
+++ b/plugins/chaos-engine/hooks/guard.py
@@ -379,6 +379,11 @@ def _stop_block_reason(event: dict, session_id: str) -> str:
         event.get("stop_hook_active") or event.get("stopHookActive")
     ):
         return ""
+    permission_mode = str(
+        event.get("permission_mode", event.get("permissionMode", ""))
+    ).strip().lower()
+    if permission_mode == "plan":
+        return ""
     elapsed = reflection.session_elapsed_seconds(session_id)
     if elapsed is not None and elapsed > 3600:
         if reflection.has_valid_terminal_receipt(session_id) or _learning_session_completed(session_id):
@@ -398,7 +403,7 @@ def _learning_session_completed(session_id: str) -> bool:
             continue
         if item.get("activity") == "learning-session-complete":
             completed = True
-        elif item.get("activity") in {"mutation", "delivery-complete"}:
+        elif item.get("activity") == "mutation":
             completed = False
     return completed
 

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -5596,20 +5596,12 @@ def _terminal_reflection_reason(hook_input: dict) -> str | None:
     elapsed = _reflection.session_elapsed_seconds(session_id)
     if elapsed is None or elapsed <= 60 * 60:
         return None
-    has_receipt = _reflection.has_valid_terminal_receipt(session_id)
-    if not has_receipt:
+    if not _reflection.has_valid_terminal_receipt(session_id):
         return (
             "Terminal reflection required: this session exceeded one hour. Append a "
             "validated long-session-completion receipt before stopping. Stores and "
             "GitHub are optional; the local task ledger is sufficient."
         )
-    raw_message = hook_input.get("last_assistant_message")
-    if raw_message is None:
-        return None
-    message = str(raw_message).casefold()
-    missing = [label for label in _TERMINAL_REFLECTION_LABELS if label not in message]
-    if missing:
-        return "Terminal reflection summary is missing: " + ", ".join(missing) + "."
     return None
 
 

--- a/shaft-capture/src/main/java/com/shaft/capture/control/PickedLocatorSnippetBuilder.java
+++ b/shaft-capture/src/main/java/com/shaft/capture/control/PickedLocatorSnippetBuilder.java
@@ -40,6 +40,9 @@ public final class PickedLocatorSnippetBuilder {
     }
 
     private static String attributeBuilder(String attribute, String value) {
+        if ("name".equals(attribute) && value.indexOf('"') >= 0) {
+            return "By.name(\"" + javaString(value) + "\")";
+        }
         return "SHAFT.GUI.Locator.hasAnyTagName().hasAttribute(\"" + javaString(attribute)
                 + "\", \"" + javaString(value) + "\").build()";
     }
@@ -86,7 +89,32 @@ public final class PickedLocatorSnippetBuilder {
         if (name.isBlank() || !name.chars().allMatch(ch -> Character.isLetterOrDigit(ch) || ch == '_' || ch == '-')) {
             return null;
         }
-        return new String[] {name, trimmed.substring(valueStart, valueEnd)};
+        return new String[] {name, cssUnescape(trimmed.substring(valueStart, valueEnd))};
+    }
+
+    private static String cssUnescape(String value) {
+        StringBuilder decoded = new StringBuilder();
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            if (character != '\\' || ++index == value.length()) {
+                decoded.append(character);
+                continue;
+            }
+            int hexStart = index;
+            while (index < value.length() && index - hexStart < 6 && Character.digit(value.charAt(index), 16) >= 0) {
+                index++;
+            }
+            if (index == hexStart) {
+                decoded.append(value.charAt(index));
+                continue;
+            }
+            decoded.appendCodePoint(Integer.parseInt(value.substring(hexStart, index), 16));
+            if (index < value.length() && Character.isWhitespace(value.charAt(index))) {
+                index++;
+            }
+            index--;
+        }
+        return decoded.toString();
     }
 
     private static String cssBuilder(String css) {

--- a/shaft-capture/src/test/java/com/shaft/capture/control/PickedLocatorSnippetBuilderTest.java
+++ b/shaft-capture/src/test/java/com/shaft/capture/control/PickedLocatorSnippetBuilderTest.java
@@ -25,6 +25,16 @@ class PickedLocatorSnippetBuilderTest {
     }
 
     @Test
+    void quotedIdAndNameUseNativeLocators() {
+        assertEquals(
+                "By.id(\"say\\\"hi\")",
+                PickedLocatorSnippetBuilder.snippet(candidate(LocatorCandidate.LocatorStrategy.ID, "say\"hi")));
+        assertEquals(
+                "By.name(\"say\\\"hi\")",
+                PickedLocatorSnippetBuilder.snippet(candidate(LocatorCandidate.LocatorStrategy.NAME, "say\"hi")));
+    }
+
+    @Test
     void hashCssRendersAsAnIdBuilderCall() {
         assertEquals(
                 "SHAFT.GUI.Locator.hasAnyTagName().hasId(\"login\").build()",
@@ -56,6 +66,14 @@ class PickedLocatorSnippetBuilderTest {
                 "SHAFT.GUI.Locator.hasAnyTagName().hasAttribute(\"data-qa\", \"checkout\").build()",
                 PickedLocatorSnippetBuilder.snippet(
                         candidate(LocatorCandidate.LocatorStrategy.TEST_ID, "[data-qa='checkout']")));
+    }
+
+    @Test
+    void testIdAttributeSelectorDecodesCssEscapesBeforeBuildingAttribute() {
+        assertEquals(
+                "SHAFT.GUI.Locator.hasAnyTagName().hasAttribute(\"data-testid\", \"login button\").build()",
+                PickedLocatorSnippetBuilder.snippet(
+                        candidate(LocatorCandidate.LocatorStrategy.TEST_ID, "[data-testid=\"login\\ button\"]")));
     }
 
     @Test

--- a/tests/scripts/test_chaos_engine_hook.py
+++ b/tests/scripts/test_chaos_engine_hook.py
@@ -271,6 +271,8 @@ class ChaosEngineHookTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}
             session = "learn-complete"
+            with patch.dict(os.environ, environment):
+                reflection.record_session_start(session, "2020-01-01T00:00:00+00:00")
             for command in (
                 "py -3 scripts/agents/chaos_engine_cli.py delivery-status --manifest m --receipt-out r",
                 "py -3 scripts/agents/learning_session.py finalize --session-id learn-complete",
@@ -289,6 +291,7 @@ class ChaosEngineHookTest(unittest.TestCase):
                 {
                     "hook_event_name": "Stop",
                     "session_id": session,
+                    "last_assistant_message": "final report",
                     "stop_hook_active": False,
                 },
                 environment,
@@ -298,6 +301,75 @@ class ChaosEngineHookTest(unittest.TestCase):
             self.assertFalse(
                 json.loads(stopped.stdout).get("reason", "").casefold().startswith("learning session:")
             )
+
+    def test_portable_plan_mode_skips_long_session_completion_gate(self):
+        for permission_key in ("permission_mode", "permissionMode"):
+            with self.subTest(permission_key=permission_key), tempfile.TemporaryDirectory() as temporary:
+                environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}
+                session = f"portable-plan-{permission_key}"
+                with patch.dict(os.environ, environment):
+                    reflection.record_session_start(session, "2020-01-01T00:00:00+00:00")
+
+                stopped = self.run_hook(
+                    {
+                        "hook_event_name": "Stop",
+                        "session_id": session,
+                        permission_key: "plan",
+                        "stop_hook_active": False,
+                    },
+                    environment,
+                )
+
+                self.assertEqual(0, stopped.returncode)
+                self.assertNotEqual("block", json.loads(stopped.stdout).get("decision"))
+
+    def test_delivery_after_learning_session_keeps_long_session_complete(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}
+            session = "learn-complete-then-delivery"
+            with patch.dict(os.environ, environment):
+                reflection.record_session_start(session, "2020-01-01T00:00:00+00:00")
+                reflection.record_activity(session, "delivery-complete")
+                reflection.record_activity(session, "learning-session-complete")
+                reflection.record_activity(session, "delivery-complete")
+
+            stopped = self.run_hook(
+                {
+                    "hook_event_name": "Stop",
+                    "session_id": session,
+                    "last_assistant_message": "final report",
+                    "stop_hook_active": False,
+                },
+                environment,
+            )
+
+            self.assertEqual(0, stopped.returncode)
+            self.assertNotEqual("block", json.loads(stopped.stdout).get("decision"))
+
+    def test_mutation_after_learning_session_reopens_reflection_not_learning_session(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}
+            session = "learn-complete-then-mutation"
+            with patch.dict(os.environ, environment):
+                reflection.record_session_start(session, "2020-01-01T00:00:00+00:00")
+                reflection.record_activity(session, "delivery-complete")
+                reflection.record_activity(session, "learning-session-complete")
+                reflection.record_activity(session, "mutation")
+
+            stopped = self.run_hook(
+                {
+                    "hook_event_name": "Stop",
+                    "session_id": session,
+                    "last_assistant_message": "final report",
+                    "stop_hook_active": False,
+                },
+                environment,
+            )
+
+            reason = json.loads(stopped.stdout).get("reason", "")
+            self.assertEqual(2, stopped.returncode)
+            self.assertIn("Terminal reflection required", reason)
+            self.assertNotIn("Learning Session", reason)
 
     def test_long_session_receipt_allows_stop_without_terminal_summary_labels(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_chaos_engine_hook.py
+++ b/tests/scripts/test_chaos_engine_hook.py
@@ -299,6 +299,43 @@ class ChaosEngineHookTest(unittest.TestCase):
                 json.loads(stopped.stdout).get("reason", "").casefold().startswith("learning session:")
             )
 
+    def test_long_session_receipt_allows_stop_without_terminal_summary_labels(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}
+            session = "portable-long-receipt"
+            with patch.dict(os.environ, environment):
+                token = reflection.record_session_start(session, "2020-01-01T00:00:00+00:00")
+                reflection.record_receipt(
+                    session,
+                    {
+                        "schemaVersion": 1,
+                        "taskId": "issue-5407",
+                        "trigger": "long-session-completion",
+                        "failureFingerprints": [],
+                        "failedAssumption": "A receipt still required labels.",
+                        "approachesCompared": ["Scan text", "Trust receipt"],
+                        "chosenExperiment": "Stop with unrelated text.",
+                        "changedApproach": "Receipt-first Stop.",
+                        "proofCommandOrCheck": "portable hook test",
+                        "proofOutcome": "Stop is allowed.",
+                        "durableDisposition": "guidance-fixed",
+                    },
+                    token,
+                )
+
+            stopped = self.run_hook(
+                {
+                    "hook_event_name": "Stop",
+                    "session_id": session,
+                    "last_assistant_message": "final report",
+                    "stop_hook_active": False,
+                },
+                environment,
+            )
+
+            self.assertEqual(0, stopped.returncode)
+            self.assertNotIn("Terminal reflection summary", stopped.stdout)
+
     def test_failed_read_only_agent_diagnostics_do_not_open_portable_checkpoint(self):
         with tempfile.TemporaryDirectory() as temporary:
             environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -801,27 +801,18 @@ class TerminalReflectionContractTest(unittest.TestCase):
                 guard.run_stop({"session_id": "short", "stop_hook_active": True})
             self.assertEqual("", output.getvalue())
 
-    def test_restart_preserves_earliest_start_and_every_summary_label_is_required(self):
+    def test_restart_preserves_earliest_start_and_receipt_makes_summary_labels_optional(self):
         with tempfile.TemporaryDirectory() as temporary, patch.dict(
             os.environ, {"TMPDIR": temporary, "TEMP": temporary}
         ):
             token = reflection.record_session_start("restart", "2020-01-01T00:00:00+00:00")
             reflection.record_session_start("restart")
             reflection.record_receipt("restart", self._receipt(), token)
-            complete = "\n".join(
-                f"{label}: recorded" for label in guard._TERMINAL_REFLECTION_LABELS
-            )
             self.assertIsNone(
                 guard._terminal_reflection_reason(
-                    {"session_id": "restart", "last_assistant_message": complete}
+                    {"session_id": "restart", "last_assistant_message": "final report"}
                 )
             )
-            for label in guard._TERMINAL_REFLECTION_LABELS:
-                missing = complete.replace(f"{label}: recorded", "")
-                reason = guard._terminal_reflection_reason(
-                    {"session_id": "restart", "last_assistant_message": missing}
-                )
-                self.assertIn(label, reason)
 
     def test_valid_receipt_allows_hosts_that_omit_the_assistant_message_to_stop(self):
         with tempfile.TemporaryDirectory() as temporary, patch.dict(


### PR DESCRIPTION
Related to #5420.

Closes #5407.
Closes #5411.
Closes #5415.

## Summary

- #5407: Stop is receipt-first on repository and portable/plugin guards. Plan Mode skips terminal completion; confirmed NUL corruption retains preservation blocking.
- #5411: Picked locator snippets safely emit quoted IDs/names and CSS-unescape TEST_ID selectors.
- #5415: Live headed IntelliJ `/codegen` recording, generation, and consumer replay completed; evidence is linked on the issue.
- Merged current `main` into the branch before delivery.

## Checks

- `python3 -m unittest tests.scripts.test_guard_lifecycle.TerminalReflectionContractTest tests.scripts.test_guard_lifecycle.PlanModeStopTests tests.scripts.test_chaos_engine_hook.ChaosEngineHookTest -q` — 30 passed after merging `main`.
- `mvn -pl shaft-capture -Dtest=PickedLocatorSnippetBuilderTest test -Dallure.automaticallyOpen=false -DheadlessExecution=true` — blocked locally because current `main` requires Java 25 and the workstation JDK does not support release 25; exact-head GitHub CI owns this proof.
- Prior branch-head focused Maven test — 9 passed.
- Consumer replay — 1 test, 0 failures; evidence linked on #5415.

## Continuation

Await exact-head CI, clear all feedback, run final acceptance, then merge.