### PR TITLE
test(engine): stabilize nightly browser coverage

### DIFF
--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -142,7 +142,7 @@ jobs:
         if: always()
         uses: ./.github/actions/post-test-report
         with:
-          job-name: MacOSX_Safari_Local_1_of_2
+          job-name: MacOSX_Safari_Local_1_of_${{ github.event.inputs.tests != '' && '1' || '2' }}
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Safari_Local_2:

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -40,7 +40,8 @@ jobs:
     if: always()
     needs:
       - Windows_Edge_Local
-      - MacOSX_Safari_Local
+      - MacOSX_Safari_Local_1
+      - MacOSX_Safari_Local_2
       - Windows_Chrome_Local
       - Windows_Managed_Lighthouse
       - Ubuntu_Managed_Android
@@ -106,15 +107,10 @@ jobs:
           job-name: Windows_Edge_Local
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-  MacOSX_Safari_Local:
-    name: MacOSX_Safari_Local_${{ matrix.shard.index }}_of_${{ matrix.shard.total }}
+  MacOSX_Safari_Local_1:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_Local,')
     runs-on: macos-latest
     timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: ${{ fromJSON(github.event_name == 'workflow_dispatch' && github.event.inputs.tests != '' && '[{"index":1,"total":1}]' || '[{"index":1,"total":2},{"index":2,"total":2}]') }}
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -140,13 +136,51 @@ jobs:
           mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-Dshaft.shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || format('{0}, !%regex[.*MobileEmulation.*]', env.GLOBAL_TESTING_SCOPE) }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-Dshaft.shard=${{ github.event.inputs.tests != '' && '1/1' || '1/2' }}" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || format('{0}, !%regex[.*MobileEmulation.*]', env.GLOBAL_TESTING_SCOPE) }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
         uses: ./.github/actions/post-test-report
         with:
-          job-name: MacOSX_Safari_Local_${{ matrix.shard.index }}_of_${{ matrix.shard.total }}
+          job-name: MacOSX_Safari_Local_1_of_2
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  MacOSX_Safari_Local_2:
+    if: (github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_Local,')) && (github.event_name != 'workflow_dispatch' || github.event.inputs.tests == '')
+    runs-on: macos-latest
+    timeout-minutes: 120
+    outputs:
+      job: ${{ steps.post_test_report.outputs.job }}
+      total: ${{ steps.post_test_report.outputs.total }}
+      passed: ${{ steps.post_test_report.outputs.passed }}
+      failed: ${{ steps.post_test_report.outputs.failed }}
+      broken: ${{ steps.post_test_report.outputs.broken }}
+      skipped: ${{ steps.post_test_report.outputs.skipped }}
+      duration: ${{ steps.post_test_report.outputs.duration }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+      - name: Setup Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          node-version: '20'
+      # See the note in e2eTests.yml: a Central refusal in this step, which has
+      # no continue-on-error, cascades into a missing Allure summary (#4445).
+      # `shell: bash` is explicit because these jobs run on Windows and macOS.
+      - name: Install optional visual test runtime
+        shell: bash
+        run: >-
+          bash scripts/ci/build_retry.sh 2 60
+          mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
+      - name: Run tests
+        continue-on-error: true
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-Dshaft.shard=2/2" "-DgenerateAllureReportArchive=true" "-Dtest=${{ format('{0}, !%regex[.*MobileEmulation.*]', env.GLOBAL_TESTING_SCOPE) }}"
+      - name: Post-Test Report and Check
+        id: post_test_report
+        if: always()
+        uses: ./.github/actions/post-test-report
+        with:
+          job-name: MacOSX_Safari_Local_2_of_2
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Windows_Chrome_Local:
@@ -612,7 +646,7 @@ jobs:
 
   notify_local_e2e_tests_failure:
     name: Notify on nightly failure
-    needs: [ Windows_Edge_Local, MacOSX_Safari_Local, Windows_Chrome_Local, Windows_Managed_Lighthouse, Ubuntu_Managed_Android, Windows_SikuliX_Local, Windows_Appium_Desktop_Local, MacOSX_Chrome_Local, Windows_Edge_Cucumber_Local ]
+    needs: [ Windows_Edge_Local, MacOSX_Safari_Local_1, MacOSX_Safari_Local_2, Windows_Chrome_Local, Windows_Managed_Lighthouse, Ubuntu_Managed_Android, Windows_SikuliX_Local, Windows_Appium_Desktop_Local, MacOSX_Chrome_Local, Windows_Edge_Cucumber_Local ]
     if: always()
     runs-on: ubuntu-22.04
     timeout-minutes: 5

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -107,9 +107,14 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Safari_Local:
+    name: MacOSX_Safari_Local_${{ matrix.shard }}_of_2
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_Local,')
     runs-on: macos-latest
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -135,13 +140,13 @@ jobs:
           mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || format('{0}, !%regex[.*MobileEmulation.*]', env.GLOBAL_TESTING_SCOPE) }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-Dshaft.shard=${{ matrix.shard }}/2" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || format('{0}, !%regex[.*MobileEmulation.*]', env.GLOBAL_TESTING_SCOPE) }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
         uses: ./.github/actions/post-test-report
         with:
-          job-name: MacOSX_Safari_Local
+          job-name: MacOSX_Safari_Local_${{ matrix.shard }}_of_2
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Windows_Chrome_Local:

--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -107,14 +107,14 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   MacOSX_Safari_Local:
-    name: MacOSX_Safari_Local_${{ matrix.shard }}_of_2
+    name: MacOSX_Safari_Local_${{ matrix.shard.index }}_of_${{ matrix.shard.total }}
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_Local,')
     runs-on: macos-latest
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: ${{ fromJSON(github.event_name == 'workflow_dispatch' && github.event.inputs.tests != '' && '[{"index":1,"total":1}]' || '[{"index":1,"total":2},{"index":2,"total":2}]') }}
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -140,13 +140,13 @@ jobs:
           mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-Dshaft.shard=${{ matrix.shard }}/2" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || format('{0}, !%regex[.*MobileEmulation.*]', env.GLOBAL_TESTING_SCOPE) }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=safari" "-Dshaft.shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || format('{0}, !%regex[.*MobileEmulation.*]', env.GLOBAL_TESTING_SCOPE) }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()
         uses: ./.github/actions/post-test-report
         with:
-          job-name: MacOSX_Safari_Local_${{ matrix.shard }}_of_2
+          job-name: MacOSX_Safari_Local_${{ matrix.shard.index }}_of_${{ matrix.shard.total }}
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Windows_Chrome_Local:

--- a/scripts/ci/validate_quality_configuration.py
+++ b/scripts/ci/validate_quality_configuration.py
@@ -722,10 +722,10 @@ def validate_quality_configuration(root: Path = ROOT) -> list[str]:
         e2e_workflow.count('"-DincludeVisualTestRuntime"')
         + local_e2e_workflow.count('"-DincludeVisualTestRuntime"')
     )
-    if grid_install_count != 4 or local_install_count != 4 or activation_count != 10:
+    if grid_install_count != 4 or local_install_count != 5 or activation_count != 11:
         errors.append(
             "e2eTests.yml and e2eLocalTests.yml must prepare and activate the visual test runtime "
-            "for 4 grid/cloud, 4 local broad-browser, and 2 OCR acceptance jobs"
+            "for 4 grid/cloud, 5 local broad-browser, and 2 OCR acceptance jobs"
         )
     for required_local_flow in (
         "Windows_SikuliX_Local",

--- a/shaft-engine/src/test/java/com/shaft/gui/mobile/MobileFileActionsTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/mobile/MobileFileActionsTest.java
@@ -18,22 +18,26 @@ import java.nio.file.Path;
 import java.util.Comparator;
 
 public class MobileFileActionsTest {
-    private Path tempDirectory;
+    private final ThreadLocal<Path> tempDirectory = new ThreadLocal<>();
 
     @BeforeMethod
     public void createTempDirectory() throws IOException {
-        tempDirectory = Files.createTempDirectory("shaft-mobile-files-test-");
+        tempDirectory.set(Files.createTempDirectory("shaft-mobile-files-test-"));
     }
 
     @AfterMethod
     public void deleteTempDirectory() throws IOException {
-        if (tempDirectory == null || !Files.exists(tempDirectory)) {
-            return;
-        }
-        try (var paths = Files.walk(tempDirectory)) {
-            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
-                Files.deleteIfExists(path);
+        Path directory = tempDirectory.get();
+        try {
+            if (directory != null && Files.exists(directory)) {
+                try (var paths = Files.walk(directory)) {
+                    for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                        Files.deleteIfExists(path);
+                    }
+                }
             }
+        } finally {
+            tempDirectory.remove();
         }
     }
 
@@ -65,10 +69,10 @@ public class MobileFileActionsTest {
         Mockito.when(driver.getSessionId()).thenReturn(new SessionId("mobile-file-paths"));
         byte[] pulled = "replacement".getBytes(StandardCharsets.UTF_8);
         Mockito.when(driver.pullFile("/device/result.txt")).thenReturn(pulled);
-        Path target = tempDirectory.resolve("nested/result.txt");
+        Path target = tempDirectory.get().resolve("nested/result.txt");
         Files.createDirectories(target.getParent());
         Files.writeString(target, "known-good", StandardCharsets.UTF_8);
-        Path source = tempDirectory.resolve("source.txt");
+        Path source = tempDirectory.get().resolve("source.txt");
         byte[] submitted = "submitted".getBytes(StandardCharsets.UTF_8);
         Files.write(source, submitted);
         MobileActions mobile = new SHAFT.GUI.WebDriver(driver).mobile();

--- a/shaft-engine/src/test/java/testPackage/DownloadWithoutPromptTest.java
+++ b/shaft-engine/src/test/java/testPackage/DownloadWithoutPromptTest.java
@@ -4,6 +4,7 @@ import com.shaft.driver.SHAFT;
 import com.shaft.properties.internal.Properties;
 import org.openqa.selenium.By;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -18,6 +19,10 @@ public class DownloadWithoutPromptTest {
 
     @BeforeMethod(alwaysRun = true)
     public void init() {
+        if (!"local".equalsIgnoreCase(SHAFT.Properties.platform.executionAddress())
+                || !"chrome".equalsIgnoreCase(SHAFT.Properties.web.targetBrowserName())) {
+            throw new SkipException("Silent download coverage requires local Chrome.");
+        }
         SHAFT.Properties.web.set().headlessExecution(true).targetBrowserName("chrome").incognitoMode(false);
         SHAFT.Properties.flags.set().automaticallyAddRecommendedChromeOptions(false);
         driver.set(new SHAFT.GUI.WebDriver());

--- a/shaft-engine/src/test/java/testPackage/legacy/DragAndDropTests.java
+++ b/shaft-engine/src/test/java/testPackage/legacy/DragAndDropTests.java
@@ -4,30 +4,24 @@ import com.shaft.driver.SHAFT;
 import com.shaft.tools.io.ReportManager;
 import com.shaft.validation.Validations;
 import org.openqa.selenium.By;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import testPackage.TestPageServer;
 
 public class DragAndDropTests {
     private static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
     @Test(description = "TC001 - Test Drag and Drop function.")
     public void dragAndDrop() {
-        driver.get().browser().navigateToURL("http://the-internet.herokuapp.com/drag_and_drop"); // PASSED
-        By dropDestinationLocator = By.xpath("//div[@id='columns']//*[contains (text(),'B')]");
-        By dragTarget1Locator = By.xpath("//div[@id='columns']//*[contains (text(),'A')]");
+        driver.get().browser().navigateToURL(TestPageServer.url("dragAndDropFixture.html"));
+        By dropDestinationLocator = By.id("drop-target");
+        By dragTargetLocator = By.id("drag-source");
 
-        // BrowserActions.navigateToURL(driver, "http://rubaxa.github.io/Sortable/");
-        // By dropDestinationLocator = By.xpath("//*[@id='bar']");
-        // By dragTarget1Locator = By.xpath("//*[@id='foo']/li[1]");
-
-        // BrowserActions.navigateToURL(driver,
-        // "http://a5hik.github.io/ng-sortable/#/kanban");
-        // http://jqueryui.com/resources/demos/sortable/connect-lists.html
-
-        // ElementActions.click(driver, dragTarget1Locator);
         ReportManager.log("Attempting Drag and Drop");
-        driver.get().element().dragAndDrop(dragTarget1Locator, dropDestinationLocator);
+        driver.get().element().dragAndDrop(dragTargetLocator, dropDestinationLocator);
 
+        Assert.assertEquals(driver.get().element().get().text(dropDestinationLocator), "Dropped");
     }
 
     @Test(description = "TC002 - Test Drag and Drop by offset function.")

--- a/shaft-engine/src/test/resources/testDataFiles/dragAndDropFixture.html
+++ b/shaft-engine/src/test/resources/testDataFiles/dragAndDropFixture.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Drag and drop fixture</title>
+    <style>
+        #drag-source, #drop-target { width: 120px; height: 80px; margin: 24px; padding: 16px; }
+        #drag-source { background: #8ecae6; }
+        #drop-target { background: #ffb703; }
+    </style>
+</head>
+<body>
+<div id="drag-source" draggable="true">Drag me</div>
+<div id="drop-target">Waiting</div>
+<script>
+    const source = document.getElementById('drag-source');
+    const target = document.getElementById('drop-target');
+    source.addEventListener('dragstart', event => event.dataTransfer.setData('text/plain', 'dragged'));
+    target.addEventListener('dragover', event => event.preventDefault());
+    target.addEventListener('drop', event => {
+        event.preventDefault();
+        target.textContent = 'Dropped';
+    });
+</script>
+</body>
+</html>

--- a/tests/scripts/test_validate_workflow_timeouts.py
+++ b/tests/scripts/test_validate_workflow_timeouts.py
@@ -135,8 +135,32 @@ jobs:
         workflow = yaml.safe_load(
             (repository_root / ".github/workflows/e2eLocalTests.yml").read_text(encoding="utf-8")
         )
-        timeout = workflow["jobs"]["MacOSX_Safari_Local"].get("timeout-minutes", 0)
-        self.assertEqual(timeout, 120)
+        safari_job = workflow["jobs"]["MacOSX_Safari_Local"]
+        self.assertEqual(safari_job.get("timeout-minutes"), 120)
+        self.assertFalse(safari_job["strategy"]["fail-fast"])
+        self.assertEqual(safari_job["strategy"]["matrix"]["shard"], [1, 2])
+
+        commands = " ".join(str(step.get("run", "")) for step in safari_job["steps"])
+        self.assertIn("-Dshaft.shard=${{ matrix.shard }}/2", commands)
+        self.assertIn("-DsetParallelMode=NONE", commands)
+
+        report_step = next(
+            step for step in safari_job["steps"] if step.get("id") == "post_test_report"
+        )
+        self.assertEqual(
+            report_step["with"]["job-name"],
+            "MacOSX_Safari_Local_${{ matrix.shard }}_of_2",
+        )
+
+    def test_local_chrome_job_remains_unsharded(self):
+        repository_root = Path(__file__).resolve().parents[2]
+        workflow = yaml.safe_load(
+            (repository_root / ".github/workflows/e2eLocalTests.yml").read_text(encoding="utf-8")
+        )
+        chrome_job = workflow["jobs"]["Windows_Chrome_Local"]
+        self.assertNotIn("strategy", chrome_job)
+        commands = " ".join(str(step.get("run", "")) for step in chrome_job["steps"])
+        self.assertNotIn("-Dshaft.shard=", commands)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_validate_workflow_timeouts.py
+++ b/tests/scripts/test_validate_workflow_timeouts.py
@@ -148,7 +148,12 @@ jobs:
             report_step = next(
                 step for step in safari_job["steps"] if step.get("id") == "post_test_report"
             )
-            self.assertEqual(report_step["with"]["job-name"], f"MacOSX_Safari_Local_{index}_of_2")
+            expected_report_name = (
+                "MacOSX_Safari_Local_1_of_${{ github.event.inputs.tests != '' && '1' || '2' }}"
+                if index == 1
+                else "MacOSX_Safari_Local_2_of_2"
+            )
+            self.assertEqual(report_step["with"]["job-name"], expected_report_name)
 
         first_commands = " ".join(str(step.get("run", "")) for step in jobs[safari_ids[0]]["steps"])
         self.assertIn("github.event.inputs.tests != '' && '1/1' || '1/2'", first_commands)

--- a/tests/scripts/test_validate_workflow_timeouts.py
+++ b/tests/scripts/test_validate_workflow_timeouts.py
@@ -130,33 +130,34 @@ jobs:
         timeout = workflow["jobs"]["iOS_Web_SAFARI_BrowserStack"].get("timeout-minutes", 0)
         self.assertEqual(timeout, 15)
 
-    def test_local_safari_job_allows_observed_nightly_runtime_headroom(self):
+    def test_local_safari_shards_preserve_outputs_and_focused_dispatches(self):
         repository_root = Path(__file__).resolve().parents[2]
         workflow = yaml.safe_load(
             (repository_root / ".github/workflows/e2eLocalTests.yml").read_text(encoding="utf-8")
         )
-        safari_job = workflow["jobs"]["MacOSX_Safari_Local"]
-        self.assertEqual(safari_job.get("timeout-minutes"), 120)
-        self.assertFalse(safari_job["strategy"]["fail-fast"])
-        shard_matrix = safari_job["strategy"]["matrix"]["shard"]
-        self.assertIn("github.event.inputs.tests != ''", shard_matrix)
-        self.assertIn('[{"index":1,"total":1}]', shard_matrix)
-        self.assertIn('[{"index":1,"total":2},{"index":2,"total":2}]', shard_matrix)
+        jobs = workflow["jobs"]
+        safari_ids = ["MacOSX_Safari_Local_1", "MacOSX_Safari_Local_2"]
+        expected_outputs = {"job", "total", "passed", "failed", "broken", "skipped", "duration"}
+        for index, job_id in enumerate(safari_ids, start=1):
+            safari_job = jobs[job_id]
+            self.assertEqual(safari_job.get("timeout-minutes"), 120)
+            self.assertEqual(set(safari_job["outputs"]), expected_outputs)
+            self.assertIn(",MacOSX_Safari_Local,", safari_job["if"])
+            commands = " ".join(str(step.get("run", "")) for step in safari_job["steps"])
+            self.assertIn("-DsetParallelMode=NONE", commands)
+            report_step = next(
+                step for step in safari_job["steps"] if step.get("id") == "post_test_report"
+            )
+            self.assertEqual(report_step["with"]["job-name"], f"MacOSX_Safari_Local_{index}_of_2")
 
-        commands = " ".join(str(step.get("run", "")) for step in safari_job["steps"])
-        self.assertIn(
-            "-Dshaft.shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}",
-            commands,
-        )
-        self.assertIn("-DsetParallelMode=NONE", commands)
-
-        report_step = next(
-            step for step in safari_job["steps"] if step.get("id") == "post_test_report"
-        )
-        self.assertEqual(
-            report_step["with"]["job-name"],
-            "MacOSX_Safari_Local_${{ matrix.shard.index }}_of_${{ matrix.shard.total }}",
-        )
+        first_commands = " ".join(str(step.get("run", "")) for step in jobs[safari_ids[0]]["steps"])
+        self.assertIn("github.event.inputs.tests != '' && '1/1' || '1/2'", first_commands)
+        second_commands = " ".join(str(step.get("run", "")) for step in jobs[safari_ids[1]]["steps"])
+        self.assertIn("-Dshaft.shard=2/2", second_commands)
+        self.assertIn("github.event.inputs.tests == ''", jobs[safari_ids[1]]["if"])
+        for consumer in ("Workflow_Summary", "notify_local_e2e_tests_failure"):
+            for job_id in safari_ids:
+                self.assertIn(job_id, jobs[consumer]["needs"])
 
     def test_local_chrome_job_remains_unsharded(self):
         repository_root = Path(__file__).resolve().parents[2]

--- a/tests/scripts/test_validate_workflow_timeouts.py
+++ b/tests/scripts/test_validate_workflow_timeouts.py
@@ -138,10 +138,16 @@ jobs:
         safari_job = workflow["jobs"]["MacOSX_Safari_Local"]
         self.assertEqual(safari_job.get("timeout-minutes"), 120)
         self.assertFalse(safari_job["strategy"]["fail-fast"])
-        self.assertEqual(safari_job["strategy"]["matrix"]["shard"], [1, 2])
+        shard_matrix = safari_job["strategy"]["matrix"]["shard"]
+        self.assertIn("github.event.inputs.tests != ''", shard_matrix)
+        self.assertIn('[{"index":1,"total":1}]', shard_matrix)
+        self.assertIn('[{"index":1,"total":2},{"index":2,"total":2}]', shard_matrix)
 
         commands = " ".join(str(step.get("run", "")) for step in safari_job["steps"])
-        self.assertIn("-Dshaft.shard=${{ matrix.shard }}/2", commands)
+        self.assertIn(
+            "-Dshaft.shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}",
+            commands,
+        )
         self.assertIn("-DsetParallelMode=NONE", commands)
 
         report_step = next(
@@ -149,7 +155,7 @@ jobs:
         )
         self.assertEqual(
             report_step["with"]["job-name"],
-            "MacOSX_Safari_Local_${{ matrix.shard }}_of_2",
+            "MacOSX_Safari_Local_${{ matrix.shard.index }}_of_${{ matrix.shard.total }}",
         )
 
     def test_local_chrome_job_remains_unsharded(self):


### PR DESCRIPTION
## Summary

- gate silent-download coverage before mutating thread-scoped browser properties, retaining local Chrome coverage
- isolate mobile file-action temporary directories per test thread and clean them deterministically
- replace the external drag-and-drop page with a local deterministic fixture and assert the final drop state
- split scheduled Safari coverage across two independent serial macOS shards while preserving focused manual dispatch as a single shard
- make Safari report and artifact identities shard-specific

## Validation

- `python3 -m unittest tests.scripts.test_validate_workflow_timeouts` (16 passed)
- focused local Chrome download and drag-and-drop tests passed
- `MobileFileActionsTest` passed normally and with parallel methods (3 tests each)
- YAML safe-load passed
- `git diff --check origin/main...HEAD` passed

## Remote acceptance

After merge, dispatch and verify the three Grid browser jobs and the two scheduled/full Safari shards. Issues #5474 and #5475 are workflow-generated reliability tickets and should close only after their successful workflow runs.

Related to #5474
Related to #5475