### PR TITLE
fix: retry transient MemPalace setup failures

### DIFF
--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -679,10 +679,20 @@ def _run_account_command(
     )
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "no process output").strip()
-        raise RuntimeError(
-            f"dependency command failed: {Path(command[0]).name}: {detail[:500]}"
+        raise _AccountCommandError(
+            f"dependency command failed: {Path(command[0]).name}: {detail[:500]}",
+            stderr=str(result.stderr or ""),
+            stdout=str(result.stdout or ""),
         )
     return result
+
+
+class _AccountCommandError(RuntimeError):
+    """Keep full process streams private while presenting a bounded error."""
+
+    def __init__(self, message: str, *, stderr: str, stdout: str) -> None:
+        super().__init__(message)
+        self.full_output = f"{stderr}\n{stdout}"
 
 
 def _run_transient_mempalace_mine(
@@ -703,8 +713,8 @@ def _run_transient_mempalace_mine(
                 extra_environment=extra_environment,
                 timeout=remaining,
             )
-        except RuntimeError as error:
-            if attempt == 2 or TRANSIENT_MEMPALACE_TLS_EOF not in str(error).upper():
+        except _AccountCommandError as error:
+            if attempt == 2 or TRANSIENT_MEMPALACE_TLS_EOF not in error.full_output.upper():
                 raise
             delay = (1, 2)[attempt]
             if deadline - time.monotonic() <= delay:

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -76,6 +76,7 @@ ACCOUNT_RECEIPT_SCHEMA = 2
 ACCOUNT_RECEIPT_NAME = ".chaos-engine-dependencies.json"
 DEPENDENCY_ACTIONS = frozenset({"reused", "installed", "upgraded", "repaired", "blocked"})
 ACCOUNT_COMMAND_TIMEOUT_SECONDS = 900
+TRANSIENT_MEMPALACE_TLS_EOF = "[SSL: UNEXPECTED_EOF_WHILE_READING]"
 _UNSTABLE_VERSION = re.compile(
     r"(?:alpha|beta|rc|pre|preview|dev|snapshot|nightly)", re.IGNORECASE
 )
@@ -703,7 +704,7 @@ def _run_transient_mempalace_mine(
                 timeout=remaining,
             )
         except RuntimeError as error:
-            if attempt == 2 or "TLS UNEXPECTED_EOF" not in str(error).upper():
+            if attempt == 2 or TRANSIENT_MEMPALACE_TLS_EOF not in str(error).upper():
                 raise
             delay = (1, 2)[attempt]
             if deadline - time.monotonic() <= delay:

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -75,6 +75,7 @@ SUPPORTED_PLATFORMS = (
 ACCOUNT_RECEIPT_SCHEMA = 2
 ACCOUNT_RECEIPT_NAME = ".chaos-engine-dependencies.json"
 DEPENDENCY_ACTIONS = frozenset({"reused", "installed", "upgraded", "repaired", "blocked"})
+ACCOUNT_COMMAND_TIMEOUT_SECONDS = 900
 _UNSTABLE_VERSION = re.compile(
     r"(?:alpha|beta|rc|pre|preview|dev|snapshot|nightly)", re.IGNORECASE
 )
@@ -659,6 +660,7 @@ def _run_account_command(
     *,
     runner=subprocess.run,
     extra_environment: dict[str, str] | None = None,
+    timeout: float = ACCOUNT_COMMAND_TIMEOUT_SECONDS,
 ) -> subprocess.CompletedProcess[str]:
     environment = os.environ.copy()
     environment["PATH"] = _account_search_path()
@@ -672,7 +674,7 @@ def _run_account_command(
         capture_output=True,
         text=True,
         check=False,
-        timeout=900,
+        timeout=timeout,
     )
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "no process output").strip()
@@ -680,6 +682,34 @@ def _run_account_command(
             f"dependency command failed: {Path(command[0]).name}: {detail[:500]}"
         )
     return result
+
+
+def _run_transient_mempalace_mine(
+    command: list[str], project: Path, *, runner=subprocess.run,
+    extra_environment: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Retry a transient MemPalace TLS EOF within one setup timeout budget."""
+    deadline = time.monotonic() + ACCOUNT_COMMAND_TIMEOUT_SECONDS
+    for attempt in range(3):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError("MemPalace setup retry budget exhausted")
+        try:
+            return _run_account_command(
+                command,
+                project,
+                runner=runner,
+                extra_environment=extra_environment,
+                timeout=remaining,
+            )
+        except RuntimeError as error:
+            if attempt == 2 or "TLS UNEXPECTED_EOF" not in str(error).upper():
+                raise
+            delay = (1, 2)[attempt]
+            if deadline - time.monotonic() <= delay:
+                raise
+            time.sleep(delay)
+    raise AssertionError("bounded MemPalace retry did not return or raise")
 
 
 def install_account_dependencies(  # noqa: MC0001 - preflight then ordered account mutation.
@@ -868,12 +898,15 @@ def install_account_dependencies(  # noqa: MC0001 - preflight then ordered accou
     if unhealthy:
         raise RuntimeError("dependency verification failed: " + ", ".join(unhealthy))
     for command in project_setup_plan(project, commands):
-        _run_account_command(
-            command,
-            project,
-            runner=runner,
-            extra_environment=mempalace_project_setup_environment(project, command),
-        )
+        environment = mempalace_project_setup_environment(project, command)
+        if command == [commands.get("mempalace"), "mine", "."]:
+            _run_transient_mempalace_mine(
+                command, project, runner=runner, extra_environment=environment
+            )
+        else:
+            _run_account_command(
+                command, project, runner=runner, extra_environment=environment
+            )
         if command[1:3] in (["init", "."], ["mine", "."]):
             mark_mempalace_project_setup(project)
 

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "221f988ded1f6f51e4c864bd03f690651ff6db0974e58f7c9535f301e1ad7bda",
+      "harnessSha256": "184616dda0fbbba87782bbe44ab325eb989f8c39d6ec601334361f7101038bfb",
       "treatmentSha256": {
-        "calibration": "a7cc156bd3283c2a15b35839f3f80e3d438c1c5d9a603282a69dc42bb978bb95",
-        "full-pilot": "b98d60e868c5572dfc83b24820b6391964c93fd15d59c23b77154ce74b433085"
+        "calibration": "3aa3d04bd8562135c08ea67ed3e4a4da72a8684daabd2d5429d6a832e98be4dc",
+        "full-pilot": "c4aaa847f05f0a419ea99ad8cd75abf7fa8a113f5f2e6c7f2d5f14dc41f44298"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e",
+      "harnessSha256": "758e57468fe31170ac9e66839e13ae2a4ab02c8ccf610ca33bc31a2d1f80e375",
       "treatmentSha256": {
-        "calibration": "939c5570dbb8bd778d5446533e7a107a2ef473ad6451790a5bb327f8a505fd31",
-        "full-pilot": "39940faa6ea5a0b511b8b840bd155708e82fc72d1e9660b752ff586b405df7c7"
+        "calibration": "785ea38b94318e89e7ec56541e7f006de39fba664c4f69f5d83621b890fe2501",
+        "full-pilot": "b83d83ee40092594bc3622c6f3b6ada7e99c517965e0eaf13de059bda5eb48d6"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "758e57468fe31170ac9e66839e13ae2a4ab02c8ccf610ca33bc31a2d1f80e375",
+      "harnessSha256": "221f988ded1f6f51e4c864bd03f690651ff6db0974e58f7c9535f301e1ad7bda",
       "treatmentSha256": {
-        "calibration": "785ea38b94318e89e7ec56541e7f006de39fba664c4f69f5d83621b890fe2501",
-        "full-pilot": "b83d83ee40092594bc3622c6f3b6ada7e99c517965e0eaf13de059bda5eb48d6"
+        "calibration": "a7cc156bd3283c2a15b35839f3f80e3d438c1c5d9a603282a69dc42bb978bb95",
+        "full-pilot": "b98d60e868c5572dfc83b24820b6391964c93fd15d59c23b77154ce74b433085"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e"
+      harness_sha256: "758e57468fe31170ac9e66839e13ae2a4ab02c8ccf610ca33bc31a2d1f80e375"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "221f988ded1f6f51e4c864bd03f690651ff6db0974e58f7c9535f301e1ad7bda"
+      harness_sha256: "184616dda0fbbba87782bbe44ab325eb989f8c39d6ec601334361f7101038bfb"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "758e57468fe31170ac9e66839e13ae2a4ab02c8ccf610ca33bc31a2d1f80e375"
+      harness_sha256: "221f988ded1f6f51e4c864bd03f690651ff6db0974e58f7c9535f301e1ad7bda"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -21,7 +21,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e"
+      harness_sha256: "758e57468fe31170ac9e66839e13ae2a4ab02c8ccf610ca33bc31a2d1f80e375"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -21,7 +21,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "758e57468fe31170ac9e66839e13ae2a4ab02c8ccf610ca33bc31a2d1f80e375"
+      harness_sha256: "221f988ded1f6f51e4c864bd03f690651ff6db0974e58f7c9535f301e1ad7bda"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -21,7 +21,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "221f988ded1f6f51e4c864bd03f690651ff6db0974e58f7c9535f301e1ad7bda"
+      harness_sha256: "184616dda0fbbba87782bbe44ab325eb989f8c39d6ec601334361f7101038bfb"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -350,7 +350,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),
-                "harness_sha256": "221f988ded1f6f51e4c864bd03f690651ff6db0974e58f7c9535f301e1ad7bda",
+                "harness_sha256": "184616dda0fbbba87782bbe44ab325eb989f8c39d6ec601334361f7101038bfb",
                 "adapter_sha256": "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             }
             if kwargs != expected:

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -350,7 +350,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),
-                "harness_sha256": "758e57468fe31170ac9e66839e13ae2a4ab02c8ccf610ca33bc31a2d1f80e375",
+                "harness_sha256": "221f988ded1f6f51e4c864bd03f690651ff6db0974e58f7c9535f301e1ad7bda",
                 "adapter_sha256": "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             }
             if kwargs != expected:

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -350,7 +350,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),
-                "harness_sha256": "ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e",
+                "harness_sha256": "758e57468fe31170ac9e66839e13ae2a4ab02c8ccf610ca33bc31a2d1f80e375",
                 "adapter_sha256": "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             }
             if kwargs != expected:

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -660,16 +660,16 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
                 palace.mkdir(parents=True, exist_ok=True)
                 palace.joinpath("sqlite_exact.sqlite3").write_bytes(b"SQLite format 3\x00")
                 if len(calls) < 3:
-                    return SimpleNamespace(returncode=1, stdout="", stderr="TLS UNEXPECTED_EOF")
+                    return SimpleNamespace(returncode=1, stdout="", stderr="[SSL: UNEXPECTED_EOF_WHILE_READING]")
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-            with mock.patch.object(module, "discover_account_commands", side_effect=((local, commands), (local, commands))), mock.patch.object(module, "resolve_account_actions", return_value=actions), mock.patch.object(module, "project_setup_plan", return_value=[mine]), mock.patch.object(module.time, "monotonic", return_value=0), mock.patch.object(module.time, "sleep") as sleep:
+            with mock.patch.object(module, "discover_account_commands", side_effect=((local, commands), (local, commands))), mock.patch.object(module, "resolve_account_actions", return_value=actions), mock.patch.object(module, "project_setup_plan", return_value=[mine]), mock.patch.object(module.time, "monotonic", side_effect=(0, 0, 1, 2, 3, 4)), mock.patch.object(module.time, "sleep") as sleep:
                 module.install_account_dependencies(project, specification, runner=runner, allow_root=True)
 
             self.assertEqual([mine, mine, mine], [command for command, _environment, _timeout in calls])
             self.assertEqual(calls[0][1], calls[1][1])
             self.assertEqual(calls[1][1], calls[2][1])
-            self.assertEqual([900, 900, 900], [timeout for _command, _environment, timeout in calls])
+            self.assertEqual([900, 898, 896], [timeout for _command, _environment, timeout in calls])
             sleep.assert_has_calls((mock.call(1), mock.call(2)))
             self.assertEqual(b"current\n", (project / ".chaos-engine-state/mempalace/.mined").read_bytes())
 
@@ -693,10 +693,10 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
                 palace = project / ".chaos-engine-state/mempalace"
                 palace.mkdir(parents=True, exist_ok=True)
                 palace.joinpath("sqlite_exact.sqlite3").write_bytes(b"SQLite format 3\x00")
-                return SimpleNamespace(returncode=1, stdout="", stderr="TLS UNEXPECTED_EOF")
+                return SimpleNamespace(returncode=1, stdout="", stderr="[SSL: UNEXPECTED_EOF_WHILE_READING]")
 
             with mock.patch.object(module, "discover_account_commands", side_effect=((local, commands), (local, commands))), mock.patch.object(module, "resolve_account_actions", return_value=actions), mock.patch.object(module, "project_setup_plan", return_value=[mine]), mock.patch.object(module.time, "monotonic", return_value=0), mock.patch.object(module.time, "sleep") as sleep:
-                with self.assertRaisesRegex(RuntimeError, "TLS UNEXPECTED_EOF"):
+                with self.assertRaisesRegex(RuntimeError, "UNEXPECTED_EOF_WHILE_READING"):
                     module.install_account_dependencies(project, specification, runner=transient_failure, allow_root=True)
 
             self.assertEqual([mine, mine, mine], calls)
@@ -728,6 +728,47 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
                     module.install_account_dependencies(project, specification, runner=permanent_failure, allow_root=True)
 
             self.assertEqual([mine], calls)
+
+    def test_mempalace_retry_rejects_near_miss_and_other_ssl_errors(self):
+        module = load_controller()
+        for detail in ("UNEXPECTED_EOF_WHILE_READING", "[SSL: CERTIFICATE_VERIFY_FAILED]"):
+            with self.subTest(detail=detail), tempfile.TemporaryDirectory() as temporary:
+                calls = []
+
+                def runner(command, **_kwargs):
+                    calls.append(command)
+                    return SimpleNamespace(returncode=1, stdout="", stderr=detail)
+
+                with mock.patch.object(module.time, "sleep") as sleep:
+                    with self.assertRaisesRegex(RuntimeError, detail):
+                        module._run_transient_mempalace_mine(
+                            ["/tools/mempalace", "mine", "."], Path(temporary), runner=runner
+                        )
+
+                self.assertEqual([["/tools/mempalace", "mine", "."]], calls)
+                sleep.assert_not_called()
+
+    def test_mempalace_retry_preserves_the_shared_deadline(self):
+        module = load_controller()
+        with tempfile.TemporaryDirectory() as temporary:
+            calls = []
+
+            def runner(command, **_kwargs):
+                calls.append(command)
+                return SimpleNamespace(
+                    returncode=1,
+                    stdout="",
+                    stderr="[SSL: UNEXPECTED_EOF_WHILE_READING]",
+                )
+
+            with mock.patch.object(module.time, "monotonic", side_effect=(0, 0, 899)), mock.patch.object(module.time, "sleep") as sleep:
+                with self.assertRaisesRegex(RuntimeError, "UNEXPECTED_EOF_WHILE_READING"):
+                    module._run_transient_mempalace_mine(
+                        ["/tools/mempalace", "mine", "."], Path(temporary), runner=runner
+                    )
+
+            self.assertEqual([["/tools/mempalace", "mine", "."]], calls)
+            sleep.assert_not_called()
 
     def test_project_setup_skips_a_repository_resolver(self):
         module = load_controller()

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -639,6 +639,96 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             module.mark_mempalace_project_setup(project)
             self.assertEqual(b"current\n", marker.read_bytes())
 
+    def test_account_setup_retries_two_transient_mempalace_tls_eofs(self):
+        module = load_controller()
+        specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        commands = {"mempalace": "/tools/mempalace", "uv": "/tools/uv", "npm": "/tools/npm"}
+        local = {
+            name: {"healthy": True, "version": "1.0", "detail": "passed"}
+            for name in ("uv", "python", "node", "java", "mempalace", "graphify", "memory", "context7")
+        }
+        actions = {name: {"action": "reused"} for name in local}
+
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            mine = [commands["mempalace"], "mine", "."]
+            calls = []
+
+            def runner(command, **kwargs):
+                calls.append((command, kwargs["env"], kwargs["timeout"]))
+                palace = project / ".chaos-engine-state/mempalace"
+                palace.mkdir(parents=True, exist_ok=True)
+                palace.joinpath("sqlite_exact.sqlite3").write_bytes(b"SQLite format 3\x00")
+                if len(calls) < 3:
+                    return SimpleNamespace(returncode=1, stdout="", stderr="TLS UNEXPECTED_EOF")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with mock.patch.object(module, "discover_account_commands", side_effect=((local, commands), (local, commands))), mock.patch.object(module, "resolve_account_actions", return_value=actions), mock.patch.object(module, "project_setup_plan", return_value=[mine]), mock.patch.object(module.time, "monotonic", return_value=0), mock.patch.object(module.time, "sleep") as sleep:
+                module.install_account_dependencies(project, specification, runner=runner, allow_root=True)
+
+            self.assertEqual([mine, mine, mine], [command for command, _environment, _timeout in calls])
+            self.assertEqual(calls[0][1], calls[1][1])
+            self.assertEqual(calls[1][1], calls[2][1])
+            self.assertEqual([900, 900, 900], [timeout for _command, _environment, timeout in calls])
+            sleep.assert_has_calls((mock.call(1), mock.call(2)))
+            self.assertEqual(b"current\n", (project / ".chaos-engine-state/mempalace/.mined").read_bytes())
+
+    def test_account_setup_stops_after_three_transient_mempalace_tls_eofs(self):
+        module = load_controller()
+        specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        commands = {"mempalace": "/tools/mempalace", "uv": "/tools/uv", "npm": "/tools/npm"}
+        local = {
+            name: {"healthy": True, "version": "1.0", "detail": "passed"}
+            for name in ("uv", "python", "node", "java", "mempalace", "graphify", "memory", "context7")
+        }
+        actions = {name: {"action": "reused"} for name in local}
+
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            mine = [commands["mempalace"], "mine", "."]
+            calls = []
+
+            def transient_failure(command, **kwargs):
+                calls.append(command)
+                palace = project / ".chaos-engine-state/mempalace"
+                palace.mkdir(parents=True, exist_ok=True)
+                palace.joinpath("sqlite_exact.sqlite3").write_bytes(b"SQLite format 3\x00")
+                return SimpleNamespace(returncode=1, stdout="", stderr="TLS UNEXPECTED_EOF")
+
+            with mock.patch.object(module, "discover_account_commands", side_effect=((local, commands), (local, commands))), mock.patch.object(module, "resolve_account_actions", return_value=actions), mock.patch.object(module, "project_setup_plan", return_value=[mine]), mock.patch.object(module.time, "monotonic", return_value=0), mock.patch.object(module.time, "sleep") as sleep:
+                with self.assertRaisesRegex(RuntimeError, "TLS UNEXPECTED_EOF"):
+                    module.install_account_dependencies(project, specification, runner=transient_failure, allow_root=True)
+
+            self.assertEqual([mine, mine, mine], calls)
+            sleep.assert_has_calls((mock.call(1), mock.call(2)))
+            self.assertFalse((project / ".chaos-engine-state/mempalace/.mined").exists())
+            self.assertFalse((project / ".chaos-engine-dependencies.json").exists())
+
+    def test_account_setup_does_not_retry_permanent_mempalace_failure(self):
+        module = load_controller()
+        specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        commands = {"mempalace": "/tools/mempalace", "uv": "/tools/uv", "npm": "/tools/npm"}
+        local = {
+            name: {"healthy": True, "version": "1.0", "detail": "passed"}
+            for name in ("uv", "python", "node", "java", "mempalace", "graphify", "memory", "context7")
+        }
+        actions = {name: {"action": "reused"} for name in local}
+
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            mine = [commands["mempalace"], "mine", "."]
+            calls = []
+
+            def permanent_failure(command, **kwargs):
+                calls.append(command)
+                return SimpleNamespace(returncode=1, stdout="", stderr="invalid project configuration")
+
+            with mock.patch.object(module, "discover_account_commands", side_effect=((local, commands), (local, commands))), mock.patch.object(module, "resolve_account_actions", return_value=actions), mock.patch.object(module, "project_setup_plan", return_value=[mine]):
+                with self.assertRaisesRegex(RuntimeError, "invalid project configuration"):
+                    module.install_account_dependencies(project, specification, runner=permanent_failure, allow_root=True)
+
+            self.assertEqual([mine], calls)
+
     def test_project_setup_skips_a_repository_resolver(self):
         module = load_controller()
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -748,6 +748,42 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
                 self.assertEqual([["/tools/mempalace", "mine", "."]], calls)
                 sleep.assert_not_called()
 
+    def test_mempalace_retry_classifies_full_captured_output(self):
+        module = load_controller()
+        signature = "[SSL: UNEXPECTED_EOF_WHILE_READING]"
+        for stderr, stdout in (("x" * 501 + signature, ""), ("unrelated stderr", signature)):
+            with self.subTest(stderr=stderr[:20], stdout=stdout), tempfile.TemporaryDirectory() as temporary:
+                calls = []
+
+                def runner(command, **_kwargs):
+                    calls.append(command)
+                    if len(calls) < 3:
+                        return SimpleNamespace(returncode=1, stdout=stdout, stderr=stderr)
+                    return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+                with mock.patch.object(module.time, "monotonic", return_value=0), mock.patch.object(module.time, "sleep") as sleep:
+                    module._run_transient_mempalace_mine(
+                        ["/tools/mempalace", "mine", "."], Path(temporary), runner=runner
+                    )
+
+                self.assertEqual(3, len(calls))
+                sleep.assert_has_calls((mock.call(1), mock.call(2)))
+
+    def test_account_command_error_keeps_public_output_bounded(self):
+        module = load_controller()
+        signature = "[SSL: UNEXPECTED_EOF_WHILE_READING]"
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaisesRegex(RuntimeError, "dependency command failed") as error:
+                module._run_account_command(
+                    ["/tools/mempalace", "mine", "."],
+                    Path(temporary),
+                    runner=lambda *_args, **_kwargs: SimpleNamespace(
+                        returncode=1, stdout="", stderr="x" * 501 + signature
+                    ),
+                )
+
+        self.assertNotIn(signature, str(error.exception))
+
     def test_mempalace_retry_preserves_the_shared_deadline(self):
         module = load_controller()
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -222,7 +222,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             agent = module.ChaosEngineCodex(
                 harness_source=str(ROOT / "chaos-engine"),
                 harness_commit="0481767def7c31fe144bc20543dfe937b8ffd4d5",
-                harness_sha256="758e57468fe31170ac9e66839e13ae2a4ab02c8ccf610ca33bc31a2d1f80e375",
+                harness_sha256="221f988ded1f6f51e4c864bd03f690651ff6db0974e58f7c9535f301e1ad7bda",
                 adapter_sha256="3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             )
 

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -222,7 +222,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             agent = module.ChaosEngineCodex(
                 harness_source=str(ROOT / "chaos-engine"),
                 harness_commit="0481767def7c31fe144bc20543dfe937b8ffd4d5",
-                harness_sha256="ef5977da8d7757b07be8b098fa381e8e9135dd6d93bdc31d30365aeac813845e",
+                harness_sha256="758e57468fe31170ac9e66839e13ae2a4ab02c8ccf610ca33bc31a2d1f80e375",
                 adapter_sha256="3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             )
 

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -222,7 +222,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             agent = module.ChaosEngineCodex(
                 harness_source=str(ROOT / "chaos-engine"),
                 harness_commit="0481767def7c31fe144bc20543dfe937b8ffd4d5",
-                harness_sha256="221f988ded1f6f51e4c864bd03f690651ff6db0974e58f7c9535f301e1ad7bda",
+                harness_sha256="184616dda0fbbba87782bbe44ab325eb989f8c39d6ec601334361f7101038bfb",
                 adapter_sha256="3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             )
 


### PR DESCRIPTION
Implements bounded dependency-acquisition recovery work for #5462.

Retries only the resolved local MemPalace mine command after the exact transient TLS EOF signature, with three total attempts, 1s/2s backoff, and a shared 900-second setup budget. Permanent failures remain fail-closed and project completion markers and receipts are only written after success.

Refreshes the immutable public ChaosGauge harness and treatment identities. No canary or pilot was run.