### PR TITLE
docs: require What's new catalog updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -71,6 +71,7 @@
 
 - Documentation PR:
 - Documentation not required because:
+- [ ] New user-facing features add or refresh a 3–4 line entry at https://shafthq.github.io/docs/features/whats-new and link the matching `ShaftHQ/shafthq.github.io` PR.
 
 
 ## 📝 Additional Notes

--- a/chaos-engine/profiles/shaft/references/playbooks/public-behavior-docs-synchronizer.md
+++ b/chaos-engine/profiles/shaft/references/playbooks/public-behavior-docs-synchronizer.md
@@ -2,6 +2,8 @@
 
 Use for user-visible SHAFT behavior changes. Keep docs work separate from code unless the task explicitly asks for both.
 
+Add or refresh the matching 3–4 line catalog entry at `/docs/features/whats-new` in the companion documentation PR.
+
 Every user-facing SHAFT behavior change opens a companion PR on
 `ShaftHQ/shafthq.github.io` `master` in the same delivery: discover the docs
 root, or use an explicitly configured root; never a fixed sibling path. Do


### PR DESCRIPTION
## Summary
- add Documentation Site checkbox for new user-facing feature catalog updates
- point public behavior docs playbook at /docs/features/whats-new

## Related issue
Related to ShaftHQ/shafthq.github.io#1028.

## Validation
- git diff --check