### PR TITLE
fix: run all ChaosGauge agents unprivileged

### DIFF
--- a/.github/workflows/chaos-gauge-public-canary.yml
+++ b/.github/workflows/chaos-gauge-public-canary.yml
@@ -1,6 +1,6 @@
 name: Run public ChaosGauge excluded canary
 
-# Owner-authorized excluded-canary exception (#5462, ShaftHQ/ChaosGauge-private#3):
+# Owner-authorized excluded-canary exception (#5462, ShaftHQ/ChaosGauge-private#4):
 # exactly one public task and two accounted arms may use the generic provider secret.
 # This workflow enforces a 60-minute runtime, exactly two arms, and a 120000-token
 # acceptance budget. It is not a provider-side spend cap. Full pilot keeps its
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           repository: ShaftHQ/ChaosGauge-private
-          ref: 08551a3db4376438acddd77422554ce710a58624
+          ref: 5c5c00896139c767946747ba38029d88fe750472
           path: private
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -42,7 +42,7 @@ jobs:
   release-governance:
     name: Release-note governance
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
@@ -382,6 +382,7 @@ jobs:
           tests.scripts.test_chaos_gauge_contracts
           tests.scripts.test_chaos_gauge_campaign
           tests.scripts.test_chaos_gauge_corpus
+          tests.scripts.test_chaos_gauge_runtime
           tests.scripts.test_chaos_gauge_recovery
           tests.scripts.test_chaos_gauge_scoring
           -v

--- a/scripts/ci/chaos_gauge/corpus.json
+++ b/scripts/ci/chaos_gauge/corpus.json
@@ -9,7 +9,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "1cb77261c1c833c1cb7fb4afd87d10b44943e1466ca6875938f211fb5db0573e"
+      "sha256": "5677baea3f56f69e0fb6b1ab6e2d8adb361b7487721704e1f616665fd5a065ba"
     },
     {
       "name": "diagnosis-failure-trace",
@@ -19,7 +19,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "e5a8993d616c2794ffd80c3394310404e2c96d309a093dcd7f48cdcc66f6b075"
+      "sha256": "ec8bdd0cbb60badb2a7ff7db2d9e4b7189700ce34bce29c7ef475cfd08d162d6"
     },
     {
       "name": "diagnosis-module-boundary",
@@ -29,7 +29,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "2e98c007f688fd094f0b6917147f1177a5e10454540adc62ad7605b094a93f3a"
+      "sha256": "2f1c31b4e2e2bab8cb876692bfd3ce144a12e5c1811884f92462000babfe5b41"
     },
     {
       "name": "repair-null-contract",
@@ -39,7 +39,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "5e68e46a63f3397db9eb79fae9c366544abed6d2579b80182de47efde4eaa026"
+      "sha256": "f0034f6dd441900320b267feca9e7703fd00ea46004c5f15f81164ff7185cc90"
     },
     {
       "name": "repair-timeout-cleanup",
@@ -49,7 +49,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "313cbf91c7ae83b8b0b8429151f2e4c1c85d4495ec5fd35b82c65af74fccdb5d"
+      "sha256": "6cdb0e3f601bec77379ffa422b744e4fe2d2681cd93f098be28440f1e7301371"
     },
     {
       "name": "repair-regression-test",
@@ -59,7 +59,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "de123704af0ccaaf9a4608d6be6ac576a399126ddb812ab061ef17be133bc288"
+      "sha256": "0a60e91111c5d604f9d88b5c4b7c7a9bb0d60d81279411525aa80d50371a50ec"
     },
     {
       "name": "recovery-cross-file-contract",
@@ -69,7 +69,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "0d99036da5c9a0d00ce5d0bfc3019b9b6d7ab5e8b3ef0f3a62d2f96783e13182"
+      "sha256": "08178c0bbca09ce747d76b05c9635b12e21d1062d8226aed1dc55c9322a2802d"
     },
     {
       "name": "recovery-broken-build",
@@ -79,7 +79,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "88cf682f6a7b7e51abf0b0ff458f56eef7ddba6b1198366fa03b9361e4259a3c"
+      "sha256": "7269c9b7cb4df165f8c0d4782e871bec243dcd2184d1610c165985f1572b5be5"
     },
     {
       "name": "recovery-partial-migration",
@@ -89,7 +89,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "7deda4a8d542fc899b6aa7e4463926e916b84b01d24e26c02038aef8f3640d51"
+      "sha256": "f945fec62d5154a6f8efb0cc0ad305aa5120184bb4eb656a6c63914927273527"
     },
     {
       "name": "safety-secret-redaction",
@@ -99,7 +99,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "de5c48b5b65e28b57363597602019392ed25d7c66ed570935c0541968fdeacbe"
+      "sha256": "f3c44c1ab9485fafdefb26060775d53a21d295259dda87e5ce43401436dc2eb2"
     },
     {
       "name": "safety-foreign-work",
@@ -109,7 +109,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "f2c69d531e6126270032a8b006a06e80ffddb0d03f2dfec44c2f7deeb3fb2a9b"
+      "sha256": "57b7670105a8a19e35ef65048cf41628e4691ec7e766c32c66568d69858ff68e"
     },
     {
       "name": "delivery-focused-proof",
@@ -119,47 +119,47 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "8ab7bb7209d7717e0f882c14aa342a95bfdcb00d6985d747eb5d563cb82fd477"
+      "sha256": "fa9d844431eb2541162bff2be0eb4344f542805349b15155188ac648a321cca5"
     },
     {
       "name": "ShaftHQ/chaosgauge-diagnosis-private-001",
-      "registryReference": "ShaftHQ/chaosgauge-private@sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485",
+      "registryReference": "ShaftHQ/chaosgauge-private@sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10",
       "visibility": "private-reference",
       "stratum": "diagnosis",
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "private-holdout",
-      "sha256": "63ab2385371d95c004cfc41cd2a2ff4ecb547be8d9875f1dc75c14261f961ff5"
+      "sha256": "5acf36b30a244b10d4e59fb7981ac56c3f741a077bb84a501f7fc261f57c8245"
     },
     {
       "name": "ShaftHQ/chaosgauge-focused-repair-private-002",
-      "registryReference": "ShaftHQ/chaosgauge-private@sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485",
+      "registryReference": "ShaftHQ/chaosgauge-private@sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10",
       "visibility": "private-reference",
       "stratum": "focused-repair",
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "private-holdout",
-      "sha256": "ea08ee50fc76c05257929e138221cdf1ddefa8875d9266018cdbd19444c75ef5"
+      "sha256": "233584a4f778787a562312cfd90c1a8518198f65fec43c7deb9c445e948b27e4"
     },
     {
       "name": "ShaftHQ/chaosgauge-cross-file-recovery-private-003",
-      "registryReference": "ShaftHQ/chaosgauge-private@sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485",
+      "registryReference": "ShaftHQ/chaosgauge-private@sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10",
       "visibility": "private-reference",
       "stratum": "cross-file-recovery",
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "private-holdout",
-      "sha256": "c38c502d1f0a2ad4438f7d3829dd0e42f8ed77275103f3bed0cbe6ffc18f5e9d"
+      "sha256": "83bfda79eae1b05e24c9fe8be9948fb1ce76f293d93a9975f6665dc43789cbd6"
     },
     {
       "name": "ShaftHQ/chaosgauge-safety-delivery-private-004",
-      "registryReference": "ShaftHQ/chaosgauge-private@sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485",
+      "registryReference": "ShaftHQ/chaosgauge-private@sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10",
       "visibility": "private-reference",
       "stratum": "safety-delivery",
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "private-holdout",
-      "sha256": "224f2088b1ae3f7244ce5fddf06d3ab61814cf0dcd4637ddd715bc67072cb1e1"
+      "sha256": "f83cc5949a2cc2f128b26c6b3d6d7ca2d737ed53f4bd07fb07025713c04f2df4"
     }
   ]
 }

--- a/scripts/ci/chaos_gauge/corpus.json
+++ b/scripts/ci/chaos_gauge/corpus.json
@@ -9,7 +9,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "bbb42d74471ba4baa53a365f22fb26c70aa3277d5279aa44d0d3d478887b829b"
+      "sha256": "1cb77261c1c833c1cb7fb4afd87d10b44943e1466ca6875938f211fb5db0573e"
     },
     {
       "name": "diagnosis-failure-trace",
@@ -19,7 +19,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "1c5bd61222521bd4d9fc3dd5b078e0408638c686581de3b8c8803bd29406480e"
+      "sha256": "e5a8993d616c2794ffd80c3394310404e2c96d309a093dcd7f48cdcc66f6b075"
     },
     {
       "name": "diagnosis-module-boundary",
@@ -29,7 +29,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "cfae3c97feb96c58a771af1957aca60b9cd2353ab257b9a2bdbb3bd735685f86"
+      "sha256": "2e98c007f688fd094f0b6917147f1177a5e10454540adc62ad7605b094a93f3a"
     },
     {
       "name": "repair-null-contract",
@@ -39,7 +39,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "5a5213e077a8460ff83c255c11ad9bb321c75d1b9b6f78fe14c3e7bf68d83c9a"
+      "sha256": "5e68e46a63f3397db9eb79fae9c366544abed6d2579b80182de47efde4eaa026"
     },
     {
       "name": "repair-timeout-cleanup",
@@ -49,7 +49,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "8e829fc3fb7ff52f3c07352b8939e3ab807c1cac63363aeee37a56f617d97552"
+      "sha256": "313cbf91c7ae83b8b0b8429151f2e4c1c85d4495ec5fd35b82c65af74fccdb5d"
     },
     {
       "name": "repair-regression-test",
@@ -59,7 +59,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "f12fe990df475c5d874065721f23548a4734ca2b7f56bc86f0e004d61a6ba421"
+      "sha256": "de123704af0ccaaf9a4608d6be6ac576a399126ddb812ab061ef17be133bc288"
     },
     {
       "name": "recovery-cross-file-contract",
@@ -69,7 +69,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "20a1c654a93adcd2590026b8181c7757395b1793075bbdd27c59e02e2d3eb0c4"
+      "sha256": "0d99036da5c9a0d00ce5d0bfc3019b9b6d7ab5e8b3ef0f3a62d2f96783e13182"
     },
     {
       "name": "recovery-broken-build",
@@ -79,7 +79,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "20fe73e34f8cc4859cb1222ab92176779578850b6dfa5507af0f04ad2054d6c1"
+      "sha256": "88cf682f6a7b7e51abf0b0ff458f56eef7ddba6b1198366fa03b9361e4259a3c"
     },
     {
       "name": "recovery-partial-migration",
@@ -89,7 +89,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "833ad2e707cdcd53bef1b56106cf94c22fb5e25639b45d4b6d22fa37c2254bbb"
+      "sha256": "7deda4a8d542fc899b6aa7e4463926e916b84b01d24e26c02038aef8f3640d51"
     },
     {
       "name": "safety-secret-redaction",
@@ -99,7 +99,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "b92c3977ca0e19f4a0e4e1cf6458533df6330ed12d8af2281b0a4a7fce4d1b3f"
+      "sha256": "de5c48b5b65e28b57363597602019392ed25d7c66ed570935c0541968fdeacbe"
     },
     {
       "name": "safety-foreign-work",
@@ -109,7 +109,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "fca4e478d4eab8852d05c1e8cec08882738671e8f53fd067f29054d7e9e8a5f4"
+      "sha256": "f2c69d531e6126270032a8b006a06e80ffddb0d03f2dfec44c2f7deeb3fb2a9b"
     },
     {
       "name": "delivery-focused-proof",
@@ -119,7 +119,7 @@
       "owner": "ShaftHQ/ChaosEngine",
       "oracle": "deterministic",
       "contaminationStatus": "public-calibration",
-      "sha256": "b004e9578cf09dd010b387b852f68ade3f4d11b7b665092b8c1b531584b0a2f3"
+      "sha256": "8ab7bb7209d7717e0f882c14aa342a95bfdcb00d6985d747eb5d563cb82fd477"
     },
     {
       "name": "ShaftHQ/chaosgauge-diagnosis-private-001",

--- a/scripts/ci/chaos_gauge/dataset/dataset.toml
+++ b/scripts/ci/chaos_gauge/dataset/dataset.toml
@@ -9,51 +9,51 @@ keywords = ["agent-harness", "codex", "chaos-engine"]
 
 [[tasks]]
 name = "ShaftHQ/diagnosis-config-precedence"
-digest = "sha256:1cb77261c1c833c1cb7fb4afd87d10b44943e1466ca6875938f211fb5db0573e"
+digest = "sha256:5677baea3f56f69e0fb6b1ab6e2d8adb361b7487721704e1f616665fd5a065ba"
 
 [[tasks]]
 name = "ShaftHQ/diagnosis-failure-trace"
-digest = "sha256:e5a8993d616c2794ffd80c3394310404e2c96d309a093dcd7f48cdcc66f6b075"
+digest = "sha256:ec8bdd0cbb60badb2a7ff7db2d9e4b7189700ce34bce29c7ef475cfd08d162d6"
 
 [[tasks]]
 name = "ShaftHQ/diagnosis-module-boundary"
-digest = "sha256:2e98c007f688fd094f0b6917147f1177a5e10454540adc62ad7605b094a93f3a"
+digest = "sha256:2f1c31b4e2e2bab8cb876692bfd3ce144a12e5c1811884f92462000babfe5b41"
 
 [[tasks]]
 name = "ShaftHQ/repair-null-contract"
-digest = "sha256:5e68e46a63f3397db9eb79fae9c366544abed6d2579b80182de47efde4eaa026"
+digest = "sha256:f0034f6dd441900320b267feca9e7703fd00ea46004c5f15f81164ff7185cc90"
 
 [[tasks]]
 name = "ShaftHQ/repair-timeout-cleanup"
-digest = "sha256:313cbf91c7ae83b8b0b8429151f2e4c1c85d4495ec5fd35b82c65af74fccdb5d"
+digest = "sha256:6cdb0e3f601bec77379ffa422b744e4fe2d2681cd93f098be28440f1e7301371"
 
 [[tasks]]
 name = "ShaftHQ/repair-regression-test"
-digest = "sha256:de123704af0ccaaf9a4608d6be6ac576a399126ddb812ab061ef17be133bc288"
+digest = "sha256:0a60e91111c5d604f9d88b5c4b7c7a9bb0d60d81279411525aa80d50371a50ec"
 
 [[tasks]]
 name = "ShaftHQ/recovery-cross-file-contract"
-digest = "sha256:0d99036da5c9a0d00ce5d0bfc3019b9b6d7ab5e8b3ef0f3a62d2f96783e13182"
+digest = "sha256:08178c0bbca09ce747d76b05c9635b12e21d1062d8226aed1dc55c9322a2802d"
 
 [[tasks]]
 name = "ShaftHQ/recovery-broken-build"
-digest = "sha256:88cf682f6a7b7e51abf0b0ff458f56eef7ddba6b1198366fa03b9361e4259a3c"
+digest = "sha256:7269c9b7cb4df165f8c0d4782e871bec243dcd2184d1610c165985f1572b5be5"
 
 [[tasks]]
 name = "ShaftHQ/recovery-partial-migration"
-digest = "sha256:7deda4a8d542fc899b6aa7e4463926e916b84b01d24e26c02038aef8f3640d51"
+digest = "sha256:f945fec62d5154a6f8efb0cc0ad305aa5120184bb4eb656a6c63914927273527"
 
 [[tasks]]
 name = "ShaftHQ/safety-secret-redaction"
-digest = "sha256:de5c48b5b65e28b57363597602019392ed25d7c66ed570935c0541968fdeacbe"
+digest = "sha256:f3c44c1ab9485fafdefb26060775d53a21d295259dda87e5ce43401436dc2eb2"
 
 [[tasks]]
 name = "ShaftHQ/safety-foreign-work"
-digest = "sha256:f2c69d531e6126270032a8b006a06e80ffddb0d03f2dfec44c2f7deeb3fb2a9b"
+digest = "sha256:57b7670105a8a19e35ef65048cf41628e4691ec7e766c32c66568d69858ff68e"
 
 [[tasks]]
 name = "ShaftHQ/delivery-focused-proof"
-digest = "sha256:8ab7bb7209d7717e0f882c14aa342a95bfdcb00d6985d747eb5d563cb82fd477"
+digest = "sha256:fa9d844431eb2541162bff2be0eb4344f542805349b15155188ac648a321cca5"
 
 [[files]]
 path = "metric.py"

--- a/scripts/ci/chaos_gauge/dataset/dataset.toml
+++ b/scripts/ci/chaos_gauge/dataset/dataset.toml
@@ -9,51 +9,51 @@ keywords = ["agent-harness", "codex", "chaos-engine"]
 
 [[tasks]]
 name = "ShaftHQ/diagnosis-config-precedence"
-digest = "sha256:bbb42d74471ba4baa53a365f22fb26c70aa3277d5279aa44d0d3d478887b829b"
+digest = "sha256:1cb77261c1c833c1cb7fb4afd87d10b44943e1466ca6875938f211fb5db0573e"
 
 [[tasks]]
 name = "ShaftHQ/diagnosis-failure-trace"
-digest = "sha256:1c5bd61222521bd4d9fc3dd5b078e0408638c686581de3b8c8803bd29406480e"
+digest = "sha256:e5a8993d616c2794ffd80c3394310404e2c96d309a093dcd7f48cdcc66f6b075"
 
 [[tasks]]
 name = "ShaftHQ/diagnosis-module-boundary"
-digest = "sha256:cfae3c97feb96c58a771af1957aca60b9cd2353ab257b9a2bdbb3bd735685f86"
+digest = "sha256:2e98c007f688fd094f0b6917147f1177a5e10454540adc62ad7605b094a93f3a"
 
 [[tasks]]
 name = "ShaftHQ/repair-null-contract"
-digest = "sha256:5a5213e077a8460ff83c255c11ad9bb321c75d1b9b6f78fe14c3e7bf68d83c9a"
+digest = "sha256:5e68e46a63f3397db9eb79fae9c366544abed6d2579b80182de47efde4eaa026"
 
 [[tasks]]
 name = "ShaftHQ/repair-timeout-cleanup"
-digest = "sha256:8e829fc3fb7ff52f3c07352b8939e3ab807c1cac63363aeee37a56f617d97552"
+digest = "sha256:313cbf91c7ae83b8b0b8429151f2e4c1c85d4495ec5fd35b82c65af74fccdb5d"
 
 [[tasks]]
 name = "ShaftHQ/repair-regression-test"
-digest = "sha256:f12fe990df475c5d874065721f23548a4734ca2b7f56bc86f0e004d61a6ba421"
+digest = "sha256:de123704af0ccaaf9a4608d6be6ac576a399126ddb812ab061ef17be133bc288"
 
 [[tasks]]
 name = "ShaftHQ/recovery-cross-file-contract"
-digest = "sha256:20a1c654a93adcd2590026b8181c7757395b1793075bbdd27c59e02e2d3eb0c4"
+digest = "sha256:0d99036da5c9a0d00ce5d0bfc3019b9b6d7ab5e8b3ef0f3a62d2f96783e13182"
 
 [[tasks]]
 name = "ShaftHQ/recovery-broken-build"
-digest = "sha256:20fe73e34f8cc4859cb1222ab92176779578850b6dfa5507af0f04ad2054d6c1"
+digest = "sha256:88cf682f6a7b7e51abf0b0ff458f56eef7ddba6b1198366fa03b9361e4259a3c"
 
 [[tasks]]
 name = "ShaftHQ/recovery-partial-migration"
-digest = "sha256:833ad2e707cdcd53bef1b56106cf94c22fb5e25639b45d4b6d22fa37c2254bbb"
+digest = "sha256:7deda4a8d542fc899b6aa7e4463926e916b84b01d24e26c02038aef8f3640d51"
 
 [[tasks]]
 name = "ShaftHQ/safety-secret-redaction"
-digest = "sha256:b92c3977ca0e19f4a0e4e1cf6458533df6330ed12d8af2281b0a4a7fce4d1b3f"
+digest = "sha256:de5c48b5b65e28b57363597602019392ed25d7c66ed570935c0541968fdeacbe"
 
 [[tasks]]
 name = "ShaftHQ/safety-foreign-work"
-digest = "sha256:fca4e478d4eab8852d05c1e8cec08882738671e8f53fd067f29054d7e9e8a5f4"
+digest = "sha256:f2c69d531e6126270032a8b006a06e80ffddb0d03f2dfec44c2f7deeb3fb2a9b"
 
 [[tasks]]
 name = "ShaftHQ/delivery-focused-proof"
-digest = "sha256:b004e9578cf09dd010b387b852f68ade3f4d11b7b665092b8c1b531584b0a2f3"
+digest = "sha256:8ab7bb7209d7717e0f882c14aa342a95bfdcb00d6985d747eb5d563cb82fd477"
 
 [[files]]
 path = "metric.py"

--- a/scripts/ci/chaos_gauge/dataset/delivery-focused-proof/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/delivery-focused-proof/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/delivery-focused-proof/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/delivery-focused-proof/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/delivery-focused-proof/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/delivery-focused-proof/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-config-precedence/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-config-precedence/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-config-precedence/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-config-precedence/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-config-precedence/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-config-precedence/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-failure-trace/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-failure-trace/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-failure-trace/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-failure-trace/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-failure-trace/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-failure-trace/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-module-boundary/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-module-boundary/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-module-boundary/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-module-boundary/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/diagnosis-module-boundary/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/diagnosis-module-boundary/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/recovery-broken-build/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/recovery-broken-build/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/recovery-broken-build/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/recovery-broken-build/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/recovery-broken-build/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/recovery-broken-build/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/recovery-cross-file-contract/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/recovery-cross-file-contract/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/recovery-cross-file-contract/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/recovery-cross-file-contract/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/recovery-cross-file-contract/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/recovery-cross-file-contract/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/recovery-partial-migration/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/recovery-partial-migration/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/recovery-partial-migration/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/recovery-partial-migration/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/recovery-partial-migration/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/recovery-partial-migration/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/repair-null-contract/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/repair-null-contract/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/repair-null-contract/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/repair-null-contract/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/repair-null-contract/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/repair-null-contract/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/repair-regression-test/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/repair-regression-test/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/repair-regression-test/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/repair-regression-test/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/repair-regression-test/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/repair-regression-test/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/repair-timeout-cleanup/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/repair-timeout-cleanup/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/repair-timeout-cleanup/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/repair-timeout-cleanup/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/repair-timeout-cleanup/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/repair-timeout-cleanup/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/safety-foreign-work/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/safety-foreign-work/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/safety-foreign-work/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/safety-foreign-work/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/safety-foreign-work/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/safety-foreign-work/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/dataset/safety-secret-redaction/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/safety-secret-redaction/environment/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb
 RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
 WORKDIR /app
 COPY --chown=chaosgauge:chaosgauge . /app
+RUN chown chaosgauge:chaosgauge /app
 ENV HOME=/home/chaosgauge
 USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/safety-secret-redaction/environment/Dockerfile
+++ b/scripts/ci/chaos_gauge/dataset/safety-secret-redaction/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f
+
+RUN useradd --create-home --uid 10001 --shell /bin/bash chaosgauge
+WORKDIR /app
+COPY --chown=chaosgauge:chaosgauge . /app
+ENV HOME=/home/chaosgauge
+USER chaosgauge

--- a/scripts/ci/chaos_gauge/dataset/safety-secret-redaction/task.toml
+++ b/scripts/ci/chaos_gauge/dataset/safety-secret-redaction/task.toml
@@ -16,6 +16,7 @@ contamination_status = "public-calibration"
 
 [agent]
 timeout_sec = 1800.0
+user = "chaosgauge"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 
@@ -32,7 +33,6 @@ storage_mb = 1024
 
 [environment]
 workdir = "/app"
-docker_image = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
 network_mode = "allowlist"
 allowed_hosts = ["api.openai.com", "auth.openai.com", "chatgpt.com", "*.openai.com", "api.github.com", "github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com", "api.adoptium.net", "pypi.org", "files.pythonhosted.org", "www.python.org", "nodejs.org", "registry.npmjs.org", "deb.debian.org"]
 cpus = 2

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -10,14 +10,14 @@
   "dataset": {
     "schemaVersion": "1.4",
     "version": "1.0.0",
-    "sha256": "f3b8a2e4b93d0a60aff774897af31fb1a6e667db177571a35b15d989f701b1b7"
+    "sha256": "110348fc316570ca97ee6bea44e934400a3939563cfdb52eb337a3af13ecf8d8"
   },
   "privatePackage": {
     "repository": "ShaftHQ/ChaosGauge-private",
-    "commit": "08551a3db4376438acddd77422554ce710a58624",
-    "contentSha256": "sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485",
+    "commit": "5c5c00896139c767946747ba38029d88fe750472",
+    "contentSha256": "sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10",
     "name": "ShaftHQ/chaosgauge-private",
-    "ref": "sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485",
+    "ref": "sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10",
     "status": "requires-credentials"
   },
   "attemptsPerTask": 5,
@@ -45,8 +45,8 @@
       "harness": "none",
       "harnessSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "treatmentSha256": {
-        "calibration": "210506dd2515a9f05ada33dee23eec1537e5b55d23b839808911725587a8a0c2",
-        "full-pilot": "bfc2c0d97e0958a30ee4ef01e46bebb33774e6b0a3c0d59569b032f5e3f64115"
+        "calibration": "577b043ac791732f048ecce50d714520f875d058bbf0aae4f207ecc36996ab6f",
+        "full-pilot": "73933bd73c6b7e05caa6ecec42df0b34b585039d2e3bb587be0c7a71504630db"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,
@@ -61,8 +61,8 @@
       "harness": "chaos-engine",
       "harnessSha256": "ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e",
       "treatmentSha256": {
-        "calibration": "0999682330a0114782cf503c98009336f535c8327edcff2af0738d13be150650",
-        "full-pilot": "15eb4603a641a47b642d3ad4a934eae81626fdbba6d8d455806befcb75036492"
+        "calibration": "939c5570dbb8bd778d5446533e7a107a2ef473ad6451790a5bb327f8a505fd31",
+        "full-pilot": "39940faa6ea5a0b511b8b840bd155708e82fc72d1e9660b752ff586b405df7c7"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,
@@ -70,21 +70,21 @@
     }
   ],
   "tasks": [
-    {"name": "diagnosis-config-precedence", "visibility": "public", "sha256": "1cb77261c1c833c1cb7fb4afd87d10b44943e1466ca6875938f211fb5db0573e"},
-    {"name": "diagnosis-failure-trace", "visibility": "public", "sha256": "e5a8993d616c2794ffd80c3394310404e2c96d309a093dcd7f48cdcc66f6b075"},
-    {"name": "diagnosis-module-boundary", "visibility": "public", "sha256": "2e98c007f688fd094f0b6917147f1177a5e10454540adc62ad7605b094a93f3a"},
-    {"name": "repair-null-contract", "visibility": "public", "sha256": "5e68e46a63f3397db9eb79fae9c366544abed6d2579b80182de47efde4eaa026"},
-    {"name": "repair-timeout-cleanup", "visibility": "public", "sha256": "313cbf91c7ae83b8b0b8429151f2e4c1c85d4495ec5fd35b82c65af74fccdb5d"},
-    {"name": "repair-regression-test", "visibility": "public", "sha256": "de123704af0ccaaf9a4608d6be6ac576a399126ddb812ab061ef17be133bc288"},
-    {"name": "recovery-cross-file-contract", "visibility": "public", "sha256": "0d99036da5c9a0d00ce5d0bfc3019b9b6d7ab5e8b3ef0f3a62d2f96783e13182"},
-    {"name": "recovery-broken-build", "visibility": "public", "sha256": "88cf682f6a7b7e51abf0b0ff458f56eef7ddba6b1198366fa03b9361e4259a3c"},
-    {"name": "recovery-partial-migration", "visibility": "public", "sha256": "7deda4a8d542fc899b6aa7e4463926e916b84b01d24e26c02038aef8f3640d51"},
-    {"name": "safety-secret-redaction", "visibility": "public", "sha256": "de5c48b5b65e28b57363597602019392ed25d7c66ed570935c0541968fdeacbe"},
-    {"name": "safety-foreign-work", "visibility": "public", "sha256": "f2c69d531e6126270032a8b006a06e80ffddb0d03f2dfec44c2f7deeb3fb2a9b"},
-    {"name": "delivery-focused-proof", "visibility": "public", "sha256": "8ab7bb7209d7717e0f882c14aa342a95bfdcb00d6985d747eb5d563cb82fd477"},
-    {"name": "ShaftHQ/chaosgauge-diagnosis-private-001", "visibility": "private-reference", "stratum": "diagnosis", "sha256": "63ab2385371d95c004cfc41cd2a2ff4ecb547be8d9875f1dc75c14261f961ff5"},
-    {"name": "ShaftHQ/chaosgauge-focused-repair-private-002", "visibility": "private-reference", "stratum": "focused-repair", "sha256": "ea08ee50fc76c05257929e138221cdf1ddefa8875d9266018cdbd19444c75ef5"},
-    {"name": "ShaftHQ/chaosgauge-cross-file-recovery-private-003", "visibility": "private-reference", "stratum": "cross-file-recovery", "sha256": "c38c502d1f0a2ad4438f7d3829dd0e42f8ed77275103f3bed0cbe6ffc18f5e9d"},
-    {"name": "ShaftHQ/chaosgauge-safety-delivery-private-004", "visibility": "private-reference", "stratum": "safety-delivery", "sha256": "224f2088b1ae3f7244ce5fddf06d3ab61814cf0dcd4637ddd715bc67072cb1e1"}
+    {"name": "diagnosis-config-precedence", "visibility": "public", "sha256": "5677baea3f56f69e0fb6b1ab6e2d8adb361b7487721704e1f616665fd5a065ba"},
+    {"name": "diagnosis-failure-trace", "visibility": "public", "sha256": "ec8bdd0cbb60badb2a7ff7db2d9e4b7189700ce34bce29c7ef475cfd08d162d6"},
+    {"name": "diagnosis-module-boundary", "visibility": "public", "sha256": "2f1c31b4e2e2bab8cb876692bfd3ce144a12e5c1811884f92462000babfe5b41"},
+    {"name": "repair-null-contract", "visibility": "public", "sha256": "f0034f6dd441900320b267feca9e7703fd00ea46004c5f15f81164ff7185cc90"},
+    {"name": "repair-timeout-cleanup", "visibility": "public", "sha256": "6cdb0e3f601bec77379ffa422b744e4fe2d2681cd93f098be28440f1e7301371"},
+    {"name": "repair-regression-test", "visibility": "public", "sha256": "0a60e91111c5d604f9d88b5c4b7c7a9bb0d60d81279411525aa80d50371a50ec"},
+    {"name": "recovery-cross-file-contract", "visibility": "public", "sha256": "08178c0bbca09ce747d76b05c9635b12e21d1062d8226aed1dc55c9322a2802d"},
+    {"name": "recovery-broken-build", "visibility": "public", "sha256": "7269c9b7cb4df165f8c0d4782e871bec243dcd2184d1610c165985f1572b5be5"},
+    {"name": "recovery-partial-migration", "visibility": "public", "sha256": "f945fec62d5154a6f8efb0cc0ad305aa5120184bb4eb656a6c63914927273527"},
+    {"name": "safety-secret-redaction", "visibility": "public", "sha256": "f3c44c1ab9485fafdefb26060775d53a21d295259dda87e5ce43401436dc2eb2"},
+    {"name": "safety-foreign-work", "visibility": "public", "sha256": "57b7670105a8a19e35ef65048cf41628e4691ec7e766c32c66568d69858ff68e"},
+    {"name": "delivery-focused-proof", "visibility": "public", "sha256": "fa9d844431eb2541162bff2be0eb4344f542805349b15155188ac648a321cca5"},
+    {"name": "ShaftHQ/chaosgauge-diagnosis-private-001", "visibility": "private-reference", "stratum": "diagnosis", "sha256": "5acf36b30a244b10d4e59fb7981ac56c3f741a077bb84a501f7fc261f57c8245"},
+    {"name": "ShaftHQ/chaosgauge-focused-repair-private-002", "visibility": "private-reference", "stratum": "focused-repair", "sha256": "233584a4f778787a562312cfd90c1a8518198f65fec43c7deb9c445e948b27e4"},
+    {"name": "ShaftHQ/chaosgauge-cross-file-recovery-private-003", "visibility": "private-reference", "stratum": "cross-file-recovery", "sha256": "83bfda79eae1b05e24c9fe8be9948fb1ce76f293d93a9975f6665dc43789cbd6"},
+    {"name": "ShaftHQ/chaosgauge-safety-delivery-private-004", "visibility": "private-reference", "stratum": "safety-delivery", "sha256": "f83cc5949a2cc2f128b26c6b3d6d7ca2d737ed53f4bd07fb07025713c04f2df4"}
   ]
 }

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -10,7 +10,7 @@
   "dataset": {
     "schemaVersion": "1.4",
     "version": "1.0.0",
-    "sha256": "6b097e3316a8365513ff93d2d0cbe3d2521eedd1c0f883ae0682065c30e9626e"
+    "sha256": "f3b8a2e4b93d0a60aff774897af31fb1a6e667db177571a35b15d989f701b1b7"
   },
   "privatePackage": {
     "repository": "ShaftHQ/ChaosGauge-private",
@@ -45,8 +45,8 @@
       "harness": "none",
       "harnessSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "treatmentSha256": {
-        "calibration": "eb08b5c36e234e455069003a011b470bbcf09b27cd18065b735cf75b6532a6c4",
-        "full-pilot": "ea69199ef6f030cf38478ecf837f1305c0eef5c5cafd3ccc5afa91d78aa03269"
+        "calibration": "210506dd2515a9f05ada33dee23eec1537e5b55d23b839808911725587a8a0c2",
+        "full-pilot": "bfc2c0d97e0958a30ee4ef01e46bebb33774e6b0a3c0d59569b032f5e3f64115"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,
@@ -61,8 +61,8 @@
       "harness": "chaos-engine",
       "harnessSha256": "ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e",
       "treatmentSha256": {
-        "calibration": "b13305e2f4b1b49bdf9bf1f480d7a753bde3fc18ab4987b1e7b7bd868efa1444",
-        "full-pilot": "a3b105beaf603c93809a16f2126346c84a3fbf7c65a2607511d7665564d58c09"
+        "calibration": "0999682330a0114782cf503c98009336f535c8327edcff2af0738d13be150650",
+        "full-pilot": "15eb4603a641a47b642d3ad4a934eae81626fdbba6d8d455806befcb75036492"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,
@@ -70,18 +70,18 @@
     }
   ],
   "tasks": [
-    {"name": "diagnosis-config-precedence", "visibility": "public", "sha256": "bbb42d74471ba4baa53a365f22fb26c70aa3277d5279aa44d0d3d478887b829b"},
-    {"name": "diagnosis-failure-trace", "visibility": "public", "sha256": "1c5bd61222521bd4d9fc3dd5b078e0408638c686581de3b8c8803bd29406480e"},
-    {"name": "diagnosis-module-boundary", "visibility": "public", "sha256": "cfae3c97feb96c58a771af1957aca60b9cd2353ab257b9a2bdbb3bd735685f86"},
-    {"name": "repair-null-contract", "visibility": "public", "sha256": "5a5213e077a8460ff83c255c11ad9bb321c75d1b9b6f78fe14c3e7bf68d83c9a"},
-    {"name": "repair-timeout-cleanup", "visibility": "public", "sha256": "8e829fc3fb7ff52f3c07352b8939e3ab807c1cac63363aeee37a56f617d97552"},
-    {"name": "repair-regression-test", "visibility": "public", "sha256": "f12fe990df475c5d874065721f23548a4734ca2b7f56bc86f0e004d61a6ba421"},
-    {"name": "recovery-cross-file-contract", "visibility": "public", "sha256": "20a1c654a93adcd2590026b8181c7757395b1793075bbdd27c59e02e2d3eb0c4"},
-    {"name": "recovery-broken-build", "visibility": "public", "sha256": "20fe73e34f8cc4859cb1222ab92176779578850b6dfa5507af0f04ad2054d6c1"},
-    {"name": "recovery-partial-migration", "visibility": "public", "sha256": "833ad2e707cdcd53bef1b56106cf94c22fb5e25639b45d4b6d22fa37c2254bbb"},
-    {"name": "safety-secret-redaction", "visibility": "public", "sha256": "b92c3977ca0e19f4a0e4e1cf6458533df6330ed12d8af2281b0a4a7fce4d1b3f"},
-    {"name": "safety-foreign-work", "visibility": "public", "sha256": "fca4e478d4eab8852d05c1e8cec08882738671e8f53fd067f29054d7e9e8a5f4"},
-    {"name": "delivery-focused-proof", "visibility": "public", "sha256": "b004e9578cf09dd010b387b852f68ade3f4d11b7b665092b8c1b531584b0a2f3"},
+    {"name": "diagnosis-config-precedence", "visibility": "public", "sha256": "1cb77261c1c833c1cb7fb4afd87d10b44943e1466ca6875938f211fb5db0573e"},
+    {"name": "diagnosis-failure-trace", "visibility": "public", "sha256": "e5a8993d616c2794ffd80c3394310404e2c96d309a093dcd7f48cdcc66f6b075"},
+    {"name": "diagnosis-module-boundary", "visibility": "public", "sha256": "2e98c007f688fd094f0b6917147f1177a5e10454540adc62ad7605b094a93f3a"},
+    {"name": "repair-null-contract", "visibility": "public", "sha256": "5e68e46a63f3397db9eb79fae9c366544abed6d2579b80182de47efde4eaa026"},
+    {"name": "repair-timeout-cleanup", "visibility": "public", "sha256": "313cbf91c7ae83b8b0b8429151f2e4c1c85d4495ec5fd35b82c65af74fccdb5d"},
+    {"name": "repair-regression-test", "visibility": "public", "sha256": "de123704af0ccaaf9a4608d6be6ac576a399126ddb812ab061ef17be133bc288"},
+    {"name": "recovery-cross-file-contract", "visibility": "public", "sha256": "0d99036da5c9a0d00ce5d0bfc3019b9b6d7ab5e8b3ef0f3a62d2f96783e13182"},
+    {"name": "recovery-broken-build", "visibility": "public", "sha256": "88cf682f6a7b7e51abf0b0ff458f56eef7ddba6b1198366fa03b9361e4259a3c"},
+    {"name": "recovery-partial-migration", "visibility": "public", "sha256": "7deda4a8d542fc899b6aa7e4463926e916b84b01d24e26c02038aef8f3640d51"},
+    {"name": "safety-secret-redaction", "visibility": "public", "sha256": "de5c48b5b65e28b57363597602019392ed25d7c66ed570935c0541968fdeacbe"},
+    {"name": "safety-foreign-work", "visibility": "public", "sha256": "f2c69d531e6126270032a8b006a06e80ffddb0d03f2dfec44c2f7deeb3fb2a9b"},
+    {"name": "delivery-focused-proof", "visibility": "public", "sha256": "8ab7bb7209d7717e0f882c14aa342a95bfdcb00d6985d747eb5d563cb82fd477"},
     {"name": "ShaftHQ/chaosgauge-diagnosis-private-001", "visibility": "private-reference", "stratum": "diagnosis", "sha256": "63ab2385371d95c004cfc41cd2a2ff4ecb547be8d9875f1dc75c14261f961ff5"},
     {"name": "ShaftHQ/chaosgauge-focused-repair-private-002", "visibility": "private-reference", "stratum": "focused-repair", "sha256": "ea08ee50fc76c05257929e138221cdf1ddefa8875d9266018cdbd19444c75ef5"},
     {"name": "ShaftHQ/chaosgauge-cross-file-recovery-private-003", "visibility": "private-reference", "stratum": "cross-file-recovery", "sha256": "c38c502d1f0a2ad4438f7d3829dd0e42f8ed77275103f3bed0cbe6ffc18f5e9d"},

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -26,4 +26,4 @@ agents:
 datasets:
   - path: scripts/ci/chaos_gauge/dataset
   - name: ShaftHQ/chaosgauge-private
-    ref: sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485
+    ref: sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-control.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-control.yaml
@@ -20,4 +20,4 @@ agents:
 datasets:
   - path: scripts/ci/chaos_gauge/dataset
   - name: ShaftHQ/chaosgauge-private
-    ref: sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485
+    ref: sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10

--- a/scripts/ci/chaos_gauge/public_canary_bridge.py
+++ b/scripts/ci/chaos_gauge/public_canary_bridge.py
@@ -30,7 +30,7 @@ SECRET_CANARIES = _release_validator.SECRET_CANARIES
 
 
 PRIVATE_REPOSITORY = "ShaftHQ/ChaosGauge-private"
-PRIVATE_COMMIT = "08551a3db4376438acddd77422554ce710a58624"
+PRIVATE_COMMIT = "5c5c00896139c767946747ba38029d88fe750472"
 RUN_ID = re.compile(r"[1-9][0-9]{0,18}")
 BUNDLE_FILES = ("raw.json", "receipt.json")
 FAILURE_BUNDLE_FILES = ("raw.json",)

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -170,10 +170,10 @@ def validate_manifest(  # noqa: MC0001 - immutable schema validation stays fail-
     private_package = _mapping(manifest["privatePackage"], "private package")
     if private_package != {
         "repository": "ShaftHQ/ChaosGauge-private",
-        "commit": "08551a3db4376438acddd77422554ce710a58624",
-        "contentSha256": "sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485",
+        "commit": "5c5c00896139c767946747ba38029d88fe750472",
+        "contentSha256": "sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10",
         "name": "ShaftHQ/chaosgauge-private",
-        "ref": "sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485",
+        "ref": "sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10",
         "status": "requires-credentials",
     }:
         raise ValueError("private package plan is invalid")

--- a/tests/scripts/test_chaos_gauge_campaign.py
+++ b/tests/scripts/test_chaos_gauge_campaign.py
@@ -211,7 +211,7 @@ class ChaosGaugeCampaignTest(TestCase):
     def test_full_pilot_binds_private_git_content_package_and_strata(self):
         package = MANIFEST["privatePackage"]
         self.assertEqual("ShaftHQ/ChaosGauge-private", package["repository"])
-        self.assertEqual("08551a3db4376438acddd77422554ce710a58624", package["commit"])
+        self.assertEqual("5c5c00896139c767946747ba38029d88fe750472", package["commit"])
         self.assertEqual("ShaftHQ/chaosgauge-private", package["name"])
         private = [task for task in MANIFEST["tasks"] if task["visibility"] == "private-reference"]
         self.assertEqual(4, len(private))

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -297,7 +297,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             self.assertEqual("scripts/ci/chaos_gauge/dataset", job["datasets"][0]["path"])
             self.assertEqual("ShaftHQ/chaosgauge-private", job["datasets"][1]["name"])
             self.assertEqual(
-                "sha256:a832b3507b8ec20731140f51efb18247819ede29f2c220269cbd7e191835d485",
+                "sha256:7db9c6399f126edbaa60226e9eda09b5742b7302e7badea663c365ec7b2dce10",
                 job["datasets"][1]["ref"],
             )
         full = MODULE.validate_job_contracts(

--- a/tests/scripts/test_chaos_gauge_public_canary_workflow.py
+++ b/tests/scripts/test_chaos_gauge_public_canary_workflow.py
@@ -69,7 +69,7 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
     def test_private_checkout_and_release_capability_precede_provider(self) -> None:
         private = self._step("Checkout pinned private corpus")
         self.assertEqual("ShaftHQ/ChaosGauge-private", private["with"]["repository"])
-        self.assertEqual("08551a3db4376438acddd77422554ce710a58624", private["with"]["ref"])
+        self.assertEqual("5c5c00896139c767946747ba38029d88fe750472", private["with"]["ref"])
         self.assertFalse(private["with"]["persist-credentials"])
         capability_index = next(index for index, step in enumerate(self.steps) if step.get("name") == "Prepare private evidence storage")
         provider_index = next(index for index, step in enumerate(self.steps) if step.get("name") == "Run excluded two-arm canary")
@@ -144,7 +144,7 @@ class PublicCanaryWorkflowTest(unittest.TestCase):
 
     def test_owner_exception_has_only_workflow_local_canary_limits(self) -> None:
         self.assertIn("owner-authorized excluded-canary exception", self.text.lower())
-        self.assertIn("ShaftHQ/ChaosGauge-private#3", self.text)
+        self.assertIn("ShaftHQ/ChaosGauge-private#4", self.text)
         self.assertIn("#5462", self.text)
         self.assertIn("not a provider-side spend cap", self.text)
         self.assertEqual(60, self.job["timeout-minutes"])

--- a/tests/scripts/test_chaos_gauge_recovery.py
+++ b/tests/scripts/test_chaos_gauge_recovery.py
@@ -8,12 +8,13 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 CHAOS_GAUGE = ROOT / "scripts" / "ci" / "chaos_gauge"
 
-# `e7d329bd3b` is merged PR #5464, immutable recovery source for #5450.
-# This covers its full public ChaosGauge tree, unlike a few representative
-# anchors that can remain after an executable or dataset member is lost.
-RECOVERED_PUBLIC_FILE_COUNT = 141
+# `e7d329bd3b` is the recovery-source baseline; deliberate public corpus
+# additions update this complete inventory together with their task digests.
+# This covers the full public ChaosGauge tree, unlike representative anchors
+# that can remain after an executable or dataset member is lost.
+RECOVERED_PUBLIC_FILE_COUNT = 153
 RECOVERED_PUBLIC_PATHS_SHA256 = (
-    "f29eac375e2a4ed365916b19b1ec4e6f2b7c01a944f1f2408b484fe92e09b59e"
+    "3ee8ea70621c13545dc2c97cf657a607c5edacf3726f196212bcf31ce7067517"
 )
 
 

--- a/tests/scripts/test_chaos_gauge_runtime.py
+++ b/tests/scripts/test_chaos_gauge_runtime.py
@@ -27,6 +27,7 @@ class ChaosGaugeRuntimeTest(unittest.TestCase):
                 self.assertIn(f"--uid {UID}", dockerfile)
                 self.assertIn(f"ENV HOME=/home/{USER}", dockerfile)
                 self.assertIn("WORKDIR /app", dockerfile)
+                self.assertIn("RUN chown chaosgauge:chaosgauge /app", dockerfile)
                 self.assertTrue(dockerfile.rstrip().endswith(f"USER {USER}"))
                 self.assertEqual("separate", config["verifier"]["environment_mode"])
                 self.assertIn("docker_image", config["verifier"]["environment"])

--- a/tests/scripts/test_chaos_gauge_runtime.py
+++ b/tests/scripts/test_chaos_gauge_runtime.py
@@ -1,0 +1,59 @@
+"""Non-root agent-runtime contract for every public ChaosGauge task."""
+
+from __future__ import annotations
+
+import subprocess
+import tomllib
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DATASET = ROOT / "scripts" / "ci" / "chaos_gauge" / "dataset"
+USER = "chaosgauge"
+UID = "10001"
+BASE = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
+
+
+class ChaosGaugeRuntimeTest(unittest.TestCase):
+    def test_every_public_agent_environment_has_fixed_non_root_contract(self) -> None:
+        for task in sorted(path for path in DATASET.iterdir() if path.is_dir()):
+            with self.subTest(task=task.name):
+                config = tomllib.loads((task / "task.toml").read_text(encoding="utf-8"))
+                dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+                self.assertEqual(USER, config["agent"]["user"])
+                self.assertNotIn("docker_image", config["environment"])
+                self.assertEqual(f"FROM {BASE}", dockerfile.splitlines()[0])
+                self.assertIn(f"--uid {UID}", dockerfile)
+                self.assertIn(f"ENV HOME=/home/{USER}", dockerfile)
+                self.assertIn("WORKDIR /app", dockerfile)
+                self.assertTrue(dockerfile.rstrip().endswith(f"USER {USER}"))
+                self.assertEqual("separate", config["verifier"]["environment_mode"])
+                self.assertIn("docker_image", config["verifier"]["environment"])
+
+    def test_runtime_probe_runs_as_task_user_with_writable_workspace(self) -> None:
+        for task in sorted(path for path in DATASET.iterdir() if path.is_dir()):
+            with self.subTest(task=task.name):
+                image = f"chaosgauge-runtime-{task.name}"
+                try:
+                    subprocess.run(
+                        ["docker", "build", "--tag", image, str(task / "environment")],
+                        check=True,
+                        capture_output=True,
+                    )
+                    probe = "test \"$(id -u)\" -ne 0; test -w /app; test -w \"$HOME\""
+                    subprocess.run(
+                        ["docker", "run", "--rm", "--network", "none", image, "sh", "-ceu", probe],
+                        check=True,
+                        capture_output=True,
+                    )
+                finally:
+                    subprocess.run(
+                        ["docker", "image", "rm", "--force", image],
+                        check=False,
+                        capture_output=True,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_chaos_gauge_runtime.py
+++ b/tests/scripts/test_chaos_gauge_runtime.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import subprocess
+import shutil
+import subprocess  # nosec B404 - invokes only the resolved Docker executable.
 import tomllib
 import unittest
 from pathlib import Path
@@ -13,6 +14,20 @@ DATASET = ROOT / "scripts" / "ci" / "chaos_gauge" / "dataset"
 USER = "chaosgauge"
 UID = "10001"
 BASE = "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f"
+TASK_NAMES = (
+    "delivery-focused-proof",
+    "diagnosis-config-precedence",
+    "diagnosis-failure-trace",
+    "diagnosis-module-boundary",
+    "recovery-broken-build",
+    "recovery-cross-file-contract",
+    "recovery-partial-migration",
+    "repair-null-contract",
+    "repair-regression-test",
+    "repair-timeout-cleanup",
+    "safety-foreign-work",
+    "safety-secret-redaction",
+)
 
 
 class ChaosGaugeRuntimeTest(unittest.TestCase):
@@ -33,24 +48,30 @@ class ChaosGaugeRuntimeTest(unittest.TestCase):
                 self.assertIn("docker_image", config["verifier"]["environment"])
 
     def test_runtime_probe_runs_as_task_user_with_writable_workspace(self) -> None:
-        for task in sorted(path for path in DATASET.iterdir() if path.is_dir()):
-            with self.subTest(task=task.name):
-                image = f"chaosgauge-runtime-{task.name}"
+        docker = shutil.which("docker")
+        if docker is None:
+            self.skipTest("Docker is required for the runtime image probe")
+        docker_path = str(Path(docker).resolve())
+        self.assertTrue(Path(docker_path).is_absolute())
+        for task_name in TASK_NAMES:
+            with self.subTest(task=task_name):
+                image = f"chaosgauge-runtime-{task_name}"
                 try:
-                    subprocess.run(
-                        ["docker", "build", "--tag", image, str(task / "environment")],
+                    subprocess.run(  # nosec B603 - resolved binary and fixed contract inputs.
+                        [docker_path, "build", "--tag", image, "."],
                         check=True,
                         capture_output=True,
+                        cwd=DATASET / task_name / "environment",
                     )
                     probe = "test \"$(id -u)\" -ne 0; test -w /app; test -w \"$HOME\""
-                    subprocess.run(
-                        ["docker", "run", "--rm", "--network", "none", image, "sh", "-ceu", probe],
+                    subprocess.run(  # nosec B603 - resolved binary and fixed contract inputs.
+                        [docker_path, "run", "--rm", "--network", "none", image, "sh", "-ceu", probe],
                         check=True,
                         capture_output=True,
                     )
                 finally:
-                    subprocess.run(
-                        ["docker", "image", "rm", "--force", image],
+                    subprocess.run(  # nosec B603 - resolved binary and fixed contract inputs.
+                        [docker_path, "image", "rm", "--force", image],
                         check=False,
                         capture_output=True,
                     )


### PR DESCRIPTION
Implements the public follow-up for #5462.

- Uses an explicit unprivileged runtime and writable agent workspace for every public task.
- Pins the merged private corpus revision and opaque integrity metadata.
- Recomputes public corpus and treatment identities; adds runtime contract coverage.

Private corpus content remains private. No canary or pilot was run.