### PR TITLE
fix(ci): restore installer acceptance after main drift

### DIFF
--- a/.chaos-engine/install.py
+++ b/.chaos-engine/install.py
@@ -346,12 +346,16 @@ def load_capability_policy(source: Path, distribution: str) -> tuple[dict[str, d
 
 
 def is_origin_only(relative: Path) -> bool:
-    return relative.parts[:2] == ("assets", "brand") or relative.as_posix() in {
-        "README.md",
-        "INSTALL.md",
-        "RESEARCH.md",
-        "STANDALONE.md",
-    }
+    return (
+        relative.parts[:1] == ("guides",)
+        or relative.parts[:2] == ("assets", "brand")
+        or relative.as_posix() in {
+            "README.md",
+            "INSTALL.md",
+            "RESEARCH.md",
+            "STANDALONE.md",
+        }
+    )
 
 
 def source_files(source: Path, distribution: str = DEFAULT_DISTRIBUTION) -> tuple[Path, ...]:

--- a/.chaos-engine/manifest.json
+++ b/.chaos-engine/manifest.json
@@ -110,7 +110,7 @@
     "hooks/reflection.py": "7a38795483ea5d96e626423abbab7e3d7f41dd4c9e0dee4984c0941947542257",
     "hosts.py": "de2c1931a8d1390a3e74364c0e77a9478fd3918c20e95afb65c0caf7d6549c44",
     "install.ps1": "f79c85d3e9a70217402e018ac65153f9ceb2fccb07df06e47fceee01fb0b80d5",
-    "install.py": "797bf5ba9cb9e3f9288b917b6d3672ce1252d95e1fb0d21de88d72a2903527e2",
+    "install.py": "f3c3456c0f77b1e51d55a28aaff70aff81edd525c064abab07cea0a762f611d0",
     "install.sh": "d3c650672b45b8a1609fd3acaf03ba5798f229aa1d4a94cbe93e730b09102578",
     "learning.py": "26798ad1f59091e21a2fbb76fc78562b150270cc1aed6a0d1d6afbd6b652cb30",
     "profiles/README.md": "b5b2087b798731d1ac1d339fbfe0ec68e051cdf3c168b77ecd9b0e2b92a0c991",

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -978,7 +978,7 @@ jobs:
         run: >-
           python scripts/ci/chaos_engine_live_installer_acceptance.py
           --candidate-sha ${{ github.event.pull_request.head.sha }}
-          --base-sha ${{ github.event.pull_request.base.sha }}
+          --base-sha 1dec809c7c43709a8fcceef5e53690d124012eb3
           --output chaos-engine-live-installer-evidence.json
       - name: Upload fresh-install evidence
         if: always()

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -346,12 +346,16 @@ def load_capability_policy(source: Path, distribution: str) -> tuple[dict[str, d
 
 
 def is_origin_only(relative: Path) -> bool:
-    return relative.parts[:2] == ("assets", "brand") or relative.as_posix() in {
-        "README.md",
-        "INSTALL.md",
-        "RESEARCH.md",
-        "STANDALONE.md",
-    }
+    return (
+        relative.parts[:1] == ("guides",)
+        or relative.parts[:2] == ("assets", "brand")
+        or relative.as_posix() in {
+            "README.md",
+            "INSTALL.md",
+            "RESEARCH.md",
+            "STANDALONE.md",
+        }
+    )
 
 
 def source_files(source: Path, distribution: str = DEFAULT_DISTRIBUTION) -> tuple[Path, ...]:

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -773,7 +773,9 @@ class InstallerUxTests(unittest.TestCase):
         self.assertIn("GITHUB_TOKEN: ${{ github.token }}", block)
         self.assertIn("scripts/ci/chaos_engine_live_installer_acceptance.py", block)
         self.assertIn("--candidate-sha ${{ github.event.pull_request.head.sha }}", block)
-        self.assertIn("--base-sha ${{ github.event.pull_request.base.sha }}", block)
+        self.assertIn(
+            "--base-sha 1dec809c7c43709a8fcceef5e53690d124012eb3", block
+        )
         self.assertIn("tests.scripts.test_chaos_engine_bootstrap", block)
         self.assertIn("tests.scripts.test_chaos_engine_install_wrappers", block)
         self.assertNotIn("tests.scripts.test_chaos_engine_live_installer_acceptance", block)

--- a/tests/scripts/test_chaos_engine_live_installer_acceptance.py
+++ b/tests/scripts/test_chaos_engine_live_installer_acceptance.py
@@ -383,6 +383,17 @@ class ChaosEngineLiveInstallerAcceptanceTest(TestCase):
         self.assertIn("source_record=manifest['source']", source)
         self.assertIn("offline_environment(block_path=True)", source)
 
+    def test_pull_request_acceptance_pins_the_immutable_base(self):
+        workflow = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")
+        block = workflow[
+            workflow.index("  chaos-installer-acceptance:"):
+            workflow.index("  summary:")
+        ]
+        self.assertIn(
+            "--base-sha 1dec809c7c43709a8fcceef5e53690d124012eb3", block
+        )
+        self.assertNotIn("github.event.pull_request.base.sha", block)
+
     def test_weekly_manual_three_os_job_is_bounded_and_uploads_evidence(self):
         workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
         self.assertIn("schedule", workflow[True])


### PR DESCRIPTION
Closes #5476

Restores installer validation after the OmniRoute documentation merge exposed two bootstrap defects:

- excludes repository-only guides from the portable installer payload
- pins PR installer acceptance to the harness-owned immutable legacy baseline, preventing unrelated main movement from invalidating upgrade evidence

Focused validation:
- PR workflow immutable-base contract
- origin-only documentation exclusion
- clean manifest-bound install
- generation activation