### PR TITLE
fix(ci): parse flat Allure 3 statistics

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -142,6 +142,10 @@ runs:
                 "duration" in document and "time" in document
             ):
                 raise ValueError("contains ambiguous mixed schemas")
+            if (has_flat_statistics and "time" in document) or (
+                not has_flat_statistics and "duration" in document
+            ):
+                raise ValueError("timing schema does not match statistics")
             if has_flat_statistics:
                 statistic = document
                 timing = document

--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -137,7 +137,12 @@ runs:
             if not isinstance(document, dict):
                 raise ValueError("root must be an object")
             fields = ("total", "passed", "failed", "broken", "skipped", "unknown")
-            if any(field in document for field in fields):
+            has_flat_statistics = any(field in document for field in fields)
+            if (has_flat_statistics and "statistic" in document) or (
+                "duration" in document and "time" in document
+            ):
+                raise ValueError("contains ambiguous mixed schemas")
+            if has_flat_statistics:
                 statistic = document
                 timing = document
             else:

--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -134,12 +134,19 @@ runs:
 
         try:
             document = json.loads(open(sys.argv[1], encoding="utf-8").read())
-            statistic = document.get("statistic", {})
-            timing = document.get("time", {})
+            if not isinstance(document, dict):
+                raise ValueError("root must be an object")
+            fields = ("total", "passed", "failed", "broken", "skipped", "unknown")
+            if any(field in document for field in fields):
+                statistic = document
+                timing = document
+            else:
+                statistic = document.get("statistic")
+                timing = document.get("time", {})
             if not isinstance(statistic, dict) or not isinstance(timing, dict):
                 raise ValueError("statistic and time must be objects")
             values = []
-            for field in ("total", "passed", "failed", "broken", "skipped", "unknown"):
+            for field in fields:
                 value = statistic.get(field, 0)
                 if isinstance(value, bool) or not isinstance(value, int) or value < 0:
                     raise ValueError(f"statistic '{field}'")

--- a/tests/scripts/test_post_test_report_action.py
+++ b/tests/scripts/test_post_test_report_action.py
@@ -120,6 +120,21 @@ class PostTestReportActionTest(unittest.TestCase):
         self.assertNotEqual(0, completed.returncode)
         self.assertIn("ambiguous mixed schemas", completed.stderr)
 
+    def test_rejects_timing_schema_that_does_not_match_statistics(self):
+        cases = (
+            ("nested-statistics-flat-duration", "nested", {"duration": 10}),
+            ("flat-statistics-nested-time", "flat", {"time": {"duration": 10}}),
+        )
+        for name, schema, document_updates in cases:
+            with self.subTest(name=name):
+                completed = self.run_summary(
+                    total=1, passed=1, failed=0, broken=0, skipped=0,
+                    schema=schema, document_updates=document_updates,
+                )
+
+                self.assertNotEqual(0, completed.returncode)
+                self.assertIn("timing schema does not match statistics", completed.stderr)
+
     def test_rejects_malformed_present_statistics(self):
         cases = (
             ("negative", {"passed": -1, "skipped": 1}),

--- a/tests/scripts/test_post_test_report_action.py
+++ b/tests/scripts/test_post_test_report_action.py
@@ -13,7 +13,8 @@ ACTION = ROOT / ".github/actions/post-test-report/action.yml"
 
 
 class PostTestReportActionTest(unittest.TestCase):
-    def run_summary(self, *, total, passed, failed, broken, skipped, unknown=None):
+    def run_summary(self, *, total, passed, failed, broken, skipped, unknown=None,
+                    schema="nested", duration=None):
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
         step = next(step for step in action["runs"]["steps"]
                     if step.get("id") == "collect_results")
@@ -34,8 +35,16 @@ class PostTestReportActionTest(unittest.TestCase):
             }
             if unknown is not None:
                 statistic["unknown"] = unknown
+            if schema == "flat":
+                document = dict(statistic)
+                if duration is not None:
+                    document["duration"] = duration
+            else:
+                document = {"statistic": statistic}
+                if duration is not None:
+                    document["time"] = {"duration": duration}
             (report / "summary.json").write_text(
-                json.dumps({"statistic": statistic}), encoding="utf-8"
+                json.dumps(document), encoding="utf-8"
             )
             script = step["run"].replace("${{ inputs.module-directory }}", str(module))
             script = script.replace("${{ inputs.job-name }}", "Safari shard 1")
@@ -64,6 +73,14 @@ class PostTestReportActionTest(unittest.TestCase):
 
         self.assertEqual(0, completed.returncode, completed.stdout)
 
+    def test_accepts_flat_allure3_statistics_with_unknown_entries(self):
+        completed = self.run_summary(
+            total=1434, passed=1408, failed=0, broken=0, skipped=12, unknown=14,
+            schema="flat", duration=123456
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stdout)
+
     def test_rejects_fewer_status_verdicts_than_total(self):
         completed = self.run_summary(total=14, passed=13, failed=0, broken=0, skipped=0)
 
@@ -88,14 +105,15 @@ class PostTestReportActionTest(unittest.TestCase):
             ("string", {"passed": "1", "skipped": 1}),
             ("boolean", {"passed": 1, "unknown": True}),
         )
-        for name, overrides in cases:
-            values = {"total": 1, "passed": 0, "failed": 0, "broken": 0, "skipped": 0}
-            values.update(overrides)
-            with self.subTest(name=name):
-                completed = self.run_summary(**values)
+        for schema in ("nested", "flat"):
+            for name, overrides in cases:
+                values = {"total": 1, "passed": 0, "failed": 0, "broken": 0, "skipped": 0}
+                values.update(overrides)
+                with self.subTest(schema=schema, name=name):
+                    completed = self.run_summary(**values, schema=schema)
 
-                self.assertNotEqual(0, completed.returncode)
-                self.assertIn("expected a non-negative integer", completed.stderr)
+                    self.assertNotEqual(0, completed.returncode)
+                    self.assertIn("expected a non-negative integer", completed.stderr)
 
     def test_preserves_failed_and_broken_verdict_failures(self):
         for failed, broken in ((1, 0), (0, 1)):

--- a/tests/scripts/test_post_test_report_action.py
+++ b/tests/scripts/test_post_test_report_action.py
@@ -14,7 +14,7 @@ ACTION = ROOT / ".github/actions/post-test-report/action.yml"
 
 class PostTestReportActionTest(unittest.TestCase):
     def run_summary(self, *, total, passed, failed, broken, skipped, unknown=None,
-                    schema="nested", duration=None):
+                    schema="nested", duration=None, document_updates=None):
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
         step = next(step for step in action["runs"]["steps"]
                     if step.get("id") == "collect_results")
@@ -43,6 +43,8 @@ class PostTestReportActionTest(unittest.TestCase):
                 document = {"statistic": statistic}
                 if duration is not None:
                     document["time"] = {"duration": duration}
+            if document_updates:
+                document.update(document_updates)
             (report / "summary.json").write_text(
                 json.dumps(document), encoding="utf-8"
             )
@@ -97,6 +99,26 @@ class PostTestReportActionTest(unittest.TestCase):
         completed = self.run_summary(total=14, passed=13, failed=0, broken=0, skipped=1)
 
         self.assertEqual(0, completed.returncode, completed.stdout)
+
+    def test_rejects_mixed_flat_and_nested_statistics(self):
+        completed = self.run_summary(
+            total=1, passed=1, failed=0, broken=0, skipped=0, schema="flat",
+            document_updates={
+                "statistic": {"total": 1, "passed": 0, "failed": 1, "broken": 0, "skipped": 0}
+            },
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("ambiguous mixed schemas", completed.stderr)
+
+    def test_rejects_mixed_nested_time_and_flat_duration(self):
+        completed = self.run_summary(
+            total=1, passed=1, failed=0, broken=0, skipped=0, duration=10,
+            document_updates={"duration": 10},
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("ambiguous mixed schemas", completed.stderr)
 
     def test_rejects_malformed_present_statistics(self):
         cases = (


### PR DESCRIPTION
## Summary

- parse both flat Allure 3 statistics and nested Allure 2 summaries
- keep schemas isolated instead of merging partial fields
- retain strict integer, accounting, all-unknown, failed, and broken guards

## Root cause

The exact-merge Firefox run completed 1,428 Surefire tests with zero failures. Its generated Allure 3 statistic document was flat (`total`, `passed`, `unknown`, and `skipped` at the root), while the strict parser assumed the older nested `statistic` object and therefore read every counter as zero.

## Validation

- exact flat Firefox 1,434-entry summary passes
- nested Allure 2 compatibility passes
- malformed types reject in both schemas
- under/over and all-unknown summaries reject
- failed and broken verdicts reject
- 8 focused tests pass
- `git diff --check`

Related to #5474
Related to #5475
