### PR TITLE
Fix installer runtime hygiene after MemPalace dedup

### DIFF
--- a/.chaos-engine/dependencies.py
+++ b/.chaos-engine/dependencies.py
@@ -575,10 +575,6 @@ def project_setup_plan(project: Path, commands: dict[str, str]) -> list[list[str
             planned.append([mempalace, "init", ".", "--yes", "--no-llm", "--auto-mine"])
     graphify = commands.get("graphify")
     if graphify:
-        if not (project / ".agents/skills/graphify/SKILL.md").is_file():
-            planned.append(
-                [graphify, "install", "--platform", "agents", "--project"]
-            )
         if not (project / "graphify-out/graph.json").is_file():
             planned.append([graphify, "extract", ".", "--code-only"])
     memory = commands.get("memory")

--- a/.chaos-engine/manifest.json
+++ b/.chaos-engine/manifest.json
@@ -101,7 +101,7 @@
     "assets/memory-v5/relation.schema.json": "df445907616886574f127277c36985e2036aa78b43c48a1cf2e808e33e2102dc",
     "bootstrap.py": "c913fafb1ef0cd77c760571bcbe78875bedcf04922023214c88c8ac598e1133c",
     "dependencies.json": "c3ad73f4afa7a1cae751bf6704de35705b22b05d7b19f72a549161c80f88bee0",
-    "dependencies.py": "66b4a8e5db2bd699e0428c53424b89812a1a5222c4a2a3379ea01129e2b7c731",
+    "dependencies.py": "917e56cca81a636c02afe31fd53c2f1114fbaf7e108bad37d5c5a5c718ac37ea",
     "hooks/guard.py": "9871d82293afee31ffda5aecd83ca92e73f87a21549509bbba72095adfdca27b",
     "hooks/kernel.py": "f73fe58894991b1b1f9824cfaaccd6a8112d5f85f747a960a30e38c01b7d2d11",
     "hooks/launch.js": "697ede00485da25ec520fa5d9eda67335cd81ab497ce106a187913ac709d1d64",

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -575,10 +575,6 @@ def project_setup_plan(project: Path, commands: dict[str, str]) -> list[list[str
             planned.append([mempalace, "init", ".", "--yes", "--no-llm", "--auto-mine"])
     graphify = commands.get("graphify")
     if graphify:
-        if not (project / ".agents/skills/graphify/SKILL.md").is_file():
-            planned.append(
-                [graphify, "install", "--platform", "agents", "--project"]
-            )
         if not (project / "graphify-out/graph.json").is_file():
             planned.append([graphify, "extract", ".", "--code-only"])
     memory = commands.get("memory")

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -86,6 +86,8 @@ FORBIDDEN_LINK_FRAGMENTS = (
 )
 IGNORED_DIRECTORIES = {
     ".chaos-engine-runtime",
+    ".chaos-engine-runtime-generations",
+    ".chaos-engine-runtime-transactions",
     ".git",
     ".idea",
     "allure-report",

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -567,7 +567,7 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
                 },
                 module.mempalace_project_setup_environment(project, configured[0]),
             )
-            self.assertIn(
+            self.assertNotIn(
                 ["/tools/graphify", "install", "--platform", "agents", "--project"],
                 fresh,
             )

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -153,6 +153,18 @@ flowchart LR
             validate_repository(self.root),
         )
 
+    def test_ignores_installer_runtime_generation_and_transaction_directories(self):
+        self.write(
+            ".chaos-engine-runtime-generations/current/node/README.md",
+            "# Generated dependency documentation\n",
+        )
+        self.write(
+            ".chaos-engine-runtime-transactions/current/package/README.md",
+            "# Transaction dependency documentation\n",
+        )
+
+        self.assertEqual(validate_repository(self.root), [])
+
     def test_rejects_unapproved_nested_readme(self):
         self.write(".github/other/README.md", "# Other\n")
 


### PR DESCRIPTION
## Summary
- stop the account dependency setup from installing a repository-local Graphify skill copy
- exclude installer-owned runtime generation and transaction directories from documentation source validation
- add focused regressions for both current-machine failures

Closes #5478

## Checks
- `python3 -m unittest tests.scripts.test_chaos_engine_dependencies tests.scripts.test_validate_documentation_boundaries`
- `python3 scripts/ci/validate_agent_setup.py --skip-external`
- `git diff --check`
- source/install dependency controller mirror parity

## Continuation
This is the current-machine validation follow-up to merged PR #5472. The failure was discovered during final post-merge installer convergence; no project Memory, MemPalace, or Graphify data is duplicated by this patch.