### PR TITLE
fix(ci): bind ChaosGauge canary custom agent

### DIFF
--- a/scripts/ci/chaos_gauge/canary.py
+++ b/scripts/ci/chaos_gauge/canary.py
@@ -7,10 +7,12 @@ import argparse
 import asyncio
 import copy
 import hashlib
+import importlib
 import importlib.util
 import json
 import os
 import re
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Callable
@@ -19,6 +21,57 @@ from typing import Callable
 ROOT = Path(__file__).resolve().parent
 ARMS = ("control", "chaos-engine")
 GIT_SHA = re.compile(r"[0-9a-f]{40}")
+AGENT_IMPORT_PATH = "scripts.ci.chaos_gauge.agent:ChaosEngineCodex"
+
+
+def _custom_agent_module_spec(repository: Path) -> importlib.machinery.ModuleSpec:
+    """Bind Harbor's custom-agent import to this checked-out repository only."""
+    root = Path(repository).resolve()
+    if not root.is_dir():
+        raise ValueError("canary repository root is invalid")
+    expected = root / "scripts" / "ci" / "chaos_gauge" / "agent.py"
+    try:
+        actual = expected.resolve(strict=True)
+    except OSError as error:
+        raise ValueError("canary agent module is unavailable") from error
+    try:
+        actual.relative_to(root)
+    except ValueError as error:
+        raise ValueError("canary agent module escapes repository root") from error
+    if actual != expected or not actual.is_file():
+        raise ValueError("canary agent module is invalid")
+    root_text = str(root)
+    sys.path[:] = [root_text, *(entry for entry in sys.path if entry != root_text)]
+    os.environ["PYTHONPATH"] = root_text
+    spec = importlib.util.find_spec(AGENT_IMPORT_PATH.partition(":")[0])
+    if spec is None or spec.origin is None or Path(spec.origin).resolve() != actual:
+        raise ValueError("canary agent module resolves outside repository root")
+    return spec
+
+
+def _bind_custom_agent_import(repository: Path) -> type:
+    """Make the exact custom treatment importable before Harbor builds trials."""
+    spec = _custom_agent_module_spec(repository)
+    try:
+        module = importlib.import_module(spec.name)
+    except ImportError as error:
+        raise ValueError("canary agent module is unavailable") from error
+    if Path(str(getattr(module, "__file__", ""))).resolve() != Path(str(spec.origin)).resolve():
+        raise ValueError("canary agent module resolves outside repository root")
+    agent = getattr(module, "ChaosEngineCodex", None)
+    if not isinstance(agent, type):
+        raise ValueError("canary agent class is invalid")
+    try:
+        factory = importlib.import_module("harbor.agents.factory")
+    except ImportError as error:
+        raise ValueError("Harbor AgentFactory is unavailable") from error
+    agent_factory = getattr(factory, "AgentFactory", None)
+    load_agent = getattr(factory, "_import_agent_class", None)
+    if not callable(getattr(agent_factory, "create_agent_from_import_path", None)) or not callable(load_agent):
+        raise ValueError("Harbor AgentFactory import contract is unavailable")
+    if load_agent(AGENT_IMPORT_PATH) is not agent:
+        raise ValueError("Harbor AgentFactory resolved wrong canary agent")
+    return agent
 
 
 def _campaign():
@@ -298,6 +351,7 @@ async def run(
     """Run exactly one excluded native pair after the complete paid-run preflight."""
     if not GIT_SHA.fullmatch(public_source_revision):
         raise ValueError("canary source revision is invalid")
+    _bind_custom_agent_import(ROOT.parents[2])
     launcher = _campaign()
     launcher.full_preflight(manifest, private_checkout, private_read_proven=private_read_proven)
     planned, config = plan(manifest), job_config(manifest)
@@ -337,12 +391,18 @@ async def run(
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, default=ROOT / "experiment.json")
-    parser.add_argument("--private-checkout", type=Path, required=True)
-    parser.add_argument("--public-source-revision", required=True)
-    parser.add_argument("--raw-out", type=Path, required=True)
-    parser.add_argument("--receipt-out", type=Path, required=True)
+    parser.add_argument("--private-checkout", type=Path)
+    parser.add_argument("--public-source-revision")
+    parser.add_argument("--raw-out", type=Path)
+    parser.add_argument("--receipt-out", type=Path)
     parser.add_argument("--private-read-proven", action="store_true")
+    parser.add_argument("--verify-agent-import", action="store_true")
     args = parser.parse_args()
+    if args.verify_agent_import:
+        _bind_custom_agent_import(ROOT.parents[2])
+        return 0
+    if None in (args.private_checkout, args.public_source_revision, args.raw_out, args.receipt_out):
+        parser.error("canary execution requires private checkout, source revision, raw output, and receipt output")
     manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
     asyncio.run(
         run(

--- a/tests/scripts/test_chaos_gauge_canary.py
+++ b/tests/scripts/test_chaos_gauge_canary.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import copy
+import importlib
 import importlib.util
 import json
+import os
 import subprocess
+import sys
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -150,6 +154,40 @@ class CanaryContractTest(unittest.TestCase):
                 MANIFEST, planned, result, public_source_revision="f" * 40,
                 native_bindings=bindings, repository=ROOT, run=unmerged,
             )
+
+    def test_agent_import_contract_rejects_missing_or_escaped_repository_root(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            with self.assertRaisesRegex(ValueError, "repository root"):
+                CANARY._custom_agent_module_spec(root / "missing")
+
+            escaped = root / "escaped-agent.py"
+            escaped.write_text("class ChaosEngineCodex: pass\n", encoding="utf-8")
+            candidate = root / "repository" / "scripts" / "ci" / "chaos_gauge"
+            candidate.mkdir(parents=True)
+            os.symlink(escaped, candidate / "agent.py")
+            with self.assertRaisesRegex(ValueError, "agent module"):
+                CANARY._custom_agent_module_spec(root / "repository")
+
+    def test_direct_canary_cli_binds_harbor_agent_from_any_cwd(self) -> None:
+        """Direct script execution must bind the configured import before provider preflight."""
+        command = [sys.executable, str(GAUGE / "canary.py"), "--verify-agent-import"]
+        environment = {
+            key: value for key, value in os.environ.items()
+            if key not in {"PYTHONPATH", "OPENAI_API_KEY", "HARBOR_API_KEY"}
+        }
+        with TemporaryDirectory() as directory:
+            for cwd in (ROOT, Path(directory)):
+                with self.subTest(cwd=cwd):
+                    result = subprocess.run(  # nosec B603 B607 - fixed local regression invocation.
+                        command, cwd=cwd, env=environment, capture_output=True, text=True
+                    )
+                    if importlib.util.find_spec("harbor"):
+                        self.assertEqual(0, result.returncode, result.stderr)
+                    else:
+                        self.assertNotEqual(0, result.returncode)
+                        self.assertIn("canary agent module is unavailable", result.stderr)
+                    self.assertNotIn("No module named 'scripts'", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Bind `scripts.ci.chaos_gauge.agent:ChaosEngineCodex` from the checked-out repository root before native Harbor creates trials. The contract rejects missing, escaped, wrong, or externally resolved agent modules and verifies the exact Harbor `AgentFactory` import path.

The direct `canary.py --verify-agent-import` subprocess regression covers repository and arbitrary working directories; when Harbor is unavailable locally it proves the script reaches the Harbor-dependent agent import without a `scripts` import failure.

## Checks

- `python3 -m unittest tests.scripts.test_chaos_gauge_canary tests.scripts.test_chaos_gauge_public_canary_workflow tests.scripts.test_chaos_gauge_contracts tests.scripts.test_chaos_gauge_campaign tests.scripts.test_chaos_gauge_corpus tests.scripts.test_chaos_gauge_recovery tests.scripts.test_chaos_gauge_scoring -v`
- `python3 scripts/ci/chaos_gauge/validate_experiment.py scripts/ci/chaos_gauge/experiment.json`
- `python3 scripts/ci/validate_agent_setup.py --skip-external`
- `git diff --check`

No canary, provider call, release mutation, or pilot execution occurred.

## Continuation

Related to #5462. The existing failed run remains marker-only and terminal; start a new run ID only after this change is merged and CI is green.