### PR TITLE
fix(ci): restore public canary bridge startup

### DIFF
--- a/.github/workflows/chaos-gauge-public-canary.yml
+++ b/.github/workflows/chaos-gauge-public-canary.yml
@@ -71,7 +71,8 @@ jobs:
           uv pip install --system --require-hashes --requirement scripts/ci/chaos_gauge/requirements.lock
           npm install --global @openai/codex@0.118.0
           docker version --format '{{.Server.Version}}'
-      - name: Capture Docker baseline
+      - id: docker-baseline
+        name: Capture Docker baseline
         env:
           CANARY_BASELINE_CONTAINERS: ${{ runner.temp }}/chaosgauge-canary-containers.txt
         run: docker ps --all --format '{{.ID}}' | sort > "$CANARY_BASELINE_CONTAINERS"
@@ -105,7 +106,7 @@ jobs:
               raise SystemExit("excluded canary exceeded its two-arm accounted-token budget")
           PY
       - name: Verify Docker teardown
-        if: always()
+        if: ${{ always() && steps.docker-baseline.outcome == 'success' }}
         env:
           CANARY_BASELINE_CONTAINERS: ${{ runner.temp }}/chaosgauge-canary-containers.txt
         run: |

--- a/scripts/ci/chaos_gauge/public_canary_bridge.py
+++ b/scripts/ci/chaos_gauge/public_canary_bridge.py
@@ -18,7 +18,15 @@ import zipfile
 from pathlib import Path
 from typing import Callable
 
-from scripts.ci.validate_shaft_pilot_release import CREDENTIAL_PATTERNS, SECRET_CANARIES
+_RELEASE_VALIDATOR = importlib.util.spec_from_file_location(
+    "shaft_pilot_release_validator", Path(__file__).parents[1] / "validate_shaft_pilot_release.py"
+)
+if _RELEASE_VALIDATOR is None or _RELEASE_VALIDATOR.loader is None:
+    raise RuntimeError("SHAFT Pilot release validator is unavailable")
+_release_validator = importlib.util.module_from_spec(_RELEASE_VALIDATOR)
+_RELEASE_VALIDATOR.loader.exec_module(_release_validator)
+CREDENTIAL_PATTERNS = _release_validator.CREDENTIAL_PATTERNS
+SECRET_CANARIES = _release_validator.SECRET_CANARIES
 
 
 PRIVATE_REPOSITORY = "ShaftHQ/ChaosGauge-private"

--- a/tests/scripts/test_chaos_gauge_public_canary_workflow.py
+++ b/tests/scripts/test_chaos_gauge_public_canary_workflow.py
@@ -7,7 +7,10 @@ from unittest.mock import patch
 import importlib.util
 import hashlib
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 from tempfile import TemporaryDirectory
 
 import yaml
@@ -57,6 +60,12 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
         self.assertIn("@openai/codex@0.118.0", install)
         self.assertIn("docker version --format", install)
 
+    def test_teardown_only_runs_after_baseline(self) -> None:
+        self.assertEqual("docker-baseline", self._step("Capture Docker baseline")["id"])
+        teardown = self._step("Verify Docker teardown")
+        self.assertEqual("${{ always() && steps.docker-baseline.outcome == 'success' }}", teardown["if"])
+        self.assertIn("comm -13", teardown["run"])
+
     def test_private_checkout_and_release_capability_precede_provider(self) -> None:
         private = self._step("Checkout pinned private corpus")
         self.assertEqual("ShaftHQ/ChaosGauge-private", private["with"]["repository"])
@@ -95,6 +104,22 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
         for step in self.steps:
             if step.get("name") != "Checkout pinned private corpus":
                 self.assertNotIn("BOT_TOKEN", step.get("env", {}))
+
+    def test_direct_prepare_cli_reaches_credential_gate_from_any_cwd(self) -> None:
+        """The documented direct script call must not depend on repository import paths."""
+        with TemporaryDirectory() as directory:
+            receipt = Path(directory) / "receipt.json"
+            command = [
+                sys.executable, str(BRIDGE_PATH), "prepare", "--repository", str(ROOT),
+                "--run-id", "123", "--receipt-out", str(receipt),
+            ]
+            environment = {key: value for key, value in os.environ.items() if key not in {"GH_TOKEN", "PYTHONPATH"}}
+            for cwd in (ROOT, Path(directory)):
+                with self.subTest(cwd=cwd):
+                    result = subprocess.run(command, cwd=cwd, env=environment, capture_output=True, text=True)
+                    self.assertNotEqual(0, result.returncode)
+                    self.assertIn("GH_TOKEN is unavailable", result.stderr)
+                    self.assertNotIn("ModuleNotFoundError", result.stderr)
 
     def test_owner_exception_has_only_workflow_local_canary_limits(self) -> None:
         self.assertIn("owner-authorized excluded-canary exception", self.text.lower())

--- a/tests/scripts/test_chaos_gauge_public_canary_workflow.py
+++ b/tests/scripts/test_chaos_gauge_public_canary_workflow.py
@@ -116,7 +116,9 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
             environment = {key: value for key, value in os.environ.items() if key not in {"GH_TOKEN", "PYTHONPATH"}}
             for cwd in (ROOT, Path(directory)):
                 with self.subTest(cwd=cwd):
-                    result = subprocess.run(command, cwd=cwd, env=environment, capture_output=True, text=True)
+                    result = subprocess.run(  # nosec B603 B607 - fixed local regression invocation.
+                        command, cwd=cwd, env=environment, capture_output=True, text=True
+                    )
                     self.assertNotEqual(0, result.returncode)
                     self.assertIn("GH_TOKEN is unavailable", result.stderr)
                     self.assertNotIn("ModuleNotFoundError", result.stderr)


### PR DESCRIPTION
## Summary

Fixes excluded public-canary startup before provider access. The bridge now loads its owned sibling release validator by local file path, so direct CLI execution does not need repository-root imports. Docker teardown runs only after a baseline exists; post-baseline leaked containers still fail.

## Validation

- `python3 -m unittest tests.scripts.test_chaos_gauge_canary tests.scripts.test_chaos_gauge_public_canary_workflow tests.scripts.test_chaos_gauge_contracts tests.scripts.test_chaos_gauge_campaign tests.scripts.test_chaos_gauge_corpus tests.scripts.test_chaos_gauge_recovery tests.scripts.test_chaos_gauge_scoring -v`
- `python3 scripts/ci/chaos_gauge/validate_experiment.py scripts/ci/chaos_gauge/experiment.json`
- `python3 scripts/ci/validate_agent_setup.py --skip-external`

No provider, Harbor, release, or canary execution occurred.

Related to #5462.