### PR TITLE
fix(ci): parse canonical Allure 2 and 3 summaries

### DIFF
--- a/.github/actions/post-test-report/action.yml
+++ b/.github/actions/post-test-report/action.yml
@@ -137,17 +137,21 @@ runs:
             if not isinstance(document, dict):
                 raise ValueError("root must be an object")
             fields = ("total", "passed", "failed", "broken", "skipped", "unknown")
-            has_flat_statistics = any(field in document for field in fields)
-            if (has_flat_statistics and "statistic" in document) or (
-                "duration" in document and "time" in document
-            ):
+            has_root_verdicts = any(field in document for field in fields)
+            has_allure3_statistics = "stats" in document
+            has_allure2_statistics = "statistic" in document
+            if has_allure3_statistics and has_allure2_statistics:
                 raise ValueError("contains ambiguous mixed schemas")
-            if (has_flat_statistics and "time" in document) or (
-                not has_flat_statistics and "duration" in document
+            if has_root_verdicts and (has_allure3_statistics or has_allure2_statistics):
+                raise ValueError("contains root verdicts beside statistics container")
+            if "duration" in document and "time" in document:
+                raise ValueError("contains ambiguous mixed schemas")
+            if (has_allure3_statistics and "time" in document) or (
+                has_allure2_statistics and "duration" in document
             ):
                 raise ValueError("timing schema does not match statistics")
-            if has_flat_statistics:
-                statistic = document
+            if has_allure3_statistics:
+                statistic = document.get("stats")
                 timing = document
             else:
                 statistic = document.get("statistic")

--- a/tests/scripts/test_post_test_report_action.py
+++ b/tests/scripts/test_post_test_report_action.py
@@ -14,7 +14,7 @@ ACTION = ROOT / ".github/actions/post-test-report/action.yml"
 
 class PostTestReportActionTest(unittest.TestCase):
     def run_summary(self, *, total, passed, failed, broken, skipped, unknown=None,
-                    schema="nested", duration=None, document_updates=None):
+                    schema="allure2", duration=None, document_updates=None):
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
         step = next(step for step in action["runs"]["steps"]
                     if step.get("id") == "collect_results")
@@ -35,8 +35,13 @@ class PostTestReportActionTest(unittest.TestCase):
             }
             if unknown is not None:
                 statistic["unknown"] = unknown
-            if schema == "flat":
-                document = dict(statistic)
+            if schema == "allure3":
+                statistic.update({"new": 2, "retries": 3})
+                document = {
+                    "stats": statistic,
+                    "reportName": "SHAFT",
+                    "metadata": {"generatedBy": "allure3"},
+                }
                 if duration is not None:
                     document["duration"] = duration
             else:
@@ -75,10 +80,10 @@ class PostTestReportActionTest(unittest.TestCase):
 
         self.assertEqual(0, completed.returncode, completed.stdout)
 
-    def test_accepts_flat_allure3_statistics_with_unknown_entries(self):
+    def test_accepts_real_allure3_summary_with_unknown_entries_and_metadata(self):
         completed = self.run_summary(
             total=1434, passed=1408, failed=0, broken=0, skipped=12, unknown=14,
-            schema="flat", duration=123456
+            schema="allure3", duration=123456
         )
 
         self.assertEqual(0, completed.returncode, completed.stdout)
@@ -100,9 +105,9 @@ class PostTestReportActionTest(unittest.TestCase):
 
         self.assertEqual(0, completed.returncode, completed.stdout)
 
-    def test_rejects_mixed_flat_and_nested_statistics(self):
+    def test_rejects_both_allure_statistics_containers(self):
         completed = self.run_summary(
-            total=1, passed=1, failed=0, broken=0, skipped=0, schema="flat",
+            total=1, passed=1, failed=0, broken=0, skipped=0, schema="allure3",
             document_updates={
                 "statistic": {"total": 1, "passed": 0, "failed": 1, "broken": 0, "skipped": 0}
             },
@@ -111,7 +116,7 @@ class PostTestReportActionTest(unittest.TestCase):
         self.assertNotEqual(0, completed.returncode)
         self.assertIn("ambiguous mixed schemas", completed.stderr)
 
-    def test_rejects_mixed_nested_time_and_flat_duration(self):
+    def test_rejects_dual_timing_containers(self):
         completed = self.run_summary(
             total=1, passed=1, failed=0, broken=0, skipped=0, duration=10,
             document_updates={"duration": 10},
@@ -120,10 +125,10 @@ class PostTestReportActionTest(unittest.TestCase):
         self.assertNotEqual(0, completed.returncode)
         self.assertIn("ambiguous mixed schemas", completed.stderr)
 
-    def test_rejects_timing_schema_that_does_not_match_statistics(self):
+    def test_rejects_cross_schema_timing(self):
         cases = (
-            ("nested-statistics-flat-duration", "nested", {"duration": 10}),
-            ("flat-statistics-nested-time", "flat", {"time": {"duration": 10}}),
+            ("allure2-statistics-allure3-duration", "allure2", {"duration": 10}),
+            ("allure3-statistics-allure2-time", "allure3", {"time": {"duration": 10}}),
         )
         for name, schema, document_updates in cases:
             with self.subTest(name=name):
@@ -142,7 +147,7 @@ class PostTestReportActionTest(unittest.TestCase):
             ("string", {"passed": "1", "skipped": 1}),
             ("boolean", {"passed": 1, "unknown": True}),
         )
-        for schema in ("nested", "flat"):
+        for schema in ("allure2", "allure3"):
             for name, overrides in cases:
                 values = {"total": 1, "passed": 0, "failed": 0, "broken": 0, "skipped": 0}
                 values.update(overrides)
@@ -151,6 +156,17 @@ class PostTestReportActionTest(unittest.TestCase):
 
                     self.assertNotEqual(0, completed.returncode)
                     self.assertIn("expected a non-negative integer", completed.stderr)
+
+    def test_rejects_root_verdicts_beside_statistics_container(self):
+        for schema in ("allure2", "allure3"):
+            with self.subTest(schema=schema):
+                completed = self.run_summary(
+                    total=1, passed=1, failed=0, broken=0, skipped=0,
+                    schema=schema, document_updates={"passed": 1},
+                )
+
+                self.assertNotEqual(0, completed.returncode)
+                self.assertIn("root verdicts beside statistics container", completed.stderr)
 
     def test_preserves_failed_and_broken_verdict_failures(self):
         for failed, broken in ((1, 0), (0, 1)):


### PR DESCRIPTION
## Summary

- parse canonical Allure 3 `stats` summaries and Allure 2 `statistic` summaries
- bind each statistics schema to its matching duration location
- reject ambiguous containers, root verdict fields, cross-schema timing, and malformed counts

## Root cause

The previous follow-up treated Allure 3 statistics as root-level verdict fields. The official Allure 3 plugin summary stores verdicts in `stats` and duration at the root, while Allure 2 stores verdicts in `statistic` and duration in `time.duration`. As a result, a valid Firefox Allure 3 summary was rejected even though 1,425 browser tests passed.

## Validation

- 12 focused post-test-report action tests pass
- action YAML parses successfully
- `git diff --check` passes

Related to #5474
Related to #5475
