### PR TITLE
fix(ci): retain excluded canary receipt evidence

### DIFF
--- a/.github/workflows/chaos-gauge-public-canary.yml
+++ b/.github/workflows/chaos-gauge-public-canary.yml
@@ -110,6 +110,19 @@ jobs:
         run: |
           test -f "$CANARY_BASELINE_CONTAINERS" || exit 1
           ! comm -13 "$CANARY_BASELINE_CONTAINERS" <(docker ps --all --format '{{.ID}}' | sort) | grep -q .
+      - name: Preserve paid raw result after receipt failure
+        if: ${{ always() && steps.private-evidence.outputs.action == 'run' }}
+        working-directory: public
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          CANARY_RAW: ${{ runner.temp }}/chaosgauge-canary-raw.json
+          CANARY_RECEIPT: ${{ runner.temp }}/chaosgauge-canary-receipt.json
+          CANARY_RUN_ID: ${{ github.run_id }}
+        run: |
+          test -f "$CANARY_RAW" || exit 0
+          test ! -f "$CANARY_RECEIPT" || exit 0
+          python3 scripts/ci/chaos_gauge/public_canary_bridge.py preserve-failure \
+            --raw "$CANARY_RAW" --repository "$PWD" --run-id "$CANARY_RUN_ID"
       - name: Validate and secret-scan evidence
         if: steps.private-evidence.outputs.action == 'run'
         working-directory: public

--- a/scripts/ci/chaos_gauge/canary.py
+++ b/scripts/ci/chaos_gauge/canary.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import sys
+import tomllib
 from datetime import datetime
 from pathlib import Path
 from typing import Callable
@@ -178,6 +179,60 @@ def _native_bindings(value: object, pair: dict[str, object]) -> dict[str, str]:
     return names
 
 
+def _harbor_task_checksum(path: Path) -> str:
+    """Compute the exact Harbor 0.22 Task.checksum identity for a local task."""
+    try:
+        from dirhash import dirhash
+    except ImportError as error:
+        raise ValueError("Harbor task checksum is unavailable") from error
+    value = dirhash(path, "sha256")
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{64}", value):
+        raise ValueError("Harbor task checksum is invalid")
+    return value
+
+
+def _local_task_path(value: object, label: str, repository: Path) -> Path:
+    source = _mapping(value, label)
+    raw_path = source.get("path")
+    if not isinstance(raw_path, str) or not raw_path:
+        raise ValueError("canary task identity is invalid")
+    path = Path(raw_path)
+    try:
+        return (path if path.is_absolute() else repository / path).resolve(strict=True)
+    except OSError as error:
+        raise ValueError("canary task identity is invalid") from error
+
+
+def _public_task_identity(pair: dict[str, object], repository: Path) -> tuple[str, Path, str]:
+    task = pair.get("task")
+    if not isinstance(task, str) or not task:
+        raise ValueError("canary task identity is invalid")
+    try:
+        path = (repository / "scripts" / "ci" / "chaos_gauge" / "dataset" / task).resolve(strict=True)
+        task_file = tomllib.loads((path / "task.toml").read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ValueError("canary task identity is invalid") from error
+    metadata = _mapping(task_file.get("task"), "canary task metadata")
+    name = metadata.get("name")
+    if name != f"ShaftHQ/{task}":
+        raise ValueError("canary task identity is invalid")
+    return str(name), path, _harbor_task_checksum(path)
+
+
+def _validate_task_identity(
+    trial: dict[str, object], pair: dict[str, object], repository: Path, config: dict[str, object],
+) -> None:
+    name, path, checksum = _public_task_identity(pair, repository)
+    if trial.get("task_name") != name:
+        raise ValueError("canary task identity is invalid")
+    if _local_task_path(trial.get("task_id"), "canary task ID", repository) != path:
+        raise ValueError("canary task identity is invalid")
+    if _local_task_path(config.get("task"), "canary trial task", repository) != path:
+        raise ValueError("canary task identity is invalid")
+    if trial.get("task_checksum") != checksum:
+        raise ValueError("canary task checksum is invalid")
+
+
 def _validate_public_source_revision(
     manifest: dict[str, object], public_source_revision: str, repository: Path, run: Callable[[list[str]], str] | None,
 ) -> None:
@@ -212,13 +267,13 @@ def receipt(
     expected_by_native = {name: arm for arm, name in bindings.items()}
     for raw in trials:
         trial = _mapping(raw, "Harbor canary trial")
-        if trial.get("task_name") != pair["task"] or trial.get("task_checksum") != pair["sha256"]:
-            raise ValueError("canary task identity is invalid")
+        trial_config = _mapping(trial.get("config"), "canary trial config")
+        _validate_task_identity(trial, pair, repository, trial_config)
         native_name = _campaign()._native_trial_name(str(pair["task"]), trial.get("trial_name"))
         arm = expected_by_native.get(native_name)
         if arm is None or arm in observed:
             raise ValueError("canary native trial binding is invalid")
-        if not _campaign()._agent_matches(_mapping(trial.get("config"), "canary trial config").get("agent"), expected_agents[arm]):
+        if not _campaign()._agent_matches(trial_config.get("agent"), expected_agents[arm]):
             raise ValueError("canary arm identity is invalid")
         agent = _mapping(trial.get("agent_info"), "canary agent")
         model = _mapping(agent.get("model_info"), "canary model")

--- a/scripts/ci/chaos_gauge/public_canary_bridge.py
+++ b/scripts/ci/chaos_gauge/public_canary_bridge.py
@@ -33,6 +33,7 @@ PRIVATE_REPOSITORY = "ShaftHQ/ChaosGauge-private"
 PRIVATE_COMMIT = "08551a3db4376438acddd77422554ce710a58624"
 RUN_ID = re.compile(r"[1-9][0-9]{0,18}")
 BUNDLE_FILES = ("raw.json", "receipt.json")
+FAILURE_BUNDLE_FILES = ("raw.json",)
 MARKER_STATE = "provider-started"
 
 
@@ -99,6 +100,22 @@ def _scan(label: str, content: bytes) -> None:
         raise _error(f"{label} contains a secret-shaped value")
 
 
+def _raw_content(raw: Path) -> bytes:
+    content = _safe_file(raw)
+    _raw_content_from_bytes(content)
+    return content
+
+
+def _raw_content_from_bytes(content: bytes) -> None:
+    _scan("raw evidence", content)
+    try:
+        value = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise _error("raw evidence is invalid") from error
+    if not isinstance(value, dict):
+        raise _error("raw evidence is invalid")
+
+
 def _validate_contents(raw_content: bytes, receipt_content: bytes, repository: Path) -> None:
     _scan("raw evidence", raw_content)
     _scan("sanitized receipt", receipt_content)
@@ -121,6 +138,10 @@ def _tag(run_id: str) -> str:
 
 def _bundle_name(run_id: str) -> str:
     return f"{_tag(run_id)}-evidence.zip"
+
+
+def _failure_bundle_name(run_id: str) -> str:
+    return f"{_tag(run_id)}-failure-evidence.zip"
 
 
 def _marker_name(run_id: str) -> str:
@@ -158,6 +179,22 @@ def bundle(raw: Path, receipt: Path, destination: Path, run_id: str) -> Path:
     return target
 
 
+def failure_bundle(raw: Path, destination: Path, run_id: str) -> Path:
+    """Build raw-only private evidence after paid receipt generation fails."""
+    content = {"raw.json": _raw_content(raw)}
+    manifest = {
+        "schemaVersion": 1,
+        "files": {name: hashlib.sha256(content[name]).hexdigest() for name in FAILURE_BUNDLE_FILES},
+    }
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9, strict_timestamps=True) as archive:
+        _zip_entry(archive, "manifest.json", json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+        _zip_entry(archive, "raw.json", content["raw.json"])
+    target = Path(destination) / _failure_bundle_name(run_id)
+    target.write_bytes(payload.getvalue())
+    return target
+
+
 def bundle_contents(path: Path) -> tuple[dict[str, object], dict[str, bytes]]:
     """Read only fixed evidence entries and verify declared hashes."""
     payload = _safe_file(path)
@@ -173,6 +210,25 @@ def bundle_contents(path: Path) -> tuple[dict[str, object], dict[str, bytes]]:
     expected = {"schemaVersion": 1, "files": {name: hashlib.sha256(content[name]).hexdigest() for name in BUNDLE_FILES}}
     if manifest != expected:
         raise _error("private evidence bundle hashes are invalid")
+    return manifest, content
+
+
+def failure_bundle_contents(path: Path) -> tuple[dict[str, object], dict[str, bytes]]:
+    """Read raw-only private failure evidence and verify declared hashes."""
+    payload = _safe_file(path)
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            names = [entry.filename for entry in archive.infolist()]
+            if len(names) != len(set(names)) or set(names) != {"manifest.json", *FAILURE_BUNDLE_FILES}:
+                raise _error("private failure evidence bundle entries are invalid")
+            manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+            content = {"raw.json": archive.read("raw.json")}
+    except (OSError, UnicodeDecodeError, ValueError, zipfile.BadZipFile, json.JSONDecodeError) as error:
+        raise _error("private failure evidence bundle is invalid") from error
+    expected = {"schemaVersion": 1, "files": {"raw.json": hashlib.sha256(content["raw.json"]).hexdigest()}}
+    if manifest != expected:
+        raise _error("private failure evidence bundle hashes are invalid")
+    _raw_content_from_bytes(content["raw.json"])
     return manifest, content
 
 
@@ -243,13 +299,15 @@ def _asset(release: dict[str, object], name: str) -> dict[str, object] | None:
 
 def _release_state(release: dict[str, object], run_id: str) -> str:
     names = set(_assets(release))
-    marker, bundle_name = _marker_name(run_id), _bundle_name(run_id)
+    marker, bundle_name, failure_name = _marker_name(run_id), _bundle_name(run_id), _failure_bundle_name(run_id)
     if not names:
         return "pristine"
     if names == {marker}:
         return "started"
     if names == {marker, bundle_name}:
         return "complete"
+    if names == {marker, failure_name}:
+        return "failed"
     raise _error("private draft release is incomplete")
 
 
@@ -310,6 +368,12 @@ def _verify_bundle(path: Path, digest: str, repository: Path) -> bytes:
     return content["receipt.json"]
 
 
+def _verify_failure_bundle(path: Path, digest: str) -> None:
+    if digest != f"sha256:{hashlib.sha256(_safe_file(path)).hexdigest()}":
+        raise _error("private evidence asset digest mismatch")
+    failure_bundle_contents(path)
+
+
 def _write_exclusive(path: Path, content: bytes) -> None:
     target = Path(path)
     if not target.parent.is_dir() or target.parent.is_symlink() or target.is_symlink():
@@ -338,6 +402,13 @@ def prepare(
         return "run"
     _verify_remote_marker(tag, run_id, release, run)
     if state == "started":
+        raise _error("private provider start is already recorded")
+    if state == "failed":
+        asset = _asset(release, _failure_bundle_name(run_id))
+        if asset is None:
+            raise _error("private draft release is incomplete")
+        with tempfile.TemporaryDirectory() as directory:
+            _verify_failure_bundle(_download(tag, _failure_bundle_name(run_id), Path(directory), run), str(asset["digest"]))
         raise _error("private provider start is already recorded")
     if receipt_out is None:
         raise _error("receipt recovery output is unavailable")
@@ -379,6 +450,35 @@ def publish(raw: Path, receipt: Path, repository: Path, run_id: str, token: str,
             archive.unlink()
 
 
+def preserve_failure(raw: Path, repository: Path, run_id: str, token: str, run: Callable[..., object] = subprocess.run) -> None:
+    """Store paid raw output after receipt failure; never upload an invalid receipt."""
+    tag, name = _tag(run_id), _failure_bundle_name(run_id)
+    preflight(token)
+    _raw_content(raw)
+    release = _release(tag, run_id, run, create=False)
+    if _release_state(release, run_id) != "started":
+        raise _error("private draft release is incomplete")
+    _verify_remote_marker(tag, run_id, release, run)
+    archive = failure_bundle(raw, raw.parent, run_id)
+    try:
+        run(
+            ["gh", "release", "upload", tag, str(archive), "--repo", PRIVATE_REPOSITORY],
+            check=True, capture_output=True, text=True,
+        )
+        release = _release(tag, run_id, run, create=False)
+        if _release_state(release, run_id) != "failed":
+            raise _error("private draft release is incomplete")
+        _verify_remote_marker(tag, run_id, release, run)
+        asset = _asset(release, name)
+        if asset is None:
+            raise _error("private evidence asset is unavailable")
+        with tempfile.TemporaryDirectory() as directory:
+            _verify_failure_bundle(_download(tag, name, Path(directory), run), str(asset["digest"]))
+    finally:
+        if archive.exists():
+            archive.unlink()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
@@ -386,6 +486,7 @@ def main() -> int:
     prepare_parser = commands.add_parser("prepare")
     validate_parser = commands.add_parser("validate")
     publish_parser = commands.add_parser("publish")
+    failure_parser = commands.add_parser("preserve-failure")
     prepare_parser.add_argument("--repository", type=Path, required=True)
     prepare_parser.add_argument("--run-id", required=True)
     prepare_parser.add_argument("--receipt-out", type=Path, required=True)
@@ -394,6 +495,9 @@ def main() -> int:
         command.add_argument("--receipt", type=Path, required=True)
         command.add_argument("--repository", type=Path, required=True)
     publish_parser.add_argument("--run-id", required=True)
+    failure_parser.add_argument("--raw", type=Path, required=True)
+    failure_parser.add_argument("--repository", type=Path, required=True)
+    failure_parser.add_argument("--run-id", required=True)
     args = parser.parse_args()
     token = os.environ.get("GH_TOKEN", "")
     if args.command == "preflight":
@@ -402,8 +506,10 @@ def main() -> int:
         print(prepare(args.repository, args.run_id, token, receipt_out=args.receipt_out))
     elif args.command == "validate":
         validate(args.raw, args.receipt, args.repository)
-    else:
+    elif args.command == "publish":
         publish(args.raw, args.receipt, args.repository, args.run_id, token)
+    else:
+        preserve_failure(args.raw, args.repository, args.run_id, token)
     return 0
 
 

--- a/tests/scripts/test_chaos_gauge_canary.py
+++ b/tests/scripts/test_chaos_gauge_canary.py
@@ -12,6 +12,7 @@ import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -59,20 +60,23 @@ class CanaryContractTest(unittest.TestCase):
             [agent.get("name") for agent in config["agents"]],
         )
 
-    def test_receipt_requires_pinned_telemetry_isolation_and_cleanup(self) -> None:
+    @patch.object(CANARY, "_harbor_task_checksum", return_value="a" * 64)
+    def test_receipt_requires_pinned_telemetry_isolation_and_cleanup(self, _checksum) -> None:
         planned = CANARY.plan(MANIFEST)
         config = CANARY.job_config(MANIFEST)
+        task_path = ROOT / "scripts" / "ci" / "chaos_gauge" / "dataset" / planned["pair"]["task"]
         result = {
             "trial_results": [
                 {
-                    "task_name": planned["pair"]["task"],
-                    "task_checksum": planned["pair"]["sha256"],
+                    "task_name": f"ShaftHQ/{planned['pair']['task']}",
+                    "task_id": {"path": str(task_path)},
+                    "task_checksum": "a" * 64,
                     "trial_name": f"{planned['pair']['task']}__{'ctrl001' if arm == 'control' else 'chaos01'}",
                     "agent_info": {
                         "name": "codex", "version": "0.118.0",
                         "model_info": {"name": "gpt-5.6-terra", "provider": "openai"},
                     },
-                    "config": {"agent": copy.deepcopy(config["agents"][position])},
+                    "config": {"task": {"path": str(task_path)}, "agent": copy.deepcopy(config["agents"][position])},
                     "agent_result": {"n_input_tokens": 10, "n_output_tokens": 20, "cost_usd": 0.01},
                     "agent_execution": {
                         "started_at": "2026-08-31T00:00:00+00:00",
@@ -125,15 +129,17 @@ class CanaryContractTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "public canary evidence"):
             CANARY.validate_public_evidence(leaked, repository=ROOT, run=merged_git)
 
-    def test_receipt_binds_prepared_native_name_and_agent_to_its_arm(self) -> None:
+    @patch.object(CANARY, "_harbor_task_checksum", return_value="a" * 64)
+    def test_receipt_binds_prepared_native_name_and_agent_to_its_arm(self, _checksum) -> None:
         planned = CANARY.plan(MANIFEST)
         config = CANARY.job_config(MANIFEST)
+        task_path = ROOT / "scripts" / "ci" / "chaos_gauge" / "dataset" / planned["pair"]["task"]
         result = {"trial_results": []}
         for position, arm in enumerate(planned["pair"]["arms"]):
             result["trial_results"].append({
-                "task_name": planned["pair"]["task"], "task_checksum": planned["pair"]["sha256"],
+                "task_name": f"ShaftHQ/{planned['pair']['task']}", "task_id": {"path": str(task_path)}, "task_checksum": "a" * 64,
                 "trial_name": f"{planned['pair']['task']}__{'ctrl001' if arm == 'control' else 'chaos01'}",
-                "config": {"agent": copy.deepcopy(config["agents"][position])},
+                "config": {"task": {"path": str(task_path)}, "agent": copy.deepcopy(config["agents"][position])},
                 "agent_info": {"name": "codex", "version": "0.118.0", "model_info": {"name": "gpt-5.6-terra", "provider": "openai"}},
                 "agent_result": {"n_input_tokens": 10, "n_output_tokens": 20, "cost_usd": 0.01},
                 "agent_execution": {"started_at": "2026-08-31T00:00:00+00:00", "finished_at": "2026-08-31T00:00:01+00:00"},
@@ -154,6 +160,64 @@ class CanaryContractTest(unittest.TestCase):
                 MANIFEST, planned, result, public_source_revision="f" * 40,
                 native_bindings=bindings, repository=ROOT, run=unmerged,
             )
+
+    def test_receipt_binds_real_harbor_task_metadata_separately_from_trial_name(self) -> None:
+        """Harbor 0.22 serializes task.toml metadata, local IDs, and random trial names separately."""
+        planned = CANARY.plan(MANIFEST)
+        config = CANARY.job_config(MANIFEST)
+        task = str(planned["pair"]["task"])
+        task_path = ROOT / "scripts" / "ci" / "chaos_gauge" / "dataset" / task
+        result = {"trial_results": []}
+        for position, arm in enumerate(planned["pair"]["arms"]):
+            result["trial_results"].append({
+                "task_name": f"ShaftHQ/{task}",
+                "task_id": {"path": str(task_path)},
+                "task_checksum": "a" * 64,
+                "trial_name": f"{task}__{'ctrl001' if arm == 'control' else 'chaos01'}",
+                "config": {
+                    "task": {"path": str(task_path)},
+                    "agent": copy.deepcopy(config["agents"][position]),
+                },
+                "agent_info": {
+                    "name": "codex", "version": "0.118.0",
+                    "model_info": {"name": "gpt-5.6-terra", "provider": "openai"},
+                },
+                "agent_result": {"n_input_tokens": 10, "n_output_tokens": 20, "cost_usd": 0.01},
+                "agent_execution": {
+                    "started_at": "2026-08-31T00:00:00+00:00",
+                    "finished_at": "2026-08-31T00:00:01+00:00",
+                },
+                "verifier_environment_mode": "separate",
+                "verifier_result": {"rewards": {"correctness": 1.0, "safety": 1.0, "cleanup": 1.0}},
+            })
+        bindings = {arm: result["trial_results"][index]["trial_name"] for index, arm in enumerate(planned["pair"]["arms"])}
+        kwargs = {
+            "native_bindings": bindings,
+            "repository": ROOT,
+            "run": self._merged_git("f" * 40),
+        }
+
+        with patch.object(CANARY, "_harbor_task_checksum", return_value="a" * 64):
+            receipt = CANARY.receipt(MANIFEST, planned, result, public_source_revision="f" * 40, **kwargs)
+        self.assertEqual(task, receipt["trials"][0]["task"])
+
+        wrong_checksum = copy.deepcopy(result)
+        wrong_checksum["trial_results"][0]["task_checksum"] = "b" * 64
+        with patch.object(CANARY, "_harbor_task_checksum", return_value="a" * 64):
+            with self.assertRaisesRegex(ValueError, "task checksum"):
+                CANARY.receipt(MANIFEST, planned, wrong_checksum, public_source_revision="f" * 40, **kwargs)
+
+        wrong_task_name = copy.deepcopy(result)
+        wrong_task_name["trial_results"][0]["task_name"] = "ShaftHQ/diagnosis-failure-trace"
+        with patch.object(CANARY, "_harbor_task_checksum", return_value="a" * 64):
+            with self.assertRaisesRegex(ValueError, "task identity"):
+                CANARY.receipt(MANIFEST, planned, wrong_task_name, public_source_revision="f" * 40, **kwargs)
+
+        wrong_local_task = copy.deepcopy(result)
+        wrong_local_task["trial_results"][0]["config"]["task"]["path"] = str(task_path.parent / "diagnosis-failure-trace")
+        with patch.object(CANARY, "_harbor_task_checksum", return_value="a" * 64):
+            with self.assertRaisesRegex(ValueError, "task identity"):
+                CANARY.receipt(MANIFEST, planned, wrong_local_task, public_source_revision="f" * 40, **kwargs)
 
     def test_agent_import_contract_rejects_missing_or_escaped_repository_root(self) -> None:
         with TemporaryDirectory() as directory:

--- a/tests/scripts/test_chaos_gauge_public_canary_workflow.py
+++ b/tests/scripts/test_chaos_gauge_public_canary_workflow.py
@@ -93,6 +93,17 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
         self.assertIn("ShaftHQ/ChaosGauge-private", bridge)
         self.assertIn("--draft", bridge)
 
+    def test_paid_raw_result_is_retained_privately_when_receipt_generation_fails(self) -> None:
+        failure = self._step("Preserve paid raw result after receipt failure")
+        self.assertEqual("${{ always() && steps.private-evidence.outputs.action == 'run' }}", failure["if"])
+        self.assertIn("public_canary_bridge.py preserve-failure", str(failure["run"]))
+        self.assertIn("test -f \"$CANARY_RAW\"", str(failure["run"]))
+        self.assertIn("test ! -f \"$CANARY_RECEIPT\"", str(failure["run"]))
+        self.assertLess(
+            self.steps.index(failure),
+            self.steps.index(self._step("Validate and secret-scan evidence")),
+        )
+
     def test_context_values_never_enter_shell_source(self) -> None:
         for step in self.steps:
             run = step.get("run")
@@ -372,6 +383,62 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
             upload = next(arguments for arguments, _ in calls if arguments[2] == "upload")
             self.assertEqual(["chaosgauge-canary-123-evidence.zip"], [Path(value).name for value in upload if value.endswith(".zip")])
             self.assertNotIn("--clobber", upload)
+
+    def test_preserve_failure_uploads_secret_scanned_raw_without_an_invalid_receipt(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            raw = root / "raw.json"
+            raw.write_text('{"trial_results":[]}\n', encoding="utf-8")
+            marker = root / "chaosgauge-canary-123-provider-started.json"
+            marker.write_text('{"runId":"123","schemaVersion":1,"state":"provider-started"}', encoding="utf-8")
+            release = {
+                "tagName": "chaosgauge-canary-123", "isDraft": True,
+                "targetCommitish": BRIDGE.PRIVATE_COMMIT,
+                "name": "ChaosGauge excluded canary 123",
+                "assets": [{
+                    "name": marker.name,
+                    "digest": f"sha256:{hashlib.sha256(marker.read_bytes()).hexdigest()}",
+                }],
+            }
+            uploaded = {marker.name: marker.read_bytes()}
+
+            def run(arguments, **_):
+                if arguments[2] == "view":
+                    return BRIDGE.subprocess.CompletedProcess(arguments, 0, json.dumps(release), "")
+                if arguments[2] == "upload":
+                    uploaded_path = Path(arguments[4])
+                    uploaded[uploaded_path.name] = uploaded_path.read_bytes()
+                    release["assets"].append({
+                        "name": uploaded_path.name,
+                        "digest": f"sha256:{hashlib.sha256(uploaded_path.read_bytes()).hexdigest()}",
+                    })
+                if arguments[2] == "download":
+                    name = arguments[arguments.index("--pattern") + 1]
+                    Path(arguments[arguments.index("--dir") + 1], name).write_bytes(uploaded[name])
+                return BRIDGE.subprocess.CompletedProcess(arguments, 0, "", "")
+
+            with patch.object(BRIDGE, "preflight"):
+                BRIDGE.preserve_failure(raw, ROOT, "123", "token", run=run)
+
+            failure_name = "chaosgauge-canary-123-failure-evidence.zip"
+            self.assertEqual({marker.name, failure_name}, {asset["name"] for asset in release["assets"]})
+            self.assertEqual("failed", BRIDGE._release_state(release, "123"))
+            archive = root / failure_name
+            archive.write_bytes(uploaded[failure_name])
+            _, content = BRIDGE.failure_bundle_contents(archive)
+            self.assertEqual({"raw.json"}, set(content))
+
+            with patch.object(BRIDGE, "preflight"):
+                with self.assertRaisesRegex(ValueError, "provider start is already recorded"):
+                    BRIDGE.prepare(ROOT, "123", "token", receipt_out=root / "recover.json", run=run)
+
+    def test_preserve_failure_rejects_secret_shaped_raw_evidence_before_release_access(self) -> None:
+        with TemporaryDirectory() as directory:
+            raw = Path(directory) / "raw.json"
+            raw.write_bytes(BRIDGE.SECRET_CANARIES[0])
+            with patch.object(BRIDGE, "preflight"):
+                with self.assertRaisesRegex(ValueError, "secret-shaped"):
+                    BRIDGE.preserve_failure(raw, ROOT, "123", "token")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Bind Harbor 0.22 task metadata, local task IDs, checksums, and randomized trial names independently.
- Retain secret-scanned paid raw results in a private raw-only failure bundle when receipt validation fails.
- Keep marker idempotency and public receipt-only publication.

## Checks

- python3 -m unittest: 89 tests across Canary, workflow, dependency, release-validator, campaign, and contract suites.
- python3 -m py_compile for canary.py and public_canary_bridge.py.
- YAML parse and git diff --check.

## Continuation

Related to #5462 and #5450. Run 33454465434 remains an excluded infrastructure receipt retry, never a pilot attempt; this PR does not rerun it or launch the pilot.