### PR TITLE
test: remove Firefox invalid-navigation race

### DIFF
--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.shaft.driver.SHAFT;
+import com.shaft.gui.browser.internal.BrowserActionsHelper;
 import com.shaft.tools.io.ReportManager;
 import io.qameta.allure.Allure;
 import io.qameta.allure.FileSystemResultsWriter;
@@ -122,16 +123,20 @@ public class AllureActionStepReportingTest extends Tests {
 
     @Test
     public void failedNavigateAgainstInvalidUrlBodyWritesExactlyOneFailedAllureStep() throws IOException {
-        String url = TestPageServer.url("navigationErrorFixture.html");
-        SHAFT.Properties.flags.set().forceCheckNavigationWasSuccessful(true);
+        driver.get().quit();
+        SHAFT.Properties.web.set().pageLoadStrategy("normal");
+        SHAFT.Properties.web.set().readinessState("complete");
+        driver.set(new SHAFT.GUI.WebDriver());
+        String url = "data:text/html;charset=utf-8,Invalid%20URL";
+        driver.get().getDriver().navigate().to(url);
         RuntimeException thrown = null;
         try {
-            driver.get().browser().navigateToURL(url);
+            new BrowserActionsHelper(false).confirmThatWebsiteIsNotDown(driver.get().getDriver(), url);
         } catch (RuntimeException exception) {
             thrown = exception;
         }
         Assert.assertNotNull(thrown,
-                "forceCheckNavigationWasSuccessful against navigationErrorFixture.html must fail navigateToURL.");
+                "confirmThatWebsiteIsNotDown against inline invalid URL HTML must fail.");
 
         JsonObject result = snapshotCurrentAllureResult();
         List<JsonObject> failedStepsForUrl = actionSteps(result, step ->


### PR DESCRIPTION
## Summary

- make the invalid-URL Allure-step assertion use a fully loaded inline document
- call the reporting helper directly after deterministic raw-driver navigation
- preserve the sibling public `navigateToURL` coverage

## Root cause

The test used SHAFT's default `pageLoadStrategy=none` and `readinessState=none`. On Firefox Grid, `navigateToURL` could inspect page source before the fixture response body arrived, so the expected `Invalid URL` failure intermittently disappeared. This restores the proven test-only resolution from #5405 without sleeps, retries, or production changes.

## Validation

- formerly flaky focused method passed 5 independent headless runs
- sibling public `navigateToURL` Allure-step test passed
- `git diff --check` passed

Related to #5474
Related to #5475
