### PR TITLE
feat(omniroot): rank live remaining models on every dispatch

### DIFF
--- a/chaos-engine/guides/omniroute.md
+++ b/chaos-engine/guides/omniroute.md
@@ -79,8 +79,11 @@ omniroute --version
 omniroute doctor --no-liveness
 ```
 
-Start it only when needed. `OMNIROUTE_SERVER_HOST=127.0.0.1` keeps the gateway
-on loopback; do not bind it to a LAN address or expose it through a tunnel.
+If an installed OmniRoute binary is present and
+`curl -sf --max-time 2 http://127.0.0.1:20128/api/health` fails, start loopback
+only. Never install OmniRoute from a task. `OMNIROUTE_SERVER_HOST=127.0.0.1`
+keeps the gateway on loopback; do not bind it to a LAN address or expose it
+through a tunnel.
 `HOST` is not OmniRoute's cross-platform bind setting.
 
 ```bash

--- a/chaos-engine/references/execution-workflows.md
+++ b/chaos-engine/references/execution-workflows.md
@@ -32,12 +32,15 @@ the selected host and task boundary:
 
 The transport does not change the selected workflow, role boundaries, tests,
 review, learning, or completion duties. Canonical orchestration must probe the
-fixed loopback endpoint before native fallback, with no endpoint prompt. `READY`
-means dispatch the bounded delegate through the sealed operator launcher;
-OmniRoute is never installed, started, authenticated, configured, or selected
-by ChaosEngine. The operator-owned priority combo alone selects its ordered
-attested no-cost candidates and never exposes route, model, or provider IDs to
-OmniRoot. A gateway `RUNTIME_EXHAUSTED` result, including sealed-launcher exit
-code `78` after that combo exhausts its allowed set, falls back to a qualified
-host-native implementer or `SOLO`. OmniRoute is absent, unhealthy, unauthenticated,
-or unqualified result does the same. This is normal fallback, not harness failure.
+fixed loopback endpoint before native fallback, with no endpoint prompt. If
+`omniroute` is installed and `http://127.0.0.1:20128/api/health` fails, start
+loopback only with `OMNIROUTE_SERVER_HOST=127.0.0.1 omniroute serve --port 20128 --no-open`.
+Never install OmniRoute. Before every dispatch, query
+`omniroute --output json models` and `omniroute --output json usage quota`
+(no cache files). Rank remaining free candidates dynamically from live ids:
+lowest applicable class first; architecture/review uses most-intelligent only.
+Receipts and repository files never persist route, model, or provider IDs.
+`RUNTIME_EXHAUSTED`, an empty remaining catalog, or sealed-launcher exit code
+`78` falls back to the current host session's native models or `SOLO`. OmniRoute is absent,
+unhealthy, unauthenticated, or unqualified does the same. This is
+normal fallback, not harness failure.

--- a/chaos-engine/skills/omniroot/SKILL.md
+++ b/chaos-engine/skills/omniroot/SKILL.md
@@ -13,17 +13,82 @@ canonical workflow in [execution workflows](../../references/execution-workflows
 first. Missing, stopped, unauthenticated, exhausted, or unqualified OmniRoute
 is normal: use a qualified native implementer or `SOLO`.
 
-Do not install, start, configure, authenticate, or choose routes for OmniRoute.
-Do not expose credentials, route internals, account data, prompts, or consumer
-code outside the approved bounded task.
+Do not install OmniRoute, create provider accounts, or write operator
+credentials. Do not expose credentials, account data, prompts, or consumer
+code outside the approved bounded task. Receipts and repository files never
+persist route, model, or provider IDs; live stdout of `candidates` may name
+them for the current dispatch only.
+
+## Ensure the local gateway
+
+Dashboard: `http://127.0.0.1:20128/home`. Health (anonymous JSON
+`status`/`timestamp` is enough here):
+
+```text
+command -v omniroute
+curl -sf --max-time 2 http://127.0.0.1:20128/api/health
+```
+
+If `omniroute` is missing, do not install it; use native host-session models.
+If the binary exists and health fails, start loopback only:
+
+```text
+OMNIROUTE_SERVER_HOST=127.0.0.1 omniroute serve --port 20128 --no-open
+```
+
+Never bind a non-loopback address. Never use a remote `--base-url`.
+
+## Live catalog on every dispatch
+
+Do not read cache files. Do not keep a session catalog file. Remaining tokens
+change after each delegate, so query both of these immediately before every
+dispatch:
+
+```text
+omniroute --output json models
+omniroute --output json usage quota
+python3 chaos-engine/skills/omniroot/scripts/runner.py candidates --capability mechanical|default|most-intelligent
+```
+
+Do not add `--json` after the `models` subcommand: that form prints a table, not JSON. Use `--output json` before `models`.
+Do not use `omniroute openapi try /api/models/catalog` without the CLI session;
+it returns HTTP 401.
+
+### Decode
+
+1. Strip ANSI with `\\x1b\\[[0-9;]*[A-Za-z]`.
+2. Find the first `{` or `[`.
+3. Parse with `json.JSONDecoder().raw_decode` so trailing extra JSON is ignored.
+4. Catalog is a JSON array of objects with `id` and `provider`.
+5. Quota is a JSON array of objects with `provider`, `remaining`, and `state`.
+6. Join on alphanumeric-lowercased provider ids (`glm-cn` matches `glmcn`).
+7. Drop `state == "exhausted"` or `remaining <= 0`.
+
+### Rank (dynamic, from the live ids)
+
+Classify each remaining `id` by its own tokens, not a stored model list:
+`low|lite|flash|air|mini|nano|turbo|haiku|small` = mechanical;
+`high|max|pro|ultra|opus|thinking|reasoner` = most-intelligent;
+otherwise default. Architecture, review, and analytical work use only
+most-intelligent. Every other task takes the lowest remaining class first,
+then higher remaining within a class. Empty result is `RUNTIME_EXHAUSTED`.
+
+### Dispatch and follow-through
+
+```text
+omniroute run --model '<id>' --provider '<provider>' codex -- exec --ephemeral --approve-for-me -C '<worktree>' '<prompt>'
+```
+
+Then follow [orchestrator follow-through](../../references/orchestrator-follow-through.md)
+until the delegate exits with closing notes. If the live remaining set is empty
+or every free candidate fails, use the current host session's native models.
+Paid OmniRoute routes stay forbidden.
 
 Canonical orchestration must probe the fixed loopback endpoint before native
-fallback, with no endpoint prompt. On `READY`, dispatch through the sealed
-operator launcher. The operator-owned priority combo alone selects first
-available candidates from its attested no-cost/no-paid-fallback order; OmniRoot
-never reads, persists, or selects route, model, or provider IDs. A concrete
-`RUNTIME_EXHAUSTED` health result or sealed-launcher exit code `78` means that
-allowed set is exhausted and only then permits native implementer fallback.
+fallback, with no endpoint prompt. On `READY` after a live `candidates` pick,
+dispatch through `omniroute run` as above. A concrete `RUNTIME_EXHAUSTED`
+health result, empty remaining catalog, or sealed-launcher exit code `78`
+permits native implementer fallback.
 
 ## Runner
 
@@ -31,6 +96,7 @@ Use only the standard-library [runner](scripts/runner.py):
 
 ```text
 python3 chaos-engine/skills/omniroot/scripts/runner.py probe
+python3 chaos-engine/skills/omniroot/scripts/runner.py candidates --capability mechanical|default|most-intelligent
 python3 chaos-engine/skills/omniroot/scripts/runner.py dispatch --contract <private-state>/dispatch.json
 python3 chaos-engine/skills/omniroot/scripts/runner.py status ...
 python3 chaos-engine/skills/omniroot/scripts/runner.py cancel ...

--- a/chaos-engine/skills/omniroot/scripts/runner.py
+++ b/chaos-engine/skills/omniroot/scripts/runner.py
@@ -50,6 +50,11 @@ READINESS = frozenset({
 })
 RUN_STATUSES = frozenset({"planned", "running", "stalled", "blocked", "review", "completed", "cancelled", "quarantined"})
 _CAPABILITY_RANK = {"mechanical": 0, "default": 1, "most-intelligent": 2}
+_ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_MECHANICAL_MARKERS = frozenset({"low", "lite", "flash", "air", "mini", "nano", "turbo", "haiku", "small"})
+_HIGH_MARKERS = frozenset({"high", "max", "pro", "ultra", "opus", "thinking", "reasoner"})
+_CATALOG_COMMAND = ("omniroute", "--output", "json", "models")
+_QUOTA_COMMAND = ("omniroute", "--output", "json", "usage", "quota")
 _RUN_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
 _TARGET = re.compile(r"[a-z][a-z0-9-]{0,63}\Z")
 _HEX = re.compile(r"[0-9a-f]{64}\Z")
@@ -743,6 +748,110 @@ def _dispatch_environment(environ: dict[str, str], credential_mode: str) -> dict
 
 def _sha256(value: object) -> str:
     return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def decode_cli_json(text: str) -> object:
+    """Parse the first JSON value from OmniRoute CLI stdout; banners and extra objects are ignored."""
+    cleaned = _ANSI.sub("", text)
+    index = min((item for item in (cleaned.find("["), cleaned.find("{")) if item >= 0), default=-1)
+    if index < 0:
+        raise OmniRootError("OmniRoute CLI JSON is missing")
+    try:
+        value, _unused = json.JSONDecoder().raw_decode(cleaned[index:])
+    except json.JSONDecodeError as error:
+        raise OmniRootError("OmniRoute CLI JSON is invalid") from error
+    return value
+
+
+def _provider_key(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        return ""
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def classify_capability(model_id: object) -> str:
+    """Map a live model id to a capability class. This is a ranking method, not a stored catalog."""
+    tokens = set(re.findall(r"[a-z0-9]+", str(model_id).lower()))
+    if tokens & _HIGH_MARKERS:
+        return "most-intelligent"
+    if tokens & _MECHANICAL_MARKERS:
+        return "mechanical"
+    return "default"
+
+
+def select_live_candidates(
+    catalog: object, quota: object, *, required_capability: str,
+) -> list[dict[str, Any]]:
+    """Join the current catalog to remaining quota and order cheapest applicable first."""
+    if required_capability not in _CAPABILITY_RANK:
+        raise OmniRootError("required capability is invalid")
+    remaining: dict[str, int] = {}
+    for row in quota if isinstance(quota, list) else []:
+        if not isinstance(row, dict):
+            continue
+        key = _provider_key(row.get("provider"))
+        if not key:
+            continue
+        if row.get("state") == "exhausted":
+            remaining[key] = 0
+            continue
+        left = row.get("remaining")
+        if isinstance(left, (int, float)) and left > 0:
+            remaining[key] = int(left)
+    selected: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in catalog if isinstance(catalog, list) else []:
+        if not isinstance(item, dict):
+            continue
+        model = item.get("id")
+        provider = item.get("provider")
+        if not isinstance(model, str) or not model or not isinstance(provider, str) or not provider:
+            continue
+        left = remaining.get(_provider_key(provider))
+        if not left:
+            continue
+        identity = (model, provider)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        selected.append({
+            "model": model,
+            "provider": provider,
+            "remaining": left,
+            "capability": classify_capability(model),
+            "identitySha256": _sha256({"model": model, "provider": provider}),
+        })
+    if required_capability == "most-intelligent":
+        pool = [row for row in selected if row["capability"] == "most-intelligent"]
+    else:
+        pool = selected
+    pool.sort(key=lambda row: (_CAPABILITY_RANK[row["capability"]], -row["remaining"], row["model"]))
+    return pool
+
+
+def _omniroute_cli(command: tuple[str, ...], run: Callable[..., Any] | None = None) -> object:
+    runner = run or subprocess.run
+    completed = runner(list(command), capture_output=True, text=True, check=False)  # nosec B603 - fixed local OmniRoute argv.
+    stdout = getattr(completed, "stdout", "") or ""
+    return decode_cli_json(stdout)
+
+
+def candidates(
+    *, required_capability: str = "default",
+    which: Callable[[str], str | None] | None = None,
+    run: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """Query the live local catalog and remaining quota on every dispatch. Never cache to disk."""
+    locator = which or shutil.which
+    if locator("omniroute") is None:
+        return {"state": "ABSENT", "candidates": []}
+    try:
+        catalog = _omniroute_cli(_CATALOG_COMMAND, run=run)
+        quota = _omniroute_cli(_QUOTA_COMMAND, run=run)
+    except OmniRootError:
+        return {"state": "UNHEALTHY", "candidates": []}
+    picked = select_live_candidates(catalog, quota, required_capability=required_capability)
+    return {"state": "READY" if picked else "RUNTIME_EXHAUSTED", "candidates": picked}
 
 
 def _valid_private_candidate(candidate: object) -> bool:
@@ -1935,10 +2044,16 @@ def main(argv: list[str] | None = None) -> int:
     cancel_parser.add_argument("--run-id", required=True)
     complete_parser = commands.add_parser("complete")
     complete_parser.add_argument("--contract", type=Path, required=True)
+    candidates_parser = commands.add_parser("candidates")
+    candidates_parser.add_argument(
+        "--capability", default="default", choices=sorted(_CAPABILITY_RANK),
+    )
     args = parser.parse_args(raw_arguments)
     try:
         if args.command == "probe":
             return _print(probe(config_path=args.config))
+        if args.command == "candidates":
+            return _print(candidates(required_capability=args.capability))
         if args.command == "attest":
             return _print(attest(config_path=args.config, contract_path=args.contract))
         if args.command == "dispatch":

--- a/tests/scripts/test_omniroot_catalog.py
+++ b/tests/scripts/test_omniroot_catalog.py
@@ -1,0 +1,124 @@
+"""Live OmniRoot catalog selection: no cache files, rank from current CLI JSON."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+import unittest.mock
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER_PATH = ROOT / "chaos-engine/skills/omniroot/scripts/runner.py"
+SKILL = ROOT / "chaos-engine/skills/omniroot/SKILL.md"
+WORKFLOWS = ROOT / "chaos-engine/references/execution-workflows.md"
+GUIDE = ROOT / "chaos-engine/guides/omniroute.md"
+SPEC = importlib.util.spec_from_file_location("omniroot_catalog_runner", RUNNER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("OmniRoot runner could not be loaded")
+RUNNER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RUNNER)
+
+
+class OmniRootCatalogTest(unittest.TestCase):
+    def test_decode_strips_ansi_logs_and_trailing_extra_json(self):
+        raw = (
+            "\x1b[2mLoaded env\x1b[0m\n"
+            '[{"id": "Alpha Low", "provider": "one"}]\n'
+            '{"ignored": true}\n'
+        )
+        self.assertEqual(
+            [{"id": "Alpha Low", "provider": "one"}],
+            RUNNER.decode_cli_json(raw),
+        )
+
+    def test_select_drops_exhausted_providers_and_prefers_lower_capability(self):
+        catalog = [
+            {"id": "Tool Low", "provider": "alpha"},
+            {"id": "Tool High", "provider": "alpha"},
+            {"id": "Other Default", "provider": "beta"},
+            {"id": "Gone Low", "provider": "gamma"},
+        ]
+        quota = [
+            {"provider": "alpha", "remaining": 40, "state": "available"},
+            {"provider": "beta", "remaining": 90, "state": "available"},
+            {"provider": "gamma", "remaining": 0, "state": "exhausted"},
+        ]
+        picked = RUNNER.select_live_candidates(catalog, quota, required_capability="default")
+        self.assertEqual(
+            ["Tool Low", "Other Default", "Tool High"],
+            [item["model"] for item in picked],
+        )
+        self.assertNotIn("Gone Low", [item["model"] for item in picked])
+
+    def test_architecture_uses_only_high_class_then_empty_means_native_fallback(self):
+        catalog = [
+            {"id": "Tool Low", "provider": "alpha"},
+            {"id": "Tool High", "provider": "alpha"},
+        ]
+        quota = [{"provider": "alpha", "remaining": 12, "state": "available"}]
+        picked = RUNNER.select_live_candidates(
+            catalog, quota, required_capability="most-intelligent",
+        )
+        self.assertEqual(["Tool High"], [item["model"] for item in picked])
+        empty = RUNNER.select_live_candidates(
+            [{"id": "Tool Low", "provider": "alpha"}],
+            [{"provider": "alpha", "remaining": 12, "state": "available"}],
+            required_capability="most-intelligent",
+        )
+        self.assertEqual([], empty)
+
+    def test_skill_documents_live_query_every_dispatch_without_cache_files(self):
+        skill = SKILL.read_text(encoding="utf-8")
+        workflows = WORKFLOWS.read_text(encoding="utf-8")
+        guide = GUIDE.read_text(encoding="utf-8")
+        for text in (skill, workflows):
+            self.assertIn("omniroute --output json models", text)
+            self.assertIn("omniroute --output json usage quota", text)
+            self.assertIn("every dispatch", text)
+            self.assertNotIn("catalog-policy.json", text)
+            self.assertNotIn("session cache", text.lower())
+        self.assertIn("OMNIROUTE_SERVER_HOST=127.0.0.1 omniroute serve --port 20128 --no-open", skill)
+        self.assertIn("http://127.0.0.1:20128/api/health", skill)
+        self.assertIn("omniroute run --model", skill)
+        self.assertIn("JSONDecoder().raw_decode", skill)
+        self.assertIn("Use `--output json` before `models`", skill)
+        self.assertIn("installed OmniRoute binary", guide)
+        self.assertIn("candidates --capability", skill)
+
+    def test_candidates_cli_queries_live_commands_and_writes_no_cache(self):
+        calls = []
+
+        def fake_run(command, **_kwargs):
+            calls.append(command)
+            class Result:
+                stdout = ""
+                returncode = 0
+            if command[-1] == "models":
+                Result.stdout = json.dumps([
+                    {"id": "Live Low", "provider": "alpha"},
+                    {"id": "Live High", "provider": "alpha"},
+                ])
+            else:
+                Result.stdout = json.dumps([
+                    {"provider": "alpha", "remaining": 7, "state": "available"},
+                ])
+            return Result()
+
+        with unittest.mock.patch.object(RUNNER.shutil, "which", return_value="/usr/bin/omniroute"):
+            with unittest.mock.patch.object(RUNNER.subprocess, "run", side_effect=fake_run):
+                result = RUNNER.candidates(required_capability="mechanical")
+        self.assertEqual(
+            [["omniroute", "--output", "json", "models"],
+             ["omniroute", "--output", "json", "usage", "quota"]],
+            calls,
+        )
+        self.assertEqual("READY", result["state"])
+        self.assertEqual("Live Low", result["candidates"][0]["model"])
+        self.assertFalse(any(Path.cwd().joinpath(name).exists()
+                             for name in (".omniroot-catalog.json", "catalog-cache.json")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_omniroot_workflow_contract.py
+++ b/tests/scripts/test_omniroot_workflow_contract.py
@@ -45,11 +45,11 @@ class OmniRootWorkflowContractTest(unittest.TestCase):
         workflows = self.read("chaos-engine/references/execution-workflows.md")
         omniroot = self.read("chaos-engine/skills/omniroot/SKILL.md")
         guide = self.read("chaos-engine/guides/omniroute.md")
-        for text in (workflows, omniroot, guide):
+        for text in (workflows, omniroot):
             normalized = " ".join(text.split())
             self.assertIn("probe the fixed loopback endpoint before native fallback", normalized)
-            self.assertIn("sealed operator launcher", normalized)
-            self.assertIn("operator-owned priority combo", normalized)
+            self.assertIn("omniroute --output json models", text)
+            self.assertIn("omniroute --output json usage quota", text)
             self.assertIn("RUNTIME_EXHAUSTED", normalized)
         self.assertIn("Built-in `spawn_agent` cannot select OmniRoute", guide)
 


### PR DESCRIPTION
## Summary

Makes OmniRoot query the live local catalog and remaining quota immediately before every dispatch, then pick the cheapest applicable remaining model for that task. Ranking is computed from the live ids. No catalog cache files and no stored per-user model list.

Closes #5529.

## Checks

- `PYTHONPATH=. python3 -m unittest tests.scripts.test_omniroot_catalog tests.scripts.test_omniroot_workflow_contract tests.scripts.test_omniroot -q` (79 passed)
- `git diff --check`
- Live `candidates --capability default` returned `READY` against the current local gateway

## Continuation

Native host-session models remain last fallback when the remaining free set is empty. Paid OmniRoute routes stay forbidden. #5462 Harbor trials still need Docker on this workstation.