### PR TITLE
fix(test): keep dependent tests inside one shard

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -218,6 +218,11 @@ runs:
             echo "::error::No tests were executed according to the Allure summary. Check test configuration."
             exit 1
           fi
+          VERDICT_TOTAL=$((PASSED + FAILED + BROKEN + SKIPPED))
+          if [ "$VERDICT_TOTAL" -eq 0 ]; then
+            echo "::error::Allure summary reports $TOTAL total tests but 0 status verdicts. Treating this as an invalid test run."
+            exit 1
+          fi
           if [ "$FAILED" -gt 0 ] || [ "$BROKEN" -gt 0 ]; then
             if command -v python3 >/dev/null 2>&1; then
               ALLURE_FAILURE_SOURCE=""

--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -219,8 +219,8 @@ runs:
             exit 1
           fi
           VERDICT_TOTAL=$((PASSED + FAILED + BROKEN + SKIPPED))
-          if [ "$VERDICT_TOTAL" -eq 0 ]; then
-            echo "::error::Allure summary reports $TOTAL total tests but 0 status verdicts. Treating this as an invalid test run."
+          if [ "$VERDICT_TOTAL" -ne "$TOTAL" ]; then
+            echo "::error::Allure summary reports $TOTAL total tests but $VERDICT_TOTAL status verdicts. Treating this as an invalid test run."
             exit 1
           fi
           if [ "$FAILED" -gt 0 ] || [ "$BROKEN" -gt 0 ]; then

--- a/scripts/mcp/install_shaft_agentic_tools.py
+++ b/scripts/mcp/install_shaft_agentic_tools.py
@@ -69,7 +69,6 @@ RETIRED_SHAFT_SKILL_DIRECTORIES = frozenset((
 # tests/scripts/test_install_shaft_mcp.py reads the real import statements and
 # fails when this list falls behind them.
 AGENT_VALIDATION_SCRIPT_FILES = (
-    "README.md",
     "chaos-engine/dependencies.json",
     "chaos-engine/README.md",
     "chaos-engine/hooks/kernel.py",

--- a/scripts/mcp/install_shaft_agentic_tools.py
+++ b/scripts/mcp/install_shaft_agentic_tools.py
@@ -69,6 +69,7 @@ RETIRED_SHAFT_SKILL_DIRECTORIES = frozenset((
 # tests/scripts/test_install_shaft_mcp.py reads the real import statements and
 # fails when this list falls behind them.
 AGENT_VALIDATION_SCRIPT_FILES = (
+    "chaos-engine/dependencies.json",
     "scripts/agents/guard.py",
     "scripts/agents/session_worktree.py",
     "scripts/agents/reflection.py",

--- a/scripts/mcp/install_shaft_agentic_tools.py
+++ b/scripts/mcp/install_shaft_agentic_tools.py
@@ -69,7 +69,11 @@ RETIRED_SHAFT_SKILL_DIRECTORIES = frozenset((
 # tests/scripts/test_install_shaft_mcp.py reads the real import statements and
 # fails when this list falls behind them.
 AGENT_VALIDATION_SCRIPT_FILES = (
+    "README.md",
     "chaos-engine/dependencies.json",
+    "chaos-engine/README.md",
+    "chaos-engine/hooks/kernel.py",
+    "chaos-engine/hooks/lifecycle.py",
     "scripts/agents/guard.py",
     "scripts/agents/session_worktree.py",
     "scripts/agents/reflection.py",

--- a/shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java
+++ b/shaft-engine/src/main/java/com/shaft/listeners/TestNGListener.java
@@ -269,11 +269,12 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
     }
 
     /**
-     * Deterministically partitions test methods by {@code -Dshaft.shard=N/M} (see
+     * Deterministically partitions test classes by {@code -Dshaft.shard=N/M} (see
      * {@link ShardPartitioner}), leaving every non-test (configuration) method untouched so
      * {@code @BeforeSuite}/{@code @BeforeClass}/etc. still run normally for the methods that do
-     * remain. A blank, malformed, or absent {@code shaft.shard} property disables filtering
-     * entirely and returns {@code methods} unchanged.
+     * remain. Class-level partitioning keeps TestNG method dependencies together. A blank,
+     * malformed, or absent {@code shaft.shard} property disables filtering entirely and returns
+     * {@code methods} unchanged.
      */
     private static List<IMethodInstance> shardFilter(List<IMethodInstance> methods) {
         ShardPartitioner.Spec spec = ShardPartitioner.parse(System.getProperty("shaft.shard", ""));
@@ -289,7 +290,7 @@ public class TestNGListener implements IAlterSuiteListener, IAnnotationTransform
                     String className = method.getTestClass() == null
                             ? method.getRealClass().getName()
                             : method.getTestClass().getName();
-                    return spec.includes(className, method.getMethodName());
+                    return spec.includes(className, "");
                 })
                 .collect(Collectors.toList());
     }

--- a/shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/TestNGListenerCoverageUnitTest.java
@@ -65,7 +65,7 @@ public class TestNGListenerCoverageUnitTest {
         TestNGListener listener = new TestNGListener();
         List<IMethodInstance> methods = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
-            methods.add(methodInstance("testPackage.unitTests.TestNGListenerCoverageUnitTest", "test" + i, true));
+            methods.add(methodInstance("testPackage.unitTests.ShardedTest" + i, "test", true));
         }
 
         List<IMethodInstance> shardOne = listener.intercept(new ArrayList<>(methods), Mockito.mock(ITestContext.class));
@@ -76,6 +76,30 @@ public class TestNGListenerCoverageUnitTest {
         Assert.assertTrue(shardTwo.size() < methods.size(), "Shard 2/2 should drop some methods");
         assertEquals(shardOne.size() + shardTwo.size(), methods.size(),
                 "The union of both shards must equal the full method list with no overlap");
+    }
+
+    @Test
+    public void interceptKeepsDependentMethodsFromTheSameClassOnOneShard() {
+        TestNGListener listener = new TestNGListener();
+        List<IMethodInstance> dependentMethods = List.of(
+                methodInstance("com.example.DependentSafariTest", "signIn", true),
+                methodInstance("com.example.DependentSafariTest", "checkout", true),
+                methodInstance("com.example.DependentSafariTest", "signOut", true));
+        Mockito.when(dependentMethods.get(1).getMethod().getMethodsDependedUpon())
+                .thenReturn(new String[]{"signIn"});
+        Mockito.when(dependentMethods.get(2).getMethod().getMethodsDependedUpon())
+                .thenReturn(new String[]{"checkout"});
+
+        System.setProperty("shaft.shard", "1/2");
+        List<IMethodInstance> shardOne = listener.intercept(new ArrayList<>(dependentMethods),
+                Mockito.mock(ITestContext.class));
+        System.setProperty("shaft.shard", "2/2");
+        List<IMethodInstance> shardTwo = listener.intercept(new ArrayList<>(dependentMethods),
+                Mockito.mock(ITestContext.class));
+
+        Assert.assertTrue(shardOne.isEmpty() || shardTwo.isEmpty(),
+                "Methods in one class must not be split because TestNG dependencies are class-scoped.");
+        assertEquals(shardOne.size() + shardTwo.size(), dependentMethods.size());
     }
 
     @Test

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -423,7 +423,7 @@ class InstallShaftMcpTest(unittest.TestCase):
         self.assertIn("scripts/ci/agent_ownership.json", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
 
     def test_agent_validation_script_files_includes_chaos_engine_dependencies(self):
-        self.assertIn("README.md", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
+        self.assertNotIn("README.md", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
         self.assertIn("chaos-engine/dependencies.json", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
         self.assertIn("chaos-engine/README.md", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
 
@@ -449,6 +449,8 @@ class InstallShaftMcpTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             target = Path(temp_dir).resolve()
             (target / "AGENTS.md").write_text("# Installed guidance\n", encoding="utf-8")
+            adopter_readme = "# Adopter project\n\nKeep this content.\n"
+            (target / "README.md").write_text(adopter_readme, encoding="utf-8")
             retired = target / "scripts" / "agents" / "learning_loop.py"
             retired.parent.mkdir(parents=True)
             retired.write_text("# installer-owned retired controller\n", encoding="utf-8")
@@ -464,6 +466,7 @@ class InstallShaftMcpTest(unittest.TestCase):
             self.assertTrue((target / "scripts" / "agents" / "learning_session.py").is_file())
             self.assertFalse(retired.exists())
             self.assertTrue((target / "scripts" / "ci" / "agent_ownership.json").is_file())
+            self.assertEqual(adopter_readme, (target / "README.md").read_text(encoding="utf-8"))
             command = (
                 "import sys; "
                 f"sys.path.insert(0, {str(target)!r}); "

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -422,6 +422,9 @@ class InstallShaftMcpTest(unittest.TestCase):
         self.assertIn("scripts/ci/validate_agent_ownership.py", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
         self.assertIn("scripts/ci/agent_ownership.json", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
 
+    def test_agent_validation_script_files_includes_chaos_engine_dependencies(self):
+        self.assertIn("chaos-engine/dependencies.json", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
+
     def test_agent_validation_manifest_ships_every_module_the_validator_imports(self):
         # Same class of defect as issue #3363 bug 9, one level up: the manifest
         # copies validate_agent_setup.py into a user's project, so any sibling
@@ -1430,4 +1433,3 @@ class AgenticToolsInstallerSurfaceTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/scripts/test_install_shaft_mcp.py
+++ b/tests/scripts/test_install_shaft_mcp.py
@@ -423,7 +423,9 @@ class InstallShaftMcpTest(unittest.TestCase):
         self.assertIn("scripts/ci/agent_ownership.json", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
 
     def test_agent_validation_script_files_includes_chaos_engine_dependencies(self):
+        self.assertIn("README.md", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
         self.assertIn("chaos-engine/dependencies.json", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
+        self.assertIn("chaos-engine/README.md", MODULE.AGENT_VALIDATION_SCRIPT_FILES)
 
     def test_agent_validation_manifest_ships_every_module_the_validator_imports(self):
         # Same class of defect as issue #3363 bug 9, one level up: the manifest
@@ -443,7 +445,7 @@ class InstallShaftMcpTest(unittest.TestCase):
             self.agent_validation_manifest_missing_imports(shipped),
         )
 
-    def test_downloaded_agent_validation_bundle_imports_from_isolated_project(self):
+    def test_downloaded_agent_validation_bundle_validates_from_isolated_project(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             target = Path(temp_dir).resolve()
             (target / "AGENTS.md").write_text("# Installed guidance\n", encoding="utf-8")
@@ -466,8 +468,9 @@ class InstallShaftMcpTest(unittest.TestCase):
                 "import sys; "
                 f"sys.path.insert(0, {str(target)!r}); "
                 "import scripts.agents.guard; "
-                "import scripts.ci.validate_agent_setup; "
-                "import scripts.ci.validate_agent_ownership"
+                "import scripts.ci.validate_agent_setup as validator; "
+                "import scripts.ci.validate_agent_ownership; "
+                f"validator.validate_repository(validator.Path({str(target)!r}), run_external=False)"
             )
             completed = subprocess.run(  # nosec B603 - fixed interpreter and generated local import script.
                 [sys.executable, "-I", "-S", "-c", command],

--- a/tests/scripts/test_post_test_report_action.py
+++ b/tests/scripts/test_post_test_report_action.py
@@ -1,5 +1,5 @@
 import os
-import subprocess
+import subprocess  # nosec B404 - integration fixture invokes fixed bash with repository-owned action text.
 import tempfile
 import unittest
 from pathlib import Path
@@ -37,7 +37,7 @@ class PostTestReportActionTest(unittest.TestCase):
                 "SHAFT_JOB_STARTED_S": "",
             })
 
-            completed = subprocess.run(
+            completed = subprocess.run(  # nosec B603 B607 - fixed bash executes trusted action fixture text.
                 ["bash", "-c", script], capture_output=True, text=True, env=environment, check=False
             )
 

--- a/tests/scripts/test_post_test_report_action.py
+++ b/tests/scripts/test_post_test_report_action.py
@@ -1,0 +1,49 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTION = ROOT / ".github/actions/post-test-report/action.yml"
+
+
+class PostTestReportActionTest(unittest.TestCase):
+    def test_rejects_nonzero_total_without_any_status_verdicts(self):
+        action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+        step = next(step for step in action["runs"]["steps"]
+                    if step.get("id") == "collect_results")
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            module = Path(temporary_directory) / "shaft-engine"
+            results = module / "allure-results"
+            report = module / "allure-report"
+            results.mkdir(parents=True)
+            report.mkdir()
+            (results / "test-result.json").write_text("{}", encoding="utf-8")
+            (report / "summary.json").write_text(
+                '{"statistic":{"total":14,"passed":0,"failed":0,"broken":0,"skipped":0}}',
+                encoding="utf-8",
+            )
+            script = step["run"].replace("${{ inputs.module-directory }}", str(module))
+            script = script.replace("${{ inputs.job-name }}", "Safari shard 1")
+            environment = os.environ.copy()
+            environment.update({
+                "GITHUB_STEP_SUMMARY": str(Path(temporary_directory) / "summary.md"),
+                "GITHUB_OUTPUT": str(Path(temporary_directory) / "outputs.txt"),
+                "SHAFT_JOB_STARTED_S": "",
+            })
+
+            completed = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True, env=environment, check=False
+            )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("14 total tests but 0 status verdicts", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_post_test_report_action.py
+++ b/tests/scripts/test_post_test_report_action.py
@@ -12,7 +12,7 @@ ACTION = ROOT / ".github/actions/post-test-report/action.yml"
 
 
 class PostTestReportActionTest(unittest.TestCase):
-    def test_rejects_nonzero_total_without_any_status_verdicts(self):
+    def run_summary(self, *, total, passed, failed, broken, skipped):
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
         step = next(step for step in action["runs"]["steps"]
                     if step.get("id") == "collect_results")
@@ -25,7 +25,10 @@ class PostTestReportActionTest(unittest.TestCase):
             report.mkdir()
             (results / "test-result.json").write_text("{}", encoding="utf-8")
             (report / "summary.json").write_text(
-                '{"statistic":{"total":14,"passed":0,"failed":0,"broken":0,"skipped":0}}',
+                '{"statistic":'
+                f'{{"total":{total},"passed":{passed},"failed":{failed},'
+                f'"broken":{broken},"skipped":{skipped}}}'
+                '}',
                 encoding="utf-8",
             )
             script = step["run"].replace("${{ inputs.module-directory }}", str(module))
@@ -40,9 +43,43 @@ class PostTestReportActionTest(unittest.TestCase):
             completed = subprocess.run(  # nosec B603 B607 - fixed bash executes trusted action fixture text.
                 ["bash", "-c", script], capture_output=True, text=True, env=environment, check=False
             )
+        return completed
+
+    def test_rejects_nonzero_total_without_any_status_verdicts(self):
+        completed = self.run_summary(total=14, passed=0, failed=0, broken=0, skipped=0)
 
         self.assertNotEqual(0, completed.returncode)
         self.assertIn("14 total tests but 0 status verdicts", completed.stdout)
+
+    def test_rejects_fewer_status_verdicts_than_total(self):
+        completed = self.run_summary(total=14, passed=13, failed=0, broken=0, skipped=0)
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("14 total tests but 13 status verdicts", completed.stdout)
+
+    def test_rejects_more_status_verdicts_than_total(self):
+        completed = self.run_summary(total=14, passed=15, failed=0, broken=0, skipped=0)
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("14 total tests but 15 status verdicts", completed.stdout)
+
+    def test_accepts_summary_when_total_matches_status_verdicts(self):
+        completed = self.run_summary(total=14, passed=13, failed=0, broken=0, skipped=1)
+
+        self.assertEqual(0, completed.returncode, completed.stdout)
+
+    def test_preserves_failed_and_broken_verdict_failures(self):
+        for failed, broken in ((1, 0), (0, 1)):
+            with self.subTest(failed=failed, broken=broken):
+                completed = self.run_summary(
+                    total=14, passed=13, failed=failed, broken=broken, skipped=0
+                )
+
+                self.assertNotEqual(0, completed.returncode)
+                self.assertIn(
+                    f"Allure report shows {failed} failed and {broken} broken test(s)",
+                    completed.stdout,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Post-merge acceptance of #5497 exposed two coupled false-green failures in the Safari shards:

- TestNG methods were partitioned independently, so `dependsOnMethods` chains were split between shards and both Safari jobs executed zero shaft-engine tests.
- the post-test report accepted an impossible Allure summary with 14 total entries but zero passed, failed, broken, or skipped verdicts.

This follow-up partitions TestNG interception at class granularity while preserving the existing `ShardPartitioner` API, and makes post-test reporting fail closed when a nonzero total has no status verdicts.

## Validation

- RED: executable post-report fixture reproduced `14/0/0/0/0` as exit 0 before the fix
- regression: a same-class `signIn -> checkout -> signOut` dependency chain stays entirely within one shard
- `python3 -W error::ResourceWarning -m unittest tests.scripts.test_post_test_report_action tests.scripts.test_validate_workflow_timeouts tests.scripts.test_validate_quality_configuration` (55 passed)
- `git diff --check origin/main...HEAD` passed
- Java regression execution is delegated to PR CI JDK 25 because this Linux environment has a runtime-only Java 25 installation without `javac`

## Acceptance

After merge, rerun the full Safari selection and require both shards to execute real tests, upload distinct nonempty reports, aggregate both outputs, and close #5475 only through the successful full workflow.

Related to #5475