### PR TITLE
fix(ci): account for Allure unknown results

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -126,14 +126,33 @@ runs:
       if: always()
       shell: bash
       run: |
-        # Extract a numeric field from Allure 3 summary.json.
-        # Returns empty string (defaults to 0 at call site) when the field is absent —
-        # e.g. "failed" is omitted when all tests pass. The "|| true" prevents
-        # set -e / pipefail from failing the step when grep finds no match.
-        extract_field() {
-          local field="$1"
-          local file="$2"
-          grep -o "\"${field}\" *: *[0-9]*" "$file" 2>/dev/null | head -1 | grep -o '[0-9]*' || true
+        # Parse Allure's JSON statistics without accepting numeric prefixes from malformed values.
+        read_statistics() {
+          python3 - "$1" <<'PY'
+        import json
+        import sys
+
+        try:
+            document = json.loads(open(sys.argv[1], encoding="utf-8").read())
+            statistic = document.get("statistic", {})
+            timing = document.get("time", {})
+            if not isinstance(statistic, dict) or not isinstance(timing, dict):
+                raise ValueError("statistic and time must be objects")
+            values = []
+            for field in ("total", "passed", "failed", "broken", "skipped", "unknown"):
+                value = statistic.get(field, 0)
+                if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                    raise ValueError(f"statistic '{field}'")
+                values.append(value)
+            duration = timing.get("duration", 0)
+            if isinstance(duration, bool) or not isinstance(duration, int) or duration < 0:
+                raise ValueError("time 'duration'")
+            values.append(duration)
+            print(*values)
+        except (OSError, json.JSONDecodeError, ValueError) as error:
+            print(f"::error::Invalid Allure summary {error}: expected a non-negative integer.", file=sys.stderr)
+            raise SystemExit(1)
+        PY
         }
 
         # Describe why RESULT_COUNT is zero: absent directory vs. present-but-empty
@@ -164,13 +183,10 @@ runs:
         ALLURE_SUMMARY="${{ inputs.module-directory }}/allure-report/summary.json"
 
         if [ -f "$ALLURE_SUMMARY" ]; then
-          TOTAL=$(extract_field total "$ALLURE_SUMMARY");   TOTAL=${TOTAL:-0}
-          PASSED=$(extract_field passed "$ALLURE_SUMMARY"); PASSED=${PASSED:-0}
-          FAILED=$(extract_field failed "$ALLURE_SUMMARY"); FAILED=${FAILED:-0}
-          BROKEN=$(extract_field broken "$ALLURE_SUMMARY"); BROKEN=${BROKEN:-0}
-          SKIPPED=$(extract_field skipped "$ALLURE_SUMMARY"); SKIPPED=${SKIPPED:-0}
-          UNKNOWN=$(extract_field unknown "$ALLURE_SUMMARY"); UNKNOWN=${UNKNOWN:-0}
-          DURATION=$(extract_field duration "$ALLURE_SUMMARY"); DURATION=${DURATION:-0}
+          if ! STATISTICS=$(read_statistics "$ALLURE_SUMMARY"); then
+            exit 1
+          fi
+          read -r TOTAL PASSED FAILED BROKEN SKIPPED UNKNOWN DURATION <<< "$STATISTICS"
         else
           TOTAL=0; PASSED=0; FAILED=0; BROKEN=0; SKIPPED=0; UNKNOWN=0; DURATION=0
         fi

--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -169,9 +169,10 @@ runs:
           FAILED=$(extract_field failed "$ALLURE_SUMMARY"); FAILED=${FAILED:-0}
           BROKEN=$(extract_field broken "$ALLURE_SUMMARY"); BROKEN=${BROKEN:-0}
           SKIPPED=$(extract_field skipped "$ALLURE_SUMMARY"); SKIPPED=${SKIPPED:-0}
+          UNKNOWN=$(extract_field unknown "$ALLURE_SUMMARY"); UNKNOWN=${UNKNOWN:-0}
           DURATION=$(extract_field duration "$ALLURE_SUMMARY"); DURATION=${DURATION:-0}
         else
-          TOTAL=0; PASSED=0; FAILED=0; BROKEN=0; SKIPPED=0; DURATION=0
+          TOTAL=0; PASSED=0; FAILED=0; BROKEN=0; SKIPPED=0; UNKNOWN=0; DURATION=0
         fi
 
         # Compute job wallclock duration using the GitHub Actions job timing recorded by setup-test-env.
@@ -206,7 +207,7 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
         echo "=== Checking test results using Allure report data ==="
-        echo "Allure Report Summary: Total=$TOTAL, Passed=$PASSED, Failed=$FAILED, Broken=$BROKEN, Skipped=$SKIPPED"
+        echo "Allure Report Summary: Total=$TOTAL, Passed=$PASSED, Failed=$FAILED, Broken=$BROKEN, Skipped=$SKIPPED, Unknown=$UNKNOWN"
 
         # Primary check: use Allure report data.
         if [ -f "$ALLURE_SUMMARY" ]; then
@@ -218,7 +219,12 @@ runs:
             echo "::error::No tests were executed according to the Allure summary. Check test configuration."
             exit 1
           fi
-          VERDICT_TOTAL=$((PASSED + FAILED + BROKEN + SKIPPED))
+          KNOWN_VERDICT_TOTAL=$((PASSED + FAILED + BROKEN + SKIPPED))
+          if [ "$KNOWN_VERDICT_TOTAL" -eq 0 ]; then
+            echo "::error::Allure summary reports $TOTAL total tests but 0 known status verdicts. Treating this as an invalid test run."
+            exit 1
+          fi
+          VERDICT_TOTAL=$((KNOWN_VERDICT_TOTAL + UNKNOWN))
           if [ "$VERDICT_TOTAL" -ne "$TOTAL" ]; then
             echo "::error::Allure summary reports $TOTAL total tests but $VERDICT_TOTAL status verdicts. Treating this as an invalid test run."
             exit 1

--- a/tests/scripts/test_post_test_report_action.py
+++ b/tests/scripts/test_post_test_report_action.py
@@ -81,6 +81,22 @@ class PostTestReportActionTest(unittest.TestCase):
 
         self.assertEqual(0, completed.returncode, completed.stdout)
 
+    def test_rejects_malformed_present_statistics(self):
+        cases = (
+            ("negative", {"passed": -1, "skipped": 1}),
+            ("fractional", {"passed": 0.5, "skipped": 1}),
+            ("string", {"passed": "1", "skipped": 1}),
+            ("boolean", {"passed": 1, "unknown": True}),
+        )
+        for name, overrides in cases:
+            values = {"total": 1, "passed": 0, "failed": 0, "broken": 0, "skipped": 0}
+            values.update(overrides)
+            with self.subTest(name=name):
+                completed = self.run_summary(**values)
+
+                self.assertNotEqual(0, completed.returncode)
+                self.assertIn("expected a non-negative integer", completed.stderr)
+
     def test_preserves_failed_and_broken_verdict_failures(self):
         for failed, broken in ((1, 0), (0, 1)):
             with self.subTest(failed=failed, broken=broken):

--- a/tests/scripts/test_post_test_report_action.py
+++ b/tests/scripts/test_post_test_report_action.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess  # nosec B404 - integration fixture invokes fixed bash with repository-owned action text.
 import tempfile
@@ -12,7 +13,7 @@ ACTION = ROOT / ".github/actions/post-test-report/action.yml"
 
 
 class PostTestReportActionTest(unittest.TestCase):
-    def run_summary(self, *, total, passed, failed, broken, skipped):
+    def run_summary(self, *, total, passed, failed, broken, skipped, unknown=None):
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
         step = next(step for step in action["runs"]["steps"]
                     if step.get("id") == "collect_results")
@@ -24,12 +25,17 @@ class PostTestReportActionTest(unittest.TestCase):
             results.mkdir(parents=True)
             report.mkdir()
             (results / "test-result.json").write_text("{}", encoding="utf-8")
+            statistic = {
+                "total": total,
+                "passed": passed,
+                "failed": failed,
+                "broken": broken,
+                "skipped": skipped,
+            }
+            if unknown is not None:
+                statistic["unknown"] = unknown
             (report / "summary.json").write_text(
-                '{"statistic":'
-                f'{{"total":{total},"passed":{passed},"failed":{failed},'
-                f'"broken":{broken},"skipped":{skipped}}}'
-                '}',
-                encoding="utf-8",
+                json.dumps({"statistic": statistic}), encoding="utf-8"
             )
             script = step["run"].replace("${{ inputs.module-directory }}", str(module))
             script = script.replace("${{ inputs.job-name }}", "Safari shard 1")
@@ -45,11 +51,18 @@ class PostTestReportActionTest(unittest.TestCase):
             )
         return completed
 
-    def test_rejects_nonzero_total_without_any_status_verdicts(self):
-        completed = self.run_summary(total=14, passed=0, failed=0, broken=0, skipped=0)
+    def test_rejects_all_unknown_summary_without_known_status_verdicts(self):
+        completed = self.run_summary(total=14, passed=0, failed=0, broken=0, skipped=0, unknown=14)
 
         self.assertNotEqual(0, completed.returncode)
-        self.assertIn("14 total tests but 0 status verdicts", completed.stdout)
+        self.assertIn("0 known status verdicts", completed.stdout)
+
+    def test_accepts_unknown_entries_alongside_accounted_known_verdicts(self):
+        completed = self.run_summary(
+            total=1434, passed=1408, failed=0, broken=0, skipped=12, unknown=14
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stdout)
 
     def test_rejects_fewer_status_verdicts_than_total(self):
         completed = self.run_summary(total=14, passed=13, failed=0, broken=0, skipped=0)
@@ -58,7 +71,7 @@ class PostTestReportActionTest(unittest.TestCase):
         self.assertIn("14 total tests but 13 status verdicts", completed.stdout)
 
     def test_rejects_more_status_verdicts_than_total(self):
-        completed = self.run_summary(total=14, passed=15, failed=0, broken=0, skipped=0)
+        completed = self.run_summary(total=14, passed=14, failed=0, broken=0, skipped=0, unknown=1)
 
         self.assertNotEqual(0, completed.returncode)
         self.assertIn("14 total tests but 15 status verdicts", completed.stdout)


### PR DESCRIPTION
## Summary

- parse Allure's `unknown` statistic during post-test validation
- still reject reports containing no known test verdicts
- require known verdicts plus unknown entries to equal the reported total

## Root cause

The Firefox Grid acceptance ran 1,431 Surefire tests with zero failures. Its Allure summary contained 1,434 total entries: 1,420 known verdicts plus 14 `unknown` entries. The previous guard omitted `unknown`, so it rejected valid full-suite accounting. The original Safari false-green remains rejected because all 14 entries were unknown and there were zero known verdicts.

## Validation

- all-unknown summary rejects
- exact Firefox 1,434-entry summary passes
- under- and over-accounting reject
- valid summary without `unknown` passes
- failed and broken verdicts still reject
- 6 focused tests pass
- `git diff --check`

Related to #5474
Related to #5475
