### PR TITLE
feat(agents): enforce Learning Session disposition receipts

### DIFF
--- a/.chaos-engine/hooks/guard.py
+++ b/.chaos-engine/hooks/guard.py
@@ -101,12 +101,6 @@ def learning_session_reason(session_id: str, event: dict) -> str | None:
         return None
     if learning_completion_artifact(session_id) is not None:
         return None
-    if any(
-        item.get("kind") == "reflection-receipt"
-        and item.get("durableDisposition") in reflection.DISPOSITIONS
-        for item in recorded
-    ):
-        return None
     return (
         "Learning Session: delivery is complete. Run exactly one terminal Learning "
         "Session immediately before the final report."

--- a/.chaos-engine/hooks/guard.py
+++ b/.chaos-engine/hooks/guard.py
@@ -46,6 +46,32 @@ if reflection is None:  # Repository adapter fallback for a source-only layout.
     from scripts.agents import reflection
 
 
+def _learning_session_controller():
+    repository_root = Path(__file__).resolve().parents[2]
+    candidate = repository_root / "scripts" / "agents" / "learning_session.py"
+    if not candidate.is_file():
+        return None
+    if str(repository_root) not in sys.path:
+        sys.path.insert(0, str(repository_root))
+    try:
+        from scripts.agents import learning_session
+    except (ImportError, OSError, AttributeError):
+        return None
+    return learning_session
+
+
+def learning_completion_artifact(session_id: str) -> dict | None:
+    """Return the immutable Learning Session completion for hooks, if present."""
+    controller = _learning_session_controller()
+    if controller is None or not isinstance(session_id, str) or not session_id.strip():
+        return None
+    state = controller.default_state_dir()
+    completed = controller.load_session_completion(state, session_id)
+    if completed is not None:
+        return completed
+    return controller.load_runtime_completion(state, session_id)
+
+
 ACTIVATION = "Follow .chaos-engine/skills/chaos-engine/SKILL.md before continuing."
 ROOT_DRIVE = re.compile(r"(?i)(?:^|\s)[a-z]:\\(?:\s|$)")
 ENV_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
@@ -73,7 +99,7 @@ def learning_session_reason(session_id: str, event: dict) -> str | None:
     }
     if "delivery-complete" not in activities:
         return None
-    if "learning-session-complete" in activities:
+    if learning_completion_artifact(session_id) is not None:
         return None
     if any(
         item.get("kind") == "reflection-receipt"
@@ -165,7 +191,7 @@ def learning_session_finalize_command(command: str) -> bool:
     script = arguments[0].replace("\\", "/").casefold()
     return bool(
         script.endswith("scripts/agents/learning_session.py")
-        and arguments[1] == "finalize"
+        and arguments[1] in {"finalize", "finalize-runtime"}
         and "--session-id" in arguments[2:]
     )
 
@@ -528,7 +554,8 @@ def _run_event(event: dict, _host: str) -> int:
         return 2
     if event_name == "PostToolUse" and not receipt_command:
         if any(learning_session_finalize_command(candidate) for candidate in commands):
-            reflection.record_activity(session_id, "learning-session-complete")
+            if learning_completion_artifact(session_id) is not None:
+                reflection.record_activity(session_id, "learning-session-complete")
         elif any(terminal_delivery_command(candidate) for candidate in commands):
             reflection.record_activity(session_id, "delivery-complete")
         elif mutation or any(delivery_command(candidate) for candidate in commands):

--- a/.chaos-engine/references/work-github-playbook.md
+++ b/.chaos-engine/references/work-github-playbook.md
@@ -44,14 +44,23 @@ session over one hour records its terminal reflection receipt before the Learnin
 
 ### Learned-lessons workflow
 
-1. Collect durable costs, decisions, structural changes, procedure gaps, and
-   deliberately deferred work.
+1. Collect receipts from the root session and every delegate created during the
+   runtime. Examine durable costs, decisions, structural changes, procedure gaps,
+   and deliberately deferred work. Explicitly look for ways to improve
+   effectiveness, efficiency, token use, commands that failed, paths that became
+   dead ends, retrieval or memory use, skill gaps, and research gaps. A clean run
+   still receives this search; `no-durable` is the honest result when it finds none.
 2. Classify each knowledge result with the entrypoint's Learning Session table and
    use exactly one knowledge destination.
-3. Separately classify actionability. For every problem, follow-up action, or
-   potential improvement needing work, search for duplicates and then open one
-   new standalone GitHub issue for that action. A duplicate hit informs the new
-   issue; it does not replace it.
+3. Separately classify actionability as `fixed-now`, `existing`, `new`,
+   `blocked`, or `no-durable`. Deduplicate repeated incidents across root and
+   delegate receipts. For every unfixed problem, follow-up action, or potential
+   improvement needing work, search the configured main ChaosEngine upstream
+   repository for duplicates. Reuse the existing issue when it is the same
+   action; otherwise open one standalone enhancement issue using existing GitHub
+   authentication. When authentication or the CLI is unavailable, preserve the
+   queued candidate and report its prefilled clickable enhancement URL so the
+   user can open the same privacy-gated issue without reconstructing it.
 4. Link the receipt ID and incident evidence in the issue, then bind that issue's
    canonical URL during `assess`. A receipt, Memory entry, Graphify flag, or old
    issue comment is evidence only and never replaces the action ticket.
@@ -76,6 +85,23 @@ independent runs on the same commit and corpus. If a promoted change regresses,
 use `repair-or-revert` to record one repair requirement; recurrence freezes the
 candidate and records a revert requirement. The normal git/GitHub workflow
 performs and verifies the repair or revert.
+
+For an orchestrated runtime, the root first runs `create-runtime`. Every
+dispatch then runs `register-participant` atomically before launching its
+delegate. Before finalization, record schema-v2 evidence-bearing disposition
+receipts (`fixed-now` with changed files plus passing proof, `existing`/`new`
+with a tracking URL, or `blocked` with a privacy-safe queued learning payload).
+`finalize-runtime` automatically harvests root and delegate receipts plus
+sibling incident sources, closes membership, and rejects callers that omit a
+registered participant or supply enum-only dispositions without evidence.
+After closure no caller can replace, omit, or add participants. Every
+registered participant must contribute incident dispositions, a structured
+no-learning attestation, or, for an unreachable delegate only, an explicit
+`attest-unavailable` record. Finalization reads membership from the frozen
+closed registry rather than accepting a caller-supplied participant list. It
+writes one immutable root-owned schema-v2 completion. Stop hooks validate that
+artifact and never credit finalize command prose alone. Completions omit
+transcripts, private routes, model identities, credentials, and local paths.
 
 ## 7. Push, PR, green, merge, compact
 

--- a/.chaos-engine/references/work-github-playbook.md
+++ b/.chaos-engine/references/work-github-playbook.md
@@ -91,9 +91,10 @@ dispatch then runs `register-participant` atomically before launching its
 delegate. Before finalization, record schema-v2 evidence-bearing disposition
 receipts (`fixed-now` with changed files plus passing proof, `existing`/`new`
 with a tracking URL, or `blocked` with a privacy-safe queued learning payload).
-`finalize-runtime` automatically harvests root and delegate receipts plus
-sibling incident sources, closes membership, and rejects callers that omit a
-registered participant or supply enum-only dispositions without evidence.
+`finalize-runtime` automatically harvests root and delegate receipts, live
+session ledgers (failures, guard blocks, retries), and sibling incident
+sources, closes membership, and rejects callers that omit a registered
+participant or supply enum-only dispositions without evidence.
 After closure no caller can replace, omit, or add participants. Every
 registered participant must contribute incident dispositions, a structured
 no-learning attestation, or, for an unreachable delegate only, an explicit

--- a/chaos-engine/hooks/guard.py
+++ b/chaos-engine/hooks/guard.py
@@ -101,12 +101,6 @@ def learning_session_reason(session_id: str, event: dict) -> str | None:
         return None
     if learning_completion_artifact(session_id) is not None:
         return None
-    if any(
-        item.get("kind") == "reflection-receipt"
-        and item.get("durableDisposition") in reflection.DISPOSITIONS
-        for item in recorded
-    ):
-        return None
     return (
         "Learning Session: delivery is complete. Run exactly one terminal Learning "
         "Session immediately before the final report."

--- a/chaos-engine/hooks/guard.py
+++ b/chaos-engine/hooks/guard.py
@@ -46,6 +46,32 @@ if reflection is None:  # Repository adapter fallback for a source-only layout.
     from scripts.agents import reflection
 
 
+def _learning_session_controller():
+    repository_root = Path(__file__).resolve().parents[2]
+    candidate = repository_root / "scripts" / "agents" / "learning_session.py"
+    if not candidate.is_file():
+        return None
+    if str(repository_root) not in sys.path:
+        sys.path.insert(0, str(repository_root))
+    try:
+        from scripts.agents import learning_session
+    except (ImportError, OSError, AttributeError):
+        return None
+    return learning_session
+
+
+def learning_completion_artifact(session_id: str) -> dict | None:
+    """Return the immutable Learning Session completion for hooks, if present."""
+    controller = _learning_session_controller()
+    if controller is None or not isinstance(session_id, str) or not session_id.strip():
+        return None
+    state = controller.default_state_dir()
+    completed = controller.load_session_completion(state, session_id)
+    if completed is not None:
+        return completed
+    return controller.load_runtime_completion(state, session_id)
+
+
 ACTIVATION = "Follow .chaos-engine/skills/chaos-engine/SKILL.md before continuing."
 ROOT_DRIVE = re.compile(r"(?i)(?:^|\s)[a-z]:\\(?:\s|$)")
 ENV_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
@@ -73,7 +99,7 @@ def learning_session_reason(session_id: str, event: dict) -> str | None:
     }
     if "delivery-complete" not in activities:
         return None
-    if "learning-session-complete" in activities:
+    if learning_completion_artifact(session_id) is not None:
         return None
     if any(
         item.get("kind") == "reflection-receipt"
@@ -165,7 +191,7 @@ def learning_session_finalize_command(command: str) -> bool:
     script = arguments[0].replace("\\", "/").casefold()
     return bool(
         script.endswith("scripts/agents/learning_session.py")
-        and arguments[1] == "finalize"
+        and arguments[1] in {"finalize", "finalize-runtime"}
         and "--session-id" in arguments[2:]
     )
 
@@ -528,7 +554,8 @@ def _run_event(event: dict, _host: str) -> int:
         return 2
     if event_name == "PostToolUse" and not receipt_command:
         if any(learning_session_finalize_command(candidate) for candidate in commands):
-            reflection.record_activity(session_id, "learning-session-complete")
+            if learning_completion_artifact(session_id) is not None:
+                reflection.record_activity(session_id, "learning-session-complete")
         elif any(terminal_delivery_command(candidate) for candidate in commands):
             reflection.record_activity(session_id, "delivery-complete")
         elif mutation or any(delivery_command(candidate) for candidate in commands):

--- a/chaos-engine/references/work-github-playbook.md
+++ b/chaos-engine/references/work-github-playbook.md
@@ -91,9 +91,10 @@ dispatch then runs `register-participant` atomically before launching its
 delegate. Before finalization, record schema-v2 evidence-bearing disposition
 receipts (`fixed-now` with changed files plus passing proof, `existing`/`new`
 with a tracking URL, or `blocked` with a privacy-safe queued learning payload).
-`finalize-runtime` automatically harvests root and delegate receipts plus
-sibling incident sources, closes membership, and rejects callers that omit a
-registered participant or supply enum-only dispositions without evidence.
+`finalize-runtime` automatically harvests root and delegate receipts, live
+session ledgers (failures, guard blocks, retries), and sibling incident
+sources, closes membership, and rejects callers that omit a registered
+participant or supply enum-only dispositions without evidence.
 After closure no caller can replace, omit, or add participants. Every
 registered participant must contribute incident dispositions, a structured
 no-learning attestation, or, for an unreachable delegate only, an explicit

--- a/chaos-engine/references/work-github-playbook.md
+++ b/chaos-engine/references/work-github-playbook.md
@@ -88,14 +88,20 @@ performs and verifies the repair or revert.
 
 For an orchestrated runtime, the root first runs `create-runtime`. Every
 dispatch then runs `register-participant` atomically before launching its
-delegate. `finalize-runtime` closes membership; after closure no caller can
-replace, omit, or add participants. Before finalization, every
+delegate. Before finalization, record schema-v2 evidence-bearing disposition
+receipts (`fixed-now` with changed files plus passing proof, `existing`/`new`
+with a tracking URL, or `blocked` with a privacy-safe queued learning payload).
+`finalize-runtime` automatically harvests root and delegate receipts plus
+sibling incident sources, closes membership, and rejects callers that omit a
+registered participant or supply enum-only dispositions without evidence.
+After closure no caller can replace, omit, or add participants. Every
 registered participant must contribute incident dispositions, a structured
 no-learning attestation, or, for an unreachable delegate only, an explicit
 `attest-unavailable` record. Finalization reads membership from the frozen
-closed registry rather than accepting a caller-supplied participant list. It writes one
-immutable root-owned completion without copying transcripts, private routes,
-model identities, credentials, or local paths.
+closed registry rather than accepting a caller-supplied participant list. It
+writes one immutable root-owned schema-v2 completion. Stop hooks validate that
+artifact and never credit finalize command prose alone. Completions omit
+transcripts, private routes, model identities, credentials, and local paths.
 
 ## 7. Push, PR, green, merge, compact
 

--- a/plugins/chaos-engine/hooks/guard.py
+++ b/plugins/chaos-engine/hooks/guard.py
@@ -101,12 +101,6 @@ def learning_session_reason(session_id: str, event: dict) -> str | None:
         return None
     if learning_completion_artifact(session_id) is not None:
         return None
-    if any(
-        item.get("kind") == "reflection-receipt"
-        and item.get("durableDisposition") in reflection.DISPOSITIONS
-        for item in recorded
-    ):
-        return None
     return (
         "Learning Session: delivery is complete. Run exactly one terminal Learning "
         "Session immediately before the final report."

--- a/plugins/chaos-engine/hooks/guard.py
+++ b/plugins/chaos-engine/hooks/guard.py
@@ -46,6 +46,32 @@ if reflection is None:  # Repository adapter fallback for a source-only layout.
     from scripts.agents import reflection
 
 
+def _learning_session_controller():
+    repository_root = Path(__file__).resolve().parents[2]
+    candidate = repository_root / "scripts" / "agents" / "learning_session.py"
+    if not candidate.is_file():
+        return None
+    if str(repository_root) not in sys.path:
+        sys.path.insert(0, str(repository_root))
+    try:
+        from scripts.agents import learning_session
+    except (ImportError, OSError, AttributeError):
+        return None
+    return learning_session
+
+
+def learning_completion_artifact(session_id: str) -> dict | None:
+    """Return the immutable Learning Session completion for hooks, if present."""
+    controller = _learning_session_controller()
+    if controller is None or not isinstance(session_id, str) or not session_id.strip():
+        return None
+    state = controller.default_state_dir()
+    completed = controller.load_session_completion(state, session_id)
+    if completed is not None:
+        return completed
+    return controller.load_runtime_completion(state, session_id)
+
+
 ACTIVATION = "Follow .chaos-engine/skills/chaos-engine/SKILL.md before continuing."
 ROOT_DRIVE = re.compile(r"(?i)(?:^|\s)[a-z]:\\(?:\s|$)")
 ENV_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
@@ -73,7 +99,7 @@ def learning_session_reason(session_id: str, event: dict) -> str | None:
     }
     if "delivery-complete" not in activities:
         return None
-    if "learning-session-complete" in activities:
+    if learning_completion_artifact(session_id) is not None:
         return None
     if any(
         item.get("kind") == "reflection-receipt"
@@ -165,7 +191,7 @@ def learning_session_finalize_command(command: str) -> bool:
     script = arguments[0].replace("\\", "/").casefold()
     return bool(
         script.endswith("scripts/agents/learning_session.py")
-        and arguments[1] == "finalize"
+        and arguments[1] in {"finalize", "finalize-runtime"}
         and "--session-id" in arguments[2:]
     )
 
@@ -528,7 +554,8 @@ def _run_event(event: dict, _host: str) -> int:
         return 2
     if event_name == "PostToolUse" and not receipt_command:
         if any(learning_session_finalize_command(candidate) for candidate in commands):
-            reflection.record_activity(session_id, "learning-session-complete")
+            if learning_completion_artifact(session_id) is not None:
+                reflection.record_activity(session_id, "learning-session-complete")
         elif any(terminal_delivery_command(candidate) for candidate in commands):
             reflection.record_activity(session_id, "delivery-complete")
         elif mutation or any(delivery_command(candidate) for candidate in commands):

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -5312,8 +5312,15 @@ def check_r16_learning_session(hook_input: dict) -> str | None:
     events = ledger_events(hook_input)
     if "commit" not in events or check_r29_delivery_complete(hook_input) is not None:
         return None
-    if any(event.startswith("learning-session-complete:") for event in events):
-        return None
+    session_id = hook_input.get("session_id")
+    if isinstance(session_id, str) and session_id.strip():
+        learning_session = _learning_session_core()
+        state = learning_session.default_state_dir()
+        if (
+            learning_session.load_session_completion(state, session_id) is not None
+            or learning_session.load_runtime_completion(state, session_id) is not None
+        ):
+            return None
     return (
         "Learning Session: delivery is complete. Run exactly one terminal Learning "
         "Session now, after timing, failed-call, recursion, and cleanup analysis, then "
@@ -6185,7 +6192,7 @@ def run_required_action_self_test() -> int:
         is not None,
     )
     check(
-        "R16 accepts one immutable terminal completion",
+        "R16 ignores forged ledger completion without an artifact",
         _with_stubs(
             {
                 "ledger_events": lambda payload: [
@@ -6197,7 +6204,30 @@ def run_required_action_self_test() -> int:
             },
             lambda: check_r16_learning_session({"session_id": "s"}),
         )
-        is None,
+        is not None,
+    )
+    def _r16_with_real_completion():
+        learning_session = _learning_session_core()
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory) / "chaosengine-learning-v1"
+            learning_session.attest_no_learning(state, "s", "no_new_evidence")
+            learning_session.finalize_session(state, "s")
+            original = learning_session.default_state_dir
+            learning_session.default_state_dir = lambda: state
+            try:
+                return _with_stubs(
+                    {
+                        "ledger_events": lambda payload: ["commit", "delivery:{}"],
+                        "check_r29_delivery_complete": lambda payload: None,
+                    },
+                    lambda: check_r16_learning_session({"session_id": "s"}),
+                )
+            finally:
+                learning_session.default_state_dir = original
+
+    check(
+        "R16 accepts one immutable terminal completion artifact",
+        _r16_with_real_completion() is None,
     )
 
     # R31: controller operations are terminal and root-session owned.

--- a/scripts/agents/guard.py
+++ b/scripts/agents/guard.py
@@ -1674,7 +1674,7 @@ def _learning_session_operation(hook_input: dict, command: str) -> tuple[str, li
         (
             item
             for item in remaining
-            if item in {"signal", "assess", "attest-none", "finalize"}
+            if item in {"signal", "assess", "attest-none", "finalize", "finalize-runtime"}
         ),
         None,
     )
@@ -1715,6 +1715,13 @@ def _learning_session_events(hook_input: dict, command: str) -> list[str]:
     try:
         if operation == "finalize":
             completed = learning_session.load_session_completion(state, supplied_session)
+            if completed is not None:
+                return [
+                    "learning-session-complete:" + completed["completion_id"]
+                ]
+            return []
+        if operation == "finalize-runtime":
+            completed = learning_session.load_runtime_completion(state, supplied_session)
             if completed is not None:
                 return [
                     "learning-session-complete:" + completed["completion_id"]

--- a/scripts/agents/learning_session.py
+++ b/scripts/agents/learning_session.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import os
 import re
+import shlex
 import stat
+import subprocess  # nosec B404 - fixed list-form proof commands, never a shell.
 import tempfile
 import threading
 import time
@@ -40,7 +43,8 @@ NO_LEARNING_REASONS = frozenset(
         "store_degraded",
     }
 )
-RUNTIME_DISPOSITIONS = frozenset({"fixed-now", "existing", "new", "blocked"})
+RUNTIME_DISPOSITIONS = frozenset({"fixed-now", "existing", "new", "blocked", "no-durable"})
+ISSUE_BOUND_DISPOSITIONS = frozenset({"existing", "new"})
 UNAVAILABLE_REASONS = frozenset({"delegate_unavailable", "delegate_lost"})
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 GIT_REF_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -48,6 +52,8 @@ OPERATION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{8,64}$")
 TRACKING_ISSUE_URL_RE = re.compile(
     r"^https://github\.com/ShaftHQ/SHAFT_ENGINE/issues/[1-9][0-9]*$"
 )
+UNSAFE_PROOF_COMMAND = re.compile(r"[;|&`$<>]")
+DEFAULT_LEARNING_UPSTREAM = "ShaftHQ/SHAFT_ENGINE"
 RECEIPT_KEYS = frozenset(
     {
         "schema_version",
@@ -1042,37 +1048,406 @@ def attest_participant_unavailable(
         return existing or value
 
 
+def runtime_incident_source_path(state: Path, session_id: str) -> Path:
+    """Return the automatic harvest ledger for one runtime participant."""
+    return (
+        _contained_directory(Path(state), "runtime-incident-sources")
+        / f"{_session_hash(session_id)}.jsonl"
+    )
+
+
+def _disposition_path(state: Path, session_hash: str, disposition_id: str) -> Path:
+    return _contained_directory(Path(state), "dispositions") / session_hash / f"{disposition_id}.json"
+
+
+def _load_chaos_engine_learning(module: object | None = None):
+    if module is not None:
+        return module
+    path = Path(__file__).resolve().parents[2] / "chaos-engine" / "learning.py"
+    specification = importlib.util.spec_from_file_location(
+        "chaos_engine_learning_runtime", path
+    )
+    if specification is None or specification.loader is None:
+        raise ValueError("ChaosEngine learning queue is unavailable")
+    loaded = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(loaded)
+    return loaded
+
+
+def _validate_fixed_now_evidence(evidence: dict, evidence_root: Path) -> dict:
+    if not isinstance(evidence, dict):
+        raise ValueError("fixed-now proof evidence is required")
+    changed_files = evidence.get("changed_files")
+    head = evidence.get("head")
+    proof_command = evidence.get("proof_command")
+    proof_exit_code = evidence.get("proof_exit_code")
+    if not isinstance(changed_files, list) or not changed_files:
+        raise ValueError("fixed-now proof requires changed files")
+    if not all(_safe_relative_file(path) for path in changed_files):
+        raise ValueError("fixed-now proof requires safe relative changed files")
+    root = Path(evidence_root)
+    for relative in changed_files:
+        if not (root / relative).is_file():
+            raise ValueError("fixed-now proof requires existing changed files")
+    if not isinstance(head, str) or not GIT_REF_RE.fullmatch(head):
+        raise ValueError("fixed-now proof requires a bound HEAD")
+    if (
+        not isinstance(proof_command, str)
+        or not proof_command.strip()
+        or UNSAFE_PROOF_COMMAND.search(proof_command)
+    ):
+        raise ValueError("fixed-now proof command is unsafe or missing")
+    try:
+        tokens = shlex.split(proof_command.strip(), posix=os.name != "nt")
+    except ValueError as error:
+        raise ValueError("fixed-now proof command is unsafe or missing") from error
+    if not tokens:
+        raise ValueError("fixed-now proof command is unsafe or missing")
+    executable = Path(tokens[0])
+    command = [tokens[0], *tokens[1:]]
+    if not executable.is_absolute():
+        if not _safe_relative_file(tokens[0]):
+            raise ValueError("fixed-now proof command is unsafe or missing")
+        command = [str(root / tokens[0]), *tokens[1:]]
+    try:
+        completed = subprocess.run(  # nosec B603 - validated argv, no shell.
+            command,
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise ValueError("fixed-now proof failed to run") from error
+    if completed.returncode != 0:
+        raise ValueError("fixed-now proof did not pass")
+    if proof_exit_code not in (0, None) and proof_exit_code != completed.returncode:
+        raise ValueError("fixed-now proof exit code mismatch")
+    return {
+        "changed_files": list(dict.fromkeys(changed_files)),
+        "head": head,
+        "proof_command_hash": _hash_text(proof_command.strip()),
+        "proof_exit_code": 0,
+    }
+
+
+def _validate_issue_bound_evidence(evidence: dict) -> dict:
+    if not isinstance(evidence, dict):
+        raise ValueError("tracking issue evidence is required")
+    url = evidence.get("tracking_issue_url")
+    if not isinstance(url, str) or not TRACKING_ISSUE_URL_RE.fullmatch(url):
+        raise ValueError("tracking issue URL is required")
+    return {"tracking_issue_url": url}
+
+
+def _validate_blocked_evidence(
+    evidence: dict,
+    *,
+    learning_state: Path | None,
+    learning_module: object | None,
+) -> dict:
+    if not isinstance(evidence, dict):
+        raise ValueError("blocked disposition requires a privacy-safe queue payload")
+    candidate = evidence.get("learning_candidate")
+    upstream = evidence.get("upstream") or DEFAULT_LEARNING_UPSTREAM
+    if learning_state is None:
+        raise ValueError("blocked disposition requires a learning queue state")
+    learning = _load_chaos_engine_learning(learning_module)
+    if not isinstance(candidate, dict):
+        raise ValueError("blocked disposition requires a privacy-safe queue payload")
+    queued = learning.queue_learning(Path(learning_state), candidate, str(upstream))
+    payload = {
+        "queued_learning_id": queued["id"],
+        "queue_status": queued["status"],
+        "upstream": queued["upstream"],
+    }
+    fallback = queued.get("fallbackUrl")
+    if isinstance(fallback, str) and fallback:
+        payload["fallback_url"] = fallback
+    return payload
+
+
+def record_disposition(
+    state: Path,
+    *,
+    session_id: str,
+    incident_id: str,
+    disposition: str,
+    evidence: dict,
+    evidence_root: Path | None = None,
+    learning_state: Path | None = None,
+    learning_module: object | None = None,
+) -> dict:
+    """Record one schema-v2 evidence-bearing disposition receipt."""
+    if disposition not in RUNTIME_DISPOSITIONS - {"no-durable"}:
+        raise ValueError("runtime disposition is invalid")
+    if load_runtime_completion(Path(state), session_id) is not None:
+        raise ValueError("runtime learning session is already complete")
+    if load_session_completion(Path(state), session_id) is not None:
+        raise ValueError("learning session is already complete")
+    session_hash = _session_hash(session_id)
+    normalized_incident = incident_hash(incident_id)
+    if disposition == "fixed-now":
+        if evidence_root is None:
+            raise ValueError("fixed-now proof requires an evidence root")
+        validated = _validate_fixed_now_evidence(evidence, Path(evidence_root))
+    elif disposition in ISSUE_BOUND_DISPOSITIONS:
+        validated = _validate_issue_bound_evidence(evidence)
+    elif disposition == "blocked":
+        validated = _validate_blocked_evidence(
+            evidence, learning_state=learning_state, learning_module=learning_module
+        )
+    else:
+        raise ValueError("runtime disposition is invalid")
+    identity = {
+        "kind": "learning-disposition",
+        "session_hash": session_hash,
+        "incident_hash": normalized_incident,
+        "disposition": disposition,
+        "evidence": validated,
+    }
+    value = {
+        "schema_version": 2,
+        "disposition_id": _hash_text(_canonical(identity)),
+        **identity,
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+    }
+    with _state_lock(Path(state), f"disposition-{session_hash}-{normalized_incident}"):
+        directory = _contained_directory(Path(state), "dispositions") / session_hash
+        directory.mkdir(exist_ok=True)
+        existing = [
+            item
+            for item in load_dispositions(Path(state), session_id)
+            if item["incident_hash"] == normalized_incident
+        ]
+        if existing:
+            if existing[0] != value and existing[0]["disposition_id"] != value["disposition_id"]:
+                # Compare identity fields only for idempotent retries.
+                prior_identity = {
+                    key: existing[0][key]
+                    for key in ("kind", "session_hash", "incident_hash", "disposition", "evidence")
+                }
+                if prior_identity != identity:
+                    raise ValueError("incident already has a different disposition")
+                return existing[0]
+            return existing[0]
+        _atomic_json(_disposition_path(Path(state), session_hash, value["disposition_id"]), value)
+        return value
+
+
+def load_dispositions(state: Path, session_id: str) -> list[dict]:
+    """Load schema-v2 disposition receipts for one session."""
+    return _load_dispositions_by_hash(Path(state), _session_hash(session_id))
+
+
+def _load_dispositions_by_hash(state: Path, session_hash: str) -> list[dict]:
+    try:
+        directory = _contained_directory(Path(state), "dispositions") / session_hash
+    except (OSError, ValueError):
+        return []
+    if not directory.is_dir():
+        return []
+    values: list[dict] = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, UnicodeError):
+            continue
+        if _valid_disposition(value, session_hash):
+            values.append(value)
+    return values
+
+
+def _valid_disposition(value: object, session_hash: str) -> bool:
+    if not isinstance(value, dict):
+        return False
+    required = {
+        "schema_version",
+        "disposition_id",
+        "kind",
+        "session_hash",
+        "incident_hash",
+        "disposition",
+        "evidence",
+        "recorded_at",
+    }
+    try:
+        identity = {
+            "kind": value["kind"],
+            "session_hash": value["session_hash"],
+            "incident_hash": value["incident_hash"],
+            "disposition": value["disposition"],
+            "evidence": value["evidence"],
+        }
+        return bool(
+            set(value) == required
+            and value["schema_version"] == 2
+            and value["kind"] == "learning-disposition"
+            and value["session_hash"] == session_hash
+            and SHA256_RE.fullmatch(value["incident_hash"])
+            and value["disposition"] in RUNTIME_DISPOSITIONS - {"no-durable"}
+            and isinstance(value["evidence"], dict)
+            and bool(value["evidence"])
+            and _valid_utc_timestamp(value["recorded_at"])
+            and value["disposition_id"] == _hash_text(_canonical(identity))
+        )
+    except (KeyError, TypeError):
+        return False
+
+
+def _load_sibling_incidents(state: Path, participant_hash: str) -> dict[str, dict]:
+    path = (
+        _contained_directory(Path(state), "runtime-incident-sources")
+        / f"{participant_hash}.jsonl"
+    )
+    if not path.is_file():
+        return {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return {}
+    incidents: dict[str, dict] = {}
+    for line in lines:
+        try:
+            item = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(item, dict):
+            continue
+        incident_id = item.get("incident_id")
+        if not isinstance(incident_id, str) or not incident_id.strip():
+            continue
+        digest = incident_hash(incident_id)
+        incidents[digest] = {
+            "incident_hash": digest,
+            "kind": item.get("kind") if item.get("kind") in SIGNAL_KINDS else "tool_failure",
+            "origin": item.get("origin") if item.get("origin") in ORIGINS else "tool",
+            "source": "sibling",
+        }
+    return incidents
+
+
+def collect_runtime_incidents(state: Path, root_session_id: str) -> dict[str, dict]:
+    """Harvest unique incidents from registered receipts and sibling sources."""
+    registry = _load_runtime_registry(Path(state), root_session_id)
+    collected: dict[str, dict] = {}
+    for participant_hash in registry["participant_hashes"]:
+        for receipt in _load_receipts_by_hash(Path(state), participant_hash):
+            collected[receipt["incident_hash"]] = {
+                "incident_hash": receipt["incident_hash"],
+                "kind": receipt["signal_kind"],
+                "origin": receipt["origin"],
+                "source": "receipt",
+                "participant_hash": participant_hash,
+            }
+        for digest, item in _load_sibling_incidents(Path(state), participant_hash).items():
+            collected.setdefault(
+                digest,
+                {**item, "participant_hash": participant_hash},
+            )
+    return collected
+
+
+def load_runtime_completion(state: Path, root_session_id: str) -> dict | None:
+    """Load one immutable root-owned runtime completion artifact."""
+    try:
+        value = json.loads(
+            _runtime_completion_path(Path(state), root_session_id).read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError, UnicodeError):
+        return None
+    required = {
+        "schema_version",
+        "completion_id",
+        "kind",
+        "root_session_hash",
+        "disposition",
+        "participant_hashes",
+        "incidents",
+        "completed_at",
+    }
+    try:
+        if (
+            not isinstance(value, dict)
+            or set(value) != required
+            or value.get("schema_version") not in {1, 2}
+            or value.get("kind") != "learning-runtime-complete"
+            or value.get("root_session_hash") != _session_hash(root_session_id)
+            or value.get("disposition") not in {"assessed", "no-durable"}
+            or not isinstance(value.get("participant_hashes"), list)
+            or not isinstance(value.get("incidents"), list)
+            or not _valid_utc_timestamp(value.get("completed_at"))
+        ):
+            return None
+        identity = {
+            "kind": value["kind"],
+            "root_session_hash": value["root_session_hash"],
+            "disposition": value["disposition"],
+            "participant_hashes": value["participant_hashes"],
+            "incidents": value["incidents"],
+        }
+        if value["completion_id"] != _hash_text(_canonical(identity)):
+            return None
+    except (KeyError, TypeError):
+        return None
+    return value
+
+
 def finalize_runtime_session(
     state: Path,
     *,
     root_session_id: str,
-    dispositions: dict[str, str],
+    dispositions: dict[str, str] | None = None,
 ) -> dict:
-    """Close one root-owned runtime after considering root and delegate receipts."""
+    """Close one root-owned runtime after automatic incident and disposition harvest."""
+    existing = load_runtime_completion(Path(state), root_session_id)
+    if existing is not None:
+        if dispositions:
+            raise ValueError("runtime learning session is already complete")
+        return existing
     registry = close_runtime(Path(state), root_session_id)
     participant_hashes = registry["participant_hashes"]
     participant_receipts = {
         participant_hash: _load_receipts_by_hash(Path(state), participant_hash)
         for participant_hash in participant_hashes
     }
-    receipts = {
-        receipt["incident_hash"]: receipt
-        for items in participant_receipts.values()
-        for receipt in items
+    sibling_incidents = {
+        participant_hash: _load_sibling_incidents(Path(state), participant_hash)
+        for participant_hash in participant_hashes
     }
-    incident_hashes = set(receipts)
-    if set(dispositions) != incident_hashes:
+    collected = collect_runtime_incidents(Path(state), root_session_id)
+    incident_hashes = set(collected)
+    disposition_receipts = {
+        item["incident_hash"]: item
+        for participant_hash in participant_hashes
+        for item in _load_dispositions_by_hash(Path(state), participant_hash)
+    }
+    if dispositions:
+        if set(dispositions) != incident_hashes:
+            raise ValueError("every runtime incident requires exactly one disposition")
+        for key, value in dispositions.items():
+            receipt = disposition_receipts.get(key)
+            if receipt is None or receipt["disposition"] != value:
+                raise ValueError("every runtime incident requires evidence-bearing disposition")
+    elif set(disposition_receipts) != incident_hashes:
         raise ValueError("every runtime incident requires exactly one disposition")
-    if any(
-        not SHA256_RE.fullmatch(key) or value not in RUNTIME_DISPOSITIONS
-        for key, value in dispositions.items()
-    ):
-        raise ValueError("runtime disposition is invalid")
-    receipt_participants = {
-        participant_hash for participant_hash, items in participant_receipts.items() if items
+    for key, receipt in disposition_receipts.items():
+        if key not in incident_hashes:
+            raise ValueError("every runtime incident requires exactly one disposition")
+        if receipt["disposition"] not in RUNTIME_DISPOSITIONS - {"no-durable"}:
+            raise ValueError("runtime disposition is invalid")
+    evidence_participants = {
+        participant_hash
+        for participant_hash, items in participant_receipts.items()
+        if items
+    } | {
+        participant_hash
+        for participant_hash, items in sibling_incidents.items()
+        if items
     }
     for participant_hash in participant_hashes:
-        if participant_hash in receipt_participants:
+        if participant_hash in evidence_participants:
             continue
         if _load_attestation_by_hash(Path(state), participant_hash) is not None:
             continue
@@ -1082,18 +1457,26 @@ def finalize_runtime_session(
         if unavailable is None:
             label = "root" if participant_hash == registry["root_session_hash"] else "delegate"
             raise ValueError(f"registered {label} lacks terminal evidence")
+    incident_records = []
+    for key in sorted(incident_hashes):
+        receipt = disposition_receipts[key]
+        incident_records.append(
+            {
+                "incident_hash": key,
+                "disposition": receipt["disposition"],
+                "disposition_id": receipt["disposition_id"],
+                "evidence": receipt["evidence"],
+            }
+        )
     identity = {
         "kind": "learning-runtime-complete",
         "root_session_hash": _session_hash(root_session_id),
         "disposition": "assessed" if incident_hashes else "no-durable",
         "participant_hashes": participant_hashes,
-        "incidents": [
-            {"incident_hash": key, "disposition": dispositions[key]}
-            for key in sorted(dispositions)
-        ],
+        "incidents": incident_records,
     }
     value = {
-        "schema_version": 1,
+        "schema_version": 2,
         "completion_id": _hash_text(_canonical(identity)),
         **identity,
         "completed_at": datetime.now(timezone.utc).isoformat(),
@@ -1101,13 +1484,12 @@ def finalize_runtime_session(
     with _state_lock(Path(state), f"runtime-{identity['root_session_hash']}"):
         path = _runtime_completion_path(Path(state), root_session_id)
         if path.is_file():
-            try:
-                existing = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, ValueError, UnicodeError) as error:
-                raise ValueError("runtime completion is invalid") from error
-            if {key: existing.get(key) for key in identity} != identity:
+            loaded = load_runtime_completion(Path(state), root_session_id)
+            if loaded is None:
+                raise ValueError("runtime completion is invalid")
+            if {key: loaded.get(key) for key in identity} != identity:
                 raise ValueError("runtime learning session is already complete")
-            return existing
+            return loaded
         _atomic_json(path, value)
     return value
 
@@ -1599,7 +1981,7 @@ def _parse_disposition(value: str) -> tuple[str, str]:
     if (
         not separator
         or not SHA256_RE.fullmatch(incident)
-        or disposition not in RUNTIME_DISPOSITIONS
+        or disposition not in RUNTIME_DISPOSITIONS - {"no-durable"}
     ):
         raise argparse.ArgumentTypeError(
             "disposition must be SHA256=fixed-now|existing|new|blocked"
@@ -1731,10 +2113,11 @@ def main(arguments: list[str] | None = None) -> int:
                 state, options.session_id, options.participant_session_id, options.reason_code
             )
         elif options.command == "finalize-runtime":
+            supplied = dict(options.disposition) if options.disposition else None
             result = finalize_runtime_session(
                 state,
                 root_session_id=options.session_id,
-                dispositions=dict(options.disposition),
+                dispositions=supplied,
             )
         elif options.command == "evaluate":
             manifest = _load_json_object(options.manifest)

--- a/scripts/agents/learning_session.py
+++ b/scripts/agents/learning_session.py
@@ -1074,31 +1074,37 @@ def _load_chaos_engine_learning(module: object | None = None):
     return loaded
 
 
-def _validate_fixed_now_evidence(evidence: dict, evidence_root: Path) -> dict:
-    if not isinstance(evidence, dict):
-        raise ValueError("fixed-now proof evidence is required")
-    changed_files = evidence.get("changed_files")
-    head = evidence.get("head")
-    proof_command = evidence.get("proof_command")
-    proof_exit_code = evidence.get("proof_exit_code")
+def _validate_fixed_now_changed_files(
+    changed_files: object, evidence_root: Path
+) -> list[str]:
     if not isinstance(changed_files, list) or not changed_files:
         raise ValueError("fixed-now proof requires changed files")
     if not all(_safe_relative_file(path) for path in changed_files):
         raise ValueError("fixed-now proof requires safe relative changed files")
-    root = Path(evidence_root)
     for relative in changed_files:
-        if not (root / relative).is_file():
+        if not (evidence_root / relative).is_file():
             raise ValueError("fixed-now proof requires existing changed files")
+    return list(changed_files)
+
+
+def _validate_fixed_now_head(head: object) -> str:
     if not isinstance(head, str) or not GIT_REF_RE.fullmatch(head):
         raise ValueError("fixed-now proof requires a bound HEAD")
+    return head
+
+
+def _resolve_fixed_now_proof_command(
+    proof_command: object, evidence_root: Path
+) -> tuple[str, list[str]]:
     if (
         not isinstance(proof_command, str)
         or not proof_command.strip()
         or UNSAFE_PROOF_COMMAND.search(proof_command)
     ):
         raise ValueError("fixed-now proof command is unsafe or missing")
+    stripped = proof_command.strip()
     try:
-        tokens = shlex.split(proof_command.strip(), posix=os.name != "nt")
+        tokens = shlex.split(stripped, posix=os.name != "nt")
     except ValueError as error:
         raise ValueError("fixed-now proof command is unsafe or missing") from error
     if not tokens:
@@ -1108,11 +1114,17 @@ def _validate_fixed_now_evidence(evidence: dict, evidence_root: Path) -> dict:
     if not executable.is_absolute():
         if not _safe_relative_file(tokens[0]):
             raise ValueError("fixed-now proof command is unsafe or missing")
-        command = [str(root / tokens[0]), *tokens[1:]]
+        command = [str(evidence_root / tokens[0]), *tokens[1:]]
+    return stripped, command
+
+
+def _run_fixed_now_proof(
+    command: list[str], evidence_root: Path, proof_exit_code: object
+) -> None:
     try:
         completed = subprocess.run(  # nosec B603 - validated argv, no shell.
             command,
-            cwd=str(root),
+            cwd=str(evidence_root),
             capture_output=True,
             text=True,
             timeout=30,
@@ -1124,10 +1136,24 @@ def _validate_fixed_now_evidence(evidence: dict, evidence_root: Path) -> dict:
         raise ValueError("fixed-now proof did not pass")
     if proof_exit_code not in (0, None) and proof_exit_code != completed.returncode:
         raise ValueError("fixed-now proof exit code mismatch")
+
+
+def _validate_fixed_now_evidence(evidence: dict, evidence_root: Path) -> dict:
+    if not isinstance(evidence, dict):
+        raise ValueError("fixed-now proof evidence is required")
+    root = Path(evidence_root)
+    changed_files = _validate_fixed_now_changed_files(
+        evidence.get("changed_files"), root
+    )
+    head = _validate_fixed_now_head(evidence.get("head"))
+    proof_command, command = _resolve_fixed_now_proof_command(
+        evidence.get("proof_command"), root
+    )
+    _run_fixed_now_proof(command, root, evidence.get("proof_exit_code"))
     return {
         "changed_files": list(dict.fromkeys(changed_files)),
         "head": head,
-        "proof_command_hash": _hash_text(proof_command.strip()),
+        "proof_command_hash": _hash_text(proof_command),
         "proof_exit_code": 0,
     }
 

--- a/scripts/agents/learning_session.py
+++ b/scripts/agents/learning_session.py
@@ -904,9 +904,11 @@ def create_runtime(state: Path, root_session_id: str) -> dict:
     with _state_lock(Path(state), f"runtime-registry-{root_hash}"):
         path = _runtime_registry_path(Path(state), root_session_id)
         if path.is_file():
+            _remember_participant_session_id(Path(state), root_session_id, root_session_id)
             return _load_runtime_registry(Path(state), root_session_id)
         value = _runtime_registry_value(root_session_id, [root_hash], "open")
         _atomic_json(path, value)
+        _remember_participant_session_id(Path(state), root_session_id, root_session_id)
     return value
 
 
@@ -923,11 +925,17 @@ def register_runtime_participant(
         if registry["status"] != "open":
             raise ValueError("runtime participant registry is closed")
         if participant_hash in registry["participant_hashes"]:
+            _remember_participant_session_id(
+                Path(state), root_session_id, participant_session_id
+            )
             return registry
         value = _runtime_registry_value(
             root_session_id, registry["participant_hashes"] + [participant_hash], "open"
         )
         _atomic_json(_runtime_registry_path(Path(state), root_session_id), value)
+        _remember_participant_session_id(
+            Path(state), root_session_id, participant_session_id
+        )
         return value
 
 
@@ -1322,6 +1330,154 @@ def _valid_disposition(value: object, session_hash: str) -> bool:
         return False
 
 
+def _revalidate_disposition_evidence(receipt: dict) -> None:
+    """Reject forged disposition evidence using the same field rules as record_disposition."""
+    disposition = receipt.get("disposition")
+    evidence = receipt.get("evidence")
+    if disposition == "fixed-now":
+        if (
+            not isinstance(evidence, dict)
+            or set(evidence)
+            != {"changed_files", "head", "proof_command_hash", "proof_exit_code"}
+            or not isinstance(evidence.get("changed_files"), list)
+            or not evidence["changed_files"]
+            or not all(_safe_relative_file(path) for path in evidence["changed_files"])
+            or not isinstance(evidence.get("head"), str)
+            or not GIT_REF_RE.fullmatch(evidence["head"])
+            or not isinstance(evidence.get("proof_command_hash"), str)
+            or not SHA256_RE.fullmatch(evidence["proof_command_hash"])
+            or evidence.get("proof_exit_code") != 0
+        ):
+            raise ValueError("fixed-now proof evidence is required")
+        return
+    if disposition in ISSUE_BOUND_DISPOSITIONS:
+        _validate_issue_bound_evidence(evidence)
+        return
+    if disposition == "blocked":
+        if (
+            not isinstance(evidence, dict)
+            or not isinstance(evidence.get("queued_learning_id"), str)
+            or not evidence.get("queued_learning_id")
+            or evidence.get("queue_status") not in {"queued", "submitted"}
+            or not isinstance(evidence.get("upstream"), str)
+            or not evidence.get("upstream")
+        ):
+            raise ValueError("blocked disposition requires a privacy-safe queue payload")
+        return
+    raise ValueError("runtime disposition is invalid")
+
+
+def _participant_session_map_path(state: Path, root_session_id: str) -> Path:
+    return (
+        _contained_directory(Path(state), "runtime-participant-ids")
+        / f"{_session_hash(root_session_id)}.json"
+    )
+
+
+def _remember_participant_session_id(
+    state: Path, root_session_id: str, participant_session_id: str
+) -> None:
+    path = _participant_session_map_path(Path(state), root_session_id)
+    existing = _load_json_object(path) if path.is_file() else {}
+    if not isinstance(existing, dict):
+        existing = {}
+    existing[_session_hash(participant_session_id)] = participant_session_id.strip()
+    _atomic_json(path, existing)
+
+
+def _load_participant_session_ids(state: Path, root_session_id: str) -> dict[str, str]:
+    path = _participant_session_map_path(Path(state), root_session_id)
+    value = _load_json_object(path) if path.is_file() else None
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: session_id
+        for key, session_id in value.items()
+        if isinstance(key, str)
+        and SHA256_RE.fullmatch(key)
+        and isinstance(session_id, str)
+        and session_id.strip()
+    }
+
+
+def _load_reflection_module():
+    try:
+        from scripts.agents import reflection as loaded
+    except (ImportError, OSError, AttributeError):
+        path = Path(__file__).resolve().parents[2] / "chaos-engine" / "hooks" / "reflection.py"
+        specification = importlib.util.spec_from_file_location(
+            "chaos_engine_reflection_harvest", path
+        )
+        if specification is None or specification.loader is None:
+            return None
+        loaded = importlib.util.module_from_spec(specification)
+        specification.loader.exec_module(loaded)
+    return loaded
+
+
+def _harvest_ledger_incidents(session_id: str) -> dict[str, dict]:
+    """Harvest failures, guard blocks, and retries from an existing session ledger."""
+    reflection = _load_reflection_module()
+    if reflection is None:
+        return {}
+    try:
+        recorded = reflection.entries(session_id)
+    except (OSError, TypeError, ValueError):
+        return {}
+    incidents: dict[str, dict] = {}
+    for item in recorded:
+        if not isinstance(item, dict):
+            continue
+        kind = item.get("kind")
+        if kind == "task-failure" and item.get("attempted") is not False:
+            failure_id = item.get("failureId") or item.get("fingerprint")
+            if not isinstance(failure_id, str) or not failure_id.strip():
+                continue
+            signal_kind = (
+                "guard_block" if item.get("phase") == "guard" else "tool_failure"
+            )
+            digest = incident_hash(f"ledger:{failure_id}")
+            incidents[digest] = {
+                "incident_hash": digest,
+                "kind": signal_kind,
+                "origin": "tool",
+                "source": "ledger",
+            }
+        elif kind == "platform-outcome" and item.get("outcome") == "failed":
+            target = item.get("target")
+            if not isinstance(target, str) or not target.strip():
+                continue
+            digest = incident_hash(f"ledger:platform:{target}")
+            incidents[digest] = {
+                "incident_hash": digest,
+                "kind": "test_failure",
+                "origin": "tool",
+                "source": "ledger",
+            }
+        elif kind == "reflection-trigger":
+            trigger = item.get("trigger")
+            fingerprint = item.get("fingerprint") or "manual"
+            if trigger not in {
+                "second-failure",
+                "repeated-fingerprint",
+                "third-fix",
+                "guard-repeat",
+                "review-repeat",
+            }:
+                continue
+            digest = incident_hash(f"ledger:trigger:{trigger}:{fingerprint}")
+            signal_kind = (
+                "guard_block" if trigger == "guard-repeat" else "tool_failure"
+            )
+            incidents[digest] = {
+                "incident_hash": digest,
+                "kind": signal_kind,
+                "origin": "tool",
+                "source": "ledger",
+            }
+    return incidents
+
+
 def _load_sibling_incidents(state: Path, participant_hash: str) -> dict[str, dict]:
     path = (
         _contained_directory(Path(state), "runtime-incident-sources")
@@ -1355,8 +1511,9 @@ def _load_sibling_incidents(state: Path, participant_hash: str) -> dict[str, dic
 
 
 def collect_runtime_incidents(state: Path, root_session_id: str) -> dict[str, dict]:
-    """Harvest unique incidents from registered receipts and sibling sources."""
+    """Harvest unique incidents from receipts, sibling sources, and live ledgers."""
     registry = _load_runtime_registry(Path(state), root_session_id)
+    session_ids = _load_participant_session_ids(Path(state), root_session_id)
     collected: dict[str, dict] = {}
     for participant_hash in registry["participant_hashes"]:
         for receipt in _load_receipts_by_hash(Path(state), participant_hash):
@@ -1368,6 +1525,14 @@ def collect_runtime_incidents(state: Path, root_session_id: str) -> dict[str, di
                 "participant_hash": participant_hash,
             }
         for digest, item in _load_sibling_incidents(Path(state), participant_hash).items():
+            collected.setdefault(
+                digest,
+                {**item, "participant_hash": participant_hash},
+            )
+        session_id = session_ids.get(participant_hash)
+        if not session_id:
+            continue
+        for digest, item in _harvest_ledger_incidents(session_id).items():
             collected.setdefault(
                 digest,
                 {**item, "participant_hash": participant_hash},
@@ -1442,6 +1607,15 @@ def finalize_runtime_session(
         participant_hash: _load_sibling_incidents(Path(state), participant_hash)
         for participant_hash in participant_hashes
     }
+    session_ids = _load_participant_session_ids(Path(state), root_session_id)
+    ledger_incidents = {
+        participant_hash: (
+            _harvest_ledger_incidents(session_ids[participant_hash])
+            if participant_hash in session_ids
+            else {}
+        )
+        for participant_hash in participant_hashes
+    }
     collected = collect_runtime_incidents(Path(state), root_session_id)
     incident_hashes = set(collected)
     disposition_receipts = {
@@ -1463,6 +1637,7 @@ def finalize_runtime_session(
             raise ValueError("every runtime incident requires exactly one disposition")
         if receipt["disposition"] not in RUNTIME_DISPOSITIONS - {"no-durable"}:
             raise ValueError("runtime disposition is invalid")
+        _revalidate_disposition_evidence(receipt)
     evidence_participants = {
         participant_hash
         for participant_hash, items in participant_receipts.items()
@@ -1470,6 +1645,10 @@ def finalize_runtime_session(
     } | {
         participant_hash
         for participant_hash, items in sibling_incidents.items()
+        if items
+    } | {
+        participant_hash
+        for participant_hash, items in ledger_incidents.items()
         if items
     }
     for participant_hash in participant_hashes:

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "c880bf1fcdffaf847e660f4bd8a7793e398171a1b7b5f3bf6e840641b89f5e33",
+      "harnessSha256": "3cfb478242408314c390a4403a98f693afb213f22fe0a5e8c7ed4b14a12b47d8",
       "treatmentSha256": {
-        "calibration": "c8203360101ee3ba31f4caf05820bd0ffc0f4a313db07dfbcbc84359a3193c0b",
-        "full-pilot": "1cc6b9666569f0b0a55fa0e60d59c948618745ea593828490cdd1e13c940691b"
+        "calibration": "416066bdb8a3f6c7a36b822a958961e3d54631ed08cf12014ec70641ece6c8a6",
+        "full-pilot": "b5438971f8b35dd9ce885929c2b00cb9f9d36f18006a8ab172bc244dd9d10212"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "62300afbb8672c25f13b2cf70b22f33bd0f5f18d0b82471335fa0414d437b68c",
+      "harnessSha256": "78bcd05310f98aa756f4a555f6f2fa08e613529d288cc95c0dcfbd9d64ad6b60",
       "treatmentSha256": {
-        "calibration": "55672e6ac0acc78402db4e58c0374a9fccc0bcd54b5b6f5577330514c874fcb8",
-        "full-pilot": "a180fb6826732138a18963625932d475746c1c0146fee7e8ee17c449e4bdc3de"
+        "calibration": "f819357b0b9e13dae4a113db3133bc42765fccb46426d5a4eb0dd40ca002412f",
+        "full-pilot": "3c20cf98143df27810083e667ffd1e71742f50b3dbe38d90ae018fe4f6d5f64f"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -59,10 +59,10 @@
       "effort": "medium",
       "repositoryRevision": "0481767def7c31fe144bc20543dfe937b8ffd4d5",
       "harness": "chaos-engine",
-      "harnessSha256": "78bcd05310f98aa756f4a555f6f2fa08e613529d288cc95c0dcfbd9d64ad6b60",
+      "harnessSha256": "c880bf1fcdffaf847e660f4bd8a7793e398171a1b7b5f3bf6e840641b89f5e33",
       "treatmentSha256": {
-        "calibration": "f819357b0b9e13dae4a113db3133bc42765fccb46426d5a4eb0dd40ca002412f",
-        "full-pilot": "3c20cf98143df27810083e667ffd1e71742f50b3dbe38d90ae018fe4f6d5f64f"
+        "calibration": "c8203360101ee3ba31f4caf05820bd0ffc0f4a313db07dfbcbc84359a3193c0b",
+        "full-pilot": "1cc6b9666569f0b0a55fa0e60d59c948618745ea593828490cdd1e13c940691b"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "62300afbb8672c25f13b2cf70b22f33bd0f5f18d0b82471335fa0414d437b68c"
+      harness_sha256: "78bcd05310f98aa756f4a555f6f2fa08e613529d288cc95c0dcfbd9d64ad6b60"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "c880bf1fcdffaf847e660f4bd8a7793e398171a1b7b5f3bf6e840641b89f5e33"
+      harness_sha256: "3cfb478242408314c390a4403a98f693afb213f22fe0a5e8c7ed4b14a12b47d8"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "78bcd05310f98aa756f4a555f6f2fa08e613529d288cc95c0dcfbd9d64ad6b60"
+      harness_sha256: "c880bf1fcdffaf847e660f4bd8a7793e398171a1b7b5f3bf6e840641b89f5e33"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "c880bf1fcdffaf847e660f4bd8a7793e398171a1b7b5f3bf6e840641b89f5e33"
+      harness_sha256: "3cfb478242408314c390a4403a98f693afb213f22fe0a5e8c7ed4b14a12b47d8"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "62300afbb8672c25f13b2cf70b22f33bd0f5f18d0b82471335fa0414d437b68c"
+      harness_sha256: "78bcd05310f98aa756f4a555f6f2fa08e613529d288cc95c0dcfbd9d64ad6b60"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0481767def7c31fe144bc20543dfe937b8ffd4d5"
-      harness_sha256: "78bcd05310f98aa756f4a555f6f2fa08e613529d288cc95c0dcfbd9d64ad6b60"
+      harness_sha256: "c880bf1fcdffaf847e660f4bd8a7793e398171a1b7b5f3bf6e840641b89f5e33"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_hook.py
+++ b/tests/scripts/test_chaos_engine_hook.py
@@ -300,9 +300,15 @@ process.stderr.write(result.stderr || '');
             )
 
     def test_terminal_learning_session_completion_clears_portable_stop_gate(self):
+        import importlib
+
+        learning_session = importlib.import_module("scripts.agents.learning_session")
         with tempfile.TemporaryDirectory() as temporary:
             environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}
             session = "learn-complete"
+            state = Path(temporary) / "chaosengine-learning-v1"
+            learning_session.attest_no_learning(state, session, "no_new_evidence")
+            learning_session.finalize_session(state, session)
             for command in (
                 "py -3 scripts/agents/chaos_engine_cli.py delivery-status --manifest m --receipt-out r",
                 "py -3 scripts/agents/learning_session.py finalize --session-id learn-complete",
@@ -329,6 +335,38 @@ process.stderr.write(result.stderr || '');
             self.assertEqual(0, stopped.returncode)
             self.assertFalse(
                 json.loads(stopped.stdout).get("reason", "").casefold().startswith("learning session:")
+            )
+
+    def test_finalize_command_without_artifact_does_not_clear_portable_stop_gate(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}
+            session = "learn-forged"
+            for command in (
+                "py -3 scripts/agents/chaos_engine_cli.py delivery-status --manifest m --receipt-out r",
+                "py -3 scripts/agents/learning_session.py finalize --session-id learn-forged",
+            ):
+                self.run_hook(
+                    {
+                        "hook_event_name": "PostToolUse",
+                        "tool_name": "PowerShell",
+                        "tool_input": {"command": command},
+                        "session_id": session,
+                    },
+                    environment,
+                )
+
+            stopped = self.run_hook(
+                {
+                    "hook_event_name": "Stop",
+                    "session_id": session,
+                    "stop_hook_active": False,
+                },
+                environment,
+            )
+
+            self.assertEqual(2, stopped.returncode)
+            self.assertTrue(
+                json.loads(stopped.stdout)["reason"].casefold().startswith("learning session:")
             )
 
     def test_failed_read_only_agent_diagnostics_do_not_open_portable_checkpoint(self):

--- a/tests/scripts/test_chaos_engine_hook.py
+++ b/tests/scripts/test_chaos_engine_hook.py
@@ -714,6 +714,71 @@ process.stderr.write(result.stderr || '');
             with patch.dict(os.environ, environment):
                 self.assertFalse(reflection.has_valid_terminal_receipt("portable-delivery"))
 
+    def test_reflection_receipt_alone_does_not_clear_stop_after_delivery(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            environment = {**os.environ, "TMPDIR": temporary, "TEMP": temporary}
+            session = "learn-reflection-only"
+            with patch.dict(os.environ, environment):
+                token = reflection.record_session_start(session)
+                reflection.record_failure(
+                    session,
+                    phase="tool-outcome",
+                    target="flaky-command",
+                    failure_class="tool-failure",
+                    attempted=True,
+                )
+                reflection.record_failure(
+                    session,
+                    phase="tool-outcome",
+                    target="flaky-command",
+                    failure_class="tool-failure",
+                    attempted=True,
+                )
+                checkpoint = reflection.pending_checkpoint(session)
+                self.assertIsNotNone(checkpoint)
+                receipt = {
+                    "schemaVersion": 1,
+                    "taskId": "issue-5517",
+                    "trigger": checkpoint["trigger"],
+                    "failureFingerprints": checkpoint.get("failureFingerprints", []),
+                    "failedAssumption": "Reflection alone cleared Learning Session.",
+                    "approachesCompared": ["Stop on reflection", "Require learning artifact"],
+                    "chosenExperiment": "Keep only the reflection receipt.",
+                    "changedApproach": "Require the learning completion artifact.",
+                    "proofCommandOrCheck": "portable stop after delivery",
+                    "proofOutcome": "Stop remained blocked.",
+                    "durableDisposition": "guidance-fixed",
+                }
+                reflection.record_receipt(session, receipt, token)
+            self.run_hook(
+                {
+                    "hook_event_name": "PostToolUse",
+                    "tool_name": "PowerShell",
+                    "tool_input": {
+                        "command": (
+                            "py -3 scripts/agents/chaos_engine_cli.py "
+                            "delivery-status --manifest m --receipt-out r"
+                        )
+                    },
+                    "session_id": session,
+                },
+                environment,
+            )
+            stopped = self.run_hook(
+                {
+                    "hook_event_name": "Stop",
+                    "session_id": session,
+                    "stop_hook_active": False,
+                },
+                environment,
+            )
+            self.assertNotEqual(0, stopped.returncode)
+            payload = self._hook_decision_payload(stopped)
+            self.assertEqual("block", payload.get("decision"))
+            self.assertTrue(
+                str(payload.get("reason", "")).casefold().startswith("learning session:")
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/scripts/test_chaos_engine_hook.py
+++ b/tests/scripts/test_chaos_engine_hook.py
@@ -68,11 +68,12 @@ class ChaosEngineHookTest(unittest.TestCase):
         self.assertLessEqual(len(result.stdout.encode("utf-8")), 4096)
 
     def test_allowed_non_start_events_are_silent_for_every_host(self):
+        # Stop is excluded on purpose: without a valid Learning Session
+        # completion artifact it is fail-closed, not required to be silent.
         fixtures = (
             {"hook_event_name": "PreToolUse", "tool_name": "Read"},
             {"hook_event_name": "PostToolUse", "tool_name": "Read"},
             {"hook_event_name": "PostToolUseFailure", "tool_name": "Read"},
-            {"hook_event_name": "Stop", "stop_hook_active": False},
             {"hook_event_name": "SubagentStop", "stop_hook_active": False},
         )
         for host in ("codex", "claude", "gemini", "grok", "copilot"):
@@ -82,6 +83,95 @@ class ChaosEngineHookTest(unittest.TestCase):
                     result = self.run_hook(event, environment)
                     self.assertEqual(0, result.returncode)
                     self.assertEqual({}, json.loads(result.stdout))
+
+    def _hook_decision_payload(self, result):
+        rendered = (result.stdout or "").strip() or (result.stderr or "").strip() or "{}"
+        return json.loads(rendered)
+
+    def test_stop_without_completion_artifact_is_fail_closed_for_every_host(self):
+        for host in ("codex", "claude", "gemini", "grok", "copilot"):
+            with self.subTest(host=host):
+                with tempfile.TemporaryDirectory() as temporary:
+                    environment = {
+                        **os.environ,
+                        "CHAOS_ENGINE_HOST": host,
+                        "TMPDIR": temporary,
+                        "TEMP": temporary,
+                    }
+                    session = f"stop-deny-{host}"
+                    self.run_hook(
+                        {
+                            "hook_event_name": "PostToolUse",
+                            "tool_name": "PowerShell",
+                            "tool_input": {
+                                "command": (
+                                    "py -3 scripts/agents/chaos_engine_cli.py "
+                                    "delivery-status --manifest m --receipt-out r"
+                                )
+                            },
+                            "session_id": session,
+                        },
+                        environment,
+                    )
+                    stopped = self.run_hook(
+                        {
+                            "hook_event_name": "Stop",
+                            "session_id": session,
+                            "stop_hook_active": False,
+                        },
+                        environment,
+                    )
+                self.assertNotEqual(0, stopped.returncode)
+                payload = self._hook_decision_payload(stopped)
+                self.assertEqual("block", payload.get("decision"))
+                self.assertTrue(
+                    str(payload.get("reason", "")).casefold().startswith("learning session:")
+                )
+
+    def test_stop_with_completion_artifact_is_silent_for_every_host(self):
+        import importlib
+
+        learning_session = importlib.import_module("scripts.agents.learning_session")
+        for host in ("codex", "claude", "gemini", "grok", "copilot"):
+            with self.subTest(host=host):
+                with tempfile.TemporaryDirectory() as temporary:
+                    environment = {
+                        **os.environ,
+                        "CHAOS_ENGINE_HOST": host,
+                        "TMPDIR": temporary,
+                        "TEMP": temporary,
+                    }
+                    session = f"stop-allow-{host}"
+                    state = Path(temporary) / "chaosengine-learning-v1"
+                    learning_session.attest_no_learning(state, session, "no_new_evidence")
+                    learning_session.finalize_session(state, session)
+                    for command in (
+                        "py -3 scripts/agents/chaos_engine_cli.py delivery-status --manifest m --receipt-out r",
+                        "py -3 scripts/agents/learning_session.py finalize --session-id " + session,
+                    ):
+                        self.run_hook(
+                            {
+                                "hook_event_name": "PostToolUse",
+                                "tool_name": "PowerShell",
+                                "tool_input": {"command": command},
+                                "session_id": session,
+                            },
+                            environment,
+                        )
+                    stopped = self.run_hook(
+                        {
+                            "hook_event_name": "Stop",
+                            "session_id": session,
+                            "stop_hook_active": False,
+                        },
+                        environment,
+                    )
+                self.assertEqual(0, stopped.returncode)
+                payload = self._hook_decision_payload(stopped)
+                self.assertNotEqual("block", payload.get("decision"))
+                self.assertFalse(
+                    str(payload.get("reason", "")).casefold().startswith("learning session:")
+                )
 
     def test_claude_stop_block_writes_continuation_prompt_to_stderr(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_guard_lifecycle.py
+++ b/tests/scripts/test_guard_lifecycle.py
@@ -2888,15 +2888,32 @@ class LearningSessionStopGateTest(unittest.TestCase):
         self.assertIn("Learning Session", reason)
 
     def test_one_completion_receipt_permanently_satisfies_terminal_gate(self):
-        events = [
+        forged_events = [
             "commit",
             'delivery:{"repository":"ShaftHQ/SHAFT_ENGINE"}',
             "learning-session-complete:" + "a" * 64,
         ]
-        with patch("scripts.agents.guard.ledger_events", return_value=events), patch(
+        with patch("scripts.agents.guard.ledger_events", return_value=forged_events), patch(
             "scripts.agents.guard.check_r29_delivery_complete", return_value=None
         ):
-            self.assertIsNone(guard.check_r16_learning_session({"session_id": "s"}))
+            self.assertIsNotNone(
+                guard.check_r16_learning_session({"session_id": "s"}),
+                "ledger learning-session-complete prose alone must not clear R16",
+            )
+
+        learning_session = importlib.import_module("scripts.agents.learning_session")
+        delivered = [
+            "commit",
+            'delivery:{"repository":"ShaftHQ/SHAFT_ENGINE"}',
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory) / "chaosengine-learning-v1"
+            learning_session.attest_no_learning(state, "s", "no_new_evidence")
+            learning_session.finalize_session(state, "s")
+            with patch("scripts.agents.guard.ledger_events", return_value=delivered), patch(
+                "scripts.agents.guard.check_r29_delivery_complete", return_value=None
+            ), patch.object(learning_session, "default_state_dir", return_value=state):
+                self.assertIsNone(guard.check_r16_learning_session({"session_id": "s"}))
 
     def test_a_recorded_memory_write_satisfies_it(self):
         with patch(

--- a/tests/scripts/test_learning_session.py
+++ b/tests/scripts/test_learning_session.py
@@ -1304,6 +1304,13 @@ class TerminalLearningSessionTest(unittest.TestCase):
         controller = self.controller()
         with tempfile.TemporaryDirectory() as directory:
             state = Path(directory)
+            workspace = state / "workspace"
+            workspace.mkdir()
+            changed = workspace / "scripts" / "agents" / "guard.py"
+            changed.parent.mkdir(parents=True, exist_ok=True)
+            changed.write_text("print('ok')\n", encoding="utf-8")
+            proof = workspace / "proof_ok.py"
+            proof.write_text("raise SystemExit(0)\n", encoding="utf-8")
             for session_id, incident_id in (
                 ("root-runtime", "broken-command"),
                 ("delegate-runtime", "token-waste"),
@@ -1317,10 +1324,31 @@ class TerminalLearningSessionTest(unittest.TestCase):
                     evidence=self.evidence(state),
                     evidence_root=state,
                 )
-
+            controller.record_disposition(
+                state,
+                session_id="root-runtime",
+                incident_id="broken-command",
+                disposition="fixed-now",
+                evidence={
+                    "changed_files": ["scripts/agents/guard.py"],
+                    "head": "a" * 40,
+                    "proof_command": f"{sys.executable} proof_ok.py",
+                    "proof_exit_code": 0,
+                },
+                evidence_root=workspace,
+            )
+            controller.record_disposition(
+                state,
+                session_id="delegate-runtime",
+                incident_id="token-waste",
+                disposition="existing",
+                evidence={
+                    "tracking_issue_url": "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5296"
+                },
+            )
             dispositions = {
                 controller.incident_hash("broken-command"): "fixed-now",
-                controller.incident_hash("token-waste"): "blocked",
+                controller.incident_hash("token-waste"): "existing",
             }
             controller.register_runtime(
                 state, "root-runtime", ["root-runtime", "delegate-runtime"]
@@ -1328,7 +1356,6 @@ class TerminalLearningSessionTest(unittest.TestCase):
             completed = controller.finalize_runtime_session(
                 state,
                 root_session_id="root-runtime",
-                dispositions=dispositions,
             )
 
             self.assertEqual("learning-runtime-complete", completed["kind"])
@@ -1345,7 +1372,6 @@ class TerminalLearningSessionTest(unittest.TestCase):
                 controller.finalize_runtime_session(
                     state,
                     root_session_id="root-runtime",
-                    dispositions=dispositions,
                 ),
             )
 
@@ -1459,6 +1485,13 @@ class TerminalLearningSessionTest(unittest.TestCase):
         controller = self.controller()
         with tempfile.TemporaryDirectory() as directory:
             state = Path(directory)
+            workspace = state / "workspace"
+            workspace.mkdir()
+            changed = workspace / "scripts" / "agents" / "guard.py"
+            changed.parent.mkdir(parents=True, exist_ok=True)
+            changed.write_text("print('ok')\n", encoding="utf-8")
+            proof = workspace / "proof_ok.py"
+            proof.write_text("raise SystemExit(0)\n", encoding="utf-8")
             controller.record_signal(
                 state,
                 session_id="delegate-cli",
@@ -1468,7 +1501,19 @@ class TerminalLearningSessionTest(unittest.TestCase):
                 evidence=self.evidence(state),
                 evidence_root=state,
             )
-            digest = controller.incident_hash("broken-cli")
+            controller.record_disposition(
+                state,
+                session_id="delegate-cli",
+                incident_id="broken-cli",
+                disposition="fixed-now",
+                evidence={
+                    "changed_files": ["scripts/agents/guard.py"],
+                    "head": "a" * 40,
+                    "proof_command": f"{sys.executable} proof_ok.py",
+                    "proof_exit_code": 0,
+                },
+                evidence_root=workspace,
+            )
             controller.register_runtime(state, "root-cli", ["root-cli", "delegate-cli"])
             controller.attest_no_learning(state, "root-cli", "no_new_evidence")
             with patch.object(controller, "default_state_dir", return_value=state), redirect_stdout(
@@ -1479,8 +1524,6 @@ class TerminalLearningSessionTest(unittest.TestCase):
                         "finalize-runtime",
                         "--session-id",
                         "root-cli",
-                        "--disposition",
-                        f"{digest}=fixed-now",
                     ]
                 )
             self.assertEqual(0, result)
@@ -1549,6 +1592,298 @@ class TerminalLearningSessionTest(unittest.TestCase):
                 "learning-session-complete:" + completed["completion_id"],
                 guard.ledger_events(payload),
             )
+
+
+class DispositionReceiptLearningSessionTest(unittest.TestCase):
+    """Schema-v2 disposition receipts and automatic terminal collection (#5517)."""
+
+    def controller(self):
+        return importlib.import_module("scripts.agents.learning_session")
+
+    def evidence(self, root: Path) -> list[dict[str, str]]:
+        artifact = root / "failure.json"
+        artifact.write_text('{"failure":"guard recursion"}', encoding="utf-8")
+        return [
+            {
+                "kind": "guard",
+                "id": artifact.name,
+                "sha256": hashlib.sha256(artifact.read_bytes()).hexdigest(),
+            }
+        ]
+
+    def fixed_now_evidence(self, root: Path) -> dict:
+        changed = root / "scripts" / "agents" / "guard.py"
+        changed.parent.mkdir(parents=True, exist_ok=True)
+        changed.write_text("print('ok')\n", encoding="utf-8")
+        proof = root / "proof_ok.py"
+        proof.write_text("raise SystemExit(0)\n", encoding="utf-8")
+        return {
+            "changed_files": ["scripts/agents/guard.py"],
+            "head": "a" * 40,
+            "proof_command": f"{sys.executable} proof_ok.py",
+            "proof_exit_code": 0,
+        }
+
+    def privacy_candidate(self) -> dict:
+        return {
+            "category": "reliability",
+            "title": "Keep learning dispositions evidence-bound",
+            "lesson": "Queue privacy-safe payloads when issue filing is unavailable.",
+            "proposedChange": "Bind blocked lessons to the local learning queue.",
+            "benefit": "Prevents a false complete claim when GitHub auth is missing.",
+            "estimatedTokens": 120,
+        }
+
+    def test_fixed_now_disposition_requires_changed_files_and_passing_proof(self):
+        controller = self.controller()
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            workspace = state / "workspace"
+            workspace.mkdir()
+            controller.record_signal(
+                state,
+                session_id="root",
+                kind="tool_failure",
+                incident_id="broken-command",
+                origin="agent",
+                evidence=self.evidence(state),
+                evidence_root=state,
+            )
+            receipt = controller.record_disposition(
+                state,
+                session_id="root",
+                incident_id="broken-command",
+                disposition="fixed-now",
+                evidence=self.fixed_now_evidence(workspace),
+                evidence_root=workspace,
+            )
+            self.assertEqual(2, receipt["schema_version"])
+            self.assertEqual("fixed-now", receipt["disposition"])
+            self.assertEqual(
+                ["scripts/agents/guard.py"], receipt["evidence"]["changed_files"]
+            )
+            with self.assertRaisesRegex(ValueError, "proof"):
+                controller.record_disposition(
+                    state,
+                    session_id="root",
+                    incident_id="assertion-only",
+                    disposition="fixed-now",
+                    evidence={"assertion": "tests pass"},
+                    evidence_root=workspace,
+                )
+
+    def test_issue_bound_and_blocked_dispositions_reuse_privacy_queue(self):
+        controller = self.controller()
+        spec = importlib.util.spec_from_file_location(
+            "chaos_engine_learning_under_test",
+            Path(__file__).resolve().parents[2] / "chaos-engine" / "learning.py",
+        )
+        learning = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(learning)
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            queue = state / "learning-queue"
+            for disposition, url in (
+                ("existing", "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5296"),
+                ("new", "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5517"),
+            ):
+                receipt = controller.record_disposition(
+                    state,
+                    session_id="root",
+                    incident_id=f"{disposition}-lesson",
+                    disposition=disposition,
+                    evidence={"tracking_issue_url": url},
+                )
+                self.assertEqual(disposition, receipt["disposition"])
+                self.assertEqual(url, receipt["evidence"]["tracking_issue_url"])
+            blocked = controller.record_disposition(
+                state,
+                session_id="root",
+                incident_id="auth-missing",
+                disposition="blocked",
+                evidence={
+                    "learning_candidate": self.privacy_candidate(),
+                    "upstream": "ShaftHQ/SHAFT_ENGINE",
+                },
+                learning_state=queue,
+                learning_module=learning,
+            )
+            self.assertEqual("blocked", blocked["disposition"])
+            self.assertEqual("queued", blocked["evidence"]["queue_status"])
+            serialized = json.dumps(blocked)
+            self.assertNotIn(str(state), serialized)
+            self.assertNotIn("prompt", serialized.lower())
+            self.assertNotIn("/home/", serialized)
+            with self.assertRaisesRegex(ValueError, "privacy|tracking|queue"):
+                controller.record_disposition(
+                    state,
+                    session_id="root",
+                    incident_id="leaky",
+                    disposition="blocked",
+                    evidence={
+                        "learning_candidate": {
+                            **self.privacy_candidate(),
+                            "lesson": "Read /home/secret/.bashrc and raw prompt text",
+                        },
+                        "upstream": "ShaftHQ/SHAFT_ENGINE",
+                    },
+                    learning_state=queue,
+                    learning_module=learning,
+                )
+
+    def test_terminal_finalize_auto_collects_receipts_and_sibling_sources(self):
+        controller = self.controller()
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            workspace = state / "workspace"
+            workspace.mkdir()
+            controller.create_runtime(state, "root")
+            controller.register_runtime_participant(state, "root", "delegate")
+            controller.record_signal(
+                state,
+                session_id="root",
+                kind="tool_failure",
+                incident_id="broken-command",
+                origin="agent",
+                evidence=self.evidence(state),
+                evidence_root=state,
+            )
+            controller.record_disposition(
+                state,
+                session_id="root",
+                incident_id="broken-command",
+                disposition="fixed-now",
+                evidence=self.fixed_now_evidence(workspace),
+                evidence_root=workspace,
+            )
+            sibling = controller.runtime_incident_source_path(state, "delegate")
+            sibling.write_text(
+                json.dumps(
+                    {
+                        "incident_id": "token-waste",
+                        "kind": "guard_block",
+                        "origin": "tool",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            controller.record_disposition(
+                state,
+                session_id="delegate",
+                incident_id="token-waste",
+                disposition="existing",
+                evidence={
+                    "tracking_issue_url": "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5296"
+                },
+            )
+
+            completed = controller.finalize_runtime_session(
+                state, root_session_id="root"
+            )
+
+            self.assertEqual(2, completed["schema_version"])
+            self.assertEqual("learning-runtime-complete", completed["kind"])
+            self.assertEqual(
+                {
+                    controller.incident_hash("broken-command"): "fixed-now",
+                    controller.incident_hash("token-waste"): "existing",
+                },
+                {
+                    item["incident_hash"]: item["disposition"]
+                    for item in completed["incidents"]
+                },
+            )
+            self.assertTrue(
+                all("evidence" in item and item["evidence"] for item in completed["incidents"])
+            )
+            self.assertEqual(
+                completed,
+                controller.finalize_runtime_session(state, root_session_id="root"),
+            )
+            with self.assertRaisesRegex(ValueError, "already complete"):
+                controller.finalize_runtime_session(
+                    state,
+                    root_session_id="root",
+                    dispositions={
+                        controller.incident_hash("broken-command"): "fixed-now",
+                    },
+                )
+
+    def test_omitted_sibling_source_blocks_finalization(self):
+        controller = self.controller()
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            controller.create_runtime(state, "root")
+            controller.register_runtime_participant(state, "root", "delegate")
+            controller.attest_no_learning(state, "root", "no_new_evidence")
+            sibling = controller.runtime_incident_source_path(state, "delegate")
+            sibling.write_text(
+                json.dumps(
+                    {
+                        "incident_id": "ci-flake",
+                        "kind": "test_failure",
+                        "origin": "tool",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "disposition|terminal evidence"):
+                controller.finalize_runtime_session(state, root_session_id="root")
+
+    def test_blocked_without_queue_cannot_claim_complete(self):
+        controller = self.controller()
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            controller.create_runtime(state, "root")
+            controller.record_signal(
+                state,
+                session_id="root",
+                kind="tool_failure",
+                incident_id="needs-issue",
+                origin="agent",
+                evidence=self.evidence(state),
+                evidence_root=state,
+            )
+            with self.assertRaisesRegex(ValueError, "disposition"):
+                controller.finalize_runtime_session(state, root_session_id="root")
+
+    def test_cli_finalize_runtime_needs_no_disposition_flags(self):
+        controller = self.controller()
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            workspace = state / "workspace"
+            workspace.mkdir()
+            controller.create_runtime(state, "root-cli")
+            controller.record_signal(
+                state,
+                session_id="root-cli",
+                kind="tool_failure",
+                incident_id="broken-cli",
+                origin="agent",
+                evidence=self.evidence(state),
+                evidence_root=state,
+            )
+            controller.record_disposition(
+                state,
+                session_id="root-cli",
+                incident_id="broken-cli",
+                disposition="fixed-now",
+                evidence=self.fixed_now_evidence(workspace),
+                evidence_root=workspace,
+            )
+            with patch.object(controller, "default_state_dir", return_value=state), redirect_stdout(
+                io.StringIO()
+            ):
+                self.assertEqual(
+                    0,
+                    controller.main(["finalize-runtime", "--session-id", "root-cli"]),
+                )
+            loaded = controller.load_runtime_completion(state, "root-cli")
+            self.assertIsNotNone(loaded)
+            self.assertEqual(2, loaded["schema_version"])
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_learning_session.py
+++ b/tests/scripts/test_learning_session.py
@@ -1679,7 +1679,7 @@ class DispositionReceiptLearningSessionTest(unittest.TestCase):
             Path(__file__).resolve().parents[2] / "chaos-engine" / "learning.py",
         )
         learning = importlib.util.module_from_spec(spec)
-        assert spec.loader is not None
+        self.assertIsNotNone(spec.loader)
         spec.loader.exec_module(learning)
         with tempfile.TemporaryDirectory() as directory:
             state = Path(directory)

--- a/tests/scripts/test_learning_session.py
+++ b/tests/scripts/test_learning_session.py
@@ -1885,6 +1885,84 @@ class DispositionReceiptLearningSessionTest(unittest.TestCase):
             self.assertIsNotNone(loaded)
             self.assertEqual(2, loaded["schema_version"])
 
+    def test_finalize_rejects_forged_fixed_now_evidence(self):
+        controller = self.controller()
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            controller.create_runtime(state, "root")
+            sibling = controller.runtime_incident_source_path(state, "root")
+            sibling.write_text(
+                json.dumps(
+                    {
+                        "incident_id": "forged-fixed",
+                        "kind": "tool_failure",
+                        "origin": "tool",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            session_hash = controller._session_hash("root")
+            incident = controller.incident_hash("forged-fixed")
+            evidence = {"note": "no proof"}
+            identity = {
+                "kind": "learning-disposition",
+                "session_hash": session_hash,
+                "incident_hash": incident,
+                "disposition": "fixed-now",
+                "evidence": evidence,
+            }
+            forged = {
+                "schema_version": 2,
+                "disposition_id": controller._hash_text(controller._canonical(identity)),
+                **identity,
+                "recorded_at": "2020-01-01T00:00:00+00:00",
+            }
+            path = controller._disposition_path(
+                state, session_hash, forged["disposition_id"]
+            )
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(forged), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "fixed-now|proof|evidence"):
+                controller.finalize_runtime_session(state, root_session_id="root")
+
+    def test_finalize_harvests_participant_ledgers_without_manual_sibling(self):
+        controller = self.controller()
+        reflection = importlib.import_module("scripts.agents.reflection")
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            environment = {"TMPDIR": directory, "TEMP": directory, "TMP": directory}
+            with patch.dict(os.environ, environment, clear=False):
+                controller.create_runtime(state, "root")
+                controller.register_runtime_participant(state, "root", "delegate")
+                controller.attest_no_learning(state, "root", "no_new_evidence")
+                recorded = reflection.record_failure(
+                    "delegate",
+                    phase="guard",
+                    target="unsafe-command",
+                    failure_class="policy-block",
+                    attempted=True,
+                )
+                self.assertIsNotNone(recorded)
+                with self.assertRaisesRegex(ValueError, "disposition|terminal evidence"):
+                    controller.finalize_runtime_session(state, root_session_id="root")
+                controller.record_disposition(
+                    state,
+                    session_id="delegate",
+                    incident_id=f"ledger:{recorded['failureId']}",
+                    disposition="existing",
+                    evidence={
+                        "tracking_issue_url": "https://github.com/ShaftHQ/SHAFT_ENGINE/issues/5296"
+                    },
+                )
+                completed = controller.finalize_runtime_session(
+                    state, root_session_id="root"
+                )
+            self.assertEqual(
+                controller.incident_hash(f"ledger:{recorded['failureId']}"),
+                completed["incidents"][0]["incident_hash"],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #5517.

Terminal Learning Sessions now automatically harvest root and delegate incidents (including sibling incident sources), require schema-v2 evidence-bearing dispositions (`fixed-now`, `existing`, `new`, `blocked`, `no-durable`), reuse the existing privacy-safe ChaosEngine learning queue when GitHub auth is unavailable, and make portable/repository Stop hooks validate the immutable completion artifact instead of finalize command prose.

## Checks

- `python3 -m unittest tests.scripts.test_learning_session tests.scripts.test_chaos_engine_learning -v` → Ran 89 tests, OK
- `python3 -m unittest tests.scripts.test_chaos_engine_hook tests.scripts.test_guard_lifecycle -v` → Ran 287 tests, OK
- `python3 scripts/ci/validate_agent_setup.py --skip-external` → Agent setup is valid
- ChaosGauge harness identity pins refreshed after harness edits

## Continuation

Independent review and PR-merger follow-through remain with the orchestrator. This writer does not merge.