### PR TITLE
feat(ci): close harness changes through owned inventory and identity preflight

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -128,6 +128,7 @@ jobs:
               - '.memory/**'
               - 'scripts/agents/**'
               - 'scripts/ci/harness_pr_gate.py'
+              - 'scripts/ci/chaos_engine_live_installer_acceptance.py'
               - 'scripts/ci/chaos_engine_promotion.py'
               - 'scripts/ci/validate_chaos_engine_readme.py'
               - 'scripts/ci/validate_agent_setup.py'
@@ -202,6 +203,13 @@ jobs:
               - 'tests/scripts/test_agnix_conformance.py'
               - 'tests/scripts/test_agent_plugin_client_smoke.py'
               - 'tests/scripts/test_harness_pr_gate.py'
+              - 'tests/scripts/test_chaos_engine_bootstrap.py'
+              - 'tests/scripts/test_chaos_engine_dependencies.py'
+              - 'tests/scripts/test_chaos_engine_generation_runtime.py'
+              - 'tests/scripts/test_chaos_engine_installer.py'
+              - 'tests/scripts/test_chaos_engine_install_wrappers.py'
+              - 'tests/scripts/test_chaos_engine_live_installer_acceptance.py'
+              - 'tests/scripts/test_chaos_engine_installer_ux.py'
               - 'tests/scripts/test_chaos_engine_promotion.py'
               - 'tests/scripts/test_validate_chaos_engine_readme.py'
               # Not agent guidance, but this is the only gate that runs the
@@ -986,7 +994,9 @@ jobs:
 
   chaos-installer-acceptance:
     name: ChaosEngine fresh installer (${{ matrix.os }})
-    needs: changes
+    needs:
+      - changes
+      - agent-guidance
     if: needs.changes.outputs.chaos_installer == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -608,6 +608,18 @@ py -3 -m unittest tests.scripts.test_chaos_engine_hosts
 py -3 scripts/ci/validate_agent_setup.py --skip-external
 ```
 
+Before pushing harness changes, run the single changed-closure preflight against
+the full lowercase `HEAD` and its resolvable merge base. The explicit
+`--write-generated` flag refreshes owned README inventory and ChaosGauge
+identity artifacts, then validates the selected closure:
+
+```bash
+python3 scripts/ci/harness_pr_gate.py \
+  --base "$(git merge-base HEAD origin/main)" \
+  --head "$(git rev-parse HEAD)" \
+  --write-generated
+```
+
 Use the equivalent Python 3 command on non-Windows hosts. Run the smallest
 affected check first, then the nearest broader gate. Never commit generated
 reports, caches, runtime indexes, or `graphify-out/`.

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "7f2e6032118771bd9b75820689e1d830a8792db4d26b36c7b769d6b6a239ac0e",
+      "harnessSha256": "fa120b117aed4c7d0f7ced1a985ed40dd39d67284a481f2d477b4b9fee1776f5",
       "treatmentSha256": {
-        "calibration": "dfd84487992368761a1b7507da162760bdec3ef6a366cb0f53273a79ff7841fe",
-        "full-pilot": "568d0f28aaf12ad3ff8781ed1a6777dc6d4ed65011995f4a02e89fd78dc8744c"
+        "calibration": "58460570fd63425800256724dc42dfe04aa6ab118779d7762c29d68eef21ccf2",
+        "full-pilot": "9dbd3b7b2bfb9b73c45dc654699d6673cba19d18b5cde33352b2f03d39aaa0a7"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "4a01612ce68a61c4309da2fadf1fb5ae3667a295ccc83225f34c58378aaee066",
+      "harnessSha256": "62300afbb8672c25f13b2cf70b22f33bd0f5f18d0b82471335fa0414d437b68c",
       "treatmentSha256": {
-        "calibration": "e36720e0bc44028dfaa412741992025d7091fe902b179b5a0907bd59648e88e6",
-        "full-pilot": "9287593d82b622e42d186b96d69b58d8ba86c031055d725b3679a7e658e8dd4d"
+        "calibration": "55672e6ac0acc78402db4e58c0374a9fccc0bcd54b5b6f5577330514c874fcb8",
+        "full-pilot": "a180fb6826732138a18963625932d475746c1c0146fee7e8ee17c449e4bdc3de"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "fa120b117aed4c7d0f7ced1a985ed40dd39d67284a481f2d477b4b9fee1776f5",
+      "harnessSha256": "4a01612ce68a61c4309da2fadf1fb5ae3667a295ccc83225f34c58378aaee066",
       "treatmentSha256": {
-        "calibration": "58460570fd63425800256724dc42dfe04aa6ab118779d7762c29d68eef21ccf2",
-        "full-pilot": "9dbd3b7b2bfb9b73c45dc654699d6673cba19d18b5cde33352b2f03d39aaa0a7"
+        "calibration": "e36720e0bc44028dfaa412741992025d7091fe902b179b5a0907bd59648e88e6",
+        "full-pilot": "9287593d82b622e42d186b96d69b58d8ba86c031055d725b3679a7e658e8dd4d"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "fa120b117aed4c7d0f7ced1a985ed40dd39d67284a481f2d477b4b9fee1776f5"
+      harness_sha256: "4a01612ce68a61c4309da2fadf1fb5ae3667a295ccc83225f34c58378aaee066"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "7f2e6032118771bd9b75820689e1d830a8792db4d26b36c7b769d6b6a239ac0e"
+      harness_sha256: "fa120b117aed4c7d0f7ced1a985ed40dd39d67284a481f2d477b4b9fee1776f5"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "4a01612ce68a61c4309da2fadf1fb5ae3667a295ccc83225f34c58378aaee066"
+      harness_sha256: "62300afbb8672c25f13b2cf70b22f33bd0f5f18d0b82471335fa0414d437b68c"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "4a01612ce68a61c4309da2fadf1fb5ae3667a295ccc83225f34c58378aaee066"
+      harness_sha256: "62300afbb8672c25f13b2cf70b22f33bd0f5f18d0b82471335fa0414d437b68c"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "7f2e6032118771bd9b75820689e1d830a8792db4d26b36c7b769d6b6a239ac0e"
+      harness_sha256: "fa120b117aed4c7d0f7ced1a985ed40dd39d67284a481f2d477b4b9fee1776f5"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "fa120b117aed4c7d0f7ced1a985ed40dd39d67284a481f2d477b4b9fee1776f5"
+      harness_sha256: "4a01612ce68a61c4309da2fadf1fb5ae3667a295ccc83225f34c58378aaee066"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -348,7 +348,7 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
         if name == "chaos-engine":
             adapter = _file_sha256(Path(__file__).with_name("agent.py"))
             expected = {
-                "version": str(kwargs.get("version")),
+                "version": "0.118.0",
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),

--- a/scripts/ci/chaos_gauge/validate_experiment.py
+++ b/scripts/ci/chaos_gauge/validate_experiment.py
@@ -346,13 +346,14 @@ def validate_job_contracts(  # noqa: MC0001 - cross-arm equality is one invarian
         if agent.get("override_setup_timeout_sec") != 900:
             raise ValueError("job setup timeout drift is not allowed")
         if name == "chaos-engine":
+            adapter = _file_sha256(Path(__file__).with_name("agent.py"))
             expected = {
-                "version": "0.118.0",
+                "version": str(kwargs.get("version")),
                 "reasoning_effort": arm.get("effort"),
                 "harness_source": "chaos-engine",
                 "harness_commit": arm.get("repositoryRevision"),
-                "harness_sha256": "7f2e6032118771bd9b75820689e1d830a8792db4d26b36c7b769d6b6a239ac0e",
-                "adapter_sha256": "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
+                "harness_sha256": arm.get("harnessSha256"),
+                "adapter_sha256": adapter,
             }
             if kwargs != expected:
                 raise ValueError("job harness treatment is invalid")
@@ -400,10 +401,103 @@ def load_manifest(path: Path) -> dict[str, object]:
     return value
 
 
+def _replace_yaml_scalar(text: str, key: str, value: str) -> str:
+    pattern = re.compile(
+        rf"^([ \t]*{re.escape(key)}:[ \t]*)\"?[0-9a-f]{{64}}\"?[ \t]*$",
+        re.MULTILINE,
+    )
+    replaced, count = pattern.subn(rf'\1"{value}"', text, count=1)
+    if count != 1:
+        raise ValueError(f"job identity field is missing: {key}")
+    return replaced
+
+
+def _replace_exact_sha(text: str, old: str, new: str) -> str:
+    if not SHA256.fullmatch(old) or not SHA256.fullmatch(new):
+        raise ValueError("identity digest is invalid")
+    if old == new:
+        return text
+    if text.count(old) != 1:
+        raise ValueError(f"identity digest is not unique: {old}")
+    return text.replace(old, new, 1)
+
+
+def write_generated(root: Path) -> None:
+    """Refresh coupled manifest and job identities from live harness bytes."""
+    repository = root.resolve()
+    gauge = _gauge_root(repository)
+    if not (repository / "chaos-engine").is_dir():
+        raise ValueError("canonical ChaosEngine source tree is required")
+    harness = _tree_sha256(repository / "chaos-engine")
+    adapter = _file_sha256(gauge / "agent.py")
+    lock = _file_sha256(gauge / "requirements.lock")
+    manifest_path = gauge / "experiment.json"
+    original = manifest_path.read_text(encoding="utf-8")
+    manifest = json.loads(original)
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("arms"), list):
+        raise ValueError("experiment manifest JSON is malformed")
+    if len(manifest["arms"]) != 2:
+        raise ValueError("experiment arms are invalid")
+    control = _mapping(manifest["arms"][0], "control arm")
+    candidate = _mapping(manifest["arms"][1], "candidate arm")
+    old_candidate_harness = str(candidate.get("harnessSha256"))
+    old_lock = str(manifest.get("dependencyLockSha256"))
+    candidate["harnessSha256"] = harness
+    treatments: dict[str, dict[str, str]] = {"control": {}, "chaos-engine": {}}
+    old_treatments: dict[str, dict[str, str]] = {"control": {}, "chaos-engine": {}}
+    for index, name in enumerate(("control", "chaos-engine")):
+        arm = _mapping(manifest["arms"][index], "experiment arm")
+        current = _mapping(arm.get("treatmentSha256"), "treatment identity")
+        for campaign in ("calibration", "full-pilot"):
+            old_treatments[name][campaign] = str(current[campaign])
+    for campaign in ("calibration", "full-pilot"):
+        prefix = "" if campaign == "calibration" else "full-pilot-"
+        path = gauge / "job-configs" / f"{prefix}chaos-engine.yaml"
+        text = path.read_text(encoding="utf-8")
+        text = _replace_yaml_scalar(text, "harness_sha256", harness)
+        text = _replace_yaml_scalar(text, "adapter_sha256", adapter)
+        path.write_text(text, encoding="utf-8")
+        jobs = load_jobs(gauge, campaign)
+        for index, name in enumerate(("control", "chaos-engine")):
+            arm = control if name == "control" else candidate
+            treatments[name][campaign] = _sha256(
+                {
+                    "repositoryRevision": arm["repositoryRevision"],
+                    "taskDataset": _mapping(manifest.get("dataset"), "dataset")["sha256"],
+                    "harnessTree": "none" if name == "control" else harness,
+                    "adapter": "none" if name == "control" else adapter,
+                    "dependencyLock": lock,
+                    "campaign": campaign,
+                    "job": jobs[name],
+                }
+            )
+    rendered = original
+    rendered = _replace_exact_sha(rendered, old_lock, lock)
+    rendered = _replace_exact_sha(rendered, old_candidate_harness, harness)
+    for name in ("control", "chaos-engine"):
+        for campaign in ("calibration", "full-pilot"):
+            rendered = _replace_exact_sha(
+                rendered,
+                old_treatments[name][campaign],
+                treatments[name][campaign],
+            )
+    if rendered != original:
+        manifest_path.write_text(rendered, encoding="utf-8")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("manifest", type=Path)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="refresh coupled manifest and job identities from live harness bytes",
+    )
     args = parser.parse_args()
+    root = args.manifest.parent
+    if args.write:
+        repository = root.parents[2] if root.name == "chaos_gauge" else root
+        write_generated(repository)
     value = load_manifest(args.manifest)
     for selected_campaign in ("calibration", "full-pilot"):
         validate_job_contracts(

--- a/scripts/ci/harness_pr_gate.py
+++ b/scripts/ci/harness_pr_gate.py
@@ -147,6 +147,26 @@ CHECKS = {
         "documentation",
         ("tests.scripts.test_validate_chaos_engine_readme",),
     ),
+    "dependency-account-contract": Check(
+        "dependency-account-contract",
+        "installer",
+        (
+            "tests.scripts.test_chaos_engine_dependencies.ChaosEngineDependenciesTest."
+            "test_account_tool_plan_uses_resolved_stable_versions_then_matching_rerun_reuses",
+            "tests.scripts.test_chaos_engine_dependencies.ChaosEngineDependenciesTest."
+            "test_account_install_passes_resolved_tool_versions_to_the_account_plan",
+        ),
+    ),
+    "identity-contract": Check(
+        "identity-contract",
+        "identities",
+        ("tests.scripts.test_chaos_gauge_contracts",),
+    ),
+    "identity-recovery-contract": Check(
+        "identity-recovery-contract",
+        "identities",
+        ("tests.scripts.test_chaos_gauge_recovery",),
+    ),
     "promotion-contract": Check(
         "promotion-contract",
         "promotion",
@@ -219,9 +239,12 @@ SURFACE_CHECKS = {
     "ci": ("ci-contract", "setup-aggregator-contract"),
     "installer": ("protected-installer-acceptance", "protected-rollback"),
     "documentation": ("documentation-inventory-contract",),
+    "identities": ("identity-contract", "identity-recovery-contract"),
     "promotion": ("promotion-contract",),
     "fallback": ("fallback-contract",),
 }
+
+DEPENDENCY_CLOSURE_PATHS = frozenset({"chaos-engine/dependencies.json"})
 
 SURFACE_PATTERNS = {
     "kernel": (
@@ -317,6 +340,9 @@ SURFACE_PATTERNS = {
         "scripts/ci/validate_chaos_engine_readme.py",
         "tests/scripts/test_validate_chaos_engine_readme.py",
     ),
+    "identities": (
+        "chaos-engine/**",
+    ),
     "promotion": (
         "scripts/ci/chaos_engine_promotion*.py",
         "tests/scripts/test_chaos_engine_promotion.py",
@@ -379,6 +405,7 @@ HARNESS_PATTERNS = (
 def classify_paths(paths: list[str]) -> GatePlan:
     selected: list[str] = []
     unknown: list[str] = []
+    dependency_closure = False
     for raw_path in paths:
         path = raw_path.replace("\\", "/")
         while path.startswith("./"):
@@ -400,6 +427,10 @@ def classify_paths(paths: list[str]) -> GatePlan:
                 if surface not in selected:
                     selected.append(surface)
                 matched = True
+        if path in DEPENDENCY_CLOSURE_PATHS:
+            dependency_closure = True
+            if "documentation" not in selected:
+                selected.append("documentation")
         harness_path = (
             path in HARNESS_FILES
             or path.startswith(HARNESS_PREFIXES)
@@ -413,6 +444,8 @@ def classify_paths(paths: list[str]) -> GatePlan:
         return GatePlan()
 
     check_ids = [check_id for surface in selected for check_id in SURFACE_CHECKS[surface]]
+    if dependency_closure:
+        check_ids.append("dependency-account-contract")
     for protected_id in ("protected-ownership", "protected-secret-safety"):
         if protected_id not in check_ids:
             check_ids.append(protected_id)
@@ -423,6 +456,34 @@ def classify_paths(paths: list[str]) -> GatePlan:
         ),
         tuple(sorted(set(unknown))),
     )
+
+
+def write_generated_artifacts(root: Path, plan: GatePlan) -> tuple[str, ...]:
+    """Refresh owned generated artifacts for the selected changed-closure surfaces."""
+    written: list[str] = []
+    root = root.resolve()
+    if "documentation" in plan.surfaces:
+        from scripts.ci.validate_chaos_engine_readme import write_generated as write_readme
+
+        readme = root / "chaos-engine/README.md"
+        before = readme.read_bytes() if readme.is_file() else b""
+        write_readme(root)
+        if readme.read_bytes() != before:
+            written.append("chaos-engine/README.md")
+    if "identities" in plan.surfaces:
+        from scripts.ci.chaos_gauge.validate_experiment import write_generated as write_identities
+
+        targets = (
+            root / "scripts/ci/chaos_gauge/experiment.json",
+            root / "scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml",
+            root / "scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml",
+        )
+        before = {path: path.read_bytes() for path in targets if path.is_file()}
+        write_identities(root)
+        for path, payload in before.items():
+            if path.read_bytes() != payload:
+                written.append(path.relative_to(root).as_posix())
+    return tuple(dict.fromkeys(written))
 
 
 def _waiver_payload(body: str) -> dict[str, object] | None:
@@ -805,6 +866,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--output", type=Path)
     parser.add_argument("--format", choices=("text", "json"), default="text")
     parser.add_argument("--plan-only", action="store_true")
+    parser.add_argument(
+        "--write-generated",
+        action="store_true",
+        help="refresh owned generated inventory and identity artifacts before validation",
+    )
     return parser
 
 
@@ -815,12 +881,16 @@ def main() -> int:
             raise GateError("budget must be between 1 and 600 seconds")
         if not re.fullmatch(r"[0-9a-f]{40}", args.head):
             raise GateError("head must be a full lowercase SHA")
+        if args.plan_only and args.write_generated:
+            raise GateError("plan-only cannot write generated artifacts")
         root = args.root.resolve()
         plan = classify_paths(changed_paths(root, args.base, args.head))
+        written = write_generated_artifacts(root, plan) if args.write_generated else ()
         if args.plan_only:
             payload = json.loads(
                 render_json(plan, head_sha=args.head, budget_seconds=args.budget_seconds)
             )
+            payload["written"] = list(written)
             exit_code = 0
         else:
             waiver = event_waiver(args.reviews, args.head)
@@ -831,6 +901,7 @@ def main() -> int:
                 budget_seconds=args.budget_seconds,
                 waiver=waiver,
             )
+            payload["written"] = list(written)
     except GateError as error:
         payload = {"schema": 1, "valid": False, "error": str(error)}
         exit_code = 2

--- a/scripts/ci/validate_chaos_engine_readme.py
+++ b/scripts/ci/validate_chaos_engine_readme.py
@@ -354,19 +354,43 @@ def validate(root: Path = ROOT) -> list[str]:
     return errors
 
 
+def write_generated(root: Path = ROOT) -> None:
+    """Rewrite source-derived inventory sections between canonical markers."""
+    root = root.resolve()
+    path = root / README
+    readme = path.read_text(encoding="utf-8")
+    for name, table in inventory_sections(root).items():
+        start = f"<!-- inventory:{name}:start -->"
+        end = f"<!-- inventory:{name}:end -->"
+        if readme.count(start) != 1 or readme.count(end) != 1:
+            raise ValueError(f"inventory marker count is invalid: {name}")
+        before, rest = readme.split(start, 1)
+        _, after = rest.split(end, 1)
+        readme = f"{before}{start}\n{table}\n{end}{after}"
+    path.write_text(readme, encoding="utf-8")
+
+
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     result.add_argument("--root", type=Path, default=ROOT)
     result.add_argument("--render", action="store_true")
+    result.add_argument(
+        "--write",
+        action="store_true",
+        help="refresh source-derived README inventory sections",
+    )
     return result
 
 
 def main() -> int:
     arguments = parser().parse_args()
+    root = arguments.root.resolve()
     if arguments.render:
-        print(rendered_inventory(arguments.root.resolve()))
+        print(rendered_inventory(root))
         return 0
-    errors = validate(arguments.root.resolve())
+    if arguments.write:
+        write_generated(root)
+    errors = validate(root)
     for error in errors:
         print(error, file=sys.stderr)
     return 1 if errors else 0

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -6,7 +6,9 @@ import copy
 import hashlib
 import importlib.util
 import json
+import shutil
 import sys
+import tempfile
 import types
 import tomllib
 from pathlib import Path
@@ -31,6 +33,64 @@ SPEC.loader.exec_module(MODULE)
 class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
     def manifest(self) -> dict[str, object]:
         return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    def test_write_generated_refreshes_coupled_identities_idempotently(self):
+        write_generated = getattr(MODULE, "write_generated", None)
+        self.assertTrue(callable(write_generated))
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            shutil.copytree(ROOT / "chaos-engine", root / "chaos-engine")
+            gauge = root / "scripts/ci/chaos_gauge"
+            shutil.copytree(GAUGE, gauge)
+            manifest_path = gauge / "experiment.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["arms"][1]["harnessSha256"] = "0" * 64
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                ValueError,
+                "job harness treatment|digest mismatch|treatment digest",
+            ):
+                MODULE.validate_job_contracts(
+                    json.loads(manifest_path.read_text(encoding="utf-8")),
+                    MODULE.load_jobs(gauge, "calibration"),
+                    root=root,
+                    campaign="calibration",
+                )
+
+            write_generated(root)
+            MODULE.validate_job_contracts(
+                json.loads(manifest_path.read_text(encoding="utf-8")),
+                MODULE.load_jobs(gauge, "calibration"),
+                root=root,
+                campaign="calibration",
+            )
+            MODULE.validate_job_contracts(
+                json.loads(manifest_path.read_text(encoding="utf-8")),
+                MODULE.load_jobs(gauge, "full-pilot"),
+                root=root,
+                campaign="full-pilot",
+            )
+            first = {
+                path.relative_to(root).as_posix(): path.read_bytes()
+                for path in (
+                    manifest_path,
+                    gauge / "job-configs/chaos-engine.yaml",
+                    gauge / "job-configs/full-pilot-chaos-engine.yaml",
+                )
+            }
+            write_generated(root)
+            second = {
+                path.relative_to(root).as_posix(): path.read_bytes()
+                for path in (
+                    manifest_path,
+                    gauge / "job-configs/chaos-engine.yaml",
+                    gauge / "job-configs/full-pilot-chaos-engine.yaml",
+                )
+            }
+            self.assertEqual(first, second)
 
     def test_canonical_manifest_is_pinned_comparable_and_reproducible(self):
         manifest = self.manifest()
@@ -160,7 +220,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
         self.assertNotEqual(identities["control"], identities["chaos-engine"])
         drifted_manifest = self.manifest()
         drifted_manifest["arms"][1]["harnessSha256"] = "f" * 64
-        with self.assertRaisesRegex(ValueError, "manifest harness source"):
+        with self.assertRaisesRegex(ValueError, "job harness treatment"):
             MODULE.validate_job_contracts(drifted_manifest, jobs, root=ROOT)
 
         drifted = copy.deepcopy(jobs)
@@ -232,8 +292,8 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
             agent = module.ChaosEngineCodex(
                 harness_source=str(ROOT / "chaos-engine"),
                 harness_commit="0481767def7c31fe144bc20543dfe937b8ffd4d5",
-                harness_sha256="7f2e6032118771bd9b75820689e1d830a8792db4d26b36c7b769d6b6a239ac0e",
-                adapter_sha256="3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd",
+                harness_sha256=MODULE._tree_sha256(ROOT / "chaos-engine"),
+                adapter_sha256=MODULE._file_sha256(GAUGE / "agent.py"),
             )
 
             await agent.install(environment)

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -238,6 +238,13 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(ValueError, "retry budget"):
             MODULE.validate_job_contracts(self.manifest(), drifted, root=ROOT)
 
+        unbound = copy.deepcopy(jobs)
+        for name in ("control", "chaos-engine"):
+            unbound[name]["agents"][0]["kwargs"]["version"] = "9.9.9"
+        with self.assertRaisesRegex(ValueError, "job harness treatment"):
+            MODULE.validate_job_contracts(self.manifest(), unbound)
+        self.assertEqual("0.118.0", jobs["chaos-engine"]["agents"][0]["kwargs"]["version"])
+
     def test_all_harbor_job_arms_add_only_the_pinned_chroma_model_host(self):
         host = "chroma-onnx-models.s3.amazonaws.com"
         for name in (

--- a/tests/scripts/test_chaos_gauge_contracts.py
+++ b/tests/scripts/test_chaos_gauge_contracts.py
@@ -35,8 +35,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
         return json.loads(MANIFEST.read_text(encoding="utf-8"))
 
     def test_write_generated_refreshes_coupled_identities_idempotently(self):
-        write_generated = getattr(MODULE, "write_generated", None)
-        self.assertTrue(callable(write_generated))
+        self.assertTrue(callable(MODULE.write_generated))
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             shutil.copytree(ROOT / "chaos-engine", root / "chaos-engine")
@@ -60,7 +59,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
                     campaign="calibration",
                 )
 
-            write_generated(root)
+            MODULE.write_generated(root)
             MODULE.validate_job_contracts(
                 json.loads(manifest_path.read_text(encoding="utf-8")),
                 MODULE.load_jobs(gauge, "calibration"),
@@ -81,7 +80,7 @@ class ChaosGaugeContractsTest(IsolatedAsyncioTestCase):
                     gauge / "job-configs/full-pilot-chaos-engine.yaml",
                 )
             }
-            write_generated(root)
+            MODULE.write_generated(root)
             second = {
                 path.relative_to(root).as_posix(): path.read_bytes()
                 for path in (

--- a/tests/scripts/test_harness_pr_gate.py
+++ b/tests/scripts/test_harness_pr_gate.py
@@ -13,7 +13,9 @@ from unittest.mock import patch
 
 import yaml
 
+import scripts.ci.harness_pr_gate as harness_pr_gate
 from scripts.ci.harness_pr_gate import (
+    Check,
     GateError,
     GatePlan,
     WaiverReceipt,
@@ -139,8 +141,18 @@ class ClassifierTest(unittest.TestCase):
         self.assertIn("documentation", plan.surfaces)
         self.assertIn("documentation-inventory-contract", {check.id for check in plan.checks})
         self.assertTrue(account_proofs.issubset(modules), modules)
-        omitted = modules - account_proofs
-        self.assertFalse(account_proofs.issubset(omitted))
+        original = harness_pr_gate.CHECKS["dependency-account-contract"]
+        dropped = account_proofs - {original.modules[0]}
+        mutated = Check(
+            original.id,
+            original.surface,
+            original.modules[:1],
+            original.protected,
+        )
+        with patch.dict(harness_pr_gate.CHECKS, {"dependency-account-contract": mutated}):
+            broken = classify_paths(["chaos-engine/dependencies.json"])
+        self.assertFalse(account_proofs.issubset(set(broken.test_modules)), broken.test_modules)
+        self.assertTrue(dropped.isdisjoint(set(broken.test_modules)), broken.test_modules)
 
     def test_harness_tree_change_closes_coupled_identity_checks(self) -> None:
         plan = classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
@@ -152,8 +164,13 @@ class ClassifierTest(unittest.TestCase):
 
         self.assertIn("identities", plan.surfaces)
         self.assertTrue(identity_proofs.issubset(modules), modules)
-        sibling_omission = modules - {"tests.scripts.test_chaos_gauge_recovery"}
-        self.assertFalse(identity_proofs.issubset(sibling_omission))
+        with patch.dict(
+            harness_pr_gate.SURFACE_CHECKS,
+            {"identities": ("identity-contract",)},
+        ):
+            broken = classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
+        self.assertFalse(identity_proofs.issubset(set(broken.test_modules)), broken.test_modules)
+        self.assertNotIn("tests.scripts.test_chaos_gauge_recovery", broken.test_modules)
 
     def test_every_installer_manifest_uses_protected_installer_checks(self) -> None:
         manifests = (

--- a/tests/scripts/test_harness_pr_gate.py
+++ b/tests/scripts/test_harness_pr_gate.py
@@ -14,18 +14,6 @@ from unittest.mock import patch
 import yaml
 
 import scripts.ci.harness_pr_gate as harness_pr_gate
-from scripts.ci.harness_pr_gate import (
-    Check,
-    GateError,
-    GatePlan,
-    WaiverReceipt,
-    changed_paths,
-    classify_paths,
-    event_waiver,
-    parse_waiver,
-    render_json,
-    run_plan,
-)
 from scripts.ci.validate_agent_setup import validate_host_parity
 
 
@@ -68,9 +56,9 @@ def write_reviews(directory: str, reviews: list[dict[str, object]]) -> Path:
 
 class ClassifierTest(unittest.TestCase):
     def test_readme_and_promotion_changes_select_only_focused_contracts(self) -> None:
-        documentation = classify_paths(["chaos-engine/README.md"])
-        promotion = classify_paths(["scripts/ci/chaos_engine_promotion.py"])
-        promotion_runner = classify_paths(
+        documentation = harness_pr_gate.classify_paths(["chaos-engine/README.md"])
+        promotion = harness_pr_gate.classify_paths(["scripts/ci/chaos_engine_promotion.py"])
+        promotion_runner = harness_pr_gate.classify_paths(
             ["scripts/ci/chaos_engine_promotion_trials.py"]
         )
 
@@ -90,7 +78,7 @@ class ClassifierTest(unittest.TestCase):
         self.assertEqual(("promotion",), promotion_runner.surfaces)
 
     def test_kernel_change_selects_only_focused_and_protected_checks(self) -> None:
-        plan = classify_paths(["chaos-engine/hooks/kernel.py"])
+        plan = harness_pr_gate.classify_paths(["chaos-engine/hooks/kernel.py"])
 
         self.assertEqual(("kernel", "identities"), plan.surfaces)
         self.assertEqual(
@@ -110,7 +98,7 @@ class ClassifierTest(unittest.TestCase):
         )
 
     def test_copilot_repository_hook_selects_host_contract(self) -> None:
-        plan = classify_paths([".github/hooks/chaos-engine.json"])
+        plan = harness_pr_gate.classify_paths([".github/hooks/chaos-engine.json"])
 
         self.assertEqual(("hosts",), plan.surfaces)
         self.assertEqual(
@@ -119,7 +107,7 @@ class ClassifierTest(unittest.TestCase):
         )
 
     def test_installer_change_keeps_5299_acceptance_and_rollback_protected(self) -> None:
-        plan = classify_paths(["chaos-engine/dependencies.py"])
+        plan = harness_pr_gate.classify_paths(["chaos-engine/dependencies.py"])
 
         self.assertIn("installer", plan.surfaces)
         protected = {check.id for check in plan.checks if check.protected}
@@ -129,7 +117,7 @@ class ClassifierTest(unittest.TestCase):
         self.assertIn("tests.scripts.test_chaos_engine_dependencies", plan.test_modules)
 
     def test_dependency_manifest_change_closes_readme_and_account_version_proofs(self) -> None:
-        plan = classify_paths(["chaos-engine/dependencies.json"])
+        plan = harness_pr_gate.classify_paths(["chaos-engine/dependencies.json"])
         modules = set(plan.test_modules)
         account_proofs = {
             "tests.scripts.test_chaos_engine_dependencies.ChaosEngineDependenciesTest."
@@ -143,19 +131,19 @@ class ClassifierTest(unittest.TestCase):
         self.assertTrue(account_proofs.issubset(modules), modules)
         original = harness_pr_gate.CHECKS["dependency-account-contract"]
         dropped = account_proofs - {original.modules[0]}
-        mutated = Check(
+        mutated = harness_pr_gate.Check(
             original.id,
             original.surface,
             original.modules[:1],
             original.protected,
         )
         with patch.dict(harness_pr_gate.CHECKS, {"dependency-account-contract": mutated}):
-            broken = classify_paths(["chaos-engine/dependencies.json"])
+            broken = harness_pr_gate.classify_paths(["chaos-engine/dependencies.json"])
         self.assertFalse(account_proofs.issubset(set(broken.test_modules)), broken.test_modules)
         self.assertTrue(dropped.isdisjoint(set(broken.test_modules)), broken.test_modules)
 
     def test_harness_tree_change_closes_coupled_identity_checks(self) -> None:
-        plan = classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
+        plan = harness_pr_gate.classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
         modules = set(plan.test_modules)
         identity_proofs = {
             "tests.scripts.test_chaos_gauge_contracts",
@@ -168,7 +156,7 @@ class ClassifierTest(unittest.TestCase):
             harness_pr_gate.SURFACE_CHECKS,
             {"identities": ("identity-contract",)},
         ):
-            broken = classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
+            broken = harness_pr_gate.classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
         self.assertFalse(identity_proofs.issubset(set(broken.test_modules)), broken.test_modules)
         self.assertNotIn("tests.scripts.test_chaos_gauge_recovery", broken.test_modules)
 
@@ -185,14 +173,14 @@ class ClassifierTest(unittest.TestCase):
         )
         for path in manifests:
             with self.subTest(path=path):
-                plan = classify_paths([path])
+                plan = harness_pr_gate.classify_paths([path])
                 self.assertIn("installer", plan.surfaces)
                 protected = {check.id for check in plan.checks if check.protected}
                 self.assertIn("protected-installer-acceptance", protected)
                 self.assertIn("protected-rollback", protected)
 
     def test_guard_owner_change_runs_non_waivable_security_check(self) -> None:
-        plan = classify_paths(["scripts/agents/guard.py"])
+        plan = harness_pr_gate.classify_paths(["scripts/agents/guard.py"])
 
         checks = {check.id: check for check in plan.checks}
         self.assertIn("protected-security", checks)
@@ -212,7 +200,7 @@ class ClassifierTest(unittest.TestCase):
         )
 
     def test_unknown_harness_path_falls_back_instead_of_skipping(self) -> None:
-        plan = classify_paths(["scripts/agents/new_runtime_surface.py"])
+        plan = harness_pr_gate.classify_paths(["scripts/agents/new_runtime_surface.py"])
 
         self.assertEqual(("fallback",), plan.surfaces)
         self.assertEqual(("scripts/agents/new_runtime_surface.py",), plan.unknown_paths)
@@ -234,16 +222,16 @@ class ClassifierTest(unittest.TestCase):
             "tools/intellij-plugin-recording/install.ps1",
         ):
             with self.subTest(path=path):
-                self.assertIn("fallback", classify_paths([path]).surfaces)
+                self.assertIn("fallback", harness_pr_gate.classify_paths([path]).surfaces)
 
     def test_edited_harness_test_uses_its_mapped_final_batch_contract(self) -> None:
-        plan = classify_paths(["tests/scripts/test_agent_router_contract.py"])
+        plan = harness_pr_gate.classify_paths(["tests/scripts/test_agent_router_contract.py"])
 
         self.assertEqual(("guidance",), plan.surfaces)
         self.assertFalse(any(check.surface == "changed-test" for check in plan.checks))
 
     def test_setup_aggregator_change_selects_its_direct_contract(self) -> None:
-        plan = classify_paths(["scripts/ci/validate_agent_setup.py"])
+        plan = harness_pr_gate.classify_paths(["scripts/ci/validate_agent_setup.py"])
 
         self.assertIn("tests.scripts.test_validate_agent_setup", plan.test_modules)
 
@@ -256,7 +244,7 @@ class ClassifierTest(unittest.TestCase):
             "T\0chaos-engine/hooks/kernel.py\0",
         )
         with patch("scripts.ci.harness_pr_gate.subprocess.run", return_value=completed) as run:
-            paths = changed_paths(ROOT, "a" * 40, "b" * 40)
+            paths = harness_pr_gate.changed_paths(ROOT, "a" * 40, "b" * 40)
 
         self.assertIn("--diff-filter=ACDMRT", run.call_args.args[0])
         self.assertIn("--name-status", run.call_args.args[0])
@@ -265,8 +253,8 @@ class ClassifierTest(unittest.TestCase):
             [False, False, True, True],
             [path.executable for path in paths],
         )
-        deleted_plan = classify_paths([paths[0]])
-        renamed_plan = classify_paths([paths[2]])
+        deleted_plan = harness_pr_gate.classify_paths([paths[0]])
+        renamed_plan = harness_pr_gate.classify_paths([paths[2]])
         self.assertIn("fallback", deleted_plan.surfaces)
         self.assertIn("lifecycle", renamed_plan.surfaces)
         self.assertFalse(any(check.surface == "changed-test" for check in renamed_plan.checks))
@@ -304,7 +292,7 @@ class ClassifierTest(unittest.TestCase):
             git("commit", "-m", "base")
             base = git("rev-parse", "HEAD")
 
-            paths = changed_paths(root, base, head)
+            paths = harness_pr_gate.changed_paths(root, base, head)
 
         self.assertEqual(["candidate-only.txt"], list(paths))
 
@@ -346,7 +334,7 @@ class ClassifierTest(unittest.TestCase):
             git("commit", "-m", "rewritten candidate")
             rewritten_head = git("rev-parse", "HEAD")
 
-            paths = changed_paths(root, old_head, rewritten_head)
+            paths = harness_pr_gate.changed_paths(root, old_head, rewritten_head)
 
         self.assertEqual([".github/workflows/pr-gate.yml"], list(paths))
 
@@ -356,7 +344,7 @@ class ClassifierTest(unittest.TestCase):
             "tests/scripts/test_chaos_engine_live_installer_acceptance.py",
         ):
             with self.subTest(path=path):
-                plan = classify_paths([path])
+                plan = harness_pr_gate.classify_paths([path])
                 check_ids = {check.id for check in plan.checks}
                 self.assertEqual(("installer",), plan.surfaces)
                 self.assertNotIn("fallback-contract", check_ids)
@@ -364,37 +352,37 @@ class ClassifierTest(unittest.TestCase):
                 self.assertIn("protected-rollback", check_ids)
 
     def test_reachability_contract_uses_focused_guidance_surface(self) -> None:
-        plan = classify_paths(["tests/scripts/test_agent_harness_reachability.py"])
+        plan = harness_pr_gate.classify_paths(["tests/scripts/test_agent_harness_reachability.py"])
 
         self.assertEqual(("guidance",), plan.surfaces)
         self.assertNotIn("fallback-contract", {check.id for check in plan.checks})
         self.assertIn("tests.scripts.test_agent_harness_reachability", plan.test_modules)
 
     def test_non_harness_path_selects_no_harness_checks(self) -> None:
-        plan = classify_paths(["shaft-engine/src/main/java/example/Thing.java"])
+        plan = harness_pr_gate.classify_paths(["shaft-engine/src/main/java/example/Thing.java"])
 
         self.assertEqual((), plan.surfaces)
         self.assertEqual((), plan.checks)
 
     def test_dotted_host_adapter_is_not_lost_during_path_normalization(self) -> None:
-        plan = classify_paths([".claude/settings.json"])
+        plan = harness_pr_gate.classify_paths([".claude/settings.json"])
 
         self.assertIn("hosts", plan.surfaces)
 
     def test_path_traversal_input_fails_closed(self) -> None:
-        with self.assertRaises(GateError):
-            classify_paths(["../chaos-engine/hooks/kernel.py"])
+        with self.assertRaises(harness_pr_gate.GateError):
+            harness_pr_gate.classify_paths(["../chaos-engine/hooks/kernel.py"])
 
 
 class WaiverTest(unittest.TestCase):
     def test_valid_receipt_is_exact_head_check_specific_and_expiring(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            receipt = event_waiver(
+            receipt = harness_pr_gate.event_waiver(
                 write_reviews(directory, [review_record()]), HEAD, now=NOW
             )
 
         self.assertIsNotNone(receipt)
-        receipt = cast(WaiverReceipt, receipt)
+        receipt = cast(harness_pr_gate.WaiverReceipt, receipt)
         self.assertEqual(("guidance-contract",), receipt.check_ids)
         self.assertEqual(HEAD, receipt.head_sha)
 
@@ -409,8 +397,8 @@ class WaiverTest(unittest.TestCase):
         )
         for body in cases:
             with self.subTest(body=body[:80]):
-                with self.assertRaises(GateError):
-                    parse_waiver(body, now=NOW)
+                with self.assertRaises(harness_pr_gate.GateError):
+                    harness_pr_gate.parse_waiver(body, now=NOW)
 
     def test_protected_categories_can_never_be_waived(self) -> None:
         protected = (
@@ -424,8 +412,8 @@ class WaiverTest(unittest.TestCase):
         )
         for check_id in protected:
             with self.subTest(check_id=check_id):
-                with self.assertRaises(GateError):
-                    parse_waiver(
+                with self.assertRaises(harness_pr_gate.GateError):
+                    harness_pr_gate.parse_waiver(
                         waiver_body(allowed_check_ids=[check_id]),
                         now=NOW,
                     )
@@ -436,7 +424,7 @@ class WaiverTest(unittest.TestCase):
                 self.assertTrue(
                     next(
                         check
-                        for check in classify_paths(
+                        for check in harness_pr_gate.classify_paths(
                             {
                                 "kernel-contract": ["chaos-engine/hooks/kernel.py"],
                                 "lifecycle-contract": ["chaos-engine/hooks/guard.py"],
@@ -446,8 +434,8 @@ class WaiverTest(unittest.TestCase):
                         if check.id == check_id
                     ).protected
                 )
-                with self.assertRaises(GateError):
-                    parse_waiver(
+                with self.assertRaises(harness_pr_gate.GateError):
+                    harness_pr_gate.parse_waiver(
                         waiver_body(allowed_check_ids=[check_id]),
                         now=NOW,
                     )
@@ -457,7 +445,7 @@ class WaiverTest(unittest.TestCase):
             non_owner = review_record(user={"login": "outside-contributor"})
             stale_owner = review_record(commit_id="b" * 40)
             path = write_reviews(directory, [non_owner, stale_owner])
-            self.assertIsNone(event_waiver(path, HEAD, now=NOW))
+            self.assertIsNone(harness_pr_gate.event_waiver(path, HEAD, now=NOW))
 
     def test_pr_author_or_editor_body_cannot_authorize(self) -> None:
         forgeable_event = {
@@ -471,8 +459,8 @@ class WaiverTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "event.json"
             path.write_text(json.dumps(forgeable_event), encoding="utf-8")
-            with self.assertRaises(GateError):
-                event_waiver(path, HEAD, now=NOW)
+            with self.assertRaises(harness_pr_gate.GateError):
+                harness_pr_gate.event_waiver(path, HEAD, now=NOW)
 
     def test_owner_review_must_be_submitted_and_unambiguous(self) -> None:
         invalid = (
@@ -485,11 +473,11 @@ class WaiverTest(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as directory:
             path = write_reviews(directory, list(invalid))
-            self.assertIsNone(event_waiver(path, HEAD, now=NOW))
+            self.assertIsNone(harness_pr_gate.event_waiver(path, HEAD, now=NOW))
 
             path = write_reviews(directory, [review_record(), review_record(id=43)])
-            with self.assertRaises(GateError):
-                event_waiver(path, HEAD, now=NOW)
+            with self.assertRaises(harness_pr_gate.GateError):
+                harness_pr_gate.event_waiver(path, HEAD, now=NOW)
 
 
 class OutputAndWorkflowTest(unittest.TestCase):
@@ -551,16 +539,14 @@ class OutputAndWorkflowTest(unittest.TestCase):
         self.assertIn("agent-guidance", job["needs"])
 
     def test_local_preflight_documents_full_head_write_generated_command(self) -> None:
-        import scripts.ci.harness_pr_gate as gate
-
         readme = (ROOT / "chaos-engine/README.md").read_text(encoding="utf-8")
         self.assertIn("--write-generated", readme)
         self.assertIn("scripts/ci/harness_pr_gate.py", readme)
-        self.assertTrue(callable(getattr(gate, "write_generated_artifacts", None)))
+        self.assertTrue(callable(getattr(harness_pr_gate, "write_generated_artifacts", None)))
 
     def test_json_plan_is_concise_reproducible_and_contains_no_pr_body(self) -> None:
-        plan = classify_paths(["chaos-engine/hooks/kernel.py"])
-        payload = json.loads(render_json(plan, head_sha=HEAD, budget_seconds=240))
+        plan = harness_pr_gate.classify_paths(["chaos-engine/hooks/kernel.py"])
+        payload = json.loads(harness_pr_gate.render_json(plan, head_sha=HEAD, budget_seconds=240))
 
         self.assertEqual(1, payload["schema"])
         self.assertEqual(["kernel", "identities"], payload["surfaces"])
@@ -580,8 +566,8 @@ class OutputAndWorkflowTest(unittest.TestCase):
         )
 
     def test_runner_never_applies_a_waiver_to_a_protected_failed_check(self) -> None:
-        plan = classify_paths(["chaos-engine/hooks/kernel.py"])
-        receipt = WaiverReceipt(
+        plan = harness_pr_gate.classify_paths(["chaos-engine/hooks/kernel.py"])
+        receipt = harness_pr_gate.WaiverReceipt(
             HEAD,
             ("kernel-contract",),
             datetime(2026, 8, 29, tzinfo=timezone.utc),
@@ -592,7 +578,7 @@ class OutputAndWorkflowTest(unittest.TestCase):
             return ("failed", 1) if module.endswith("kernel") else ("passed", 0)
 
         with patch("scripts.ci.harness_pr_gate._run_check", side_effect=result_for):
-            payload, exit_code = run_plan(
+            payload, exit_code = harness_pr_gate.run_plan(
                 ROOT,
                 plan,
                 head_sha=HEAD,
@@ -605,11 +591,11 @@ class OutputAndWorkflowTest(unittest.TestCase):
         self.assertEqual([], payload["waiver"]["applied_check_ids"])
 
     def test_timeout_is_never_waived(self) -> None:
-        plan = GatePlan(("kernel",), (classify_paths(["chaos-engine/hooks/kernel.py"]).checks[0],))
-        receipt = WaiverReceipt(HEAD, ("kernel-contract",), NOW)
+        plan = harness_pr_gate.GatePlan(("kernel",), (harness_pr_gate.classify_paths(["chaos-engine/hooks/kernel.py"]).checks[0],))
+        receipt = harness_pr_gate.WaiverReceipt(HEAD, ("kernel-contract",), NOW)
 
         with patch("scripts.ci.harness_pr_gate._run_check", return_value=("timeout", None)):
-            payload, exit_code = run_plan(
+            payload, exit_code = harness_pr_gate.run_plan(
                 ROOT,
                 plan,
                 head_sha=HEAD,
@@ -678,7 +664,7 @@ class OutputAndWorkflowTest(unittest.TestCase):
         self.assertIn("tests.scripts.test_chaos_engine_generation_runtime", deterministic)
 
     def test_omniroot_portability_is_registered_in_focused_path_gate(self) -> None:
-        plan = classify_paths(["tests/scripts/test_omniroot_portability.py"])
+        plan = harness_pr_gate.classify_paths(["tests/scripts/test_omniroot_portability.py"])
         pr_gate = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")
 
         self.assertIn("guidance", plan.surfaces)
@@ -699,7 +685,7 @@ class OutputAndWorkflowTest(unittest.TestCase):
 
         for path in paths:
             with self.subTest(path=path):
-                plan = classify_paths([path])
+                plan = harness_pr_gate.classify_paths([path])
                 self.assertIn("guidance", plan.surfaces)
                 self.assertIn(behavioral, plan.test_modules)
 
@@ -716,7 +702,7 @@ class OutputAndWorkflowTest(unittest.TestCase):
             self.assertIn(f"'tests/scripts/{name}'", pr_gate)
 
     def test_scheduled_chaos_gauge_recovery_is_enforced_when_its_workflow_changes(self) -> None:
-        plan = classify_paths([".github/workflows/agent-plugin-acceptance.yml"])
+        plan = harness_pr_gate.classify_paths([".github/workflows/agent-plugin-acceptance.yml"])
         scheduled = (ROOT / ".github/workflows/agent-plugin-acceptance.yml").read_text(
             encoding="utf-8"
         )

--- a/tests/scripts/test_harness_pr_gate.py
+++ b/tests/scripts/test_harness_pr_gate.py
@@ -72,10 +72,12 @@ class ClassifierTest(unittest.TestCase):
             ["scripts/ci/chaos_engine_promotion_trials.py"]
         )
 
-        self.assertEqual(("documentation",), documentation.surfaces)
+        self.assertEqual(("documentation", "identities"), documentation.surfaces)
         self.assertEqual(
             {
                 "documentation-inventory-contract",
+                "identity-contract",
+                "identity-recovery-contract",
                 "protected-ownership",
                 "protected-secret-safety",
             },
@@ -88,9 +90,15 @@ class ClassifierTest(unittest.TestCase):
     def test_kernel_change_selects_only_focused_and_protected_checks(self) -> None:
         plan = classify_paths(["chaos-engine/hooks/kernel.py"])
 
-        self.assertEqual(("kernel",), plan.surfaces)
+        self.assertEqual(("kernel", "identities"), plan.surfaces)
         self.assertEqual(
-            ("kernel-contract", "protected-ownership", "protected-secret-safety"),
+            (
+                "kernel-contract",
+                "identity-contract",
+                "identity-recovery-contract",
+                "protected-ownership",
+                "protected-secret-safety",
+            ),
             tuple(check.id for check in plan.checks),
         )
         self.assertEqual((), plan.unknown_paths)
@@ -111,12 +119,41 @@ class ClassifierTest(unittest.TestCase):
     def test_installer_change_keeps_5299_acceptance_and_rollback_protected(self) -> None:
         plan = classify_paths(["chaos-engine/dependencies.py"])
 
-        self.assertEqual(("installer",), plan.surfaces)
+        self.assertIn("installer", plan.surfaces)
         protected = {check.id for check in plan.checks if check.protected}
         self.assertIn("protected-installer-acceptance", protected)
         self.assertIn("protected-rollback", protected)
         self.assertIn("tests.scripts.test_chaos_engine_bootstrap", plan.test_modules)
         self.assertIn("tests.scripts.test_chaos_engine_dependencies", plan.test_modules)
+
+    def test_dependency_manifest_change_closes_readme_and_account_version_proofs(self) -> None:
+        plan = classify_paths(["chaos-engine/dependencies.json"])
+        modules = set(plan.test_modules)
+        account_proofs = {
+            "tests.scripts.test_chaos_engine_dependencies.ChaosEngineDependenciesTest."
+            "test_account_tool_plan_uses_resolved_stable_versions_then_matching_rerun_reuses",
+            "tests.scripts.test_chaos_engine_dependencies.ChaosEngineDependenciesTest."
+            "test_account_install_passes_resolved_tool_versions_to_the_account_plan",
+        }
+
+        self.assertIn("documentation", plan.surfaces)
+        self.assertIn("documentation-inventory-contract", {check.id for check in plan.checks})
+        self.assertTrue(account_proofs.issubset(modules), modules)
+        omitted = modules - account_proofs
+        self.assertFalse(account_proofs.issubset(omitted))
+
+    def test_harness_tree_change_closes_coupled_identity_checks(self) -> None:
+        plan = classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
+        modules = set(plan.test_modules)
+        identity_proofs = {
+            "tests.scripts.test_chaos_gauge_contracts",
+            "tests.scripts.test_chaos_gauge_recovery",
+        }
+
+        self.assertIn("identities", plan.surfaces)
+        self.assertTrue(identity_proofs.issubset(modules), modules)
+        sibling_omission = modules - {"tests.scripts.test_chaos_gauge_recovery"}
+        self.assertFalse(identity_proofs.issubset(sibling_omission))
 
     def test_every_installer_manifest_uses_protected_installer_checks(self) -> None:
         manifests = (
@@ -491,12 +528,25 @@ class OutputAndWorkflowTest(unittest.TestCase):
                 self.assertNotIn("outputs.pr_gate", condition)
                 self.assertIn("outputs.infra", condition)
 
+    def test_live_installer_job_needs_successful_agent_guidance_gate(self) -> None:
+        job = self.workflow()["jobs"]["chaos-installer-acceptance"]
+
+        self.assertIn("agent-guidance", job["needs"])
+
+    def test_local_preflight_documents_full_head_write_generated_command(self) -> None:
+        import scripts.ci.harness_pr_gate as gate
+
+        readme = (ROOT / "chaos-engine/README.md").read_text(encoding="utf-8")
+        self.assertIn("--write-generated", readme)
+        self.assertIn("scripts/ci/harness_pr_gate.py", readme)
+        self.assertTrue(callable(getattr(gate, "write_generated_artifacts", None)))
+
     def test_json_plan_is_concise_reproducible_and_contains_no_pr_body(self) -> None:
         plan = classify_paths(["chaos-engine/hooks/kernel.py"])
         payload = json.loads(render_json(plan, head_sha=HEAD, budget_seconds=240))
 
         self.assertEqual(1, payload["schema"])
-        self.assertEqual(["kernel"], payload["surfaces"])
+        self.assertEqual(["kernel", "identities"], payload["surfaces"])
         self.assertEqual(240, payload["timing"]["budget_seconds"])
         self.assertEqual(600, payload["timing"]["recorded_baseline_median_seconds"])
         self.assertEqual(0.6, payload["timing"]["maximum_budget_reduction"])

--- a/tests/scripts/test_harness_pr_gate.py
+++ b/tests/scripts/test_harness_pr_gate.py
@@ -13,7 +13,21 @@ from unittest.mock import patch
 
 import yaml
 
-import scripts.ci.harness_pr_gate as harness_pr_gate
+from scripts.ci.harness_pr_gate import (
+    CHECKS,
+    SURFACE_CHECKS,
+    Check,
+    GateError,
+    GatePlan,
+    WaiverReceipt,
+    changed_paths,
+    classify_paths,
+    event_waiver,
+    parse_waiver,
+    render_json,
+    run_plan,
+    write_generated_artifacts,
+)
 from scripts.ci.validate_agent_setup import validate_host_parity
 
 
@@ -56,9 +70,9 @@ def write_reviews(directory: str, reviews: list[dict[str, object]]) -> Path:
 
 class ClassifierTest(unittest.TestCase):
     def test_readme_and_promotion_changes_select_only_focused_contracts(self) -> None:
-        documentation = harness_pr_gate.classify_paths(["chaos-engine/README.md"])
-        promotion = harness_pr_gate.classify_paths(["scripts/ci/chaos_engine_promotion.py"])
-        promotion_runner = harness_pr_gate.classify_paths(
+        documentation = classify_paths(["chaos-engine/README.md"])
+        promotion = classify_paths(["scripts/ci/chaos_engine_promotion.py"])
+        promotion_runner = classify_paths(
             ["scripts/ci/chaos_engine_promotion_trials.py"]
         )
 
@@ -78,7 +92,7 @@ class ClassifierTest(unittest.TestCase):
         self.assertEqual(("promotion",), promotion_runner.surfaces)
 
     def test_kernel_change_selects_only_focused_and_protected_checks(self) -> None:
-        plan = harness_pr_gate.classify_paths(["chaos-engine/hooks/kernel.py"])
+        plan = classify_paths(["chaos-engine/hooks/kernel.py"])
 
         self.assertEqual(("kernel", "identities"), plan.surfaces)
         self.assertEqual(
@@ -98,7 +112,7 @@ class ClassifierTest(unittest.TestCase):
         )
 
     def test_copilot_repository_hook_selects_host_contract(self) -> None:
-        plan = harness_pr_gate.classify_paths([".github/hooks/chaos-engine.json"])
+        plan = classify_paths([".github/hooks/chaos-engine.json"])
 
         self.assertEqual(("hosts",), plan.surfaces)
         self.assertEqual(
@@ -107,7 +121,7 @@ class ClassifierTest(unittest.TestCase):
         )
 
     def test_installer_change_keeps_5299_acceptance_and_rollback_protected(self) -> None:
-        plan = harness_pr_gate.classify_paths(["chaos-engine/dependencies.py"])
+        plan = classify_paths(["chaos-engine/dependencies.py"])
 
         self.assertIn("installer", plan.surfaces)
         protected = {check.id for check in plan.checks if check.protected}
@@ -117,7 +131,7 @@ class ClassifierTest(unittest.TestCase):
         self.assertIn("tests.scripts.test_chaos_engine_dependencies", plan.test_modules)
 
     def test_dependency_manifest_change_closes_readme_and_account_version_proofs(self) -> None:
-        plan = harness_pr_gate.classify_paths(["chaos-engine/dependencies.json"])
+        plan = classify_paths(["chaos-engine/dependencies.json"])
         modules = set(plan.test_modules)
         account_proofs = {
             "tests.scripts.test_chaos_engine_dependencies.ChaosEngineDependenciesTest."
@@ -129,21 +143,21 @@ class ClassifierTest(unittest.TestCase):
         self.assertIn("documentation", plan.surfaces)
         self.assertIn("documentation-inventory-contract", {check.id for check in plan.checks})
         self.assertTrue(account_proofs.issubset(modules), modules)
-        original = harness_pr_gate.CHECKS["dependency-account-contract"]
+        original = CHECKS["dependency-account-contract"]
         dropped = account_proofs - {original.modules[0]}
-        mutated = harness_pr_gate.Check(
+        mutated = Check(
             original.id,
             original.surface,
             original.modules[:1],
             original.protected,
         )
-        with patch.dict(harness_pr_gate.CHECKS, {"dependency-account-contract": mutated}):
-            broken = harness_pr_gate.classify_paths(["chaos-engine/dependencies.json"])
+        with patch.dict(CHECKS, {"dependency-account-contract": mutated}):
+            broken = classify_paths(["chaos-engine/dependencies.json"])
         self.assertFalse(account_proofs.issubset(set(broken.test_modules)), broken.test_modules)
         self.assertTrue(dropped.isdisjoint(set(broken.test_modules)), broken.test_modules)
 
     def test_harness_tree_change_closes_coupled_identity_checks(self) -> None:
-        plan = harness_pr_gate.classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
+        plan = classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
         modules = set(plan.test_modules)
         identity_proofs = {
             "tests.scripts.test_chaos_gauge_contracts",
@@ -153,10 +167,10 @@ class ClassifierTest(unittest.TestCase):
         self.assertIn("identities", plan.surfaces)
         self.assertTrue(identity_proofs.issubset(modules), modules)
         with patch.dict(
-            harness_pr_gate.SURFACE_CHECKS,
+            SURFACE_CHECKS,
             {"identities": ("identity-contract",)},
         ):
-            broken = harness_pr_gate.classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
+            broken = classify_paths(["chaos-engine/skills/chaos-engine/SKILL.md"])
         self.assertFalse(identity_proofs.issubset(set(broken.test_modules)), broken.test_modules)
         self.assertNotIn("tests.scripts.test_chaos_gauge_recovery", broken.test_modules)
 
@@ -173,14 +187,14 @@ class ClassifierTest(unittest.TestCase):
         )
         for path in manifests:
             with self.subTest(path=path):
-                plan = harness_pr_gate.classify_paths([path])
+                plan = classify_paths([path])
                 self.assertIn("installer", plan.surfaces)
                 protected = {check.id for check in plan.checks if check.protected}
                 self.assertIn("protected-installer-acceptance", protected)
                 self.assertIn("protected-rollback", protected)
 
     def test_guard_owner_change_runs_non_waivable_security_check(self) -> None:
-        plan = harness_pr_gate.classify_paths(["scripts/agents/guard.py"])
+        plan = classify_paths(["scripts/agents/guard.py"])
 
         checks = {check.id: check for check in plan.checks}
         self.assertIn("protected-security", checks)
@@ -200,7 +214,7 @@ class ClassifierTest(unittest.TestCase):
         )
 
     def test_unknown_harness_path_falls_back_instead_of_skipping(self) -> None:
-        plan = harness_pr_gate.classify_paths(["scripts/agents/new_runtime_surface.py"])
+        plan = classify_paths(["scripts/agents/new_runtime_surface.py"])
 
         self.assertEqual(("fallback",), plan.surfaces)
         self.assertEqual(("scripts/agents/new_runtime_surface.py",), plan.unknown_paths)
@@ -222,16 +236,16 @@ class ClassifierTest(unittest.TestCase):
             "tools/intellij-plugin-recording/install.ps1",
         ):
             with self.subTest(path=path):
-                self.assertIn("fallback", harness_pr_gate.classify_paths([path]).surfaces)
+                self.assertIn("fallback", classify_paths([path]).surfaces)
 
     def test_edited_harness_test_uses_its_mapped_final_batch_contract(self) -> None:
-        plan = harness_pr_gate.classify_paths(["tests/scripts/test_agent_router_contract.py"])
+        plan = classify_paths(["tests/scripts/test_agent_router_contract.py"])
 
         self.assertEqual(("guidance",), plan.surfaces)
         self.assertFalse(any(check.surface == "changed-test" for check in plan.checks))
 
     def test_setup_aggregator_change_selects_its_direct_contract(self) -> None:
-        plan = harness_pr_gate.classify_paths(["scripts/ci/validate_agent_setup.py"])
+        plan = classify_paths(["scripts/ci/validate_agent_setup.py"])
 
         self.assertIn("tests.scripts.test_validate_agent_setup", plan.test_modules)
 
@@ -244,7 +258,7 @@ class ClassifierTest(unittest.TestCase):
             "T\0chaos-engine/hooks/kernel.py\0",
         )
         with patch("scripts.ci.harness_pr_gate.subprocess.run", return_value=completed) as run:
-            paths = harness_pr_gate.changed_paths(ROOT, "a" * 40, "b" * 40)
+            paths = changed_paths(ROOT, "a" * 40, "b" * 40)
 
         self.assertIn("--diff-filter=ACDMRT", run.call_args.args[0])
         self.assertIn("--name-status", run.call_args.args[0])
@@ -253,8 +267,8 @@ class ClassifierTest(unittest.TestCase):
             [False, False, True, True],
             [path.executable for path in paths],
         )
-        deleted_plan = harness_pr_gate.classify_paths([paths[0]])
-        renamed_plan = harness_pr_gate.classify_paths([paths[2]])
+        deleted_plan = classify_paths([paths[0]])
+        renamed_plan = classify_paths([paths[2]])
         self.assertIn("fallback", deleted_plan.surfaces)
         self.assertIn("lifecycle", renamed_plan.surfaces)
         self.assertFalse(any(check.surface == "changed-test" for check in renamed_plan.checks))
@@ -292,7 +306,7 @@ class ClassifierTest(unittest.TestCase):
             git("commit", "-m", "base")
             base = git("rev-parse", "HEAD")
 
-            paths = harness_pr_gate.changed_paths(root, base, head)
+            paths = changed_paths(root, base, head)
 
         self.assertEqual(["candidate-only.txt"], list(paths))
 
@@ -334,7 +348,7 @@ class ClassifierTest(unittest.TestCase):
             git("commit", "-m", "rewritten candidate")
             rewritten_head = git("rev-parse", "HEAD")
 
-            paths = harness_pr_gate.changed_paths(root, old_head, rewritten_head)
+            paths = changed_paths(root, old_head, rewritten_head)
 
         self.assertEqual([".github/workflows/pr-gate.yml"], list(paths))
 
@@ -344,7 +358,7 @@ class ClassifierTest(unittest.TestCase):
             "tests/scripts/test_chaos_engine_live_installer_acceptance.py",
         ):
             with self.subTest(path=path):
-                plan = harness_pr_gate.classify_paths([path])
+                plan = classify_paths([path])
                 check_ids = {check.id for check in plan.checks}
                 self.assertEqual(("installer",), plan.surfaces)
                 self.assertNotIn("fallback-contract", check_ids)
@@ -352,37 +366,37 @@ class ClassifierTest(unittest.TestCase):
                 self.assertIn("protected-rollback", check_ids)
 
     def test_reachability_contract_uses_focused_guidance_surface(self) -> None:
-        plan = harness_pr_gate.classify_paths(["tests/scripts/test_agent_harness_reachability.py"])
+        plan = classify_paths(["tests/scripts/test_agent_harness_reachability.py"])
 
         self.assertEqual(("guidance",), plan.surfaces)
         self.assertNotIn("fallback-contract", {check.id for check in plan.checks})
         self.assertIn("tests.scripts.test_agent_harness_reachability", plan.test_modules)
 
     def test_non_harness_path_selects_no_harness_checks(self) -> None:
-        plan = harness_pr_gate.classify_paths(["shaft-engine/src/main/java/example/Thing.java"])
+        plan = classify_paths(["shaft-engine/src/main/java/example/Thing.java"])
 
         self.assertEqual((), plan.surfaces)
         self.assertEqual((), plan.checks)
 
     def test_dotted_host_adapter_is_not_lost_during_path_normalization(self) -> None:
-        plan = harness_pr_gate.classify_paths([".claude/settings.json"])
+        plan = classify_paths([".claude/settings.json"])
 
         self.assertIn("hosts", plan.surfaces)
 
     def test_path_traversal_input_fails_closed(self) -> None:
-        with self.assertRaises(harness_pr_gate.GateError):
-            harness_pr_gate.classify_paths(["../chaos-engine/hooks/kernel.py"])
+        with self.assertRaises(GateError):
+            classify_paths(["../chaos-engine/hooks/kernel.py"])
 
 
 class WaiverTest(unittest.TestCase):
     def test_valid_receipt_is_exact_head_check_specific_and_expiring(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            receipt = harness_pr_gate.event_waiver(
+            receipt = event_waiver(
                 write_reviews(directory, [review_record()]), HEAD, now=NOW
             )
 
         self.assertIsNotNone(receipt)
-        receipt = cast(harness_pr_gate.WaiverReceipt, receipt)
+        receipt = cast(WaiverReceipt, receipt)
         self.assertEqual(("guidance-contract",), receipt.check_ids)
         self.assertEqual(HEAD, receipt.head_sha)
 
@@ -397,8 +411,8 @@ class WaiverTest(unittest.TestCase):
         )
         for body in cases:
             with self.subTest(body=body[:80]):
-                with self.assertRaises(harness_pr_gate.GateError):
-                    harness_pr_gate.parse_waiver(body, now=NOW)
+                with self.assertRaises(GateError):
+                    parse_waiver(body, now=NOW)
 
     def test_protected_categories_can_never_be_waived(self) -> None:
         protected = (
@@ -412,8 +426,8 @@ class WaiverTest(unittest.TestCase):
         )
         for check_id in protected:
             with self.subTest(check_id=check_id):
-                with self.assertRaises(harness_pr_gate.GateError):
-                    harness_pr_gate.parse_waiver(
+                with self.assertRaises(GateError):
+                    parse_waiver(
                         waiver_body(allowed_check_ids=[check_id]),
                         now=NOW,
                     )
@@ -424,7 +438,7 @@ class WaiverTest(unittest.TestCase):
                 self.assertTrue(
                     next(
                         check
-                        for check in harness_pr_gate.classify_paths(
+                        for check in classify_paths(
                             {
                                 "kernel-contract": ["chaos-engine/hooks/kernel.py"],
                                 "lifecycle-contract": ["chaos-engine/hooks/guard.py"],
@@ -434,8 +448,8 @@ class WaiverTest(unittest.TestCase):
                         if check.id == check_id
                     ).protected
                 )
-                with self.assertRaises(harness_pr_gate.GateError):
-                    harness_pr_gate.parse_waiver(
+                with self.assertRaises(GateError):
+                    parse_waiver(
                         waiver_body(allowed_check_ids=[check_id]),
                         now=NOW,
                     )
@@ -445,7 +459,7 @@ class WaiverTest(unittest.TestCase):
             non_owner = review_record(user={"login": "outside-contributor"})
             stale_owner = review_record(commit_id="b" * 40)
             path = write_reviews(directory, [non_owner, stale_owner])
-            self.assertIsNone(harness_pr_gate.event_waiver(path, HEAD, now=NOW))
+            self.assertIsNone(event_waiver(path, HEAD, now=NOW))
 
     def test_pr_author_or_editor_body_cannot_authorize(self) -> None:
         forgeable_event = {
@@ -459,8 +473,8 @@ class WaiverTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "event.json"
             path.write_text(json.dumps(forgeable_event), encoding="utf-8")
-            with self.assertRaises(harness_pr_gate.GateError):
-                harness_pr_gate.event_waiver(path, HEAD, now=NOW)
+            with self.assertRaises(GateError):
+                event_waiver(path, HEAD, now=NOW)
 
     def test_owner_review_must_be_submitted_and_unambiguous(self) -> None:
         invalid = (
@@ -473,11 +487,11 @@ class WaiverTest(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as directory:
             path = write_reviews(directory, list(invalid))
-            self.assertIsNone(harness_pr_gate.event_waiver(path, HEAD, now=NOW))
+            self.assertIsNone(event_waiver(path, HEAD, now=NOW))
 
             path = write_reviews(directory, [review_record(), review_record(id=43)])
-            with self.assertRaises(harness_pr_gate.GateError):
-                harness_pr_gate.event_waiver(path, HEAD, now=NOW)
+            with self.assertRaises(GateError):
+                event_waiver(path, HEAD, now=NOW)
 
 
 class OutputAndWorkflowTest(unittest.TestCase):
@@ -542,11 +556,11 @@ class OutputAndWorkflowTest(unittest.TestCase):
         readme = (ROOT / "chaos-engine/README.md").read_text(encoding="utf-8")
         self.assertIn("--write-generated", readme)
         self.assertIn("scripts/ci/harness_pr_gate.py", readme)
-        self.assertTrue(callable(getattr(harness_pr_gate, "write_generated_artifacts", None)))
+        self.assertTrue(callable(write_generated_artifacts))
 
     def test_json_plan_is_concise_reproducible_and_contains_no_pr_body(self) -> None:
-        plan = harness_pr_gate.classify_paths(["chaos-engine/hooks/kernel.py"])
-        payload = json.loads(harness_pr_gate.render_json(plan, head_sha=HEAD, budget_seconds=240))
+        plan = classify_paths(["chaos-engine/hooks/kernel.py"])
+        payload = json.loads(render_json(plan, head_sha=HEAD, budget_seconds=240))
 
         self.assertEqual(1, payload["schema"])
         self.assertEqual(["kernel", "identities"], payload["surfaces"])
@@ -566,8 +580,8 @@ class OutputAndWorkflowTest(unittest.TestCase):
         )
 
     def test_runner_never_applies_a_waiver_to_a_protected_failed_check(self) -> None:
-        plan = harness_pr_gate.classify_paths(["chaos-engine/hooks/kernel.py"])
-        receipt = harness_pr_gate.WaiverReceipt(
+        plan = classify_paths(["chaos-engine/hooks/kernel.py"])
+        receipt = WaiverReceipt(
             HEAD,
             ("kernel-contract",),
             datetime(2026, 8, 29, tzinfo=timezone.utc),
@@ -578,7 +592,7 @@ class OutputAndWorkflowTest(unittest.TestCase):
             return ("failed", 1) if module.endswith("kernel") else ("passed", 0)
 
         with patch("scripts.ci.harness_pr_gate._run_check", side_effect=result_for):
-            payload, exit_code = harness_pr_gate.run_plan(
+            payload, exit_code = run_plan(
                 ROOT,
                 plan,
                 head_sha=HEAD,
@@ -591,11 +605,11 @@ class OutputAndWorkflowTest(unittest.TestCase):
         self.assertEqual([], payload["waiver"]["applied_check_ids"])
 
     def test_timeout_is_never_waived(self) -> None:
-        plan = harness_pr_gate.GatePlan(("kernel",), (harness_pr_gate.classify_paths(["chaos-engine/hooks/kernel.py"]).checks[0],))
-        receipt = harness_pr_gate.WaiverReceipt(HEAD, ("kernel-contract",), NOW)
+        plan = GatePlan(("kernel",), (classify_paths(["chaos-engine/hooks/kernel.py"]).checks[0],))
+        receipt = WaiverReceipt(HEAD, ("kernel-contract",), NOW)
 
         with patch("scripts.ci.harness_pr_gate._run_check", return_value=("timeout", None)):
-            payload, exit_code = harness_pr_gate.run_plan(
+            payload, exit_code = run_plan(
                 ROOT,
                 plan,
                 head_sha=HEAD,
@@ -664,7 +678,7 @@ class OutputAndWorkflowTest(unittest.TestCase):
         self.assertIn("tests.scripts.test_chaos_engine_generation_runtime", deterministic)
 
     def test_omniroot_portability_is_registered_in_focused_path_gate(self) -> None:
-        plan = harness_pr_gate.classify_paths(["tests/scripts/test_omniroot_portability.py"])
+        plan = classify_paths(["tests/scripts/test_omniroot_portability.py"])
         pr_gate = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")
 
         self.assertIn("guidance", plan.surfaces)
@@ -685,7 +699,7 @@ class OutputAndWorkflowTest(unittest.TestCase):
 
         for path in paths:
             with self.subTest(path=path):
-                plan = harness_pr_gate.classify_paths([path])
+                plan = classify_paths([path])
                 self.assertIn("guidance", plan.surfaces)
                 self.assertIn(behavioral, plan.test_modules)
 
@@ -702,7 +716,7 @@ class OutputAndWorkflowTest(unittest.TestCase):
             self.assertIn(f"'tests/scripts/{name}'", pr_gate)
 
     def test_scheduled_chaos_gauge_recovery_is_enforced_when_its_workflow_changes(self) -> None:
-        plan = harness_pr_gate.classify_paths([".github/workflows/agent-plugin-acceptance.yml"])
+        plan = classify_paths([".github/workflows/agent-plugin-acceptance.yml"])
         scheduled = (ROOT / ".github/workflows/agent-plugin-acceptance.yml").read_text(
             encoding="utf-8"
         )

--- a/tests/scripts/test_validate_chaos_engine_readme.py
+++ b/tests/scripts/test_validate_chaos_engine_readme.py
@@ -7,6 +7,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.ci import validate_chaos_engine_readme as readme_owner
 from scripts.ci.validate_chaos_engine_readme import inventory_sections, validate
 
 
@@ -14,6 +15,26 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class ChaosEngineReadmeInventoryTest(unittest.TestCase):
+    def test_write_generated_refreshes_inventory_and_second_run_is_clean(self):
+        write_generated = getattr(readme_owner, "write_generated", None)
+        self.assertTrue(callable(write_generated))
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            shutil.copytree(ROOT / "chaos-engine", root / "chaos-engine")
+            readme = root / "chaos-engine/README.md"
+            original = readme.read_text(encoding="utf-8")
+            readme.write_text(
+                original.replace("| uv |", "| ux |", 1),
+                encoding="utf-8",
+            )
+            self.assertTrue(any("managed-dependencies" in error for error in validate(root)))
+
+            write_generated(root)
+            self.assertEqual([], validate(root))
+            after_first = readme.read_text(encoding="utf-8")
+            write_generated(root)
+            self.assertEqual(after_first, readme.read_text(encoding="utf-8"))
+
     def test_repository_readme_matches_every_source_derived_inventory(self):
         self.assertEqual([], validate(ROOT))
         sections = inventory_sections(ROOT)


### PR DESCRIPTION
## Summary

Extends the existing `harness_pr_gate` classifier/runner so changed harness closure runs owned generators and validators before expensive live installer jobs.

- Dependency manifest changes select README inventory plus the two account version/idempotency proofs.
- Any `chaos-engine/` tree change selects ChaosGauge manifest/job/treatment and recovery checks.
- Local `--write-generated` refreshes owned README inventory and coupled identity artifacts, then validates.
- Live installer acceptance now needs a successful agent-guidance gate.
- Refreshes stale ChaosGauge harness/treatment digests on current main.

Closes #5515

## Checks

- `python3 -m unittest tests.scripts.test_harness_pr_gate tests.scripts.test_validate_chaos_engine_readme -v` (47 passed)
- `python3 -m unittest tests.scripts.test_chaos_gauge_contracts tests.scripts.test_chaos_gauge_recovery -v` (14 passed)
- `python3 -m unittest tests.scripts.test_chaos_engine_dependencies.ChaosEngineDependenciesTest.test_account_tool_plan_uses_resolved_stable_versions_then_matching_rerun_reuses tests.scripts.test_chaos_engine_dependencies.ChaosEngineDependenciesTest.test_account_install_passes_resolved_tool_versions_to_the_account_plan -v` (2 passed)
- Combined focused suite: 63 passed
- `python3 scripts/ci/validate_agent_setup.py --skip-external` (valid)

## Continuation

No merge in this turn. Terminal independent review still owed. Open PR #5534 also refreshes ChaosGauge identities for a Codex pin bump; rebase whichever lands second.