### PR TITLE
research(chaos-engine): compare decision models and define operational rubric

### DIFF
--- a/chaos-engine/decision-quality-rubric.md
+++ b/chaos-engine/decision-quality-rubric.md
@@ -1,0 +1,220 @@
+# ChaosEngine decision-quality operational rubric
+
+Accessed: 2026-09-01. Imports the metrics dictionary, sampling protocol, and
+taxonomy classes from `chaos-engine/decision-quality-baseline.md` (#5520) by
+reference. Does not redefine those contracts. Parent tracking epic: #5514.
+Deliverable for #5521.
+
+Privacy: no prompts, transcripts, secrets, private paths, provider routes,
+model IDs, endpoint URLs, or runtime indexes.
+
+---
+
+## Research sources (Accessed: 2026-09-01)
+
+| Source | Use in this artifact | URL |
+| --- | --- | --- |
+| Stanford Encyclopedia of Philosophy — Decision Theory (rev. 2025-08-20) | Normative choice framing under uncertainty | https://plato.stanford.edu/entries/decision-theory/ |
+| SEP — Expected Utility | Risk-weighted choice vocabulary | https://plato.stanford.edu/entries/rationality-normative-utility/ |
+| Howard, R.A. (1966) Information Value Theory | Primary value-of-information lineage | https://ieeexplore.ieee.org/document/4082278 |
+| Value of information (Raiffa/Schlaifer lineage overview) | EVPI/EVSI intuition for discriminating experiments | https://en.wikipedia.org/wiki/Value_of_information |
+| Satisficing (Simon) | Stop and aspiration rules when further search is waste | https://en.wikipedia.org/wiki/Satisficing |
+| OODA loop (Boyd) | Competing stage-cycle model | https://en.wikipedia.org/wiki/OODA_loop |
+| PDCA (Deming) | Competing plan-do-check-act model | https://en.wikipedia.org/wiki/PDCA |
+| Cynefin framework | Domain routing in the rejected stage-gate model | https://en.wikipedia.org/wiki/Cynefin_framework |
+| ISO 31000 overview | Risk-process vocabulary | https://en.wikipedia.org/wiki/ISO_31000 |
+| NIST SP 800-37 Rev. 2 | Risk-management lifecycle posture | https://csrc.nist.gov/pubs/sp/800/37/r2/final |
+| Five Whys | RCA limit note (symptom chains vs root owner) | https://en.wikipedia.org/wiki/Five_whys |
+
+---
+
+## Competing decision models
+
+### Model A — Value-of-Information Discriminating Gate (chosen)
+
+**Complete claim:** choose the next action that maximizes expected information
+about the named objective and invariant per unit of cost, latency, and flake
+risk. When expected information gain is zero or below that cost, stop,
+escalate, defer, or schedule instead of repeating.
+
+**Operators:**
+
+1. Name the objective and the invariant under test.
+2. State uncertainty and missing evidence explicitly (never invent values for
+   `UNAVAILABLE` metrics from the baseline dictionary).
+3. Estimate risk posture, blast radius, and reversibility.
+4. List candidate next actions. For each, estimate information gain, cost,
+   latency, and flake or external-dependency risk.
+5. Select the cheapest discriminating experiment: highest expected information
+   gain relative to cost + latency + flake risk.
+6. Run that experiment once. Update beliefs. If repeating the same action would
+   yield no new information, do not repeat it (`STALE-RETRIEVAL` stop).
+7. Exit through exactly one terminal: **stop**, **escalate**, **defer**, or
+   **schedule**.
+
+**Lineage:** Howard VOI (1966), Raiffa/Schlaifer decision analysis, Simon
+satisficing, NIST risk posture.
+
+### Model B — Stage-Gate OODA/PDCA Compliance Loop (rejected)
+
+**Complete claim:** decision quality comes from completing a mandatory
+Observe→Orient→Decide→Act or Plan→Do→Check→Act cycle with phase artifacts and
+Cynefin domain classification before any skip is allowed. ISO 31000-style risk
+process lives inside Orient/Plan. Check is never optional.
+
+**Operators:**
+
+1. Observe: gather current signals without acting.
+2. Orient/Plan: classify domain (clear / complicated / complex / chaotic), list
+   risks, and write the intended Check.
+3. Decide/Do: act only after the Orient/Plan artifact exists.
+4. Check/Act: verify; on failure restart the loop; never skip Check.
+5. Escalate only for chaotic domain or missing authority; defer only when Plan
+   names an external owner; schedule exhaustive proof as a Plan item.
+
+#### Steelman of Model B
+
+Model B deserves serious weight. Mandatory Check blocks premature YAGNI and
+under-testing. Cynefin domain routing blocks treating complex failures as
+simple retries. Stage gates reduce escaped defects and false confidence better
+than opportunistic information-gain scores that agents can game. Ritual
+coverage is an asset under adversarial conditions where skipping proof is easy
+to rationalize. PDCA Check/Act is the historical backbone of continuous
+improvement; discarding it for a thin score risks metric theater.
+
+#### Why Model B still loses on the reviewed corpus
+
+Against `STALE-RETRIEVAL`, mandatory re-Observe/re-Orient has no intrinsic
+staleness gate, so zero-information re-queries remain compliant. Against
+`SYM-BEFORE-ROOT`, Act can still patch the latest signal inside a valid loop
+without naming the root owner. Against `LATE-ARCH`, Orient can complete without
+forcing an architectural-boundary hypothesis, so multiple full cycles can
+accrue (`fix_iterations` before boundary named = 4 in the baseline) before
+collapse. Model A’s discriminating-experiment rule and zero-information stop
+attack those three measured classes directly, while still allowing escalate or
+schedule when residual risk requires broader proof.
+
+---
+
+## Corpus evaluation (same reviewed #5520 set)
+
+Metrics and class definitions are those in
+`chaos-engine/decision-quality-baseline.md`. Missing telemetry remains
+`UNAVAILABLE`. This comparison is qualitative on the reviewed public corpus; it
+is not a statistical trial (#5522 owns controlled calibration).
+
+| Taxonomy class | Model A effect on class mechanism | Model B effect on class mechanism | Winner |
+| --- | --- | --- | --- |
+| `SYM-BEFORE-ROOT` | Requires invariant/root-owner naming before the experiment; targets fewer `fix_iterations` | Allows symptom Acts inside otherwise valid loops | A |
+| `STALE-RETRIEVAL` | Forbids zero-information re-query; targets lower `retry_count` on stable stores | Re-Observe can be zero-information and still compliant | A |
+| `LATE-ARCH` | Boundary hypothesis is part of uncertainty framing before act | Boundary may stay unnamed across complete cycles | A |
+
+Public anchors reused from the baseline (redacted): catalog-boundary collapse
+after multiple transport failures; repeated stable-catalog reads with no new
+information units; `fix_iterations` before boundary named = 4 and after = 1.
+
+---
+
+## Operational rubric (Model A)
+
+Use this checklist before every non-trivial tool call, test, workflow, review,
+retry, or retrieval. Keep it short. Do not invent numeric precision that
+telemetry does not support.
+
+### 1. Objective / invariant
+
+- State the user-visible objective in one sentence.
+- Name the single invariant that must hold (API contract, ownership boundary,
+  privacy gate, proof owner, or equivalent).
+- If the invariant owner is unknown, the next experiment must identify it
+  (`LATE-ARCH` / `SYM-BEFORE-ROOT` pressure), not patch the latest symptom.
+
+### 2. Uncertainty
+
+- List what is unknown that could change the action.
+- Prefer the cheapest unknown that can falsify the current plan.
+- Record baseline metrics as `UNAVAILABLE` when unobserved; never substitute 0.
+
+### 3. Risk
+
+- Sketch probability × impact qualitatively (low / medium / high) using NIST-
+  style posture, not fake precision.
+- Include correctness, security, user-authority, and preservation-of-work as
+  non-negotiable ceilings from epic #5514.
+
+### 4. Reversibility
+
+- Two-way (diff deletable, no persisted external side effect) vs one-way
+  (published artifact, external system, irreversible data change).
+- One-way actions require higher information gain or explicit escalate.
+
+### 5. Information gain
+
+- Ask: if this action succeeds or fails, which belief about the invariant
+  updates?
+- Expected information gain = 0 when the source is unchanged since last valid
+  read, or when the action cannot discriminate competing hypotheses.
+
+### 6. Cost / latency / flake risk
+
+- Cost: tokens, human attention, money.
+- Latency: wall time until the signal returns.
+- Flake / external risk: nondeterminism, shared CI queues, third-party quotas.
+- Prefer local deterministic proof when it discriminates the same invariant.
+
+### 7. Cheapest discriminating experiment
+
+- Among actions with non-zero expected information gain, pick the lowest
+  combined cost + latency + flake risk that can falsify at least one live
+  hypothesis about the invariant.
+- One experiment, then reassess. Do not batch low-information repeats.
+
+### 8. Stop / escalate / defer / schedule
+
+| Terminal | When |
+| --- | --- |
+| **stop** | Invariant proven or disproven with adequate evidence; or further actions have expected information gain ≤ cost |
+| **escalate** | Authority, safety, or one-way blast radius exceeds current mandate |
+| **defer** | Blocked on an external dependency that this agent cannot clear |
+| **schedule** | Broader or exhaustive proof has a later rightful owner (for example nightly CI) and current residual risk does not require it now |
+
+Efficient never means skipping required evidence. It means selecting the
+smallest evidence that discriminates the real risk at the right lifecycle
+stage.
+
+---
+
+## Failure modes (both models)
+
+| Failure mode | How it appears | Guard in this rubric |
+| --- | --- | --- |
+| Analysis paralysis | Endless Orient/estimation without an experiment | Cap modeling; run the cheapest discriminating experiment |
+| Metric gaming | Inflated information-gain scores to justify preferred actions | Require a falsifiable belief update; zero-IG actions are forbidden |
+| Under-testing | Skipping Check because local confidence feels high | Non-negotiable ceilings; schedule/escalate when residual risk remains |
+| Premature YAGNI | Deleting needed proof or structure because cost looks high | Reversibility + invariant owner first; do not optimize tokens alone |
+| False confidence | Treating HTTP/status symptoms as root cause | Force invariant/boundary naming before repeated Acts |
+
+---
+
+## Privacy constraints (normative)
+
+Same gate as the baseline artifact. This rubric and any worked example must
+never record prompt content, transcripts, model IDs, provider routes, endpoint
+URLs, credentials, private paths, or runtime indexes. Redaction failure
+invalidates the example.
+
+---
+
+## Reuse contract for #5522–#5525
+
+Sibling issues may:
+
+- Import this rubric and the #5520 dictionary/taxonomy by reference.
+- Pressure-test Model A vs no-guidance controls (#5522).
+- Add focused harness guidance only after controlled evidence of improvement.
+
+Sibling issues must not:
+
+- Silently redefine baseline metrics or taxonomy classes here.
+- Convert one anecdote into global policy without cross-project evidence.
+- Close parent #5514 from this deliverable alone.

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "e27666c4142db025c5fc7ad92b81a6a32528f8970dd386798d00a120b41561b4",
+      "harnessSha256": "ee40eca24611ace28a4c1b2c55e986577433f015f7a938eee571f15e02210b91",
       "treatmentSha256": {
-        "calibration": "66281aa50681374196a8226ac604884d4f01d0cfd473260ba207062d1b2ee48d",
-        "full-pilot": "3de67e6fa4f34c62f3f9af60e3722a74d30ed0f9f563b280ccec6a62a8756e4f"
+        "calibration": "a7ef53754725276740ec724bef5080f52eb47762b02aef095735ff40a7fd49cc",
+        "full-pilot": "5f34fb120b8e1181e0f8d46ad6f3ed58411ddfcf11c7a98ec95f957b769d1d6b"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "e27666c4142db025c5fc7ad92b81a6a32528f8970dd386798d00a120b41561b4"
+      harness_sha256: "ee40eca24611ace28a4c1b2c55e986577433f015f7a938eee571f15e02210b91"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "e27666c4142db025c5fc7ad92b81a6a32528f8970dd386798d00a120b41561b4"
+      harness_sha256: "ee40eca24611ace28a4c1b2c55e986577433f015f7a938eee571f15e02210b91"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -50,6 +50,7 @@ ALLOWED_EXACT = {
     ".chaos-engine/THIRD_PARTY_NOTICES.md",
     "chaos-engine/RESEARCH.md",
     "chaos-engine/decision-quality-baseline.md",
+    "chaos-engine/decision-quality-rubric.md",
     "chaos-engine/STANDALONE.md",
     "chaos-engine/INSTALL.md",
     "chaos-engine/THIRD_PARTY_NOTICES.md",

--- a/tests/scripts/test_decision_quality_rubric.py
+++ b/tests/scripts/test_decision_quality_rubric.py
@@ -1,0 +1,197 @@
+"""Behavioral regression for the decision-quality operational rubric (#5521)."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RUBRIC = ROOT / "chaos-engine/decision-quality-rubric.md"
+BASELINE = ROOT / "chaos-engine/decision-quality-baseline.md"
+
+REQUIRED_RUBRIC_SECTIONS = [
+    "Objective / invariant",
+    "Uncertainty",
+    "Risk",
+    "Reversibility",
+    "Information gain",
+    "Cost / latency / flake risk",
+    "Cheapest discriminating experiment",
+    "Stop / escalate / defer / schedule",
+]
+
+REQUIRED_MODELS = [
+    "Value-of-Information Discriminating Gate",
+    "Stage-Gate OODA/PDCA Compliance Loop",
+]
+
+REQUIRED_TAXONOMY_CLASSES = [
+    "SYM-BEFORE-ROOT",
+    "STALE-RETRIEVAL",
+    "LATE-ARCH",
+]
+
+REQUIRED_TERMINALS = ["stop", "escalate", "defer", "schedule"]
+
+REQUIRED_FAILURE_MODES = [
+    "Analysis paralysis",
+    "Metric gaming",
+    "Under-testing",
+    "Premature YAGNI",
+    "False confidence",
+]
+
+FORBIDDEN_PRIVACY_TERMS = [
+    r"model_id\s*:",
+    r"provider_route\s*:",
+    r"endpoint\s*:",
+    r"anthropic\.com/",
+    r"openai\.com/",
+]
+
+
+class DecisionQualityRubricExistenceTest(unittest.TestCase):
+    def test_rubric_file_exists(self):
+        self.assertTrue(RUBRIC.exists(), f"Rubric artifact missing: {RUBRIC}")
+
+    def test_rubric_file_is_dated(self):
+        content = RUBRIC.read_text(encoding="utf-8")
+        self.assertRegex(
+            content,
+            r"Accessed:\s+\d{4}-\d{2}-\d{2}",
+            "Rubric must have an 'Accessed: YYYY-MM-DD' date line",
+        )
+
+    def test_rubric_references_parent_and_issues(self):
+        content = RUBRIC.read_text(encoding="utf-8")
+        self.assertIn("#5514", content)
+        self.assertIn("#5521", content)
+        self.assertIn("#5520", content)
+
+    def test_rubric_imports_baseline_by_reference(self):
+        content = RUBRIC.read_text(encoding="utf-8")
+        self.assertIn("decision-quality-baseline.md", content)
+        self.assertTrue(BASELINE.exists(), "Baseline must remain available for import")
+
+
+class CompetingModelsTest(unittest.TestCase):
+    def setUp(self):
+        self.content = RUBRIC.read_text(encoding="utf-8")
+
+    def test_both_complete_models_named(self):
+        for name in REQUIRED_MODELS:
+            self.assertIn(name, self.content, f"Missing competing model: {name}")
+
+    def test_chosen_model_is_voi_gate(self):
+        self.assertIn("Value-of-Information Discriminating Gate (chosen)", self.content)
+
+    def test_rejected_model_is_stage_gate(self):
+        self.assertIn("Stage-Gate OODA/PDCA Compliance Loop (rejected)", self.content)
+
+    def test_rejected_model_is_steelmanned(self):
+        lower = self.content.lower()
+        self.assertIn("steelman", lower)
+        # Steelman must argue B's strengths, not only dismiss it.
+        rejected_idx = self.content.index("Stage-Gate OODA/PDCA Compliance Loop (rejected)")
+        steelman_idx = lower.index("steelman", rejected_idx)
+        why_loses_idx = lower.index("why model b still loses", steelman_idx)
+        steelman_block = self.content[steelman_idx:why_loses_idx].lower()
+        self.assertIn("check", steelman_block)
+        self.assertIn("cynefin", steelman_block)
+
+    def test_corpus_scorecard_covers_all_baseline_classes(self):
+        for cls in REQUIRED_TAXONOMY_CLASSES:
+            self.assertIn(cls, self.content, f"Corpus scorecard missing {cls}")
+
+    def test_corpus_declares_model_a_winner_for_each_class(self):
+        # Scorecard rows end with Winner column value A for each class block.
+        for cls in REQUIRED_TAXONOMY_CLASSES:
+            pattern = re.compile(
+                rf"\| `{re.escape(cls)}` \|.*?\| A \|",
+                re.DOTALL,
+            )
+            self.assertIsNotNone(
+                pattern.search(self.content),
+                f"Scorecard must pick Model A for {cls}",
+            )
+
+
+class OperationalRubricTest(unittest.TestCase):
+    def setUp(self):
+        self.content = RUBRIC.read_text(encoding="utf-8")
+        self.lower = self.content.lower()
+
+    def test_all_required_rubric_dimensions_present(self):
+        for section in REQUIRED_RUBRIC_SECTIONS:
+            self.assertIn(section, self.content, f"Rubric missing dimension: {section}")
+
+    def test_terminals_documented(self):
+        for terminal in REQUIRED_TERMINALS:
+            self.assertIn(f"**{terminal}**", self.content)
+
+    def test_failure_modes_documented(self):
+        for mode in REQUIRED_FAILURE_MODES:
+            self.assertIn(mode, self.content)
+
+    def test_unavailable_policy_preserved(self):
+        self.assertIn("UNAVAILABLE", self.content)
+
+    def test_cheapest_discriminating_experiment_is_actionable(self):
+        self.assertIn("Cheapest discriminating experiment", self.content)
+        self.assertIn("falsify", self.lower)
+
+
+class PrivacyAndSourcesTest(unittest.TestCase):
+    def setUp(self):
+        self.content = RUBRIC.read_text(encoding="utf-8")
+
+    def test_research_sources_section_exists(self):
+        self.assertIn("Research sources", self.content)
+        self.assertIn("plato.stanford.edu/entries/decision-theory/", self.content)
+        self.assertIn("ieeexplore.ieee.org/document/4082278", self.content)
+
+    def test_no_forbidden_privacy_terms(self):
+        for pattern in FORBIDDEN_PRIVACY_TERMS:
+            self.assertIsNone(
+                re.search(pattern, self.content, re.IGNORECASE),
+                f"Forbidden privacy term found matching: {pattern}",
+            )
+
+    def test_privacy_constraints_section_exists(self):
+        self.assertIn("Privacy constraints", self.content)
+
+
+class ModelApplicationContractTest(unittest.TestCase):
+    """Contract: both models can be scored against the same taxonomy corpus."""
+
+    @staticmethod
+    def _score_model(model: str, taxonomy_class: str) -> str:
+        """Minimal deterministic scorer mirroring the rubric scorecard."""
+        a_wins = {
+            "SYM-BEFORE-ROOT",
+            "STALE-RETRIEVAL",
+            "LATE-ARCH",
+        }
+        if taxonomy_class not in a_wins:
+            raise ValueError(f"unknown taxonomy class: {taxonomy_class}")
+        if model == "A":
+            return "prevents"
+        if model == "B":
+            return "allows_or_misses"
+        raise ValueError(f"unknown model: {model}")
+
+    def test_model_a_prevents_all_reviewed_classes(self):
+        for cls in REQUIRED_TAXONOMY_CLASSES:
+            self.assertEqual(self._score_model("A", cls), "prevents")
+
+    def test_model_b_does_not_prevent_stale_retrieval(self):
+        self.assertEqual(self._score_model("B", "STALE-RETRIEVAL"), "allows_or_misses")
+
+    def test_unknown_class_rejected(self):
+        with self.assertRaises(ValueError):
+            self._score_model("A", "NOT-A-CLASS")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -100,6 +100,10 @@ flowchart LR
             "chaos-engine/decision-quality-baseline.md",
             "# Decision-quality baseline\n",
         )
+        self.write(
+            "chaos-engine/decision-quality-rubric.md",
+            "# Decision-quality rubric\n",
+        )
         self.write("chaos-engine/STANDALONE.md", "# Spec\n")
         self.write("chaos-engine/INSTALL.md", "# Install\n")
         self.write("chaos-engine/THIRD_PARTY_NOTICES.md", "# Notices\n")


### PR DESCRIPTION
## Summary
- Adds `chaos-engine/decision-quality-rubric.md`: dated research comparing two complete decision models (Value-of-Information Discriminating Gate vs Stage-Gate OODA/PDCA), steelmans the rejected model, scores both on the reviewed #5520 corpus (`SYM-BEFORE-ROOT`, `STALE-RETRIEVAL`, `LATE-ARCH`), and delivers the smallest operational rubric covering objective/invariant, uncertainty, risk, reversibility, information gain, cost/latency/flake risk, cheapest discriminating experiment, and stop/escalate/defer/schedule.
- Reuses the #5520 metrics dictionary and taxonomy by reference; does not reopen #5520.
- Adds focused regression `tests/scripts/test_decision_quality_rubric.py`, allowlists the new Markdown path, and refreshes ChaosGauge harness digests.

Closes #5521.

## Checks
- [x] `python3 -m unittest tests.scripts.test_decision_quality_rubric tests.scripts.test_validate_documentation_boundaries tests.scripts.test_chaos_gauge_contracts` (76 tests, OK)
- [x] `python3 scripts/ci/validate_documentation_boundaries.py` (valid)

## Continuation
- Chosen model: Value-of-Information Discriminating Gate
- Rejected (steelmanned): Stage-Gate OODA/PDCA Compliance Loop
- Parent epic #5514 remains open
- Next program step: #5522 controlled calibration

## Model choice
**Chosen:** Model A — VOI Discriminating Gate (Howard/Raiffa lineage + Simon stop rules).
**Rejected:** Model B — Stage-Gate OODA/PDCA (steelmanned for mandatory Check and Cynefin routing; loses on zero-IG re-query and late boundary naming against the reviewed corpus).