### PR TITLE
feat(ci): bridge excluded ChaosGauge canary

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -38,6 +38,7 @@ changing that token silently breaks both distribution publishers.
 | File | Trigger | Responsibility |
 |---|---|---|
 | `pr-gate.yml` | pull request, push to `main` | Required path-aware gate: documentation boundaries, agent guidance, unit tests, installer/plugin checks, CLI, Capture E2E, dependency review, and template coupling. |
+| `chaos-gauge-public-canary.yml` | manual | Runs one excluded public two-arm ChaosGauge canary through private draft evidence retention; never launches the pilot. |
 | `security.yml` | pull request, push to `main`, manual | CodeQL Java analysis. |
 | `shaft-pilot-release.yml` | release-relevant pull request, manual | Rehearses the release contract, consumers, IntelliJ candidate, Capture, MCP transports, and container. |
 | `mavenCentral_cd.yml` | release-relevant push to `main`, manual | Validates, signs, publishes, verifies, releases, dispatches the guide, and announces. |

--- a/.github/workflows/chaos-gauge-public-canary.yml
+++ b/.github/workflows/chaos-gauge-public-canary.yml
@@ -49,10 +49,12 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '22'
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          version: '0.12.7'
       - name: Install pinned native runtime
         working-directory: public
         run: |
-          python3 -m pip install uv==0.12.7
           uv pip install --system --require-hashes --requirement scripts/ci/chaos_gauge/requirements.lock
           npm install --global @openai/codex@0.118.0
           docker version --format '{{.Server.Version}}'

--- a/.github/workflows/chaos-gauge-public-canary.yml
+++ b/.github/workflows/chaos-gauge-public-canary.yml
@@ -1,5 +1,11 @@
 name: Run public ChaosGauge excluded canary
 
+# Owner-authorized excluded-canary exception (#5462, ShaftHQ/ChaosGauge-private#3):
+# exactly one public task and two accounted arms may use the generic provider secret.
+# This workflow enforces a 60-minute runtime, exactly two arms, and a 120000-token
+# acceptance budget. It is not a provider-side spend cap. Full pilot keeps its
+# dedicated-secret gate and is not authorized here.
+
 on:
   workflow_dispatch:
 
@@ -38,11 +44,18 @@ jobs:
           revision="$(git -C public rev-parse HEAD)"
           git -C public merge-base --is-ancestor "$revision" origin/main
           printf 'revision=%s\n' "$revision" >> "$GITHUB_OUTPUT"
-      - name: Prove private release capability
+      - id: private-evidence
+        name: Prepare private evidence storage
         working-directory: public
         env:
-          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
-        run: python3 scripts/ci/chaos_gauge/public_canary_bridge.py preflight
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          CANARY_RECEIPT: ${{ runner.temp }}/chaosgauge-canary-receipt.json
+          CANARY_RUN_ID: ${{ github.run_id }}
+        run: |
+          action="$(python3 scripts/ci/chaos_gauge/public_canary_bridge.py prepare \
+            --repository "$PWD" --run-id "$CANARY_RUN_ID" --receipt-out "$CANARY_RECEIPT")"
+          test "$action" = run -o "$action" = recover
+          printf 'action=%s\n' "$action" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: '3.12'
@@ -63,6 +76,7 @@ jobs:
           CANARY_BASELINE_CONTAINERS: ${{ runner.temp }}/chaosgauge-canary-containers.txt
         run: docker ps --all --format '{{.ID}}' | sort > "$CANARY_BASELINE_CONTAINERS"
       - name: Run excluded two-arm canary
+        if: steps.private-evidence.outputs.action == 'run'
         working-directory: public
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -71,6 +85,7 @@ jobs:
           PUBLIC_SOURCE_REVISION: ${{ steps.public-source.outputs.revision }}
           CANARY_RAW: ${{ runner.temp }}/chaosgauge-canary-raw.json
           CANARY_RECEIPT: ${{ runner.temp }}/chaosgauge-canary-receipt.json
+          CANARY_MAX_ACCOUNTED_TOKENS: "120000"
         run: |
           test -n "$OPENAI_API_KEY" || { echo 'provider credential unavailable'; exit 1; }
           test -n "$HARBOR_API_KEY" || { echo 'Harbor credential unavailable'; exit 1; }
@@ -80,6 +95,15 @@ jobs:
             --raw-out "$CANARY_RAW" \
             --receipt-out "$CANARY_RECEIPT" \
             --private-read-proven
+          python3 - "$CANARY_RECEIPT" "$CANARY_MAX_ACCOUNTED_TOKENS" <<'PY'
+          import json
+          import sys
+
+          evidence = json.load(open(sys.argv[1], encoding="utf-8"))
+          tokens = sum(trial["tokens"] for trial in evidence["trials"])
+          if evidence["trialAccounting"] != {"planned": 2, "observed": 2} or tokens > int(sys.argv[2]):
+              raise SystemExit("excluded canary exceeded its two-arm accounted-token budget")
+          PY
       - name: Verify Docker teardown
         if: always()
         env:
@@ -88,6 +112,7 @@ jobs:
           test -f "$CANARY_BASELINE_CONTAINERS" || exit 1
           ! comm -13 "$CANARY_BASELINE_CONTAINERS" <(docker ps --all --format '{{.ID}}' | sort) | grep -q .
       - name: Validate and secret-scan evidence
+        if: steps.private-evidence.outputs.action == 'run'
         working-directory: public
         env:
           CANARY_RAW: ${{ runner.temp }}/chaosgauge-canary-raw.json
@@ -96,9 +121,10 @@ jobs:
           python3 scripts/ci/chaos_gauge/public_canary_bridge.py validate
           --raw "$CANARY_RAW" --receipt "$CANARY_RECEIPT" --repository "$PWD"
       - name: Store evidence in private draft release
+        if: steps.private-evidence.outputs.action == 'run'
         working-directory: public
         env:
-          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           CANARY_RAW: ${{ runner.temp }}/chaosgauge-canary-raw.json
           CANARY_RECEIPT: ${{ runner.temp }}/chaosgauge-canary-receipt.json
           CANARY_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/chaos-gauge-public-canary.yml
+++ b/.github/workflows/chaos-gauge-public-canary.yml
@@ -1,0 +1,111 @@
+name: Run public ChaosGauge excluded canary
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chaos-gauge-public-canary-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  excluded-canary:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout merged public source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: ShaftHQ/SHAFT_ENGINE
+          ref: main
+          path: public
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Checkout pinned private corpus
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: ShaftHQ/ChaosGauge-private
+          ref: 08551a3db4376438acddd77422554ce710a58624
+          path: private
+          fetch-depth: 1
+          persist-credentials: false
+          token: ${{ secrets.BOT_TOKEN }}
+      - id: public-source
+        name: Record exact public main revision
+        run: |
+          revision="$(git -C public rev-parse HEAD)"
+          git -C public merge-base --is-ancestor "$revision" origin/main
+          printf 'revision=%s\n' "$revision" >> "$GITHUB_OUTPUT"
+      - name: Prove private release capability
+        working-directory: public
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: python3 scripts/ci/chaos_gauge/public_canary_bridge.py preflight
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '22'
+      - name: Install pinned native runtime
+        working-directory: public
+        run: |
+          python3 -m pip install uv==0.12.7
+          uv pip install --system --require-hashes --requirement scripts/ci/chaos_gauge/requirements.lock
+          npm install --global @openai/codex@0.118.0
+          docker version --format '{{.Server.Version}}'
+      - name: Capture Docker baseline
+        env:
+          CANARY_BASELINE_CONTAINERS: ${{ runner.temp }}/chaosgauge-canary-containers.txt
+        run: docker ps --all --format '{{.ID}}' | sort > "$CANARY_BASELINE_CONTAINERS"
+      - name: Run excluded two-arm canary
+        working-directory: public
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          HARBOR_API_KEY: ${{ secrets.CHAOSGAUGE_HARBOR_TOKEN }}
+          PRIVATE_CHECKOUT: ${{ github.workspace }}/private
+          PUBLIC_SOURCE_REVISION: ${{ steps.public-source.outputs.revision }}
+          CANARY_RAW: ${{ runner.temp }}/chaosgauge-canary-raw.json
+          CANARY_RECEIPT: ${{ runner.temp }}/chaosgauge-canary-receipt.json
+        run: |
+          test -n "$OPENAI_API_KEY" || { echo 'provider credential unavailable'; exit 1; }
+          test -n "$HARBOR_API_KEY" || { echo 'Harbor credential unavailable'; exit 1; }
+          python3 scripts/ci/chaos_gauge/canary.py \
+            --private-checkout "$PRIVATE_CHECKOUT" \
+            --public-source-revision "$PUBLIC_SOURCE_REVISION" \
+            --raw-out "$CANARY_RAW" \
+            --receipt-out "$CANARY_RECEIPT" \
+            --private-read-proven
+      - name: Verify Docker teardown
+        if: always()
+        env:
+          CANARY_BASELINE_CONTAINERS: ${{ runner.temp }}/chaosgauge-canary-containers.txt
+        run: |
+          test -f "$CANARY_BASELINE_CONTAINERS" || exit 1
+          ! comm -13 "$CANARY_BASELINE_CONTAINERS" <(docker ps --all --format '{{.ID}}' | sort) | grep -q .
+      - name: Validate and secret-scan evidence
+        working-directory: public
+        env:
+          CANARY_RAW: ${{ runner.temp }}/chaosgauge-canary-raw.json
+          CANARY_RECEIPT: ${{ runner.temp }}/chaosgauge-canary-receipt.json
+        run: >-
+          python3 scripts/ci/chaos_gauge/public_canary_bridge.py validate
+          --raw "$CANARY_RAW" --receipt "$CANARY_RECEIPT" --repository "$PWD"
+      - name: Store evidence in private draft release
+        working-directory: public
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          CANARY_RAW: ${{ runner.temp }}/chaosgauge-canary-raw.json
+          CANARY_RECEIPT: ${{ runner.temp }}/chaosgauge-canary-receipt.json
+          CANARY_RUN_ID: ${{ github.run_id }}
+        run: >-
+          python3 scripts/ci/chaos_gauge/public_canary_bridge.py publish
+          --raw "$CANARY_RAW" --receipt "$CANARY_RECEIPT" --repository "$PWD" --run-id "$CANARY_RUN_ID"
+      - name: Publish sanitized receipt
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: chaosgauge-excluded-canary-receipt-${{ github.run_id }}
+          path: ${{ runner.temp }}/chaosgauge-canary-receipt.json
+          if-no-files-found: error

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -103,6 +103,7 @@ jobs:
             chaos_gauge:
               - 'scripts/ci/chaos_gauge/**'
               - 'tests/scripts/test_chaos_gauge_*.py'
+              - '.github/workflows/chaos-gauge-public-canary.yml'
             # Agent guidance had no CI gate at all: validate_agent_setup.py and
             # the harness suites were local-only, so drift only surfaced when
             # someone ran them by hand.
@@ -377,6 +378,7 @@ jobs:
         run: >-
           python3 -m unittest
           tests.scripts.test_chaos_gauge_canary
+          tests.scripts.test_chaos_gauge_public_canary_workflow
           tests.scripts.test_chaos_gauge_contracts
           tests.scripts.test_chaos_gauge_campaign
           tests.scripts.test_chaos_gauge_corpus

--- a/scripts/ci/chaos_gauge/campaign.py
+++ b/scripts/ci/chaos_gauge/campaign.py
@@ -870,7 +870,9 @@ def provider_capability_is_available(run: Callable[[list[str]], str]) -> bool:
     return output.strip() == CAPABILITY_MARKER
 
 
-def full_preflight(manifest: object, checkout: Path, run: Callable[[list[str]], str] = _run) -> None:
+def full_preflight(
+    manifest: object, checkout: Path, run: Callable[[list[str]], str] = _run, *, private_read_proven: bool = False,
+) -> None:
     """Validate live content, private package, runtime, and paid-model capability before a run."""
     value = _object(manifest, "experiment manifest")
     package = _object(value.get("privatePackage"), "private package")
@@ -884,7 +886,7 @@ def full_preflight(manifest: object, checkout: Path, run: Callable[[list[str]], 
         raise ValueError("implementation revision does not contain campaign source") from error
     if run(["git", "-C", str(checkout), "rev-parse", "HEAD"]).strip() != package["commit"]:
         raise ValueError("private checkout commit is invalid")
-    if not run(["git", "-C", str(checkout), "ls-remote", "origin", "HEAD"]).strip():
+    if not private_read_proven and not run(["git", "-C", str(checkout), "ls-remote", "origin", "HEAD"]).strip():
         raise ValueError("private checkout credentials are unavailable")
     dataset = checkout / "dataset.toml"
     if not dataset.is_file() or f"sha256:{hashlib.sha256(dataset.read_bytes()).hexdigest()}" != package["contentSha256"]:

--- a/scripts/ci/chaos_gauge/campaign.py
+++ b/scripts/ci/chaos_gauge/campaign.py
@@ -24,7 +24,6 @@ GIT_SHA = re.compile(r"[0-9a-f]{40}")
 SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
 ROOT = Path(__file__).resolve().parent
 NATIVE_NAME = re.compile(r"[A-Za-z0-9]{7}")
-CAPABILITY_MARKER = "CHAOSGAUGE_CAPABILITY_OK"
 
 
 def _object(value: object, label: str) -> dict[str, object]:
@@ -862,18 +861,10 @@ def codex_version_is_pinned(output: str) -> bool:
     return output.strip() == "codex-cli 0.118.0"
 
 
-def provider_capability_is_available(run: Callable[[list[str]], str]) -> bool:
-    try:
-        output = run(["codex", "exec", "--ephemeral", "--skip-git-repo-check", "--sandbox", "read-only", "--model", "gpt-5.6-terra", "-c", 'model_reasoning_effort="medium"', f"Reply with exactly {CAPABILITY_MARKER}."])
-    except (OSError, subprocess.CalledProcessError):
-        return False
-    return output.strip() == CAPABILITY_MARKER
-
-
 def full_preflight(
     manifest: object, checkout: Path, run: Callable[[list[str]], str] = _run, *, private_read_proven: bool = False,
 ) -> None:
-    """Validate live content, private package, runtime, and paid-model capability before a run."""
+    """Validate live content, private package, and runtime before accounted arms run."""
     value = _object(manifest, "experiment manifest")
     package = _object(value.get("privatePackage"), "private package")
     if not checkout.is_dir() or checkout.is_symlink():
@@ -899,8 +890,6 @@ def full_preflight(
         raise ValueError("Harbor version is invalid")
     if not codex_version_is_pinned(run(["codex", "--version"])):
         raise ValueError("Codex version is invalid")
-    if not provider_capability_is_available(run):
-        raise ValueError("Codex provider credentials or gpt-5.6-terra capability is unavailable")
 
 
 def main() -> int:

--- a/scripts/ci/chaos_gauge/canary.py
+++ b/scripts/ci/chaos_gauge/canary.py
@@ -293,12 +293,13 @@ async def run(
     public_source_revision: str,
     raw_out: Path,
     receipt_out: Path,
+    private_read_proven: bool = False,
 ) -> dict[str, object]:
     """Run exactly one excluded native pair after the complete paid-run preflight."""
     if not GIT_SHA.fullmatch(public_source_revision):
         raise ValueError("canary source revision is invalid")
     launcher = _campaign()
-    launcher.full_preflight(manifest, private_checkout)
+    launcher.full_preflight(manifest, private_checkout, private_read_proven=private_read_proven)
     planned, config = plan(manifest), job_config(manifest)
     environment = _mapping(config.get("environment"), "canary environment")
     if environment.get("type") != "docker" or environment.get("delete") is not True:
@@ -340,6 +341,7 @@ def main() -> int:
     parser.add_argument("--public-source-revision", required=True)
     parser.add_argument("--raw-out", type=Path, required=True)
     parser.add_argument("--receipt-out", type=Path, required=True)
+    parser.add_argument("--private-read-proven", action="store_true")
     args = parser.parse_args()
     manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
     asyncio.run(
@@ -349,6 +351,7 @@ def main() -> int:
             public_source_revision=args.public_source_revision,
             raw_out=args.raw_out,
             receipt_out=args.receipt_out,
+            private_read_proven=args.private_read_proven,
         )
     )
     return 0

--- a/scripts/ci/chaos_gauge/public_canary_bridge.py
+++ b/scripts/ci/chaos_gauge/public_canary_bridge.py
@@ -25,6 +25,7 @@ PRIVATE_REPOSITORY = "ShaftHQ/ChaosGauge-private"
 PRIVATE_COMMIT = "08551a3db4376438acddd77422554ce710a58624"
 RUN_ID = re.compile(r"[1-9][0-9]{0,18}")
 BUNDLE_FILES = ("raw.json", "receipt.json")
+MARKER_STATE = "provider-started"
 
 
 def _error(message: str) -> ValueError:
@@ -114,6 +115,17 @@ def _bundle_name(run_id: str) -> str:
     return f"{_tag(run_id)}-evidence.zip"
 
 
+def _marker_name(run_id: str) -> str:
+    return f"{_tag(run_id)}-{MARKER_STATE}.json"
+
+
+def _marker(run_id: str) -> bytes:
+    return json.dumps(
+        {"runId": run_id, "schemaVersion": 1, "state": MARKER_STATE},
+        sort_keys=True, separators=(",", ":"),
+    ).encode("utf-8")
+
+
 def _zip_entry(archive: zipfile.ZipFile, name: str, content: bytes) -> None:
     info = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
     info.compress_type = zipfile.ZIP_DEFLATED
@@ -199,18 +211,76 @@ def _release(tag: str, run_id: str, run: Callable[..., object], *, create: bool)
     return value
 
 
-def _asset(release: dict[str, object], name: str) -> dict[str, object] | None:
+def _assets(release: dict[str, object]) -> dict[str, dict[str, object]]:
     assets = release["assets"]
     if not isinstance(assets, list):
         raise _error("private draft release is invalid")
-    if not assets:
+    result: dict[str, dict[str, object]] = {}
+    for asset in assets:
+        if not isinstance(asset, dict) or not isinstance(asset.get("name"), str) or asset["name"] in result:
+            raise _error("private draft release is incomplete")
+        result[asset["name"]] = asset
+    return result
+
+
+def _asset(release: dict[str, object], name: str) -> dict[str, object] | None:
+    asset = _assets(release).get(name)
+    if asset is None:
         return None
-    if len(assets) != 1 or not isinstance(assets[0], dict) or assets[0].get("name") != name:
-        raise _error("private draft release is incomplete")
-    digest = assets[0].get("digest")
+    digest = asset.get("digest")
     if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
         raise _error("private evidence asset digest is invalid")
-    return assets[0]
+    return asset
+
+
+def _release_state(release: dict[str, object], run_id: str) -> str:
+    names = set(_assets(release))
+    marker, bundle_name = _marker_name(run_id), _bundle_name(run_id)
+    if not names:
+        return "pristine"
+    if names == {marker}:
+        return "started"
+    if names == {marker, bundle_name}:
+        return "complete"
+    raise _error("private draft release is incomplete")
+
+
+def _verify_marker(path: Path, digest: str, run_id: str) -> None:
+    content = _safe_file(path)
+    if digest != f"sha256:{hashlib.sha256(content).hexdigest()}":
+        raise _error("private provider marker digest mismatch")
+    _scan("private provider marker", content)
+    try:
+        marker = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise _error("private provider marker is invalid") from error
+    if marker != {"runId": run_id, "schemaVersion": 1, "state": MARKER_STATE}:
+        raise _error("private provider marker is invalid")
+
+
+def _verify_remote_marker(tag: str, run_id: str, release: dict[str, object], run: Callable[..., object]) -> None:
+    marker = _marker_name(run_id)
+    asset = _asset(release, marker)
+    if asset is None:
+        raise _error("private draft release is incomplete")
+    with tempfile.TemporaryDirectory() as directory:
+        _verify_marker(_download(tag, marker, Path(directory), run), str(asset["digest"]), run_id)
+
+
+def _start_remote_provider_lease(tag: str, run_id: str, run: Callable[..., object]) -> dict[str, object]:
+    marker = _marker_name(run_id)
+    with tempfile.TemporaryDirectory() as directory:
+        marker_path = Path(directory) / marker
+        marker_path.write_bytes(_marker(run_id))
+        run(
+            ["gh", "release", "upload", tag, str(marker_path), "--repo", PRIVATE_REPOSITORY],
+            check=True, capture_output=True, text=True,
+        )
+        release = _release(tag, run_id, run, create=False)
+        if _release_state(release, run_id) != "started":
+            raise _error("private draft release is incomplete")
+        _verify_remote_marker(tag, run_id, release, run)
+    return release
 
 
 def _download(tag: str, name: str, destination: Path, run: Callable[..., object]) -> Path:
@@ -254,11 +324,18 @@ def prepare(
     tag, name = _tag(run_id), _bundle_name(run_id)
     preflight(token)
     release = _release(tag, run_id, run, create=True)
-    asset = _asset(release, name)
-    if asset is None:
+    state = _release_state(release, run_id)
+    if state == "pristine":
+        _start_remote_provider_lease(tag, run_id, run)
         return "run"
+    _verify_remote_marker(tag, run_id, release, run)
+    if state == "started":
+        raise _error("private provider start is already recorded")
     if receipt_out is None:
         raise _error("receipt recovery output is unavailable")
+    asset = _asset(release, name)
+    if asset is None:
+        raise _error("private draft release is incomplete")
     with tempfile.TemporaryDirectory() as directory:
         receipt = _verify_bundle(_download(tag, name, Path(directory), run), str(asset["digest"]), repository)
     _write_exclusive(receipt_out, receipt)
@@ -266,18 +343,25 @@ def prepare(
 
 
 def publish(raw: Path, receipt: Path, repository: Path, run_id: str, token: str, run: Callable[..., object] = subprocess.run) -> None:
-    """Replace one private bundle and verify remote copy before public recovery."""
+    """Store one complete private bundle only after a verified provider-start lease."""
     tag, name = _tag(run_id), _bundle_name(run_id)
     preflight(token)
     validate(raw, receipt, repository)
-    _asset(_release(tag, run_id, run, create=False), name)
+    release = _release(tag, run_id, run, create=False)
+    if _release_state(release, run_id) != "started":
+        raise _error("private draft release is incomplete")
+    _verify_remote_marker(tag, run_id, release, run)
     archive = bundle(raw, receipt, raw.parent, run_id)
     try:
         run(
-            ["gh", "release", "upload", tag, str(archive), "--repo", PRIVATE_REPOSITORY, "--clobber"],
+            ["gh", "release", "upload", tag, str(archive), "--repo", PRIVATE_REPOSITORY],
             check=True, capture_output=True, text=True,
         )
-        asset = _asset(_release(tag, run_id, run, create=False), name)
+        release = _release(tag, run_id, run, create=False)
+        if _release_state(release, run_id) != "complete":
+            raise _error("private draft release is incomplete")
+        _verify_remote_marker(tag, run_id, release, run)
+        asset = _asset(release, name)
         if asset is None:
             raise _error("private evidence asset is unavailable")
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/ci/chaos_gauge/public_canary_bridge.py
+++ b/scripts/ci/chaos_gauge/public_canary_bridge.py
@@ -4,13 +4,17 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
+import io
 import json
 import os
 import re
 import subprocess
+import tempfile
 import urllib.error
 import urllib.request
+import zipfile
 from pathlib import Path
 from typing import Callable
 
@@ -20,6 +24,7 @@ from scripts.ci.validate_shaft_pilot_release import CREDENTIAL_PATTERNS, SECRET_
 PRIVATE_REPOSITORY = "ShaftHQ/ChaosGauge-private"
 PRIVATE_COMMIT = "08551a3db4376438acddd77422554ce710a58624"
 RUN_ID = re.compile(r"[1-9][0-9]{0,18}")
+BUNDLE_FILES = ("raw.json", "receipt.json")
 
 
 def _error(message: str) -> ValueError:
@@ -28,7 +33,7 @@ def _error(message: str) -> ValueError:
 
 def _metadata(token: str, opener: Callable[..., object] = urllib.request.urlopen) -> tuple[dict[str, object], str]:
     if not token:
-        raise _error("BOT_TOKEN is unavailable")
+        raise _error("GH_TOKEN is unavailable")
     request = urllib.request.Request(
         f"https://api.github.com/repos/{PRIVATE_REPOSITORY}",
         headers={
@@ -42,9 +47,9 @@ def _metadata(token: str, opener: Callable[..., object] = urllib.request.urlopen
             value = json.loads(response.read().decode("utf-8"))
             scopes = str(response.headers.get("X-OAuth-Scopes", ""))
     except (OSError, urllib.error.HTTPError, json.JSONDecodeError) as error:
-        raise _error("BOT_TOKEN metadata is unavailable") from error
+        raise _error("GH_TOKEN metadata is unavailable") from error
     if not isinstance(value, dict):
-        raise _error("BOT_TOKEN metadata is invalid")
+        raise _error("GH_TOKEN metadata is invalid")
     return value, scopes
 
 
@@ -58,10 +63,10 @@ def preflight(token: str, opener: Callable[..., object] = urllib.request.urlopen
         or permissions.get("pull") is not True
         or permissions.get("push") is not True
     ):
-        raise _error("BOT_TOKEN lacks private release capability")
+        raise _error("GH_TOKEN lacks private release capability")
     granted = {scope.strip() for scope in scopes.split(",") if scope.strip()}
     if not {"repo", "workflow"}.issubset(granted):
-        raise _error("BOT_TOKEN release scopes are not provable")
+        raise _error("GH_TOKEN release scopes are not provable")
 
 
 def _canary_module():
@@ -85,50 +90,224 @@ def _scan(label: str, content: bytes) -> None:
         raise _error(f"{label} contains a secret-shaped value")
 
 
-def validate(raw: Path, receipt: Path, repository: Path) -> None:
-    """Reject unsafe raw data and receipt drift before any upload."""
-    raw_content, receipt_content = _safe_file(raw), _safe_file(receipt)
+def _validate_contents(raw_content: bytes, receipt_content: bytes, repository: Path) -> None:
     _scan("raw evidence", raw_content)
     _scan("sanitized receipt", receipt_content)
     try:
-        value = json.loads(receipt_content.decode("utf-8"))
-        _canary_module().validate_public_evidence(value, repository=repository)
+        _canary_module().validate_public_evidence(json.loads(receipt_content.decode("utf-8")), repository=repository)
     except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as error:
         raise _error("sanitized receipt is invalid") from error
 
 
-def publish(raw: Path, receipt: Path, repository: Path, run_id: str, token: str, run: Callable[..., object] = subprocess.run) -> None:
-    """Store exactly raw and sanitized evidence in one private draft release."""
+def validate(raw: Path, receipt: Path, repository: Path) -> None:
+    """Reject unsafe raw data and receipt drift before any upload."""
+    _validate_contents(_safe_file(raw), _safe_file(receipt), repository)
+
+
+def _tag(run_id: str) -> str:
     if not RUN_ID.fullmatch(run_id):
         raise _error("run ID is invalid")
+    return f"chaosgauge-canary-{run_id}"
+
+
+def _bundle_name(run_id: str) -> str:
+    return f"{_tag(run_id)}-evidence.zip"
+
+
+def _zip_entry(archive: zipfile.ZipFile, name: str, content: bytes) -> None:
+    info = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = 0o100600 << 16
+    archive.writestr(info, content, compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+
+
+def bundle(raw: Path, receipt: Path, destination: Path, run_id: str) -> Path:
+    """Build one deterministic private evidence bundle with a hash manifest."""
+    content = {"raw.json": _safe_file(raw), "receipt.json": _safe_file(receipt)}
+    manifest = {
+        "schemaVersion": 1,
+        "files": {name: hashlib.sha256(content[name]).hexdigest() for name in BUNDLE_FILES},
+    }
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9, strict_timestamps=True) as archive:
+        _zip_entry(archive, "manifest.json", json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+        for name in BUNDLE_FILES:
+            _zip_entry(archive, name, content[name])
+    target = Path(destination) / _bundle_name(run_id)
+    target.write_bytes(payload.getvalue())
+    return target
+
+
+def bundle_contents(path: Path) -> tuple[dict[str, object], dict[str, bytes]]:
+    """Read only fixed evidence entries and verify declared hashes."""
+    payload = _safe_file(path)
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            names = [entry.filename for entry in archive.infolist()]
+            if len(names) != len(set(names)) or set(names) != {"manifest.json", *BUNDLE_FILES}:
+                raise _error("private evidence bundle entries are invalid")
+            manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+            content = {name: archive.read(name) for name in BUNDLE_FILES}
+    except (OSError, UnicodeDecodeError, ValueError, zipfile.BadZipFile, json.JSONDecodeError) as error:
+        raise _error("private evidence bundle is invalid") from error
+    expected = {"schemaVersion": 1, "files": {name: hashlib.sha256(content[name]).hexdigest() for name in BUNDLE_FILES}}
+    if manifest != expected:
+        raise _error("private evidence bundle hashes are invalid")
+    return manifest, content
+
+
+def _run_json(arguments: list[str], run: Callable[..., object]) -> dict[str, object]:
+    result = run(arguments, check=True, capture_output=True, text=True)
+    output = result if isinstance(result, str) else getattr(result, "stdout", "")
+    try:
+        value = json.loads(output)
+    except (TypeError, json.JSONDecodeError) as error:
+        raise _error("private release metadata is invalid") from error
+    if not isinstance(value, dict):
+        raise _error("private release metadata is invalid")
+    return value
+
+
+def _release_view(tag: str, run: Callable[..., object]) -> dict[str, object]:
+    return _run_json(
+        ["gh", "release", "view", tag, "--repo", PRIVATE_REPOSITORY, "--json", "tagName,isDraft,targetCommitish,name,assets"], run,
+    )
+
+
+def _release(tag: str, run_id: str, run: Callable[..., object], *, create: bool) -> dict[str, object]:
+    try:
+        value = _release_view(tag, run)
+    except subprocess.CalledProcessError:
+        if not create:
+            raise _error("private draft release is unavailable")
+        run(
+            [
+                "gh", "release", "create", tag, "--repo", PRIVATE_REPOSITORY, "--target", PRIVATE_COMMIT,
+                "--draft", "--title", f"ChaosGauge excluded canary {run_id}",
+                "--notes", "Private raw evidence and validated sanitized receipt.",
+            ], check=True, capture_output=True, text=True,
+        )
+        value = _release_view(tag, run)
+    if (
+        value.get("tagName") != tag
+        or value.get("isDraft") is not True
+        or value.get("targetCommitish") != PRIVATE_COMMIT
+        or value.get("name") != f"ChaosGauge excluded canary {run_id}"
+        or not isinstance(value.get("assets"), list)
+    ):
+        raise _error("private draft release is invalid")
+    return value
+
+
+def _asset(release: dict[str, object], name: str) -> dict[str, object] | None:
+    assets = release["assets"]
+    if not isinstance(assets, list):
+        raise _error("private draft release is invalid")
+    if not assets:
+        return None
+    if len(assets) != 1 or not isinstance(assets[0], dict) or assets[0].get("name") != name:
+        raise _error("private draft release is incomplete")
+    digest = assets[0].get("digest")
+    if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+        raise _error("private evidence asset digest is invalid")
+    return assets[0]
+
+
+def _download(tag: str, name: str, destination: Path, run: Callable[..., object]) -> Path:
+    run(
+        ["gh", "release", "download", tag, "--repo", PRIVATE_REPOSITORY, "--pattern", name, "--dir", str(destination)],
+        check=True, capture_output=True, text=True,
+    )
+    path = destination / name
+    if not path.is_file() or path.is_symlink():
+        raise _error("private evidence asset is unavailable")
+    return path
+
+
+def _verify_bundle(path: Path, digest: str, repository: Path) -> bytes:
+    if digest != f"sha256:{hashlib.sha256(_safe_file(path)).hexdigest()}":
+        raise _error("private evidence asset digest mismatch")
+    _, content = bundle_contents(path)
+    _validate_contents(content["raw.json"], content["receipt.json"], repository)
+    return content["receipt.json"]
+
+
+def _write_exclusive(path: Path, content: bytes) -> None:
+    target = Path(path)
+    if not target.parent.is_dir() or target.parent.is_symlink() or target.is_symlink():
+        raise _error("receipt output is unavailable")
+    try:
+        descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as error:
+        raise _error("receipt output already exists") from error
+    with os.fdopen(descriptor, "wb") as output:
+        output.write(content)
+        output.flush()
+        os.fsync(output.fileno())
+
+
+def prepare(
+    repository: Path, run_id: str, token: str, *, receipt_out: Path | None = None,
+    run: Callable[..., object] = subprocess.run,
+) -> str:
+    """Create/reconcile storage before provider work; recover a complete prior bundle."""
+    tag, name = _tag(run_id), _bundle_name(run_id)
+    preflight(token)
+    release = _release(tag, run_id, run, create=True)
+    asset = _asset(release, name)
+    if asset is None:
+        return "run"
+    if receipt_out is None:
+        raise _error("receipt recovery output is unavailable")
+    with tempfile.TemporaryDirectory() as directory:
+        receipt = _verify_bundle(_download(tag, name, Path(directory), run), str(asset["digest"]), repository)
+    _write_exclusive(receipt_out, receipt)
+    return "recover"
+
+
+def publish(raw: Path, receipt: Path, repository: Path, run_id: str, token: str, run: Callable[..., object] = subprocess.run) -> None:
+    """Replace one private bundle and verify remote copy before public recovery."""
+    tag, name = _tag(run_id), _bundle_name(run_id)
     preflight(token)
     validate(raw, receipt, repository)
-    run(
-        [
-            "gh", "release", "create", f"chaosgauge-canary-{run_id}", str(raw), str(receipt),
-            "--repo", PRIVATE_REPOSITORY, "--target", PRIVATE_COMMIT,
-            "--draft", "--title", f"ChaosGauge excluded canary {run_id}",
-            "--notes", "Private raw evidence and validated sanitized receipt.",
-        ],
-        check=True,
-    )
+    _asset(_release(tag, run_id, run, create=False), name)
+    archive = bundle(raw, receipt, raw.parent, run_id)
+    try:
+        run(
+            ["gh", "release", "upload", tag, str(archive), "--repo", PRIVATE_REPOSITORY, "--clobber"],
+            check=True, capture_output=True, text=True,
+        )
+        asset = _asset(_release(tag, run_id, run, create=False), name)
+        if asset is None:
+            raise _error("private evidence asset is unavailable")
+        with tempfile.TemporaryDirectory() as directory:
+            _verify_bundle(_download(tag, name, Path(directory), run), str(asset["digest"]), repository)
+    finally:
+        if archive.exists():
+            archive.unlink()
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
     commands.add_parser("preflight")
+    prepare_parser = commands.add_parser("prepare")
     validate_parser = commands.add_parser("validate")
     publish_parser = commands.add_parser("publish")
+    prepare_parser.add_argument("--repository", type=Path, required=True)
+    prepare_parser.add_argument("--run-id", required=True)
+    prepare_parser.add_argument("--receipt-out", type=Path, required=True)
     for command in (validate_parser, publish_parser):
         command.add_argument("--raw", type=Path, required=True)
         command.add_argument("--receipt", type=Path, required=True)
         command.add_argument("--repository", type=Path, required=True)
     publish_parser.add_argument("--run-id", required=True)
     args = parser.parse_args()
-    token = os.environ.get("BOT_TOKEN", "")
+    token = os.environ.get("GH_TOKEN", "")
     if args.command == "preflight":
         preflight(token)
+    elif args.command == "prepare":
+        print(prepare(args.repository, args.run_id, token, receipt_out=args.receipt_out))
     elif args.command == "validate":
         validate(args.raw, args.receipt, args.repository)
     else:

--- a/scripts/ci/chaos_gauge/public_canary_bridge.py
+++ b/scripts/ci/chaos_gauge/public_canary_bridge.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Fail-closed credential and evidence boundary for public ChaosGauge canaries."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Callable
+
+from scripts.ci.validate_shaft_pilot_release import CREDENTIAL_PATTERNS, SECRET_CANARIES
+
+
+PRIVATE_REPOSITORY = "ShaftHQ/ChaosGauge-private"
+PRIVATE_COMMIT = "08551a3db4376438acddd77422554ce710a58624"
+RUN_ID = re.compile(r"[1-9][0-9]{0,18}")
+
+
+def _error(message: str) -> ValueError:
+    return ValueError(f"public canary bridge: {message}")
+
+
+def _metadata(token: str, opener: Callable[..., object] = urllib.request.urlopen) -> tuple[dict[str, object], str]:
+    if not token:
+        raise _error("BOT_TOKEN is unavailable")
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{PRIVATE_REPOSITORY}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2026-03-10",
+        },
+    )
+    try:
+        with opener(request, timeout=20) as response:
+            value = json.loads(response.read().decode("utf-8"))
+            scopes = str(response.headers.get("X-OAuth-Scopes", ""))
+    except (OSError, urllib.error.HTTPError, json.JSONDecodeError) as error:
+        raise _error("BOT_TOKEN metadata is unavailable") from error
+    if not isinstance(value, dict):
+        raise _error("BOT_TOKEN metadata is invalid")
+    return value, scopes
+
+
+def preflight(token: str, opener: Callable[..., object] = urllib.request.urlopen) -> None:
+    """Prove private read/release capability with metadata only; never probe-write."""
+    metadata, scopes = _metadata(token, opener)
+    permissions = metadata.get("permissions")
+    if (
+        metadata.get("private") is not True
+        or not isinstance(permissions, dict)
+        or permissions.get("pull") is not True
+        or permissions.get("push") is not True
+    ):
+        raise _error("BOT_TOKEN lacks private release capability")
+    granted = {scope.strip() for scope in scopes.split(",") if scope.strip()}
+    if not {"repo", "workflow"}.issubset(granted):
+        raise _error("BOT_TOKEN release scopes are not provable")
+
+
+def _canary_module():
+    path = Path(__file__).with_name("canary.py")
+    spec = importlib.util.spec_from_file_location("chaos_gauge_canary", path)
+    if spec is None or spec.loader is None:
+        raise _error("canary validation is unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _safe_file(path: Path) -> bytes:
+    if not path.is_file() or path.is_symlink():
+        raise _error("evidence file is unavailable")
+    return path.read_bytes()
+
+
+def _scan(label: str, content: bytes) -> None:
+    if any(marker in content for marker in SECRET_CANARIES) or any(pattern.search(content) for pattern in CREDENTIAL_PATTERNS):
+        raise _error(f"{label} contains a secret-shaped value")
+
+
+def validate(raw: Path, receipt: Path, repository: Path) -> None:
+    """Reject unsafe raw data and receipt drift before any upload."""
+    raw_content, receipt_content = _safe_file(raw), _safe_file(receipt)
+    _scan("raw evidence", raw_content)
+    _scan("sanitized receipt", receipt_content)
+    try:
+        value = json.loads(receipt_content.decode("utf-8"))
+        _canary_module().validate_public_evidence(value, repository=repository)
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as error:
+        raise _error("sanitized receipt is invalid") from error
+
+
+def publish(raw: Path, receipt: Path, repository: Path, run_id: str, token: str, run: Callable[..., object] = subprocess.run) -> None:
+    """Store exactly raw and sanitized evidence in one private draft release."""
+    if not RUN_ID.fullmatch(run_id):
+        raise _error("run ID is invalid")
+    preflight(token)
+    validate(raw, receipt, repository)
+    run(
+        [
+            "gh", "release", "create", f"chaosgauge-canary-{run_id}", str(raw), str(receipt),
+            "--repo", PRIVATE_REPOSITORY, "--target", PRIVATE_COMMIT,
+            "--draft", "--title", f"ChaosGauge excluded canary {run_id}",
+            "--notes", "Private raw evidence and validated sanitized receipt.",
+        ],
+        check=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("preflight")
+    validate_parser = commands.add_parser("validate")
+    publish_parser = commands.add_parser("publish")
+    for command in (validate_parser, publish_parser):
+        command.add_argument("--raw", type=Path, required=True)
+        command.add_argument("--receipt", type=Path, required=True)
+        command.add_argument("--repository", type=Path, required=True)
+    publish_parser.add_argument("--run-id", required=True)
+    args = parser.parse_args()
+    token = os.environ.get("BOT_TOKEN", "")
+    if args.command == "preflight":
+        preflight(token)
+    elif args.command == "validate":
+        validate(args.raw, args.receipt, args.repository)
+    else:
+        publish(args.raw, args.receipt, args.repository, args.run_id, token)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_chaos_gauge_campaign.py
+++ b/tests/scripts/test_chaos_gauge_campaign.py
@@ -531,7 +531,7 @@ class ChaosGaugeCampaignTest(TestCase):
         with self.assertRaisesRegex(ValueError, "pair job identity"):
             CAMPAIGN.resume_pair_jobs(MANIFEST, planned, bindings, drifted, {first: completed[first]})
 
-    def test_preflight_validates_live_root_and_provider_capability(self):
+    def test_preflight_validates_live_root_without_unaccounted_provider_probe(self):
         calls = []
 
         class Validator:
@@ -549,12 +549,7 @@ class ChaosGaugeCampaignTest(TestCase):
         self.assertEqual(("manifest", ROOT), calls[0])
         self.assertEqual({ROOT}, {call[-1] for call in calls if call[0] == "contracts"})
 
-        probe = []
-        self.assertTrue(CAMPAIGN.provider_capability_is_available(
-            lambda command: probe.append(command) or "CHAOSGAUGE_CAPABILITY_OK\n"
-        ))
-        self.assertIn("gpt-5.6-terra", probe[0])
-        self.assertFalse(CAMPAIGN.provider_capability_is_available(lambda command: "unauthorized"))
+        self.assertNotIn("codex", CAMPAIGN.full_preflight.__code__.co_names)
 
     def test_exact_codex_pin_and_merged_execution_proof_fail_closed(self):
         self.assertTrue(CAMPAIGN.codex_version_is_pinned("codex-cli 0.118.0"))
@@ -595,8 +590,6 @@ class ChaosGaugeCampaignTest(TestCase):
                     return "0.22.0\n"
                 if command == ["codex", "--version"]:
                     return "codex-cli 0.118.0\n"
-                if command[0:2] == ["codex", "exec"]:
-                    return CAMPAIGN.CAPABILITY_MARKER + "\n"
                 return ""
 
             with (
@@ -605,6 +598,7 @@ class ChaosGaugeCampaignTest(TestCase):
             ):
                 CAMPAIGN.full_preflight(manifest, checkout, run, private_read_proven=True)
             self.assertFalse(any("ls-remote" in command for command in calls))
+            self.assertFalse(any(command[0:2] == ["codex", "exec"] for command in calls))
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_chaos_gauge_campaign.py
+++ b/tests/scripts/test_chaos_gauge_campaign.py
@@ -574,6 +574,38 @@ class ChaosGaugeCampaignTest(TestCase):
             )
         self.assertEqual([], calls)
 
+    def test_metadata_proven_private_read_skips_only_remote_credential_probe(self):
+        manifest = copy.deepcopy(MANIFEST)
+        with TemporaryDirectory() as directory:
+            checkout = Path(directory)
+            dataset = checkout / "dataset.toml"
+            dataset.write_text("private = true\n", encoding="utf-8")
+            manifest["privatePackage"]["commit"] = "a" * 40
+            import hashlib
+            manifest["privatePackage"]["contentSha256"] = f"sha256:{hashlib.sha256(dataset.read_bytes()).hexdigest()}"
+            calls = []
+
+            def run(command):
+                calls.append(command)
+                if "rev-parse" in command:
+                    return "a" * 40 + "\n"
+                if "docker" in command:
+                    return "26.1.0\n"
+                if any("importlib.metadata" in argument for argument in command):
+                    return "0.22.0\n"
+                if command == ["codex", "--version"]:
+                    return "codex-cli 0.118.0\n"
+                if command[0:2] == ["codex", "exec"]:
+                    return CAMPAIGN.CAPABILITY_MARKER + "\n"
+                return ""
+
+            with (
+                patch.object(CAMPAIGN, "_validate_live_campaign"),
+                patch.object(CAMPAIGN, "_load_validator"),
+            ):
+                CAMPAIGN.full_preflight(manifest, checkout, run, private_read_proven=True)
+            self.assertFalse(any("ls-remote" in command for command in calls))
+
 
 if __name__ == "__main__":
     main()

--- a/tests/scripts/test_chaos_gauge_public_canary_workflow.py
+++ b/tests/scripts/test_chaos_gauge_public_canary_workflow.py
@@ -46,8 +46,11 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
         self.assertFalse(public["with"]["persist-credentials"])
         capture = str(self._step("Record exact public main revision")["run"])
         self.assertIn("git -C public rev-parse HEAD", capture)
+        uv_setup = next(step for step in self.steps if step.get("uses", "").startswith("astral-sh/setup-uv@"))
+        self.assertEqual("0.12.7", uv_setup["with"]["version"])
         install = str(self._step("Install pinned native runtime")["run"])
-        self.assertIn("--require-hashes", install)
+        self.assertNotIn("python3 -m pip install", install)
+        self.assertIn("uv pip install --system --require-hashes", install)
         self.assertIn("@openai/codex@0.118.0", install)
         self.assertIn("docker version --format", install)
 

--- a/tests/scripts/test_chaos_gauge_public_canary_workflow.py
+++ b/tests/scripts/test_chaos_gauge_public_canary_workflow.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 import importlib.util
+import hashlib
+import json
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import yaml
 
@@ -59,13 +62,16 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
         self.assertEqual("ShaftHQ/ChaosGauge-private", private["with"]["repository"])
         self.assertEqual("08551a3db4376438acddd77422554ce710a58624", private["with"]["ref"])
         self.assertFalse(private["with"]["persist-credentials"])
-        capability_index = next(index for index, step in enumerate(self.steps) if step.get("name") == "Prove private release capability")
+        capability_index = next(index for index, step in enumerate(self.steps) if step.get("name") == "Prepare private evidence storage")
         provider_index = next(index for index, step in enumerate(self.steps) if step.get("name") == "Run excluded two-arm canary")
         self.assertLess(capability_index, provider_index)
         capability = str(self.steps[capability_index]["run"])
-        self.assertIn("public_canary_bridge.py preflight", capability)
-        self.assertEqual("${{ secrets.BOT_TOKEN }}", self.steps[capability_index]["env"]["BOT_TOKEN"])
+        self.assertIn("public_canary_bridge.py prepare", capability)
+        self.assertEqual("${{ secrets.BOT_TOKEN }}", self.steps[capability_index]["env"]["GH_TOKEN"])
         self.assertEqual("read", self.workflow["permissions"]["contents"])
+        provider = self.steps[provider_index]["env"]
+        self.assertNotIn("BOT_TOKEN", provider)
+        self.assertNotIn("GH_TOKEN", provider)
 
     def test_raw_evidence_cannot_upload_publicly(self) -> None:
         artifact = self._step("Publish sanitized receipt")
@@ -83,9 +89,23 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
             run = step.get("run")
             if isinstance(run, str):
                 self.assertNotIn("${{", run)
-        self.assertIn("BOT_TOKEN: ${{ secrets.BOT_TOKEN }}", self.text)
+        self.assertIn("GH_TOKEN: ${{ secrets.BOT_TOKEN }}", self.text)
         self.assertIn("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}", self.text)
         self.assertIn("HARBOR_API_KEY: ${{ secrets.CHAOSGAUGE_HARBOR_TOKEN }}", self.text)
+        for step in self.steps:
+            if step.get("name") != "Checkout pinned private corpus":
+                self.assertNotIn("BOT_TOKEN", step.get("env", {}))
+
+    def test_owner_exception_has_only_workflow_local_canary_limits(self) -> None:
+        self.assertIn("owner-authorized excluded-canary exception", self.text.lower())
+        self.assertIn("ShaftHQ/ChaosGauge-private#3", self.text)
+        self.assertIn("#5462", self.text)
+        self.assertIn("not a provider-side spend cap", self.text)
+        self.assertEqual(60, self.job["timeout-minutes"])
+        provider = self._step("Run excluded two-arm canary")
+        self.assertEqual("120000", provider["env"]["CANARY_MAX_ACCOUNTED_TOKENS"])
+        self.assertIn("two-arm accounted-token budget", str(provider["run"]))
+        self.assertNotIn("CHAOSGAUGE_OPENAI_API_KEY", self.text)
 
     def test_metadata_preflight_requires_read_write_and_workflow_scopes_without_writing(self) -> None:
         seen = []
@@ -116,22 +136,125 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "scopes are not provable"):
             BRIDGE.preflight("token", lambda *_args, **_kwargs: ReadOnlyResponse())
 
-    def test_private_draft_release_uses_argv_not_shell_and_only_two_evidence_assets(self) -> None:
-        calls = []
-        with (
-            patch.object(BRIDGE, "preflight"),
-            patch.object(BRIDGE, "validate"),
-        ):
-            BRIDGE.publish(
-                Path("raw.json"), Path("receipt.json"), ROOT, "123", "token",
-                run=lambda arguments, **kwargs: calls.append((arguments, kwargs)),
+    def test_private_evidence_is_one_deterministic_bundle(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            raw, receipt = root / "raw.json", root / "receipt.json"
+            raw.write_text('{"raw":true}\n', encoding="utf-8")
+            receipt.write_text('{"receipt":true}\n', encoding="utf-8")
+            first = BRIDGE.bundle(raw, receipt, root, "123")
+            second = BRIDGE.bundle(raw, receipt, root, "123")
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+            manifest, entries = BRIDGE.bundle_contents(first)
+            self.assertEqual({"raw.json", "receipt.json"}, set(entries))
+            self.assertEqual(
+                hashlib.sha256(raw.read_bytes()).hexdigest(), manifest["files"]["raw.json"]
             )
-        arguments, kwargs = calls[0]
-        self.assertEqual(["raw.json", "receipt.json"], [value for value in arguments if value.endswith(".json")])
-        self.assertIn("--repo", arguments)
-        self.assertEqual("ShaftHQ/ChaosGauge-private", arguments[arguments.index("--repo") + 1])
-        self.assertIn("--draft", arguments)
-        self.assertTrue(kwargs["check"])
+            self.assertEqual(
+                hashlib.sha256(receipt.read_bytes()).hexdigest(), manifest["files"]["receipt.json"]
+            )
+
+    def test_prepare_creates_exact_private_draft_before_provider(self) -> None:
+        calls = []
+        tag = "chaosgauge-canary-123"
+        release = {
+            "tagName": tag, "isDraft": True, "targetCommitish": BRIDGE.PRIVATE_COMMIT,
+            "name": "ChaosGauge excluded canary 123", "assets": [],
+        }
+
+        def run(arguments, **kwargs):
+            calls.append((arguments, kwargs))
+            if arguments[2] == "view" and len(calls) == 1:
+                raise BRIDGE.subprocess.CalledProcessError(1, arguments)
+            if arguments[2] == "view":
+                return BRIDGE.subprocess.CompletedProcess(arguments, 0, json.dumps(release), "")
+            return BRIDGE.subprocess.CompletedProcess(arguments, 0, "", "")
+
+        with patch.object(BRIDGE, "preflight"):
+            self.assertEqual("run", BRIDGE.prepare(ROOT, "123", "token", run=run))
+        self.assertEqual("create", calls[1][0][2])
+        self.assertIn("--draft", calls[1][0])
+
+    def test_prepare_recovers_existing_complete_bundle_without_provider(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            raw, receipt, recovered = root / "raw.json", root / "receipt.json", root / "recovered.json"
+            raw.write_text('{"raw":true}\n', encoding="utf-8")
+            receipt.write_text('{"receipt":true}\n', encoding="utf-8")
+            bundle = BRIDGE.bundle(raw, receipt, root, "123")
+            digest = f"sha256:{hashlib.sha256(bundle.read_bytes()).hexdigest()}"
+            release = {
+                "tagName": "chaosgauge-canary-123", "isDraft": True,
+                "targetCommitish": BRIDGE.PRIVATE_COMMIT,
+                "name": "ChaosGauge excluded canary 123",
+                "assets": [{"name": bundle.name, "digest": digest}],
+            }
+            calls = []
+
+            def run(arguments, **kwargs):
+                calls.append((arguments, kwargs))
+                if arguments[2] == "view":
+                    return BRIDGE.subprocess.CompletedProcess(arguments, 0, json.dumps(release), "")
+                if arguments[2] == "download":
+                    Path(arguments[arguments.index("--dir") + 1], bundle.name).write_bytes(bundle.read_bytes())
+                return BRIDGE.subprocess.CompletedProcess(arguments, 0, "", "")
+
+            with (
+                patch.object(BRIDGE, "preflight"),
+                patch.object(BRIDGE, "_validate_contents"),
+            ):
+                self.assertEqual("recover", BRIDGE.prepare(ROOT, "123", "token", receipt_out=recovered, run=run))
+            self.assertEqual(receipt.read_bytes(), recovered.read_bytes())
+            self.assertTrue(any(arguments[2] == "download" for arguments, _ in calls))
+
+    def test_prepare_refuses_partial_private_evidence_before_provider(self) -> None:
+        release = {
+            "tagName": "chaosgauge-canary-123", "isDraft": True,
+            "targetCommitish": BRIDGE.PRIVATE_COMMIT,
+            "name": "ChaosGauge excluded canary 123",
+            "assets": [{"name": "raw.json", "digest": "sha256:" + "0" * 64}],
+        }
+
+        def run(arguments, **_):
+            return BRIDGE.subprocess.CompletedProcess(arguments, 0, json.dumps(release), "")
+
+        with patch.object(BRIDGE, "preflight"):
+            with self.assertRaisesRegex(ValueError, "release is incomplete"):
+                BRIDGE.prepare(ROOT, "123", "token", receipt_out=ROOT / "receipt.json", run=run)
+
+    def test_publish_replaces_one_bundle_then_verifies_remote_digest(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            raw, receipt = root / "raw.json", root / "receipt.json"
+            raw.write_text('{"raw":true}\n', encoding="utf-8")
+            receipt.write_text('{"receipt":true}\n', encoding="utf-8")
+            bundle = BRIDGE.bundle(raw, receipt, root, "123")
+            digest = f"sha256:{hashlib.sha256(bundle.read_bytes()).hexdigest()}"
+            release = {
+                "tagName": "chaosgauge-canary-123", "isDraft": True,
+                "targetCommitish": BRIDGE.PRIVATE_COMMIT,
+                "name": "ChaosGauge excluded canary 123",
+                "assets": [{"name": bundle.name, "digest": digest}],
+            }
+            calls = []
+
+            def run(arguments, **kwargs):
+                calls.append((arguments, kwargs))
+                if arguments[2] == "view":
+                    return BRIDGE.subprocess.CompletedProcess(arguments, 0, json.dumps(release), "")
+                if arguments[2] == "download":
+                    Path(arguments[arguments.index("--dir") + 1], bundle.name).write_bytes(bundle.read_bytes())
+                return BRIDGE.subprocess.CompletedProcess(arguments, 0, "", "")
+
+            with (
+                patch.object(BRIDGE, "preflight"),
+                patch.object(BRIDGE, "validate"),
+                patch.object(BRIDGE, "_validate_contents"),
+            ):
+                BRIDGE.publish(raw, receipt, ROOT, "123", "token", run=run)
+            upload = next(arguments for arguments, _ in calls if arguments[2] == "upload")
+            self.assertEqual([bundle.name], [Path(value).name for value in upload if value.endswith(".zip")])
+            self.assertIn("--clobber", upload)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_chaos_gauge_public_canary_workflow.py
+++ b/tests/scripts/test_chaos_gauge_public_canary_workflow.py
@@ -1,0 +1,135 @@
+"""Public excluded-canary bridge contract (#5462)."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "chaos-gauge-public-canary.yml"
+BRIDGE_PATH = ROOT / "scripts" / "ci" / "chaos_gauge" / "public_canary_bridge.py"
+BRIDGE_SPEC = importlib.util.spec_from_file_location("chaos_gauge_public_canary_bridge", BRIDGE_PATH)
+if BRIDGE_SPEC is None or BRIDGE_SPEC.loader is None:
+    raise RuntimeError("public canary bridge is unavailable")
+BRIDGE = importlib.util.module_from_spec(BRIDGE_SPEC)
+BRIDGE_SPEC.loader.exec_module(BRIDGE)
+
+
+class PublicCanaryWorkflowTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.text = WORKFLOW.read_text(encoding="utf-8")
+        self.workflow = yaml.safe_load(self.text)
+        self.job = self.workflow["jobs"]["excluded-canary"]
+        self.steps = self.job["steps"]
+
+    def _step(self, name: str) -> dict[str, object]:
+        return next(step for step in self.steps if step.get("name") == name)
+
+    def test_is_manual_excluded_canary_never_a_pilot(self) -> None:
+        self.assertIn("workflow_dispatch", self.text)
+        self.assertNotIn("full-pilot", self.text)
+        self.assertNotIn("--campaign", self.text)
+        run = str(self._step("Run excluded two-arm canary")["run"])
+        self.assertIn("scripts/ci/chaos_gauge/canary.py", run)
+        self.assertIn("--private-read-proven", run)
+        self.assertNotIn("campaign.py", run)
+
+    def test_pins_public_source_runtime_and_docker_preflight(self) -> None:
+        public = self._step("Checkout merged public source")
+        self.assertEqual("ShaftHQ/SHAFT_ENGINE", public["with"]["repository"])
+        self.assertEqual("main", public["with"]["ref"])
+        self.assertFalse(public["with"]["persist-credentials"])
+        capture = str(self._step("Record exact public main revision")["run"])
+        self.assertIn("git -C public rev-parse HEAD", capture)
+        install = str(self._step("Install pinned native runtime")["run"])
+        self.assertIn("--require-hashes", install)
+        self.assertIn("@openai/codex@0.118.0", install)
+        self.assertIn("docker version --format", install)
+
+    def test_private_checkout_and_release_capability_precede_provider(self) -> None:
+        private = self._step("Checkout pinned private corpus")
+        self.assertEqual("ShaftHQ/ChaosGauge-private", private["with"]["repository"])
+        self.assertEqual("08551a3db4376438acddd77422554ce710a58624", private["with"]["ref"])
+        self.assertFalse(private["with"]["persist-credentials"])
+        capability_index = next(index for index, step in enumerate(self.steps) if step.get("name") == "Prove private release capability")
+        provider_index = next(index for index, step in enumerate(self.steps) if step.get("name") == "Run excluded two-arm canary")
+        self.assertLess(capability_index, provider_index)
+        capability = str(self.steps[capability_index]["run"])
+        self.assertIn("public_canary_bridge.py preflight", capability)
+        self.assertEqual("${{ secrets.BOT_TOKEN }}", self.steps[capability_index]["env"]["BOT_TOKEN"])
+        self.assertEqual("read", self.workflow["permissions"]["contents"])
+
+    def test_raw_evidence_cannot_upload_publicly(self) -> None:
+        artifact = self._step("Publish sanitized receipt")
+        self.assertIn("actions/upload-artifact@", artifact["uses"])
+        self.assertEqual("${{ runner.temp }}/chaosgauge-canary-receipt.json", artifact["with"]["path"])
+        self.assertNotIn("raw", str(artifact["with"]))
+        release = str(self._step("Store evidence in private draft release")["run"])
+        self.assertIn("public_canary_bridge.py publish", release)
+        bridge = BRIDGE_PATH.read_text(encoding="utf-8")
+        self.assertIn("ShaftHQ/ChaosGauge-private", bridge)
+        self.assertIn("--draft", bridge)
+
+    def test_context_values_never_enter_shell_source(self) -> None:
+        for step in self.steps:
+            run = step.get("run")
+            if isinstance(run, str):
+                self.assertNotIn("${{", run)
+        self.assertIn("BOT_TOKEN: ${{ secrets.BOT_TOKEN }}", self.text)
+        self.assertIn("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}", self.text)
+        self.assertIn("HARBOR_API_KEY: ${{ secrets.CHAOSGAUGE_HARBOR_TOKEN }}", self.text)
+
+    def test_metadata_preflight_requires_read_write_and_workflow_scopes_without_writing(self) -> None:
+        seen = []
+
+        class Response:
+            headers = {"X-OAuth-Scopes": "repo, workflow"}
+
+            def read(self):
+                return b'{"private": true, "permissions": {"pull": true, "push": true}}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return None
+
+        def opener(request, **_):
+            seen.append(request)
+            return Response()
+
+        BRIDGE.preflight("token", opener)
+        self.assertEqual("GET", seen[0].get_method())
+        self.assertEqual("https://api.github.com/repos/ShaftHQ/ChaosGauge-private", seen[0].full_url)
+
+        class ReadOnlyResponse(Response):
+            headers = {"X-OAuth-Scopes": "repo"}
+
+        with self.assertRaisesRegex(ValueError, "scopes are not provable"):
+            BRIDGE.preflight("token", lambda *_args, **_kwargs: ReadOnlyResponse())
+
+    def test_private_draft_release_uses_argv_not_shell_and_only_two_evidence_assets(self) -> None:
+        calls = []
+        with (
+            patch.object(BRIDGE, "preflight"),
+            patch.object(BRIDGE, "validate"),
+        ):
+            BRIDGE.publish(
+                Path("raw.json"), Path("receipt.json"), ROOT, "123", "token",
+                run=lambda arguments, **kwargs: calls.append((arguments, kwargs)),
+            )
+        arguments, kwargs = calls[0]
+        self.assertEqual(["raw.json", "receipt.json"], [value for value in arguments if value.endswith(".json")])
+        self.assertIn("--repo", arguments)
+        self.assertEqual("ShaftHQ/ChaosGauge-private", arguments[arguments.index("--repo") + 1])
+        self.assertIn("--draft", arguments)
+        self.assertTrue(kwargs["check"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_chaos_gauge_public_canary_workflow.py
+++ b/tests/scripts/test_chaos_gauge_public_canary_workflow.py
@@ -157,6 +157,8 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
     def test_prepare_creates_exact_private_draft_before_provider(self) -> None:
         calls = []
         tag = "chaosgauge-canary-123"
+        marker_name = f"{tag}-provider-started.json"
+        marker_content = b'{"runId":"123","schemaVersion":1,"state":"provider-started"}'
         release = {
             "tagName": tag, "isDraft": True, "targetCommitish": BRIDGE.PRIVATE_COMMIT,
             "name": "ChaosGauge excluded canary 123", "assets": [],
@@ -168,12 +170,55 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
                 raise BRIDGE.subprocess.CalledProcessError(1, arguments)
             if arguments[2] == "view":
                 return BRIDGE.subprocess.CompletedProcess(arguments, 0, json.dumps(release), "")
+            if arguments[2] == "upload":
+                marker = Path(arguments[4])
+                self.assertEqual(marker_name, marker.name)
+                self.assertEqual(marker_content, marker.read_bytes())
+                release["assets"] = [{
+                    "name": marker.name,
+                    "digest": f"sha256:{hashlib.sha256(marker_content).hexdigest()}",
+                }]
+            if arguments[2] == "download":
+                Path(arguments[arguments.index("--dir") + 1], marker_name).write_bytes(marker_content)
             return BRIDGE.subprocess.CompletedProcess(arguments, 0, "", "")
 
         with patch.object(BRIDGE, "preflight"):
             self.assertEqual("run", BRIDGE.prepare(ROOT, "123", "token", run=run))
         self.assertEqual("create", calls[1][0][2])
         self.assertIn("--draft", calls[1][0])
+        self.assertTrue(any(arguments[2] == "upload" for arguments, _ in calls))
+        self.assertTrue(any(arguments[2] == "download" for arguments, _ in calls))
+
+    def test_prepare_refuses_marker_only_state_after_evidence_upload_failure(self) -> None:
+        """A run lease survives post-provider loss, so a rerun never repays provider arms."""
+        tag = "chaosgauge-canary-123"
+        marker_name = f"{tag}-provider-started.json"
+        release = {
+            "tagName": tag, "isDraft": True, "targetCommitish": BRIDGE.PRIVATE_COMMIT,
+            "name": "ChaosGauge excluded canary 123", "assets": [],
+        }
+
+        def run(arguments, **_):
+            if arguments[2] == "view":
+                return BRIDGE.subprocess.CompletedProcess(arguments, 0, json.dumps(release), "")
+            if arguments[2] == "upload":
+                marker = Path(arguments[4])
+                release["assets"] = [{
+                    "name": marker.name,
+                    "digest": f"sha256:{hashlib.sha256(marker.read_bytes()).hexdigest()}",
+                }]
+            if arguments[2] == "download":
+                Path(arguments[arguments.index("--dir") + 1], marker_name).write_text(
+                    '{"runId":"123","schemaVersion":1,"state":"provider-started"}', encoding="utf-8"
+                )
+            return BRIDGE.subprocess.CompletedProcess(arguments, 0, "", "")
+
+        with patch.object(BRIDGE, "preflight"):
+            self.assertEqual("run", BRIDGE.prepare(ROOT, "123", "token", run=run))
+            with self.assertRaisesRegex(ValueError, "provider start is already recorded"):
+                BRIDGE.prepare(ROOT, "123", "token", run=run)
+
+        self.assertEqual([marker_name], [asset["name"] for asset in release["assets"]])
 
     def test_prepare_recovers_existing_complete_bundle_without_provider(self) -> None:
         with TemporaryDirectory() as directory:
@@ -182,12 +227,17 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
             raw.write_text('{"raw":true}\n', encoding="utf-8")
             receipt.write_text('{"receipt":true}\n', encoding="utf-8")
             bundle = BRIDGE.bundle(raw, receipt, root, "123")
+            marker = root / "chaosgauge-canary-123-provider-started.json"
+            marker.write_text('{"runId":"123","schemaVersion":1,"state":"provider-started"}', encoding="utf-8")
             digest = f"sha256:{hashlib.sha256(bundle.read_bytes()).hexdigest()}"
             release = {
                 "tagName": "chaosgauge-canary-123", "isDraft": True,
                 "targetCommitish": BRIDGE.PRIVATE_COMMIT,
                 "name": "ChaosGauge excluded canary 123",
-                "assets": [{"name": bundle.name, "digest": digest}],
+                "assets": [
+                    {"name": marker.name, "digest": f"sha256:{hashlib.sha256(marker.read_bytes()).hexdigest()}"},
+                    {"name": bundle.name, "digest": digest},
+                ],
             }
             calls = []
 
@@ -196,7 +246,9 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
                 if arguments[2] == "view":
                     return BRIDGE.subprocess.CompletedProcess(arguments, 0, json.dumps(release), "")
                 if arguments[2] == "download":
-                    Path(arguments[arguments.index("--dir") + 1], bundle.name).write_bytes(bundle.read_bytes())
+                    destination = Path(arguments[arguments.index("--dir") + 1])
+                    name = arguments[arguments.index("--pattern") + 1]
+                    destination.joinpath(name).write_bytes({marker.name: marker.read_bytes(), bundle.name: bundle.read_bytes()}[name])
                 return BRIDGE.subprocess.CompletedProcess(arguments, 0, "", "")
 
             with (
@@ -206,6 +258,24 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
                 self.assertEqual("recover", BRIDGE.prepare(ROOT, "123", "token", receipt_out=recovered, run=run))
             self.assertEqual(receipt.read_bytes(), recovered.read_bytes())
             self.assertTrue(any(arguments[2] == "download" for arguments, _ in calls))
+
+    def test_prepare_refuses_bundle_without_remote_start_marker(self) -> None:
+        release = {
+            "tagName": "chaosgauge-canary-123", "isDraft": True,
+            "targetCommitish": BRIDGE.PRIVATE_COMMIT,
+            "name": "ChaosGauge excluded canary 123",
+            "assets": [{
+                "name": "chaosgauge-canary-123-evidence.zip",
+                "digest": "sha256:" + "0" * 64,
+            }],
+        }
+
+        def run(arguments, **_):
+            return BRIDGE.subprocess.CompletedProcess(arguments, 0, json.dumps(release), "")
+
+        with patch.object(BRIDGE, "preflight"):
+            with self.assertRaisesRegex(ValueError, "release is incomplete"):
+                BRIDGE.prepare(ROOT, "123", "token", receipt_out=ROOT / "receipt.json", run=run)
 
     def test_prepare_refuses_partial_private_evidence_before_provider(self) -> None:
         release = {
@@ -228,22 +298,34 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
             raw, receipt = root / "raw.json", root / "receipt.json"
             raw.write_text('{"raw":true}\n', encoding="utf-8")
             receipt.write_text('{"receipt":true}\n', encoding="utf-8")
-            bundle = BRIDGE.bundle(raw, receipt, root, "123")
-            digest = f"sha256:{hashlib.sha256(bundle.read_bytes()).hexdigest()}"
+            marker = root / "chaosgauge-canary-123-provider-started.json"
+            marker.write_text('{"runId":"123","schemaVersion":1,"state":"provider-started"}', encoding="utf-8")
             release = {
                 "tagName": "chaosgauge-canary-123", "isDraft": True,
                 "targetCommitish": BRIDGE.PRIVATE_COMMIT,
                 "name": "ChaosGauge excluded canary 123",
-                "assets": [{"name": bundle.name, "digest": digest}],
+                "assets": [{
+                    "name": marker.name,
+                    "digest": f"sha256:{hashlib.sha256(marker.read_bytes()).hexdigest()}",
+                }],
             }
             calls = []
+            uploaded = {marker.name: marker.read_bytes()}
 
             def run(arguments, **kwargs):
                 calls.append((arguments, kwargs))
                 if arguments[2] == "view":
                     return BRIDGE.subprocess.CompletedProcess(arguments, 0, json.dumps(release), "")
+                if arguments[2] == "upload":
+                    uploaded_path = Path(arguments[4])
+                    uploaded[uploaded_path.name] = uploaded_path.read_bytes()
+                    release["assets"].append({
+                        "name": uploaded_path.name,
+                        "digest": f"sha256:{hashlib.sha256(uploaded_path.read_bytes()).hexdigest()}",
+                    })
                 if arguments[2] == "download":
-                    Path(arguments[arguments.index("--dir") + 1], bundle.name).write_bytes(bundle.read_bytes())
+                    name = arguments[arguments.index("--pattern") + 1]
+                    Path(arguments[arguments.index("--dir") + 1], name).write_bytes(uploaded[name])
                 return BRIDGE.subprocess.CompletedProcess(arguments, 0, "", "")
 
             with (
@@ -253,8 +335,8 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
             ):
                 BRIDGE.publish(raw, receipt, ROOT, "123", "token", run=run)
             upload = next(arguments for arguments, _ in calls if arguments[2] == "upload")
-            self.assertEqual([bundle.name], [Path(value).name for value in upload if value.endswith(".zip")])
-            self.assertIn("--clobber", upload)
+            self.assertEqual(["chaosgauge-canary-123-evidence.zip"], [Path(value).name for value in upload if value.endswith(".zip")])
+            self.assertNotIn("--clobber", upload)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_chaos_gauge_recovery.py
+++ b/tests/scripts/test_chaos_gauge_recovery.py
@@ -11,9 +11,9 @@ CHAOS_GAUGE = ROOT / "scripts" / "ci" / "chaos_gauge"
 # `e7d329bd3b` is merged PR #5464, immutable recovery source for #5450.
 # This covers its full public ChaosGauge tree, unlike a few representative
 # anchors that can remain after an executable or dataset member is lost.
-RECOVERED_PUBLIC_FILE_COUNT = 140
+RECOVERED_PUBLIC_FILE_COUNT = 141
 RECOVERED_PUBLIC_PATHS_SHA256 = (
-    "4a6eac9a728eb15e556667c401f01493046a1d3a0270b3dc780bb17be43047a2"
+    "f29eac375e2a4ed365916b19b1ec4e6f2b7c01a944f1f2408b484fe92e09b59e"
 )
 
 

--- a/tests/scripts/test_ci_python_dependencies.py
+++ b/tests/scripts/test_ci_python_dependencies.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 REQUIREMENTS = ROOT / "requirements-ci.txt"
+CHAOS_GAUGE_REQUIREMENTS = ROOT / "scripts/ci/chaos_gauge/requirements.lock"
 EXPECTED_PINS = {
     "attrs": "26.1.0",
     "jsonschema": "4.26.0",
@@ -34,6 +35,22 @@ EXPECTED_INSTALLS = {
     ".github/workflows/publish-shaft-mcp.yml": (
         "python3 -m pip install --no-deps --requirement ../requirements-ci.txt --quiet",
     ),
+    ".github/workflows/chaos-gauge-public-canary.yml": (
+        "pip install --system --require-hashes --requirement scripts/ci/chaos_gauge/requirements.lock",
+    ),
+}
+EXPECTED_SETUP_PYTHON = {
+    **{path: ("actions/setup-python@v7", "3.13") for path in EXPECTED_INSTALLS if path != ".github/workflows/chaos-gauge-public-canary.yml"},
+    ".github/workflows/chaos-gauge-public-canary.yml": (
+        "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1", "3.12",
+    ),
+}
+EXPECTED_REQUIREMENTS = {
+    **{path: REQUIREMENTS for path in EXPECTED_INSTALLS if path != ".github/workflows/chaos-gauge-public-canary.yml"},
+    ".github/workflows/chaos-gauge-public-canary.yml": CHAOS_GAUGE_REQUIREMENTS,
+}
+EXPECTED_WORKING_DIRECTORIES = {
+    ".github/workflows/chaos-gauge-public-canary.yml": "public",
 }
 
 
@@ -110,20 +127,26 @@ class CiPythonDependenciesTest(unittest.TestCase):
             with self.subTest(workflow=relative_path, job=job_name):
                 arguments = shlex.split(command)
                 requirement = arguments[arguments.index("--requirement") + 1]
-                resolved = (ROOT / working_directory / requirement).resolve()
-                self.assertEqual(resolved, REQUIREMENTS.resolve())
+                if relative_path in EXPECTED_WORKING_DIRECTORIES:
+                    self.assertEqual(working_directory, EXPECTED_WORKING_DIRECTORIES[relative_path])
+                source_root = ROOT if working_directory == "public" else ROOT / working_directory
+                resolved = (source_root / requirement).resolve()
+                self.assertEqual(resolved, EXPECTED_REQUIREMENTS[relative_path].resolve())
                 self.assertTrue(resolved.is_file())
+                if resolved == CHAOS_GAUGE_REQUIREMENTS:
+                    self.assertIn("--require-hashes", arguments)
 
     def test_each_install_job_sets_up_supported_python_before_installing(self):
         for relative_path, job_name, steps, install_index, _, _ in self.workflow_install_steps():
             with self.subTest(workflow=relative_path, job=job_name):
+                expected_action, expected_version = EXPECTED_SETUP_PYTHON[relative_path]
                 setup_steps = [
                     step
                     for step in steps[:install_index]
-                    if step.get("uses") == "actions/setup-python@v7"
+                    if step.get("uses") == expected_action
                 ]
                 self.assertTrue(setup_steps, "install job must set up repository-standard Python")
-                self.assertEqual(setup_steps[-1].get("with", {}).get("python-version"), "3.13")
+                self.assertEqual(setup_steps[-1].get("with", {}).get("python-version"), expected_version)
 
     def test_chaos_gauge_installs_dependencies_before_contracts(self):
         yaml = __import__("yaml")


### PR DESCRIPTION
## Summary

- adds one manual public Actions bridge for the excluded one-task/two-arm ChaosGauge canary
- captures the public `main` SHA, pins the private corpus/runtime, and proves `BOT_TOKEN` private read/release scope metadata before any provider call
- retains raw evidence only in a private draft release; validates, secret-scans, and uploads only the existing sanitized receipt schema publicly

## Checks

- `python3 -m unittest tests.scripts.test_chaos_gauge_public_canary_workflow tests.scripts.test_chaos_gauge_canary tests.scripts.test_chaos_gauge_campaign tests.scripts.test_chaos_gauge_contracts tests.scripts.test_chaos_gauge_corpus tests.scripts.test_chaos_gauge_recovery tests.scripts.test_chaos_gauge_scoring -v` (60 tests)
- `python3 scripts/ci/chaos_gauge/validate_experiment.py scripts/ci/chaos_gauge/experiment.json`
- `python3 scripts/ci/validate_workflow_timeouts.py`
- `python3 scripts/ci/validate_quality_configuration.py`
- `python3 scripts/ci/validate_agent_setup.py --skip-external`

## Continuation

Related to #5462. This is excluded-canary infrastructure only: it never launches or counts toward the 160-trial pilot. It is intentionally unrun in this PR; absent or unprovable provider, Harbor, or private-release credentials fail before paid execution.
