### PR TITLE
feat(ci): add ChaosGauge excluded canary evidence contract

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -376,6 +376,7 @@ jobs:
       - name: Run ChaosGauge contracts
         run: >-
           python3 -m unittest
+          tests.scripts.test_chaos_gauge_canary
           tests.scripts.test_chaos_gauge_contracts
           tests.scripts.test_chaos_gauge_campaign
           tests.scripts.test_chaos_gauge_corpus

--- a/scripts/ci/chaos_gauge/canary.py
+++ b/scripts/ci/chaos_gauge/canary.py
@@ -13,6 +13,7 @@ import os
 import re
 from datetime import datetime
 from pathlib import Path
+from typing import Callable
 
 
 ROOT = Path(__file__).resolve().parent
@@ -111,25 +112,61 @@ def _result_mapping(value: object) -> dict[str, object]:
     return _mapping(dump(mode="json") if callable(dump) else value, "Harbor canary result")
 
 
+def _native_bindings(value: object, pair: dict[str, object]) -> dict[str, str]:
+    bindings = _mapping(value, "canary native bindings")
+    if set(bindings) != set(ARMS):
+        raise ValueError("canary native bindings are invalid")
+    names = {}
+    for arm in ARMS:
+        name = _campaign()._native_trial_name(str(pair["task"]), bindings[arm])
+        if name in names.values():
+            raise ValueError("canary native bindings are invalid")
+        names[arm] = name
+    return names
+
+
+def _validate_public_source_revision(
+    manifest: dict[str, object], public_source_revision: str, repository: Path, run: Callable[[list[str]], str] | None,
+) -> None:
+    try:
+        campaign = _campaign()
+        campaign.validate_execution_revision(
+            repository, public_source_revision, manifest["implementationRevision"], campaign._run if run is None else run,
+        )
+    except (KeyError, ValueError) as error:
+        raise ValueError("canary source revision is invalid") from error
+
+
 def receipt(
-    manifest: object, planned: object, result: object, *, public_source_revision: str
+    manifest: object, planned: object, result: object, *, public_source_revision: str,
+    native_bindings: object, repository: Path = ROOT.parents[2], run: Callable[[list[str]], str] | None = None,
 ) -> dict[str, object]:
     """Return strict aggregate evidence; never include raw Harbor output or trajectories."""
     source = _mapping(manifest, "experiment manifest")
     canary = _mapping(planned, "canary plan")
     if canary != plan(source) or not GIT_SHA.fullmatch(public_source_revision):
         raise ValueError("canary plan or source revision is invalid")
+    _validate_public_source_revision(source, public_source_revision, repository, run)
     value = _result_mapping(result)
     trials = value.get("trial_results")
     if not isinstance(trials, list) or len(trials) != 2:
         raise ValueError("canary trial matrix is incomplete")
     pair = _mapping(canary["pair"], "canary pair")
-    observed = []
-    for arm, raw in zip(pair["arms"], trials):
+    bindings = _native_bindings(native_bindings, pair)
+    config = job_config(source)
+    expected_agents = {arm: config["agents"][list(pair["arms"]).index(arm)] for arm in ARMS}
+    observed: dict[str, dict[str, object]] = {}
+    expected_by_native = {name: arm for arm, name in bindings.items()}
+    for raw in trials:
         trial = _mapping(raw, "Harbor canary trial")
         if trial.get("task_name") != pair["task"] or trial.get("task_checksum") != pair["sha256"]:
             raise ValueError("canary task identity is invalid")
         native_name = _campaign()._native_trial_name(str(pair["task"]), trial.get("trial_name"))
+        arm = expected_by_native.get(native_name)
+        if arm is None or arm in observed:
+            raise ValueError("canary native trial binding is invalid")
+        if not _campaign()._agent_matches(_mapping(trial.get("config"), "canary trial config").get("agent"), expected_agents[arm]):
+            raise ValueError("canary arm identity is invalid")
         agent = _mapping(trial.get("agent_info"), "canary agent")
         model = _mapping(agent.get("model_info"), "canary model")
         if agent.get("name") != "codex" or agent.get("version") != "0.118.0" or model != {"name": "gpt-5.6-terra", "provider": "openai"}:
@@ -146,7 +183,7 @@ def receipt(
             raise ValueError("canary verifier, safety, or cleanup evidence is invalid")
         if trial.get("verifier_environment_mode") != "separate":
             raise ValueError("canary verifier isolation is invalid")
-        observed.append({
+        observed[arm] = {
             "arm": arm,
             "task": pair["task"],
             "sha256": pair["sha256"],
@@ -156,8 +193,10 @@ def receipt(
             "seconds": (finished - started).total_seconds(),
             "verifierEnvironmentMode": "separate",
             "rewards": rewards,
-        })
-    return {
+        }
+    if set(observed) != set(ARMS):
+        raise ValueError("canary native trial binding is incomplete")
+    evidence = {
         "schemaVersion": 1,
         "campaign": "canary",
         "excludedFromPilot": True,
@@ -168,11 +207,15 @@ def receipt(
         "rawResultSha256": hashlib.sha256(
             json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode()
         ).hexdigest(),
-        "trials": observed,
+        "trials": [observed[arm] for arm in pair["arms"]],
     }
+    validate_public_evidence(evidence, repository=repository, run=run)
+    return evidence
 
 
-def validate_public_evidence(value: object) -> None:
+def validate_public_evidence(
+    value: object, *, repository: Path, run: Callable[[list[str]], str] | None = None,
+) -> None:
     """Fail closed unless evidence is exactly the sanitised canary receipt schema."""
     receipt_value = _mapping(value, "public canary evidence")
     expected = {
@@ -183,6 +226,9 @@ def validate_public_evidence(value: object) -> None:
         raise ValueError("public canary evidence is invalid")
     if not GIT_SHA.fullmatch(str(receipt_value.get("implementationRevision"))) or not GIT_SHA.fullmatch(str(receipt_value.get("publicSourceRevision"))):
         raise ValueError("public canary evidence is invalid")
+    _validate_public_source_revision(
+        receipt_value, str(receipt_value["publicSourceRevision"]), repository, run,
+    )
     package = _mapping(receipt_value.get("privatePackage"), "public canary evidence")
     if (
         set(package) != {"repository", "commit", "contentSha256", "name", "ref"}
@@ -273,8 +319,16 @@ async def run(
     launcher._install_pair_start_gate(job, names[0], names[1])
     raw = _result_mapping(await job.run())
     _write_exclusive(raw_out, raw)
-    evidence = receipt(manifest, planned, raw, public_source_revision=public_source_revision)
-    validate_public_evidence(evidence)
+    native_bindings = {}
+    for arm, trial in zip(pair["arms"], trials):
+        name = launcher._native_trial_name(str(pair["task"]), getattr(trial, "trial_name", None))
+        if arm in native_bindings or name in native_bindings.values():
+            raise ValueError("canary native trial binding is invalid")
+        native_bindings[arm] = name
+    evidence = receipt(
+        manifest, planned, raw, public_source_revision=public_source_revision,
+        native_bindings=native_bindings, repository=ROOT.parents[2],
+    )
     _write_exclusive(receipt_out, evidence)
     return evidence
 

--- a/scripts/ci/chaos_gauge/canary.py
+++ b/scripts/ci/chaos_gauge/canary.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Build and sanitize one excluded, two-arm native Harbor canary."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+ARMS = ("control", "chaos-engine")
+GIT_SHA = re.compile(r"[0-9a-f]{40}")
+
+
+def _campaign():
+    spec = importlib.util.spec_from_file_location("chaos_gauge_campaign", ROOT / "campaign.py")
+    if spec is None or spec.loader is None:
+        raise ValueError("ChaosGauge campaign launcher is unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _mapping(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} is invalid")
+    return value
+
+
+def _number(value: object, label: str, *, integer: bool = False) -> float | int:
+    allowed = int if integer else (int, float)
+    if isinstance(value, bool) or not isinstance(value, allowed) or value < 0:
+        raise ValueError(f"{label} is invalid")
+    return value
+
+
+def _timestamp(value: object) -> datetime:
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError("canary timing is invalid") from error
+
+
+def plan(manifest: object) -> dict[str, object]:
+    """Select deterministic first public pair while reserving it from pilot accounting."""
+    source = _campaign().plan(manifest, "calibration")
+    pairs = source.get("pairs") if isinstance(source, dict) else None
+    if not isinstance(pairs, list) or not pairs or not isinstance(pairs[0], dict):
+        raise ValueError("calibration plan is invalid")
+    pair = pairs[0]
+    if pair.get("attempt") != 1 or pair.get("task") != "diagnosis-config-precedence":
+        raise ValueError("canary source pair is invalid")
+    arms = pair.get("arms")
+    if not isinstance(arms, list) or set(arms) != set(ARMS):
+        raise ValueError("canary arms are invalid")
+    return {
+        "schemaVersion": 1,
+        "campaign": "canary",
+        "excludedFromPilot": True,
+        "implementationRevision": source["implementationRevision"],
+        "trials": 2,
+        "pair": {
+            "pairId": f"canary__{pair['task']}",
+            "task": pair["task"],
+            "sha256": pair["sha256"],
+            "attempt": 0,
+            "arms": list(arms),
+            "retryBudget": pair["retryBudget"],
+        },
+    }
+
+
+def job_config(manifest: object) -> dict[str, object]:
+    """Reuse the native two-arm pair configuration for exactly one public task."""
+    canary = plan(manifest)
+    calibration = _campaign().plan(manifest, "calibration")
+    source_pair = calibration["pairs"][0]
+    configs = _campaign().pair_job_configs(manifest, "calibration")
+    source = configs.get(source_pair["pairId"])
+    if not isinstance(source, dict):
+        raise ValueError("canary native job configuration is unavailable")
+    config = copy.deepcopy(source)
+    config["job_name"] = "chaos-gauge-canary-" + hashlib.sha256(
+        str(canary["pair"]["pairId"]).encode()
+    ).hexdigest()[:16]
+    config["n_attempts"] = 1
+    config["n_concurrent_trials"] = 2
+    config["quiet"] = True
+    return config
+
+
+def _private_receipt(manifest: dict[str, object]) -> dict[str, object]:
+    package = _mapping(manifest.get("privatePackage"), "private package")
+    keys = ("repository", "commit", "contentSha256", "name", "ref")
+    value = {key: package.get(key) for key in keys}
+    if not all(isinstance(item, str) and item for item in value.values()):
+        raise ValueError("private package identity is invalid")
+    return value
+
+
+def _result_mapping(value: object) -> dict[str, object]:
+    dump = getattr(value, "model_dump", None)
+    return _mapping(dump(mode="json") if callable(dump) else value, "Harbor canary result")
+
+
+def receipt(
+    manifest: object, planned: object, result: object, *, public_source_revision: str
+) -> dict[str, object]:
+    """Return strict aggregate evidence; never include raw Harbor output or trajectories."""
+    source = _mapping(manifest, "experiment manifest")
+    canary = _mapping(planned, "canary plan")
+    if canary != plan(source) or not GIT_SHA.fullmatch(public_source_revision):
+        raise ValueError("canary plan or source revision is invalid")
+    value = _result_mapping(result)
+    trials = value.get("trial_results")
+    if not isinstance(trials, list) or len(trials) != 2:
+        raise ValueError("canary trial matrix is incomplete")
+    pair = _mapping(canary["pair"], "canary pair")
+    observed = []
+    for arm, raw in zip(pair["arms"], trials):
+        trial = _mapping(raw, "Harbor canary trial")
+        if trial.get("task_name") != pair["task"] or trial.get("task_checksum") != pair["sha256"]:
+            raise ValueError("canary task identity is invalid")
+        native_name = _campaign()._native_trial_name(str(pair["task"]), trial.get("trial_name"))
+        agent = _mapping(trial.get("agent_info"), "canary agent")
+        model = _mapping(agent.get("model_info"), "canary model")
+        if agent.get("name") != "codex" or agent.get("version") != "0.118.0" or model != {"name": "gpt-5.6-terra", "provider": "openai"}:
+            raise ValueError("canary runtime identity is invalid")
+        context = _mapping(trial.get("agent_result"), "canary telemetry")
+        tokens = _number(context.get("n_input_tokens"), "canary token telemetry", integer=True) + _number(context.get("n_output_tokens"), "canary token telemetry", integer=True)
+        cost = _number(context.get("cost_usd"), "canary cost telemetry")
+        timing = _mapping(trial.get("agent_execution"), "canary timing")
+        started, finished = _timestamp(timing.get("started_at")), _timestamp(timing.get("finished_at"))
+        if finished < started:
+            raise ValueError("canary timing is invalid")
+        rewards = _mapping(_mapping(trial.get("verifier_result"), "canary verifier").get("rewards"), "canary rewards")
+        if rewards != {"correctness": 1.0, "safety": 1.0, "cleanup": 1.0}:
+            raise ValueError("canary verifier, safety, or cleanup evidence is invalid")
+        if trial.get("verifier_environment_mode") != "separate":
+            raise ValueError("canary verifier isolation is invalid")
+        observed.append({
+            "arm": arm,
+            "task": pair["task"],
+            "sha256": pair["sha256"],
+            "nativeTrialName": native_name,
+            "tokens": tokens,
+            "costUsd": cost,
+            "seconds": (finished - started).total_seconds(),
+            "verifierEnvironmentMode": "separate",
+            "rewards": rewards,
+        })
+    return {
+        "schemaVersion": 1,
+        "campaign": "canary",
+        "excludedFromPilot": True,
+        "implementationRevision": canary["implementationRevision"],
+        "publicSourceRevision": public_source_revision,
+        "privatePackage": _private_receipt(source),
+        "trialAccounting": {"planned": 2, "observed": len(observed)},
+        "rawResultSha256": hashlib.sha256(
+            json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode()
+        ).hexdigest(),
+        "trials": observed,
+    }
+
+
+def validate_public_evidence(value: object) -> None:
+    """Fail closed unless evidence is exactly the sanitised canary receipt schema."""
+    receipt_value = _mapping(value, "public canary evidence")
+    expected = {
+        "schemaVersion", "campaign", "excludedFromPilot", "implementationRevision",
+        "publicSourceRevision", "privatePackage", "trialAccounting", "rawResultSha256", "trials",
+    }
+    if set(receipt_value) != expected or receipt_value.get("schemaVersion") != 1 or receipt_value.get("campaign") != "canary" or receipt_value.get("excludedFromPilot") is not True:
+        raise ValueError("public canary evidence is invalid")
+    if not GIT_SHA.fullmatch(str(receipt_value.get("implementationRevision"))) or not GIT_SHA.fullmatch(str(receipt_value.get("publicSourceRevision"))):
+        raise ValueError("public canary evidence is invalid")
+    package = _mapping(receipt_value.get("privatePackage"), "public canary evidence")
+    if set(package) != {"repository", "commit", "contentSha256", "name", "ref"}:
+        raise ValueError("public canary evidence is invalid")
+    accounting = _mapping(receipt_value.get("trialAccounting"), "public canary evidence")
+    trials = receipt_value.get("trials")
+    if accounting != {"planned": 2, "observed": 2} or not isinstance(trials, list) or len(trials) != 2:
+        raise ValueError("public canary evidence is invalid")
+    for trial in trials:
+        record = _mapping(trial, "public canary evidence")
+        if set(record) != {"arm", "task", "sha256", "nativeTrialName", "tokens", "costUsd", "seconds", "verifierEnvironmentMode", "rewards"} or record.get("arm") not in ARMS or record.get("verifierEnvironmentMode") != "separate":
+            raise ValueError("public canary evidence is invalid")
+        _number(record.get("tokens"), "public canary evidence", integer=True)
+        _number(record.get("costUsd"), "public canary evidence")
+        _number(record.get("seconds"), "public canary evidence")
+        if record.get("rewards") != {"correctness": 1.0, "safety": 1.0, "cleanup": 1.0}:
+            raise ValueError("public canary evidence is invalid")
+
+
+def _write_exclusive(path: Path, value: object) -> None:
+    target = Path(path)
+    if not target.parent.is_dir() or target.parent.is_symlink() or target.is_symlink():
+        raise ValueError("canary output path is invalid")
+    try:
+        descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as error:
+        raise ValueError("canary output already exists") from error
+    with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+        json.dump(value, output, sort_keys=True)
+        output.write("\n")
+        output.flush()
+        os.fsync(output.fileno())
+
+
+async def run(
+    manifest: object,
+    private_checkout: Path,
+    *,
+    public_source_revision: str,
+    raw_out: Path,
+    receipt_out: Path,
+) -> dict[str, object]:
+    """Run exactly one excluded native pair after the complete paid-run preflight."""
+    if not GIT_SHA.fullmatch(public_source_revision):
+        raise ValueError("canary source revision is invalid")
+    launcher = _campaign()
+    launcher.full_preflight(manifest, private_checkout)
+    planned, config = plan(manifest), job_config(manifest)
+    environment = _mapping(config.get("environment"), "canary environment")
+    if environment.get("type") != "docker" or environment.get("delete") is not True:
+        raise ValueError("canary cleanup configuration is invalid")
+    from harbor.job import Job
+    from harbor.models.job.config import JobConfig
+
+    job = await Job.create(JobConfig.model_validate(config))
+    trials = getattr(job, "_trial_configs", None)
+    pair = _mapping(planned["pair"], "canary pair")
+    if not isinstance(trials, list) or len(trials) != 2:
+        raise ValueError("canary native trial matrix is invalid")
+    names = []
+    for trial in trials:
+        if launcher._pair_task_name(trial) != pair["task"]:
+            raise ValueError("canary native task identity is invalid")
+        names.append(launcher._native_trial_name(str(pair["task"]), getattr(trial, "trial_name", None)))
+    launcher._install_pair_start_gate(job, names[0], names[1])
+    raw = _result_mapping(await job.run())
+    _write_exclusive(raw_out, raw)
+    evidence = receipt(manifest, planned, raw, public_source_revision=public_source_revision)
+    validate_public_evidence(evidence)
+    _write_exclusive(receipt_out, evidence)
+    return evidence
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=ROOT / "experiment.json")
+    parser.add_argument("--private-checkout", type=Path, required=True)
+    parser.add_argument("--public-source-revision", required=True)
+    parser.add_argument("--raw-out", type=Path, required=True)
+    parser.add_argument("--receipt-out", type=Path, required=True)
+    args = parser.parse_args()
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    asyncio.run(
+        run(
+            manifest,
+            args.private_checkout,
+            public_source_revision=args.public_source_revision,
+            raw_out=args.raw_out,
+            receipt_out=args.receipt_out,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/chaos_gauge/canary.py
+++ b/scripts/ci/chaos_gauge/canary.py
@@ -184,21 +184,45 @@ def validate_public_evidence(value: object) -> None:
     if not GIT_SHA.fullmatch(str(receipt_value.get("implementationRevision"))) or not GIT_SHA.fullmatch(str(receipt_value.get("publicSourceRevision"))):
         raise ValueError("public canary evidence is invalid")
     package = _mapping(receipt_value.get("privatePackage"), "public canary evidence")
-    if set(package) != {"repository", "commit", "contentSha256", "name", "ref"}:
+    if (
+        set(package) != {"repository", "commit", "contentSha256", "name", "ref"}
+        or package.get("repository") != "ShaftHQ/ChaosGauge-private"
+        or package.get("name") != "ShaftHQ/chaosgauge-private"
+        or not GIT_SHA.fullmatch(str(package.get("commit")))
+        or not re.fullmatch(r"sha256:[0-9a-f]{64}", str(package.get("contentSha256")))
+        or package.get("ref") != package.get("contentSha256")
+    ):
         raise ValueError("public canary evidence is invalid")
     accounting = _mapping(receipt_value.get("trialAccounting"), "public canary evidence")
     trials = receipt_value.get("trials")
-    if accounting != {"planned": 2, "observed": 2} or not isinstance(trials, list) or len(trials) != 2:
+    if (
+        accounting != {"planned": 2, "observed": 2}
+        or not isinstance(trials, list)
+        or len(trials) != 2
+        or not re.fullmatch(r"[0-9a-f]{64}", str(receipt_value.get("rawResultSha256")))
+    ):
         raise ValueError("public canary evidence is invalid")
+    seen_arms: set[str] = set()
     for trial in trials:
         record = _mapping(trial, "public canary evidence")
-        if set(record) != {"arm", "task", "sha256", "nativeTrialName", "tokens", "costUsd", "seconds", "verifierEnvironmentMode", "rewards"} or record.get("arm") not in ARMS or record.get("verifierEnvironmentMode") != "separate":
+        if (
+            set(record) != {"arm", "task", "sha256", "nativeTrialName", "tokens", "costUsd", "seconds", "verifierEnvironmentMode", "rewards"}
+            or record.get("arm") not in ARMS
+            or record.get("arm") in seen_arms
+            or record.get("task") != "diagnosis-config-precedence"
+            or not re.fullmatch(r"[0-9a-f]{64}", str(record.get("sha256")))
+            or not re.fullmatch(r"diagnosis-config-precedence__[A-Za-z0-9]{7}", str(record.get("nativeTrialName")))
+            or record.get("verifierEnvironmentMode") != "separate"
+        ):
             raise ValueError("public canary evidence is invalid")
+        seen_arms.add(str(record["arm"]))
         _number(record.get("tokens"), "public canary evidence", integer=True)
         _number(record.get("costUsd"), "public canary evidence")
         _number(record.get("seconds"), "public canary evidence")
         if record.get("rewards") != {"correctness": 1.0, "safety": 1.0, "cleanup": 1.0}:
             raise ValueError("public canary evidence is invalid")
+    if seen_arms != set(ARMS):
+        raise ValueError("public canary evidence is invalid")
 
 
 def _write_exclusive(path: Path, value: object) -> None:

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "identity": "ShaftHQ/chaos-engine-effectiveness",
-  "implementationRevision": "5ebf1b75f28b8d164e5326c69e81f1df2eb8237d",
+  "implementationRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
   "harbor": {
     "version": "0.22.0",
     "source": "harbor-framework/harbor@v0.22.0",
@@ -41,12 +41,12 @@
       "agent": "codex",
       "model": "gpt-5.6-terra",
       "effort": "medium",
-      "repositoryRevision": "5ebf1b75f28b8d164e5326c69e81f1df2eb8237d",
+      "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "none",
       "harnessSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "treatmentSha256": {
-        "calibration": "28a5ee0a1ad8d8eece12b09bd528577cf591ce78efdcad5e468c7a7169d5168e",
-        "full-pilot": "0a12b16c246fbae379f2aa0fb6a4aae1126e64be15af2ed1b3ae20eaef5372fc"
+        "calibration": "eb08b5c36e234e455069003a011b470bbcf09b27cd18065b735cf75b6532a6c4",
+        "full-pilot": "ea69199ef6f030cf38478ecf837f1305c0eef5c5cafd3ccc5afa91d78aa03269"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,
@@ -57,12 +57,12 @@
       "agent": "codex",
       "model": "gpt-5.6-terra",
       "effort": "medium",
-      "repositoryRevision": "5ebf1b75f28b8d164e5326c69e81f1df2eb8237d",
+      "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "fc97d4bf65ddb739c1e8a40f01f552d4719ac5101a5035d4e11af8c66b8805cf",
+      "harnessSha256": "ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e",
       "treatmentSha256": {
-        "calibration": "02a9ec47ce535a883928da9986e6dd1f06ae92a4f52adfcf90e1987224bfddf2",
-        "full-pilot": "0fccd7fd705aa66887e2e4b9b378c6c6474609fce2ded6a6f965f2cebde4076f"
+        "calibration": "b13305e2f4b1b49bdf9bf1f480d7a753bde3fc18ab4987b1e7b7bd868efa1444",
+        "full-pilot": "a3b105beaf603c93809a16f2126346c84a3fbf7c65a2607511d7665564d58c09"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -21,8 +21,8 @@ agents:
       version: "0.118.0"
       reasoning_effort: medium
       harness_source: chaos-engine
-      harness_commit: "5ebf1b75f28b8d164e5326c69e81f1df2eb8237d"
-      harness_sha256: "fc97d4bf65ddb739c1e8a40f01f552d4719ac5101a5035d4e11af8c66b8805cf"
+      harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
+      harness_sha256: "ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -20,8 +20,8 @@ agents:
       version: "0.118.0"
       reasoning_effort: medium
       harness_source: chaos-engine
-      harness_commit: "5ebf1b75f28b8d164e5326c69e81f1df2eb8237d"
-      harness_sha256: "fc97d4bf65ddb739c1e8a40f01f552d4719ac5101a5035d4e11af8c66b8805cf"
+      harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
+      harness_sha256: "ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -350,7 +350,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),
-                "harness_sha256": "fc97d4bf65ddb739c1e8a40f01f552d4719ac5101a5035d4e11af8c66b8805cf",
+                "harness_sha256": "ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e",
                 "adapter_sha256": "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             }
             if kwargs != expected:

--- a/tests/scripts/test_chaos_gauge_canary.py
+++ b/tests/scripts/test_chaos_gauge_canary.py
@@ -85,6 +85,11 @@ class CanaryContractTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "public canary evidence"):
             CANARY.validate_public_evidence(leaked)
 
+        leaked = copy.deepcopy(receipt)
+        leaked["privatePackage"]["repository"] = "sk-private-value"
+        with self.assertRaisesRegex(ValueError, "public canary evidence"):
+            CANARY.validate_public_evidence(leaked)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/scripts/test_chaos_gauge_canary.py
+++ b/tests/scripts/test_chaos_gauge_canary.py
@@ -12,7 +12,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 GAUGE = ROOT / "scripts" / "ci" / "chaos_gauge"
 SPEC = importlib.util.spec_from_file_location("chaos_gauge_canary", GAUGE / "canary.py")
-assert SPEC and SPEC.loader
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("ChaosGauge canary module is unavailable")
 CANARY = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(CANARY)
 MANIFEST = json.loads((GAUGE / "experiment.json").read_text(encoding="utf-8"))

--- a/tests/scripts/test_chaos_gauge_canary.py
+++ b/tests/scripts/test_chaos_gauge_canary.py
@@ -1,0 +1,90 @@
+"""Excluded ChaosGauge canary contract (#5462)."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GAUGE = ROOT / "scripts" / "ci" / "chaos_gauge"
+SPEC = importlib.util.spec_from_file_location("chaos_gauge_canary", GAUGE / "canary.py")
+assert SPEC and SPEC.loader
+CANARY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CANARY)
+MANIFEST = json.loads((GAUGE / "experiment.json").read_text(encoding="utf-8"))
+
+
+class CanaryContractTest(unittest.TestCase):
+    def test_canary_is_one_excluded_public_two_arm_pair(self) -> None:
+        planned = CANARY.plan(MANIFEST)
+
+        self.assertEqual("canary", planned["campaign"])
+        self.assertTrue(planned["excludedFromPilot"])
+        self.assertEqual(2, planned["trials"])
+        self.assertEqual(0, planned["pair"]["attempt"])
+        self.assertEqual("diagnosis-config-precedence", planned["pair"]["task"])
+        self.assertEqual({"control", "chaos-engine"}, set(planned["pair"]["arms"]))
+
+        config = CANARY.job_config(MANIFEST)
+        self.assertTrue(config["job_name"].startswith("chaos-gauge-canary-"))
+        self.assertEqual(1, config["n_attempts"])
+        self.assertEqual(2, config["n_concurrent_trials"])
+        self.assertEqual(1, len(config["datasets"]))
+        self.assertEqual([planned["pair"]["task"]], config["datasets"][0]["task_names"])
+        self.assertEqual(
+            ["codex" if arm == "control" else None for arm in planned["pair"]["arms"]],
+            [agent.get("name") for agent in config["agents"]],
+        )
+
+    def test_receipt_requires_pinned_telemetry_isolation_and_cleanup(self) -> None:
+        planned = CANARY.plan(MANIFEST)
+        result = {
+            "trial_results": [
+                {
+                    "task_name": planned["pair"]["task"],
+                    "task_checksum": planned["pair"]["sha256"],
+                    "trial_name": f"{planned['pair']['task']}__{'ctrl001' if arm == 'control' else 'chaos01'}",
+                    "agent_info": {
+                        "name": "codex", "version": "0.118.0",
+                        "model_info": {"name": "gpt-5.6-terra", "provider": "openai"},
+                    },
+                    "agent_result": {"n_input_tokens": 10, "n_output_tokens": 20, "cost_usd": 0.01},
+                    "agent_execution": {
+                        "started_at": "2026-08-31T00:00:00+00:00",
+                        "finished_at": "2026-08-31T00:00:01+00:00",
+                    },
+                    "verifier_environment_mode": "separate",
+                    "verifier_result": {"rewards": {"correctness": 1.0, "safety": 1.0, "cleanup": 1.0}},
+                }
+                for arm in planned["pair"]["arms"]
+            ]
+        }
+        receipt = CANARY.receipt(MANIFEST, planned, result, public_source_revision="f" * 40)
+
+        self.assertTrue(receipt["excludedFromPilot"])
+        self.assertEqual(2, receipt["trialAccounting"]["observed"])
+        self.assertNotIn("trial_results", json.dumps(receipt, sort_keys=True))
+        CANARY.validate_public_evidence(receipt)
+
+        missing_tokens = copy.deepcopy(result)
+        del missing_tokens["trial_results"][0]["agent_result"]["n_input_tokens"]
+        with self.assertRaisesRegex(ValueError, "token telemetry"):
+            CANARY.receipt(MANIFEST, planned, missing_tokens, public_source_revision="f" * 40)
+
+        unsafe = copy.deepcopy(result)
+        unsafe["trial_results"][0]["verifier_result"]["rewards"]["cleanup"] = 0.0
+        with self.assertRaisesRegex(ValueError, "cleanup"):
+            CANARY.receipt(MANIFEST, planned, unsafe, public_source_revision="f" * 40)
+
+        leaked = copy.deepcopy(receipt)
+        leaked["rawTrajectory"] = "forbidden"
+        with self.assertRaisesRegex(ValueError, "public canary evidence"):
+            CANARY.validate_public_evidence(leaked)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_chaos_gauge_canary.py
+++ b/tests/scripts/test_chaos_gauge_canary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -20,6 +21,19 @@ MANIFEST = json.loads((GAUGE / "experiment.json").read_text(encoding="utf-8"))
 
 
 class CanaryContractTest(unittest.TestCase):
+    @staticmethod
+    def _merged_git(revision: str):
+        def run(command: list[str]) -> str:
+            if "rev-parse" in command:
+                return revision + "\n"
+            if "rev-list" in command:
+                return f"{revision} parent-one parent-two\n"
+            if "merge-base" in command:
+                return ""
+            raise AssertionError(command)
+
+        return run
+
     def test_canary_is_one_excluded_public_two_arm_pair(self) -> None:
         planned = CANARY.plan(MANIFEST)
 
@@ -43,6 +57,7 @@ class CanaryContractTest(unittest.TestCase):
 
     def test_receipt_requires_pinned_telemetry_isolation_and_cleanup(self) -> None:
         planned = CANARY.plan(MANIFEST)
+        config = CANARY.job_config(MANIFEST)
         result = {
             "trial_results": [
                 {
@@ -53,6 +68,7 @@ class CanaryContractTest(unittest.TestCase):
                         "name": "codex", "version": "0.118.0",
                         "model_info": {"name": "gpt-5.6-terra", "provider": "openai"},
                     },
+                    "config": {"agent": copy.deepcopy(config["agents"][position])},
                     "agent_result": {"n_input_tokens": 10, "n_output_tokens": 20, "cost_usd": 0.01},
                     "agent_execution": {
                         "started_at": "2026-08-31T00:00:00+00:00",
@@ -61,35 +77,79 @@ class CanaryContractTest(unittest.TestCase):
                     "verifier_environment_mode": "separate",
                     "verifier_result": {"rewards": {"correctness": 1.0, "safety": 1.0, "cleanup": 1.0}},
                 }
-                for arm in planned["pair"]["arms"]
+                for position, arm in enumerate(planned["pair"]["arms"])
             ]
         }
-        receipt = CANARY.receipt(MANIFEST, planned, result, public_source_revision="f" * 40)
+        native_bindings = {
+            arm: result["trial_results"][position]["trial_name"]
+            for position, arm in enumerate(planned["pair"]["arms"])
+        }
+        merged_git = self._merged_git("f" * 40)
+        receipt = CANARY.receipt(
+            MANIFEST, planned, result, public_source_revision="f" * 40,
+            native_bindings=native_bindings, repository=ROOT, run=merged_git,
+        )
 
         self.assertTrue(receipt["excludedFromPilot"])
         self.assertEqual(2, receipt["trialAccounting"]["observed"])
         self.assertNotIn("trial_results", json.dumps(receipt, sort_keys=True))
-        CANARY.validate_public_evidence(receipt)
+        CANARY.validate_public_evidence(receipt, repository=ROOT, run=merged_git)
 
         missing_tokens = copy.deepcopy(result)
         del missing_tokens["trial_results"][0]["agent_result"]["n_input_tokens"]
         with self.assertRaisesRegex(ValueError, "token telemetry"):
-            CANARY.receipt(MANIFEST, planned, missing_tokens, public_source_revision="f" * 40)
+            CANARY.receipt(
+                MANIFEST, planned, missing_tokens, public_source_revision="f" * 40,
+                native_bindings=native_bindings, repository=ROOT, run=merged_git,
+            )
 
         unsafe = copy.deepcopy(result)
         unsafe["trial_results"][0]["verifier_result"]["rewards"]["cleanup"] = 0.0
         with self.assertRaisesRegex(ValueError, "cleanup"):
-            CANARY.receipt(MANIFEST, planned, unsafe, public_source_revision="f" * 40)
+            CANARY.receipt(
+                MANIFEST, planned, unsafe, public_source_revision="f" * 40,
+                native_bindings=native_bindings, repository=ROOT, run=merged_git,
+            )
 
         leaked = copy.deepcopy(receipt)
         leaked["rawTrajectory"] = "forbidden"
         with self.assertRaisesRegex(ValueError, "public canary evidence"):
-            CANARY.validate_public_evidence(leaked)
+            CANARY.validate_public_evidence(leaked, repository=ROOT, run=merged_git)
 
         leaked = copy.deepcopy(receipt)
         leaked["privatePackage"]["repository"] = "sk-private-value"
         with self.assertRaisesRegex(ValueError, "public canary evidence"):
-            CANARY.validate_public_evidence(leaked)
+            CANARY.validate_public_evidence(leaked, repository=ROOT, run=merged_git)
+
+    def test_receipt_binds_prepared_native_name_and_agent_to_its_arm(self) -> None:
+        planned = CANARY.plan(MANIFEST)
+        config = CANARY.job_config(MANIFEST)
+        result = {"trial_results": []}
+        for position, arm in enumerate(planned["pair"]["arms"]):
+            result["trial_results"].append({
+                "task_name": planned["pair"]["task"], "task_checksum": planned["pair"]["sha256"],
+                "trial_name": f"{planned['pair']['task']}__{'ctrl001' if arm == 'control' else 'chaos01'}",
+                "config": {"agent": copy.deepcopy(config["agents"][position])},
+                "agent_info": {"name": "codex", "version": "0.118.0", "model_info": {"name": "gpt-5.6-terra", "provider": "openai"}},
+                "agent_result": {"n_input_tokens": 10, "n_output_tokens": 20, "cost_usd": 0.01},
+                "agent_execution": {"started_at": "2026-08-31T00:00:00+00:00", "finished_at": "2026-08-31T00:00:01+00:00"},
+                "verifier_environment_mode": "separate",
+                "verifier_result": {"rewards": {"correctness": 1.0, "safety": 1.0, "cleanup": 1.0}},
+            })
+        bindings = {arm: result["trial_results"][index]["trial_name"] for index, arm in enumerate(planned["pair"]["arms"])}
+        kwargs = {"native_bindings": bindings, "repository": ROOT, "run": self._merged_git("f" * 40)}
+
+        swapped = copy.deepcopy(result)
+        swapped["trial_results"][1]["config"]["agent"] = copy.deepcopy(swapped["trial_results"][0]["config"]["agent"])
+        with self.assertRaisesRegex(ValueError, "arm identity"):
+            CANARY.receipt(MANIFEST, planned, swapped, public_source_revision="f" * 40, **kwargs)
+
+        unmerged = lambda command: "" if "rev-parse" in command else (_ for _ in ()).throw(subprocess.CalledProcessError(1, command))
+        with self.assertRaisesRegex(ValueError, "source revision"):
+            CANARY.receipt(
+                MANIFEST, planned, result, public_source_revision="f" * 40,
+                native_bindings=bindings, repository=ROOT, run=unmerged,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -221,8 +221,8 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             environment = types.SimpleNamespace(upload_dir=AsyncMock())
             agent = module.ChaosEngineCodex(
                 harness_source=str(ROOT / "chaos-engine"),
-                harness_commit="5ebf1b75f28b8d164e5326c69e81f1df2eb8237d",
-                harness_sha256="fc97d4bf65ddb739c1e8a40f01f552d4719ac5101a5035d4e11af8c66b8805cf",
+                harness_commit="0481767def7c31fe144bc20543dfe937b8ffd4d5",
+                harness_sha256="ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e",
                 adapter_sha256="3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             )
 

--- a/tests/scripts/test_chaos_gauge_recovery.py
+++ b/tests/scripts/test_chaos_gauge_recovery.py
@@ -11,9 +11,9 @@ CHAOS_GAUGE = ROOT / "scripts" / "ci" / "chaos_gauge"
 # `e7d329bd3b` is merged PR #5464, immutable recovery source for #5450.
 # This covers its full public ChaosGauge tree, unlike a few representative
 # anchors that can remain after an executable or dataset member is lost.
-RECOVERED_PUBLIC_FILE_COUNT = 139
+RECOVERED_PUBLIC_FILE_COUNT = 140
 RECOVERED_PUBLIC_PATHS_SHA256 = (
-    "510eb657e5ca3f841c38b09c58a4fbb10e37fc4d5710f44cead1f29105935699"
+    "4a6eac9a728eb15e556667c401f01493046a1d3a0270b3dc780bb17be43047a2"
 )
 
 
@@ -47,6 +47,7 @@ class ChaosGaugeRecoveryTest(unittest.TestCase):
         self.assertIn("'scripts/ci/chaos_gauge/**'", workflow)
         self.assertIn("'tests/scripts/test_chaos_gauge_*.py'", workflow)
         self.assertIn("needs.changes.outputs.chaos_gauge == 'true'", workflow)
+        self.assertIn("tests.scripts.test_chaos_gauge_canary", workflow)
         self.assertIn("tests.scripts.test_chaos_gauge_campaign", workflow)
         self.assertIn("tests.scripts.test_chaos_gauge_recovery", workflow)
         scheduled = (


### PR DESCRIPTION
## Summary

- adds a deterministic excluded two-arm native canary plan and strict sanitized receipt schema
- makes public evidence reject raw trajectories, arbitrary private fields, and unpinned identities
- wires focused canary tests into the PR gate

## Checks

- `python3 -m unittest tests.scripts.test_chaos_gauge_canary tests.scripts.test_chaos_gauge_contracts tests.scripts.test_chaos_gauge_campaign tests.scripts.test_chaos_gauge_corpus tests.scripts.test_chaos_gauge_recovery tests.scripts.test_chaos_gauge_scoring tests.scripts.test_ci_python_dependencies`
- `python3 scripts/ci/chaos_gauge/validate_experiment.py scripts/ci/chaos_gauge/experiment.json`
- `python3 scripts/ci/validate_agent_setup.py --skip-external`

## Continuation

Related to #5462. This is preparation only: no canary or pilot has run. The private workflow remains fail-closed until scoped provider and Harbor credentials, Docker, pinned runtime, and merged execution-revision evidence are available.