### PR TITLE
fix(installer): refuse extra empty nested MemPalace dirs

### DIFF
--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -679,16 +679,20 @@ def restore_candidate_mempalace_state(project: Path, image: dict[str, object]) -
             },
         )
     if exists:
-        recorded_ancestors = {
-            PurePosixPath(relative).parts[0]
-            for relative in after_files
-            if len(PurePosixPath(relative).parts) > 1
-        }
-        for child in palace.iterdir():
-            if child.is_dir() and child.name not in recorded_ancestors:
+        recorded_ancestors: set[str] = set()
+        for relative in after_files:
+            parts = PurePosixPath(relative).parts
+            for depth in range(1, len(parts)):
+                recorded_ancestors.add(PurePosixPath(*parts[:depth]).as_posix())
+        for child in sorted(
+            (item for item in palace.rglob("*") if item.is_dir()),
+            key=lambda item: item.relative_to(palace).as_posix(),
+        ):
+            relative = child.relative_to(palace).as_posix()
+            if relative not in recorded_ancestors:
                 mismatches.append(
                     {
-                        "path": _mempalace_state_relative(child.name),
+                        "path": _mempalace_state_relative(relative),
                         "expectedDigest": None,
                         "actualDigest": None,
                     }

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -719,6 +719,45 @@ module.install_with_dependencies(project, source, "2" * 40)
             )
             self.assertFalse(palace.exists())
 
+    def test_restore_candidate_mempalace_refuses_extra_empty_nested_directory(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            palace = project / ".chaos-engine-state" / "mempalace"
+            nested = palace / ".mempalace"
+            nested.mkdir(parents=True)
+            origin = nested.joinpath("origin.json")
+            origin.write_text('{"wing":"exact"}\n', encoding="utf-8")
+            exists, files = MODULE.project_setup_output_files(
+                project, MODULE.MEMPALACE_STATE_OUTPUT
+            )
+            self.assertTrue(exists)
+            self.assertEqual({".mempalace/origin.json"}, set(files))
+            rooms = nested / "rooms"
+            rooms.mkdir()
+
+            with self.assertRaises(ValueError) as raised:
+                MODULE.restore_candidate_mempalace_state(
+                    project,
+                    {
+                        "before": {"exists": False, "files": {}},
+                        "after": {"exists": True, "files": files},
+                    },
+                )
+            message = str(raised.exception)
+            self.assertIn("candidate MemPalace state changed", message)
+            payload = json.loads(message[message.index("{") :])
+            self.assertEqual(
+                ".chaos-engine-state/mempalace/.mempalace/rooms",
+                payload["path"],
+            )
+            self.assertIsNone(payload["expectedDigest"])
+            self.assertIsNone(payload["actualDigest"])
+            self.assertEqual("project", payload["owner"])
+            self.assertEqual("blocked", payload["action"])
+            self.assertTrue(rooms.is_dir())
+            self.assertEqual('{"wing":"exact"}\n', origin.read_text(encoding="utf-8"))
+
     def test_restore_candidate_mempalace_refuses_extra_non_ancestor_directory(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "consumer"


### PR DESCRIPTION
## Summary

- Fail closed when an extra empty nested MemPalace directory exists under a recorded ancestor (for example `.mempalace/rooms/` beside matching `.mempalace/origin.json`).
- Report structured relative-path evidence and leave the extra directory untouched.
- Keep nested matching-digest restores green (#5526 F1).

Closes #5533

## Checks

Writer-reported on `59f802660470564f86ee397379d09f263eb8cd50`:
- RED: `test_restore_candidate_mempalace_refuses_extra_empty_nested_directory` failed with `AssertionError: ValueError not raised` before the production change.
- GREEN: `python3 -m unittest tests.scripts.test_chaos_engine_installer -v` — 132 passed
- Focused: `test_restore_candidate_mempalace_refuses_extra_empty_nested_directory` — ok
- Focused: `test_restore_candidate_mempalace_allows_nested_dirs_with_matching_digests` — ok

## Scope

Only `chaos-engine/install.py` and `tests/scripts/test_chaos_engine_installer.py`. Does not touch bootstrap.py (#5531) or hosts/hooks (#5535).

## Continuation

- Head: `59f802660470564f86ee397379d09f263eb8cd50`
- Branch: `ChaosEngine/fix-empty-nested-mempalace-5533`
- Opened for review; do not merge from this writer session.
- Exact-head CI and independent review remain owner/orchestrator owned.

## Documentation Site

- Documentation not required because: installer fail-closed MemPalace rollback behavior is harness-internal; no public SHAFT user-facing docs change.