### PR TITLE
fix(ci): run excluded canary on local Harbor runtime

### DIFF
--- a/.github/workflows/chaos-gauge-public-canary.yml
+++ b/.github/workflows/chaos-gauge-public-canary.yml
@@ -81,7 +81,6 @@ jobs:
         working-directory: public
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          HARBOR_API_KEY: ${{ secrets.CHAOSGAUGE_HARBOR_TOKEN }}
           PRIVATE_CHECKOUT: ${{ github.workspace }}/private
           PUBLIC_SOURCE_REVISION: ${{ steps.public-source.outputs.revision }}
           CANARY_RAW: ${{ runner.temp }}/chaosgauge-canary-raw.json
@@ -89,7 +88,6 @@ jobs:
           CANARY_MAX_ACCOUNTED_TOKENS: "120000"
         run: |
           test -n "$OPENAI_API_KEY" || { echo 'provider credential unavailable'; exit 1; }
-          test -n "$HARBOR_API_KEY" || { echo 'Harbor credential unavailable'; exit 1; }
           python3 scripts/ci/chaos_gauge/canary.py \
             --private-checkout "$PRIVATE_CHECKOUT" \
             --public-source-revision "$PUBLIC_SOURCE_REVISION" \

--- a/tests/scripts/test_chaos_gauge_public_canary_workflow.py
+++ b/tests/scripts/test_chaos_gauge_public_canary_workflow.py
@@ -100,10 +100,18 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
                 self.assertNotIn("${{", run)
         self.assertIn("GH_TOKEN: ${{ secrets.BOT_TOKEN }}", self.text)
         self.assertIn("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}", self.text)
-        self.assertIn("HARBOR_API_KEY: ${{ secrets.CHAOSGAUGE_HARBOR_TOKEN }}", self.text)
         for step in self.steps:
             if step.get("name") != "Checkout pinned private corpus":
                 self.assertNotIn("BOT_TOKEN", step.get("env", {}))
+
+    def test_excluded_canary_uses_local_harbor_without_hub_credential_or_claim(self) -> None:
+        """This native-runtime canary must not require or advertise Harbor Hub."""
+        provider = self._step("Run excluded two-arm canary")
+        self.assertNotIn("HARBOR_API_KEY", provider["env"])
+        self.assertNotIn("CHAOSGAUGE_HARBOR_TOKEN", self.text)
+        self.assertNotIn("Harbor credential unavailable", str(provider["run"]))
+        self.assertNotIn("Harbor Hub", self.text)
+        self.assertNotIn("Hub URL", self.text)
 
     def test_direct_prepare_cli_reaches_credential_gate_from_any_cwd(self) -> None:
         """The documented direct script call must not depend on repository import paths."""


### PR DESCRIPTION
## Summary

Removes the Harbor Hub token environment and nonempty-secret gate from the public excluded-canary workflow. The workflow still installs and validates the pinned local Harbor 0.22.0 runtime, preserves private draft-release storage and public-receipt-only publication, and remains excluded from the 160-trial pilot.

Adds a workflow contract regression that fails if this excluded canary regains a Hub credential requirement or advertises a Hub publication claim. Full-pilot credential gates are outside this workflow and unchanged.

## Evidence

- RED: `test_excluded_canary_uses_local_harbor_without_hub_credential_or_claim` failed against the prior `HARBOR_API_KEY` gate.
- GREEN: `python3 -m unittest tests.scripts.test_chaos_gauge_public_canary_workflow tests.scripts.test_chaos_gauge_canary tests.scripts.test_chaos_gauge_campaign -v` (36 tests)
- `python3 scripts/ci/chaos_gauge/validate_experiment.py scripts/ci/chaos_gauge/experiment.json`
- `git diff --check`

## Live failure evidence

Run 33452407275 reached Docker baseline, then failed at the empty Harbor token check before `canary.py`; its provider key was present. The private draft release is still marker-only and terminal (`chaosgauge-canary-33452407275`); no rerun or deletion occurred.

Related to #5462.