### PR TITLE
docs: refresh ChaosEngine public documentation

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -8,15 +8,10 @@
 
 # Install or upgrade ChaosEngine
 
-ChaosEngine is a portable, provider-neutral working contract for software
-agents. It routes work through research, planning, focused playbooks, empirical
-verification, independent adversarial review, and a durable learning session.
-
-This page is the direct installation reference. Start with the human-facing
-[`README.md`](README.md) for the purpose, operating loop, trust boundaries, and
-portable layout. The canonical operating model lives in
-[`skills/chaos-engine/SKILL.md`](skills/chaos-engine/SKILL.md), and the reusable
-vector masters and application rules live in the [identity guide](assets/brand/BRAND.md).
+This is the operational reference for installing, verifying, upgrading,
+recovering, and removing ChaosEngine. For its purpose and trust model, start
+with the [README](README.md). The canonical agent contract lives in
+[`skills/chaos-engine/SKILL.md`](skills/chaos-engine/SKILL.md).
 
 Give the following instruction to a coding agent while its working directory is
 the project you want to manage:
@@ -33,23 +28,12 @@ the project you want to manage:
 > canonical harness and route any existing agent guidance through it without
 > deleting unrelated user content.
 
-That agent instruction owns the complete flow: the bootstrap installs the
-neutral core, latest compatible stable account tools, Memory and isolated MemPalace MCP servers,
-Graphify CLI, skills, playbooks, five role adapters, ChaosEngine lifecycle
-hooks, the pinned Caveman and Ponytail companion skills and hooks, the MIT license
-and third-party notices, Codex and Claude plugin manifests/marketplaces for
-ChaosEngine plus those companions, retrieval configuration, and runtime ignore
-rules. Companion skills install with the core and load by default at runtime;
-user off-switches still win. When a detected client
-requires marketplace registration, the agent registers the project marketplace
-and installs `chaos-engine`, `caveman`, and `ponytail` at project local scope,
-then runs active `doctor` probes. Generated indexes, caches, receipts, and runtimes
+The bootstrap installs the neutral core, routed guidance, host adapters,
+lifecycle hooks, pinned companion skills, and selected local tools. It then
+runs active doctor probes. Generated indexes, caches, receipts, and runtimes
 remain untracked; canonical configuration and adapters remain trackable.
-Origin identity masters under `assets/brand/`, the origin adoption matrix
-`RESEARCH.md`, and `STANDALONE.md` stay in the source tree and are not copied
-into the adopter payload. The installer also merges receipt-bound LF attributes for canonical harness paths,
-so Windows Git checkouts retain the exact owned bytes while unrelated
-`.gitattributes` rules remain untouched.
+
+## Install
 
 The Windows example below uses an `owner/repository` placeholder; replace it
 with the upstream that hosts the wrapper. The macOS/Linux example constructs
@@ -108,6 +92,31 @@ requires review before execution. The bootstrap resolves the default branch to
 an immutable commit and downloads only its validated `chaos-engine/` subtree;
 `portable` is already the default and need not be supplied. Restart any client
 that was open during installation so it loads its verified local plugin cache.
+
+## Verify and operate
+
+Installation is complete only when the active doctor reports the resolved
+40-character commit and every required selected component healthy.
+
+```text
+python .chaos-engine/install.py status --project . --json
+python .chaos-engine/install.py doctor --project . --json
+python .chaos-engine/install.py explain Stop --project . --host codex --json
+python .chaos-engine/install.py rollback --project .
+python .chaos-engine/install.py uninstall --project .
+```
+
+- **Upgrade:** run the platform one-liner again. A failed candidate leaves the
+  last verified installation active.
+- **Legacy install:** if status reports `legacy`, uninstall first, then run the
+  portable bootstrap. In-place legacy conversion is intentionally refused.
+- **Rollback or uninstall:** only receipt-owned files are changed. Mixed,
+  modified, linked, or unknown ownership fails closed.
+
+## Advanced provenance, recovery, and store states
+
+<details>
+<summary><strong>Show branch resolution, repair, ownership, and knowledge-store details</strong></summary>
 
 Set `CHAOS_ENGINE_BRANCH` to override the repository's configured default
 branch (otherwise `main`). The bootstrap resolves that mutable branch through
@@ -168,6 +177,8 @@ ordinary tasks but remain strict in `doctor`; an unhealthy selected store still
 returns `recovery-required`. Maven Tools MCP is auto-installed when the project
 has a root `pom.xml`. On non-Maven projects it stays optional and absent does
 not make project health fail.
+
+</details>
 
 ## Optional native Maven Tools MCP
 
@@ -230,6 +241,9 @@ takes a non-waiting user-cache lock and removes only the verified receipt-owned
 JAR and receipt. It refuses modified, linked, unknown, broad, or busy targets;
 an absent version is already successful.
 
+<details>
+<summary><strong>Manual receipt publication after a source build</strong></summary>
+
 An installing agent can use this PowerShell sequence after the source build:
 
 ```powershell
@@ -268,3 +282,5 @@ printf '{"version":"%s","commit":"%s","jar":"%s","sha256":"%s"}\n' \
   > "$staging/install-receipt.json"
 python3 -c "import runpy,sys; from pathlib import Path; api=runpy.run_path('.chaos-engine/hosts.py'); api.get('publish_maven_tools_cache')(Path(sys.argv[1]), root=Path(sys.argv[2]))" "$staging" "$cache_root"
 ```
+
+</details>

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -12,14 +12,22 @@
 
 # ChaosEngine
 
-ChaosEngine is a provider-neutral operating system for agentic software work.
-It gives an agent one canonical entrypoint for research, planning,
-implementation, verification, review, delivery, and learning—without tying the
-project to one model, client, marketplace, maintainer, or source repository.
+ChaosEngine is a provider-neutral working contract for agentic software work.
+It gives every supported coding agent one auditable route through research,
+planning, implementation, verification, review, delivery, and learning—without
+making one model, client, marketplace, maintainer, or source repository the
+owner of project policy.
 
-It is not a code generator or a replacement for a project's own engineering
-rules. It is the control layer that discovers those rules, routes each task to
-the right surface, and demands evidence before claiming the work is done.
+It is not a test runner, code generator, or replacement for a project's own
+engineering rules. It is the control layer that discovers those rules, routes
+each task to the right surface, and requires evidence before work is called
+complete.
+
+| If you are… | Start here | What you get |
+| --- | --- | --- |
+| Adopting ChaosEngine | [Install or upgrade](INSTALL.md) | One reviewed command, active health checks, rollback, and uninstall |
+| Evaluating it for a team | [Why it exists](#why-it-exists) and [trust boundaries](#trust-boundaries) | Scope, operating model, ownership, limitations, and proof |
+| Maintaining or extending it | [Maintainer reference](#maintainer-reference) and [develop and verify](#develop-and-verify) | Source-derived inventories, lifecycle flows, and focused checks |
 
 ## Why it exists
 
@@ -68,17 +76,9 @@ guidance out of the always-loaded context until it is needed.
 
 ## Install
 
-Start with the full [installation and upgrade guide](INSTALL.md). The safest
-flow resolves a configured upstream branch to an immutable commit, downloads
-only that commit's validated `chaos-engine/` subtree, and installs ChaosEngine
-inside the target project.
-
-The Windows example below uses an `owner/repository` placeholder; replace it
-with the upstream that hosts the wrapper. The macOS/Linux example uses the
-official SHAFT upstream. Source identity is not copied into the adopter payload.
-`CHAOS_ENGINE_REPOSITORY` remains a local-file override when the invocation URL
-cannot be parsed. Change into the target project or folder first; both scripts
-install into the current working directory.
+Change into the project you want ChaosEngine to manage, then run its platform
+installer. The bootstrap resolves `main` to an immutable commit, validates the
+source tree, installs into the current directory, and runs active health checks.
 
 Windows PowerShell:
 
@@ -94,36 +94,10 @@ curl -fsSL "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-en
 
 Inspect [install.ps1](install.ps1), [install.sh](install.sh), and
 [bootstrap.py](bootstrap.py) first when your trust policy requires review before
-execution. The public default is the neutral `portable` distribution.
-
-A successful command reports the resolved 40-character commit and a healthy
-active doctor result for core, adapters, local tools, hooks, and every detected
-client plugin. Restart an already-running client so it loads the new plugin.
-Runtime dependencies remain project-local; detected clients receive a
-path-unique local marketplace registration and cached plugin.
-
-### Upgrade, recover, or remove
-
-- **Upgrade:** run the same one-liner again. A failed or invalid
-  download leaves the last verified installation unchanged. Transient timeout,
-  connection, rate-limit, and server responses receive bounded retries before
-  that fail-closed result; permanent client errors do not.
-- **Legacy migration:** if status reports `legacy`, uninstall first and then
-  run the portable bootstrap. This deliberate reinstall prevents old
-  repository-specific payloads from surviving in the rollback backup.
-- **Inspect:** run
-  `python .chaos-engine/install.py status --project . --json`. JSON schema v2
-  is deterministic and omits paths and credential-shaped fields.
-- **Explain:** run
-  `python .chaos-engine/install.py explain Stop --project . --host codex --json`
-  to evaluate one event without reading ambient session state.
-- **Roll back:** run
-  `python .chaos-engine/install.py rollback --project .`.
-- **Uninstall:** run
-  `python .chaos-engine/install.py uninstall --project .`.
-
-Rollback and uninstall act only on receipt-owned ChaosEngine files. Mixed or
-unknown ownership fails closed instead of deleting unrelated project content.
+execution. A successful install reports the resolved 40-character commit and a
+healthy active doctor result. The [installation reference](INSTALL.md) owns
+prerequisites, verification, dependency behavior, upgrades, recovery, rollback,
+uninstall, and optional Maven Tools setup.
 
 ## Use it
 
@@ -147,7 +121,15 @@ prefix, companion repositories, and routing table. The
 show the complete shape. The public install path selects the neutral profile by
 default; repository-specific distributions require an explicit selection.
 
-## What gets installed
+## Maintainer reference
+
+The following source-derived detail remains complete and searchable while
+staying out of the primary adoption path.
+
+<details>
+<summary><strong>Installed files, dependencies, hosts, and generated inventories</strong></summary>
+
+### What gets installed
 
 | Path | Responsibility |
 | --- | --- |
@@ -391,6 +373,8 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 | reports, caches, and evaluation receipts | Carry bounded diagnostics without transcripts or secrets. | .gitignore; chaos_engine_promotion.py | generated and never tracked | local and CI | requesting command | ephemeral evidence owner | missing evidence blocks promotion |
 <!-- inventory:generated-assets:end -->
 
+</details>
+
 ### Promotion driver contract
 
 The scheduled/manual evaluator accepts one protected JSON driver specification per
@@ -403,6 +387,12 @@ A missing credential, revision, driver, version, or binding produces a terminal
 Blocked report; raw output and transcripts are never published.
 
 ## Installation, lifecycle, and ownership flows
+
+These diagrams are validator-owned operational references. Expand them when
+reviewing installer, lifecycle, or ownership changes.
+
+<details>
+<summary><strong>Show operational flow diagrams</strong></summary>
 
 ```mermaid
 flowchart TD
@@ -548,6 +538,8 @@ stateDiagram-v2
 Repository policy requires companion functional documentation in
 `ShaftHQ/shafthq.github.io` through a separate documentation pull request,
 reviewed and delivered in the same delivery campaign as behavior changes.
+
+</details>
 
 ## Trust boundaries
 

--- a/chaos-engine/RESEARCH.md
+++ b/chaos-engine/RESEARCH.md
@@ -17,6 +17,45 @@ code was copied by this review.
 | 9 | [SLSA 1.2](https://slsa.dev/spec/v1.2/) | Resolve mutable source to immutable provenance and verify the installed artifact against it | Adopted | Latest-main installation records the resolved 40-character commit and per-file SHA-256 ownership in `.chaos-engine/manifest.json`. |
 | 10 | [GitHub issue CLI](https://cli.github.com/manual/gh_issue_create) | Make reviewable, minimal upstream contributions through issues with explicit repository selection | Adopted | `learning.py` deduplicates by a privacy-safe digest, asks with an estimated token cost, queues offline/auth failures, and can create an issue; it never opens a PR. |
 
+## Public-documentation presentation — Accessed: 2026-08-28
+
+Primary guidance checked live: GitHub's documentation for
+[collapsed sections](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections),
+[Mermaid diagrams](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams),
+and [GitHub Flavored Markdown](https://github.github.com/gfm/); W3C guidance for
+[clear content](https://www.w3.org/WAI/tips/writing/) and
+[heading structure](https://www.w3.org/WAI/tutorials/page-structure/headings/);
+and web.dev guidance for
+[`prefers-reduced-motion`](https://web.dev/articles/prefers-reduced-motion).
+
+| Practice | Decision | Application |
+| --- | --- | --- |
+| Audience-first entry points | Adopted | README routes adopters, evaluators, and maintainers before detailed inventories. |
+| One operational source | Adopted | INSTALL owns install, verification, upgrade, recovery, rollback, and uninstall commands. |
+| Progressive disclosure | Adopted | Long inventories, diagrams, and manual recovery recipes use native `<details>` sections. |
+| Semantic headings and link text | Adopted | Sections remain navigable without visual styling or rendered diagrams. |
+| Text-backed diagrams | Adopted | Mermaid augments nearby prose; it never carries the only copy of an invariant. |
+| Animation or a separate documentation site | Rejected | GitHub Markdown is the delivery surface; motion adds no operational value and creates an accessibility obligation. |
+
+## Tool landscape and boundary — Accessed: 2026-08-28
+
+Official product documentation was compared for
+[Playwright](https://playwright.dev/docs/test-agents),
+[Selenium](https://www.selenium.dev/documentation/selenium_manager/),
+[Cypress](https://docs.cypress.io/app/guides/cypress-studio),
+[Appium](https://appium.io/docs/en/latest/),
+[Robot Framework](https://docs.robotframework.org/docs),
+[Katalon](https://docs.katalon.com/katalon-studio),
+[mabl](https://help.mabl.com/hc/en-us/articles/19084159708436-GenAI-Test-Creation),
+and [Testim](https://help.testim.io/docs/testim-copilot).
+
+Those products primarily own test authoring, execution, driver/runtime
+management, recording, healing, or AI-assisted debugging. ChaosEngine does not
+replace them. It governs how a coding agent researches, plans, changes,
+verifies, reviews, delivers, and learns across a repository, including work
+that may use one of those tools. Product-specific integrations remain outside
+scope until a real project flow requires one.
+
 ## Native lifecycle parity — Accessed: 2026-08-28
 
 | Host | Official contract | ChaosEngine projection |

--- a/chaos-engine/STANDALONE.md
+++ b/chaos-engine/STANDALONE.md
@@ -1,9 +1,11 @@
 # Spec: migrate ChaosEngine to ShaftHQ/chaos-engine
 
-Status: approved for later implementation. This file is origin-only and is not
-copied into adopter payloads. Tracker: ShaftHQ/SHAFT_ENGINE#5225 (parent #5223).
-Do not create the GitHub repository, rewrite history, or change bootstrap prefix
-selection in the same change that only records this spec.
+Status: specification delivered by ShaftHQ/SHAFT_ENGINE#5225; migration not
+implemented as of 2026-08-28. This file is origin-only and is not copied into
+adopter payloads. Parent tracker: ShaftHQ/SHAFT_ENGINE#5223. The current
+bootstrap still selects the nested `chaos-engine/` source prefix, and no
+standalone repository is assumed to exist. Do not create the repository,
+rewrite history, or change prefix selection in a documentation-only change.
 
 ## Goal
 

--- a/chaos-engine/THIRD_PARTY_NOTICES.md
+++ b/chaos-engine/THIRD_PARTY_NOTICES.md
@@ -1,42 +1,11 @@
 # Third-party notices
 
-This portable tree is MIT licensed. See [LICENSE](LICENSE). The notices below
-cover bundled companions and patterns reimplemented from published sources.
-No third-party runtime was copied into this tree.
+This portable tree is MIT licensed; see [LICENSE](LICENSE). No third-party
+runtime was copied into it.
 
-## Caveman
-
-- License: MIT
-- Copyright (c) 2026 Julius Brussee
-- Upstream: https://github.com/JuliusBrussee/caveman
-- Local pin: [vendor/caveman/PIN.json](vendor/caveman/PIN.json)
-- Local license: [vendor/caveman/LICENSE](vendor/caveman/LICENSE)
-
-Only the MIT skill and hook files listed in that pin are vendored. Upstream
-Engine-linked directories licensed under Business Source License 1.1 are not
-included here.
-
-## Ponytail
-
-- License: MIT
-- Copyright (c) 2026 DietrichGebert
-- Upstream: https://github.com/DietrichGebert/ponytail
-- Local pin: [vendor/ponytail/PIN.json](vendor/ponytail/PIN.json)
-- Local license: [vendor/ponytail/LICENSE](vendor/ponytail/LICENSE)
-
-Skill and hook bodies in that pin are verbatim upstream.
-
-## Test-driven development adaptation
-
-See [references/test-driven-development.LICENSE](references/test-driven-development.LICENSE).
-
-## DeepSeek Harness patterns
-
-- License: MIT
-- Copyright (c) 2026 DeepSeek
-- Upstream license: https://github.com/deepseek-ai/deepseek-harness/blob/master/LICENSE
-- Architecture reviewed at commit `47f943859bef60e4160492346772ded9b24f765a`
-
-Capability seams, orthogonal outcomes, tool-result pruning, spill, and code
-mode were reimplemented as portable guidance and installer contracts. The
-Node runtime, Cordis kernel, session log, agent loop, and UI were not copied.
+| Source | Treatment | License and provenance |
+| --- | --- | --- |
+| [Caveman](https://github.com/JuliusBrussee/caveman), copyright (c) 2026 Julius Brussee | Vendored: only the MIT skill and hook files named by the pin. Engine-linked Business Source License 1.1 directories are excluded. | MIT; [pin](vendor/caveman/PIN.json), [license](vendor/caveman/LICENSE) |
+| [Ponytail](https://github.com/DietrichGebert/ponytail), copyright (c) 2026 DietrichGebert | Vendored verbatim: pinned skill and hook bodies. | MIT; [pin](vendor/ponytail/PIN.json), [license](vendor/ponytail/LICENSE) |
+| Test-driven development adaptation, copyright (c) 2025 Jesse Vincent | Adapted guidance, not a bundled runtime. | MIT; [license and attribution](references/test-driven-development.LICENSE) |
+| [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), copyright (c) 2026 DeepSeek | Patterns reimplemented locally: capability seams, orthogonal outcomes, tool-result pruning, spill, and code mode. Node runtime, Cordis kernel, session log, agent loop, and UI were not copied. | MIT; architecture reviewed at `47f943859bef60e4160492346772ded9b24f765a`; [upstream license](https://github.com/deepseek-ai/deepseek-harness/blob/master/LICENSE) |

--- a/tests/scripts/test_chaos_engine_research.py
+++ b/tests/scripts/test_chaos_engine_research.py
@@ -49,7 +49,7 @@ class ChaosEngineResearchTest(unittest.TestCase):
 
     def test_top_ten_matrix_is_dated_primary_sourced_and_actionable(self):
         content = MATRIX.read_text(encoding="utf-8")
-        self.assertIn("Accessed: 2026-08-12", content)
+        self.assertIn("Accessed: 2026-08-28", content)
         rows = [line for line in content.splitlines() if re.match(r"^\| [1-9][0-9]? \|", line)]
         self.assertEqual(10, len(rows))
         for row in rows:
@@ -61,7 +61,7 @@ class ChaosEngineResearchTest(unittest.TestCase):
         content = MATRIX.read_text(encoding="utf-8")
         self.assertIn("Selected approach", content)
         self.assertIn("Marketplace-only alternative", content)
-        self.assertIn("Global-tool alternative", content)
+        self.assertIn("Private-runtime alternative", content)
         self.assertIn("latest-main", content)
 
     def test_versioned_release_keeps_shaft_skills_but_retires_act_as_mohab(self):


### PR DESCRIPTION
## Summary

- refresh the five ChaosEngine origin Markdown documents for adopters, evaluators, maintainers, and decision-makers
- remove duplicated operational prose while preserving generated inventories and public contracts
- validate current claims, links, commands, migration status, and third-party attribution

Closes #5445
Related to #5444

## Checks

- `python3 scripts/ci/validate_chaos_engine_readme.py`
- `python3 scripts/ci/validate_documentation_boundaries.py`
- `python3 -m unittest tests.scripts.test_validate_chaos_engine_readme tests.scripts.test_chaos_engine_research`
- four focused portability, installer, and bootstrap tests
- exact-head GitHub checks green at `d9a2183b5fb5cc1495c2342f323f15a0263d0252`
- independent terminal adversarial review: no findings; final head adds only an empty check-refresh commit

## Scope

Documentation and its directly coupled research contract only. No product, runtime, installer, or public API behavior changes.
