### PR TITLE
feat(chaos-engine): isolate harness fixtures and resume delegates

### DIFF
--- a/agent-plugins/chaos-engine/CHANGELOG.md
+++ b/agent-plugins/chaos-engine/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## 10.3.20260820 - 2026-08-24
+## 10.3.20260824 - 2026-08-24
 
 - Breaking: rename the portable plugin, zipapp, and CLI from `act-as-mohab`
   to `chaos-engine`. Remove the discoverable compatibility-alias skill.
+- Isolate delivery and fresh-base fixtures without weakening production guards.
+- Add bounded OmniRoot delegate continuity with capability enforcement, private
+  per-candidate invocation selection, immutable deadlines, and redacted state.
 
 ## 10.3.20260820 - 2026-08-20
 

--- a/agent-plugins/chaos-engine/COMPATIBILITY.md
+++ b/agent-plugins/chaos-engine/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Compatibility
 
-Evidence applies to `chaos-engine` 10.3.20260820 as of 2026-08-24. This release exposes
+Evidence applies to `chaos-engine` 10.3.20260824 as of 2026-08-24. This release exposes
 one discoverable `chaos-engine` skill; its consultation and retrieval stages
 remain available as internal references, including the mandatory executable
 planning contract and repository-safe plan-artifact routing. Its bundled
@@ -11,7 +11,7 @@ caller-relative or explicit; no SHAFT checkout path is embedded.
 
 | Client | Discovery and validation | Clean live load |
 | --- | --- | --- |
-| Codex | Native `.codex-plugin` adapter and package validation passed. | Clean native load passed for 10.3.20260820 in the scheduled/manual acceptance workflow. The earlier evidence is recorded in [#4576](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/4576). |
-| Claude Code | Native `.claude-plugin` adapter; `claude plugin validate --strict` passed. | Clean native load passed for 10.3.20260820 in the scheduled/manual acceptance workflow. |
+| Codex | Native `.codex-plugin` adapter and package validation passed. | Most recent clean native load passed for 10.3.20260820 in the scheduled/manual acceptance workflow. The earlier evidence is recorded in [#4576](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/4576). |
+| Claude Code | Native `.claude-plugin` adapter; `claude plugin validate --strict` passed. | Most recent clean native load passed for 10.3.20260820 in the scheduled/manual acceptance workflow. |
 
 The Claude live-load proof remains tracked in [#4636](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/4636). Consumers should validate the package in their own client before relying on it.

--- a/chaos-engine/skills/omniroot/SKILL.md
+++ b/chaos-engine/skills/omniroot/SKILL.md
@@ -97,3 +97,21 @@ learning disposition before the sole Learning Session.
 
 The operator configures the user-local configuration and attestation outside
 the repository. The runner treats both as untrusted input and fails closed.
+
+## Delegate continuity
+
+Dispatch may opt into bounded continuity. Omit `continuity` for unchanged
+legacy behavior. Continuity freezes capability floor, maximum attempts,
+retryable exit codes, bounded backoff, authority/checkpoint hashes, completed
+action hashes, tracker/PR hashes, and ordered alternate identity/session hashes.
+Raw prompts, credentials, links, provider/model names, commands, and local paths
+never enter continuity state.
+
+Replacement starts only after prior process-group death is proven. Lower
+capability alternates are skipped. Learning registration precedes launch;
+registration failure creates no participant or process. One live replacement
+sets `replacement_running`, making repeated resume calls idempotent. Exhausted
+attempts open the breaker and block; unverifiable process death or identity
+quarantines. Terminal receipts include only redacted continuity hashes,
+attempt/state, and participant hashes. Root still owns final evidence import and
+the sole Learning Session.

--- a/chaos-engine/skills/omniroot/SKILL.md
+++ b/chaos-engine/skills/omniroot/SKILL.md
@@ -115,3 +115,12 @@ attempts open the breaker and block; unverifiable process death or identity
 quarantines. Terminal receipts include only redacted continuity hashes,
 attempt/state, and participant hashes. Root still owns final evidence import and
 the sole Learning Session.
+
+For opted-in dispatches, runner starts its private `_supervise` process instead
+of one-shot `_capture`. Supervisor retains raw alternate session identifiers
+only in its inherited process environment, removes them before launching any
+delegate, and never writes them to disk. It observes sealed-launcher exit,
+proves process-group death, applies backoff and capability selection, registers
+replacement, then launches same frozen task command. Final successful evidence
+moves normal `status` flow to review without owner input. `_supervise` is an
+internal runner command, not an operator-facing interface.

--- a/chaos-engine/skills/omniroot/SKILL.md
+++ b/chaos-engine/skills/omniroot/SKILL.md
@@ -104,6 +104,10 @@ Dispatch may opt into bounded continuity. Omit `continuity` for unchanged
 legacy behavior. Continuity freezes capability floor, maximum attempts,
 retryable exit codes, bounded backoff, authority/checkpoint hashes, completed
 action hashes, tracker/PR hashes, and ordered alternate identity/session hashes.
+At most four writers may participate: one initial writer plus no more than three
+alternates, with no more than four total attempts. Each private alternate also
+carries one validated target and bounded argument list. The supervisor keeps the
+sealed launcher fixed while selecting those inputs in memory for each attempt.
 Raw prompts, credentials, links, provider/model names, commands, and local paths
 never enter continuity state.
 
@@ -121,6 +125,9 @@ of one-shot `_capture`. Supervisor retains raw alternate session identifiers
 only in its inherited process environment, removes them before launching any
 delegate, and never writes them to disk. It observes sealed-launcher exit,
 proves process-group death, applies backoff and capability selection, registers
-replacement, then launches same frozen task command. Final successful evidence
+replacement, then launches candidate-specific private inputs against the same
+frozen task and authority. Final successful evidence
 moves normal `status` flow to review without owner input. `_supervise` is an
 internal runner command, not an operator-facing interface.
+The original timezone-aware deadline bounds all attempts, backoff, and process
+runtime. Expiry blocks continuity before another launch.

--- a/chaos-engine/skills/omniroot/scripts/runner.py
+++ b/chaos-engine/skills/omniroot/scripts/runner.py
@@ -43,6 +43,7 @@ _SAFE_RUNTIME_ENVIRONMENT = (
     else ("USERPROFILE", "SystemRoot", "TEMP", "TMP")
 )
 _GIT_EXECUTABLE = shutil.which("git")
+_LOCAL_MONITORS: dict[int, Any] = {}
 if _GIT_EXECUTABLE is not None:
     _GIT_EXECUTABLE = str(Path(_GIT_EXECUTABLE).resolve())
 
@@ -752,7 +753,127 @@ def _capture_command(arguments: list[str]) -> int:
         process, Path(arguments[0]), timeout_seconds=timeout_seconds,
         secrets=[os.environ.get("OMNIROUTE_API_KEY", "")],
     )
+    process.stdout.close()
+    process.stderr.close()
     return int(process.returncode or 0)
+
+
+def _supervise_command(arguments: list[str]) -> int:
+    """Outlive delegates and replace retryable failures without owner input."""
+    if len(arguments) < 13 or arguments[11] != "--":
+        raise OmniRootError("supervisor arguments are invalid")
+    diagnostic_path, process_path, manifest_path = map(Path, arguments[:3])
+    try:
+        timeout_seconds = int(arguments[3])
+        expected_identity = (*tuple(int(value) for value in arguments[4:10]), arguments[10])
+    except ValueError as error:
+        raise OmniRootError("supervisor timeout is invalid") from error
+    command = arguments[12:]
+    if not 1 <= timeout_seconds <= 86400 or not command:
+        raise OmniRootError("supervisor arguments are invalid")
+    raw = os.environ.pop("OMNIROOT_CONTINUITY", "")
+    learning_state = os.environ.pop("OMNIROOT_LEARNING_STATE", "")
+    learning_root = os.environ.pop("OMNIROOT_LEARNING_ROOT", "")
+    active_session = os.environ.pop("OMNIROOT_INITIAL_SESSION", "")
+    try:
+        candidates = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise OmniRootError("supervisor continuity input is invalid") from error
+    if not isinstance(candidates, list):
+        raise OmniRootError("supervisor continuity input is invalid")
+    qualified = _resolved_executable(command)
+    if qualified is None or qualified[1] != expected_identity:
+        raise OmniRootError("qualified launcher changed before execution")
+    command = qualified[0]
+    for _ in range(100):
+        manifest = _load_json(manifest_path)
+        if isinstance(manifest.get("continuity"), dict):
+            break
+        time.sleep(0.05)
+    else:
+        raise OmniRootError("supervisor manifest was not published")
+
+    def attest_launch_failure(session_id: str) -> None:
+        source_root = str(Path(__file__).resolve().parents[4])
+        if source_root not in sys.path:
+            sys.path.insert(0, source_root)
+        from scripts.agents.learning_session import attest_participant_unavailable
+        attest_participant_unavailable(Path(learning_state), learning_root, session_id, "launch-failure")
+
+    while True:
+        try:
+            process = subprocess.Popen(  # nosec B603 - sealed command identity is verified.
+                command, shell=False, close_fds=True, start_new_session=True,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+        except OSError:
+            with contextlib.suppress(Exception):
+                attest_launch_failure(active_session)
+            manifest["status"] = "blocked"
+            manifest["continuity"]["state"] = "blocked"
+            manifest["continuity"]["reason"] = "replacement launch failed"
+            _write_json(manifest_path, manifest)
+            return 1
+        identity = process_identity(process.pid)
+        if identity is None:
+            _terminate_group(process)
+            manifest["status"] = "quarantined"
+            manifest["continuity"]["state"] = "quarantined"
+            manifest["continuity"]["reason"] = "replacement process identity cannot be proven"
+            _write_json(manifest_path, manifest)
+            return 1
+        process_evidence = {
+            "schemaVersion": SCHEMA_VERSION, "pid": process.pid,
+            "pgid": os.getpgid(process.pid), "processIdentity": identity,
+        }
+        _write_json(process_path, process_evidence)
+        _collect_diagnostics(process, diagnostic_path, timeout_seconds=timeout_seconds,
+                             secrets=[os.environ.get("OMNIROUTE_API_KEY", "")])
+        process.stdout.close()
+        process.stderr.close()
+        diagnostic = _validated_diagnostic(_load_json(diagnostic_path))
+        if _group_alive(process_evidence["pgid"]):
+            try:
+                _terminate_group(process)
+            except OmniRootError:
+                manifest["status"] = "quarantined"
+                manifest["continuity"]["state"] = "quarantined"
+                manifest["continuity"]["reason"] = "prior process group death cannot be proven"
+                _write_json(manifest_path, manifest)
+                return 1
+        if diagnostic["exitCode"] == 0:
+            manifest["continuity"]["state"] = "review"
+            manifest["status"] = "running"
+            _write_json(manifest_path, manifest)
+            return 0
+
+        launched: dict[str, Any] = {}
+        def register(session_id: str) -> None:
+            source_root = str(Path(__file__).resolve().parents[4])
+            if source_root not in sys.path:
+                sys.path.insert(0, source_root)
+            from scripts.agents.learning_session import register_runtime_participant
+            register_runtime_participant(Path(learning_state), learning_root, session_id)
+
+        def launch(candidate: dict[str, str]) -> dict[str, Any]:
+            launched["candidate"] = candidate
+            return {"pid": -1, "pgid": -1, "processIdentity": "pending"}
+
+        def compensate(session_id: str) -> None:
+            attest_launch_failure(session_id)
+
+        supervisor_monitor = manifest.get("monitor")
+        manifest = _advance_continuity(
+            manifest, exit_code=diagnostic["exitCode"], group_dead=True,
+            candidates=candidates, register=register, launch=launch, compensate=compensate,
+        )
+        if manifest.get("status") != "running" or not launched:
+            _write_json(manifest_path, manifest)
+            return diagnostic["exitCode"]
+        manifest["monitor"] = supervisor_monitor
+        manifest["continuity"]["state"] = "replacement_running"
+        _write_json(manifest_path, manifest)
+        active_session = launched["candidate"]["sessionId"]
 
 
 def _validated_diagnostic(value: dict[str, Any]) -> dict[str, Any]:
@@ -974,11 +1095,27 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
         with contextlib.suppress(OSError):
             path.unlink()
         raise OmniRootError("bounded process-tree timeout is unsupported on this host")
-    launched_argv = (
-        [sys.executable, str(Path(__file__).resolve()), "_capture", str(diagnostic_path),
-         str(delegate_process_path), str(timeout_seconds), *(str(value) for value in launcher_identity), "--", *argv]
-        if durable_monitor else argv
-    )
+    if durable_monitor and continuity_manifest is not None:
+        launched_argv = [
+            sys.executable, str(Path(__file__).resolve()), "_supervise", str(diagnostic_path),
+            str(delegate_process_path), str(path), str(timeout_seconds),
+            *(str(value) for value in launcher_identity), "--", *argv,
+        ]
+    elif durable_monitor:
+        launched_argv = [
+            sys.executable, str(Path(__file__).resolve()), "_capture", str(diagnostic_path),
+            str(delegate_process_path), str(timeout_seconds), *(str(value) for value in launcher_identity), "--", *argv,
+        ]
+    else:
+        launched_argv = argv
+    launch_environment = dict(dispatch_environment)
+    if durable_monitor and continuity_manifest is not None:
+        launch_environment.update({
+            "OMNIROOT_CONTINUITY": json.dumps(continuity["alternates"], separators=(",", ":")),
+            "OMNIROOT_LEARNING_STATE": str(learning_state),
+            "OMNIROOT_LEARNING_ROOT": str(learning_root_session_id),
+            "OMNIROOT_INITIAL_SESSION": str(delegate_session_id),
+        })
     registered = False
     try:
         if not _same_executable(launcher_argv, launcher_identity):
@@ -993,7 +1130,7 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
         except Exception as registration_error:
             raise OmniRootError("delegate learning registration failed") from registration_error
         process = popen(
-            launched_argv, cwd=str(worktree), env=dispatch_environment, shell=False,
+            launched_argv, cwd=str(worktree), env=launch_environment, shell=False,
             close_fds=True, start_new_session=True,
             stdout=subprocess.DEVNULL if durable_monitor else subprocess.PIPE,
             stderr=subprocess.DEVNULL if durable_monitor else subprocess.PIPE,
@@ -1023,6 +1160,8 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
         with contextlib.suppress(OSError):
             path.unlink()
         raise OmniRootError("durable process identity cannot be proven; use native fallback")
+    if durable_monitor:
+        _LOCAL_MONITORS[pid] = process
     timestamp = _utc_now().isoformat()
     manifest = {
         "schemaVersion": SCHEMA_VERSION, "runId": run_id, "taskId": task_id, "workflow": workflow,
@@ -1074,6 +1213,13 @@ def status(run_id: str, state_dir: Path, *, process_identity: Callable[[int], st
         diagnostic_path = Path(state_dir) / "diagnostics" / f"{run_id}.json"
         diagnostic = _validated_diagnostic(_load_json(diagnostic_path)) if diagnostic_path.is_file() else None
         if diagnostic is not None and isinstance(diagnostic.get("exitCode"), int):
+            continuity = manifest.get("continuity")
+            monitor = manifest.get("monitor", {})
+            if (isinstance(continuity, dict) and continuity.get("state") not in {
+                    "review", "blocked", "breaker_open", "quarantined"}
+                    and isinstance(monitor.get("pid"), int)
+                    and process_identity(monitor["pid"]) == monitor.get("processIdentity")):
+                return manifest
             process_path = Path(state_dir) / "processes" / f"{run_id}.json"
             delegate_process = _load_json(process_path) if process_path.is_file() else None
             if not isinstance(delegate_process, dict) or not isinstance(delegate_process.get("pgid"), int) \
@@ -1092,6 +1238,10 @@ def status(run_id: str, state_dir: Path, *, process_identity: Callable[[int], st
             }
             manifest.setdefault("timestamps", {})["updatedAt"] = _utc_now().isoformat()
             _write_json(path, manifest)
+            monitor_process = _LOCAL_MONITORS.pop(manifest.get("monitor", {}).get("pid"), None)
+            if monitor_process is not None:
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    monitor_process.wait(timeout=1)
             return manifest
         monitor = manifest.get("monitor", {})
         pid, identity = monitor.get("pid"), monitor.get("processIdentity")
@@ -1257,6 +1407,12 @@ def main(argv: list[str] | None = None) -> int:
     if raw_arguments and raw_arguments[0] == "_capture":
         try:
             return _capture_command(raw_arguments[1:])
+        except OmniRootError as error:
+            print(str(error), file=sys.stderr)
+            return 1
+    if raw_arguments and raw_arguments[0] == "_supervise":
+        try:
+            return _supervise_command(raw_arguments[1:])
         except OmniRootError as error:
             print(str(error), file=sys.stderr)
             return 1

--- a/chaos-engine/skills/omniroot/scripts/runner.py
+++ b/chaos-engine/skills/omniroot/scripts/runner.py
@@ -34,6 +34,7 @@ READINESS = frozenset({
     "ABSENT", "UNHEALTHY", "UNAUTHENTICATED", "ROUTE_UNQUALIFIED", "READY", "RUNTIME_EXHAUSTED",
 })
 RUN_STATUSES = frozenset({"planned", "running", "stalled", "blocked", "review", "completed", "cancelled", "quarantined"})
+_CAPABILITY_RANK = {"mechanical": 0, "default": 1, "most-intelligent": 2}
 _RUN_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
 _TARGET = re.compile(r"[a-z][a-z0-9-]{0,63}\Z")
 _HEX = re.compile(r"[0-9a-f]{64}\Z")
@@ -455,6 +456,149 @@ def _sha256(value: object) -> str:
     return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
+def _continuity_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Validate opt-in failover state; persist identities and links as hashes only."""
+    if value is None:
+        return None
+    required = {
+        "requiredCapability", "maxAttempts", "retryableExitCodes", "backoffSeconds",
+        "authoritySha256", "checkpointSha256", "completedActionSha256s",
+        "trackerUrlSha256", "pullRequestUrlSha256", "alternates",
+    }
+    if not isinstance(value, dict) or set(value) != required:
+        raise OmniRootError("continuity contract fields are invalid")
+    capability = value.get("requiredCapability")
+    attempts = value.get("maxAttempts")
+    exits = value.get("retryableExitCodes")
+    backoff = value.get("backoffSeconds")
+    hashes = [value.get(name) for name in (
+        "authoritySha256", "checkpointSha256", "trackerUrlSha256", "pullRequestUrlSha256",
+    )]
+    completed = value.get("completedActionSha256s")
+    alternates = value.get("alternates")
+    if capability not in _CAPABILITY_RANK or not isinstance(attempts, int) or not 2 <= attempts <= 8:
+        raise OmniRootError("continuity bounds are invalid")
+    if (not isinstance(exits, list) or not exits or len(set(exits)) != len(exits)
+            or not all(isinstance(code, int) and 1 <= code <= 255 for code in exits)):
+        raise OmniRootError("continuity retry exits are invalid")
+    if not isinstance(backoff, int) or not 0 <= backoff <= 300:
+        raise OmniRootError("continuity backoff is invalid")
+    if not all(isinstance(item, str) and _HEX.fullmatch(item) for item in hashes):
+        raise OmniRootError("continuity evidence hashes are invalid")
+    if (not isinstance(completed, list) or len(set(completed)) != len(completed)
+            or not all(isinstance(item, str) and _HEX.fullmatch(item) for item in completed)):
+        raise OmniRootError("continuity completed actions are invalid")
+    if not isinstance(alternates, list) or not alternates:
+        raise OmniRootError("continuity alternates are invalid")
+    safe_alternates = []
+    seen = set()
+    for candidate in alternates:
+        if (not isinstance(candidate, dict) or set(candidate) != {"identity", "sessionId", "capability"}
+                or candidate.get("capability") not in _CAPABILITY_RANK
+                or not all(isinstance(candidate.get(name), str) and candidate[name]
+                           for name in ("identity", "sessionId"))):
+            raise OmniRootError("continuity alternate is invalid")
+        identity = (_sha256(candidate["identity"]), _sha256(candidate["sessionId"]))
+        if identity in seen:
+            raise OmniRootError("continuity alternates must be unique")
+        seen.add(identity)
+        safe_alternates.append({
+            "identitySha256": identity[0], "sessionSha256": identity[1],
+            "capability": candidate["capability"],
+        })
+    return {
+        "requiredCapability": capability, "maxAttempts": attempts,
+        "retryableExitCodes": sorted(exits), "backoffSeconds": backoff,
+        "authoritySha256": value["authoritySha256"],
+        "checkpointSha256": value["checkpointSha256"],
+        "completedActionSha256s": sorted(completed),
+        "trackerUrlSha256": value["trackerUrlSha256"],
+        "pullRequestUrlSha256": value["pullRequestUrlSha256"],
+        "alternates": safe_alternates, "attempt": 1, "state": "running",
+        "participants": [],
+    }
+
+
+def _advance_continuity(
+    manifest: dict[str, Any], *, exit_code: int, group_dead: bool,
+    candidates: list[dict[str, str]], register: Callable[[str], None],
+    launch: Callable[[dict[str, str]], dict[str, Any]],
+    compensate: Callable[[str], None] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    """Advance one in-memory failover attempt without persisting launch inputs."""
+    continuity = manifest.get("continuity")
+    if not isinstance(continuity, dict) or continuity.get("state") == "replacement_running":
+        return manifest
+    if not group_dead:
+        manifest["status"] = "quarantined"
+        continuity["state"] = "quarantined"
+        continuity["reason"] = "prior process group death cannot be proven"
+        return manifest
+    if exit_code not in continuity["retryableExitCodes"]:
+        manifest["status"] = "blocked"
+        continuity["state"] = "blocked"
+        continuity["reason"] = "non-retryable exit"
+        return manifest
+    if continuity["attempt"] >= continuity["maxAttempts"]:
+        manifest["status"] = "blocked"
+        continuity["state"] = "breaker_open"
+        continuity["reason"] = "continuity attempts exhausted"
+        return manifest
+    used = {item["sessionSha256"] for item in continuity["participants"]}
+    required = _CAPABILITY_RANK[continuity["requiredCapability"]]
+    candidate = next((item for item in candidates
+                      if item.get("capability") in _CAPABILITY_RANK
+                      and _CAPABILITY_RANK[item["capability"]] >= required
+                      and _sha256(item.get("sessionId")) not in used), None)
+    if candidate is None:
+        manifest["status"] = "blocked"
+        continuity["state"] = "blocked"
+        continuity["reason"] = "no compatible continuity alternate"
+        return manifest
+    try:
+        register(candidate["sessionId"])
+    except Exception:
+        manifest["status"] = "blocked"
+        continuity["state"] = "blocked"
+        continuity["reason"] = "replacement learning registration failed"
+        return manifest
+    participant = {
+        "identitySha256": _sha256(candidate["identity"]),
+        "sessionSha256": _sha256(candidate["sessionId"]),
+        "capability": candidate["capability"],
+    }
+    continuity["participants"].append(participant)
+    continuity["state"] = "failover_pending"
+    sleep(continuity["backoffSeconds"])
+    continuity["state"] = "half_open"
+    try:
+        process = launch(candidate)
+    except Exception:
+        if compensate is not None:
+            with contextlib.suppress(Exception):
+                compensate(candidate["sessionId"])
+        continuity["attempt"] += 1
+        continuity["state"] = "failover_pending"
+        continuity["reason"] = "replacement launch failed"
+        manifest["status"] = "stalled"
+        return manifest
+    if (not isinstance(process, dict) or not isinstance(process.get("pid"), int)
+            or not isinstance(process.get("pgid"), int)
+            or not isinstance(process.get("processIdentity"), str)):
+        manifest["status"] = "quarantined"
+        continuity["state"] = "quarantined"
+        continuity["reason"] = "replacement process identity cannot be proven"
+        return manifest
+    continuity["attempt"] += 1
+    continuity["state"] = "replacement_running"
+    continuity.pop("reason", None)
+    manifest["status"] = "running"
+    manifest["delegate"] = {**manifest.get("delegate", {}), **participant}
+    manifest["monitor"] = dict(process)
+    return manifest
+
+
 _SECRET_TEXT = re.compile(
     r'''(?ix)
     (authorization\s*:\s*(?:bearer|basic)\s+)([^\s]+)
@@ -734,6 +878,7 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
     learning_state: Path | None = None,
     learning_root_session_id: str | None = None,
     delegate_session_id: str | None = None,
+    continuity: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Launch one bounded implementer only after a fresh strict readiness check."""
     _platform_preflight()
@@ -769,6 +914,12 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
         raise OmniRootError("a future timezone-aware deadline is required")
     if not isinstance(delegate, dict) or not delegate.get("pathOwnership"):
         raise OmniRootError("explicit non-empty delegate ownership is required")
+    continuity_manifest = _continuity_contract(continuity)
+    if (continuity_manifest is not None
+            and (delegate.get("capability") not in _CAPABILITY_RANK
+                 or _CAPABILITY_RANK[delegate["capability"]]
+                 < _CAPABILITY_RANK[continuity_manifest["requiredCapability"]])):
+        raise OmniRootError("initial delegate does not satisfy continuity capability floor")
     environment = os.environ.copy() if environ is None else dict(environ)
     config = _read_config(config_path or default_config_path())
     if config is None:
@@ -828,6 +979,7 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
          str(delegate_process_path), str(timeout_seconds), *(str(value) for value in launcher_identity), "--", *argv]
         if durable_monitor else argv
     )
+    registered = False
     try:
         if not _same_executable(launcher_argv, launcher_identity):
             raise OmniRootError("qualified launcher changed before execution")
@@ -837,6 +989,7 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
         try:
             from scripts.agents.learning_session import register_runtime_participant
             register_runtime_participant(Path(learning_state), learning_root_session_id, delegate_session_id)
+            registered = True
         except Exception as registration_error:
             raise OmniRootError("delegate learning registration failed") from registration_error
         process = popen(
@@ -848,6 +1001,12 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
     except (OSError, OmniRootError) as error:
         with contextlib.suppress(OSError):
             path.unlink()
+        if registered:
+            with contextlib.suppress(Exception):
+                from scripts.agents.learning_session import attest_participant_unavailable
+                attest_participant_unavailable(
+                    Path(learning_state), learning_root_session_id, delegate_session_id, "launch-failure"
+                )
         if isinstance(error, OmniRootError):
             raise
         raise OmniRootError("OmniRoute launcher could not start") from error
@@ -880,6 +1039,13 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
         "delegateProcess": {"path": str(delegate_process_path)},
         "receipt": {"path": str(_receipt_path(Path(state_dir), run_id)), "sha256": None},
     }
+    if continuity_manifest is not None:
+        continuity_manifest["participants"] = [{
+            "identitySha256": _sha256(delegate.get("identity", "anonymous")),
+            "sessionSha256": _sha256(delegate_session_id),
+            "capability": delegate.get("capability", "default"),
+        }]
+        manifest["continuity"] = continuity_manifest
     try:
         _write_json(path, manifest)
     except Exception:
@@ -1056,6 +1222,14 @@ def complete(  # noqa: MC0001 - receipt validation remains one fail-closed audit
             "stderrTruncated": diagnostic.get("stderrTruncated") is True,
         },
     }
+    continuity = manifest.get("continuity")
+    if isinstance(continuity, dict):
+        receipt["continuity"] = {
+            key: continuity[key] for key in (
+                "authoritySha256", "checkpointSha256", "completedActionSha256s",
+                "trackerUrlSha256", "pullRequestUrlSha256", "attempt", "state", "participants",
+            ) if key in continuity
+        }
     receipt_path = _receipt_path(Path(state_dir), run_id)
     _create_immutable_json(receipt_path, receipt)
     manifest["status"] = receipt["status"]
@@ -1109,7 +1283,7 @@ def main(argv: list[str] | None = None) -> int:
                         "rootSessionId", "baseCommit", "integrationBranch", "integrationWorktree",
                         "delegate", "cadenceSeconds", "deadline", "timeoutSeconds", "learningState",
                         "learningRootSessionId", "delegateSessionId"}
-            if set(contract) != required:
+            if set(contract) not in (required, required | {"continuity"}):
                 raise OmniRootError("dispatch contract fields are invalid")
             return _print(dispatch(run_id=contract["runId"], worktree=Path(contract["worktree"]),
                 state_dir=args.state_dir, config_path=args.config, target=contract["target"],
@@ -1120,7 +1294,7 @@ def main(argv: list[str] | None = None) -> int:
                 cadence_seconds=contract["cadenceSeconds"], deadline=contract["deadline"],
                 timeout_seconds=contract["timeoutSeconds"], learning_state=Path(contract["learningState"]),
                 learning_root_session_id=contract["learningRootSessionId"],
-                delegate_session_id=contract["delegateSessionId"]))
+                delegate_session_id=contract["delegateSessionId"], continuity=contract.get("continuity")))
         if args.command == "status":
             return _print(status(args.run_id, args.state_dir))
         if args.command == "cancel":

--- a/chaos-engine/skills/omniroot/scripts/runner.py
+++ b/chaos-engine/skills/omniroot/scripts/runner.py
@@ -791,8 +791,7 @@ def _capture_command(arguments: list[str]) -> int:
     return int(process.returncode or 0)
 
 
-def _supervise_command(arguments: list[str]) -> int:
-    """Outlive delegates and replace retryable failures without owner input."""
+def _supervisor_arguments(arguments: list[str]) -> tuple[Path, Path, Path, int, tuple[Any, ...], list[str]]:
     if len(arguments) < 13 or arguments[11] != "--":
         raise OmniRootError("supervisor arguments are invalid")
     diagnostic_path, process_path, manifest_path = map(Path, arguments[:3])
@@ -804,6 +803,10 @@ def _supervise_command(arguments: list[str]) -> int:
     command = arguments[12:]
     if not 1 <= timeout_seconds <= 86400 or not command:
         raise OmniRootError("supervisor arguments are invalid")
+    return diagnostic_path, process_path, manifest_path, timeout_seconds, expected_identity, command
+
+
+def _supervisor_environment(command: list[str]) -> tuple[list[dict[str, str]], str, str, str, str, int]:
     raw = os.environ.pop("OMNIROOT_CONTINUITY", "")
     learning_state = os.environ.pop("OMNIROOT_LEARNING_STATE", "")
     learning_root = os.environ.pop("OMNIROOT_LEARNING_ROOT", "")
@@ -826,18 +829,51 @@ def _supervise_command(arguments: list[str]) -> int:
     if (not candidates or len(candidates) >= MAX_CONTINUITY_WRITERS
             or not all(_valid_private_candidate(candidate) for candidate in candidates)):
         raise OmniRootError("supervisor continuity input is invalid")
+    return candidates, learning_state, learning_root, active_session, invocation_mode, launcher_argc
+
+
+def _supervisor_manifest(path: Path) -> dict[str, Any]:
+    for _ in range(100):
+        manifest = _load_json(path)
+        if isinstance(manifest.get("continuity"), dict):
+            return manifest
+        time.sleep(0.05)
+    raise OmniRootError("supervisor manifest was not published")
+
+
+def _finish_supervision(path: Path, manifest: dict[str, Any], status: str, state: str, reason: str) -> int:
+    manifest["status"] = status
+    manifest["continuity"]["state"] = state
+    manifest["continuity"]["reason"] = reason
+    _write_json(path, manifest)
+    return 1
+
+
+def _replacement_command(
+    launcher_command: list[str], candidate: dict[str, str], invocation_mode: str, credential_mode: str,
+) -> list[str]:
+    if invocation_mode == "direct":
+        return [*launcher_command, *candidate["arguments"]]
+    command = [*launcher_command, candidate["target"], "--port", "20128"]
+    if credential_mode == "environment":
+        command.extend(["--api-key-env", "OMNIROUTE_API_KEY"])
+    command.extend(["--", *candidate["arguments"]])
+    return command
+
+
+def _supervise_command(arguments: list[str]) -> int:
+    """Outlive delegates and replace retryable failures without owner input."""
+    (diagnostic_path, process_path, manifest_path, timeout_seconds,
+     expected_identity, command) = _supervisor_arguments(arguments)
+    credential_mode = os.environ.get("OMNIROOT_CREDENTIAL_MODE", "")
+    (candidates, learning_state, learning_root, active_session,
+     invocation_mode, launcher_argc) = _supervisor_environment(command)
     qualified = _resolved_executable(command)
     if qualified is None or qualified[1] != expected_identity:
         raise OmniRootError("qualified launcher changed before execution")
     command = qualified[0]
     launcher_command = command[:launcher_argc]
-    for _ in range(100):
-        manifest = _load_json(manifest_path)
-        if isinstance(manifest.get("continuity"), dict):
-            break
-        time.sleep(0.05)
-    else:
-        raise OmniRootError("supervisor manifest was not published")
+    manifest = _supervisor_manifest(manifest_path)
 
     def attest_launch_failure(session_id: str) -> None:
         source_root = str(Path(__file__).resolve().parents[4])
@@ -849,11 +885,9 @@ def _supervise_command(arguments: list[str]) -> int:
     while True:
         deadline = _parse_time(manifest.get("deadline"))
         if deadline is None or deadline <= _utc_now():
-            manifest["status"] = "blocked"
-            manifest["continuity"]["state"] = "blocked"
-            manifest["continuity"]["reason"] = "overall deadline expired"
-            _write_json(manifest_path, manifest)
-            return 1
+            return _finish_supervision(
+                manifest_path, manifest, "blocked", "blocked", "overall deadline expired",
+            )
         try:
             process = subprocess.Popen(  # nosec B603 - sealed command identity is verified.
                 command, shell=False, close_fds=True, start_new_session=True,
@@ -862,19 +896,16 @@ def _supervise_command(arguments: list[str]) -> int:
         except OSError:
             with contextlib.suppress(Exception):
                 attest_launch_failure(active_session)
-            manifest["status"] = "blocked"
-            manifest["continuity"]["state"] = "blocked"
-            manifest["continuity"]["reason"] = "replacement launch failed"
-            _write_json(manifest_path, manifest)
-            return 1
+            return _finish_supervision(
+                manifest_path, manifest, "blocked", "blocked", "replacement launch failed",
+            )
         identity = process_identity(process.pid)
         if identity is None:
             _terminate_group(process)
-            manifest["status"] = "quarantined"
-            manifest["continuity"]["state"] = "quarantined"
-            manifest["continuity"]["reason"] = "replacement process identity cannot be proven"
-            _write_json(manifest_path, manifest)
-            return 1
+            return _finish_supervision(
+                manifest_path, manifest, "quarantined", "quarantined",
+                "replacement process identity cannot be proven",
+            )
         process_evidence = {
             "schemaVersion": SCHEMA_VERSION, "pid": process.pid,
             "pgid": os.getpgid(process.pid), "processIdentity": identity,
@@ -883,11 +914,9 @@ def _supervise_command(arguments: list[str]) -> int:
         remaining_seconds = (deadline - _utc_now()).total_seconds()
         if remaining_seconds <= 0:
             _terminate_group(process)
-            manifest["status"] = "blocked"
-            manifest["continuity"]["state"] = "blocked"
-            manifest["continuity"]["reason"] = "overall deadline expired"
-            _write_json(manifest_path, manifest)
-            return 1
+            return _finish_supervision(
+                manifest_path, manifest, "blocked", "blocked", "overall deadline expired",
+            )
         _collect_diagnostics(process, diagnostic_path,
                              timeout_seconds=min(timeout_seconds, remaining_seconds),
                              secrets=[os.environ.get("OMNIROUTE_API_KEY", "")])
@@ -898,11 +927,10 @@ def _supervise_command(arguments: list[str]) -> int:
             try:
                 _terminate_group(process)
             except OmniRootError:
-                manifest["status"] = "quarantined"
-                manifest["continuity"]["state"] = "quarantined"
-                manifest["continuity"]["reason"] = "prior process group death cannot be proven"
-                _write_json(manifest_path, manifest)
-                return 1
+                return _finish_supervision(
+                    manifest_path, manifest, "quarantined", "quarantined",
+                    "prior process group death cannot be proven",
+                )
         if diagnostic["exitCode"] == 0:
             manifest["continuity"]["state"] = "review"
             manifest["status"] = "running"
@@ -937,13 +965,7 @@ def _supervise_command(arguments: list[str]) -> int:
         _write_json(manifest_path, manifest)
         active_session = launched["candidate"]["sessionId"]
         candidate = launched["candidate"]
-        if invocation_mode == "direct":
-            command = [*launcher_command, *candidate["arguments"]]
-        else:
-            command = [*launcher_command, candidate["target"], "--port", "20128"]
-            if credential_mode == "environment":
-                command.extend(["--api-key-env", "OMNIROUTE_API_KEY"])
-            command.extend(["--", *candidate["arguments"]])
+        command = _replacement_command(launcher_command, candidate, invocation_mode, credential_mode)
 
 
 def _validated_diagnostic(value: dict[str, Any]) -> dict[str, Any]:

--- a/chaos-engine/skills/omniroot/scripts/runner.py
+++ b/chaos-engine/skills/omniroot/scripts/runner.py
@@ -522,7 +522,9 @@ def _resumption_secrets(raw: str) -> list[str]:
     return secrets
 
 
-def _continuity_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
+def _continuity_contract(
+    value: dict[str, Any] | None, *, authoritative_task_sha256: str | None = None,
+) -> dict[str, Any] | None:
     """Validate opt-in failover state; persist identities and links as hashes only."""
     if value is None:
         return None
@@ -585,6 +587,8 @@ def _continuity_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
             "identitySha256": identity[0], "sessionSha256": identity[1],
             "capability": candidate["capability"],
         })
+    if authoritative_task_sha256 is not None and task_sha256 != authoritative_task_sha256:
+        raise OmniRootError("continuity resumption does not match authoritative task")
     return {
         "requiredCapability": capability, "maxAttempts": attempts,
         "retryableExitCodes": sorted(exits), "backoffSeconds": backoff,
@@ -939,25 +943,27 @@ def _supervised_diagnostic(
     manifest: dict[str, Any], timeout_seconds: int, active_session: str,
     learning_state: str, learning_root: str,
 ) -> tuple[dict[str, Any] | None, int | None]:
+    resumption_secret = os.environ.pop("OMNIROOT_RESUMPTION", "")
     deadline = _parse_time(manifest.get("deadline"))
     if deadline is None or deadline <= _utc_now():
         return None, _finish_supervision(
             manifest_path, manifest, "blocked", "blocked", "overall deadline expired",
         )
-    resumption_secret = os.environ.get("OMNIROOT_RESUMPTION", "")
+    child_environment = None
+    if resumption_secret:
+        child_environment = dict(os.environ)
+        child_environment["OMNIROOT_RESUMPTION"] = resumption_secret
     try:
         process = subprocess.Popen(  # nosec B603 - sealed command identity is verified.
             command, shell=False, close_fds=True, start_new_session=True,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=child_environment,
         )
     except OSError:
-        os.environ.pop("OMNIROOT_RESUMPTION", None)
         with contextlib.suppress(Exception):
             _learning_action(learning_state, learning_root, active_session, unavailable=True)
         return None, _finish_supervision(
             manifest_path, manifest, "blocked", "blocked", "replacement launch failed",
         )
-    os.environ.pop("OMNIROOT_RESUMPTION", None)
     identity = process_identity(process.pid)
     if identity is None:
         _terminate_group(process)
@@ -1212,7 +1218,7 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
         raise OmniRootError("a future timezone-aware deadline is required")
     if not isinstance(delegate, dict) or not delegate.get("pathOwnership"):
         raise OmniRootError("explicit non-empty delegate ownership is required")
-    continuity_manifest = _continuity_contract(continuity)
+    continuity_manifest = _continuity_contract(continuity, authoritative_task_sha256=_sha256(task_id))
     if (continuity_manifest is not None
             and (delegate.get("capability") not in _CAPABILITY_RANK
                  or _CAPABILITY_RANK[delegate["capability"]]

--- a/chaos-engine/skills/omniroot/scripts/runner.py
+++ b/chaos-engine/skills/omniroot/scripts/runner.py
@@ -28,6 +28,9 @@ DEFAULT_ENDPOINT = "http://127.0.0.1:20128/"
 HEALTH_PATH = "api/health"
 MAX_RESPONSE_BYTES = 64 * 1024
 MAX_DIAGNOSTIC_BYTES = 16 * 1024
+MAX_CONTINUITY_WRITERS = 4
+MAX_DELEGATE_ARGUMENTS = 64
+MAX_DELEGATE_ARGUMENT_BYTES = 16 * 1024
 HTTP_TIMEOUT_SECONDS = 2
 SCHEMA_VERSION = 1
 READINESS = frozenset({
@@ -457,6 +460,22 @@ def _sha256(value: object) -> str:
     return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
+def _valid_private_candidate(candidate: object) -> bool:
+    return bool(
+        isinstance(candidate, dict)
+        and set(candidate) == {"identity", "sessionId", "capability", "target", "arguments"}
+        and candidate.get("capability") in _CAPABILITY_RANK
+        and _TARGET.fullmatch(candidate.get("target", ""))
+        and isinstance(candidate.get("arguments"), list)
+        and len(candidate["arguments"]) <= MAX_DELEGATE_ARGUMENTS
+        and all(isinstance(item, str) and "\x00" not in item for item in candidate["arguments"])
+        and sum(len(item.encode("utf-8")) for item in candidate["arguments"])
+        <= MAX_DELEGATE_ARGUMENT_BYTES
+        and all(isinstance(candidate.get(name), str) and candidate[name]
+                for name in ("identity", "sessionId"))
+    )
+
+
 def _continuity_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
     """Validate opt-in failover state; persist identities and links as hashes only."""
     if value is None:
@@ -477,7 +496,8 @@ def _continuity_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
     )]
     completed = value.get("completedActionSha256s")
     alternates = value.get("alternates")
-    if capability not in _CAPABILITY_RANK or not isinstance(attempts, int) or not 2 <= attempts <= 8:
+    if (capability not in _CAPABILITY_RANK or not isinstance(attempts, int)
+            or not 2 <= attempts <= MAX_CONTINUITY_WRITERS):
         raise OmniRootError("continuity bounds are invalid")
     if (not isinstance(exits, list) or not exits or len(set(exits)) != len(exits)
             or not all(isinstance(code, int) and 1 <= code <= 255 for code in exits)):
@@ -489,15 +509,13 @@ def _continuity_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
     if (not isinstance(completed, list) or len(set(completed)) != len(completed)
             or not all(isinstance(item, str) and _HEX.fullmatch(item) for item in completed)):
         raise OmniRootError("continuity completed actions are invalid")
-    if not isinstance(alternates, list) or not alternates:
+    if (not isinstance(alternates, list) or not alternates
+            or len(alternates) >= MAX_CONTINUITY_WRITERS):
         raise OmniRootError("continuity alternates are invalid")
     safe_alternates = []
     seen = set()
     for candidate in alternates:
-        if (not isinstance(candidate, dict) or set(candidate) != {"identity", "sessionId", "capability"}
-                or candidate.get("capability") not in _CAPABILITY_RANK
-                or not all(isinstance(candidate.get(name), str) and candidate[name]
-                           for name in ("identity", "sessionId"))):
+        if not _valid_private_candidate(candidate):
             raise OmniRootError("continuity alternate is invalid")
         identity = (_sha256(candidate["identity"]), _sha256(candidate["sessionId"]))
         if identity in seen:
@@ -526,10 +544,17 @@ def _advance_continuity(
     launch: Callable[[dict[str, str]], dict[str, Any]],
     compensate: Callable[[str], None] | None = None,
     sleep: Callable[[float], None] = time.sleep,
+    now: Callable[[], datetime] = _utc_now,
 ) -> dict[str, Any]:
     """Advance one in-memory failover attempt without persisting launch inputs."""
     continuity = manifest.get("continuity")
     if not isinstance(continuity, dict) or continuity.get("state") == "replacement_running":
+        return manifest
+    deadline = _parse_time(manifest.get("deadline"))
+    if deadline is None or deadline <= now():
+        manifest["status"] = "blocked"
+        continuity["state"] = "blocked"
+        continuity["reason"] = "overall deadline expired"
         return manifest
     if not group_dead:
         manifest["status"] = "quarantined"
@@ -572,6 +597,14 @@ def _advance_continuity(
     continuity["participants"].append(participant)
     continuity["state"] = "failover_pending"
     sleep(continuity["backoffSeconds"])
+    if deadline <= now():
+        if compensate is not None:
+            with contextlib.suppress(Exception):
+                compensate(candidate["sessionId"])
+        manifest["status"] = "blocked"
+        continuity["state"] = "blocked"
+        continuity["reason"] = "overall deadline expired"
+        return manifest
     continuity["state"] = "half_open"
     try:
         process = launch(candidate)
@@ -678,7 +711,7 @@ def _terminate_group(process: Any) -> int:
     return int(code)
 
 
-def _collect_diagnostics(process: Any, path: Path, *, timeout_seconds: int, secrets: list[str] | None = None) -> None:
+def _collect_diagnostics(process: Any, path: Path, *, timeout_seconds: float, secrets: list[str] | None = None) -> None:
     """Drain both pipes, enforce runtime bound, then persist only redacted caps."""
     streams: dict[str, tuple[bytes, bool]] = {}
 
@@ -775,16 +808,29 @@ def _supervise_command(arguments: list[str]) -> int:
     learning_state = os.environ.pop("OMNIROOT_LEARNING_STATE", "")
     learning_root = os.environ.pop("OMNIROOT_LEARNING_ROOT", "")
     active_session = os.environ.pop("OMNIROOT_INITIAL_SESSION", "")
+    invocation_mode = os.environ.pop("OMNIROOT_INVOCATION_MODE", "")
+    credential_mode = os.environ.pop("OMNIROOT_CREDENTIAL_MODE", "")
+    raw_launcher_argc = os.environ.pop("OMNIROOT_LAUNCHER_ARGC", "")
     try:
         candidates = json.loads(raw)
     except json.JSONDecodeError as error:
         raise OmniRootError("supervisor continuity input is invalid") from error
-    if not isinstance(candidates, list):
+    try:
+        launcher_argc = int(raw_launcher_argc)
+    except ValueError as error:
+        raise OmniRootError("supervisor continuity input is invalid") from error
+    if (not isinstance(candidates, list) or invocation_mode not in {"direct", "gateway"}
+            or credential_mode not in {"environment", "launcher"}
+            or not 1 <= launcher_argc <= len(command)):
+        raise OmniRootError("supervisor continuity input is invalid")
+    if (not candidates or len(candidates) >= MAX_CONTINUITY_WRITERS
+            or not all(_valid_private_candidate(candidate) for candidate in candidates)):
         raise OmniRootError("supervisor continuity input is invalid")
     qualified = _resolved_executable(command)
     if qualified is None or qualified[1] != expected_identity:
         raise OmniRootError("qualified launcher changed before execution")
     command = qualified[0]
+    launcher_command = command[:launcher_argc]
     for _ in range(100):
         manifest = _load_json(manifest_path)
         if isinstance(manifest.get("continuity"), dict):
@@ -801,6 +847,13 @@ def _supervise_command(arguments: list[str]) -> int:
         attest_participant_unavailable(Path(learning_state), learning_root, session_id, "launch-failure")
 
     while True:
+        deadline = _parse_time(manifest.get("deadline"))
+        if deadline is None or deadline <= _utc_now():
+            manifest["status"] = "blocked"
+            manifest["continuity"]["state"] = "blocked"
+            manifest["continuity"]["reason"] = "overall deadline expired"
+            _write_json(manifest_path, manifest)
+            return 1
         try:
             process = subprocess.Popen(  # nosec B603 - sealed command identity is verified.
                 command, shell=False, close_fds=True, start_new_session=True,
@@ -827,7 +880,16 @@ def _supervise_command(arguments: list[str]) -> int:
             "pgid": os.getpgid(process.pid), "processIdentity": identity,
         }
         _write_json(process_path, process_evidence)
-        _collect_diagnostics(process, diagnostic_path, timeout_seconds=timeout_seconds,
+        remaining_seconds = (deadline - _utc_now()).total_seconds()
+        if remaining_seconds <= 0:
+            _terminate_group(process)
+            manifest["status"] = "blocked"
+            manifest["continuity"]["state"] = "blocked"
+            manifest["continuity"]["reason"] = "overall deadline expired"
+            _write_json(manifest_path, manifest)
+            return 1
+        _collect_diagnostics(process, diagnostic_path,
+                             timeout_seconds=min(timeout_seconds, remaining_seconds),
                              secrets=[os.environ.get("OMNIROUTE_API_KEY", "")])
         process.stdout.close()
         process.stderr.close()
@@ -874,6 +936,14 @@ def _supervise_command(arguments: list[str]) -> int:
         manifest["continuity"]["state"] = "replacement_running"
         _write_json(manifest_path, manifest)
         active_session = launched["candidate"]["sessionId"]
+        candidate = launched["candidate"]
+        if invocation_mode == "direct":
+            command = [*launcher_command, *candidate["arguments"]]
+        else:
+            command = [*launcher_command, candidate["target"], "--port", "20128"]
+            if credential_mode == "environment":
+                command.extend(["--api-key-env", "OMNIROUTE_API_KEY"])
+            command.extend(["--", *candidate["arguments"]])
 
 
 def _validated_diagnostic(value: dict[str, Any]) -> dict[str, Any]:
@@ -1115,6 +1185,9 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
             "OMNIROOT_LEARNING_STATE": str(learning_state),
             "OMNIROOT_LEARNING_ROOT": str(learning_root_session_id),
             "OMNIROOT_INITIAL_SESSION": str(delegate_session_id),
+            "OMNIROOT_INVOCATION_MODE": invocation_mode,
+            "OMNIROOT_CREDENTIAL_MODE": credential_mode,
+            "OMNIROOT_LAUNCHER_ARGC": str(len(launcher_argv)),
         })
     registered = False
     try:

--- a/chaos-engine/skills/omniroot/scripts/runner.py
+++ b/chaos-engine/skills/omniroot/scripts/runner.py
@@ -463,7 +463,7 @@ def _sha256(value: object) -> str:
 def _valid_private_candidate(candidate: object) -> bool:
     return bool(
         isinstance(candidate, dict)
-        and set(candidate) == {"identity", "sessionId", "capability", "target", "arguments"}
+        and set(candidate) == {"identity", "sessionId", "capability", "target", "arguments", "resumption"}
         and candidate.get("capability") in _CAPABILITY_RANK
         and _TARGET.fullmatch(candidate.get("target", ""))
         and isinstance(candidate.get("arguments"), list)
@@ -474,6 +474,52 @@ def _valid_private_candidate(candidate: object) -> bool:
         and all(isinstance(candidate.get(name), str) and candidate[name]
                 for name in ("identity", "sessionId"))
     )
+
+
+def _resumption_hashes(value: object) -> dict[str, Any] | None:
+    required = {"task", "authority", "checkpoint", "completedActions", "trackerUrl", "pullRequestUrl"}
+    if not isinstance(value, dict) or set(value) != required:
+        return None
+    completed = value.get("completedActions")
+    if (not all(isinstance(value.get(name), str) and value[name]
+                for name in required - {"completedActions"})
+            or not isinstance(completed, list) or len(set(completed)) != len(completed)
+            or not all(isinstance(item, str) and item for item in completed)):
+        return None
+    return {
+        "taskSha256": _sha256(value["task"]),
+        "authoritySha256": _sha256(value["authority"]),
+        "checkpointSha256": _sha256(value["checkpoint"]),
+        "completedActionSha256s": sorted(_sha256(item) for item in completed),
+        "trackerUrlSha256": _sha256(value["trackerUrl"]),
+        "pullRequestUrlSha256": _sha256(value["pullRequestUrl"]),
+    }
+
+
+def _verified_resumption(candidate: dict[str, Any], continuity: dict[str, Any]) -> dict[str, Any]:
+    hashes = _resumption_hashes(candidate.get("resumption"))
+    expected = {name: continuity.get(name) for name in (
+        "taskSha256", "authoritySha256", "checkpointSha256", "completedActionSha256s",
+        "trackerUrlSha256", "pullRequestUrlSha256",
+    )}
+    if hashes != expected:
+        raise OmniRootError("continuity resumption does not match frozen evidence")
+    return candidate["resumption"]
+
+
+def _resumption_secrets(raw: str) -> list[str]:
+    if not raw:
+        return []
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return [raw]
+    secrets = [raw]
+    if isinstance(value, dict):
+        secrets.extend(item for item in value.values() if isinstance(item, str))
+        secrets.extend(item for items in value.values() if isinstance(items, list)
+                       for item in items if isinstance(item, str))
+    return secrets
 
 
 def _continuity_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -500,7 +546,8 @@ def _continuity_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
             or not 2 <= attempts <= MAX_CONTINUITY_WRITERS):
         raise OmniRootError("continuity bounds are invalid")
     if (not isinstance(exits, list) or not exits or len(set(exits)) != len(exits)
-            or not all(isinstance(code, int) and 1 <= code <= 255 for code in exits)):
+            or not all(isinstance(code, int) and (1 <= code <= 255 or -code in signal.valid_signals())
+                       for code in exits)):
         raise OmniRootError("continuity retry exits are invalid")
     if not isinstance(backoff, int) or not 0 <= backoff <= 300:
         raise OmniRootError("continuity backoff is invalid")
@@ -514,9 +561,22 @@ def _continuity_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
         raise OmniRootError("continuity alternates are invalid")
     safe_alternates = []
     seen = set()
+    task_sha256 = None
     for candidate in alternates:
         if not _valid_private_candidate(candidate):
             raise OmniRootError("continuity alternate is invalid")
+        resumption_hashes = _resumption_hashes(candidate["resumption"])
+        expected_hashes = {
+            name: value[name] for name in (
+                "authoritySha256", "checkpointSha256", "completedActionSha256s",
+                "trackerUrlSha256", "pullRequestUrlSha256",
+            )
+        }
+        if (resumption_hashes is None
+                or {name: resumption_hashes[name] for name in expected_hashes} != expected_hashes
+                or task_sha256 not in {None, resumption_hashes["taskSha256"]}):
+            raise OmniRootError("continuity resumption does not match frozen evidence")
+        task_sha256 = resumption_hashes["taskSha256"]
         identity = (_sha256(candidate["identity"]), _sha256(candidate["sessionId"]))
         if identity in seen:
             raise OmniRootError("continuity alternates must be unique")
@@ -528,6 +588,7 @@ def _continuity_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
     return {
         "requiredCapability": capability, "maxAttempts": attempts,
         "retryableExitCodes": sorted(exits), "backoffSeconds": backoff,
+        "taskSha256": task_sha256,
         "authoritySha256": value["authoritySha256"],
         "checkpointSha256": value["checkpointSha256"],
         "completedActionSha256s": sorted(completed),
@@ -883,17 +944,20 @@ def _supervised_diagnostic(
         return None, _finish_supervision(
             manifest_path, manifest, "blocked", "blocked", "overall deadline expired",
         )
+    resumption_secret = os.environ.get("OMNIROOT_RESUMPTION", "")
     try:
         process = subprocess.Popen(  # nosec B603 - sealed command identity is verified.
             command, shell=False, close_fds=True, start_new_session=True,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         )
     except OSError:
+        os.environ.pop("OMNIROOT_RESUMPTION", None)
         with contextlib.suppress(Exception):
             _learning_action(learning_state, learning_root, active_session, unavailable=True)
         return None, _finish_supervision(
             manifest_path, manifest, "blocked", "blocked", "replacement launch failed",
         )
+    os.environ.pop("OMNIROOT_RESUMPTION", None)
     identity = process_identity(process.pid)
     if identity is None:
         _terminate_group(process)
@@ -914,7 +978,7 @@ def _supervised_diagnostic(
         )
     _collect_diagnostics(
         process, diagnostic_path, timeout_seconds=min(timeout_seconds, remaining_seconds),
-        secrets=[os.environ.get("OMNIROUTE_API_KEY", "")],
+        secrets=[os.environ.get("OMNIROUTE_API_KEY", ""), *_resumption_secrets(resumption_secret)],
     )
     process.stdout.close()
     process.stderr.close()
@@ -964,6 +1028,7 @@ def _supervise_command(arguments: list[str]) -> int:
 
         def launch(candidate: dict[str, str]) -> dict[str, Any]:
             launched["candidate"] = candidate
+            launched["resumption"] = _verified_resumption(candidate, manifest["continuity"])
             return {"pid": -1, "pgid": -1, "processIdentity": "pending"}
 
         def compensate(session_id: str) -> None:
@@ -982,6 +1047,9 @@ def _supervise_command(arguments: list[str]) -> int:
         _write_json(manifest_path, manifest)
         active_session = launched["candidate"]["sessionId"]
         candidate = launched["candidate"]
+        os.environ["OMNIROOT_RESUMPTION"] = json.dumps(
+            launched["resumption"], sort_keys=True, separators=(",", ":"),
+        )
         command = _replacement_command(launcher_command, candidate, invocation_mode, credential_mode)
 
 
@@ -1488,7 +1556,7 @@ def complete(  # noqa: MC0001 - receipt validation remains one fail-closed audit
     if isinstance(continuity, dict):
         receipt["continuity"] = {
             key: continuity[key] for key in (
-                "authoritySha256", "checkpointSha256", "completedActionSha256s",
+                "taskSha256", "authoritySha256", "checkpointSha256", "completedActionSha256s",
                 "trackerUrlSha256", "pullRequestUrlSha256", "attempt", "state", "participants",
             ) if key in continuity
         }

--- a/chaos-engine/skills/omniroot/scripts/runner.py
+++ b/chaos-engine/skills/omniroot/scripts/runner.py
@@ -861,6 +861,80 @@ def _replacement_command(
     return command
 
 
+def _learning_action(state: str, root: str, session_id: str, *, unavailable: bool) -> None:
+    source_root = str(Path(__file__).resolve().parents[4])
+    if source_root not in sys.path:
+        sys.path.insert(0, source_root)
+    if unavailable:
+        from scripts.agents.learning_session import attest_participant_unavailable
+        attest_participant_unavailable(Path(state), root, session_id, "launch-failure")
+    else:
+        from scripts.agents.learning_session import register_runtime_participant
+        register_runtime_participant(Path(state), root, session_id)
+
+
+def _supervised_diagnostic(
+    command: list[str], *, diagnostic_path: Path, process_path: Path, manifest_path: Path,
+    manifest: dict[str, Any], timeout_seconds: int, active_session: str,
+    learning_state: str, learning_root: str,
+) -> tuple[dict[str, Any] | None, int | None]:
+    deadline = _parse_time(manifest.get("deadline"))
+    if deadline is None or deadline <= _utc_now():
+        return None, _finish_supervision(
+            manifest_path, manifest, "blocked", "blocked", "overall deadline expired",
+        )
+    try:
+        process = subprocess.Popen(  # nosec B603 - sealed command identity is verified.
+            command, shell=False, close_fds=True, start_new_session=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+    except OSError:
+        with contextlib.suppress(Exception):
+            _learning_action(learning_state, learning_root, active_session, unavailable=True)
+        return None, _finish_supervision(
+            manifest_path, manifest, "blocked", "blocked", "replacement launch failed",
+        )
+    identity = process_identity(process.pid)
+    if identity is None:
+        _terminate_group(process)
+        return None, _finish_supervision(
+            manifest_path, manifest, "quarantined", "quarantined",
+            "replacement process identity cannot be proven",
+        )
+    process_evidence = {
+        "schemaVersion": SCHEMA_VERSION, "pid": process.pid,
+        "pgid": os.getpgid(process.pid), "processIdentity": identity,
+    }
+    _write_json(process_path, process_evidence)
+    remaining_seconds = (deadline - _utc_now()).total_seconds()
+    if remaining_seconds <= 0:
+        _terminate_group(process)
+        return None, _finish_supervision(
+            manifest_path, manifest, "blocked", "blocked", "overall deadline expired",
+        )
+    _collect_diagnostics(
+        process, diagnostic_path, timeout_seconds=min(timeout_seconds, remaining_seconds),
+        secrets=[os.environ.get("OMNIROUTE_API_KEY", "")],
+    )
+    process.stdout.close()
+    process.stderr.close()
+    diagnostic = _validated_diagnostic(_load_json(diagnostic_path))
+    if _group_alive(process_evidence["pgid"]):
+        try:
+            _terminate_group(process)
+        except OmniRootError:
+            return None, _finish_supervision(
+                manifest_path, manifest, "quarantined", "quarantined",
+                "prior process group death cannot be proven",
+            )
+    if diagnostic["exitCode"] == 0:
+        manifest["continuity"]["state"] = "review"
+        manifest["status"] = "running"
+        _write_json(manifest_path, manifest)
+        return None, 0
+    return diagnostic, None
+
+
 def _supervise_command(arguments: list[str]) -> int:
     """Outlive delegates and replace retryable failures without owner input."""
     (diagnostic_path, process_path, manifest_path, timeout_seconds,
@@ -875,82 +949,25 @@ def _supervise_command(arguments: list[str]) -> int:
     launcher_command = command[:launcher_argc]
     manifest = _supervisor_manifest(manifest_path)
 
-    def attest_launch_failure(session_id: str) -> None:
-        source_root = str(Path(__file__).resolve().parents[4])
-        if source_root not in sys.path:
-            sys.path.insert(0, source_root)
-        from scripts.agents.learning_session import attest_participant_unavailable
-        attest_participant_unavailable(Path(learning_state), learning_root, session_id, "launch-failure")
-
     while True:
-        deadline = _parse_time(manifest.get("deadline"))
-        if deadline is None or deadline <= _utc_now():
-            return _finish_supervision(
-                manifest_path, manifest, "blocked", "blocked", "overall deadline expired",
-            )
-        try:
-            process = subprocess.Popen(  # nosec B603 - sealed command identity is verified.
-                command, shell=False, close_fds=True, start_new_session=True,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            )
-        except OSError:
-            with contextlib.suppress(Exception):
-                attest_launch_failure(active_session)
-            return _finish_supervision(
-                manifest_path, manifest, "blocked", "blocked", "replacement launch failed",
-            )
-        identity = process_identity(process.pid)
-        if identity is None:
-            _terminate_group(process)
-            return _finish_supervision(
-                manifest_path, manifest, "quarantined", "quarantined",
-                "replacement process identity cannot be proven",
-            )
-        process_evidence = {
-            "schemaVersion": SCHEMA_VERSION, "pid": process.pid,
-            "pgid": os.getpgid(process.pid), "processIdentity": identity,
-        }
-        _write_json(process_path, process_evidence)
-        remaining_seconds = (deadline - _utc_now()).total_seconds()
-        if remaining_seconds <= 0:
-            _terminate_group(process)
-            return _finish_supervision(
-                manifest_path, manifest, "blocked", "blocked", "overall deadline expired",
-            )
-        _collect_diagnostics(process, diagnostic_path,
-                             timeout_seconds=min(timeout_seconds, remaining_seconds),
-                             secrets=[os.environ.get("OMNIROUTE_API_KEY", "")])
-        process.stdout.close()
-        process.stderr.close()
-        diagnostic = _validated_diagnostic(_load_json(diagnostic_path))
-        if _group_alive(process_evidence["pgid"]):
-            try:
-                _terminate_group(process)
-            except OmniRootError:
-                return _finish_supervision(
-                    manifest_path, manifest, "quarantined", "quarantined",
-                    "prior process group death cannot be proven",
-                )
-        if diagnostic["exitCode"] == 0:
-            manifest["continuity"]["state"] = "review"
-            manifest["status"] = "running"
-            _write_json(manifest_path, manifest)
-            return 0
+        diagnostic, result = _supervised_diagnostic(
+            command, diagnostic_path=diagnostic_path, process_path=process_path,
+            manifest_path=manifest_path, manifest=manifest, timeout_seconds=timeout_seconds,
+            active_session=active_session, learning_state=learning_state, learning_root=learning_root,
+        )
+        if result is not None:
+            return result
 
         launched: dict[str, Any] = {}
         def register(session_id: str) -> None:
-            source_root = str(Path(__file__).resolve().parents[4])
-            if source_root not in sys.path:
-                sys.path.insert(0, source_root)
-            from scripts.agents.learning_session import register_runtime_participant
-            register_runtime_participant(Path(learning_state), learning_root, session_id)
+            _learning_action(learning_state, learning_root, session_id, unavailable=False)
 
         def launch(candidate: dict[str, str]) -> dict[str, Any]:
             launched["candidate"] = candidate
             return {"pid": -1, "pgid": -1, "processIdentity": "pending"}
 
         def compensate(session_id: str) -> None:
-            attest_launch_failure(session_id)
+            _learning_action(learning_state, learning_root, session_id, unavailable=True)
 
         supervisor_monitor = manifest.get("monitor")
         manifest = _advance_continuity(

--- a/tests/scripts/test_delivery_status.py
+++ b/tests/scripts/test_delivery_status.py
@@ -5,6 +5,7 @@ import json
 import subprocess  # nosec B404 - fixed local test doubles and commands.
 import tempfile
 import unittest
+from contextlib import contextmanager
 
 from pathlib import Path
 
@@ -131,8 +132,27 @@ class _CleanupScenario:
 class DeliveryStatusTest(unittest.TestCase):
     cleanup = {"primarySynced": True, "taskWorktreesAbsent": True, "taskBranchesAbsent": True, "unrelatedDirtyPreserved": True, "repositories": []}
 
+    @contextmanager
+    def authorized(self, plan=None):
+        plan = manifest() if plan is None else plan
+        with tempfile.TemporaryDirectory() as temporary:
+            for index, item in enumerate(plan["ownedPullRequests"]):
+                root = Path(temporary) / str(index)
+                receipt_dir = root / ".git" / "chaos-engine"
+                receipt_dir.mkdir(parents=True)
+                (receipt_dir / "user-authority.json").write_text(json.dumps({
+                    "schemaVersion": 1,
+                    "kind": "user-merge-authority",
+                    "repository": item["repository"],
+                    "observedAt": "2026-08-12T10:00:00+00:00",
+                    "decision": "allow",
+                }), encoding="utf-8")
+                item.update(root=str(root), authorityEvidence=None)
+            yield plan
+
     def test_authorized_merged_pr_and_scoped_cleanup_allow_completion(self):
-        receipt = evaluate_delivery(manifest(), [merged()], self.cleanup, execution_repository="ShaftHQ/SHAFT_ENGINE", execution_head="abc")
+        with self.authorized() as plan:
+            receipt = evaluate_delivery(plan, [merged()], self.cleanup, execution_repository="ShaftHQ/SHAFT_ENGINE", execution_head="abc")
         self.assertEqual("allow", receipt["decision"])
         self.assertEqual(1, receipt["mergedCount"])
         self.assertEqual("complete", receipt["cleanupDecision"])
@@ -146,7 +166,8 @@ class DeliveryStatusTest(unittest.TestCase):
         ]
         status = {**merged(), "headOid": head}
 
-        receipt = evaluate_delivery(plan, [status], self.cleanup)
+        with self.authorized(plan):
+            receipt = evaluate_delivery(plan, [status], self.cleanup)
 
         self.assertEqual("allow", receipt["decision"])
         self.assertEqual(
@@ -184,7 +205,8 @@ class DeliveryStatusTest(unittest.TestCase):
             "warnings": ["cleanup-residue-remains"],
         }
 
-        receipt = evaluate_delivery(manifest(), [merged()], cleanup)
+        with self.authorized() as plan:
+            receipt = evaluate_delivery(plan, [merged()], cleanup)
 
         self.assertEqual("allow", receipt["decision"])
         self.assertEqual("allow", receipt["deliveryDecision"])
@@ -192,7 +214,8 @@ class DeliveryStatusTest(unittest.TestCase):
         self.assertEqual(cleanup["residues"], receipt["cleanup"]["residues"])
 
     def test_cleanup_unavailability_does_not_hide_successful_delivery(self):
-        receipt = evaluate_delivery(manifest(), [merged()], None)
+        with self.authorized() as plan:
+            receipt = evaluate_delivery(plan, [merged()], None)
 
         self.assertEqual("unavailable", receipt["decision"])
         self.assertEqual("allow", receipt["deliveryDecision"])
@@ -252,8 +275,9 @@ class DeliveryStatusTest(unittest.TestCase):
         })
         engine = merged()
         docs = {**merged(), "repository": "ShaftHQ/shafthq.github.io", "number": 8, "headOid": "def"}
-        self.assertEqual("allow", evaluate_delivery(plan, [engine, docs], self.cleanup)["decision"])
-        self.assertEqual("unavailable", evaluate_delivery(plan, [docs], self.cleanup)["decision"])
+        with self.authorized(plan):
+            self.assertEqual("allow", evaluate_delivery(plan, [engine, docs], self.cleanup)["decision"])
+            self.assertEqual("unavailable", evaluate_delivery(plan, [docs], self.cleanup)["decision"])
 
     def test_failed_audit_or_incomplete_cleanup_blocks(self):
         for mutate in (
@@ -336,6 +360,9 @@ class DeliveryStatusTest(unittest.TestCase):
         scenario = _CleanupScenario()
         self.addCleanup(scenario.close)
         plan = scenario.plan
+        authority = self.authorized(plan)
+        authority.__enter__()
+        self.addCleanup(authority.__exit__, None, None, None)
         target = plan["cleanup"]["repositories"][0]
         state = scenario.state
         removal_calls = scenario.removal_calls

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -4877,6 +4877,19 @@ class FreshBaseGateTest(unittest.TestCase):
         os.makedirs(outside, exist_ok=True)
         return root, outside
 
+    def repository_target(self):
+        root, _ = self.repository()
+        subprocess.run(
+            ["git", "init", "--quiet", root],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        target = os.path.join(root, "scripts", "x.py")
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        Path(target).touch()
+        return root, target
+
     def test_functions_exec_apply_patch_uses_absolute_target_worktree_for_r19_scoping(self):
         """Literal wrapped patch targets, not hook cwd, scope R19 (#5289)."""
         main_root, _ = self.repository()
@@ -5060,18 +5073,27 @@ class FreshBaseGateTest(unittest.TestCase):
     def test_editing_on_the_default_branch_is_refused(self):
         for branch in ("main", "master"):
             with self.subTest(branch=branch):
-                with patch("scripts.agents.guard._current_branch", return_value=branch):
-                    reason = guard.check_r19_fresh_base(self.payload("scripts/x.py"), "Write")
+                root, target = self.repository_target()
+                with patch("scripts.agents.guard._repository_root", return_value=root), patch(
+                    "scripts.agents.guard._current_branch", return_value=branch
+                ):
+                    reason = guard.check_r19_fresh_base(self.payload(target, cwd=root), "Write")
                 self.assertIsNotNone(reason)
                 self.assertIn("ChaosEngine/", reason)
 
     def test_editing_on_a_task_branch_is_allowed(self):
-        with patch("scripts.agents.guard._current_branch", return_value="ChaosEngine/thing-1"):
-            self.assertIsNone(guard.check_r19_fresh_base(self.payload("scripts/x.py"), "Write"))
+        root, target = self.repository_target()
+        with patch("scripts.agents.guard._repository_root", return_value=root), patch(
+            "scripts.agents.guard._current_branch", return_value="ChaosEngine/thing-1"
+        ):
+            self.assertIsNone(guard.check_r19_fresh_base(self.payload(target, cwd=root), "Write"))
 
     def test_a_detached_head_is_not_the_default_branch(self):
-        with patch("scripts.agents.guard._current_branch", return_value=None):
-            self.assertIsNone(guard.check_r19_fresh_base(self.payload("scripts/x.py"), "Write"))
+        root, target = self.repository_target()
+        with patch("scripts.agents.guard._repository_root", return_value=root), patch(
+            "scripts.agents.guard._current_branch", return_value=None
+        ):
+            self.assertIsNone(guard.check_r19_fresh_base(self.payload(target, cwd=root), "Write"))
 
     def test_non_write_tools_are_untouched(self):
         with patch("scripts.agents.guard._current_branch", return_value="main"):

--- a/tests/scripts/test_omniroot.py
+++ b/tests/scripts/test_omniroot.py
@@ -671,7 +671,7 @@ class OmniRootRunnerTest(unittest.TestCase):
         )
         self.launcher.chmod(0o700)
         resumption = {
-            "task": "resume bounded delegate", "authority": "owner-approved",
+            "task": "task-1", "authority": "owner-approved",
             "checkpoint": "checkpoint-1", "completedActions": ["action-1"],
             "trackerUrl": "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5489",
             "pullRequestUrl": "https://github.com/ShaftHQ/SHAFT_ENGINE/pull/5493",
@@ -703,6 +703,36 @@ class OmniRootRunnerTest(unittest.TestCase):
         self.assertEqual(2, result["continuity"]["attempt"])
         self.assertEqual("2", counter.read_text(encoding="utf-8"))
         self.assertNotIn("replacement-session", json.dumps(result))
+
+    def test_dispatch_rejects_candidates_bound_to_different_task(self):
+        resumption = {
+            "task": "different-task", "authority": "owner-approved",
+            "checkpoint": "checkpoint-1", "completedActions": [],
+            "trackerUrl": "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5489",
+            "pullRequestUrl": "https://github.com/ShaftHQ/SHAFT_ENGINE/pull/5493",
+        }
+        continuity = {
+            "requiredCapability": "default", "maxAttempts": 2,
+            "retryableExitCodes": [75], "backoffSeconds": 0,
+            "authoritySha256": RUNNER._sha256(resumption["authority"]),
+            "checkpointSha256": RUNNER._sha256(resumption["checkpoint"]),
+            "completedActionSha256s": [],
+            "trackerUrlSha256": RUNNER._sha256(resumption["trackerUrl"]),
+            "pullRequestUrlSha256": RUNNER._sha256(resumption["pullRequestUrl"]),
+            "alternates": [{"identity": "replacement", "sessionId": "replacement-session",
+                            "capability": "default", "target": "qualified-target",
+                            "arguments": [], "resumption": resumption}],
+        }
+        with self.assertRaisesRegex(RUNNER.OmniRootError, "authoritative task"):
+            self._dispatch(
+                run_id="wrong-task", worktree=self.worktree, state_dir=self.state,
+                config_path=self.config, target="host-cli", delegate_args=[],
+                opener=lambda *_, **__: _Response(), environ={"OMNIROUTE_API_KEY": "secret"},
+                delegate={"identity": "failed", "role": "implementer", "capability": "default",
+                          "assignment": "bounded", "pathOwnership": ["docs"]},
+                continuity=continuity, popen=lambda *_args, **_kwargs: _Process(),
+                process_identity=lambda _pid: "identity",
+            )
 
     def test_dispatch_rejects_fabricated_default_runtime_contract(self):
         with self.assertRaises(RUNNER.OmniRootError):

--- a/tests/scripts/test_omniroot.py
+++ b/tests/scripts/test_omniroot.py
@@ -12,6 +12,7 @@ import signal
 import subprocess  # nosec B404 - tests run fixed local executables with controlled argv.
 import sys
 import tempfile
+import time
 import unittest
 from unittest.mock import patch
 from datetime import UTC, datetime, timedelta
@@ -526,7 +527,7 @@ class OmniRootRunnerTest(unittest.TestCase):
         })
         with patch.object(RUNNER, "_group_alive", return_value=False):
             result = RUNNER.status("run-4", self.state, process_identity=lambda _: None)
-        self.assertEqual("review", result["status"])
+        self.assertEqual("review", result["status"], result)
         self.assertEqual(0, result["diagnostics"]["exitCode"])
         self.assertEqual(RUNNER._sha256(diagnostic), result["diagnostics"]["sha256"])
         self.assertNotIn("stdout", result["diagnostics"])
@@ -660,6 +661,39 @@ class OmniRootRunnerTest(unittest.TestCase):
                     popen=lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("boom")),
                     process_identity=lambda _: "identity")
         attest.assert_called_once_with(self.learning_state, "root-1", "launch-fail", "launch-failure")
+
+    def test_dispatch_durable_supervisor_reaches_review_after_retryable_interruption(self):
+        counter = self.root / "attempts"
+        self.launcher.write_text(
+            "#!/usr/bin/env python3\nfrom pathlib import Path\n"
+            f"p=Path({str(counter)!r}); n=int(p.read_text() if p.exists() else '0')+1; p.write_text(str(n)); raise SystemExit(75 if n == 1 else 0)\n",
+            encoding="utf-8",
+        )
+        self.launcher.chmod(0o700)
+        continuity = {
+            "requiredCapability": "default", "maxAttempts": 2,
+            "retryableExitCodes": [75], "backoffSeconds": 0,
+            "authoritySha256": "a" * 64, "checkpointSha256": "b" * 64,
+            "completedActionSha256s": ["c" * 64],
+            "trackerUrlSha256": "d" * 64, "pullRequestUrlSha256": "e" * 64,
+            "alternates": [{"identity": "replacement", "sessionId": "replacement-session",
+                            "capability": "default"}],
+        }
+        self._dispatch(run_id="failover-e2e", worktree=self.worktree, state_dir=self.state,
+            config_path=self.config, target="host-cli", delegate_args=[],
+            opener=lambda *_, **__: _Response(), environ={"OMNIROUTE_API_KEY": "secret"},
+            delegate={"identity": "failed", "role": "implementer", "capability": "default",
+                      "assignment": "bounded", "pathOwnership": ["docs"]},
+            continuity=continuity)
+        for _ in range(100):
+            result = RUNNER.status("failover-e2e", self.state)
+            if result["status"] == "review":
+                break
+            time.sleep(0.05)
+        self.assertEqual("review", result["status"], result)
+        self.assertEqual(2, result["continuity"]["attempt"])
+        self.assertEqual("2", counter.read_text(encoding="utf-8"))
+        self.assertNotIn("replacement-session", json.dumps(result))
 
     def test_dispatch_rejects_fabricated_default_runtime_contract(self):
         with self.assertRaises(RUNNER.OmniRootError):

--- a/tests/scripts/test_omniroot.py
+++ b/tests/scripts/test_omniroot.py
@@ -670,15 +670,23 @@ class OmniRootRunnerTest(unittest.TestCase):
             encoding="utf-8",
         )
         self.launcher.chmod(0o700)
+        resumption = {
+            "task": "resume bounded delegate", "authority": "owner-approved",
+            "checkpoint": "checkpoint-1", "completedActions": ["action-1"],
+            "trackerUrl": "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5489",
+            "pullRequestUrl": "https://github.com/ShaftHQ/SHAFT_ENGINE/pull/5493",
+        }
         continuity = {
             "requiredCapability": "default", "maxAttempts": 2,
             "retryableExitCodes": [75], "backoffSeconds": 0,
-            "authoritySha256": "a" * 64, "checkpointSha256": "b" * 64,
-            "completedActionSha256s": ["c" * 64],
-            "trackerUrlSha256": "d" * 64, "pullRequestUrlSha256": "e" * 64,
+            "authoritySha256": RUNNER._sha256(resumption["authority"]),
+            "checkpointSha256": RUNNER._sha256(resumption["checkpoint"]),
+            "completedActionSha256s": [RUNNER._sha256("action-1")],
+            "trackerUrlSha256": RUNNER._sha256(resumption["trackerUrl"]),
+            "pullRequestUrlSha256": RUNNER._sha256(resumption["pullRequestUrl"]),
             "alternates": [{"identity": "replacement", "sessionId": "replacement-session",
                             "capability": "default", "target": "qualified-target",
-                            "arguments": []}],
+                            "arguments": [], "resumption": resumption}],
         }
         self._dispatch(run_id="failover-e2e", worktree=self.worktree, state_dir=self.state,
             config_path=self.config, target="host-cli", delegate_args=[],

--- a/tests/scripts/test_omniroot.py
+++ b/tests/scripts/test_omniroot.py
@@ -651,6 +651,16 @@ class OmniRootRunnerTest(unittest.TestCase):
         self.assertEqual([], launched)
         self.assertFalse((self.state / "runs/learning-fail.json").exists())
 
+    def test_launch_failure_attests_registered_participant_unavailable(self):
+        with patch("scripts.agents.learning_session.attest_participant_unavailable") as attest:
+            with self.assertRaisesRegex(RUNNER.OmniRootError, "could not start"):
+                self._dispatch(run_id="launch-fail", worktree=self.worktree, state_dir=self.state,
+                    config_path=self.config, target="host-cli", delegate_args=[],
+                    opener=lambda *_, **__: _Response(), environ={"OMNIROUTE_API_KEY": "secret"},
+                    popen=lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("boom")),
+                    process_identity=lambda _: "identity")
+        attest.assert_called_once_with(self.learning_state, "root-1", "launch-fail", "launch-failure")
+
     def test_dispatch_rejects_fabricated_default_runtime_contract(self):
         with self.assertRaises(RUNNER.OmniRootError):
             RUNNER.dispatch(run_id="incomplete", worktree=self.worktree, state_dir=self.state,

--- a/tests/scripts/test_omniroot.py
+++ b/tests/scripts/test_omniroot.py
@@ -677,7 +677,8 @@ class OmniRootRunnerTest(unittest.TestCase):
             "completedActionSha256s": ["c" * 64],
             "trackerUrlSha256": "d" * 64, "pullRequestUrlSha256": "e" * 64,
             "alternates": [{"identity": "replacement", "sessionId": "replacement-session",
-                            "capability": "default"}],
+                            "capability": "default", "target": "qualified-target",
+                            "arguments": []}],
         }
         self._dispatch(run_id="failover-e2e", worktree=self.worktree, state_dir=self.state,
             config_path=self.config, target="host-cli", delegate_args=[],

--- a/tests/scripts/test_omniroot_failover.py
+++ b/tests/scripts/test_omniroot_failover.py
@@ -1,6 +1,8 @@
 import importlib.util
 import tempfile
 import unittest
+import os
+from unittest.mock import patch
 from pathlib import Path
 
 
@@ -141,6 +143,47 @@ class OmniRootFailoverTest(unittest.TestCase):
         manifest = {"status": "running"}
         self.assertIsNone(RUNNER._continuity_contract(None))
         self.assertNotIn("continuity", manifest)
+
+    def test_durable_supervisor_replaces_retryable_process_without_owner_input(self):
+        launcher = Path(self.temporary.name) / "launcher.py"
+        counter = Path(self.temporary.name) / "counter"
+        launcher.write_text(
+            "#!/usr/bin/env python3\nfrom pathlib import Path\n"
+            f"p=Path({str(counter)!r}); n=int(p.read_text() if p.exists() else '0')+1; p.write_text(str(n)); raise SystemExit(75 if n == 1 else 0)\n",
+            encoding="utf-8",
+        )
+        launcher.chmod(0o700)
+        command, identity = RUNNER._resolved_executable([str(launcher)])
+        diagnostic = self.state / "diagnostics/run.json"
+        process = self.state / "processes/run.json"
+        manifest_path = self.state / "runs/run.json"
+        manifest = self.manifest()
+        manifest["continuity"]["participants"] = [{
+            "identitySha256": RUNNER._sha256("failed"),
+            "sessionSha256": RUNNER._sha256("failed-session"),
+            "capability": "most-intelligent",
+        }]
+        RUNNER._write_json(manifest_path, manifest)
+        learning = Path(self.temporary.name) / "learning.json"
+        from scripts.agents.learning_session import create_runtime, register_runtime_participant
+        create_runtime(learning, "root")
+        register_runtime_participant(learning, "root", "failed-session")
+        environment = {
+            "OMNIROOT_CONTINUITY": __import__("json").dumps(self.candidates()),
+            "OMNIROOT_LEARNING_STATE": str(learning),
+            "OMNIROOT_LEARNING_ROOT": "root",
+        }
+        arguments = [str(diagnostic), str(process), str(manifest_path), "10",
+                     *(str(value) for value in identity), "--", *command]
+        with patch.dict(os.environ, environment, clear=False):
+            result = RUNNER._supervise_command(arguments)
+        final = RUNNER._load_json(manifest_path)
+        self.assertEqual(0, result)
+        self.assertEqual("review", final["continuity"]["state"])
+        self.assertEqual(2, final["continuity"]["attempt"])
+        self.assertEqual(2, len(final["continuity"]["participants"]))
+        self.assertEqual(0, RUNNER._load_json(diagnostic)["exitCode"])
+        self.assertEqual("2", counter.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_omniroot_failover.py
+++ b/tests/scripts/test_omniroot_failover.py
@@ -2,6 +2,7 @@ import importlib.util
 import tempfile
 import unittest
 import os
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 from pathlib import Path
 
@@ -33,8 +34,10 @@ class OmniRootFailoverTest(unittest.TestCase):
             "trackerUrlSha256": "d" * 64,
             "pullRequestUrlSha256": "e" * 64,
             "alternates": [
-                {"identity": "replacement-low", "sessionId": "low", "capability": "default"},
-                {"identity": "replacement-high", "sessionId": "high", "capability": "most-intelligent"},
+                {"identity": "replacement-low", "sessionId": "low", "capability": "default",
+                 "target": "low-route", "arguments": ["--candidate", "low"]},
+                {"identity": "replacement-high", "sessionId": "high", "capability": "most-intelligent",
+                 "target": "high-route", "arguments": ["--candidate", "high"]},
             ],
         }
 
@@ -46,6 +49,7 @@ class OmniRootFailoverTest(unittest.TestCase):
             "delegate": {"identity": "failed", "capability": "high"},
             "continuity": RUNNER._continuity_contract(self.continuity()),
             "timestamps": {},
+            "deadline": "2030-01-01T00:00:00+00:00",
         }
 
     def candidates(self):
@@ -64,6 +68,7 @@ class OmniRootFailoverTest(unittest.TestCase):
         self.assertEqual("running", result["status"])
         self.assertEqual(RUNNER._sha256("replacement-high"), result["delegate"]["identitySha256"])
         self.assertEqual("b" * 64, result["continuity"]["checkpointSha256"])
+        self.assertEqual("a" * 64, result["continuity"]["authoritySha256"])
         self.assertEqual(["c" * 64], result["continuity"]["completedActionSha256s"])
         self.assertEqual(2, result["continuity"]["attempt"])
         self.assertEqual([("registered", "high"), ("launched", "replacement-high")], launched)
@@ -139,6 +144,49 @@ class OmniRootFailoverTest(unittest.TestCase):
         with self.assertRaises(RUNNER.OmniRootError):
             RUNNER._continuity_contract(invalid)
 
+    def test_contract_caps_total_attempts_and_writers_at_four(self):
+        invalid = self.continuity()
+        invalid["maxAttempts"] = 5
+        with self.assertRaises(RUNNER.OmniRootError):
+            RUNNER._continuity_contract(invalid)
+        invalid = self.continuity()
+        invalid["alternates"] *= 2
+        with self.assertRaises(RUNNER.OmniRootError):
+            RUNNER._continuity_contract(invalid)
+
+    def test_expired_overall_deadline_blocks_before_registration_or_launch(self):
+        manifest = self.manifest()
+        manifest["deadline"] = "2029-12-31T23:59:59+00:00"
+        result = RUNNER._advance_continuity(
+            manifest, exit_code=75, group_dead=True,
+            candidates=self.candidates(),
+            register=lambda _session_id: self.fail("must not register"),
+            launch=lambda _candidate: self.fail("must not launch"),
+            now=lambda: datetime(2030, 1, 1, tzinfo=UTC),
+        )
+        self.assertEqual("blocked", result["status"])
+        self.assertEqual("overall deadline expired", result["continuity"]["reason"])
+
+    def test_deadline_expiring_during_backoff_blocks_without_launch(self):
+        manifest = self.manifest()
+        start = datetime(2029, 12, 31, 23, 59, 59, tzinfo=UTC)
+        manifest["deadline"] = (start + timedelta(seconds=1)).isoformat()
+        clock = [start]
+        compensated = []
+
+        def sleep(_seconds):
+            clock[0] += timedelta(seconds=2)
+
+        result = RUNNER._advance_continuity(
+            manifest, exit_code=75, group_dead=True,
+            candidates=self.candidates(), register=lambda _session_id: None,
+            launch=lambda _candidate: self.fail("must not launch"),
+            compensate=compensated.append, sleep=sleep, now=lambda: clock[0],
+        )
+        self.assertEqual("blocked", result["status"])
+        self.assertEqual("overall deadline expired", result["continuity"]["reason"])
+        self.assertEqual(["high"], compensated)
+
     def test_legacy_manifest_has_no_continuity_behavior(self):
         manifest = {"status": "running"}
         self.assertIsNone(RUNNER._continuity_contract(None))
@@ -172,6 +220,9 @@ class OmniRootFailoverTest(unittest.TestCase):
             "OMNIROOT_CONTINUITY": __import__("json").dumps(self.candidates()),
             "OMNIROOT_LEARNING_STATE": str(learning),
             "OMNIROOT_LEARNING_ROOT": "root",
+            "OMNIROOT_INVOCATION_MODE": "direct",
+            "OMNIROOT_CREDENTIAL_MODE": "launcher",
+            "OMNIROOT_LAUNCHER_ARGC": "1",
         }
         arguments = [str(diagnostic), str(process), str(manifest_path), "10",
                      *(str(value) for value in identity), "--", *command]
@@ -184,6 +235,54 @@ class OmniRootFailoverTest(unittest.TestCase):
         self.assertEqual(2, len(final["continuity"]["participants"]))
         self.assertEqual(0, RUNNER._load_json(diagnostic)["exitCode"])
         self.assertEqual("2", counter.read_text(encoding="utf-8"))
+
+    def test_durable_supervisor_changes_candidate_invocation_without_persisting_it(self):
+        launcher = Path(self.temporary.name) / "launcher.py"
+        invocations = Path(self.temporary.name) / "invocations"
+        launcher.write_text(
+            "#!/usr/bin/env python3\nimport sys\nfrom pathlib import Path\n"
+            f"p=Path({str(invocations)!r}); old=p.read_text() if p.exists() else ''; p.write_text(old+'|'.join(sys.argv[1:])+'\\n'); raise SystemExit(75 if not old else 0)\n",
+            encoding="utf-8",
+        )
+        launcher.chmod(0o700)
+        command, identity = RUNNER._resolved_executable([str(launcher)])
+        diagnostic = self.state / "diagnostics/run.json"
+        process = self.state / "processes/run.json"
+        manifest_path = self.state / "runs/run.json"
+        manifest = self.manifest()
+        manifest["continuity"]["participants"] = [{
+            "identitySha256": RUNNER._sha256("failed"),
+            "sessionSha256": RUNNER._sha256("failed-session"),
+            "capability": "most-intelligent",
+        }]
+        RUNNER._write_json(manifest_path, manifest)
+        learning = Path(self.temporary.name) / "learning.json"
+        from scripts.agents.learning_session import create_runtime, register_runtime_participant
+        create_runtime(learning, "root")
+        register_runtime_participant(learning, "root", "failed-session")
+        candidates = self.candidates()
+        environment = {
+            "OMNIROOT_CONTINUITY": __import__("json").dumps(candidates),
+            "OMNIROOT_LEARNING_STATE": str(learning),
+            "OMNIROOT_LEARNING_ROOT": "root",
+            "OMNIROOT_INITIAL_SESSION": "failed-session",
+            "OMNIROOT_INVOCATION_MODE": "gateway",
+            "OMNIROOT_CREDENTIAL_MODE": "launcher",
+            "OMNIROOT_LAUNCHER_ARGC": "1",
+        }
+        initial = [*command, "initial-route", "--port", "20128", "--", "--candidate", "initial"]
+        arguments = [str(diagnostic), str(process), str(manifest_path), "10",
+                     *(str(value) for value in identity), "--", *initial]
+        with patch.dict(os.environ, environment, clear=False):
+            result = RUNNER._supervise_command(arguments)
+        self.assertEqual(0, result)
+        self.assertEqual([
+            "initial-route|--port|20128|--|--candidate|initial",
+            "high-route|--port|20128|--|--candidate|high",
+        ], invocations.read_text(encoding="utf-8").splitlines())
+        persisted = manifest_path.read_text(encoding="utf-8")
+        self.assertNotIn("high-route", persisted)
+        self.assertNotIn("--candidate", persisted)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_omniroot_failover.py
+++ b/tests/scripts/test_omniroot_failover.py
@@ -227,7 +227,7 @@ class OmniRootFailoverTest(unittest.TestCase):
 
     def test_expired_overall_deadline_blocks_before_registration_or_launch(self):
         manifest = self.manifest()
-        manifest["deadline"] = "2029-12-31T23:59:59+00:00"
+        manifest["deadline"] = "2000-01-01T00:00:00+00:00"
         result = RUNNER._advance_continuity(
             manifest, exit_code=75, group_dead=True,
             candidates=self.candidates(),
@@ -237,6 +237,23 @@ class OmniRootFailoverTest(unittest.TestCase):
         )
         self.assertEqual("blocked", result["status"])
         self.assertEqual("overall deadline expired", result["continuity"]["reason"])
+
+    def test_expired_supervisor_clears_private_resumption_before_popen(self):
+        manifest = self.manifest()
+        manifest["deadline"] = "2000-01-01T00:00:00+00:00"
+        manifest_path = self.state / "runs/expired.json"
+        RUNNER._write_json(manifest_path, manifest)
+        with patch.dict(os.environ, {"OMNIROOT_RESUMPTION": "private-envelope"}, clear=False):
+            with patch.object(RUNNER.subprocess, "Popen", side_effect=AssertionError("must not launch")):
+                diagnostic, result = RUNNER._supervised_diagnostic(
+                    ["unused"], diagnostic_path=self.state / "diagnostics/expired.json",
+                    process_path=self.state / "processes/expired.json", manifest_path=manifest_path,
+                    manifest=manifest, timeout_seconds=10, active_session="failed",
+                    learning_state="unused", learning_root="root",
+                )
+            self.assertIsNone(diagnostic)
+            self.assertEqual(1, result)
+            self.assertNotIn("OMNIROOT_RESUMPTION", os.environ)
 
     def test_deadline_expiring_during_backoff_blocks_without_launch(self):
         manifest = self.manifest()

--- a/tests/scripts/test_omniroot_failover.py
+++ b/tests/scripts/test_omniroot_failover.py
@@ -1,0 +1,147 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER_PATH = ROOT / "chaos-engine/skills/omniroot/scripts/runner.py"
+SPEC = importlib.util.spec_from_file_location("omniroot_failover_runner", RUNNER_PATH)
+RUNNER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RUNNER)
+
+
+class OmniRootFailoverTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.state = Path(self.temporary.name) / "state"
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def continuity(self):
+        return {
+            "requiredCapability": "most-intelligent",
+            "maxAttempts": 3,
+            "retryableExitCodes": [75],
+            "backoffSeconds": 0,
+            "authoritySha256": "a" * 64,
+            "checkpointSha256": "b" * 64,
+            "completedActionSha256s": ["c" * 64],
+            "trackerUrlSha256": "d" * 64,
+            "pullRequestUrlSha256": "e" * 64,
+            "alternates": [
+                {"identity": "replacement-low", "sessionId": "low", "capability": "default"},
+                {"identity": "replacement-high", "sessionId": "high", "capability": "most-intelligent"},
+            ],
+        }
+
+    def manifest(self):
+        return {
+            "schemaVersion": 1,
+            "runId": "run",
+            "status": "running",
+            "delegate": {"identity": "failed", "capability": "high"},
+            "continuity": RUNNER._continuity_contract(self.continuity()),
+            "timestamps": {},
+        }
+
+    def candidates(self):
+        return self.continuity()["alternates"]
+
+    def test_retryable_failure_selects_compatible_replacement_and_preserves_checkpoint(self):
+        launched = []
+        result = RUNNER._advance_continuity(
+            self.manifest(), exit_code=75, group_dead=True,
+            candidates=self.candidates(),
+            register=lambda session_id: launched.append(("registered", session_id)),
+            launch=lambda candidate: launched.append(("launched", candidate["identity"])) or {
+                "pid": 9001, "pgid": 9001, "processIdentity": "replacement-process"
+            },
+        )
+        self.assertEqual("running", result["status"])
+        self.assertEqual(RUNNER._sha256("replacement-high"), result["delegate"]["identitySha256"])
+        self.assertEqual("b" * 64, result["continuity"]["checkpointSha256"])
+        self.assertEqual(["c" * 64], result["continuity"]["completedActionSha256s"])
+        self.assertEqual(2, result["continuity"]["attempt"])
+        self.assertEqual([("registered", "high"), ("launched", "replacement-high")], launched)
+
+    def test_lower_capability_only_blocks_without_launch(self):
+        continuity = self.continuity()
+        continuity["alternates"] = [continuity["alternates"][0]]
+        manifest = self.manifest()
+        manifest["continuity"] = RUNNER._continuity_contract(continuity)
+        result = RUNNER._advance_continuity(
+            manifest, exit_code=75, group_dead=True,
+            candidates=continuity["alternates"],
+            register=lambda _session_id: self.fail("must not register"),
+            launch=lambda _candidate: self.fail("must not launch"),
+        )
+        self.assertEqual("blocked", result["status"])
+        self.assertEqual("no compatible continuity alternate", result["continuity"]["reason"])
+
+    def test_unproven_group_death_quarantines(self):
+        result = RUNNER._advance_continuity(
+            self.manifest(), exit_code=75, group_dead=False,
+            candidates=self.candidates(),
+            register=lambda _session_id: self.fail("must not register"),
+            launch=lambda _candidate: self.fail("must not launch"),
+        )
+        self.assertEqual("quarantined", result["status"])
+
+    def test_non_retryable_failure_preserves_legacy_blocked_result(self):
+        result = RUNNER._advance_continuity(
+            self.manifest(), exit_code=2, group_dead=True,
+            candidates=self.candidates(),
+            register=lambda _session_id: self.fail("must not register"),
+            launch=lambda _candidate: self.fail("must not launch"),
+        )
+        self.assertEqual("blocked", result["status"])
+        self.assertEqual("non-retryable exit", result["continuity"]["reason"])
+
+    def test_concurrent_resume_is_idempotent_and_completed_actions_are_hashes_only(self):
+        manifest = self.manifest()
+        manifest["continuity"]["state"] = "replacement_running"
+        launched = []
+        result = RUNNER._advance_continuity(
+            manifest, exit_code=75, group_dead=True,
+            candidates=self.candidates(),
+            register=lambda session_id: launched.append(session_id),
+            launch=lambda candidate: launched.append(candidate),
+        )
+        self.assertIs(manifest, result)
+        self.assertEqual([], launched)
+        self.assertNotIn("assignment", str(result["continuity"]).lower())
+
+    def test_registration_failure_is_compensated_and_next_attempt_can_continue(self):
+        def fail_registration(_session_id):
+            raise RuntimeError("closed")
+
+        result = RUNNER._advance_continuity(
+            self.manifest(), exit_code=75, group_dead=True,
+            candidates=self.candidates(),
+            register=fail_registration,
+            launch=lambda _candidate: self.fail("must not launch"),
+        )
+        self.assertEqual("blocked", result["status"])
+        self.assertEqual("replacement learning registration failed", result["continuity"]["reason"])
+        self.assertEqual([], result["continuity"]["participants"])
+
+    def test_contract_rejects_raw_links_secrets_and_duplicate_candidates(self):
+        invalid = self.continuity()
+        invalid["trackerUrl"] = "https://github.example/secret"
+        with self.assertRaises(RUNNER.OmniRootError):
+            RUNNER._continuity_contract(invalid)
+        invalid = self.continuity()
+        invalid["alternates"].append(dict(invalid["alternates"][1]))
+        with self.assertRaises(RUNNER.OmniRootError):
+            RUNNER._continuity_contract(invalid)
+
+    def test_legacy_manifest_has_no_continuity_behavior(self):
+        manifest = {"status": "running"}
+        self.assertIsNone(RUNNER._continuity_contract(None))
+        self.assertNotIn("continuity", manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_omniroot_failover.py
+++ b/tests/scripts/test_omniroot_failover.py
@@ -23,21 +23,29 @@ class OmniRootFailoverTest(unittest.TestCase):
         self.temporary.cleanup()
 
     def continuity(self):
+        resumption = {
+            "task": "deliver issue 5489",
+            "authority": "owner-approved",
+            "checkpoint": "checkpoint-1",
+            "completedActions": ["action-1"],
+            "trackerUrl": "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5489",
+            "pullRequestUrl": "https://github.com/ShaftHQ/SHAFT_ENGINE/pull/5493",
+        }
         return {
             "requiredCapability": "most-intelligent",
             "maxAttempts": 3,
             "retryableExitCodes": [75],
             "backoffSeconds": 0,
-            "authoritySha256": "a" * 64,
-            "checkpointSha256": "b" * 64,
-            "completedActionSha256s": ["c" * 64],
-            "trackerUrlSha256": "d" * 64,
-            "pullRequestUrlSha256": "e" * 64,
+            "authoritySha256": RUNNER._sha256(resumption["authority"]),
+            "checkpointSha256": RUNNER._sha256(resumption["checkpoint"]),
+            "completedActionSha256s": [RUNNER._sha256("action-1")],
+            "trackerUrlSha256": RUNNER._sha256(resumption["trackerUrl"]),
+            "pullRequestUrlSha256": RUNNER._sha256(resumption["pullRequestUrl"]),
             "alternates": [
                 {"identity": "replacement-low", "sessionId": "low", "capability": "default",
-                 "target": "low-route", "arguments": ["--candidate", "low"]},
+                 "target": "low-route", "arguments": ["--candidate", "low"], "resumption": resumption},
                 {"identity": "replacement-high", "sessionId": "high", "capability": "most-intelligent",
-                 "target": "high-route", "arguments": ["--candidate", "high"]},
+                 "target": "high-route", "arguments": ["--candidate", "high"], "resumption": resumption},
             ],
         }
 
@@ -67,9 +75,9 @@ class OmniRootFailoverTest(unittest.TestCase):
         )
         self.assertEqual("running", result["status"])
         self.assertEqual(RUNNER._sha256("replacement-high"), result["delegate"]["identitySha256"])
-        self.assertEqual("b" * 64, result["continuity"]["checkpointSha256"])
-        self.assertEqual("a" * 64, result["continuity"]["authoritySha256"])
-        self.assertEqual(["c" * 64], result["continuity"]["completedActionSha256s"])
+        self.assertEqual(RUNNER._sha256("checkpoint-1"), result["continuity"]["checkpointSha256"])
+        self.assertEqual(RUNNER._sha256("owner-approved"), result["continuity"]["authoritySha256"])
+        self.assertEqual([RUNNER._sha256("action-1")], result["continuity"]["completedActionSha256s"])
         self.assertEqual(2, result["continuity"]["attempt"])
         self.assertEqual([("registered", "high"), ("launched", "replacement-high")], launched)
 
@@ -144,6 +152,65 @@ class OmniRootFailoverTest(unittest.TestCase):
         with self.assertRaises(RUNNER.OmniRootError):
             RUNNER._continuity_contract(invalid)
 
+    def test_contract_rejects_candidate_resumption_not_bound_to_frozen_hashes(self):
+        invalid = self.continuity()
+        invalid["alternates"][1]["resumption"] = dict(invalid["alternates"][1]["resumption"])
+        invalid["alternates"][1]["resumption"]["checkpoint"] = "changed"
+        with self.assertRaises(RUNNER.OmniRootError):
+            RUNNER._continuity_contract(invalid)
+
+    def test_real_signal_status_can_trigger_failover_and_resumption_prevents_replay(self):
+        launcher = Path(self.temporary.name) / "signal-launcher.py"
+        actions = Path(self.temporary.name) / "actions"
+        received = Path(self.temporary.name) / "received"
+        launcher.write_text(
+            "#!/usr/bin/env python3\nimport json, os, signal\nfrom pathlib import Path\n"
+            f"actions=Path({str(actions)!r}); received=Path({str(received)!r})\n"
+            "if 'OMNIROOT_RESUMPTION' not in os.environ:\n"
+            " actions.write_text('action-1\\n'); os.kill(os.getpid(), signal.SIGTERM)\n"
+            "state=json.loads(os.environ['OMNIROOT_RESUMPTION'])\n"
+            "print(os.environ['OMNIROOT_RESUMPTION'])\n"
+            "assert state['completedActions'] == ['action-1']\n"
+            "if 'action-1' not in state['completedActions']:\n actions.write_text(actions.read_text()+'action-1\\n')\n"
+            "received.write_text(state['checkpoint'])\n",
+            encoding="utf-8",
+        )
+        launcher.chmod(0o700)
+        command, identity = RUNNER._resolved_executable([str(launcher)])
+        diagnostic = self.state / "diagnostics/signal.json"
+        process = self.state / "processes/signal.json"
+        manifest_path = self.state / "runs/signal.json"
+        continuity = self.continuity()
+        continuity["retryableExitCodes"] = [-15]
+        manifest = self.manifest()
+        manifest["continuity"] = RUNNER._continuity_contract(continuity)
+        RUNNER._write_json(manifest_path, manifest)
+        learning = Path(self.temporary.name) / "learning-signal.json"
+        from scripts.agents.learning_session import create_runtime
+        create_runtime(learning, "root")
+        environment = {
+            "OMNIROOT_CONTINUITY": __import__("json").dumps(continuity["alternates"]),
+            "OMNIROOT_LEARNING_STATE": str(learning), "OMNIROOT_LEARNING_ROOT": "root",
+            "OMNIROOT_INVOCATION_MODE": "direct", "OMNIROOT_CREDENTIAL_MODE": "launcher",
+            "OMNIROOT_LAUNCHER_ARGC": "1",
+        }
+        arguments = [str(diagnostic), str(process), str(manifest_path), "10",
+                     *(str(value) for value in identity), "--", *command]
+        with patch.dict(os.environ, environment, clear=False):
+            result = RUNNER._supervise_command(arguments)
+        self.assertEqual(0, result)
+        self.assertEqual("action-1\n", actions.read_text(encoding="utf-8"))
+        self.assertEqual("checkpoint-1", received.read_text(encoding="utf-8"))
+        self.assertNotIn("OMNIROOT_RESUMPTION", os.environ)
+        persisted = manifest_path.read_text(encoding="utf-8")
+        self.assertNotIn("owner-approved", persisted)
+        self.assertNotIn("checkpoint-1", persisted)
+        self.assertNotIn("action-1", persisted)
+        diagnostic_text = diagnostic.read_text(encoding="utf-8")
+        self.assertNotIn("owner-approved", diagnostic_text)
+        self.assertNotIn("checkpoint-1", diagnostic_text)
+        self.assertNotIn("action-1", diagnostic_text)
+
     def test_contract_caps_total_attempts_and_writers_at_four(self):
         invalid = self.continuity()
         invalid["maxAttempts"] = 5
@@ -151,6 +218,10 @@ class OmniRootFailoverTest(unittest.TestCase):
             RUNNER._continuity_contract(invalid)
         invalid = self.continuity()
         invalid["alternates"] *= 2
+        with self.assertRaises(RUNNER.OmniRootError):
+            RUNNER._continuity_contract(invalid)
+        invalid = self.continuity()
+        invalid["retryableExitCodes"] = [-65]
         with self.assertRaises(RUNNER.OmniRootError):
             RUNNER._continuity_contract(invalid)
 

--- a/tests/scripts/test_omniroot_failover.py
+++ b/tests/scripts/test_omniroot_failover.py
@@ -113,8 +113,8 @@ class OmniRootFailoverTest(unittest.TestCase):
         result = RUNNER._advance_continuity(
             manifest, exit_code=75, group_dead=True,
             candidates=self.candidates(),
-            register=lambda session_id: launched.append(session_id),
-            launch=lambda candidate: launched.append(candidate),
+            register=launched.append,
+            launch=launched.append,
         )
         self.assertIs(manifest, result)
         self.assertEqual([], launched)


### PR DESCRIPTION
## Summary

- Make delivery authority and FreshBaseGate tests self-contained outside maintainer checkout state.
- Add bounded OmniRoot continuity that supervises retryable delegate interruption, enforces capability and deadline limits, changes the actual private candidate invocation, preserves one-writer ownership, and records hash-only evidence.
- Synchronize ChaosEngine package changelog and compatibility metadata with the current Maven version.

Closes #5466
Closes #5467
Closes #5468
Closes #5489

## Checks

- 439 focused and directly impacted Python tests passed under ResourceWarning-as-error.
- `python3 scripts/ci/validate_agent_setup.py --skip-external`
- Portable ChaosEngine plugin assembly and `validate_agent_plugins.py`
- `git diff --check origin/main...HEAD`
- Clean-archive RED/GREEN reproduction for delivery authority and FreshBaseGate fixtures.

## Continuation

- Issue #5491 remains open for explicit default-endpoint and redirect regression coverage; the existing fixed endpoint, no-proxy health probe, no-redirect opener, and qualification states remain unchanged.
- Issue #5470 remains blocked on the supported upstream Node.js 24 Maven dependency-submission action.
- Nightly browser issues #5474 and #5475 continue in the second grouped PR after this PR merges.