### PR TITLE
test(chaos-engine): land blocked decision-quality calibration harness

### DIFF
--- a/chaos-engine/decision-quality-calibration.md
+++ b/chaos-engine/decision-quality-calibration.md
@@ -1,0 +1,125 @@
+# ChaosEngine decision-quality public calibration
+
+Accessed: 2026-09-01. Parent tracking epic: #5514. Deliverable for #5522.
+
+Imports by reference:
+
+- metrics dictionary, sampling protocol, and taxonomy from
+  `chaos-engine/decision-quality-baseline.md` (#5520)
+- operational Model A rubric from `chaos-engine/decision-quality-rubric.md`
+  (#5521)
+- immutable Harbor / ChaosGauge public calibration contracts under
+  `scripts/ci/chaos_gauge/` (#5450 lineage)
+
+Does not redefine those contracts. Does not change public task identities,
+seed, arm names, attempt count, or treatment digests.
+
+Privacy: no prompts, transcripts, secrets, private paths, provider routes,
+endpoint URLs, or runtime indexes. Model identity remains only where existing
+ChaosGauge manifests already pin it.
+
+---
+
+## Campaign identity (frozen)
+
+| Field | Value |
+| --- | --- |
+| Campaign | `calibration` |
+| Seed | `5450` |
+| Public tasks | 12 |
+| Arms | `control`, `chaos-engine` |
+| Attempts per task | 5 |
+| Planned trials | 120 |
+| Private resolution | not required |
+
+Public task names and content digests stay exactly as published in
+`scripts/ci/chaos_gauge/experiment.json`.
+
+---
+
+## Metric mapping
+
+Ticket comparison fields map onto ChaosGauge compare output as follows.
+Missing telemetry remains `UNAVAILABLE`. It is never substituted with 0, an
+estimate, or a null.
+
+| Decision-quality field | ChaosGauge source | Missing policy |
+| --- | --- | --- |
+| `correctness` | arm `effectiveness` | `UNAVAILABLE` |
+| `tokens` | `tokensPerSuccess` when `tokenProvenance=reported` | `UNAVAILABLE` |
+| `latency_seconds` | `secondsPerSuccess` | `UNAVAILABLE` |
+| `external_run_minutes` | not emitted by Harbor compare today | `UNAVAILABLE` |
+| `actions` | not emitted by Harbor compare today | `UNAVAILABLE` |
+| `retries` | compare `retries[arm]` | `UNAVAILABLE` when absent |
+| `cost_usd` | `costPerSuccess` when present | `UNAVAILABLE` |
+| `variance` | width of paired 95% bootstrap interval when both bounds exist | `UNAVAILABLE` |
+
+Harness owner: `scripts/ci/chaos_gauge/decision_quality_calibration.py`.
+
+---
+
+## Runtime gate
+
+Paid public calibration may start only when all of the following are true:
+
+1. Harbor package version is exactly `0.22.0`.
+2. Docker engine access works for Harbor trial sandboxes.
+3. A provider credential is present in the process environment for the pinned
+   ChaosGauge agent.
+4. Owner authorization for the full 120-trial public calibration budget is
+   granted through `CHAOS_GAUGE_PUBLIC_CALIBRATION_AUTHORIZED=1`.
+
+The excluded public canary workflow is not this campaign. It authorizes only
+one public task and two accounted arms under a separate token budget and must
+not be reused as silent permission for 120 paid trials.
+
+Probe command:
+
+```bash
+python3 scripts/ci/chaos_gauge/decision_quality_calibration.py probe
+```
+
+Blocked evidence command (records exact missing inputs, observed trials = 0):
+
+```bash
+python3 scripts/ci/chaos_gauge/decision_quality_calibration.py blocked --out /tmp/dq-calibration-blocked.json
+```
+
+---
+
+## Evidence status for #5522
+
+Live probe in the implementing environment found the campaign blocked. Exact
+missing inputs:
+
+1. `harbor==0.22.0`
+2. `docker-engine-access`
+3. `OPENAI_API_KEY`
+4. `CHAOS_GAUGE_PUBLIC_CALIBRATION_AUTHORIZED=1` (owner-authorized 120-trial
+   public calibration budget)
+
+**120 paid trials did not run.** No trial metrics were invented. The landable
+slice for this issue is the harness wiring, redacted aggregate schema, blocked
+evidence path, and focused regressions above.
+
+When the four inputs are supplied, rerun the existing ChaosGauge calibration
+launcher/collector/compare path, then:
+
+```bash
+python3 scripts/ci/chaos_gauge/decision_quality_calibration.py build \
+  --comparison /path/to/comparison.json \
+  --collect-receipt /path/to/collect.json \
+  --out /path/to/redacted-aggregate.json
+```
+
+Preserve only secret-scanned redacted aggregate evidence in git or public
+comments.
+
+---
+
+## Rollback
+
+Delete this artifact, `scripts/ci/chaos_gauge/decision_quality_calibration.py`,
+and `tests/scripts/test_decision_quality_calibration.py`, then refresh ChaosGauge
+harness digests if the `chaos-engine/` tree hash changes. Baseline and rubric
+artifacts remain owned by #5520 and #5521.

--- a/scripts/ci/chaos_gauge/decision_quality_calibration.py
+++ b/scripts/ci/chaos_gauge/decision_quality_calibration.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Map ChaosGauge public calibration outputs to redacted decision-quality evidence.
+"""
+Map ChaosGauge public calibration outputs to redacted decision-quality evidence.
 
 Reuses the immutable #5450 calibration campaign (12 public tasks, two arms, five
 attempts, seed 5450) without changing task identities. Missing telemetry is the
@@ -13,7 +14,7 @@ import argparse
 import json
 import os
 import re
-import subprocess
+import subprocess  # nosec B404 - fixed local harbor/docker probe commands only.
 from pathlib import Path
 from typing import Callable
 
@@ -56,7 +57,9 @@ def _object(value: object, label: str) -> dict[str, object]:
 
 
 def _run(command: list[str]) -> str:
-    return subprocess.run(command, check=True, capture_output=True, text=True).stdout  # nosec B603
+    return subprocess.run(  # nosec B603 B607 - fixed local probe argv, never shell=True.
+        command, check=True, capture_output=True, text=True
+    ).stdout
 
 
 def load_manifest(path: Path | None = None) -> dict[str, object]:
@@ -312,14 +315,7 @@ def _walk_strings(value: object) -> list[str]:
     return []
 
 
-def validate_redacted_aggregate(value: object, manifest: object) -> None:
-    """Fail closed on identity drift, zero-filled gaps, or privacy leaks."""
-    evidence = _object(value, "redacted aggregate")
-    identity = calibration_identity(manifest)
-    if evidence.get("schemaVersion") != 1 or evidence.get("campaign") != "calibration":
-        raise ValueError("redacted aggregate schema is invalid")
-    if evidence.get("identity") != identity:
-        raise ValueError("redacted aggregate identity drifted from #5450 contracts")
+def _validate_trial_accounting(evidence: dict[str, object]) -> None:
     accounting = _object(evidence.get("trialAccounting"), "trial accounting")
     if accounting.get("planned") != TRIAL_COUNT:
         raise ValueError("redacted aggregate planned trial count is invalid")
@@ -333,6 +329,9 @@ def validate_redacted_aggregate(value: object, manifest: object) -> None:
         raise ValueError("blocked evidence must not claim observed trials")
     if status == "blocked" and not evidence.get("missingInputs"):
         raise ValueError("blocked evidence must list exact missing inputs")
+
+
+def _validate_arm_metrics(evidence: dict[str, object]) -> None:
     metrics = _object(evidence.get("metrics"), "metrics")
     if set(metrics) != set(ARMS):
         raise ValueError("redacted aggregate arms are invalid")
@@ -345,10 +344,26 @@ def validate_redacted_aggregate(value: object, manifest: object) -> None:
                 raise ValueError(f"{arm}.{name} must use UNAVAILABLE rather than null")
             if item != UNAVAILABLE and not isinstance(item, (int, float)):
                 raise ValueError(f"{arm}.{name} is invalid")
+
+
+def _validate_privacy(evidence: dict[str, object]) -> None:
     for text in _walk_strings(evidence):
         for pattern in FORBIDDEN_PRIVACY:
             if pattern.search(text):
                 raise ValueError("redacted aggregate failed privacy scan")
+
+
+def validate_redacted_aggregate(value: object, manifest: object) -> None:
+    """Fail closed on identity drift, zero-filled gaps, or privacy leaks."""
+    evidence = _object(value, "redacted aggregate")
+    identity = calibration_identity(manifest)
+    if evidence.get("schemaVersion") != 1 or evidence.get("campaign") != "calibration":
+        raise ValueError("redacted aggregate schema is invalid")
+    if evidence.get("identity") != identity:
+        raise ValueError("redacted aggregate identity drifted from #5450 contracts")
+    _validate_trial_accounting(evidence)
+    _validate_arm_metrics(evidence)
+    _validate_privacy(evidence)
 
 
 def main() -> int:

--- a/scripts/ci/chaos_gauge/decision_quality_calibration.py
+++ b/scripts/ci/chaos_gauge/decision_quality_calibration.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Map ChaosGauge public calibration outputs to redacted decision-quality evidence.
+
+Reuses the immutable #5450 calibration campaign (12 public tasks, two arms, five
+attempts, seed 5450) without changing task identities. Missing telemetry is the
+literal string UNAVAILABLE and is never coerced to zero. Blocked runs record
+exact missing runtime inputs instead of inventing trial results.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+
+ROOT = Path(__file__).resolve().parent
+UNAVAILABLE = "UNAVAILABLE"
+ARMS = ("control", "chaos-engine")
+CALIBRATION_METRICS = (
+    "correctness",
+    "tokens",
+    "latency_seconds",
+    "external_run_minutes",
+    "actions",
+    "retries",
+    "cost_usd",
+    "variance",
+)
+PUBLIC_TASK_COUNT = 12
+ATTEMPTS_PER_TASK = 5
+TRIAL_COUNT = 120
+SEED = 5450
+HARBOR_VERSION = "0.22.0"
+AUTHORIZATION_ENV = "CHAOS_GAUGE_PUBLIC_CALIBRATION_AUTHORIZED"
+FORBIDDEN_PRIVACY = (
+    re.compile(r"model_id\s*:", re.I),
+    re.compile(r"provider_route\s*:", re.I),
+    re.compile(r"endpoint\s*:", re.I),
+    re.compile(r"anthropic\.com/", re.I),
+    re.compile(r"openai\.com/", re.I),
+    re.compile(r"prompt content", re.I),
+    re.compile(r"session transcript", re.I),
+    re.compile(r"~/\."),
+)
+
+
+def _object(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} is invalid")
+    return value
+
+
+def _run(command: list[str]) -> str:
+    return subprocess.run(command, check=True, capture_output=True, text=True).stdout  # nosec B603
+
+
+def load_manifest(path: Path | None = None) -> dict[str, object]:
+    target = ROOT / "experiment.json" if path is None else Path(path)
+    return _object(json.loads(target.read_text(encoding="utf-8")), "experiment manifest")
+
+
+def public_tasks(manifest: object) -> list[dict[str, object]]:
+    value = _object(manifest, "experiment manifest")
+    tasks = [
+        _object(task, "task")
+        for task in value.get("tasks", [])
+        if isinstance(task, dict) and task.get("visibility") == "public"
+    ]
+    return tasks
+
+
+def calibration_identity(manifest: object) -> dict[str, object]:
+    """Freeze the public calibration identity surface from the live manifest."""
+    value = _object(manifest, "experiment manifest")
+    selected = _object(_object(value.get("campaigns"), "campaigns").get("calibration"), "calibration")
+    tasks = public_tasks(value)
+    if (
+        value.get("seed") != SEED
+        or value.get("attemptsPerTask") != ATTEMPTS_PER_TASK
+        or selected.get("taskCount") != PUBLIC_TASK_COUNT
+        or selected.get("taskVisibility") != ["public"]
+        or selected.get("privateResolutionRequired") is not False
+        or len(tasks) != PUBLIC_TASK_COUNT
+        or len(tasks) * 2 * ATTEMPTS_PER_TASK != TRIAL_COUNT
+    ):
+        raise ValueError("calibration identity drifted from #5450 public contracts")
+    arms = [_object(arm, "arm").get("name") for arm in value.get("arms", []) if isinstance(arm, dict)]
+    if arms != list(ARMS):
+        raise ValueError("calibration arm identity is invalid")
+    return {
+        "seed": SEED,
+        "campaign": "calibration",
+        "taskCount": PUBLIC_TASK_COUNT,
+        "attemptsPerTask": ATTEMPTS_PER_TASK,
+        "trialCount": TRIAL_COUNT,
+        "arms": list(ARMS),
+        "taskVisibility": ["public"],
+        "implementationRevision": value.get("implementationRevision"),
+        "tasks": [{"name": task["name"], "sha256": task["sha256"]} for task in tasks],
+    }
+
+
+def metric_or_unavailable(value: object) -> object:
+    """Return UNAVAILABLE for missing telemetry; never coerce absence to zero."""
+    if value is None:
+        return UNAVAILABLE
+    if isinstance(value, bool):
+        raise ValueError("boolean telemetry is invalid")
+    if isinstance(value, (int, float)):
+        if value != value or value in (float("inf"), float("-inf")):  # noqa: PLR0124
+            return UNAVAILABLE
+        return value
+    if value == UNAVAILABLE:
+        return UNAVAILABLE
+    raise ValueError("metric value is invalid")
+
+
+def unavailable_arm_metrics(*, retries: object = UNAVAILABLE) -> dict[str, object]:
+    values = {name: UNAVAILABLE for name in CALIBRATION_METRICS}
+    values["retries"] = metric_or_unavailable(retries)
+    return values
+
+
+def probe_runtime(run: Callable[[list[str]], str] = _run) -> dict[str, object]:
+    """Return exact missing inputs required before paid public calibration may start."""
+    missing: list[str] = []
+    details: dict[str, object] = {}
+
+    try:
+        harbor = run(
+            ["python3", "-c", "from importlib.metadata import version; print(version('harbor'))"]
+        ).strip()
+        details["harborVersion"] = harbor
+        if harbor != HARBOR_VERSION:
+            missing.append(f"harbor=={HARBOR_VERSION} (found {harbor or 'none'})")
+    except (OSError, subprocess.CalledProcessError):
+        details["harborVersion"] = UNAVAILABLE
+        missing.append(f"harbor=={HARBOR_VERSION}")
+
+    try:
+        docker = run(["docker", "version", "--format", "{{.Server.Version}}"]).strip()
+        details["dockerServerVersion"] = docker or UNAVAILABLE
+        if not docker:
+            missing.append("docker-engine-access")
+    except (OSError, subprocess.CalledProcessError):
+        details["dockerServerVersion"] = UNAVAILABLE
+        missing.append("docker-engine-access")
+
+    provider = os.environ.get("OPENAI_API_KEY", "").strip()
+    details["providerCredential"] = "present" if provider else UNAVAILABLE
+    if not provider:
+        missing.append("OPENAI_API_KEY")
+
+    authorized = os.environ.get(AUTHORIZATION_ENV, "").strip() == "1"
+    details["campaignAuthorization"] = "granted" if authorized else UNAVAILABLE
+    if not authorized:
+        missing.append(
+            f"{AUTHORIZATION_ENV}=1 (owner-authorized 120-trial public calibration budget)"
+        )
+
+    return {
+        "ready": not missing,
+        "missingInputs": missing,
+        "details": details,
+        "plannedTrials": TRIAL_COUNT,
+    }
+
+
+def _arm_metrics(comparison_arm: object, retries: object) -> dict[str, object]:
+    arm = _object(comparison_arm, "comparison arm")
+    provenance = arm.get("tokenProvenance")
+    tokens = arm.get("tokensPerSuccess") if provenance == "reported" else None
+    return {
+        "correctness": metric_or_unavailable(arm.get("effectiveness")),
+        "tokens": metric_or_unavailable(tokens),
+        "latency_seconds": metric_or_unavailable(arm.get("secondsPerSuccess")),
+        "external_run_minutes": UNAVAILABLE,
+        "actions": UNAVAILABLE,
+        "retries": metric_or_unavailable(retries),
+        "cost_usd": metric_or_unavailable(arm.get("costPerSuccess")),
+        "variance": UNAVAILABLE,
+    }
+
+
+def _comparison_variance(interval: object) -> object:
+    bounds = _object(interval, "confidence interval")
+    lower = metric_or_unavailable(bounds.get("lower"))
+    upper = metric_or_unavailable(bounds.get("upper"))
+    if lower is UNAVAILABLE or upper is UNAVAILABLE:
+        return UNAVAILABLE
+    if not isinstance(lower, (int, float)) or not isinstance(upper, (int, float)):
+        return UNAVAILABLE
+    return upper - lower
+
+
+def build_redacted_aggregate(
+    manifest: object,
+    comparison: object,
+    *,
+    collect_receipt: object | None = None,
+) -> dict[str, object]:
+    """Build secret-scanned redacted aggregate evidence from ChaosGauge compare output."""
+    identity = calibration_identity(manifest)
+    report = _object(comparison, "comparison report")
+    if report.get("campaign") != "calibration":
+        raise ValueError("comparison campaign is not calibration")
+    arms = _object(report.get("arms"), "comparison arms")
+    if set(arms) != set(ARMS):
+        raise ValueError("comparison arms are invalid")
+    retries = _object(report.get("retries"), "comparison retries")
+    interval = _object(report.get("confidenceInterval95"), "confidence interval")
+    variance = _comparison_variance(interval)
+    metrics = {}
+    for arm in ARMS:
+        values = _arm_metrics(arms[arm], retries.get(arm))
+        values["variance"] = variance
+        metrics[arm] = values
+    # Never invent observed=120. Without a collect receipt, observed stays 0.
+    observed = 0
+    if collect_receipt is not None:
+        receipt = _object(collect_receipt, "collect receipt")
+        accounting = _object(receipt.get("trialAccounting"), "trial accounting")
+        observed_value = accounting.get("observed")
+        if isinstance(observed_value, bool) or not isinstance(observed_value, int) or observed_value < 0:
+            raise ValueError("collect receipt trial accounting is invalid")
+        observed = observed_value
+    status = "complete" if observed == TRIAL_COUNT else "incomplete"
+    score_delta = report.get("scoreDelta")
+    evidence = {
+        "schemaVersion": 1,
+        "campaign": "calibration",
+        "status": status,
+        "identity": identity,
+        "trialAccounting": {"planned": TRIAL_COUNT, "observed": observed},
+        "missingInputs": [],
+        "metrics": metrics,
+        "comparison": {
+            "verdict": _object(report.get("verdict"), "verdict"),
+            "scoreDelta": metric_or_unavailable(score_delta),
+            "confidenceInterval95": {
+                "lower": metric_or_unavailable(interval.get("lower")),
+                "upper": metric_or_unavailable(interval.get("upper")),
+            },
+            "scoreVersion": report.get("scoreVersion"),
+            "bootstrapIterations": report.get("bootstrapIterations"),
+        },
+        "privacy": {
+            "prompts": False,
+            "transcripts": False,
+            "secrets": False,
+            "privatePaths": False,
+            "providerRoutes": False,
+            "modelIds": False,
+        },
+    }
+    validate_redacted_aggregate(evidence, manifest)
+    return evidence
+
+
+def blocked_evidence(manifest: object, missing_inputs: list[str]) -> dict[str, object]:
+    """Emit honest blocked evidence with planned trials and UNAVAILABLE metrics only."""
+    if not missing_inputs:
+        raise ValueError("blocked evidence requires exact missing inputs")
+    identity = calibration_identity(manifest)
+    evidence = {
+        "schemaVersion": 1,
+        "campaign": "calibration",
+        "status": "blocked",
+        "identity": identity,
+        "trialAccounting": {"planned": TRIAL_COUNT, "observed": 0},
+        "missingInputs": list(missing_inputs),
+        "metrics": {arm: unavailable_arm_metrics() for arm in ARMS},
+        "comparison": {
+            "verdict": {"state": "insufficient evidence", "winner": None},
+            "scoreDelta": UNAVAILABLE,
+            "confidenceInterval95": {"lower": UNAVAILABLE, "upper": UNAVAILABLE},
+            "scoreVersion": UNAVAILABLE,
+            "bootstrapIterations": UNAVAILABLE,
+        },
+        "privacy": {
+            "prompts": False,
+            "transcripts": False,
+            "secrets": False,
+            "privatePaths": False,
+            "providerRoutes": False,
+            "modelIds": False,
+        },
+    }
+    validate_redacted_aggregate(evidence, manifest)
+    return evidence
+
+
+def _walk_strings(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        found: list[str] = []
+        for key, item in value.items():
+            found.extend(_walk_strings(str(key)))
+            found.extend(_walk_strings(item))
+        return found
+    if isinstance(value, list):
+        found = []
+        for item in value:
+            found.extend(_walk_strings(item))
+        return found
+    return []
+
+
+def validate_redacted_aggregate(value: object, manifest: object) -> None:
+    """Fail closed on identity drift, zero-filled gaps, or privacy leaks."""
+    evidence = _object(value, "redacted aggregate")
+    identity = calibration_identity(manifest)
+    if evidence.get("schemaVersion") != 1 or evidence.get("campaign") != "calibration":
+        raise ValueError("redacted aggregate schema is invalid")
+    if evidence.get("identity") != identity:
+        raise ValueError("redacted aggregate identity drifted from #5450 contracts")
+    accounting = _object(evidence.get("trialAccounting"), "trial accounting")
+    if accounting.get("planned") != TRIAL_COUNT:
+        raise ValueError("redacted aggregate planned trial count is invalid")
+    observed = accounting.get("observed")
+    if isinstance(observed, bool) or not isinstance(observed, int) or observed < 0 or observed > TRIAL_COUNT:
+        raise ValueError("redacted aggregate observed trial count is invalid")
+    status = evidence.get("status")
+    if status not in {"blocked", "incomplete", "complete"}:
+        raise ValueError("redacted aggregate status is invalid")
+    if status == "blocked" and observed != 0:
+        raise ValueError("blocked evidence must not claim observed trials")
+    if status == "blocked" and not evidence.get("missingInputs"):
+        raise ValueError("blocked evidence must list exact missing inputs")
+    metrics = _object(evidence.get("metrics"), "metrics")
+    if set(metrics) != set(ARMS):
+        raise ValueError("redacted aggregate arms are invalid")
+    for arm in ARMS:
+        arm_metrics = _object(metrics[arm], f"{arm} metrics")
+        if set(arm_metrics) != set(CALIBRATION_METRICS):
+            raise ValueError(f"{arm} metric set is invalid")
+        for name, item in arm_metrics.items():
+            if item is None:
+                raise ValueError(f"{arm}.{name} must use UNAVAILABLE rather than null")
+            if item != UNAVAILABLE and not isinstance(item, (int, float)):
+                raise ValueError(f"{arm}.{name} is invalid")
+    for text in _walk_strings(evidence):
+        for pattern in FORBIDDEN_PRIVACY:
+            if pattern.search(text):
+                raise ValueError("redacted aggregate failed privacy scan")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("probe", "blocked", "build", "validate"))
+    parser.add_argument("--manifest", type=Path, default=ROOT / "experiment.json")
+    parser.add_argument("--comparison", type=Path)
+    parser.add_argument("--collect-receipt", type=Path)
+    parser.add_argument("--evidence", type=Path)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+    manifest = load_manifest(args.manifest)
+    if args.command == "probe":
+        print(json.dumps(probe_runtime(), sort_keys=True, indent=2))
+        return 0
+    if args.command == "blocked":
+        probe = probe_runtime()
+        evidence = blocked_evidence(manifest, list(probe["missingInputs"]))
+        payload = json.dumps(evidence, sort_keys=True, indent=2) + "\n"
+        if args.out is None:
+            print(payload, end="")
+        else:
+            args.out.write_text(payload, encoding="utf-8")
+        return 0
+    if args.command == "build":
+        if args.comparison is None:
+            raise ValueError("comparison JSON is required")
+        comparison = json.loads(args.comparison.read_text(encoding="utf-8"))
+        collect = (
+            None
+            if args.collect_receipt is None
+            else json.loads(args.collect_receipt.read_text(encoding="utf-8"))
+        )
+        evidence = build_redacted_aggregate(manifest, comparison, collect_receipt=collect)
+        payload = json.dumps(evidence, sort_keys=True, indent=2) + "\n"
+        if args.out is None:
+            print(payload, end="")
+        else:
+            args.out.write_text(payload, encoding="utf-8")
+        return 0
+    if args.evidence is None:
+        raise ValueError("evidence JSON is required")
+    validate_redacted_aggregate(json.loads(args.evidence.read_text(encoding="utf-8")), manifest)
+    print("ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "ee40eca24611ace28a4c1b2c55e986577433f015f7a938eee571f15e02210b91",
+      "harnessSha256": "87c641c706eb29a01e3d83fc17c34500b38b1fb81123a71098502198b9764f10",
       "treatmentSha256": {
-        "calibration": "a7ef53754725276740ec724bef5080f52eb47762b02aef095735ff40a7fd49cc",
-        "full-pilot": "5f34fb120b8e1181e0f8d46ad6f3ed58411ddfcf11c7a98ec95f957b769d1d6b"
+        "calibration": "e167d9e7d1ce840380a7cd1deee7c44f274510c74f95d8a3c18e0d3a549ccbf5",
+        "full-pilot": "f29e96f65b1fd1d2a76cb0db509c199b500aa27a1c6e9a21d2c9fe988847b67e"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "ee40eca24611ace28a4c1b2c55e986577433f015f7a938eee571f15e02210b91"
+      harness_sha256: "87c641c706eb29a01e3d83fc17c34500b38b1fb81123a71098502198b9764f10"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "ee40eca24611ace28a4c1b2c55e986577433f015f7a938eee571f15e02210b91"
+      harness_sha256: "87c641c706eb29a01e3d83fc17c34500b38b1fb81123a71098502198b9764f10"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -51,6 +51,7 @@ ALLOWED_EXACT = {
     "chaos-engine/RESEARCH.md",
     "chaos-engine/decision-quality-baseline.md",
     "chaos-engine/decision-quality-rubric.md",
+    "chaos-engine/decision-quality-calibration.md",
     "chaos-engine/STANDALONE.md",
     "chaos-engine/INSTALL.md",
     "chaos-engine/THIRD_PARTY_NOTICES.md",

--- a/tests/scripts/test_chaos_gauge_recovery.py
+++ b/tests/scripts/test_chaos_gauge_recovery.py
@@ -12,9 +12,9 @@ CHAOS_GAUGE = ROOT / "scripts" / "ci" / "chaos_gauge"
 # additions update this complete inventory together with their task digests.
 # This covers the full public ChaosGauge tree, unlike representative anchors
 # that can remain after an executable or dataset member is lost.
-RECOVERED_PUBLIC_FILE_COUNT = 155
+RECOVERED_PUBLIC_FILE_COUNT = 156
 RECOVERED_PUBLIC_PATHS_SHA256 = (
-    "f78b7b36aa37371c1c8304054585417faece9b5dda3f92ade50737c51af402b8"
+    "6f376745c8bf415af551c818ae7972cfcffbb03fcfe8d6898656edb78def5f9b"
 )
 GENERATED_PUBLIC_PARTS = frozenset({"jobs", "reports", "private", "__pycache__"})
 

--- a/tests/scripts/test_decision_quality_calibration.py
+++ b/tests/scripts/test_decision_quality_calibration.py
@@ -1,0 +1,276 @@
+"""Behavioral regression for decision-quality public calibration (#5522)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GAUGE = ROOT / "scripts/ci/chaos_gauge"
+ARTIFACT = ROOT / "chaos-engine/decision-quality-calibration.md"
+MODULE_PATH = GAUGE / "decision_quality_calibration.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("decision_quality_calibration", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("decision_quality_calibration module is unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = load_module()
+
+
+class ArtifactContractTest(unittest.TestCase):
+    def setUp(self):
+        self.content = ARTIFACT.read_text(encoding="utf-8")
+
+    def test_artifact_exists_and_is_dated(self):
+        self.assertTrue(ARTIFACT.exists())
+        self.assertRegex(self.content, r"Accessed:\s+\d{4}-\d{2}-\d{2}")
+
+    def test_references_parent_and_siblings(self):
+        for marker in ("#5514", "#5522", "#5520", "#5521", "decision-quality-baseline.md", "decision-quality-rubric.md"):
+            self.assertIn(marker, self.content)
+
+    def test_records_that_trials_did_not_run(self):
+        self.assertIn("120 paid trials did not run", self.content)
+
+    def test_unavailable_policy_and_privacy_gate(self):
+        self.assertIn("UNAVAILABLE", self.content)
+        lower = self.content.lower()
+        self.assertNotIn("never zero", lower)
+        for pattern in (r"model_id\s*:", r"provider_route\s*:", r"endpoint\s*:", r"anthropic\.com/", r"openai\.com/"):
+            self.assertIsNone(re.search(pattern, self.content, re.I))
+
+
+class CalibrationIdentityTest(unittest.TestCase):
+    def setUp(self):
+        self.manifest = MODULE.load_manifest()
+        self.identity = MODULE.calibration_identity(self.manifest)
+
+    def test_frozen_public_identity(self):
+        self.assertEqual(5450, self.identity["seed"])
+        self.assertEqual(12, self.identity["taskCount"])
+        self.assertEqual(5, self.identity["attemptsPerTask"])
+        self.assertEqual(120, self.identity["trialCount"])
+        self.assertEqual(["control", "chaos-engine"], self.identity["arms"])
+        self.assertEqual(12, len(self.identity["tasks"]))
+
+    def test_public_task_names_unchanged(self):
+        expected = [
+            task["name"]
+            for task in self.manifest["tasks"]
+            if task["visibility"] == "public"
+        ]
+        self.assertEqual(expected, [task["name"] for task in self.identity["tasks"]])
+        self.assertEqual(
+            [task["sha256"] for task in self.manifest["tasks"] if task["visibility"] == "public"],
+            [task["sha256"] for task in self.identity["tasks"]],
+        )
+
+
+class UnavailablePolicyTest(unittest.TestCase):
+    def test_none_becomes_unavailable_not_zero(self):
+        self.assertEqual(MODULE.UNAVAILABLE, MODULE.metric_or_unavailable(None))
+        self.assertEqual(0, MODULE.metric_or_unavailable(0))
+        self.assertEqual(1.5, MODULE.metric_or_unavailable(1.5))
+
+    def test_blocked_evidence_uses_unavailable(self):
+        evidence = MODULE.blocked_evidence(
+            MODULE.load_manifest(),
+            ["harbor==0.22.0", "docker-engine-access"],
+        )
+        self.assertEqual("blocked", evidence["status"])
+        self.assertEqual({"planned": 120, "observed": 0}, evidence["trialAccounting"])
+        for arm in MODULE.ARMS:
+            for name, value in evidence["metrics"][arm].items():
+                self.assertEqual(
+                    MODULE.UNAVAILABLE,
+                    value,
+                    f"{arm}.{name} must stay UNAVAILABLE when blocked",
+                )
+                self.assertIsNot(value, 0)
+                self.assertIsNotNone(value)
+
+    def test_missing_token_provenance_stays_unavailable(self):
+        comparison = {
+            "schemaVersion": 1,
+            "scoreVersion": "chaos-gauge-60-20-20-v1",
+            "bootstrapIterations": 10000,
+            "seed": 5450,
+            "campaign": "calibration",
+            "arms": {
+                "control": {
+                    "sampleSize": 60,
+                    "successCount": 30,
+                    "effectiveness": 0.5,
+                    "reliability": 0.5,
+                    "safetyEligible": True,
+                    "verifierComplete": True,
+                    "tokenProvenance": "unavailable",
+                    "tokensPerSuccess": None,
+                    "secondsPerSuccess": 12.0,
+                    "costPerSuccess": None,
+                    "efficiency": None,
+                    "overallScore": None,
+                    "equalWeightScore": None,
+                },
+                "chaos-engine": {
+                    "sampleSize": 60,
+                    "successCount": 36,
+                    "effectiveness": 0.6,
+                    "reliability": 0.6,
+                    "safetyEligible": True,
+                    "verifierComplete": True,
+                    "tokenProvenance": "unavailable",
+                    "tokensPerSuccess": None,
+                    "secondsPerSuccess": 10.0,
+                    "costPerSuccess": None,
+                    "efficiency": None,
+                    "overallScore": None,
+                    "equalWeightScore": None,
+                },
+            },
+            "scoreDelta": None,
+            "confidenceInterval95": {"lower": None, "upper": None},
+            "verdict": {"state": "insufficient evidence", "winner": None},
+            "retries": {"control": 1, "chaos-engine": 2},
+            "exclusions": [],
+            "pairAccounting": {"planned": 60, "excluded": 0, "analyzed": 60},
+        }
+        evidence = MODULE.build_redacted_aggregate(MODULE.load_manifest(), comparison)
+        self.assertEqual({"planned": 120, "observed": 0}, evidence["trialAccounting"])
+        self.assertEqual("incomplete", evidence["status"])
+        self.assertEqual(MODULE.UNAVAILABLE, evidence["metrics"]["control"]["tokens"])
+        self.assertEqual(MODULE.UNAVAILABLE, evidence["metrics"]["control"]["cost_usd"])
+        self.assertEqual(MODULE.UNAVAILABLE, evidence["metrics"]["control"]["actions"])
+        self.assertEqual(MODULE.UNAVAILABLE, evidence["metrics"]["control"]["external_run_minutes"])
+        self.assertEqual(MODULE.UNAVAILABLE, evidence["metrics"]["control"]["variance"])
+        self.assertEqual(0.5, evidence["metrics"]["control"]["correctness"])
+        self.assertEqual(1, evidence["metrics"]["control"]["retries"])
+        self.assertEqual(MODULE.UNAVAILABLE, evidence["comparison"]["scoreDelta"])
+        self.assertNotEqual(0, evidence["metrics"]["control"]["tokens"])
+
+    def test_build_requires_collect_receipt_for_observed_trials(self):
+        comparison = {
+            "schemaVersion": 1,
+            "scoreVersion": "chaos-gauge-60-20-20-v1",
+            "bootstrapIterations": 10000,
+            "seed": 5450,
+            "campaign": "calibration",
+            "arms": {
+                "control": {
+                    "sampleSize": 60,
+                    "successCount": 30,
+                    "effectiveness": 0.5,
+                    "reliability": 0.5,
+                    "safetyEligible": True,
+                    "verifierComplete": True,
+                    "tokenProvenance": "reported",
+                    "tokensPerSuccess": 100,
+                    "secondsPerSuccess": 12.0,
+                    "costPerSuccess": 0.01,
+                    "efficiency": 1.0,
+                    "overallScore": 0.5,
+                    "equalWeightScore": 0.5,
+                },
+                "chaos-engine": {
+                    "sampleSize": 60,
+                    "successCount": 36,
+                    "effectiveness": 0.6,
+                    "reliability": 0.6,
+                    "safetyEligible": True,
+                    "verifierComplete": True,
+                    "tokenProvenance": "reported",
+                    "tokensPerSuccess": 90,
+                    "secondsPerSuccess": 10.0,
+                    "costPerSuccess": 0.009,
+                    "efficiency": 1.1,
+                    "overallScore": 0.6,
+                    "equalWeightScore": 0.6,
+                },
+            },
+            "scoreDelta": 0.1,
+            "confidenceInterval95": {"lower": 0.01, "upper": 0.2},
+            "verdict": {"state": "significant", "winner": "chaos-engine"},
+            "retries": {"control": 1, "chaos-engine": 2},
+            "exclusions": [],
+            "pairAccounting": {"planned": 60, "excluded": 0, "analyzed": 60},
+        }
+        without_receipt = MODULE.build_redacted_aggregate(MODULE.load_manifest(), comparison)
+        self.assertEqual(0, without_receipt["trialAccounting"]["observed"])
+        self.assertEqual("incomplete", without_receipt["status"])
+
+        with_receipt = MODULE.build_redacted_aggregate(
+            MODULE.load_manifest(),
+            comparison,
+            collect_receipt={"trialAccounting": {"planned": 120, "observed": 120}},
+        )
+        self.assertEqual({"planned": 120, "observed": 120}, with_receipt["trialAccounting"])
+        self.assertEqual("complete", with_receipt["status"])
+        self.assertEqual(100, with_receipt["metrics"]["control"]["tokens"])
+
+
+class ProbeAndValidateTest(unittest.TestCase):
+    def test_probe_reports_exact_missing_inputs(self):
+        def fake_run(command):
+            raise OSError("unavailable")
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            probe = MODULE.probe_runtime(run=fake_run)
+        self.assertFalse(probe["ready"])
+        joined = " | ".join(probe["missingInputs"])
+        self.assertIn("harbor==0.22.0", joined)
+        self.assertIn("docker-engine-access", joined)
+        self.assertIn("OPENAI_API_KEY", joined)
+        self.assertIn("CHAOS_GAUGE_PUBLIC_CALIBRATION_AUTHORIZED=1", joined)
+        self.assertEqual(120, probe["plannedTrials"])
+
+    def test_validate_rejects_null_metrics_and_privacy_leaks(self):
+        evidence = MODULE.blocked_evidence(MODULE.load_manifest(), ["harbor==0.22.0"])
+        evidence["metrics"]["control"]["tokens"] = None
+        with self.assertRaisesRegex(ValueError, "UNAVAILABLE rather than null"):
+            MODULE.validate_redacted_aggregate(evidence, MODULE.load_manifest())
+
+        evidence = MODULE.blocked_evidence(MODULE.load_manifest(), ["harbor==0.22.0"])
+        evidence["missingInputs"] = ["see openai.com/docs"]
+        with self.assertRaisesRegex(ValueError, "privacy scan"):
+            MODULE.validate_redacted_aggregate(evidence, MODULE.load_manifest())
+
+    def test_cli_blocked_writes_json(self):
+        import subprocess
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temporary:
+            out = Path(temporary) / "blocked.json"
+            completed = subprocess.run(
+                [
+                    "python3",
+                    str(MODULE_PATH),
+                    "blocked",
+                    "--out",
+                    str(out),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "OPENAI_API_KEY": "", "CHAOS_GAUGE_PUBLIC_CALIBRATION_AUTHORIZED": ""},
+            )
+            self.assertEqual(0, completed.returncode)
+            payload = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual("blocked", payload["status"])
+            self.assertEqual(0, payload["trialAccounting"]["observed"])
+            self.assertGreaterEqual(len(payload["missingInputs"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_decision_quality_calibration.py
+++ b/tests/scripts/test_decision_quality_calibration.py
@@ -247,14 +247,15 @@ class ProbeAndValidateTest(unittest.TestCase):
             MODULE.validate_redacted_aggregate(evidence, MODULE.load_manifest())
 
     def test_cli_blocked_writes_json(self):
-        import subprocess
+        import subprocess  # nosec B404 - fixed local module CLI under sys.executable.
+        import sys
         import tempfile
 
         with tempfile.TemporaryDirectory() as temporary:
             out = Path(temporary) / "blocked.json"
-            completed = subprocess.run(
+            completed = subprocess.run(  # nosec B603 - fixed interpreter and repository module path.
                 [
-                    "python3",
+                    sys.executable,
                     str(MODULE_PATH),
                     "blocked",
                     "--out",

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -104,6 +104,10 @@ flowchart LR
             "chaos-engine/decision-quality-rubric.md",
             "# Decision-quality rubric\n",
         )
+        self.write(
+            "chaos-engine/decision-quality-calibration.md",
+            "# Decision-quality calibration\n",
+        )
         self.write("chaos-engine/STANDALONE.md", "# Spec\n")
         self.write("chaos-engine/INSTALL.md", "# Install\n")
         self.write("chaos-engine/THIRD_PARTY_NOTICES.md", "# Notices\n")


### PR DESCRIPTION
## Summary
- Lands the issue 5522 decision-quality public calibration harness and redacted aggregate schema on top of immutable issue 5450 public contracts.
- Runtime probe is blocked (Harbor 0.22.0 missing, Docker engine access denied, provider credential absent, and no owner authorization for the 120-trial budget), so 120 paid trials did not run. Issue 5522 stays open; this PR is Refs-only for that issue.
- `build_redacted_aggregate` no longer defaults `observed=120` without a collect receipt; blocked evidence keeps `planned=120`, `observed=0`, and metrics as `UNAVAILABLE` (never substituted with 0).
- Allowlists `chaos-engine/decision-quality-calibration.md` and refreshes ChaosGauge harness digests.
- Refreshes the ChaosGauge public recovery inventory for `decision_quality_calibration.py`.

Related: issue 5522.

## Checks
- [x] `python3 -m unittest tests.scripts.test_chaos_gauge_recovery tests.scripts.test_chaos_gauge_contracts tests.scripts.test_decision_quality_calibration -q` (OK)
- [x] `python3 scripts/ci/chaos_gauge/validate_experiment.py scripts/ci/chaos_gauge/experiment.json`

## Continuation
- Parent epic issue 5514 remains open.
- Issue 5522 remains open until Harbor, Docker, credential, and authorized 120-trial budget are available and the campaign actually runs.