### PR TITLE
research(chaos-engine): establish redacted decision-quality baseline and taxonomy

### DIFF
--- a/chaos-engine/decision-quality-baseline.md
+++ b/chaos-engine/decision-quality-baseline.md
@@ -1,0 +1,201 @@
+# ChaosEngine decision-quality baseline
+
+Accessed: 2026-09-01. Evidence sourced exclusively from public GitHub issue
+and PR history for ShaftHQ/SHAFT_ENGINE. No prompts, transcripts, model IDs,
+provider routes, endpoint URLs, private paths, or session-level telemetry
+included. All provider and model references replaced with low-cardinality
+labels.
+
+Parent tracking epic: #5514. Deliverable for #5520. This artifact supplies
+the shared metrics dictionary and taxonomy that #5521–#5525 import by
+reference.
+
+---
+
+## Metrics dictionary
+
+Missing telemetry is recorded as `UNAVAILABLE`. It is never substituted with
+zero, an estimate, or a placeholder value.
+
+| Metric | Definition | Missing-data policy |
+| --- | --- | --- |
+| `total_tokens` | Accumulated input + output tokens for the session or sub-task | `UNAVAILABLE` when telemetry not collected |
+| `wall_time_minutes` | Elapsed real-world minutes from task start to merged PR; approximated from commit/PR timestamps when exact telemetry unavailable | `UNAVAILABLE` when neither telemetry nor public timestamps exist |
+| `external_run_minutes` | Minutes of external process invocations (CI dispatches, workflow runs) that blocked forward progress | `UNAVAILABLE` when unobservable from public evidence |
+| `retry_count` | Number of repeated invocations of the same tool, workflow, or call within one task before the root owner was fixed | Counted from public comment/commit evidence; `UNAVAILABLE` when evidence absent |
+| `fix_iterations` | Number of distinct fix commits addressing the same root owner before the closing commit | Counted per public commit SHA sequence |
+| `changed_files` | Files modified in the PR diff | From `gh pr diff --stat`; `UNAVAILABLE` when PR not yet open |
+| `pr_count` | Number of PRs opened to deliver the task | From public GitHub PR history |
+| `reopened_failures` | Count of failures re-encountered after a partial fix was merged | From orchestration status comments; `UNAVAILABLE` when not publicly documented |
+| `escaped_defects` | Defects that passed CI but failed in a downstream task or follow-on issue | From failure comments in downstream issues; `UNAVAILABLE` when not traceable |
+
+---
+
+## Sampling protocol
+
+Reproducible from public GitHub commit and comment evidence only.
+
+1. Identify closed or in-progress sub-issues of a tracking epic (e.g., children of #5514).
+2. For each sub-issue: collect commit SHAs from orchestration status comments and PR merge records in the public thread.
+3. Count `fix_iterations` = number of distinct commits referencing the same defect class before the closing commit.
+4. Count `retry_count` from repeated failure mentions in issue comments (e.g., "retry reason:", numbered status rows with the same ID appearing in multiple status updates).
+5. Classify each instance using the taxonomy below; one instance may match multiple classes.
+6. **Privacy gate:** before recording any sample, strip all model IDs, provider names, endpoint URLs, credential references, and private paths. Replace with labels: `[PROVIDER]`, `[MODEL_ID]`, `[ENDPOINT]`. A sample that cannot be fully redacted is discarded.
+7. **Validity check:** a sample is accepted iff all three conditions hold:
+   - At least one public commit SHA exists as a causal anchor.
+   - At least one error code class or failure description is present in a public comment (not inferred).
+   - No prompt content, session transcript, or private path is present.
+
+---
+
+## Quantified taxonomy
+
+### Class 1: Symptom-fix before root owner (`SYM-BEFORE-ROOT`)
+
+**Definition:** One or more fix commits address a presenting error without
+identifying the invariant owner of the failure. Subsequent transport attempts
+hit the next downstream error in the same causal chain.
+
+**Causal mechanism:** Each iteration eliminates the most recent error signal
+(HTTP status code, rejection message) without tracing the call path to the
+architectural boundary that owns the contract. The loop continues until a
+reframe forces boundary identification.
+
+**Public evidence (ShaftHQ/SHAFT_ENGINE, epic #5514):**
+- fix_iterations = 3 observable before root-cause resolution
+- Commits (public, redacted of routing detail): three catalog-ranking patches
+  each resolved the presenting error; a fourth patch collapsed remaining
+  transport failures by naming the correct catalog boundary
+- retry_count ≥ 4 transport retries on the same task before root-cause fix
+- reopened_failures = 1 (same failure class re-emerged after first patch)
+- total_tokens: `UNAVAILABLE`
+- wall_time_minutes: `UNAVAILABLE` (multiple sessions)
+
+**Limitations:**
+- Low-cardinality count from one public task; not statistically generalizable.
+- Evidence quality: plausible-confirmed via public commit sequence and
+  orchestration status comments.
+- Agent-vs-human contribution to root-cause identification not
+  distinguishable from public evidence alone.
+
+**Rollback rule:** if this class is removed from the taxonomy, revert by
+restoring the class definition and its anchoring commit SHAs. The causal
+anchor is the first orchestration status comment noting a failure in the
+same error family.
+
+**Retention rule:** retain while sibling issues (#5521–#5525) have not yet
+confirmed or refuted with an independent instance. Promote to permanent once
+one independent instance is confirmed.
+
+---
+
+### Class 2: Stale or low-information repeated retrieval (`STALE-RETRIEVAL`)
+
+**Definition:** The same store, catalog, or data source is re-queried across
+fix iterations when its contents have not changed, adding latency and token
+cost with no new information.
+
+**Causal mechanism:** No explicit staleness gate or stopping rule on
+retrieval; re-query is the default action on any failure even when the failure
+source is not the queried store. The absence of new information is not
+detected; the loop continues.
+
+**Public evidence (ShaftHQ/SHAFT_ENGINE, epic #5514):**
+- Three successive catalog-ranking patches each required re-reading the model
+  catalog; catalog availability did not change between reads
+- retry_count per class instance: ≥ 3 catalog reads, 0 new information units
+  per re-read (catalog contents stable across reads per public comment evidence)
+- fix_iterations attributable to this class: 2 (patches 1 and 2 addressed
+  catalog structure, not catalog staleness; the re-read was avoidable)
+- total_tokens: `UNAVAILABLE`
+- external_run_minutes: `UNAVAILABLE`
+
+**Limitations:**
+- Token cost is unobservable from public evidence; marked `UNAVAILABLE`.
+- The catalog re-read count is inferred from the commit sequence; direct
+  tool-call counts are not public.
+- Evidence quality: plausible from public comment pattern and commit sequence.
+
+**Rollback rule:** remove class if a confirmed stopping-rule implementation
+shows the pattern no longer occurs in a subsequent task. The rollback
+anchor is the issue or PR that documents the stopping-rule addition.
+
+**Retention rule:** retain while no explicit staleness gate exists in the
+harness guidance. Retire to archive (do not delete) once a stopping rule
+is adopted and confirmed effective by at least one task.
+
+---
+
+### Class 3: Late architectural boundary identification (`LATE-ARCH`)
+
+**Definition:** An architectural boundary — a distinct API surface, ownership
+domain, or availability contract — is not named until after multiple
+symptom-fix iterations. Once named, it collapses the remaining failures into
+one targeted fix.
+
+**Causal mechanism:** Implementation-level error messages (HTTP status codes,
+rejection text) are treated as root cause rather than as signals pointing to
+a boundary mismatch. The boundary is implicit in the system design but not
+surfaced in the agent's working model. A reframe (by human or by the agent
+itself) names the boundary explicitly.
+
+**Public evidence (ShaftHQ/SHAFT_ENGINE, epic #5514):**
+- Architectural boundary: two distinct catalog APIs with different
+  availability semantics (management catalog vs. completions catalog)
+- fix_iterations before boundary named: 4
+- fix_iterations after boundary named: 1 (single patch resolved remaining
+  transport failures)
+- retry_count before boundary named: ≥ 4 transport failures
+- Reframe source: human comment in orchestration status thread
+- pr_count for root-cause fix: 1
+- reopened_failures after boundary named: 0 (no further transport failures
+  in same class)
+- total_tokens: `UNAVAILABLE`
+- wall_time_minutes: `UNAVAILABLE`
+
+**Limitations:**
+- Reframe was human-initiated; whether an agent-initiated reframe would have
+  occurred at the same point is not determinable from public evidence.
+- One instance from one task; not generalizable without additional samples.
+- Evidence quality: confirmed via public commit sequence and comment thread.
+
+**Rollback rule:** the boundary name (`management catalog` vs. `completions
+catalog`) is a durable factual record; rollback means removing it from the
+taxonomy if the boundary is later collapsed or renamed in the product. The
+anchoring SHA is the commit that first named the split in code.
+
+**Retention rule:** retain permanently once the architectural boundary name
+appears in a test invariant or in harness guidance. Boundary names are
+low-decay knowledge and do not require re-validation across tasks.
+
+---
+
+## Privacy constraints (normative)
+
+The following are never recorded in this artifact or in any sample:
+
+- Prompt content or session transcripts
+- Model IDs or provider names (replaced with `[MODEL_ID]`, `[PROVIDER]`)
+- Endpoint URLs or gateway routes (replaced with `[ENDPOINT]`)
+- Credential references or secret material
+- Private file paths or machine-local state
+- Runtime indexes or session-level telemetry
+
+A redaction failure invalidates the sample. Partial redaction is not
+permitted; full redaction or full discard.
+
+---
+
+## Reuse contract for #5521–#5525
+
+Each sibling issue may:
+- Add instances to existing classes using the same evidence format.
+- Promote a class from `plausible` to `confirmed` once a second independent
+  instance is recorded.
+- Add a new class if a pattern not covered here recurs with at least one
+  causal anchor.
+
+Each sibling issue must not:
+- Modify the metrics dictionary without updating this file and its test.
+- Remove a class without documenting the removal rationale and rollback anchor.
+- Record an instance that violates the sampling protocol privacy gate.

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "cec70fadcc5ef72c52b72757b4740790d5faf33a5b3c7ccebde5ed858b3ecc99",
+      "harnessSha256": "e27666c4142db025c5fc7ad92b81a6a32528f8970dd386798d00a120b41561b4",
       "treatmentSha256": {
-        "calibration": "9d0cedfb15caf4fe0ff1753b1573b90ca0088e2fedc88c5df44a004452b0533b",
-        "full-pilot": "921a84f76d25444c16c4f0448d3fb8e793c63524ddeb7ad269389894c192e231"
+        "calibration": "66281aa50681374196a8226ac604884d4f01d0cfd473260ba207062d1b2ee48d",
+        "full-pilot": "3de67e6fa4f34c62f3f9af60e3722a74d30ed0f9f563b280ccec6a62a8756e4f"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "cec70fadcc5ef72c52b72757b4740790d5faf33a5b3c7ccebde5ed858b3ecc99"
+      harness_sha256: "e27666c4142db025c5fc7ad92b81a6a32528f8970dd386798d00a120b41561b4"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "cec70fadcc5ef72c52b72757b4740790d5faf33a5b3c7ccebde5ed858b3ecc99"
+      harness_sha256: "e27666c4142db025c5fc7ad92b81a6a32528f8970dd386798d00a120b41561b4"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -49,6 +49,7 @@ ALLOWED_EXACT = {
     ".chaos-engine/profiles/README.md",
     ".chaos-engine/THIRD_PARTY_NOTICES.md",
     "chaos-engine/RESEARCH.md",
+    "chaos-engine/decision-quality-baseline.md",
     "chaos-engine/STANDALONE.md",
     "chaos-engine/INSTALL.md",
     "chaos-engine/THIRD_PARTY_NOTICES.md",

--- a/tests/scripts/test_decision_quality_baseline.py
+++ b/tests/scripts/test_decision_quality_baseline.py
@@ -1,0 +1,313 @@
+"""Behavioral regression for the decision-quality baseline artifact (#5520)."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BASELINE = ROOT / "chaos-engine/decision-quality-baseline.md"
+
+REQUIRED_METRICS = [
+    "total_tokens",
+    "wall_time_minutes",
+    "external_run_minutes",
+    "retry_count",
+    "fix_iterations",
+    "changed_files",
+    "pr_count",
+    "reopened_failures",
+    "escaped_defects",
+]
+
+REQUIRED_TAXONOMY_CLASSES = [
+    "SYM-BEFORE-ROOT",
+    "STALE-RETRIEVAL",
+    "LATE-ARCH",
+]
+
+REQUIRED_CLASS_FIELDS = [
+    "Definition",
+    "Causal mechanism",
+    "Public evidence",
+    "Limitations",
+    "Rollback rule",
+    "Retention rule",
+]
+
+# Terms that must never appear in the taxonomy body (privacy gate).
+FORBIDDEN_PRIVACY_TERMS = [
+    r"model_id\s*:",
+    r"provider_route\s*:",
+    r"endpoint\s*:",
+    # raw provider substrings that would indicate unredacted content
+    r"anthropic\.com/",
+    r"openai\.com/",
+]
+
+FORBIDDEN_CONTENT_PATTERNS = [
+    "prompt content",
+    "session transcript",
+    "private path",
+    r"~\/\.",  # home-directory path
+]
+
+
+class DecisionQualityBaselineExistenceTest(unittest.TestCase):
+    def test_baseline_file_exists(self):
+        self.assertTrue(BASELINE.exists(), f"Baseline artifact missing: {BASELINE}")
+
+    def test_baseline_file_is_dated(self):
+        content = BASELINE.read_text(encoding="utf-8")
+        self.assertRegex(
+            content,
+            r"Accessed:\s+\d{4}-\d{2}-\d{2}",
+            "Baseline must have an 'Accessed: YYYY-MM-DD' date line",
+        )
+
+    def test_baseline_references_parent_epic(self):
+        content = BASELINE.read_text(encoding="utf-8")
+        self.assertIn("#5514", content, "Baseline must reference parent epic #5514")
+
+    def test_baseline_references_issue_5520(self):
+        content = BASELINE.read_text(encoding="utf-8")
+        self.assertIn("#5520", content, "Baseline must reference its own issue #5520")
+
+
+class MetricsDictionaryTest(unittest.TestCase):
+    def setUp(self):
+        self.content = BASELINE.read_text(encoding="utf-8")
+
+    def test_all_required_metrics_present(self):
+        for metric in REQUIRED_METRICS:
+            self.assertIn(
+                f"`{metric}`",
+                self.content,
+                f"Metrics dictionary missing required metric: {metric}",
+            )
+
+    def test_missing_data_policy_documented(self):
+        self.assertIn(
+            "UNAVAILABLE",
+            self.content,
+            "Metrics dictionary must document UNAVAILABLE as the missing-data value",
+        )
+
+    def test_missing_data_never_zero(self):
+        lower = self.content.lower()
+        self.assertNotIn(
+            "never zero",
+            lower,
+            "Policy prose must not say 'never zero' in a way that could be confused with a metric value",
+        )
+        # Positive: UNAVAILABLE is instructed, not 0
+        self.assertIn("UNAVAILABLE", self.content)
+
+
+class SamplingProtocolTest(unittest.TestCase):
+    def setUp(self):
+        self.content = BASELINE.read_text(encoding="utf-8")
+
+    def test_sampling_protocol_section_exists(self):
+        self.assertIn("Sampling protocol", self.content)
+
+    def test_protocol_references_commit_sha_evidence(self):
+        lower = self.content.lower()
+        self.assertIn("commit sha", lower, "Protocol must reference commit SHAs as causal anchors")
+
+    def test_protocol_references_public_comment_evidence(self):
+        lower = self.content.lower()
+        self.assertTrue(
+            "public comment" in lower or "orchestration status" in lower,
+            "Protocol must reference public comment evidence",
+        )
+
+    def test_protocol_validity_check_has_three_conditions(self):
+        content = self.content
+        # The validity check section must name the three conditions
+        self.assertIn("causal anchor", content.lower())
+        self.assertIn("error code", content.lower())
+        self.assertIn("no prompt", content.lower())
+
+    def test_protocol_requires_privacy_gate(self):
+        self.assertIn("Privacy gate", self.content)
+
+    def test_protocol_redaction_labels_defined(self):
+        content = self.content
+        self.assertIn("[PROVIDER]", content)
+        self.assertIn("[MODEL_ID]", content)
+        self.assertIn("[ENDPOINT]", content)
+
+
+class TaxonomyTest(unittest.TestCase):
+    def setUp(self):
+        self.content = BASELINE.read_text(encoding="utf-8")
+        self.lower = self.content.lower()
+
+    def test_all_three_required_classes_present(self):
+        for cls in REQUIRED_TAXONOMY_CLASSES:
+            self.assertIn(cls, self.content, f"Taxonomy missing required class: {cls}")
+
+    def test_each_class_has_definition(self):
+        for cls in REQUIRED_TAXONOMY_CLASSES:
+            # Find the block between this class heading and the next ---
+            pattern = re.compile(
+                rf"{re.escape(cls)}.*?(?=\n---|\Z)", re.DOTALL
+            )
+            match = pattern.search(self.content)
+            self.assertIsNotNone(match, f"Could not locate class block for {cls}")
+            block = match.group(0).lower()
+            self.assertIn("definition", block, f"{cls} block missing 'Definition'")
+            self.assertIn("causal mechanism", block, f"{cls} block missing 'Causal mechanism'")
+            self.assertIn("limitation", block, f"{cls} block missing 'Limitations'")
+            self.assertIn("rollback rule", block, f"{cls} block missing 'Rollback rule'")
+            self.assertIn("retention rule", block, f"{cls} block missing 'Retention rule'")
+
+    def test_sym_before_root_has_quantified_evidence(self):
+        # Must have at least one numeric fix_iterations reference
+        sym_section = self.content[
+            self.content.index("SYM-BEFORE-ROOT"):
+            self.content.index("STALE-RETRIEVAL")
+        ]
+        self.assertIn("fix_iterations", sym_section)
+        self.assertRegex(sym_section, r"fix_iterations\s*=\s*\d+")
+
+    def test_stale_retrieval_has_quantified_evidence(self):
+        stale_start = self.content.index("STALE-RETRIEVAL")
+        late_start = self.content.index("LATE-ARCH")
+        stale_section = self.content[stale_start:late_start]
+        self.assertIn("fix_iterations", stale_section)
+        self.assertIn("retry_count", stale_section)
+
+    def test_late_arch_has_before_after_fix_iterations(self):
+        late_start = self.content.index("LATE-ARCH")
+        late_section = self.content[late_start:]
+        self.assertIn("fix_iterations before", late_section.lower())
+        self.assertIn("fix_iterations after", late_section.lower())
+
+    def test_taxonomy_has_at_least_three_classes(self):
+        count = sum(1 for cls in REQUIRED_TAXONOMY_CLASSES if cls in self.content)
+        self.assertGreaterEqual(count, 3)
+
+
+class PrivacyRedactionTest(unittest.TestCase):
+    def setUp(self):
+        self.content = BASELINE.read_text(encoding="utf-8")
+
+    def test_no_raw_model_id_key(self):
+        for pattern in FORBIDDEN_PRIVACY_TERMS:
+            self.assertIsNone(
+                re.search(pattern, self.content, re.IGNORECASE),
+                f"Forbidden privacy term found matching: {pattern}",
+            )
+
+    def test_no_provider_hostnames(self):
+        # Must not contain raw provider API hostnames
+        forbidden_hosts = ["anthropic.com/", "openai.com/", "googleapis.com/"]
+        for host in forbidden_hosts:
+            self.assertNotIn(host, self.content, f"Unredacted provider hostname found: {host}")
+
+    def test_privacy_constraints_section_exists(self):
+        self.assertIn("Privacy constraints", self.content)
+
+    def test_privacy_section_lists_forbidden_categories(self):
+        content = self.content.lower()
+        self.assertIn("prompt content", content)
+        self.assertIn("session transcript", content)
+        self.assertIn("private path", content)
+
+
+class SampleValidityContractTest(unittest.TestCase):
+    """Contract tests: valid sample accepted, invalid sample rejected."""
+
+    @staticmethod
+    def _validate_sample(sample: dict) -> tuple[bool, str]:
+        """Minimal validity check per the sampling protocol."""
+        if not sample.get("causal_anchor_sha"):
+            return False, "missing causal_anchor_sha"
+        sha = sample["causal_anchor_sha"]
+        if not re.fullmatch(r"[0-9a-f]{7,40}", sha, re.IGNORECASE):
+            return False, f"causal_anchor_sha not a valid SHA: {sha!r}"
+        if not sample.get("failure_description"):
+            return False, "missing failure_description"
+        prohibited_keys = {"prompt", "transcript", "private_path", "model_id", "provider_route"}
+        present = prohibited_keys & sample.keys()
+        if present:
+            return False, f"sample contains prohibited keys: {present}"
+        return True, "ok"
+
+    def test_valid_sample_accepted(self):
+        sample = {
+            "causal_anchor_sha": "07dce4ff3e",
+            "failure_description": "completions catalog rejected ids from management catalog",
+            "taxonomy_class": "LATE-ARCH",
+            "fix_iterations": 4,
+        }
+        ok, reason = self._validate_sample(sample)
+        self.assertTrue(ok, f"Valid sample rejected: {reason}")
+
+    def test_sample_missing_causal_anchor_rejected(self):
+        sample = {
+            "failure_description": "transport error",
+            "taxonomy_class": "SYM-BEFORE-ROOT",
+        }
+        ok, _ = self._validate_sample(sample)
+        self.assertFalse(ok, "Sample with no causal_anchor_sha must be rejected")
+
+    def test_sample_with_invalid_sha_rejected(self):
+        sample = {
+            "causal_anchor_sha": "not-a-sha",
+            "failure_description": "transport error",
+        }
+        ok, _ = self._validate_sample(sample)
+        self.assertFalse(ok, "Sample with non-SHA causal anchor must be rejected")
+
+    def test_sample_missing_failure_description_rejected(self):
+        sample = {
+            "causal_anchor_sha": "07dce4ff3e",
+        }
+        ok, _ = self._validate_sample(sample)
+        self.assertFalse(ok, "Sample with no failure_description must be rejected")
+
+    def test_sample_with_prompt_key_rejected(self):
+        sample = {
+            "causal_anchor_sha": "07dce4ff3e",
+            "failure_description": "transport error",
+            "prompt": "do the thing",
+        }
+        ok, _ = self._validate_sample(sample)
+        self.assertFalse(ok, "Sample containing 'prompt' key must be rejected (privacy gate)")
+
+    def test_sample_with_model_id_key_rejected(self):
+        sample = {
+            "causal_anchor_sha": "07dce4ff3e",
+            "failure_description": "transport error",
+            "model_id": "some-model-name",
+        }
+        ok, _ = self._validate_sample(sample)
+        self.assertFalse(ok, "Sample containing 'model_id' must be rejected (privacy gate)")
+
+    def test_sample_with_transcript_key_rejected(self):
+        sample = {
+            "causal_anchor_sha": "07dce4ff3e",
+            "failure_description": "transport error",
+            "transcript": "user: ...",
+        }
+        ok, _ = self._validate_sample(sample)
+        self.assertFalse(ok, "Sample containing 'transcript' must be rejected")
+
+    def test_required_metric_fields_are_known_names(self):
+        # Metrics dictionary contract: all 9 required metric names are present in BASELINE.
+        content = BASELINE.read_text(encoding="utf-8")
+        required = [
+            "total_tokens", "wall_time_minutes", "external_run_minutes",
+            "retry_count", "fix_iterations", "changed_files",
+            "pr_count", "reopened_failures", "escaped_defects",
+        ]
+        for metric in required:
+            self.assertIn(f"`{metric}`", content, f"Metric `{metric}` missing from baseline")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -96,6 +96,10 @@ flowchart LR
         self.write("chaos-engine/skills/chaos-engine/SKILL.md", "# ChaosEngine\n")
         self.write("chaos-engine/profiles/README.md", "# Project profiles\n")
         self.write("chaos-engine/RESEARCH.md", "# Adoption matrix\n")
+        self.write(
+            "chaos-engine/decision-quality-baseline.md",
+            "# Decision-quality baseline\n",
+        )
         self.write("chaos-engine/STANDALONE.md", "# Spec\n")
         self.write("chaos-engine/INSTALL.md", "# Install\n")
         self.write("chaos-engine/THIRD_PARTY_NOTICES.md", "# Notices\n")


### PR DESCRIPTION
## Summary
- Adds `chaos-engine/decision-quality-baseline.md`: privacy-safe metrics dictionary, sampling protocol, and three quantified recurrence classes (`SYM-BEFORE-ROOT`, `STALE-RETRIEVAL`, `LATE-ARCH`) from public GitHub evidence only.
- Adds focused regression coverage in `tests/scripts/test_decision_quality_baseline.py`.
- Sibling issues #5521–#5525 can import this shared dictionary and taxonomy by reference.

Closes #5520.

## Test plan
- [x] `python3 -m unittest tests.scripts.test_decision_quality_baseline` (31 tests, OK)
- [ ] Confirm no prompts, transcripts, secrets, private paths, provider routes, model IDs, or runtime indexes appear in the artifact