### PR TITLE
docs(chaos-engine): publish decision-quality report and README evidence

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -141,6 +141,7 @@ sends you there; the rest by
 - [decision-quality rubric](../../chaos-engine/decision-quality-rubric.md)
 - [decision-quality calibration](../../chaos-engine/decision-quality-calibration.md)
 - [decision-quality calibration aggregate](../../chaos-engine/decision-quality-calibration.aggregate.json)
+- [decision-quality report](../../chaos-engine/decision-quality-report.md)
 - [task isolation](../../chaos-engine/references/task-isolation.md)
 - [verification-gap lens](../../chaos-engine/references/verification-gap-lens.md)
 - [reflection checkpoints](../../chaos-engine/references/reflection-checkpoints.md)

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -158,6 +158,49 @@ never installs, configures, starts, or authenticates OmniRoute. An absent or
 unqualified gateway leaves every normal workflow valid through native
 implementers or `SOLO`.
 
+## OmniRoute decision-quality evidence
+
+Transparent side-by-side results from the free OmniRoute walking skeleton
+(#5522 / #5465). Values below are generated from the committed aggregate and
+are published regardless of positive, neutral, negative, or inconclusive
+outcome.
+
+<!-- evidence:omniroute-calibration:start -->
+This section is generated from
+[`chaos-engine/decision-quality-calibration.aggregate.json`](decision-quality-calibration.aggregate.json).
+Do not hand-edit the numbers; refresh with
+`python3 scripts/ci/validate_chaos_engine_readme.py --write`.
+
+Label: **directional walking skeleton** (n=12/12 observed/planned trials).
+This is not a Harbor 95% CI powered pilot.
+
+| Field | Value |
+| --- | --- |
+| Gate verdict | NO |
+| Gate reason | correctness did not beat control |
+| Correctness delta (treatment - control) | 0.0 |
+| Models used | nvidia/nemotron-3-ultra-550b-a55b |
+| Preferred model | agy/gemini-3.7-flash-high |
+| Tasks | diagnosis-failure-trace, repair-regression-test, delivery-focused-proof |
+| Status | complete |
+
+| Metric | control | chaos-engine |
+| --- | --- | --- |
+| `correctness` | 0.0 | 0.0 |
+| `tokens` | 351.6666666666667 | 371.1666666666667 |
+| `latency_seconds` | 24.54195623733055 | 36.893572025665584 |
+| `external_run_minutes` | UNAVAILABLE | UNAVAILABLE |
+| `actions` | 1.0 | 1.0 |
+| `retries` | 0.0 | 0.0 |
+| `cost_usd` | UNAVAILABLE | UNAVAILABLE |
+| `variance` | 0.0 | 0.0 |
+
+Methodology and final report:
+[decision-quality-calibration.md](decision-quality-calibration.md),
+[decision-quality-report.md](decision-quality-report.md).
+Missing telemetry remains the literal `UNAVAILABLE` (never `0`).
+<!-- evidence:omniroute-calibration:end -->
+
 ## What gets installed
 
 | Path | Responsibility |

--- a/chaos-engine/decision-quality-report.md
+++ b/chaos-engine/decision-quality-report.md
@@ -26,8 +26,9 @@ Harbor trials were required for this program slice.
    latency were higher on the chaos-engine arm than on control.
 4. `cost_usd` and `external_run_minutes` remain literal **`UNAVAILABLE`**
    (never coerced to `0`).
-5. Preferred free model `agy/gemini-3.7-flash-high` cooled (429); remaining
-   pairs used free most-intelligent failover
+5. Preferred free model `agy/gemini-3.7-flash-high` was unavailable; committed
+   `failoverEvents` reason is `operator-pin-after-preferred-unavailable`.
+   Remaining pairs used free most-intelligent pin
    `nvidia/nemotron-3-ultra-550b-a55b` with the same named model on both arms
    of each pair.
 6. The only global harness policy change shipped in this program is the
@@ -41,8 +42,9 @@ Harbor trials were required for this program slice.
 - Zero correctness on both arms means the skeleton measured transport and
   prompt packaging more than end-to-end repair quality. Treat the gate as a
   correct fail-closed signal, not as proof that ChaosEngine harms outcomes.
-- Failover and cooling behavior are first-class operational risks for free
-  OmniRoute campaigns; pin and document model identity per pair.
+- Preferred-model unavailability and operator pin/failover are first-class
+  operational risks for free OmniRoute campaigns; pin and document model
+  identity per pair from committed `failoverEvents` only.
 - Transparency still requires publishing the unfavorable result in the primary
   README (#5465), without reframing or suppressing dimensions.
 
@@ -72,8 +74,8 @@ needs a new evidence gate before those ideas are reconsidered.
   not a Harbor-powered 95% confidence-interval pilot.
 - Correctness stayed at 0.0 on both arms; the campaign cannot discriminate
   harness benefit on repair quality.
-- Local OmniRoute `requestQueue.maxWaitMs=15000` and model cooling/failover
-  bound external validity.
+- Local OmniRoute `requestQueue.maxWaitMs=15000` and preferred-model failover
+  (`operator-pin-after-preferred-unavailable`) bound external validity.
 - Token and latency means are descriptive only; do not over-claim efficiency
   regressions beyond the recorded gate.
 - Private prompts, transcripts, secrets, private paths, and provider routes

--- a/chaos-engine/decision-quality-report.md
+++ b/chaos-engine/decision-quality-report.md
@@ -1,0 +1,142 @@
+# ChaosEngine decision-quality final report
+
+Accessed: 2026-09-02. Parent tracker: #5549. Deliverable for #5525.
+Supersedes the methodology-publication scope previously tracked as #5463.
+
+Evidence source: the committed #5522 OmniRoute 12-trial paired free-model
+campaign. Numeric scorecard values are not hand-copied here; they live in
+[`decision-quality-calibration.md`](decision-quality-calibration.md) and
+[`decision-quality-calibration.aggregate.json`](decision-quality-calibration.aggregate.json),
+and the primary README evidence block is generated from that aggregate by
+`scripts/ci/validate_chaos_engine_readme.py`.
+
+Transport: local OmniRoute loopback, free/remaining catalog only. No paid
+Harbor trials were required for this program slice.
+
+---
+
+## Findings
+
+1. The walking skeleton completed **12/12** planned trials with balanced cover
+   (3 public ChaosGauge task identities × 2 arms × 2 attempts).
+2. Both arms scored **correctness 0.0**. Applyable patches were not emitted
+   under the local OmniRoute generation ceiling observed during the campaign.
+3. Gate verdict is **NO** (`correctness did not beat control`). Treatment did
+   not win an efficiency dimension without regression: observed mean tokens and
+   latency were higher on the chaos-engine arm than on control.
+4. `cost_usd` and `external_run_minutes` remain literal **`UNAVAILABLE`**
+   (never coerced to `0`).
+5. Preferred free model `agy/gemini-3.7-flash-high` cooled (429); remaining
+   pairs used free most-intelligent failover
+   `nvidia/nemotron-3-ultra-550b-a55b` with the same named model on both arms
+   of each pair.
+6. The only global harness policy change shipped in this program is the
+   process-owner / Scrum-master reference (#5550 / PR #5551). No other global
+   policy mutation landed.
+
+## Inference
+
+- Directional evidence does **not** justify promoting gated efficiency or
+  repeat-failure policy changes from this campaign.
+- Zero correctness on both arms means the skeleton measured transport and
+  prompt packaging more than end-to-end repair quality. Treat the gate as a
+  correct fail-closed signal, not as proof that ChaosEngine harms outcomes.
+- Failover and cooling behavior are first-class operational risks for free
+  OmniRoute campaigns; pin and document model identity per pair.
+- Transparency still requires publishing the unfavorable result in the primary
+  README (#5465), without reframing or suppressing dimensions.
+
+## Rejected ideas
+
+| Idea | Issue | Disposition | Reason |
+| --- | --- | --- | --- |
+| Repeat-failure reframing and root-owner selection guard | #5523 | Rejected / closed `not_planned` | #5522 gate **NO**; correctness did not beat control |
+| Context, retrieval, and tool-call economy improvements | #5524 | Rejected / closed `not_planned` | Same gate; no efficiency win without regression |
+| Global policy ADR for #5523/#5524 | (none opened) | Not required | Rejected slices shipped no policy change |
+| Paid Harbor 120-trial / 95% CI power for this tracker | withdrawn under #5549 | Superseded | Free OmniRoute walking skeleton is the acceptance path |
+
+Do not reopen #5523 or #5524 implementation from this report. A future campaign
+needs a new evidence gate before those ideas are reconsidered.
+
+## Global ADR disposition
+
+**No new global policy ADR** for this delivery.
+
+- Shipped elsewhere: process-owner / Scrum-master reference (#5550).
+- Rejected slices (#5523, #5524) produced no accepted global rule, so an ADR
+  would invent policy that was never adopted.
+
+## Limitations (directional power)
+
+- **n=12** paired free-model trials. This is a directional walking skeleton,
+  not a Harbor-powered 95% confidence-interval pilot.
+- Correctness stayed at 0.0 on both arms; the campaign cannot discriminate
+  harness benefit on repair quality.
+- Local OmniRoute `requestQueue.maxWaitMs=15000` and model cooling/failover
+  bound external validity.
+- Token and latency means are descriptive only; do not over-claim efficiency
+  regressions beyond the recorded gate.
+- Private prompts, transcripts, secrets, private paths, and provider routes
+  are intentionally absent from committed evidence.
+
+## Ranked backlog leftovers
+
+1. Improve the walking-skeleton task loop so applyable patches (or an explicit
+   non-patch success signal) can yield non-zero correctness under free
+   OmniRoute constraints.
+2. Capture comparable `cost_usd` / `external_run_minutes` when free transport
+   exposes them; keep `UNAVAILABLE` until then.
+3. Only after a future gate beats control: reconsider narrow, evidence-bound
+   slices formerly tracked as #5523 / #5524 under a new issue.
+4. Keep ChaosGauge Harbor methodology available as a later powered campaign;
+   do not block README transparency on it (#5450 respec under #5549).
+5. Refresh ChaosGauge harness digests whenever origin-only decision-quality
+   artifacts change the `chaos-engine/` tree hash.
+
+## Scorecard linkage (#5522)
+
+| Artifact | Role |
+| --- | --- |
+| [`decision-quality-calibration.aggregate.json`](decision-quality-calibration.aggregate.json) | Machine-readable redacted aggregate (source of truth) |
+| [`decision-quality-calibration.md`](decision-quality-calibration.md) | Human scorecard rendered from the aggregate |
+| [`README.md`](README.md) OmniRoute evidence section | Adopter-facing transparency block generated from the aggregate |
+| [`scripts/ci/chaos_gauge/omniroute_calibration.py`](../scripts/ci/chaos_gauge/omniroute_calibration.py) | Runner / validator / scorecard renderer |
+| PR #5552 | Landed calibration evidence (`Closes #5522`) |
+
+Recompute / verify:
+
+```bash
+python3 scripts/ci/chaos_gauge/omniroute_calibration.py validate \
+  --evidence chaos-engine/decision-quality-calibration.aggregate.json
+python3 scripts/ci/validate_chaos_engine_readme.py --write
+python3 -m unittest tests.scripts.test_omniroute_calibration \
+  tests.scripts.test_decision_quality_readme_evidence -q
+```
+
+## Rollback and observation window
+
+**Rollback (documentation / evidence packaging only):**
+
+1. Remove this report and the README evidence markers/section.
+2. Leave #5522 aggregate/scorecard in place unless rolling back that PR as
+   well; if removing calibration artifacts, also delete
+   `scripts/ci/chaos_gauge/omniroute_calibration.py` and
+   `tests/scripts/test_omniroute_calibration.py`.
+3. Refresh ChaosGauge digests with
+   `python3 scripts/ci/chaos_gauge/validate_experiment.py --write scripts/ci/chaos_gauge/experiment.json`.
+4. Revert documentation allowlist / origin-only entries added for these files.
+
+**Observation window:** watch adopter README readers and follow-on issues for
+misreading the directional skeleton as a powered Harbor win/loss claim. If
+that confusion appears, tighten the README label and link text; do not invent
+metrics.
+
+## Companion documentation disposition
+
+No companion PR on `ShaftHQ/shafthq.github.io` for this slice.
+
+Evidence: #5465 acceptance (2026-09-02 respec) publishes transparency in the
+ChaosEngine primary README inside `ShaftHQ/SHAFT_ENGINE`. This delivery does
+not change user-facing SHAFT product/adopter functional docs; methodology
+publication formerly tracked as #5463 is superseded here as harness-origin
+evidence, not site docs.

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -363,6 +363,9 @@ def is_origin_only(relative: Path) -> bool:
             "STANDALONE.md",
             "decision-quality-baseline.md",
             "decision-quality-rubric.md",
+            "decision-quality-calibration.md",
+            "decision-quality-calibration.aggregate.json",
+            "decision-quality-report.md",
         }
     )
 

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "fa05205862c7df8555aef2f6a29fd0861be9b3d389b41ed74c859a49d919c771",
+      "harnessSha256": "078ffa0b25bf1cde16cd3d6ff7f6509700ea387ba7899a5776c389fbb6fe093c",
       "treatmentSha256": {
-        "calibration": "accd23e9b9d474ed3f8ba24fa9c22f71527c6b15c3680e8d358eb9ce7ccb6205",
-        "full-pilot": "87571f97182cb0230d7be8e4caf8b48f53d9edb6f65ab6868f9f07288d9d0256"
+        "calibration": "e6db03d026b2e577ef016ff44f48cb074660238025ba18f1185ddd1b222e9080",
+        "full-pilot": "a1ce7e219be0a083cdcbe0af06a19c1034904b302db553ac44dfc6625ef14b3a"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "2dff1e04c1c3a48cd0336145933b13f771df1b659dfb20e9ce7a36b5cf5585cf",
+      "harnessSha256": "fa05205862c7df8555aef2f6a29fd0861be9b3d389b41ed74c859a49d919c771",
       "treatmentSha256": {
-        "calibration": "ce9988854dbdc2c12ee77bdaebb786c3c9a69389ea0eb4bbe1c16de60159b902",
-        "full-pilot": "ed0c9073bc0d576ecce1ebef33f2cd1a6fe60d4ad02f025d79c8ed17c66fa042"
+        "calibration": "accd23e9b9d474ed3f8ba24fa9c22f71527c6b15c3680e8d358eb9ce7ccb6205",
+        "full-pilot": "87571f97182cb0230d7be8e4caf8b48f53d9edb6f65ab6868f9f07288d9d0256"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "2dff1e04c1c3a48cd0336145933b13f771df1b659dfb20e9ce7a36b5cf5585cf"
+      harness_sha256: "fa05205862c7df8555aef2f6a29fd0861be9b3d389b41ed74c859a49d919c771"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "fa05205862c7df8555aef2f6a29fd0861be9b3d389b41ed74c859a49d919c771"
+      harness_sha256: "078ffa0b25bf1cde16cd3d6ff7f6509700ea387ba7899a5776c389fbb6fe093c"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "fa05205862c7df8555aef2f6a29fd0861be9b3d389b41ed74c859a49d919c771"
+      harness_sha256: "078ffa0b25bf1cde16cd3d6ff7f6509700ea387ba7899a5776c389fbb6fe093c"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "2dff1e04c1c3a48cd0336145933b13f771df1b659dfb20e9ce7a36b5cf5585cf"
+      harness_sha256: "fa05205862c7df8555aef2f6a29fd0861be9b3d389b41ed74c859a49d919c771"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/validate_chaos_engine_readme.py
+++ b/scripts/ci/validate_chaos_engine_readme.py
@@ -13,6 +13,18 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 README = Path("chaos-engine/README.md")
+AGGREGATE = Path("chaos-engine/decision-quality-calibration.aggregate.json")
+EVIDENCE_MARKERS = ("omniroute-calibration",)
+EVIDENCE_METRICS = (
+    "correctness",
+    "tokens",
+    "latency_seconds",
+    "external_run_minutes",
+    "actions",
+    "retries",
+    "cost_usd",
+    "variance",
+)
 FIELDS = ("Item", "Purpose", "Source of truth", "Status", "Platforms", "Provisioner", "Owner", "Failure behavior")
 REQUIRED_DIAGRAMS = {
     "Prerequisite and dependency topology",
@@ -240,6 +252,85 @@ def rendered_inventory(root: Path = ROOT) -> str:
     return "\n\n".join(parts)
 
 
+def _load_aggregate(root: Path) -> dict[str, object]:
+    path = root / AGGREGATE
+    if not path.is_file():
+        raise ValueError(f"missing committed aggregate: {AGGREGATE.as_posix()}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("committed aggregate must be a JSON object")
+    return value
+
+
+def render_omniroute_evidence(root: Path = ROOT) -> str:
+    """Render the README evidence block from the committed #5522 aggregate only."""
+    evidence = _load_aggregate(root)
+    identity = evidence.get("identity")
+    metrics = evidence.get("metrics")
+    comparison = evidence.get("comparison")
+    accounting = evidence.get("trialAccounting")
+    if not isinstance(identity, dict) or not isinstance(metrics, dict):
+        raise ValueError("committed aggregate identity/metrics are invalid")
+    if not isinstance(comparison, dict) or not isinstance(accounting, dict):
+        raise ValueError("committed aggregate comparison/accounting are invalid")
+    gate = comparison.get("gateVerdict")
+    if not isinstance(gate, dict):
+        raise ValueError("committed aggregate gateVerdict is invalid")
+    control = metrics.get("control")
+    treatment = metrics.get("chaos-engine")
+    if not isinstance(control, dict) or not isinstance(treatment, dict):
+        raise ValueError("committed aggregate arm metrics are invalid")
+
+    task_names = []
+    for task in identity.get("tasks") or []:
+        if isinstance(task, dict) and isinstance(task.get("name"), str):
+            task_names.append(task["name"])
+    models = evidence.get("modelsUsed") or []
+    if not isinstance(models, list):
+        models = []
+    model_text = ", ".join(str(model) for model in models) or "UNAVAILABLE"
+
+    lines = [
+        "This section is generated from",
+        f"[`{AGGREGATE.as_posix()}`]({AGGREGATE.name}).",
+        "Do not hand-edit the numbers; refresh with",
+        "`python3 scripts/ci/validate_chaos_engine_readme.py --write`.",
+        "",
+        "Label: **directional walking skeleton** (n="
+        f"{accounting.get('observed')}/{accounting.get('planned')} observed/planned trials).",
+        "This is not a Harbor 95% CI powered pilot.",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Gate verdict | {gate.get('verdict')} |",
+        f"| Gate reason | {gate.get('reason')} |",
+        f"| Correctness delta (treatment - control) | {comparison.get('correctnessDelta')} |",
+        f"| Models used | {model_text} |",
+        f"| Preferred model | {identity.get('preferredModel')} |",
+        f"| Tasks | {', '.join(task_names)} |",
+        f"| Status | {evidence.get('status')} |",
+        "",
+        "| Metric | control | chaos-engine |",
+        "| --- | --- | --- |",
+    ]
+    for name in EVIDENCE_METRICS:
+        lines.append(f"| `{name}` | {control.get(name)} | {treatment.get(name)} |")
+    lines.extend(
+        [
+            "",
+            "Methodology and final report:",
+            "[decision-quality-calibration.md](decision-quality-calibration.md),",
+            "[decision-quality-report.md](decision-quality-report.md).",
+            "Missing telemetry remains the literal `UNAVAILABLE` (never `0`).",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def evidence_sections(root: Path = ROOT) -> dict[str, str]:
+    return {"omniroute-calibration": render_omniroute_evidence(root)}
+
+
 def _skip_spaces(value: str, position: int) -> int:
     while position < len(value) and value[position] in " \t":
         position += 1
@@ -328,6 +419,16 @@ def _parse_mermaid(readme: str) -> tuple[set[str], list[str]]:
     return set(titles), errors
 
 
+def _replace_marked_section(readme: str, kind: str, name: str, body: str) -> str:
+    start = f"<!-- {kind}:{name}:start -->"
+    end = f"<!-- {kind}:{name}:end -->"
+    if readme.count(start) != 1 or readme.count(end) != 1:
+        raise ValueError(f"{kind} marker count is invalid: {name}")
+    before, rest = readme.split(start, 1)
+    _, after = rest.split(end, 1)
+    return f"{before}{start}\n{body}\n{end}{after}"
+
+
 def validate(root: Path = ROOT) -> list[str]:
     readme = (root / README).read_text(encoding="utf-8")
     errors: list[str] = []
@@ -340,6 +441,23 @@ def validate(root: Path = ROOT) -> list[str]:
         actual = readme.split(start, 1)[1].split(end, 1)[0].strip()
         if actual != table:
             errors.append(f"source-derived inventory drift: {name}")
+    try:
+        sections = evidence_sections(root)
+    except ValueError as exc:
+        errors.append(str(exc))
+        sections = {}
+    for name in EVIDENCE_MARKERS:
+        start = f"<!-- evidence:{name}:start -->"
+        end = f"<!-- evidence:{name}:end -->"
+        if readme.count(start) != 1 or readme.count(end) != 1:
+            errors.append(f"evidence marker count is invalid: {name}")
+            continue
+        expected = sections.get(name)
+        if expected is None:
+            continue
+        actual = readme.split(start, 1)[1].split(end, 1)[0].strip()
+        if actual != expected:
+            errors.append(f"source-derived evidence drift: {name}")
     titles, mermaid_errors = _parse_mermaid(readme)
     errors.extend(mermaid_errors)
     missing_titles = REQUIRED_DIAGRAMS - titles
@@ -355,18 +473,14 @@ def validate(root: Path = ROOT) -> list[str]:
 
 
 def write_generated(root: Path = ROOT) -> None:
-    """Rewrite source-derived inventory sections between canonical markers."""
+    """Rewrite source-derived inventory and evidence sections between markers."""
     root = root.resolve()
     path = root / README
     readme = path.read_text(encoding="utf-8")
     for name, table in inventory_sections(root).items():
-        start = f"<!-- inventory:{name}:start -->"
-        end = f"<!-- inventory:{name}:end -->"
-        if readme.count(start) != 1 or readme.count(end) != 1:
-            raise ValueError(f"inventory marker count is invalid: {name}")
-        before, rest = readme.split(start, 1)
-        _, after = rest.split(end, 1)
-        readme = f"{before}{start}\n{table}\n{end}{after}"
+        readme = _replace_marked_section(readme, "inventory", name, table)
+    for name, body in evidence_sections(root).items():
+        readme = _replace_marked_section(readme, "evidence", name, body)
     path.write_text(readme, encoding="utf-8")
 
 

--- a/scripts/ci/validate_documentation_boundaries.py
+++ b/scripts/ci/validate_documentation_boundaries.py
@@ -52,6 +52,7 @@ ALLOWED_EXACT = {
     "chaos-engine/decision-quality-baseline.md",
     "chaos-engine/decision-quality-rubric.md",
     "chaos-engine/decision-quality-calibration.md",
+    "chaos-engine/decision-quality-report.md",
     "chaos-engine/STANDALONE.md",
     "chaos-engine/INSTALL.md",
     "chaos-engine/THIRD_PARTY_NOTICES.md",

--- a/tests/scripts/test_decision_quality_readme_evidence.py
+++ b/tests/scripts/test_decision_quality_readme_evidence.py
@@ -35,8 +35,12 @@ class DecisionQualityReadmeEvidenceTest(unittest.TestCase):
         self.assertIn("UNAVAILABLE", block)
         self.assertIn("decision-quality-calibration.aggregate.json", block)
         self.assertIn("decision-quality-report.md", block)
-        # Missing cost must stay literal UNAVAILABLE, never coerced to 0 in the table.
+        # Missing cost/external-run-minutes stay literal UNAVAILABLE, never coerced to 0.
         self.assertRegex(block, r"\|\s*`cost_usd`\s*\|\s*UNAVAILABLE\s*\|\s*UNAVAILABLE\s*\|")
+        self.assertRegex(
+            block,
+            r"\|\s*`external_run_minutes`\s*\|\s*UNAVAILABLE\s*\|\s*UNAVAILABLE\s*\|",
+        )
 
     def test_repository_readme_evidence_matches_renderer_and_write_is_idempotent(self):
         write_generated = getattr(readme_owner, "write_generated", None)

--- a/tests/scripts/test_decision_quality_readme_evidence.py
+++ b/tests/scripts/test_decision_quality_readme_evidence.py
@@ -1,0 +1,79 @@
+"""README evidence block must be generated from the committed #5522 aggregate."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.ci import validate_chaos_engine_readme as readme_owner
+
+
+ROOT = Path(__file__).resolve().parents[2]
+AGGREGATE = ROOT / "chaos-engine/decision-quality-calibration.aggregate.json"
+
+
+class DecisionQualityReadmeEvidenceTest(unittest.TestCase):
+    def test_renderer_uses_aggregate_values_without_zero_filling_unavailable(self):
+        evidence = json.loads(AGGREGATE.read_text(encoding="utf-8"))
+        render = getattr(readme_owner, "render_omniroute_evidence", None)
+        self.assertTrue(callable(render))
+
+        block = render(ROOT)
+        metrics = evidence["metrics"]
+        gate = evidence["comparison"]["gateVerdict"]
+
+        self.assertIn("directional walking skeleton", block.casefold())
+        self.assertIn(str(evidence["trialAccounting"]["observed"]), block)
+        self.assertIn(str(gate["verdict"]), block)
+        self.assertIn(str(metrics["control"]["tokens"]), block)
+        self.assertIn(str(metrics["chaos-engine"]["tokens"]), block)
+        self.assertIn(str(metrics["control"]["latency_seconds"]), block)
+        self.assertIn(str(metrics["chaos-engine"]["latency_seconds"]), block)
+        self.assertIn("UNAVAILABLE", block)
+        self.assertIn("decision-quality-calibration.aggregate.json", block)
+        self.assertIn("decision-quality-report.md", block)
+        # Missing cost must stay literal UNAVAILABLE, never coerced to 0 in the table.
+        self.assertRegex(block, r"\|\s*`cost_usd`\s*\|\s*UNAVAILABLE\s*\|\s*UNAVAILABLE\s*\|")
+
+    def test_repository_readme_evidence_matches_renderer_and_write_is_idempotent(self):
+        write_generated = getattr(readme_owner, "write_generated", None)
+        self.assertTrue(callable(write_generated))
+        self.assertEqual([], readme_owner.validate(ROOT))
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            shutil.copytree(ROOT / "chaos-engine", root / "chaos-engine")
+            readme = root / "chaos-engine/README.md"
+            original = readme.read_text(encoding="utf-8")
+            start = "<!-- evidence:omniroute-calibration:start -->"
+            end = "<!-- evidence:omniroute-calibration:end -->"
+            self.assertEqual(1, original.count(start))
+            self.assertEqual(1, original.count(end))
+
+            before, rest = original.split(start, 1)
+            _, after = rest.split(end, 1)
+            readme.write_text(
+                f"{before}{start}\n| Metric | control | chaos-engine |\n| --- | --- | --- |\n| `tokens` | 1 | 2 |\n{end}{after}",
+                encoding="utf-8",
+            )
+            errors = readme_owner.validate(root)
+            self.assertTrue(
+                any("omniroute-calibration" in error for error in errors),
+                errors,
+            )
+
+            write_generated(root)
+            self.assertEqual([], readme_owner.validate(root))
+            after_first = readme.read_text(encoding="utf-8")
+            write_generated(root)
+            self.assertEqual(after_first, readme.read_text(encoding="utf-8"))
+            expected = readme_owner.render_omniroute_evidence(root)
+            actual = after_first.split(start, 1)[1].split(end, 1)[0].strip()
+            self.assertEqual(expected, actual)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_validate_documentation_boundaries.py
+++ b/tests/scripts/test_validate_documentation_boundaries.py
@@ -108,6 +108,10 @@ flowchart LR
             "chaos-engine/decision-quality-calibration.md",
             "# Decision-quality calibration\n",
         )
+        self.write(
+            "chaos-engine/decision-quality-report.md",
+            "# Decision-quality report\n",
+        )
         self.write("chaos-engine/STANDALONE.md", "# Spec\n")
         self.write("chaos-engine/INSTALL.md", "# Install\n")
         self.write("chaos-engine/THIRD_PARTY_NOTICES.md", "# Notices\n")


### PR DESCRIPTION
## Summary
- Lands `#5525` final decision-quality report under `chaos-engine/decision-quality-report.md` (findings, inference, rejected `#5523`/`#5524`, directional-power limitations, ranked leftovers, scorecard links, rollback/observation notes).
- Satisfies `#5465` README transparency: OmniRoute evidence section is **generated/verified** from the committed `#5522` aggregate (no hand-copied numbers; `UNAVAILABLE` preserved).
- States **no new global ADR** beyond shipped process-owner `#5550`; rejected slices need none.
- Marks calibration/report artifacts origin-only; refreshes ChaosGauge harness digests.
- **Companion docs PR skipped:** `#5465` respec publishes in ChaosEngine primary README inside this repo; no user-facing SHAFT product docs change on `ShaftHQ/shafthq.github.io` (methodology `#5463` superseded here as harness-origin evidence).

Closes #5525
Closes #5465
Refs #5549
Updates #5450

## Checks
- [x] `python3 -m unittest tests.scripts.test_decision_quality_readme_evidence tests.scripts.test_validate_chaos_engine_readme -q`
- [x] `python3 -m unittest tests.scripts.test_omniroute_calibration tests.scripts.test_validate_documentation_boundaries tests.scripts.test_chaos_gauge_recovery tests.scripts.test_chaos_gauge_contracts -q`
- [x] `python3 scripts/ci/validate_chaos_engine_readme.py`
- [x] `python3 scripts/ci/validate_documentation_boundaries.py`
- [x] `python3 scripts/ci/chaos_gauge/validate_experiment.py scripts/ci/chaos_gauge/experiment.json`
- [x] `python3 scripts/ci/validate_agent_setup.py --skip-external` (valid; unrelated orphan-branch hygiene warnings only)