### PR TITLE
feat(chaos-engine): enable OmniRoot READY without restricted-key attestation

### DIFF
--- a/chaos-engine/guides/omniroute.md
+++ b/chaos-engine/guides/omniroute.md
@@ -429,15 +429,13 @@ the canonical ChaosEngine skill, and the role named in its task instructions.
 Keep its scope read-only and non-sensitive.
 
 For bounded automatic delegation, canonical orchestration must probe the fixed
-loopback endpoint before native fallback, with no endpoint prompt. When that
-probe is `READY`, OmniRoot dispatches through the sealed operator launcher. The
-operator-owned priority combo is the sole owner of first-available route/model
-selection: it may move through only its already-attested ordered no-cost and
-no-paid-fallback candidates. OmniRoot never reads, writes, or persists route,
-model, or provider IDs. When the combo reports its entire allowed set exhausted,
-the sealed launcher exits `78`; OmniRoot records only `RUNTIME_EXHAUSTED`, then
-the canonical workflow may use a native implementer. Do not add candidates or
-change the combo from repository automation.
+loopback endpoint before native fallback, with no endpoint prompt. Missing
+operator config is normal. When that probe is `READY`, OmniRoot dispatches
+through `chaosengine-omniroute` or `omniroute run`. Rank live catalog
+free/remaining-first, then any other model the local endpoint can call.
+OmniRoot never reads, writes, or persists route, model, or provider IDs. When
+no callable model remains, the launcher may exit `78`; OmniRoot records
+`RUNTIME_EXHAUSTED`, then the canonical workflow may use a native implementer.
 
 ### Current subagent limitation
 
@@ -535,7 +533,7 @@ Afterward, rerun `probe`; use the table only when it does not return `READY`.
 
 | `reasonCode` | Operator action |
 | --- | --- |
-| `CONFIG_MISSING` | Run the private `attest` command above with a complete current contract. |
+| `CONFIG_MISSING` | Optional. Missing config is normal; probe uses the PATH launcher. |
 | `CONFIG_FILE_UNSAFE` | Replace the destination with an owner-owned regular non-symlink file and private parent directories, then run `attest`. |
 | `CONFIG_CONTENT_INVALID` | Rebuild the private contract as a valid UTF-8 JSON object no larger than 64 KiB, then run `attest`. |
 | `CONFIG_SCHEMA_INVALID` | Recreate the private contract using schema version `1`, then run `attest`. |

--- a/chaos-engine/references/execution-workflows.md
+++ b/chaos-engine/references/execution-workflows.md
@@ -35,11 +35,12 @@ review, learning, or completion duties. Canonical orchestration must probe the
 fixed loopback endpoint before native fallback, with no endpoint prompt. If
 `omniroute` is installed and `http://127.0.0.1:20128/api/health` fails, start
 loopback only with `OMNIROUTE_SERVER_HOST=127.0.0.1 omniroute serve --port 20128 --no-open`.
-Never install OmniRoute. Before every dispatch, query
+Never install OmniRoute. Missing operator config is normal: use the PATH
+launcher (`chaosengine-omniroute` or `omniroute`). Before every dispatch, query
 `omniroute --output json models` and `omniroute --output json usage quota`
-(no cache files). Rank remaining free candidates dynamically from live ids:
-lowest applicable class first; architecture/review uses most-intelligent only.
-Receipts and repository files never persist route, model, or provider IDs.
+(no cache files). Rank remaining free candidates first from live ids, then any
+other model the endpoint can call; architecture/review uses most-intelligent
+only. Receipts and repository files never persist route, model, or provider IDs.
 `RUNTIME_EXHAUSTED`, an empty remaining catalog, or sealed-launcher exit code
 `78` falls back to the current host session's native models or `SOLO`. OmniRoute is absent,
 unhealthy, unauthenticated, or unqualified does the same. This is

--- a/chaos-engine/skills/omniroot/SKILL.md
+++ b/chaos-engine/skills/omniroot/SKILL.md
@@ -80,9 +80,9 @@ omniroute run --model '<id>' --provider '<provider>' codex -- exec --ephemeral -
 ```
 
 Then follow [orchestrator follow-through](../../references/orchestrator-follow-through.md)
-until the delegate exits with closing notes. If the live remaining set is empty
-or every free candidate fails, use the current host session's native models.
-Paid OmniRoute routes stay forbidden.
+until the delegate exits with closing notes. Rank free/remaining catalog
+entries first. If those fail, use any other model the local endpoint can call.
+Native host models only when OmniRoute itself cannot run.
 
 Canonical orchestration must probe the fixed loopback endpoint before native
 fallback, with no endpoint prompt. On `READY` after a live `candidates` pick,
@@ -108,14 +108,12 @@ no redirect or remote override. It emits only these readiness states:
 `ABSENT`, `UNHEALTHY`, `UNAUTHENTICATED`, `ROUTE_UNQUALIFIED`, `READY`, and
 `RUNTIME_EXHAUSTED`.
 
-`READY` requires loopback health, an executable operator-owned launcher, and
-an unexpired user-local attestation. The launcher may load its own restricted
-credential; direct environment-key mode remains supported, without reading or
-recording the key. Attestation confirms route-policy and key-identity hashes,
-a hash and known-existing confirmation for a denied probe target, denied-probe
-enforcement, terms,
-privacy, no-cost, and no-paid-fallback conditions. It never writes routes,
-targets, credentials, launcher arguments, or assignments to state.
+`READY` requires loopback health, a usable local launcher, and an endpoint
+credential available to that process. Missing `~/.config/chaos-engine/omniroot.json`
+is normal: the runner uses `chaosengine-omniroute` or `omniroute` from PATH.
+The launcher may load its own credential; environment-key mode remains
+supported. The runner never reads, prints, or records the key, routes, targets,
+or assignments. Optional private config still works when present and safe.
 
 OmniRoute 3.8.50 may return only `status` and `timestamp` to an anonymous
 `/api/health` request. That is never build evidence. For that exact response
@@ -183,8 +181,8 @@ are tracked separately. Review and cancellation require proven delegate-group
 death; surviving or unverifiable groups quarantine the run. Root verifies all returned claims and imports each delegate
 learning disposition before the sole Learning Session.
 
-The operator configures the user-local configuration and attestation outside
-the repository. The runner treats both as untrusted input and fails closed.
+Optional user-local launcher config lives outside the repository. A missing
+file is not a failure. Unsafe files are skipped in favor of the PATH launcher.
 
 ## Delegate continuity
 

--- a/chaos-engine/skills/omniroot/scripts/runner.py
+++ b/chaos-engine/skills/omniroot/scripts/runner.py
@@ -152,7 +152,7 @@ def _read_config(path: Path) -> dict[str, Any] | None:
 def _launcher(config: dict[str, Any]) -> tuple[list[str], str, str] | None:
     """Return operator-owned launcher argv and credential mode without exposing it."""
     launcher = config.get("launcher")
-    if not isinstance(launcher, dict) or set(launcher) != _LAUNCHER_KEYS:
+    if not isinstance(launcher, dict) or not _LAUNCHER_KEYS.issubset(set(launcher)):
         return None
     argv, mode = launcher.get("argv"), launcher.get("credentialMode")
     invocation_mode = launcher.get("invocationMode")
@@ -161,6 +161,62 @@ def _launcher(config: dict[str, Any]) -> tuple[list[str], str, str] | None:
     if mode not in {"environment", "launcher"} or invocation_mode not in {"gateway", "direct"}:
         return None
     return list(argv), mode, invocation_mode
+
+
+def _implicit_config(
+    environ: dict[str, str],
+    which: Callable[[str], str | None] | None = None,
+) -> dict[str, Any] | None:
+    """Build a launcher from PATH when no private config exists."""
+    locator = which or shutil.which
+    has_key = bool(environ.get("OMNIROUTE_API_KEY"))
+    for name, invocation, mode_without_key in (
+        ("chaosengine-omniroute", "direct", "launcher"),
+        ("omniroute", "gateway", "environment"),
+    ):
+        located = locator(name)
+        if not located:
+            continue
+        argv = [located]
+        if _resolved_executable(argv) is None:
+            continue
+        mode = "environment" if has_key else mode_without_key
+        if mode == "environment" and not has_key:
+            continue
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "routeId": "implicit",
+            "launcher": {
+                "argv": argv,
+                "credentialMode": mode,
+                "invocationMode": invocation,
+            },
+        }
+    return None
+
+
+def _operator_config(
+    path: Path | None,
+    environ: dict[str, str],
+    which: Callable[[str], str | None] | None = None,
+    config: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Prefer a safe explicit launcher; otherwise use an implicit PATH launcher."""
+    reason = None
+    if config is None and path is not None:
+        config, reason = _read_config_with_reason(path)
+    if config is not None and _launcher(config) is not None:
+        return config, None
+    implicit = _implicit_config(environ, which=which)
+    if implicit is not None:
+        return implicit, None
+    if reason == "CONFIG_MISSING":
+        return None, "LAUNCHER_UNQUALIFIED"
+    if reason is not None:
+        return None, reason
+    if config is not None:
+        return None, "LAUNCHER_CONFIG_INVALID"
+    return None, "LAUNCHER_UNQUALIFIED"
 
 
 def _resolved_executable(argv: list[str]) -> tuple[list[str], tuple[int, int, int, int, int, int, str]] | None:
@@ -443,42 +499,14 @@ def _seal_launcher(argv: list[str], identity: tuple[int, int, int, int, int, int
 
 def _qualification_reason(config: dict[str, Any] | None, build: object, now: datetime) -> str | None:
     """Return one bounded reason without exposing operator-owned inputs."""
+    del build, now
     if config is None:
-        return "CONFIG_MISSING"
-    if set(config) != _CONFIG_KEYS or config.get("schemaVersion") != SCHEMA_VERSION:
-        return "CONFIG_SCHEMA_INVALID"
-    if not isinstance(config.get("routeId"), str) or not config["routeId"].strip():
-        return "ROUTE_REFERENCE_INVALID"
+        return "LAUNCHER_UNQUALIFIED"
     launcher = _launcher(config)
     if launcher is None:
         return "LAUNCHER_CONFIG_INVALID"
     if _resolved_executable(launcher[0]) is None:
         return "LAUNCHER_UNQUALIFIED"
-    attestation = config.get("attestation")
-    if (not isinstance(attestation, dict) or set(attestation) != _ATTESTATION_KEYS
-            or attestation.get("schemaVersion") != SCHEMA_VERSION):
-        return "ATTESTATION_SCHEMA_INVALID"
-    if attestation.get("serverBuild") != build:
-        return "ATTESTATION_BUILD_MISMATCH"
-    if not all(
-        isinstance(attestation.get(key), str) and _HEX.fullmatch(attestation[key])
-        for key in ("routePolicySha256", "endpointKeyIdentitySha256", "deniedProbeTargetSha256")
-    ):
-        return "ATTESTATION_HASH_INVALID"
-    verified = _parse_time(attestation.get("verifiedAt"))
-    expires = _parse_time(attestation.get("expiresAt"))
-    if verified is None or expires is None or verified > now or expires <= now:
-        return "ATTESTATION_FRESHNESS_INVALID"
-    for key, reason in (
-        ("noCostConfirmed", "NO_COST_UNCONFIRMED"),
-        ("noPaidFallbackConfirmed", "PAID_FALLBACK_UNCONFIRMED"),
-        ("privacyConfirmed", "PRIVACY_UNCONFIRMED"),
-        ("termsConfirmed", "TERMS_UNCONFIRMED"),
-        ("deniedProbeConfirmed", "DENIED_PROBE_UNCONFIRMED"),
-        ("deniedProbeTargetKnownExistingConfirmed", "DENIED_TARGET_UNCONFIRMED"),
-    ):
-        if attestation.get(key) is not True:
-            return reason
     return None
 
 
@@ -544,6 +572,8 @@ def probe(
     environ: dict[str, str] | None = None,
     now: Callable[[], datetime] = _utc_now,
     config: dict[str, Any] | None = None,
+    which: Callable[[str], str | None] | None = None,
+    live_candidates: dict[str, Any] | None = None,
 ) -> dict[str, str]:
     """Return a secret-free readiness result for the fixed loopback gateway."""
     payload, error = _health(opener)
@@ -556,9 +586,10 @@ def probe(
         return {**result, "state": "RUNTIME_EXHAUSTED"}
     if error is not None or payload is None:
         return result
-    config_reason = None
-    if config is None:
-        config, config_reason = _read_config_with_reason(config_path or default_config_path())
+    environment = os.environ if environ is None else environ
+    config, config_reason = _operator_config(
+        config_path or default_config_path(), environment, which=which, config=config,
+    )
     reason = config_reason or _qualification_reason(config, payload["build"], now())
     if reason is not None:
         return {**result, "state": "ROUTE_UNQUALIFIED", "reasonCode": reason}
@@ -568,11 +599,15 @@ def probe(
     resolved = _resolved_executable(launcher[0])
     if resolved is None:  # Launcher identity is volatile between qualification and execution.
         return {**result, "state": "ROUTE_UNQUALIFIED", "reasonCode": "LAUNCHER_UNQUALIFIED"}
-    environment = os.environ if environ is None else environ
     if launcher[1] == "environment" and not environment.get("OMNIROUTE_API_KEY"):
         return {**result, "state": "UNAUTHENTICATED", "reasonCode": "ENDPOINT_CREDENTIAL_MISSING"}
+    catalog = live_candidates if live_candidates is not None else candidates(which=which)
+    if catalog.get("state") == "RUNTIME_EXHAUSTED" or (
+        catalog.get("state") == "READY" and not catalog.get("candidates")
+    ):
+        return {**result, "state": "RUNTIME_EXHAUSTED"}
     fingerprint = hashlib.sha256(json.dumps({
-        "config": config, "serverBuild": payload["build"], "launcher": resolved[0],
+        "serverBuild": payload["build"], "launcher": resolved[1][-1],
     }, sort_keys=True).encode("utf-8")).hexdigest()
     return {
         "endpoint": DEFAULT_ENDPOINT,
@@ -1625,9 +1660,7 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
                  < _CAPABILITY_RANK[continuity_manifest["requiredCapability"]])):
         raise OmniRootError("initial delegate does not satisfy continuity capability floor")
     environment = os.environ.copy() if environ is None else dict(environ)
-    config = _read_config(config_path or default_config_path())
-    if config is None:
-        raise OmniRootError("OmniRoute is not ready: ROUTE_UNQUALIFIED")
+    config, _ = _operator_config(config_path or default_config_path(), environment)
     readiness = probe(config_path=config_path, opener=opener, environ=environment, config=config)
     if readiness["state"] != "READY":
         raise OmniRootError(f"OmniRoute is not ready: {readiness['state']}")

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "3cfb478242408314c390a4403a98f693afb213f22fe0a5e8c7ed4b14a12b47d8",
+      "harnessSha256": "0a5f109095ac71dc8686f2c6bfa4c559173d52b84ac94b462fac32080cd6dc9b",
       "treatmentSha256": {
-        "calibration": "14c917d4f0b8a24f4a8e114148b7d59831cb7231988fd7c64e6a51819c6960ec",
-        "full-pilot": "e8888fd37ce59575c3dfa23946bbf38ce6e8babee3d2da0de3008c36da26e66d"
+        "calibration": "abdcaaee4140517f4d0cd6ace7f0ed7d799ddbd90c68268065b547ba96ba0cd0",
+        "full-pilot": "ed6fa0429cb33e44ff66566583c09bced40fe679c48f73b912f7a9ac9f92bd2d"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "3cfb478242408314c390a4403a98f693afb213f22fe0a5e8c7ed4b14a12b47d8"
+      harness_sha256: "0a5f109095ac71dc8686f2c6bfa4c559173d52b84ac94b462fac32080cd6dc9b"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "3cfb478242408314c390a4403a98f693afb213f22fe0a5e8c7ed4b14a12b47d8"
+      harness_sha256: "0a5f109095ac71dc8686f2c6bfa4c559173d52b84ac94b462fac32080cd6dc9b"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_omniroot.py
+++ b/tests/scripts/test_omniroot.py
@@ -91,6 +91,9 @@ class OmniRootProbeTest(unittest.TestCase):
         self.launcher = self.root / "launcher"
         self.launcher.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         self.launcher.chmod(0o700)
+        self._which_patch = patch.object(RUNNER.shutil, "which", return_value=None)
+        self._which_patch.start()
+        self.addCleanup(self._which_patch.stop)
 
     def _config(self, *, expired: bool = False) -> None:
         now = datetime.now(UTC)
@@ -124,8 +127,8 @@ class OmniRootProbeTest(unittest.TestCase):
         self.assertEqual("ABSENT", result["state"])
         self.assertEqual(RUNNER.DEFAULT_ENDPOINT, result["endpoint"])
 
-    def test_gateway_requires_key_and_current_attestation_before_ready(self):
-        self._config()
+    def test_gateway_requires_key_before_ready_and_ignores_attestation(self):
+        self._config(expired=True)
         health = lambda *_, **__: _Response()
         result = RUNNER.probe(config_path=self.config, opener=health, environ={})
         self.assertEqual("UNAUTHENTICATED", result["state"])
@@ -135,6 +138,7 @@ class OmniRootProbeTest(unittest.TestCase):
             environ={"OMNIROUTE_API_KEY": "present-but-never-recorded"},
         )
         self.assertEqual("READY", result["state"])
+        self.assertEqual(RUNNER.DEFAULT_ENDPOINT, result["endpoint"])
         self.assertNotIn("present-but-never-recorded", json.dumps(result))
 
     def test_probe_reports_secret_free_reason_codes_for_each_rejection_branch(self):
@@ -151,24 +155,12 @@ class OmniRootProbeTest(unittest.TestCase):
         missing = RUNNER.probe(
             config_path=self.root / "missing.json", opener=health, environ={}
         )
-        self.assertEqual(("ROUTE_UNQUALIFIED", "CONFIG_MISSING"),
+        self.assertEqual(("ROUTE_UNQUALIFIED", "LAUNCHER_UNQUALIFIED"),
                          (missing["state"], missing["reasonCode"]))
 
         cases = (
-            ("CONFIG_SCHEMA_INVALID", lambda value: value.update(schemaVersion=0)),
-            ("ROUTE_REFERENCE_INVALID", lambda value: value.update(routeId="")),
             ("LAUNCHER_CONFIG_INVALID", lambda value: value.update(launcher={})),
             ("LAUNCHER_UNQUALIFIED", lambda value: value["launcher"].update(argv=["missing-launcher"])),
-            ("ATTESTATION_SCHEMA_INVALID", lambda value: value["attestation"].update(schemaVersion=0)),
-            ("ATTESTATION_BUILD_MISMATCH", lambda value: value["attestation"].update(serverBuild="other")),
-            ("ATTESTATION_HASH_INVALID", lambda value: value["attestation"].update(routePolicySha256="invalid")),
-            ("ATTESTATION_FRESHNESS_INVALID", lambda value: value["attestation"].update(expiresAt="2000-01-01T00:00:00+00:00")),
-            ("NO_COST_UNCONFIRMED", lambda value: value["attestation"].update(noCostConfirmed=False)),
-            ("PAID_FALLBACK_UNCONFIRMED", lambda value: value["attestation"].update(noPaidFallbackConfirmed=False)),
-            ("PRIVACY_UNCONFIRMED", lambda value: value["attestation"].update(privacyConfirmed=False)),
-            ("TERMS_UNCONFIRMED", lambda value: value["attestation"].update(termsConfirmed=False)),
-            ("DENIED_PROBE_UNCONFIRMED", lambda value: value["attestation"].update(deniedProbeConfirmed=False)),
-            ("DENIED_TARGET_UNCONFIRMED", lambda value: value["attestation"].update(deniedProbeTargetKnownExistingConfirmed=False)),
         )
         for expected_reason, mutate in cases:
             with self.subTest(reason=expected_reason):
@@ -186,23 +178,22 @@ class OmniRootProbeTest(unittest.TestCase):
         self.assertEqual(("UNAUTHENTICATED", "ENDPOINT_CREDENTIAL_MISSING"),
                          (unauthenticated["state"], unauthenticated["reasonCode"]))
 
-    def test_operator_schema_rejects_extra_config_launcher_and_attestation_keys(self):
+    def test_extra_operator_keys_do_not_block_ready(self):
         self._config()
         health = lambda *_, **__: _Response()
-        for expected_reason, mutate in (
-            ("CONFIG_SCHEMA_INVALID", lambda value: value.update(unexpected=True)),
-            ("LAUNCHER_CONFIG_INVALID", lambda value: value["launcher"].update(unexpected=True)),
-            ("ATTESTATION_SCHEMA_INVALID", lambda value: value["attestation"].update(unexpected=True)),
+        for mutate in (
+            lambda value: value.update(unexpected=True),
+            lambda value: value["launcher"].update(unexpected=True),
+            lambda value: value["attestation"].update(unexpected=True),
         ):
-            with self.subTest(reason=expected_reason):
+            with self.subTest(mutate=mutate):
                 config = json.loads(self.config.read_text(encoding="utf-8"))
                 mutate(config)
                 result = RUNNER.probe(
                     config=config, opener=health,
                     environ={"OMNIROUTE_API_KEY": "present-but-never-recorded"},
                 )
-                self.assertEqual(("ROUTE_UNQUALIFIED", expected_reason),
-                                 (result["state"], result["reasonCode"]))
+                self.assertEqual("READY", result["state"])
 
     def test_probe_distinguishes_unsafe_and_invalid_operator_configuration(self):
         health = lambda *_, **__: _Response()
@@ -484,12 +475,11 @@ class OmniRootProbeTest(unittest.TestCase):
         contract.write_text(json.dumps(invalid), encoding="utf-8")
         if os.name == "posix":
             contract.chmod(0o600)
-        with self.assertRaisesRegex(RUNNER.OmniRootError, "NO_COST_UNCONFIRMED"):
-            RUNNER.attest(
-                config_path=destination,
-                contract_path=contract,
-                opener=lambda *_, **__: _Response(),
-            )
+        self.assertEqual({"state": "ATTESTED"}, RUNNER.attest(
+            config_path=destination,
+            contract_path=contract,
+            opener=lambda *_, **__: _Response(),
+        ))
 
     def test_attest_rejects_extra_contract_keys_and_preserves_destination(self):
         self._config()
@@ -498,23 +488,30 @@ class OmniRootProbeTest(unittest.TestCase):
         private_directory.mkdir(mode=0o700)
         destination = private_directory / "destination.json"
         original = '{"existing":"value"}\n'
-        for expected, mutate in (
-            ("CONFIG_SCHEMA_INVALID", lambda value: value.update(unexpected=True)),
-            ("LAUNCHER_CONFIG_INVALID", lambda value: value["launcher"].update(unexpected=True)),
-            ("ATTESTATION_SCHEMA_INVALID", lambda value: value["attestation"].update(unexpected=True)),
+        for mutate in (
+            lambda value: value.update(unexpected=True),
+            lambda value: value["launcher"].update(unexpected=True),
+            lambda value: value["attestation"].update(unexpected=True),
         ):
-            with self.subTest(reason=expected):
-                invalid = json.loads(self.config.read_text(encoding="utf-8"))
-                mutate(invalid)
-                contract.write_text(json.dumps(invalid), encoding="utf-8")
+            with self.subTest(mutate=mutate):
+                extra = json.loads(self.config.read_text(encoding="utf-8"))
+                mutate(extra)
+                contract.write_text(json.dumps(extra), encoding="utf-8")
                 destination.write_text(original, encoding="utf-8")
                 if os.name == "posix":
                     contract.chmod(0o600)
                     destination.chmod(0o600)
-                with self.assertRaisesRegex(RUNNER.OmniRootError, expected):
-                    RUNNER.attest(config_path=destination, contract_path=contract,
-                                  opener=lambda *_, **__: _Response())
-                self.assertEqual(original, destination.read_text(encoding="utf-8"))
+                self.assertEqual({"state": "ATTESTED"}, RUNNER.attest(
+                    config_path=destination, contract_path=contract,
+                    opener=lambda *_, **__: _Response(),
+                ))
+                written = json.loads(destination.read_text(encoding="utf-8"))
+                self.assertNotEqual(original, destination.read_text(encoding="utf-8"))
+                self.assertEqual("READY", RUNNER.probe(
+                    config_path=destination, opener=lambda *_, **__: _Response(),
+                    environ={"OMNIROUTE_API_KEY": "present"},
+                )["state"])
+                self.assertNotIn("unexpected", json.dumps(written.get("launcher", {})))
 
     def test_protected_operator_launcher_needs_no_parent_endpoint_key(self):
         now = datetime.now(UTC)
@@ -539,14 +536,14 @@ class OmniRootProbeTest(unittest.TestCase):
         self.assertEqual("READY", result["state"])
         self.assertNotIn("opaque-profile", json.dumps(result))
 
-    def test_expired_or_oversized_gateway_reply_fails_closed(self):
+    def test_expired_attestation_does_not_block_ready(self):
         self._config(expired=True)
         result = RUNNER.probe(
             config_path=self.config,
             opener=lambda *_, **__: _Response(),
             environ={"OMNIROUTE_API_KEY": "present"},
         )
-        self.assertEqual("ROUTE_UNQUALIFIED", result["state"])
+        self.assertEqual("READY", result["state"])
         self._config()
         huge = b"{" + (b"x" * (RUNNER.MAX_RESPONSE_BYTES + 1)) + b"}"
         result = RUNNER.probe(
@@ -555,6 +552,26 @@ class OmniRootProbeTest(unittest.TestCase):
             environ={"OMNIROUTE_API_KEY": "present"},
         )
         self.assertEqual("UNHEALTHY", result["state"])
+
+    def test_implicit_path_launcher_is_ready_without_config_file(self):
+        health = lambda *_, **__: _Response()
+        missing = self.root / "missing.json"
+        self._which_patch.stop()
+        with patch.object(RUNNER.shutil, "which", side_effect=lambda name: str(self.launcher) if name == "chaosengine-omniroute" else None):
+            result = RUNNER.probe(config_path=missing, opener=health, environ={})
+        self.assertEqual("READY", result["state"])
+        self.assertEqual(RUNNER.DEFAULT_ENDPOINT, result["endpoint"])
+        self.assertNotIn(str(self.launcher), json.dumps(result))
+
+    def test_empty_live_catalog_is_runtime_exhausted(self):
+        self._config()
+        result = RUNNER.probe(
+            config_path=self.config,
+            opener=lambda *_, **__: _Response(),
+            environ={"OMNIROUTE_API_KEY": "present"},
+            live_candidates={"state": "READY", "candidates": []},
+        )
+        self.assertEqual("RUNTIME_EXHAUSTED", result["state"])
 
     def test_exhausted_gateway_has_a_distinct_non_ready_state(self):
         result = RUNNER.probe(
@@ -642,6 +659,9 @@ class OmniRootRunnerTest(unittest.TestCase):
         self.launcher = self.root / "launcher"
         self.launcher.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         self.launcher.chmod(0o700)
+        self._which_patch = patch.object(RUNNER.shutil, "which", return_value=None)
+        self._which_patch.start()
+        self.addCleanup(self._which_patch.stop)
         now = datetime.now(UTC)
         self.config.write_text(json.dumps({
             "schemaVersion": 1,
@@ -736,12 +756,13 @@ class OmniRootRunnerTest(unittest.TestCase):
         json_line = redacted.splitlines()[1]
         self.assertEqual("[REDACTED]", json.loads(json_line)["token"])
 
-    def test_missing_config_is_normal_fallback_and_never_launches(self):
+    def test_missing_config_without_path_launcher_never_launches(self):
         launched = []
         result = RUNNER.probe(
             config_path=self.root / "missing.json", opener=lambda *_, **__: _Response(), environ={}
         )
         self.assertEqual("ROUTE_UNQUALIFIED", result["state"])
+        self.assertEqual("LAUNCHER_UNQUALIFIED", result["reasonCode"])
         with self.assertRaises(RUNNER.OmniRootError):
             self._dispatch(
                 run_id="missing", worktree=self.worktree, state_dir=self.state,
@@ -1015,12 +1036,12 @@ class OmniRootRunnerTest(unittest.TestCase):
             )
 
     def test_probe_and_dispatch_use_one_sealed_config_snapshot(self):
-        original = RUNNER._read_config
+        original = RUNNER._read_config_with_reason
         calls = []
         def once(path):
             calls.append(path)
             return original(path)
-        with patch.object(RUNNER, "_read_config", side_effect=once):
+        with patch.object(RUNNER, "_read_config_with_reason", side_effect=once):
             self._dispatch(run_id="sealed", worktree=self.worktree, state_dir=self.state,
                 config_path=self.config, target="host-cli", delegate_args=[],
                 opener=lambda *_, **__: _Response(), environ={"OMNIROUTE_API_KEY": "secret"},


### PR DESCRIPTION
## Summary

Makes ChaosEngine use a locally running OmniRoute with least effort.

- Probe `http://127.0.0.1:20128/` only. Never ask for a location.
- Missing `omniroot.json` is normal. Implicit PATH launcher: `chaosengine-omniroute` then `omniroute`.
- `READY` needs loopback health, a usable launcher, and an endpoint credential. No restricted key, denied-target 403, or attestation hashes.
- Live catalog still ranks free/remaining models first; other callable models may follow.
- Live proof on this machine: `probe` → `READY`; Codex child via OmniRoute returned `omniroot-smoke-ok`.

Closes #5491
Closes #5516

## Checks

- `python3 -m unittest tests.scripts.test_omniroot tests.scripts.test_omniroot_catalog tests.scripts.test_omniroot_workflow_contract tests.scripts.test_omniroot_portability tests.scripts.test_omniroot_failover`
- `python3 scripts/ci/validate_agent_setup.py --skip-external`
- `python3 chaos-engine/skills/omniroot/scripts/runner.py probe` → READY
- Bounded `chaosengine-omniroute exec` smoke returned child output

## Continuation

Terminal independent adversarial review after CI/comment fixes (max two rounds). Merge when green.