### PR TITLE
fix: permit pinned Chroma model acquisition

### DIFF
--- a/.github/workflows/chaos-gauge-public-canary.yml
+++ b/.github/workflows/chaos-gauge-public-canary.yml
@@ -69,6 +69,7 @@ jobs:
         working-directory: public
         run: |
           uv pip install --system --require-hashes --requirement scripts/ci/chaos_gauge/requirements.lock
+          python3 scripts/ci/chaos_gauge/validate_harbor_network_policy.py
           npm install --global @openai/codex@0.118.0
           docker version --format '{{.Server.Version}}'
       - id: docker-baseline

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -336,7 +336,7 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | graphify | Managed commands: graphify; packages: graphifyy==0.9.43, tree-sitter-sql==0.3.11. | chaos-engine/dependencies.json | required | Windows, Linux, macOS | immutable generation installer | installer receipt | repair full candidate or retain prior active generation |
 | memory | Managed commands: memory, memory-mcp; packages: @aictx/memory@0.2.1. | chaos-engine/dependencies.json | required | Windows, Linux, macOS | immutable generation installer | installer receipt | repair full candidate or retain prior active generation |
-| mempalace | Managed commands: mempalace, mempalace-mcp; packages: mempalace==3.8.0. | chaos-engine/dependencies.json | required | Windows, Linux, macOS | immutable generation installer | installer receipt | repair full candidate or retain prior active generation |
+| mempalace | Managed commands: mempalace, mempalace-mcp; packages: mempalace==3.8.0, chromadb==1.5.9. | chaos-engine/dependencies.json | required | Windows, Linux, macOS | immutable generation installer | installer receipt | repair full candidate or retain prior active generation |
 | uv | Managed commands: uv; packages: uv==0.11.29. | chaos-engine/dependencies.json | required | Windows, Linux, macOS | immutable generation installer | installer receipt | repair full candidate or retain prior active generation |
 <!-- inventory:managed-dependencies:end -->
 

--- a/chaos-engine/dependencies.json
+++ b/chaos-engine/dependencies.json
@@ -41,7 +41,7 @@
   },
   "tools": {
     "uv": {"package": "uv==0.11.29"},
-    "mempalace": {"package": "mempalace==3.8.0", "commands": ["mempalace", "mempalace-mcp"]},
+    "mempalace": {"package": "mempalace==3.8.0", "with": ["chromadb==1.5.9"], "commands": ["mempalace", "mempalace-mcp"]},
     "graphify": {"package": "graphifyy==0.9.43", "with": ["tree-sitter-sql==0.3.11"], "commands": ["graphify"]},
     "memory": {"package": "@aictx/memory@0.2.1", "commands": ["memory", "memory-mcp"]}
   },

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -223,12 +223,19 @@ def account_tool_plan(
     *,
     actions: dict[str, str],
     executables: dict[str, str],
+    resolved_versions: dict[str, str | None] | None = None,
 ) -> dict[str, list[list[str]]]:
     """Render user-scope tool commands; project initialization is a separate phase."""
     del project
     validate_runtime_specification(specification)
     uv = executables["uv"]
     npm = executables["npm"]
+
+    def resolved_package(name: str, package: str, separator: str) -> str:
+        version = (resolved_versions or {}).get(name)
+        if not version or name == "mempalace":
+            return package
+        return f"{package.rsplit(separator, 1)[0]}{separator}{version}"
 
     def uv_commands(
         name: str, package: str, extra: tuple[str, ...] = ()
@@ -237,12 +244,15 @@ def account_tool_plan(
         options = [item for dependency in extra for item in ("--with", dependency)]
         if action in {"installed", "upgraded", "repaired"}:
             force = ["--force"] if action in {"upgraded", "repaired"} else []
-            return [[uv, "tool", "install", *force, *options, package]]
+            return [[
+                uv, "tool", "install", *force, *options,
+                resolved_package(name, package, "=="),
+            ]]
         return []
 
     def npm_commands(name: str, package: str) -> list[list[str]]:
         return (
-            [[npm, "install", "-g", package]]
+            [[npm, "install", "-g", resolved_package(name, package, "@")]]
             if actions.get(name) in {"installed", "upgraded", "repaired"}
             else []
         )
@@ -934,6 +944,11 @@ def install_account_dependencies(  # noqa: MC0001 - preflight then ordered accou
         specification,
         actions=tool_actions,
         executables={"uv": commands["uv"], "npm": commands["npm"]},
+        resolved_versions={
+            name: actions[name].get("resolvedVersion")
+            if isinstance(actions[name].get("resolvedVersion"), str) else None
+            for name in tool_actions
+        },
     ).items():
         for command in planned:
             _run_account_command(command, project, runner=runner)

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -53,6 +53,8 @@ REQUIRED_DISPATCHES = {
     "memory",
     "memory-mcp",
 }
+PINNED_MEMPALACE_PACKAGE = "mempalace==3.8.0"
+PINNED_MEMPALACE_WITH = ("chromadb==1.5.9",)
 WINDOWS_UV_JUNCTION_TAG = 0xA0000003
 WINDOWS_UV_ALIAS = re.compile(
     r"uv-python/cpython-(?P<version>3\.\d+)-windows-(?P<arch>x86_64|aarch64)-none"
@@ -207,8 +209,7 @@ def account_tool_plan(
 ) -> dict[str, list[list[str]]]:
     """Render user-scope tool commands; project initialization is a separate phase."""
     del project
-    if specification.get("schemaVersion") != 3:
-        raise ValueError("dependency specification schema is unsupported")
+    validate_runtime_specification(specification)
     uv = executables["uv"]
     npm = executables["npm"]
 
@@ -217,10 +218,9 @@ def account_tool_plan(
     ) -> list[list[str]]:
         action = actions.get(name)
         options = [item for dependency in extra for item in ("--with", dependency)]
-        if action in {"installed", "repaired"}:
-            return [[uv, "tool", "install", *options, package]]
-        if action == "upgraded":
-            return [[uv, "tool", "upgrade", *options, package]]
+        if action in {"installed", "upgraded", "repaired"}:
+            force = ["--force"] if action in {"upgraded", "repaired"} else []
+            return [[uv, "tool", "install", *force, *options, package]]
         return []
 
     def npm_commands(name: str, package: str) -> list[list[str]]:
@@ -235,7 +235,10 @@ def account_tool_plan(
             "mempalace", str(specification["tools"]["mempalace"]["package"]),
             tuple(specification["tools"]["mempalace"].get("with", [])),
         ),
-        "graphify": uv_commands("graphify", "graphifyy"),
+        "graphify": uv_commands(
+            "graphify", str(specification["tools"]["graphify"]["package"]),
+            tuple(specification["tools"]["graphify"].get("with", [])),
+        ),
         "memory": npm_commands("memory", "@aictx/memory@latest"),
         "context7": npm_commands("context7", "ctx7@latest"),
     }
@@ -467,6 +470,12 @@ def discover_account_commands(
         probed = probe_account_dependency(
             name, sibling_paths[primary], value, runner=runner
         )
+        if (
+            name == "mempalace"
+            and probed["version"]
+            != PINNED_MEMPALACE_PACKAGE.removeprefix("mempalace==")
+        ):
+            probed = {**probed, "healthy": False, "detail": "version-mismatch"}
         components[name] = {
             "status": "healthy" if probed["healthy"] else "broken",
             **probed,
@@ -483,7 +492,9 @@ def resolve_account_actions(
     opener=urllib.request.urlopen,
 ) -> dict[str, dict[str, object]]:
     """Combine local health with independently attempted stable-channel resolution."""
+    validate_runtime_specification(specification)
     contracts = specification["dependencies"]
+    pinned_mempalace_version = PINNED_MEMPALACE_PACKAGE.removeprefix("mempalace==")
     resolved: dict[str, dict[str, object]] = {}
     for name, contract in contracts.items():  # type: ignore[union-attr]
         if name == "maven-tools-mcp":
@@ -492,11 +503,15 @@ def resolve_account_actions(
         latest = None
         verified = False
         lookup_error = None
-        try:
-            latest = resolve_stable_version(name, contract, opener=opener)
+        if name == "mempalace":
+            latest = pinned_mempalace_version
             verified = True
-        except (OSError, ValueError, json.JSONDecodeError) as error:
-            lookup_error = type(error).__name__
+        else:
+            try:
+                latest = resolve_stable_version(name, contract, opener=opener)
+                verified = True
+            except (OSError, ValueError, json.JSONDecodeError) as error:
+                lookup_error = type(error).__name__
         installed = record.get("version") if isinstance(record.get("version"), str) else None
         healthy = record.get("healthy") is True
         action = dependency_action(
@@ -975,11 +990,21 @@ def validate_runtime_specification(specification: dict[str, object]) -> None:
         raise ValueError("dependency specification schema is unsupported")
     if specification.get("schemaVersion") == 3:
         dependencies = specification.get("dependencies")
+        tools = specification.get("tools")
         if not isinstance(dependencies, dict) or not {
             "uv", "python", "node", "java", "mempalace", "graphify", "memory", "context7",
             "maven-tools-mcp",
         } <= set(dependencies):
             raise ValueError("account dependency specification is invalid")
+        if not isinstance(tools, dict):
+            raise ValueError("tool dependency specification is invalid")
+        mempalace = tools.get("mempalace")
+        if (
+            not isinstance(mempalace, dict)
+            or mempalace.get("package") != PINNED_MEMPALACE_PACKAGE
+            or mempalace.get("with") != list(PINNED_MEMPALACE_WITH)
+        ):
+            raise ValueError("MemPalace tool dependency pin is invalid")
         for name, contract in dependencies.items():
             if (
                 not isinstance(contract, dict)
@@ -2379,6 +2404,8 @@ def generation_environment(generation: Path, transaction: Path) -> dict[str, str
 def generation_install_plan(
     generation: Path, specification: dict[str, object]
 ) -> dict[str, list[list[str]]]:
+    if specification.get("schemaVersion") == 3:
+        validate_runtime_specification(specification)
     tools = specification.get("tools")
     if specification.get("schemaVersion") not in {2, 3} or not isinstance(tools, dict):
         raise ValueError("dependency specification schema is unsupported")
@@ -3448,6 +3475,8 @@ def finalize_generation_remove(project: Path) -> None:
 
 
 def install_plan(runtime: Path, specification: dict[str, object]) -> dict[str, list[list[str]]]:
+    if specification.get("schemaVersion") == 3:
+        validate_runtime_specification(specification)
     tools = specification.get("tools")
     if specification.get("schemaVersion") not in {2, 3} or not isinstance(tools, dict):
         raise ValueError("dependency specification schema is unsupported")

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -55,6 +55,23 @@ REQUIRED_DISPATCHES = {
 }
 PINNED_MEMPALACE_PACKAGE = "mempalace==3.8.0"
 PINNED_MEMPALACE_WITH = ("chromadb==1.5.9",)
+SCHEMA3_TOOLS = {
+    "uv": {"package": "uv==0.11.29"},
+    "mempalace": {
+        "package": PINNED_MEMPALACE_PACKAGE,
+        "with": list(PINNED_MEMPALACE_WITH),
+        "commands": ["mempalace", "mempalace-mcp"],
+    },
+    "graphify": {
+        "package": "graphifyy==0.9.43",
+        "with": ["tree-sitter-sql==0.3.11"],
+        "commands": ["graphify"],
+    },
+    "memory": {
+        "package": "@aictx/memory@0.2.1",
+        "commands": ["memory", "memory-mcp"],
+    },
+}
 WINDOWS_UV_JUNCTION_TAG = 0xA0000003
 WINDOWS_UV_ALIAS = re.compile(
     r"uv-python/cpython-(?P<version>3\.\d+)-windows-(?P<arch>x86_64|aarch64)-none"
@@ -239,7 +256,9 @@ def account_tool_plan(
             "graphify", str(specification["tools"]["graphify"]["package"]),
             tuple(specification["tools"]["graphify"].get("with", [])),
         ),
-        "memory": npm_commands("memory", "@aictx/memory@latest"),
+        "memory": npm_commands(
+            "memory", str(specification["tools"]["memory"]["package"])
+        ),
         "context7": npm_commands("context7", "ctx7@latest"),
     }
 
@@ -998,13 +1017,8 @@ def validate_runtime_specification(specification: dict[str, object]) -> None:
             raise ValueError("account dependency specification is invalid")
         if not isinstance(tools, dict):
             raise ValueError("tool dependency specification is invalid")
-        mempalace = tools.get("mempalace")
-        if (
-            not isinstance(mempalace, dict)
-            or mempalace.get("package") != PINNED_MEMPALACE_PACKAGE
-            or mempalace.get("with") != list(PINNED_MEMPALACE_WITH)
-        ):
-            raise ValueError("MemPalace tool dependency pin is invalid")
+        if tools != SCHEMA3_TOOLS:
+            raise ValueError("tool dependency specification is not the exact schema v3 contract")
         for name, contract in dependencies.items():
             if (
                 not isinstance(contract, dict)

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -212,12 +212,15 @@ def account_tool_plan(
     uv = executables["uv"]
     npm = executables["npm"]
 
-    def uv_commands(name: str, package: str) -> list[list[str]]:
+    def uv_commands(
+        name: str, package: str, extra: tuple[str, ...] = ()
+    ) -> list[list[str]]:
         action = actions.get(name)
+        options = [item for dependency in extra for item in ("--with", dependency)]
         if action in {"installed", "repaired"}:
-            return [[uv, "tool", "install", package]]
+            return [[uv, "tool", "install", *options, package]]
         if action == "upgraded":
-            return [[uv, "tool", "upgrade", package]]
+            return [[uv, "tool", "upgrade", *options, package]]
         return []
 
     def npm_commands(name: str, package: str) -> list[list[str]]:
@@ -228,7 +231,10 @@ def account_tool_plan(
         )
 
     return {
-        "mempalace": uv_commands("mempalace", "mempalace"),
+        "mempalace": uv_commands(
+            "mempalace", str(specification["tools"]["mempalace"]["package"]),
+            tuple(specification["tools"]["mempalace"].get("with", [])),
+        ),
         "graphify": uv_commands("graphify", "graphifyy"),
         "memory": npm_commands("memory", "@aictx/memory@latest"),
         "context7": npm_commands("context7", "ctx7@latest"),
@@ -2385,12 +2391,13 @@ def generation_install_plan(
         else "node/lib/node_modules/npm/bin/npm-cli.js"
     )
     graphify = tools.get("graphify")
+    mempalace = tools.get("mempalace")
     python_runtime = specification.get("runtimes", {}).get("python", {})
     python_version = python_runtime.get("version") if isinstance(python_runtime, dict) else None
     if not isinstance(python_version, str) or re.fullmatch(r"3\.\d+", python_version) is None:
         raise ValueError("Python runtime specification is invalid")
-    if not isinstance(graphify, dict):
-        raise ValueError("graphify dependency specification is invalid")
+    if not isinstance(graphify, dict) or not isinstance(mempalace, dict):
+        raise ValueError("tool dependency specification is invalid")
     uv_commands = [[uv, "--version"]] if Path(uv).is_file() else [
         [sys.executable, "-m", "venv", "--copies", str(bootstrap)],
         [executable(bootstrap / scripts, "python"), "-m", "pip", "install", "--no-cache-dir", "--upgrade", str(tools["uv"]["package"])],  # type: ignore[index]
@@ -2407,7 +2414,9 @@ def generation_install_plan(
             python_version,
             "--link-mode",
             "copy",
-            str(tools["mempalace"]["package"]),  # type: ignore[index]
+            "--with",
+            str(mempalace["with"][0]),
+            str(mempalace["package"]),
         ]],
         "graphify": [[
             uv,
@@ -3448,15 +3457,16 @@ def install_plan(runtime: Path, specification: dict[str, object]) -> dict[str, l
     npm_prefix = runtime / "npm"
     npm = npm_executable(runtime / ("node" if os.name == "nt" else "node/bin"), "npm")
     graphify = tools["graphify"]
-    if not isinstance(graphify, dict):
-        raise ValueError("graphify dependency specification is invalid")
+    mempalace = tools["mempalace"]
+    if not isinstance(graphify, dict) or not isinstance(mempalace, dict):
+        raise ValueError("tool dependency specification is invalid")
     return {
         "uv": [
             [sys.executable, "-m", "venv", "--copies", str(environment)],
             [executable(scripts, "python"), "-m", "pip", "install", "--upgrade", str(tools["uv"]["package"])],  # type: ignore[index]
         ],
         "mempalace": [
-            [uv, "tool", "install", "--managed-python", "--link-mode", "copy", str(tools["mempalace"]["package"])],  # type: ignore[index]
+            [uv, "tool", "install", "--managed-python", "--link-mode", "copy", "--with", str(mempalace["with"][0]), str(mempalace["package"])],
         ],
         "graphify": [
             [uv, "tool", "install", "--managed-python", "--link-mode", "copy", "--with", str(graphify["with"][0]), str(graphify["package"])],  # type: ignore[index]

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "713984b045644ea2c4b3233a5b9764cb3054faf8b38b41c3c922707ff0001694",
+      "harnessSha256": "c508262b1fc5eb8d8ec4880a9a21badd822f2f6650686fd86008fe415510ce72",
       "treatmentSha256": {
-        "calibration": "e81e81c0d8d56cea3beb6b608324676f09670eb28de29b60daf6d0ca4f769efa",
-        "full-pilot": "1d34e2212981cc43b8e1253aa816544e6f180cc63918e5a20db987c2166f01f0"
+        "calibration": "9a4d25b11bd63353f9abe1b8805c9f31c09c476e547b49d52cc1aafc30989958",
+        "full-pilot": "ce6fee0c06ac8f2403a9e2648bb0c4aefcd20f081c540d3c41c56c61d8511778"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "43399970878aadf93f0f1cde927bc6de1762a398d99c3495aef9f44a3e22f0fc",
+      "harnessSha256": "713984b045644ea2c4b3233a5b9764cb3054faf8b38b41c3c922707ff0001694",
       "treatmentSha256": {
-        "calibration": "d3562c392931fb156a3537122ca1ba8f385043c55755e7bdc850a286a8922e09",
-        "full-pilot": "e38fa1aae233ac7d6edea9a720c5f95507906d452463fc2153b610515c4d7e48"
+        "calibration": "e81e81c0d8d56cea3beb6b608324676f09670eb28de29b60daf6d0ca4f769efa",
+        "full-pilot": "1d34e2212981cc43b8e1253aa816544e6f180cc63918e5a20db987c2166f01f0"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "c508262b1fc5eb8d8ec4880a9a21badd822f2f6650686fd86008fe415510ce72",
+      "harnessSha256": "7f2e6032118771bd9b75820689e1d830a8792db4d26b36c7b769d6b6a239ac0e",
       "treatmentSha256": {
-        "calibration": "9a4d25b11bd63353f9abe1b8805c9f31c09c476e547b49d52cc1aafc30989958",
-        "full-pilot": "ce6fee0c06ac8f2403a9e2648bb0c4aefcd20f081c540d3c41c56c61d8511778"
+        "calibration": "dfd84487992368761a1b7507da162760bdec3ef6a366cb0f53273a79ff7841fe",
+        "full-pilot": "568d0f28aaf12ad3ff8781ed1a6777dc6d4ed65011995f4a02e89fd78dc8744c"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "28be870ed7cca15e13f5f10ff1dcc678c8913463cb68908bad7ca60e8b4c1a79",
+      "harnessSha256": "43399970878aadf93f0f1cde927bc6de1762a398d99c3495aef9f44a3e22f0fc",
       "treatmentSha256": {
-        "calibration": "fee765a5a30f6517ecae56d43ce2a087bf397a65884157627069f389b7d3c963",
-        "full-pilot": "4e3926cc8c873abe0222026de42c3d4d11b1127b0551dda6d81cf8a59fb506ba"
+        "calibration": "d3562c392931fb156a3537122ca1ba8f385043c55755e7bdc850a286a8922e09",
+        "full-pilot": "e38fa1aae233ac7d6edea9a720c5f95507906d452463fc2153b610515c4d7e48"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -45,8 +45,8 @@
       "harness": "none",
       "harnessSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "treatmentSha256": {
-        "calibration": "577b043ac791732f048ecce50d714520f875d058bbf0aae4f207ecc36996ab6f",
-        "full-pilot": "73933bd73c6b7e05caa6ecec42df0b34b585039d2e3bb587be0c7a71504630db"
+        "calibration": "878e97de8ecffecb7538920f5ec08f13238ff3784458868391f02d4d4a802570",
+        "full-pilot": "a9e9c76ee80ee941b3d71f2c59a5272e50939f412959ebd96429eac0f0c27438"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "184616dda0fbbba87782bbe44ab325eb989f8c39d6ec601334361f7101038bfb",
+      "harnessSha256": "28be870ed7cca15e13f5f10ff1dcc678c8913463cb68908bad7ca60e8b4c1a79",
       "treatmentSha256": {
-        "calibration": "3aa3d04bd8562135c08ea67ed3e4a4da72a8684daabd2d5429d6a832e98be4dc",
-        "full-pilot": "c4aaa847f05f0a419ea99ad8cd75abf7fa8a113f5f2e6c7f2d5f14dc41f44298"
+        "calibration": "fee765a5a30f6517ecae56d43ce2a087bf397a65884157627069f389b7d3c963",
+        "full-pilot": "4e3926cc8c873abe0222026de42c3d4d11b1127b0551dda6d81cf8a59fb506ba"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "43399970878aadf93f0f1cde927bc6de1762a398d99c3495aef9f44a3e22f0fc"
+      harness_sha256: "713984b045644ea2c4b3233a5b9764cb3054faf8b38b41c3c922707ff0001694"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -8,6 +8,7 @@ environment:
   delete: true
   cpu_enforcement_policy: limit
   memory_enforcement_policy: limit
+  extra_allowed_hosts: [chroma-onnx-models.s3.amazonaws.com]
 retry:
   max_retries: 2
   include_exceptions:
@@ -22,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "184616dda0fbbba87782bbe44ab325eb989f8c39d6ec601334361f7101038bfb"
+      harness_sha256: "28be870ed7cca15e13f5f10ff1dcc678c8913463cb68908bad7ca60e8b4c1a79"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "713984b045644ea2c4b3233a5b9764cb3054faf8b38b41c3c922707ff0001694"
+      harness_sha256: "c508262b1fc5eb8d8ec4880a9a21badd822f2f6650686fd86008fe415510ce72"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "28be870ed7cca15e13f5f10ff1dcc678c8913463cb68908bad7ca60e8b4c1a79"
+      harness_sha256: "43399970878aadf93f0f1cde927bc6de1762a398d99c3495aef9f44a3e22f0fc"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "c508262b1fc5eb8d8ec4880a9a21badd822f2f6650686fd86008fe415510ce72"
+      harness_sha256: "7f2e6032118771bd9b75820689e1d830a8792db4d26b36c7b769d6b6a239ac0e"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/control.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/control.yaml
@@ -8,6 +8,7 @@ environment:
   delete: true
   cpu_enforcement_policy: limit
   memory_enforcement_policy: limit
+  extra_allowed_hosts: [chroma-onnx-models.s3.amazonaws.com]
 retry:
   max_retries: 2
   include_exceptions:

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -9,6 +9,7 @@ environment:
   delete: true
   cpu_enforcement_policy: limit
   memory_enforcement_policy: limit
+  extra_allowed_hosts: [chroma-onnx-models.s3.amazonaws.com]
 retry:
   max_retries: 2
   include_exceptions: [EnvironmentStartError, EnvironmentBuildError]
@@ -21,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "184616dda0fbbba87782bbe44ab325eb989f8c39d6ec601334361f7101038bfb"
+      harness_sha256: "28be870ed7cca15e13f5f10ff1dcc678c8913463cb68908bad7ca60e8b4c1a79"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "28be870ed7cca15e13f5f10ff1dcc678c8913463cb68908bad7ca60e8b4c1a79"
+      harness_sha256: "43399970878aadf93f0f1cde927bc6de1762a398d99c3495aef9f44a3e22f0fc"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "c508262b1fc5eb8d8ec4880a9a21badd822f2f6650686fd86008fe415510ce72"
+      harness_sha256: "7f2e6032118771bd9b75820689e1d830a8792db4d26b36c7b769d6b6a239ac0e"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "713984b045644ea2c4b3233a5b9764cb3054faf8b38b41c3c922707ff0001694"
+      harness_sha256: "c508262b1fc5eb8d8ec4880a9a21badd822f2f6650686fd86008fe415510ce72"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "43399970878aadf93f0f1cde927bc6de1762a398d99c3495aef9f44a3e22f0fc"
+      harness_sha256: "713984b045644ea2c4b3233a5b9764cb3054faf8b38b41c3c922707ff0001694"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-control.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-control.yaml
@@ -9,6 +9,7 @@ environment:
   delete: true
   cpu_enforcement_policy: limit
   memory_enforcement_policy: limit
+  extra_allowed_hosts: [chroma-onnx-models.s3.amazonaws.com]
 retry:
   max_retries: 2
   include_exceptions: [EnvironmentStartError, EnvironmentBuildError]

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -351,7 +351,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),
-                "harness_sha256": "c508262b1fc5eb8d8ec4880a9a21badd822f2f6650686fd86008fe415510ce72",
+                "harness_sha256": "7f2e6032118771bd9b75820689e1d830a8792db4d26b36c7b769d6b6a239ac0e",
                 "adapter_sha256": "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             }
             if kwargs != expected:

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -351,7 +351,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),
-                "harness_sha256": "713984b045644ea2c4b3233a5b9764cb3054faf8b38b41c3c922707ff0001694",
+                "harness_sha256": "c508262b1fc5eb8d8ec4880a9a21badd822f2f6650686fd86008fe415510ce72",
                 "adapter_sha256": "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             }
             if kwargs != expected:

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -351,7 +351,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),
-                "harness_sha256": "43399970878aadf93f0f1cde927bc6de1762a398d99c3495aef9f44a3e22f0fc",
+                "harness_sha256": "713984b045644ea2c4b3233a5b9764cb3054faf8b38b41c3c922707ff0001694",
                 "adapter_sha256": "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             }
             if kwargs != expected:

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -311,6 +311,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
         expected_environment = {
             "type": "docker", "delete": True,
             "cpu_enforcement_policy": "limit", "memory_enforcement_policy": "limit",
+            "extra_allowed_hosts": ["chroma-onnx-models.s3.amazonaws.com"],
         }
         if job.get("environment") != expected_environment:
             raise ValueError("Harbor environment budget drift is not allowed")
@@ -350,7 +351,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),
-                "harness_sha256": "184616dda0fbbba87782bbe44ab325eb989f8c39d6ec601334361f7101038bfb",
+                "harness_sha256": "28be870ed7cca15e13f5f10ff1dcc678c8913463cb68908bad7ca60e8b4c1a79",
                 "adapter_sha256": "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             }
             if kwargs != expected:

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -351,7 +351,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),
-                "harness_sha256": "28be870ed7cca15e13f5f10ff1dcc678c8913463cb68908bad7ca60e8b4c1a79",
+                "harness_sha256": "43399970878aadf93f0f1cde927bc6de1762a398d99c3495aef9f44a3e22f0fc",
                 "adapter_sha256": "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             }
             if kwargs != expected:

--- a/scripts/ci/chaos_gauge/validate_harbor_network_policy.py
+++ b/scripts/ci/chaos_gauge/validate_harbor_network_policy.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Exercise Harbor 0.22's phase-scoped allowlist merge before a canary starts."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import yaml
+from harbor.models.task.config import TaskConfig, VerifierEnvironmentMode
+from harbor.models.task.verifier_mode import resolve_task_verifier_mode
+from harbor.models.trial.config import AgentConfig as TrialAgentConfig
+from harbor.models.trial.config import EnvironmentConfig as TrialEnvironmentConfig
+from harbor.trial.network_policy import resolve_trial_network_plan
+
+
+ROOT = Path(__file__).resolve().parents[3]
+GAUGE = ROOT / "scripts/ci/chaos_gauge"
+MODEL_HOST = "chroma-onnx-models.s3.amazonaws.com"
+JOB_NAMES = ("control", "chaos-engine", "full-pilot-control", "full-pilot-chaos-engine")
+
+
+def _plan(task: TaskConfig):
+    return resolve_trial_network_plan(
+        task,
+        TrialAgentConfig(),
+        TrialEnvironmentConfig(extra_allowed_hosts=[MODEL_HOST]),
+        None,
+        verifier_mode=resolve_task_verifier_mode(task),
+    )
+
+
+def validate() -> None:
+    for name in JOB_NAMES:
+        job = yaml.safe_load((GAUGE / f"job-configs/{name}.yaml").read_text(encoding="utf-8"))
+        if job["environment"].get("extra_allowed_hosts") != [MODEL_HOST]:
+            raise ValueError("Harbor environment model-host overlay is invalid")
+        if "extra_allowed_hosts" in job["agents"][0]:
+            raise ValueError("Harbor model-host overlay must not reach the agent phase")
+
+    for path in (GAUGE / "dataset").glob("*/task.toml"):
+        plan = _plan(TaskConfig.model_validate(tomllib.loads(path.read_text(encoding="utf-8"))))
+        if MODEL_HOST not in plan.agent_env_baseline.allowed_hosts:
+            raise ValueError("public environment baseline omitted the model host")
+        if MODEL_HOST in plan.agent_phase.allowed_hosts:
+            raise ValueError("public agent phase inherited the model host")
+        if plan.verifier_phase.network_mode.value != "no-network":
+            raise ValueError("public verifier phase network isolation drifted")
+
+    private_baseline = TaskConfig.model_validate({
+        "environment": {"network_mode": "no-network"},
+        "agent": {"network_mode": "no-network"},
+        "verifier": {
+            "environment_mode": "separate",
+            "environment": {"network_mode": "no-network"},
+        },
+    })
+    plan = _plan(private_baseline)
+    if (
+        plan.agent_env_baseline.network_mode.value != "allowlist"
+        or plan.agent_env_baseline.allowed_hosts != [MODEL_HOST]
+        or plan.agent_phase.network_mode.value != "no-network"
+        or plan.verifier_phase.network_mode.value != "no-network"
+    ):
+        raise ValueError("private phase-scoped model-host isolation drifted")
+
+
+if __name__ == "__main__":
+    validate()

--- a/scripts/ci/chaos_gauge/validate_harbor_network_policy.py
+++ b/scripts/ci/chaos_gauge/validate_harbor_network_policy.py
@@ -7,7 +7,7 @@ import tomllib
 from pathlib import Path
 
 import yaml
-from harbor.models.task.config import TaskConfig, VerifierEnvironmentMode
+from harbor.models.task.config import TaskConfig
 from harbor.models.task.verifier_mode import resolve_task_verifier_mode
 from harbor.models.trial.config import AgentConfig as TrialAgentConfig
 from harbor.models.trial.config import EnvironmentConfig as TrialEnvironmentConfig

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -213,7 +213,7 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             plan["graphify"],
         )
         self.assertEqual(
-            [["/user/bin/npm", "install", "-g", "@aictx/memory@latest"]],
+            [["/user/bin/npm", "install", "-g", "@aictx/memory@0.2.1"]],
             plan["memory"],
         )
         self.assertEqual([], plan["context7"])
@@ -250,33 +250,47 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             self.assertEqual("chromadb==1.5.9", command[command.index("--with") + 1])
             self.assertEqual("mempalace==3.8.0", command[-1])
 
-    def test_runtime_specification_rejects_any_mempalace_pin_drift(self):
+    def test_runtime_specification_rejects_any_schema3_tool_contract_drift(self):
         module = load_controller()
         source = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
         mutations = {
-            "missing": lambda value: value["tools"]["mempalace"].pop("with"),
             "empty": lambda value: value["tools"]["mempalace"].__setitem__("with", []),
             "floating": lambda value: value["tools"]["mempalace"].update(package="mempalace"),
             "wrong": lambda value: value["tools"]["mempalace"].__setitem__("with", ["chromadb==1.5.8"]),
             "multiple": lambda value: value["tools"]["mempalace"].__setitem__("with", ["chromadb==1.5.9", "other==1.0.0"]),
             "future": lambda value: value["tools"]["mempalace"].update(package="mempalace==3.8.1"),
+            "extra-tool": lambda value: value["tools"].update(rogue={"package": "rogue==1.0.0"}),
         }
+        for name, fields in source["tools"].items():
+            mutations[f"missing-tool-{name}"] = lambda value, name=name: value["tools"].pop(name)
+            for key, expected in fields.items():
+                mutations[f"missing-{name}-{key}"] = (
+                    lambda value, name=name, key=key: value["tools"][name].pop(key)
+                )
+                malformed = "malformed" if isinstance(expected, list) else []
+                mutations[f"malformed-{name}-{key}"] = (
+                    lambda value, name=name, key=key, malformed=malformed:
+                    value["tools"][name].__setitem__(key, malformed)
+                )
+            mutations[f"extra-{name}-field"] = (
+                lambda value, name=name: value["tools"][name].update(rogue="value")
+            )
         for label, mutate in mutations.items():
             with self.subTest(label=label):
                 specification = copy.deepcopy(source)
                 mutate(specification)
-                with self.assertRaisesRegex(ValueError, "MemPalace tool dependency pin"):
+                with self.assertRaisesRegex(ValueError, "tool dependency specification is not the exact"):
                     module.validate_runtime_specification(specification)
                 with tempfile.TemporaryDirectory() as temporary:
                     root = Path(temporary)
-                    with self.assertRaisesRegex(ValueError, "MemPalace tool dependency pin"):
+                    with self.assertRaisesRegex(ValueError, "tool dependency specification is not the exact"):
                         module.account_tool_plan(
                             root, specification, actions={},
                             executables={"uv": "/user/bin/uv", "npm": "/user/bin/npm"},
                         )
-                    with self.assertRaisesRegex(ValueError, "MemPalace tool dependency pin"):
+                    with self.assertRaisesRegex(ValueError, "tool dependency specification is not the exact"):
                         module.generation_install_plan(root, specification)
-                    with self.assertRaisesRegex(ValueError, "MemPalace tool dependency pin"):
+                    with self.assertRaisesRegex(ValueError, "tool dependency specification is not the exact"):
                         module.install_plan(root, specification)
 
     def test_mempalace_action_resolution_uses_the_declared_pin_not_the_latest_channel(self):
@@ -1183,7 +1197,7 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             runtime = Path(temporary) / ".chaos-engine-runtime"
             first = module.repair(runtime, specification, runner=self.fake_runner(runtime))
             changed = json.loads(json.dumps(specification))
-            changed["tools"]["graphify"]["package"] = "graphifyy==next"
+            changed["runtimes"]["python"]["version"] = "3.12"
             upgraded = module.repair(runtime, changed, runner=self.fake_runner(runtime))
 
             self.assertNotEqual(first["specificationSha256"], upgraded["specificationSha256"])
@@ -1575,7 +1589,7 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             runtime = Path(temporary) / ".chaos-engine-runtime"
             module.repair(runtime, specification, runner=self.fake_runner(runtime))
             changed = json.loads(json.dumps(specification))
-            changed["tools"]["memory"]["package"] = "@aictx/memory@next"
+            changed["runtimes"]["python"]["version"] = "3.12"
             receipt = module.repair(
                 runtime, changed, runner=self.fake_runner(runtime), force=True
             )

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -303,6 +303,115 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
         self.assertEqual("3.8.0", actions["mempalace"]["resolvedVersion"])
         self.assertEqual("upgraded", actions["mempalace"]["action"])
 
+    def test_account_tool_plan_uses_resolved_stable_versions_then_matching_rerun_reuses(self):
+        module = load_controller()
+        specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        versions = {
+            "graphify": "0.9.53",
+            "memory": "0.2.2",
+            "context7": "0.4.0",
+        }
+        first_plan = module.account_tool_plan(
+            Path("."), specification,
+            actions={name: "installed" for name in versions},
+            executables={"uv": "/user/bin/uv", "npm": "/user/bin/npm"},
+            resolved_versions=versions,
+        )
+        self.assertEqual(
+            [[
+                "/user/bin/uv", "tool", "install", "--with",
+                "tree-sitter-sql==0.3.11", "graphifyy==0.9.53",
+            ]],
+            first_plan["graphify"],
+        )
+        self.assertEqual(
+            [["/user/bin/npm", "install", "-g", "@aictx/memory@0.2.2"]],
+            first_plan["memory"],
+        )
+        self.assertEqual(
+            [["/user/bin/npm", "install", "-g", "ctx7@0.4.0"]],
+            first_plan["context7"],
+        )
+
+        local = {
+            name: {"healthy": True, "version": "99.0.0"}
+            for name in specification["dependencies"]
+        }
+        local.update({
+            name: {"healthy": True, "version": version}
+            for name, version in versions.items()
+        })
+        local["mempalace"] = {"healthy": True, "version": "3.8.0"}
+        with mock.patch.object(
+            module,
+            "resolve_stable_version",
+            side_effect=lambda name, *_args, **_kwargs: versions.get(name, "99.0.0"),
+        ):
+            actions = module.resolve_account_actions(specification, local)
+        self.assertTrue(all(actions[name]["action"] == "reused" for name in versions))
+        self.assertEqual(
+            {"mempalace": [], "graphify": [], "memory": [], "context7": []},
+            module.account_tool_plan(
+                Path("."), specification,
+                actions={
+                    name: str(actions[name]["action"])
+                    for name in ("mempalace", "graphify", "memory", "context7")
+                },
+                executables={"uv": "/user/bin/uv", "npm": "/user/bin/npm"},
+                resolved_versions={
+                    name: actions[name]["resolvedVersion"]
+                    for name in ("mempalace", "graphify", "memory", "context7")
+                },
+            ),
+        )
+
+    def test_account_install_passes_resolved_tool_versions_to_the_account_plan(self):
+        module = load_controller()
+        specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        commands = {"uv": "/tools/uv", "npm": "/tools/npm"}
+        local = {
+            name: {"healthy": True, "version": "1.0", "detail": "passed"}
+            for name in specification["dependencies"]
+            if name != "maven-tools-mcp"
+        }
+        actions = {
+            name: {"action": "reused", "resolvedVersion": "1.0"}
+            for name in local
+        }
+        actions.update({
+            "mempalace": {"action": "reused", "resolvedVersion": "3.8.0"},
+            "graphify": {"action": "upgraded", "resolvedVersion": "0.9.53"},
+            "memory": {"action": "upgraded", "resolvedVersion": "0.2.2"},
+            "context7": {"action": "installed", "resolvedVersion": "0.4.0"},
+        })
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            with mock.patch.object(
+                module, "discover_account_commands",
+                side_effect=((local, commands), (local, commands)),
+            ), mock.patch.object(
+                module, "resolve_account_actions", return_value=actions
+            ), mock.patch.object(
+                module, "require_user_writable_npm_prefix"
+            ), mock.patch.object(
+                module,
+                "account_tool_plan",
+                return_value={
+                    "mempalace": [], "graphify": [], "memory": [], "context7": [],
+                },
+            ) as plan, mock.patch.object(module, "project_setup_plan", return_value=[]):
+                module.install_account_dependencies(project, specification, allow_root=True)
+
+        self.assertEqual(
+            {
+                "mempalace": "3.8.0",
+                "graphify": "0.9.53",
+                "memory": "0.2.2",
+                "context7": "0.4.0",
+            },
+            plan.call_args.kwargs["resolved_versions"],
+        )
+
     def test_mempalace_probe_rejects_a_nonpinned_postinstall_version(self):
         module = load_controller()
         specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import importlib.util
 import json
 import os
@@ -205,7 +206,10 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             plan["mempalace"],
         )
         self.assertEqual(
-            [["/user/bin/uv", "tool", "upgrade", "graphifyy"]],
+            [[
+                "/user/bin/uv", "tool", "install", "--force", "--with",
+                "tree-sitter-sql==0.3.11", "graphifyy==0.9.43",
+            ]],
             plan["graphify"],
         )
         self.assertEqual(
@@ -213,6 +217,24 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             plan["memory"],
         )
         self.assertEqual([], plan["context7"])
+
+    def test_mempalace_account_plan_reinstalls_every_nonreused_action_with_pins(self):
+        module = load_controller()
+        specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        expected = {
+            "installed": ["/user/bin/uv", "tool", "install", "--with", "chromadb==1.5.9", "mempalace==3.8.0"],
+            "upgraded": ["/user/bin/uv", "tool", "install", "--force", "--with", "chromadb==1.5.9", "mempalace==3.8.0"],
+            "repaired": ["/user/bin/uv", "tool", "install", "--force", "--with", "chromadb==1.5.9", "mempalace==3.8.0"],
+        }
+        for action, command in expected.items():
+            with self.subTest(action=action):
+                plan = module.account_tool_plan(
+                    Path("."), specification,
+                    actions={"mempalace": action},
+                    executables={"uv": "/user/bin/uv", "npm": "/user/bin/npm"},
+                )
+                self.assertEqual([command], plan["mempalace"])
+                self.assertNotIn("upgrade", command)
 
     def test_mempalace_install_plans_pin_chromadb_model_loader(self):
         module = load_controller()
@@ -227,6 +249,69 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             self.assertIn("--with", command)
             self.assertEqual("chromadb==1.5.9", command[command.index("--with") + 1])
             self.assertEqual("mempalace==3.8.0", command[-1])
+
+    def test_runtime_specification_rejects_any_mempalace_pin_drift(self):
+        module = load_controller()
+        source = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        mutations = {
+            "missing": lambda value: value["tools"]["mempalace"].pop("with"),
+            "empty": lambda value: value["tools"]["mempalace"].__setitem__("with", []),
+            "floating": lambda value: value["tools"]["mempalace"].update(package="mempalace"),
+            "wrong": lambda value: value["tools"]["mempalace"].__setitem__("with", ["chromadb==1.5.8"]),
+            "multiple": lambda value: value["tools"]["mempalace"].__setitem__("with", ["chromadb==1.5.9", "other==1.0.0"]),
+            "future": lambda value: value["tools"]["mempalace"].update(package="mempalace==3.8.1"),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(label=label):
+                specification = copy.deepcopy(source)
+                mutate(specification)
+                with self.assertRaisesRegex(ValueError, "MemPalace tool dependency pin"):
+                    module.validate_runtime_specification(specification)
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    with self.assertRaisesRegex(ValueError, "MemPalace tool dependency pin"):
+                        module.account_tool_plan(
+                            root, specification, actions={},
+                            executables={"uv": "/user/bin/uv", "npm": "/user/bin/npm"},
+                        )
+                    with self.assertRaisesRegex(ValueError, "MemPalace tool dependency pin"):
+                        module.generation_install_plan(root, specification)
+                    with self.assertRaisesRegex(ValueError, "MemPalace tool dependency pin"):
+                        module.install_plan(root, specification)
+
+    def test_mempalace_action_resolution_uses_the_declared_pin_not_the_latest_channel(self):
+        module = load_controller()
+        specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        local = {name: {"healthy": True, "version": "99.0.0"} for name in specification["dependencies"]}
+        local["mempalace"] = {"healthy": True, "version": "3.7.9"}
+        with mock.patch.object(module, "resolve_stable_version", return_value="99.0.0"):
+            actions = module.resolve_account_actions(specification, local)
+        self.assertEqual("3.8.0", actions["mempalace"]["resolvedVersion"])
+        self.assertEqual("upgraded", actions["mempalace"]["action"])
+
+    def test_mempalace_probe_rejects_a_nonpinned_postinstall_version(self):
+        module = load_controller()
+        specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory() as temporary:
+            tools = Path(temporary)
+            executables = {
+                name: tools / name
+                for contract in specification["dependencies"].values()
+                for name in contract["executables"]
+            }
+            for executable in executables.values():
+                executable.write_text("tool\n", encoding="utf-8")
+            local, _commands = module.discover_account_commands(
+                specification,
+                which=lambda name, **_kwargs: str(executables[name]),
+                runner=lambda command, **_kwargs: SimpleNamespace(
+                    returncode=0,
+                    stdout="mempalace 3.8.1" if command[0].endswith("mempalace") else "tool 1.0",
+                    stderr="",
+                ),
+            )
+        self.assertFalse(local["mempalace"]["healthy"])
+        self.assertEqual("version-mismatch", local["mempalace"]["detail"])
 
     def test_stable_versions_reject_prerelease_and_yanked_candidates(self):
         module = load_controller()

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -201,7 +201,7 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
 
         self.assertEqual(3, specification["schemaVersion"])
         self.assertEqual(
-            [["/user/bin/uv", "tool", "install", "mempalace"]],
+            [["/user/bin/uv", "tool", "install", "--with", "chromadb==1.5.9", "mempalace==3.8.0"]],
             plan["mempalace"],
         )
         self.assertEqual(
@@ -213,6 +213,20 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             plan["memory"],
         )
         self.assertEqual([], plan["context7"])
+
+    def test_mempalace_install_plans_pin_chromadb_model_loader(self):
+        module = load_controller()
+        specification = json.loads(SPECIFICATION.read_text(encoding="utf-8"))
+        self.assertEqual("mempalace==3.8.0", specification["tools"]["mempalace"]["package"])
+        self.assertEqual(["chromadb==1.5.9"], specification["tools"]["mempalace"]["with"])
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            generated = module.generation_install_plan(root, specification)["mempalace"][0]
+            legacy = module.install_plan(root, specification)["mempalace"][0]
+        for command in (generated, legacy):
+            self.assertIn("--with", command)
+            self.assertEqual("chromadb==1.5.9", command[command.index("--with") + 1])
+            self.assertEqual("mempalace==3.8.0", command[-1])
 
     def test_stable_versions_reject_prerelease_and_yanked_candidates(self):
         module = load_controller()

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -232,7 +232,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             agent = module.ChaosEngineCodex(
                 harness_source=str(ROOT / "chaos-engine"),
                 harness_commit="0481767def7c31fe144bc20543dfe937b8ffd4d5",
-                harness_sha256="28be870ed7cca15e13f5f10ff1dcc678c8913463cb68908bad7ca60e8b4c1a79",
+                harness_sha256="43399970878aadf93f0f1cde927bc6de1762a398d99c3495aef9f44a3e22f0fc",
                 adapter_sha256="3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             )
 

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -232,7 +232,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             agent = module.ChaosEngineCodex(
                 harness_source=str(ROOT / "chaos-engine"),
                 harness_commit="0481767def7c31fe144bc20543dfe937b8ffd4d5",
-                harness_sha256="c508262b1fc5eb8d8ec4880a9a21badd822f2f6650686fd86008fe415510ce72",
+                harness_sha256="7f2e6032118771bd9b75820689e1d830a8792db4d26b36c7b769d6b6a239ac0e",
                 adapter_sha256="3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             )
 

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -139,6 +139,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
         )
         self.assertNotIn("name", jobs["chaos-engine"]["agents"][0])
         self.assertNotIn("skills", jobs["chaos-engine"]["agents"][0])
+
         control = copy.deepcopy(jobs["control"])
         candidate = copy.deepcopy(jobs["chaos-engine"])
         for job in (control, candidate):
@@ -176,6 +177,15 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
         drifted["control"]["retry"]["max_retries"] = 3
         with self.assertRaisesRegex(ValueError, "retry budget"):
             MODULE.validate_job_contracts(self.manifest(), drifted, root=ROOT)
+
+    def test_all_harbor_job_arms_add_only_the_pinned_chroma_model_host(self):
+        host = "chroma-onnx-models.s3.amazonaws.com"
+        for name in (
+            "control", "chaos-engine", "full-pilot-control", "full-pilot-chaos-engine",
+        ):
+            job = yaml.safe_load((GAUGE / f"job-configs/{name}.yaml").read_text())
+            self.assertEqual([host], job["environment"].get("extra_allowed_hosts"))
+            self.assertNotIn("extra_allowed_hosts", job["agents"][0])
 
     async def test_custom_agent_delegates_to_codex_and_installs_full_harness(self):
         calls = []
@@ -222,7 +232,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             agent = module.ChaosEngineCodex(
                 harness_source=str(ROOT / "chaos-engine"),
                 harness_commit="0481767def7c31fe144bc20543dfe937b8ffd4d5",
-                harness_sha256="184616dda0fbbba87782bbe44ab325eb989f8c39d6ec601334361f7101038bfb",
+                harness_sha256="28be870ed7cca15e13f5f10ff1dcc678c8913463cb68908bad7ca60e8b4c1a79",
                 adapter_sha256="3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             )
 

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -232,7 +232,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             agent = module.ChaosEngineCodex(
                 harness_source=str(ROOT / "chaos-engine"),
                 harness_commit="0481767def7c31fe144bc20543dfe937b8ffd4d5",
-                harness_sha256="713984b045644ea2c4b3233a5b9764cb3054faf8b38b41c3c922707ff0001694",
+                harness_sha256="c508262b1fc5eb8d8ec4880a9a21badd822f2f6650686fd86008fe415510ce72",
                 adapter_sha256="3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             )
 

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -232,7 +232,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             agent = module.ChaosEngineCodex(
                 harness_source=str(ROOT / "chaos-engine"),
                 harness_commit="0481767def7c31fe144bc20543dfe937b8ffd4d5",
-                harness_sha256="43399970878aadf93f0f1cde927bc6de1762a398d99c3495aef9f44a3e22f0fc",
+                harness_sha256="713984b045644ea2c4b3233a5b9764cb3054faf8b38b41c3c922707ff0001694",
                 adapter_sha256="3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
             )
 

--- a/tests/scripts/test_chaos_gauge_recovery.py
+++ b/tests/scripts/test_chaos_gauge_recovery.py
@@ -12,9 +12,9 @@ CHAOS_GAUGE = ROOT / "scripts" / "ci" / "chaos_gauge"
 # additions update this complete inventory together with their task digests.
 # This covers the full public ChaosGauge tree, unlike representative anchors
 # that can remain after an executable or dataset member is lost.
-RECOVERED_PUBLIC_FILE_COUNT = 153
+RECOVERED_PUBLIC_FILE_COUNT = 154
 RECOVERED_PUBLIC_PATHS_SHA256 = (
-    "3ee8ea70621c13545dc2c97cf657a607c5edacf3726f196212bcf31ce7067517"
+    "0de219fd104b229aeb3967b03c25ebc040e80ea493921920f7f36c28ae54e93d"
 )
 
 


### PR DESCRIPTION
Allows only the pinned Chroma ONNX model host during the Harbor environment phase and installs the exact Chroma dependency alongside MemPalace.

The agent and separate verifier policies remain unchanged. All job and treatment identities are rehashed.

Related to #5462.