### PR TITLE
fix(installer): recover interrupted account upgrades safely

### DIFF
--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -679,8 +679,13 @@ def restore_candidate_mempalace_state(project: Path, image: dict[str, object]) -
             },
         )
     if exists:
+        recorded_ancestors = {
+            PurePosixPath(relative).parts[0]
+            for relative in after_files
+            if len(PurePosixPath(relative).parts) > 1
+        }
         for child in palace.iterdir():
-            if child.is_dir():
+            if child.is_dir() and child.name not in recorded_ancestors:
                 mismatches.append(
                     {
                         "path": _mempalace_state_relative(child.name),
@@ -704,6 +709,13 @@ def restore_candidate_mempalace_state(project: Path, image: dict[str, object]) -
     for relative in set(after_files) - set(before_files):
         (palace / relative).unlink()
     if not before_exists and after_exists:
+        for directory in sorted(
+            (item for item in palace.rglob("*") if item.is_dir()),
+            key=lambda item: len(item.parts),
+            reverse=True,
+        ):
+            if not any(directory.iterdir()):
+                directory.rmdir()
         palace.rmdir()
         state_root = palace.parent
         if state_root.exists() and not any(state_root.iterdir()):
@@ -1207,7 +1219,6 @@ def recover_account_rollback_journal(project: Path) -> None:
             _receipt, current_host = controller.read_receipt(project)
             if current_host != expected_host:
                 raise ValueError("account rollback host receipt changed during recovery")
-            validate_prior_host_receipt(project, controller, expected_host, desired_commit)
         _restore_account_receipt_from_journal(
             project, controller, pending["priorAccountReceipt"]
         )
@@ -1297,6 +1308,7 @@ def validate_prior_host_receipt(
         or receipt.get("coreCommit") != desired_commit
         or receipt.get("hosts") != controller.host_routes()
         or receipt.get("rollbackIntent") is not None
+        or controller.receipt_bytes(receipt, project) != raw
     ):
         raise ValueError("cross-resource rollback journal is invalid")
     controller.decode_images(receipt.get("before"), nullable=True)

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -580,6 +580,63 @@ def mempalace_rollback_image(
     }
 
 
+def _mempalace_state_relative(relative: str = "") -> str:
+    path = PurePosixPath(MEMPALACE_STATE_OUTPUT)
+    if relative:
+        child = PurePosixPath(relative)
+        if child.is_absolute() or any(part in {"", ".", ".."} for part in child.parts):
+            raise ValueError("account rollback has invalid MemPalace state image")
+        path = path / child
+    return path.as_posix()
+
+
+def _mempalace_changed_error(
+    mismatches: list[dict[str, str | None]],
+) -> ValueError:
+    capability = legacy_capability_policy()["mempalace"]
+    evidence = [
+        {
+            "path": item["path"],
+            "expectedDigest": item.get("expectedDigest"),
+            "actualDigest": item.get("actualDigest"),
+            "owner": capability["owner"],
+            "action": "blocked",
+        }
+        for item in mismatches
+    ]
+    payload = evidence[0] if len(evidence) == 1 else {
+        "path": _mempalace_state_relative(),
+        "expectedDigest": None,
+        "actualDigest": None,
+        "owner": capability["owner"],
+        "action": "blocked",
+        "files": evidence,
+    }
+    return ValueError(
+        "candidate MemPalace state changed before rollback: "
+        + json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    )
+
+
+def _mempalace_file_mismatches(
+    expected_files: dict[str, str],
+    actual_files: dict[str, str],
+) -> list[dict[str, str | None]]:
+    mismatches: list[dict[str, str | None]] = []
+    for relative in sorted(set(expected_files) | set(actual_files)):
+        expected = expected_files.get(relative)
+        actual = actual_files.get(relative)
+        if expected != actual:
+            mismatches.append(
+                {
+                    "path": _mempalace_state_relative(relative),
+                    "expectedDigest": expected,
+                    "actualDigest": actual,
+                }
+            )
+    return mismatches
+
+
 def restore_candidate_mempalace_state(project: Path, image: dict[str, object]) -> None:
     """Restore a base palace by deleting only unchanged candidate-created files."""
     before = image.get("before")
@@ -611,12 +668,39 @@ def restore_candidate_mempalace_state(project: Path, image: dict[str, object]) -
         raise ValueError("account rollback has invalid MemPalace state image")
     palace = project / MEMPALACE_STATE_OUTPUT
     exists, current = project_setup_output_files(project, MEMPALACE_STATE_OUTPUT)
-    if exists != after_exists or current != after_files or (
-        exists and any(child.is_dir() for child in palace.iterdir())
-    ):
-        raise ValueError("candidate MemPalace state changed before rollback")
-    if any(after_files.get(relative) != digest for relative, digest in before_files.items()):
-        raise ValueError("candidate MemPalace state changed before rollback")
+    mismatches = _mempalace_file_mismatches(after_files, current)
+    if exists != after_exists:
+        mismatches.insert(
+            0,
+            {
+                "path": _mempalace_state_relative(),
+                "expectedDigest": None,
+                "actualDigest": None,
+            },
+        )
+    if exists:
+        for child in palace.iterdir():
+            if child.is_dir():
+                mismatches.append(
+                    {
+                        "path": _mempalace_state_relative(child.name),
+                        "expectedDigest": None,
+                        "actualDigest": None,
+                    }
+                )
+    if mismatches:
+        raise _mempalace_changed_error(mismatches)
+    before_mismatches = [
+        {
+            "path": _mempalace_state_relative(relative),
+            "expectedDigest": digest,
+            "actualDigest": after_files.get(relative),
+        }
+        for relative, digest in sorted(before_files.items())
+        if after_files.get(relative) != digest
+    ]
+    if before_mismatches:
+        raise _mempalace_changed_error(before_mismatches)
     for relative in set(after_files) - set(before_files):
         (palace / relative).unlink()
     if not before_exists and after_exists:
@@ -627,8 +711,18 @@ def restore_candidate_mempalace_state(project: Path, image: dict[str, object]) -
     restored_exists, restored_files = project_setup_output_files(
         project, MEMPALACE_STATE_OUTPUT
     )
-    if restored_exists != before_exists or restored_files != before_files:
-        raise ValueError("candidate MemPalace state changed before rollback")
+    restored_mismatches = _mempalace_file_mismatches(before_files, restored_files)
+    if restored_exists != before_exists:
+        restored_mismatches.insert(
+            0,
+            {
+                "path": _mempalace_state_relative(),
+                "expectedDigest": None,
+                "actualDigest": None,
+            },
+        )
+    if restored_mismatches:
+        raise _mempalace_changed_error(restored_mismatches)
 
 
 def restore_project_setup_outputs(
@@ -1053,7 +1147,18 @@ def _account_upgrade_host_receipt_is_durable(
         else None
     )
     if actual_host != expected_host:
-        return False
+        normalize = getattr(controller, "rollback_base_receipt", None)
+        if (
+            not callable(normalize)
+            or not isinstance(actual_host, bytes)
+            or not isinstance(expected_host, bytes)
+        ):
+            return False
+        try:
+            if normalize(project, actual_host) != normalize(project, expected_host):
+                return False
+        except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+            return False
     expected_account = pending["priorAccountReceipt"]
     encoded_account = receipt.get(controller.ROLLBACK_PREVIOUS_ACCOUNT_RECEIPT)
     actual_account = (
@@ -1192,7 +1297,6 @@ def validate_prior_host_receipt(
         or receipt.get("coreCommit") != desired_commit
         or receipt.get("hosts") != controller.host_routes()
         or receipt.get("rollbackIntent") is not None
-        or controller.receipt_bytes(receipt, project) != raw
     ):
         raise ValueError("cross-resource rollback journal is invalid")
     controller.decode_images(receipt.get("before"), nullable=True)
@@ -1786,9 +1890,13 @@ def rollback(  # noqa: MC0001 - cross-resource rollback is one journaled state m
                     previous_hosts.reconcile(
                         project, prior_after, (current_images, prior_after)
                     )
-                    previous_hosts.write_receipt(
-                        project, prior_host_receipt_value, current_raw
-                    )
+                    if current_raw != prior_host_receipt:
+                        receipt_name = getattr(
+                            previous_hosts, "RECEIPT_NAME", ".chaos-engine-hosts.json"
+                        )
+                        previous_hosts.atomic_write(
+                            project, project / receipt_name, prior_host_receipt, current_raw
+                        )
                 else:
                     desired_manifest = verify_install(target)
                     previous_hosts.install(
@@ -2351,10 +2459,6 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
                     prior_host_receipt = (
                         host_snapshot.get("raw") if isinstance(host_snapshot, dict) else None
                     )
-                    if isinstance(prior_host_receipt, bytes):
-                        prior_host_receipt = host_controller.rollback_base_receipt(
-                            project, prior_host_receipt
-                        )
                     account_rollback_journal = write_account_rollback_journal(
                         project,
                         old_commit,
@@ -2677,6 +2781,19 @@ def status_with_dependencies(project: Path, *, active_probes: bool = False) -> d
             if result["kernel"]["status"] != "healthy":  # type: ignore[index]
                 result["status"] = "recovery-required"
             host_controller = load_installed_controller(target, "hosts")
+            if (project / ACCOUNT_ROLLBACK_JOURNAL_NAME).exists():
+                result["status"] = "recovery-required"
+                result["hosts"] = {"status": "recovery-required"}
+                result["dependencies"] = {"status": "recovery-required"}
+                attach_component_status(
+                    result,
+                    project,
+                    target,
+                    "recovery-required",
+                    host_controller,
+                    inspect_retrieval_state=False,
+                )
+                return result
             pending_rollback = read_cross_rollback_journal(project)
             if pending_rollback is not None:
                 result["hosts"] = host_controller.verify(project)
@@ -2790,6 +2907,9 @@ def doctor_with_dependencies(
 ) -> dict[str, object]:
     """Verify installed files and actively execute every dependency entrypoint probe."""
     result = status_with_dependencies(project, active_probes=True)
+    if (project.resolve() / ACCOUNT_ROLLBACK_JOURNAL_NAME).exists():
+        result["clients"] = {}
+        return result
     target = project.resolve() / INSTALL_DIRECTORY
     host_controller = load_installed_controller(target, "hosts")
     dependency = result.get("dependencies")

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import importlib.util
 import json
@@ -669,10 +670,211 @@ module.install_with_dependencies(project, source, "2" * 40)
 
             self.assertEqual("recovery-required", status["status"])
             self.assertEqual("recovery-required", doctor["status"])
+            self.assertEqual(2, rendered_status["schemaVersion"])
+            self.assertEqual(2, rendered_doctor["schemaVersion"])
+            self.assertEqual("status", rendered_status["kind"])
+            self.assertEqual("doctor", rendered_doctor["kind"])
             self.assertEqual("recovery-required", rendered_status["status"])
             self.assertEqual("recovery-required", rendered_doctor["status"])
-            self.assertNotEqual("CE_DIAGNOSTIC_UNAVAILABLE", rendered_status.get("diagnosticCode"))
-            self.assertNotEqual("CE_DIAGNOSTIC_UNAVAILABLE", rendered_doctor.get("diagnosticCode"))
+            self.assertEqual(
+                rendered_status,
+                MODULE.validate_diagnostic_json(rendered_status),
+            )
+            self.assertEqual(
+                rendered_doctor,
+                MODULE.validate_diagnostic_json(rendered_doctor),
+            )
+            self.assertNotIn("diagnosticCode", rendered_status)
+            self.assertNotIn("diagnosticCode", rendered_doctor)
+
+    def test_restore_candidate_mempalace_allows_nested_dirs_with_matching_digests(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            palace = project / ".chaos-engine-state" / "mempalace"
+            nested = palace / ".mempalace"
+            nested.mkdir(parents=True)
+            nested.joinpath("origin.json").write_text('{"wing":"exact"}\n', encoding="utf-8")
+            palace.joinpath(".mined").write_bytes(b"mined\n")
+            palace.joinpath("sqlite_exact.sqlite3").write_bytes(b"candidate sqlite")
+            exists, files = MODULE.project_setup_output_files(
+                project, MODULE.MEMPALACE_STATE_OUTPUT
+            )
+            self.assertTrue(exists)
+            self.assertEqual(
+                {
+                    ".mempalace/origin.json",
+                    ".mined",
+                    "sqlite_exact.sqlite3",
+                },
+                set(files),
+            )
+
+            MODULE.restore_candidate_mempalace_state(
+                project,
+                {
+                    "before": {"exists": False, "files": {}},
+                    "after": {"exists": True, "files": files},
+                },
+            )
+            self.assertFalse(palace.exists())
+
+    def test_restore_candidate_mempalace_refuses_extra_non_ancestor_directory(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            palace = project / ".chaos-engine-state" / "mempalace"
+            palace.mkdir(parents=True)
+            palace.joinpath("sqlite_exact.sqlite3").write_bytes(b"candidate sqlite")
+            palace.joinpath("foreign-dir").mkdir()
+            exists, files = MODULE.project_setup_output_files(
+                project, MODULE.MEMPALACE_STATE_OUTPUT
+            )
+            self.assertEqual({"sqlite_exact.sqlite3"}, set(files))
+
+            with self.assertRaisesRegex(ValueError, "candidate MemPalace state changed"):
+                MODULE.restore_candidate_mempalace_state(
+                    project,
+                    {
+                        "before": {"exists": False, "files": {}},
+                        "after": {"exists": True, "files": files},
+                    },
+                )
+            self.assertTrue(palace.joinpath("foreign-dir").is_dir())
+            self.assertEqual(
+                b"candidate sqlite",
+                palace.joinpath("sqlite_exact.sqlite3").read_bytes(),
+            )
+
+    def test_three_generation_failure_retry_restores_exact_generation_two_bytes(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            load_controller = MODULE.load_dependency_controller
+
+            def load_account_controller(installed_root):
+                return AccountDependencyController(load_controller(installed_root))
+
+            with mock.patch.object(
+                MODULE, "load_dependency_controller", side_effect=load_account_controller
+            ):
+                MODULE.install_with_dependencies(project, SOURCE, "1" * 40)
+                MODULE.install_with_dependencies(project, SOURCE, "2" * 40)
+
+            host_receipt = project / ".chaos-engine-hosts.json"
+            account_receipt = project / ".chaos-engine-dependencies.json"
+            generation_two_host = host_receipt.read_bytes()
+            generation_two_account = account_receipt.read_bytes()
+            format_only_host = generation_two_host + b"\n"
+            host_receipt.write_bytes(format_only_host)
+            hosts = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            self.assertNotEqual(
+                hosts.receipt_bytes(
+                    json.loads(format_only_host.decode("utf-8")),
+                    project,
+                ),
+                format_only_host,
+            )
+            self.assertNotEqual(
+                hosts.rollback_base_receipt(project, format_only_host),
+                format_only_host,
+            )
+
+            crash_script = """
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+installer_path = Path(sys.argv[1])
+source = Path(sys.argv[2])
+project = Path(sys.argv[3])
+spec = importlib.util.spec_from_file_location("crash_installer", installer_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+original = module.load_dependency_controller
+
+class Controller:
+    def __init__(self, delegate):
+        self.delegate = delegate
+    def __getattr__(self, name):
+        return getattr(self.delegate, name)
+    def install_account_dependencies(self, target, _specification):
+        journal = target / ".chaos-engine-account-rollback" / "journal.json"
+        if not journal.is_file():
+            os._exit(87)
+        target.joinpath(".chaos-engine-dependencies.json").write_text(json.dumps({
+            "schemaVersion": 2, "scope": "user", "components": {}, "commands": {}
+        }), encoding="utf-8")
+        os._exit(86)
+
+module.load_dependency_controller = lambda root: Controller(original(root))
+module.install_with_dependencies(project, source, "3" * 40)
+"""
+            crashed = subprocess.run(
+                [sys.executable, "-c", crash_script, str(INSTALLER), str(SOURCE), str(project)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(86, crashed.returncode)
+            journal = json.loads(
+                project.joinpath(
+                    ".chaos-engine-account-rollback/journal.json"
+                ).read_text(encoding="utf-8")
+            )
+            journal_host = base64.b64decode(journal["priorHostReceipt"])
+            journal_account = base64.b64decode(journal["priorAccountReceipt"])
+            self.assertEqual(format_only_host, journal_host)
+            self.assertEqual(generation_two_account, journal_account)
+            self.assertNotEqual(
+                hosts.rollback_base_receipt(project, journal_host),
+                journal_host,
+            )
+
+            with mock.patch.object(
+                MODULE, "load_dependency_controller", side_effect=load_account_controller
+            ):
+                MODULE.recover_account_rollback_journal(project)
+
+            self.assertEqual("2" * 40, MODULE.status(project)["commit"])
+            self.assertEqual(format_only_host, host_receipt.read_bytes())
+            self.assertEqual(generation_two_account, account_receipt.read_bytes())
+            self.assertFalse(project.joinpath(".chaos-engine-account-rollback").exists())
+
+            with mock.patch.object(
+                MODULE, "load_dependency_controller", side_effect=load_account_controller
+            ):
+                MODULE.install_with_dependencies(project, SOURCE, "3" * 40)
+            self.assertEqual("3" * 40, MODULE.status(project)["commit"])
+
+    def test_validate_prior_host_receipt_requires_canonical_bytes(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            load_controller = MODULE.load_dependency_controller
+
+            def load_account_controller(installed_root):
+                return AccountDependencyController(load_controller(installed_root))
+
+            with mock.patch.object(
+                MODULE, "load_dependency_controller", side_effect=load_account_controller
+            ):
+                MODULE.install_with_dependencies(project, SOURCE, "1" * 40)
+
+            hosts = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            raw = project.joinpath(".chaos-engine-hosts.json").read_bytes()
+            format_only = raw + b"\n"
+            self.assertNotEqual(
+                hosts.receipt_bytes(json.loads(format_only.decode("utf-8")), project),
+                format_only,
+            )
+            with self.assertRaisesRegex(ValueError, "cross-resource rollback journal is invalid"):
+                MODULE.validate_prior_host_receipt(
+                    project, hosts, format_only, "1" * 40
+                )
+            MODULE.validate_prior_host_receipt(project, hosts, raw, "1" * 40)
 
     def test_account_rollback_journal_syncs_directory_entries(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -528,6 +528,152 @@ module.install_with_dependencies(project, source, "2" * 40)
             self.assertFalse(project.joinpath(".chaos-engine-account-rollback").exists())
             self.assertEqual("2" * 40, MODULE.status(project)["commit"])
 
+    def test_account_journal_recovers_format_only_prior_host_receipt(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            load_controller = MODULE.load_dependency_controller
+
+            def load_account_controller(installed_root):
+                return AccountDependencyController(load_controller(installed_root))
+
+            with mock.patch.object(
+                MODULE, "load_dependency_controller", side_effect=load_account_controller
+            ):
+                MODULE.install_with_dependencies(project, SOURCE, "1" * 40)
+            host_receipt = project / ".chaos-engine-hosts.json"
+            exact_raw = host_receipt.read_bytes() + b"\n"
+            host_receipt.write_bytes(exact_raw)
+            self.assertNotEqual(
+                MODULE.load_installed_controller(
+                    project / ".chaos-engine", "hosts"
+                ).receipt_bytes(
+                    json.loads(exact_raw.decode("utf-8")),
+                    project,
+                ),
+                exact_raw,
+            )
+
+            crash_script = """
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+installer_path = Path(sys.argv[1])
+source = Path(sys.argv[2])
+project = Path(sys.argv[3])
+spec = importlib.util.spec_from_file_location("crash_installer", installer_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+original = module.load_dependency_controller
+
+class Controller:
+    def __init__(self, delegate):
+        self.delegate = delegate
+    def __getattr__(self, name):
+        return getattr(self.delegate, name)
+    def install_account_dependencies(self, target, _specification):
+        journal = target / ".chaos-engine-account-rollback" / "journal.json"
+        if not journal.is_file():
+            os._exit(87)
+        target.joinpath(".chaos-engine-dependencies.json").write_text(json.dumps({
+            "schemaVersion": 2, "scope": "user", "components": {}, "commands": {}
+        }), encoding="utf-8")
+        os._exit(86)
+
+module.load_dependency_controller = lambda root: Controller(original(root))
+module.install_with_dependencies(project, source, "2" * 40)
+"""
+            crashed = subprocess.run(
+                [sys.executable, "-c", crash_script, str(INSTALLER), str(SOURCE), str(project)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(86, crashed.returncode)
+            self.assertTrue(
+                project.joinpath(".chaos-engine-account-rollback/journal.json").is_file()
+            )
+
+            with mock.patch.object(
+                MODULE, "load_dependency_controller", side_effect=load_account_controller
+            ):
+                MODULE.install_with_dependencies(project, SOURCE, "2" * 40)
+
+            self.assertFalse(project.joinpath(".chaos-engine-account-rollback").exists())
+            self.assertEqual("2" * 40, MODULE.status(project)["commit"])
+
+    def test_status_and_doctor_report_recovery_for_interrupted_account_journal(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            load_controller = MODULE.load_dependency_controller
+
+            def load_account_controller(installed_root):
+                return AccountDependencyController(load_controller(installed_root))
+
+            with mock.patch.object(
+                MODULE, "load_dependency_controller", side_effect=load_account_controller
+            ):
+                MODULE.install_with_dependencies(project, SOURCE, "1" * 40)
+
+            crash_script = """
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+installer_path = Path(sys.argv[1])
+source = Path(sys.argv[2])
+project = Path(sys.argv[3])
+spec = importlib.util.spec_from_file_location("crash_installer", installer_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+original = module.load_dependency_controller
+
+class Controller:
+    def __init__(self, delegate):
+        self.delegate = delegate
+    def __getattr__(self, name):
+        return getattr(self.delegate, name)
+    def install_account_dependencies(self, target, _specification):
+        journal = target / ".chaos-engine-account-rollback" / "journal.json"
+        if not journal.is_file():
+            os._exit(87)
+        target.joinpath(".chaos-engine-dependencies.json").write_text(json.dumps({
+            "schemaVersion": 2, "scope": "user", "components": {}, "commands": {}
+        }), encoding="utf-8")
+        os._exit(86)
+
+module.load_dependency_controller = lambda root: Controller(original(root))
+module.install_with_dependencies(project, source, "2" * 40)
+"""
+            crashed = subprocess.run(
+                [sys.executable, "-c", crash_script, str(INSTALLER), str(SOURCE), str(project)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(86, crashed.returncode)
+            self.assertTrue(
+                project.joinpath(".chaos-engine-account-rollback/journal.json").is_file()
+            )
+
+            status = MODULE.status_with_dependencies(project)
+            doctor = MODULE.doctor_with_dependencies(project, verify_clients=False)
+            rendered_status = MODULE.status_json(project)
+            rendered_doctor = MODULE.status_json(project, active_probes=True)
+
+            self.assertEqual("recovery-required", status["status"])
+            self.assertEqual("recovery-required", doctor["status"])
+            self.assertEqual("recovery-required", rendered_status["status"])
+            self.assertEqual("recovery-required", rendered_doctor["status"])
+            self.assertNotEqual("CE_DIAGNOSTIC_UNAVAILABLE", rendered_status.get("diagnosticCode"))
+            self.assertNotEqual("CE_DIAGNOSTIC_UNAVAILABLE", rendered_doctor.get("diagnosticCode"))
+
     def test_account_rollback_journal_syncs_directory_entries(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary)
@@ -623,6 +769,53 @@ module.install_with_dependencies(project, source, "2" * 40)
                     MODULE.rollback(project)
 
             self.assertEqual(b"user changed", state.read_bytes())
+
+    def test_mempalace_fail_closed_evidence_uses_safe_relative_paths(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            calls = []
+            load_controller = MODULE.load_dependency_controller
+
+            def load_account_controller(installed_root):
+                controller = AccountDependencyController(load_controller(installed_root))
+                install_account = controller.install_account_dependencies
+
+                def install_with_candidate_state(*args, **kwargs):
+                    receipt = install_account(*args, **kwargs)
+                    calls.append(args[0])
+                    if len(calls) == 2:
+                        palace = args[0] / ".chaos-engine-state/mempalace"
+                        palace.mkdir(parents=True)
+                        palace.joinpath("sqlite_exact.sqlite3").write_bytes(b"candidate sqlite")
+                    return receipt
+
+                controller.install_account_dependencies = install_with_candidate_state
+                return controller
+
+            with mock.patch.object(
+                MODULE, "load_dependency_controller", side_effect=load_account_controller
+            ):
+                MODULE.install_with_dependencies(project, SOURCE, "1" * 40)
+                MODULE.install_with_dependencies(project, SOURCE, "2" * 40)
+                state = project / ".chaos-engine-state/mempalace/sqlite_exact.sqlite3"
+                state.write_bytes(b"user changed")
+                with self.assertRaises(ValueError) as raised:
+                    MODULE.rollback(project)
+
+            message = str(raised.exception)
+            self.assertIn("candidate MemPalace state changed", message)
+            self.assertNotIn(str(project.resolve()), message)
+            self.assertNotIn(str(state.resolve()), message)
+            payload = json.loads(message[message.index("{") :])
+            self.assertEqual(
+                ".chaos-engine-state/mempalace/sqlite_exact.sqlite3",
+                payload["path"],
+            )
+            self.assertEqual(hashlib.sha256(b"candidate sqlite").hexdigest(), payload["expectedDigest"])
+            self.assertEqual(hashlib.sha256(b"user changed").hexdigest(), payload["actualDigest"])
+            self.assertEqual("project", payload["owner"])
+            self.assertEqual("blocked", payload["action"])
 
     def test_account_rollback_restores_legacy_marker_without_candidate_sqlite(self):
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- preserve and compare exact raw host receipt bytes during account rollback recovery
- report account-journal mixed state as recovery-required in status and doctor
- keep MemPalace drift fail-closed while exposing safe structured relative-path and digest evidence
- ignore nested MemPalace ancestor directories when recorded file digests match (review F1)
- restore canonical `receipt_bytes` checks on cross-resource journals; confine whitespace tolerance to account embedded compare (review F4)

Closes #5494
Closes #5495

## Checks

Writer-reported on `0777a3319e`:
- `python3 -m unittest tests.scripts.test_chaos_engine_installer -v` — 131 passed
- `python3 -m unittest tests.scripts.test_chaos_engine_installer_ux tests.scripts.test_chaos_engine_bootstrap -v` — 72 passed
- `python3 scripts/ci/validate_agent_setup.py --skip-external` — passed

Independently re-run on that SHA:
- `test_restore_candidate_mempalace_allows_nested_dirs_with_matching_digests` — ok
- `test_three_generation_failure_retry_restores_exact_generation_two_bytes` — ok

## Scope

Only `chaos-engine/install.py` and focused installer regressions. No overlap with #5450/#5462/#5463/#5465/#5516/PR #5518. ETA remaining-time removal is #5530, separate branch.

## Continuation

- Head: `0777a3319e6a266160d808e179ca81a56579daff`
- Round 1 review: BLOCK (F1–F4). Batch-fix committed on this SHA.
- Round 2/2 independent review in flight.
- Do not merge until round 2 and exact-head CI are green.