### PR TITLE
fix(chaos-engine): tolerate package-equal host hooks and OmniRoute exhaustion backoff

### DIFF
--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -1024,9 +1024,11 @@ def classify_install_error(error: BaseException) -> str:
 def one_line_cause(error: BaseException) -> str:
     text = str(error).strip() or error.__class__.__name__
     text = " ".join(text.split())
+    # Non-HTML [path] so GitHub issue forms cannot strip the marker and leave a
+    # mount prefix such as /media/.../OS after redacting /Users/...
     text = re.sub(
-        r"(?<!:)(?:[A-Za-z]:[\\/]|/(?:home|Users|tmp|var|private)/)\S+",
-        "<path>",
+        r"(?<!:)(?:[A-Za-z]:[\\/]|\\\\[^\s\\/]+[\\/]|/(?:(?:media|mnt|Volumes)(?:/\S+?)?/(?:Users|home)|home|Users|tmp|var|private)/)\S+",
+        "[path]",
         text,
     )
     return re.sub(

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -2920,6 +2920,31 @@ def managed_codex_block(content: str) -> str | None:
     return content[start:finish]
 
 
+_CODEX_ABSOLUTE_COMMAND = re.compile(
+    r'command(?:Windows)? = "(?:[A-Za-z]:[\\/]|/|\\\\)[^"\n]*"'
+)
+_CODEX_MANAGED_WINDOWS_ARGS = re.compile(
+    r'argsWindows = \[(?!("-3", ))'
+)
+
+
+def normalize_codex_interpreter_spelling(block: str) -> str:
+    """Map absolute managed interpreters to python3/py -3 spelling for equivalence."""
+    normalized = block.replace("\r\n", "\n")
+    for match in list(_CODEX_ABSOLUTE_COMMAND.finditer(normalized)):
+        text = match.group(0)
+        if text.startswith("commandWindows"):
+            normalized = normalized.replace(text, 'commandWindows = "py"', 1)
+        else:
+            normalized = normalized.replace(text, 'command = "python3"', 1)
+    # Managed absolute Windows args omit the py -3 prefix; restore it for compare.
+    def restore_windows_prefix(match: re.Match[str]) -> str:
+        return 'argsWindows = ["-3", '
+
+    normalized = _CODEX_MANAGED_WINDOWS_ARGS.sub(restore_windows_prefix, normalized)
+    return normalized
+
+
 def strip_known_codex_ownership(
     current: bytes, before: bytes | None, after: bytes | None
 ) -> bytes:
@@ -2943,9 +2968,9 @@ def strip_known_codex_ownership(
         *(legacy_codex_python_block(platform) for platform in ("nt", "posix")),
         legacy_portable_codex_block(),
     )
-    normalized = block.replace("\r\n", "\n")
+    normalized = normalize_codex_interpreter_spelling(block)
     accepted = {
-        item.replace("\r\n", "\n")
+        normalize_codex_interpreter_spelling(item)
         for item in (*legacy, before_block, recorded_block)
         if item is not None
     }
@@ -3985,29 +4010,19 @@ def desired_content(
         commit=PONYTAIL_UPSTREAM_COMMIT,
         version=PONYTAIL_PLUGIN_VERSION,
     )
-    roles = {
-        "orchestrator": "Own planning, architecture, synthesis, and final verification.",
-        "implementer": "Implement one bounded specification before consolidated validation.",
-        "reviewer": "Perform an independent read-only adversarial review; never edit.",
-        "tester": "Reproduce behavior and produce regression and acceptance evidence.",
-        "mechanical-helper": "Perform deterministic reversible spec-exact work; stop on ambiguity.",
-    }
-    for role, responsibility in roles.items():
-        slug = f"chaos-engine-{role}"
-        tools = "Read, Grep, Glob, Bash" if role == "reviewer" else "Read, Grep, Glob, Bash, Write, Edit"
-        after[f".claude/agents/{slug}.md"] = (
-            f"---\nname: {slug}\ndescription: {responsibility}\n"
-            f"tools: {tools}\n---\n\n"
-            f"Load `.chaos-engine/skills/chaos-engine/SKILL.md` and follow "
-            f"`.chaos-engine/references/roles.md#{role}`. {responsibility}\n"
-        ).encode()
-        sandbox = 'sandbox_mode = "read-only"\n' if role == "reviewer" else ""
-        after[f".codex/agents/{slug}.toml"] = (
-            f'name = "{slug}"\n'
-            f'description = {json.dumps(responsibility)}\n'
-            f'developer_instructions = {json.dumps(f"Load .chaos-engine/skills/chaos-engine/SKILL.md and follow .chaos-engine/references/roles.md#{role}. {responsibility}")}\n'
-            f"{sandbox}"
-        ).encode()
+    for role in (
+        "orchestrator",
+        "implementer",
+        "reviewer",
+        "tester",
+        "mechanical-helper",
+    ):
+        after[f".claude/agents/chaos-engine-{role}.md"] = role_adapter_desired(
+            f".claude/agents/chaos-engine-{role}.md"
+        )
+        after[f".codex/agents/chaos-engine-{role}.toml"] = role_adapter_desired(
+            f".codex/agents/chaos-engine-{role}.toml"
+        )
     memory_before = before[".memory/config.json"]
     if memory_before is None:
         normalized_name = re.sub(r"[^a-z0-9]+", "-", project_name.casefold()).strip("-") or "project"
@@ -4648,18 +4663,106 @@ def strip_known_json_ownership(
     return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
 
 
-def known_legacy_guard(project: Path, current: bytes) -> bool:
-    """Accept only an exact installed-core guard while replacing its plugin copy."""
-    for relative in (
-        ".chaos-engine/hooks/guard.py",
-        ".chaos-engine.backup/hooks/guard.py",
+PACKAGE_HOOK_FILES = (
+    "guard.py",
+    "kernel.py",
+    "launch.js",
+    "lifecycle.py",
+    "matchers.json",
+    "reflection.py",
+)
+PACKAGE_HOOK_PATHS = tuple(
+    f"plugins/chaos-engine/hooks/{name}" for name in PACKAGE_HOOK_FILES
+)
+ROLE_ADAPTER_PATHS = tuple(
+    f"{root}/chaos-engine-{role}{suffix}"
+    for root, suffix in ((".claude/agents", ".md"), (".codex/agents", ".toml"))
+    for role in (
+        "orchestrator",
+        "implementer",
+        "reviewer",
+        "tester",
+        "mechanical-helper",
+    )
+)
+
+
+def package_hook_bytes(name: str) -> bytes:
+    """Return the candidate package hook bytes shipped beside this module."""
+    return (Path(__file__).resolve().parent / "hooks" / name).read_bytes()
+
+
+def known_package_equal_hook(project: Path, relative: str, current: bytes) -> bool:
+    """Accept exact plugin hooks that match core, backup, or package copies."""
+    name = Path(relative).name
+    if name not in PACKAGE_HOOK_FILES:
+        return False
+    for candidate in (
+        project / ".chaos-engine/hooks" / name,
+        project / ".chaos-engine.backup/hooks" / name,
+        Path(__file__).resolve().parent / "hooks" / name,
     ):
         try:
-            if read_file(project, project / relative) == current:
+            if candidate.is_file() and candidate.read_bytes() == current:
                 return True
-        except ValueError:
+        except OSError:
             continue
     return False
+
+
+def known_legacy_guard(project: Path, current: bytes) -> bool:
+    """Accept only an exact installed-core or package-equal guard plugin copy."""
+    return known_package_equal_hook(
+        project, "plugins/chaos-engine/hooks/guard.py", current
+    )
+
+
+def role_adapter_desired(relative: str) -> bytes | None:
+    """Return the candidate fully-owned role adapter bytes for one managed path."""
+    roles = {
+        "orchestrator": "Own planning, architecture, synthesis, and final verification.",
+        "implementer": "Implement one bounded specification before consolidated validation.",
+        "reviewer": "Perform an independent read-only adversarial review; never edit.",
+        "tester": "Reproduce behavior and produce regression and acceptance evidence.",
+        "mechanical-helper": "Perform deterministic reversible spec-exact work; stop on ambiguity.",
+    }
+    match = re.fullmatch(
+        r"\.(claude|codex)/agents/chaos-engine-([a-z-]+)\.(md|toml)", relative
+    )
+    if match is None:
+        return None
+    host, role, kind = match.groups()
+    responsibility = roles.get(role)
+    if responsibility is None:
+        return None
+    process_owner = (
+        " In orchestrated mode also load `.chaos-engine/references/process-owner-scrum-master.md`."
+        if role == "orchestrator"
+        else ""
+    )
+    body = (
+        f"Load `.chaos-engine/skills/chaos-engine/SKILL.md` and follow "
+        f"`.chaos-engine/references/roles.md#{role}`.{process_owner} {responsibility}"
+    )
+    if host == "claude" and kind == "md":
+        tools = (
+            "Read, Grep, Glob, Bash"
+            if role == "reviewer"
+            else "Read, Grep, Glob, Bash, Write, Edit"
+        )
+        return (
+            f"---\nname: chaos-engine-{role}\ndescription: {responsibility}\n"
+            f"tools: {tools}\n---\n\n{body}\n"
+        ).encode()
+    if host == "codex" and kind == "toml":
+        sandbox = 'sandbox_mode = "read-only"\n' if role == "reviewer" else ""
+        return (
+            f'name = "chaos-engine-{role}"\n'
+            f"description = {json.dumps(responsibility)}\n"
+            f"developer_instructions = {json.dumps(body)}\n"
+            f"{sandbox}"
+        ).encode()
+    return None
 
 
 def upgrade_before_images(
@@ -4707,10 +4810,21 @@ def upgrade_before_images(
         if relative == ".agents/skills/README.md":
             restored[relative] = observed
             continue
-        if relative == "plugins/chaos-engine/hooks/guard.py":
-            if not isinstance(observed, bytes) or not known_legacy_guard(project, observed):
-                raise ValueError(f"ChaosEngine host adapter drift detected: {project / relative}")
+        if relative in PACKAGE_HOOK_PATHS:
+            if not isinstance(observed, bytes) or not known_package_equal_hook(
+                project, relative, observed
+            ):
+                raise ValueError(
+                    f"ChaosEngine host adapter drift detected: {project / relative}"
+                )
             continue
+        if relative in ROLE_ADAPTER_PATHS:
+            desired = role_adapter_desired(relative)
+            if isinstance(observed, bytes) and desired is not None and observed == desired:
+                continue
+            raise ValueError(
+                f"ChaosEngine host adapter drift detected: {project / relative}"
+            )
         if relative in {
             ".codex/hooks.json",
             ".grok/hooks/lifecycle.json",

--- a/chaos-engine/hosts.py
+++ b/chaos-engine/hosts.py
@@ -2921,27 +2921,55 @@ def managed_codex_block(content: str) -> str | None:
 
 
 _CODEX_ABSOLUTE_COMMAND = re.compile(
-    r'command(?:Windows)? = "(?:[A-Za-z]:[\\/]|/|\\\\)[^"\n]*"'
+    r'(command(?:Windows)?) = "((?:[A-Za-z]:[\\/]|/|\\\\)[^"\n]*)"'
 )
 _CODEX_MANAGED_WINDOWS_ARGS = re.compile(
     r'argsWindows = \[(?!("-3", ))'
 )
+_CODEX_MANAGED_INTERPRETER_NAMES = frozenset(
+    {"python", "python3", "python.exe", "python3.exe"}
+)
 
 
-def normalize_codex_interpreter_spelling(block: str) -> str:
-    """Map absolute managed interpreters to python3/py -3 spelling for equivalence."""
+def _codex_absolute_command_paths(block: str) -> frozenset[str]:
+    return frozenset(match.group(2) for match in _CODEX_ABSOLUTE_COMMAND.finditer(block))
+
+
+def _is_known_managed_codex_interpreter(path: str, known_absolutes: frozenset[str]) -> bool:
+    if path in known_absolutes:
+        return True
+    normalized = path.replace("\\", "/")
+    if normalized in known_absolutes:
+        return True
+    base = normalized.rsplit("/", 1)[-1].casefold()
+    if base not in _CODEX_MANAGED_INTERPRETER_NAMES:
+        return False
+    lower = normalized.casefold()
+    return "uv-tools/mempalace" in lower or "chaos-engine-runtime" in lower
+
+
+def normalize_codex_interpreter_spelling(
+    block: str, *, known_absolutes: frozenset[str] = frozenset()
+) -> str:
+    """Map known absolute managed interpreters to python3/py -3 spelling for equivalence."""
     normalized = block.replace("\r\n", "\n")
+    rewritten_windows = False
     for match in list(_CODEX_ABSOLUTE_COMMAND.finditer(normalized)):
+        key, path = match.group(1), match.group(2)
+        if not _is_known_managed_codex_interpreter(path, known_absolutes):
+            continue
         text = match.group(0)
-        if text.startswith("commandWindows"):
+        if key == "commandWindows":
             normalized = normalized.replace(text, 'commandWindows = "py"', 1)
+            rewritten_windows = True
         else:
             normalized = normalized.replace(text, 'command = "python3"', 1)
     # Managed absolute Windows args omit the py -3 prefix; restore it for compare.
-    def restore_windows_prefix(match: re.Match[str]) -> str:
-        return 'argsWindows = ["-3", '
+    if rewritten_windows or known_absolutes:
+        def restore_windows_prefix(match: re.Match[str]) -> str:
+            return 'argsWindows = ["-3", '
 
-    normalized = _CODEX_MANAGED_WINDOWS_ARGS.sub(restore_windows_prefix, normalized)
+        normalized = _CODEX_MANAGED_WINDOWS_ARGS.sub(restore_windows_prefix, normalized)
     return normalized
 
 
@@ -2968,9 +2996,18 @@ def strip_known_codex_ownership(
         *(legacy_codex_python_block(platform) for platform in ("nt", "posix")),
         legacy_portable_codex_block(),
     )
-    normalized = normalize_codex_interpreter_spelling(block)
+    known_absolutes = frozenset().union(
+        *(
+            _codex_absolute_command_paths(item)
+            for item in (before_block, recorded_block)
+            if item is not None
+        )
+    )
+    normalized = normalize_codex_interpreter_spelling(
+        block, known_absolutes=known_absolutes
+    )
     accepted = {
-        normalize_codex_interpreter_spelling(item)
+        normalize_codex_interpreter_spelling(item, known_absolutes=known_absolutes)
         for item in (*legacy, before_block, recorded_block)
         if item is not None
     }

--- a/chaos-engine/skills/omniroute/SKILL.md
+++ b/chaos-engine/skills/omniroute/SKILL.md
@@ -46,8 +46,9 @@ Remaining tokens change after each delegate, so query live `models` and
 provider-exhaustion backoff cache (XDG state, never committed) may store only
 negative `exhausted_until` / retry-after entries; it is not a positive catalog cache.
 Update it on exhaustion signals (`state==exhausted`, `remaining<=0`, HTTP 429,
-quota-reset text), skip still-exhausted providers before ranking, and expire
-entries when time passes.
+quota-reset / insufficient-balance / stream-disconnect text). Pass the failed
+identity through `candidates(..., diagnostic=..., failed_identity_sha256=...,
+failed_provider=...)` so the next ranking skips that entry until expiry.
 
 ```text
 omniroute --output json models

--- a/chaos-engine/skills/omniroute/SKILL.md
+++ b/chaos-engine/skills/omniroute/SKILL.md
@@ -40,9 +40,14 @@ Never bind a non-loopback address. Never use a remote `--base-url`.
 
 ## Live catalog on every dispatch
 
-Do not read cache files. Do not keep a session catalog file. Remaining tokens
-change after each delegate, so query both of these immediately before every
-dispatch:
+Do not keep a session catalog file and do not cache positive catalog rows.
+Remaining tokens change after each delegate, so query live `models` and
+`usage quota` immediately before every dispatch. A **user-local**
+provider-exhaustion backoff cache (XDG state, never committed) may store only
+negative `exhausted_until` / retry-after entries; it is not a positive catalog cache.
+Update it on exhaustion signals (`state==exhausted`, `remaining<=0`, HTTP 429,
+quota-reset text), skip still-exhausted providers before ranking, and expire
+entries when time passes.
 
 ```text
 omniroute --output json models
@@ -64,7 +69,7 @@ it returns HTTP 401.
 4. Gateway `/api/models` rows use `model` (native id), `name` (display), `provider`, and `available`. CLI `omniroute models` JSON sets `id` from `name` when `id` is missing, so prefer `model` over `id`/`name`.
 5. Quota is a JSON array of objects with `provider`, `remaining`, and `state`.
 6. Join on alphanumeric-lowercased provider ids (`glm-cn` matches `glmcn`).
-7. Drop `state == "exhausted"` or `remaining <= 0`. Do not drop `available: false`: that management flag hid models the completions live catalog still accepts. Do not drop `supportsVision: true` for implementation ranking.
+7. Drop `state == "exhausted"` or `remaining <= 0`. Also drop providers/identities still present in the user-local provider-exhaustion backoff cache before their `exhausted_until`. Do not drop `available: false`: that management flag hid models the completions live catalog still accepts. Do not drop `supportsVision: true` for implementation ranking.
 8. Whitespace display names become native ids by stripping parentheticals, lowercasing, and replacing spaces with hyphens. Already-slugged ids stay unchanged. Compose `--model` as `provider/model` when the native id has no provider prefix.
 
 ### Rank (dynamic, from the live ids)

--- a/chaos-engine/skills/omniroute/scripts/runner.py
+++ b/chaos-engine/skills/omniroute/scripts/runner.py
@@ -20,7 +20,7 @@ import sys
 import tempfile
 import threading
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
@@ -873,9 +873,150 @@ def codex_model_overlay(provider: str, model: str) -> list[str]:
     return ["-c", f'model="{catalog_request_id(provider, model)}"']
 
 
+_DEFAULT_EXHAUSTION_SECONDS = 2 * 60 * 60
+_EXHAUSTION_CACHE_NAME = "provider-exhaustion.json"
+
+
+def exhaustion_cache_path(state_dir: Path | None = None) -> Path:
+    """User-local exhaustion backoff file under the OmniRoute state directory."""
+    root = Path(state_dir) if state_dir is not None else default_state_path()
+    return root / _EXHAUSTION_CACHE_NAME
+
+
+def _parse_exhausted_until(value: object) -> datetime | None:
+    parsed = _parse_time(value)
+    return parsed if parsed is not None and parsed.tzinfo is not None else None
+
+
+def load_exhaustion_cache(
+    state_dir: Path | None = None, *, now: datetime | None = None
+) -> dict[str, Any]:
+    """Load active provider/identity exhaustion entries; drop expired ones."""
+    path = exhaustion_cache_path(state_dir)
+    clock = now or _utc_now()
+    empty: dict[str, Any] = {"schemaVersion": 1, "providers": {}, "identities": {}}
+    if not path.is_file():
+        return empty
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return empty
+    if not isinstance(payload, dict):
+        return empty
+    providers: dict[str, Any] = {}
+    for key, row in (payload.get("providers") or {}).items() if isinstance(payload.get("providers"), dict) else ():
+        if not isinstance(key, str) or not isinstance(row, dict):
+            continue
+        until = _parse_exhausted_until(row.get("exhausted_until"))
+        if until is None or until <= clock:
+            continue
+        providers[key] = {
+            "exhausted_until": until.isoformat().replace("+00:00", "Z"),
+            "reason": row.get("reason") if isinstance(row.get("reason"), str) else "",
+        }
+    identities: dict[str, Any] = {}
+    for key, row in (payload.get("identities") or {}).items() if isinstance(payload.get("identities"), dict) else ():
+        if not isinstance(key, str) or not _HEX.fullmatch(key) or not isinstance(row, dict):
+            continue
+        until = _parse_exhausted_until(row.get("exhausted_until"))
+        if until is None or until <= clock:
+            continue
+        identities[key] = {
+            "exhausted_until": until.isoformat().replace("+00:00", "Z"),
+            "reason": row.get("reason") if isinstance(row.get("reason"), str) else "",
+        }
+    return {"schemaVersion": 1, "providers": providers, "identities": identities}
+
+
+def _write_exhaustion_cache(path: Path, payload: dict[str, Any]) -> None:
+    _write_json(path, payload)
+
+
+def record_provider_exhaustion(
+    provider: str,
+    *,
+    exhausted_until: datetime,
+    state_dir: Path | None = None,
+    now: datetime | None = None,
+    reason: str = "",
+) -> None:
+    """Record a negative backoff for one provider until exhausted_until."""
+    key = _provider_key(provider)
+    if not key:
+        return
+    clock = now or _utc_now()
+    if exhausted_until.tzinfo is None:
+        exhausted_until = exhausted_until.replace(tzinfo=UTC)
+    if exhausted_until <= clock:
+        return
+    path = exhaustion_cache_path(state_dir)
+    cache = load_exhaustion_cache(state_dir, now=clock)
+    cache.setdefault("providers", {})[key] = {
+        "exhausted_until": exhausted_until.isoformat().replace("+00:00", "Z"),
+        "reason": reason[:200],
+    }
+    _write_exhaustion_cache(path, cache)
+
+
+def record_identity_exhaustion(
+    identity_sha256: str,
+    *,
+    exhausted_until: datetime,
+    state_dir: Path | None = None,
+    now: datetime | None = None,
+    reason: str = "",
+) -> None:
+    """Record a negative backoff for one catalog identity until exhausted_until."""
+    if not isinstance(identity_sha256, str) or not _HEX.fullmatch(identity_sha256):
+        return
+    clock = now or _utc_now()
+    if exhausted_until.tzinfo is None:
+        exhausted_until = exhausted_until.replace(tzinfo=UTC)
+    if exhausted_until <= clock:
+        return
+    path = exhaustion_cache_path(state_dir)
+    cache = load_exhaustion_cache(state_dir, now=clock)
+    cache.setdefault("identities", {})[identity_sha256] = {
+        "exhausted_until": exhausted_until.isoformat().replace("+00:00", "Z"),
+        "reason": reason[:200],
+    }
+    _write_exhaustion_cache(path, cache)
+
+
+def update_exhaustion_cache_from_quota(
+    quota: object,
+    *,
+    state_dir: Path | None = None,
+    now: datetime | None = None,
+    retry_after_seconds: int = _DEFAULT_EXHAUSTION_SECONDS,
+) -> None:
+    """Update the user-local backoff cache from live quota exhaustion signals."""
+    clock = now or _utc_now()
+    until = clock + timedelta(seconds=max(1, int(retry_after_seconds)))
+    for row in quota if isinstance(quota, list) else []:
+        if not isinstance(row, dict):
+            continue
+        provider = row.get("provider")
+        if not isinstance(provider, str):
+            continue
+        left = row.get("remaining")
+        exhausted = row.get("state") == "exhausted" or (
+            isinstance(left, (int, float)) and left <= 0
+        )
+        if exhausted:
+            record_provider_exhaustion(
+                provider,
+                exhausted_until=until,
+                state_dir=state_dir,
+                now=clock,
+                reason="quota exhausted",
+            )
+
+
 def select_live_candidates(
     catalog: object, quota: object, *, required_capability: str,
     skip_identity_sha256s: object = (),
+    exhaustion_cache: object = None,
 ) -> list[dict[str, Any]]:
     """Join the current catalog to remaining quota and order the next usable model."""
     if required_capability not in _CAPABILITY_RANK:
@@ -884,6 +1025,15 @@ def select_live_candidates(
         item for item in skip_identity_sha256s or ()
         if isinstance(item, str) and _HEX.fullmatch(item)
     }
+    cache = exhaustion_cache if isinstance(exhaustion_cache, dict) else {}
+    blocked_providers = {
+        key for key in (cache.get("providers") or {})
+        if isinstance(key, str)
+    } if isinstance(cache.get("providers"), dict) else set()
+    blocked_identities = {
+        key for key in (cache.get("identities") or {})
+        if isinstance(key, str) and _HEX.fullmatch(key)
+    } if isinstance(cache.get("identities"), dict) else set()
     remaining: dict[str, int] = {}
     for row in quota if isinstance(quota, list) else []:
         if not isinstance(row, dict):
@@ -905,13 +1055,16 @@ def select_live_candidates(
         provider = item.get("provider")
         if not isinstance(provider, str) or not provider:
             continue
+        provider_key = _provider_key(provider)
+        if provider_key in blocked_providers:
+            continue
         native = catalog_native_id(item)
         if not native:
             continue
         model = catalog_request_id(provider, native)
         if not model:
             continue
-        left = remaining.get(_provider_key(provider))
+        left = remaining.get(provider_key)
         if not left:
             continue
         identity = (model, provider)
@@ -919,7 +1072,7 @@ def select_live_candidates(
             continue
         seen.add(identity)
         identity_sha = _sha256({"model": model, "provider": provider})
-        if identity_sha in skipped:
+        if identity_sha in skipped or identity_sha in blocked_identities:
             continue
         selected.append({
             "model": model,
@@ -1061,8 +1214,9 @@ def candidates(
     which: Callable[[str], str | None] | None = None,
     run: Callable[..., Any] | None = None,
     skip_identity_sha256s: object = (),
+    state_dir: Path | None = None,
 ) -> dict[str, Any]:
-    """Query the live local catalog and remaining quota on every dispatch. Never cache to disk."""
+    """Query live catalog and quota every dispatch; overlay user-local exhaustion backoff only."""
     locator = which or shutil.which
     if locator("omniroute") is None:
         return {"state": "ABSENT", "candidates": []}
@@ -1071,9 +1225,16 @@ def candidates(
         catalog = _live_catalog_rows(quota, run=run, which=locator)
     except OmniRouteError:
         return {"state": "UNHEALTHY", "candidates": []}
+    root = Path(state_dir) if state_dir is not None else default_state_path()
+    try:
+        update_exhaustion_cache_from_quota(quota, state_dir=root)
+        cache = load_exhaustion_cache(root)
+    except (OmniRouteError, OSError):
+        cache = {"schemaVersion": 1, "providers": {}, "identities": {}}
     picked = select_live_candidates(
         catalog, quota, required_capability=required_capability,
         skip_identity_sha256s=skip_identity_sha256s,
+        exhaustion_cache=cache,
     )
     return {"state": "READY" if picked else "RUNTIME_EXHAUSTED", "candidates": picked}
 

--- a/chaos-engine/skills/omniroute/scripts/runner.py
+++ b/chaos-engine/skills/omniroute/scripts/runner.py
@@ -843,6 +843,13 @@ def classify_capability(model_id: object) -> str:
 
 _DEFAULT_TASK_ORDER = {"default": 0, "most-intelligent": 1, "mechanical": 2}
 _RATE_LIMIT_MARKERS = ("429", "too many requests", "resource_exhausted", "rate limit")
+_QUOTA_RESET_MARKERS = ("quota reset", "quota-reset", "rate limit reset")
+_BALANCE_MARKERS = (
+    "insufficient balance",
+    "please recharge",
+    "no resource package",
+    "payment required",
+)
 _CATALOG_MISS_MARKERS = ("not available in the active live catalog",)
 
 
@@ -850,6 +857,18 @@ def diagnostic_is_rate_limited(text: object) -> bool:
     """True when child output shows HTTP 429 / provider rate limit, not auth failure."""
     blob = str(text or "").casefold()
     return any(marker in blob for marker in _RATE_LIMIT_MARKERS)
+
+
+def diagnostic_is_quota_reset(text: object) -> bool:
+    """True when child output shows quota-reset / retry-after cooldown text."""
+    blob = str(text or "").casefold()
+    return any(marker in blob for marker in _QUOTA_RESET_MARKERS)
+
+
+def diagnostic_is_insufficient_balance(text: object) -> bool:
+    """True when child output shows provider balance / payment exhaustion."""
+    blob = str(text or "").casefold()
+    return any(marker in blob for marker in _BALANCE_MARKERS)
 
 
 def diagnostic_is_catalog_mismatch(text: object) -> bool:
@@ -862,6 +881,17 @@ def diagnostic_is_stream_disconnected(text: object) -> bool:
     """True when Codex/OmniRoute closes the responses stream before completion."""
     blob = str(text or "").casefold()
     return "stream disconnected before completion" in blob or "stream closed before response.completed" in blob
+
+
+def diagnostic_signals_exhaustion(text: object) -> bool:
+    """True when diagnostics should update the user-local exhaustion backoff cache."""
+    return (
+        diagnostic_is_rate_limited(text)
+        or diagnostic_is_quota_reset(text)
+        or diagnostic_is_insufficient_balance(text)
+        or diagnostic_is_stream_disconnected(text)
+        or diagnostic_is_catalog_mismatch(text)
+    )
 
 
 def codex_model_overlay(provider: str, model: str) -> list[str]:
@@ -1011,6 +1041,46 @@ def update_exhaustion_cache_from_quota(
                 now=clock,
                 reason="quota exhausted",
             )
+
+
+def update_exhaustion_cache_from_diagnostic(
+    text: object,
+    *,
+    identity_sha256: str | None = None,
+    provider: str | None = None,
+    state_dir: Path | None = None,
+    now: datetime | None = None,
+    retry_after_seconds: int = _DEFAULT_EXHAUSTION_SECONDS,
+) -> bool:
+    """Update backoff cache from rate-limit / quota-reset / balance diagnostics."""
+    if not diagnostic_signals_exhaustion(text):
+        return False
+    clock = now or _utc_now()
+    until = clock + timedelta(seconds=max(1, int(retry_after_seconds)))
+    reason = str(text or "").strip()[:200]
+    recorded = False
+    block_provider = diagnostic_is_insufficient_balance(text) or (
+        provider is not None and identity_sha256 is None
+    )
+    if isinstance(identity_sha256, str) and _HEX.fullmatch(identity_sha256):
+        record_identity_exhaustion(
+            identity_sha256,
+            exhausted_until=until,
+            state_dir=state_dir,
+            now=clock,
+            reason=reason or "diagnostic exhaustion",
+        )
+        recorded = True
+    if block_provider and isinstance(provider, str) and provider:
+        record_provider_exhaustion(
+            provider,
+            exhausted_until=until,
+            state_dir=state_dir,
+            now=clock,
+            reason=reason or "diagnostic exhaustion",
+        )
+        recorded = True
+    return recorded
 
 
 def select_live_candidates(
@@ -1215,6 +1285,9 @@ def candidates(
     run: Callable[..., Any] | None = None,
     skip_identity_sha256s: object = (),
     state_dir: Path | None = None,
+    diagnostic: object = None,
+    failed_identity_sha256: str | None = None,
+    failed_provider: str | None = None,
 ) -> dict[str, Any]:
     """Query live catalog and quota every dispatch; overlay user-local exhaustion backoff only."""
     locator = which or shutil.which
@@ -1228,6 +1301,13 @@ def candidates(
     root = Path(state_dir) if state_dir is not None else default_state_path()
     try:
         update_exhaustion_cache_from_quota(quota, state_dir=root)
+        if diagnostic is not None:
+            update_exhaustion_cache_from_diagnostic(
+                diagnostic,
+                identity_sha256=failed_identity_sha256,
+                provider=failed_provider,
+                state_dir=root,
+            )
         cache = load_exhaustion_cache(root)
     except (OmniRouteError, OSError):
         cache = {"schemaVersion": 1, "providers": {}, "identities": {}}

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "078ffa0b25bf1cde16cd3d6ff7f6509700ea387ba7899a5776c389fbb6fe093c",
+      "harnessSha256": "20aa408f8ed71caeaeb81be8a2a14c23d9273b31bd4c6002b686b6471d6ac7f7",
       "treatmentSha256": {
-        "calibration": "e6db03d026b2e577ef016ff44f48cb074660238025ba18f1185ddd1b222e9080",
-        "full-pilot": "a1ce7e219be0a083cdcbe0af06a19c1034904b302db553ac44dfc6625ef14b3a"
+        "calibration": "53344722df0703bb375c04547cd6473545e3b4137c834e491b038038cb62c312",
+        "full-pilot": "b6e0e86f3ab1f45f238746da379e05c0886ad90ea1c913bc613da0b9545fd1d7"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "078ffa0b25bf1cde16cd3d6ff7f6509700ea387ba7899a5776c389fbb6fe093c"
+      harness_sha256: "20aa408f8ed71caeaeb81be8a2a14c23d9273b31bd4c6002b686b6471d6ac7f7"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "078ffa0b25bf1cde16cd3d6ff7f6509700ea387ba7899a5776c389fbb6fe093c"
+      harness_sha256: "20aa408f8ed71caeaeb81be8a2a14c23d9273b31bd4c6002b686b6471d6ac7f7"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -4118,6 +4118,23 @@ class ChaosEngineHostsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Codex configuration collision"):
             module.upgrade_before_images(Path("."), before, after, mutated)
 
+        foreign = dict(after)
+        foreign[".codex/config.toml"] = module.codex_content(
+            None, managed_python=Path("/tmp/evil-python")
+        )
+        with self.assertRaisesRegex(ValueError, "Codex configuration collision"):
+            module.upgrade_before_images(Path("."), before, after, foreign)
+
+    def test_preflight_rejects_foreign_role_adapter_bytes(self):
+        module = load(HOSTS, "chaos_engine_hosts_foreign_role_adapter")
+        before = {path: None for path in module.managed_paths()}
+        after = dict(before)
+        after[".claude/agents/chaos-engine-implementer.md"] = b"stale implementer\n"
+        current = dict(after)
+        current[".claude/agents/chaos-engine-implementer.md"] = b"foreign-role-adapter\n"
+        with self.assertRaisesRegex(ValueError, "host adapter drift detected"):
+            module.upgrade_before_images(Path("."), before, after, current)
+
     def test_tool_launcher_rejects_legacy_flat_runtime_without_active_pointer(self):
         module = load(TOOL, "chaos_engine_tool")
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_chaos_engine_hosts.py
+++ b/tests/scripts/test_chaos_engine_hosts.py
@@ -4039,6 +4039,85 @@ class ChaosEngineHostsTest(unittest.TestCase):
 
         self.assertEqual(b"new-foreign/\nexisting/\n", snapshot[".gitignore"])
 
+    def test_preflight_accepts_stale_receipt_when_plugin_hooks_match_package(self):
+        module = load(HOSTS, "chaos_engine_hosts_package_equal_hooks")
+        before = {path: None for path in module.managed_paths()}
+        after = dict(before)
+        current = dict(after)
+        for name in (
+            "guard.py",
+            "kernel.py",
+            "launch.js",
+            "lifecycle.py",
+            "matchers.json",
+            "reflection.py",
+        ):
+            relative = f"plugins/chaos-engine/hooks/{name}"
+            after[relative] = f"stale-{name}".encode()
+            current[relative] = (
+                Path(module.__file__).resolve().parent / "hooks" / name
+            ).read_bytes()
+        snapshot = module.upgrade_before_images(Path("."), before, after, current)
+        self.assertIsNone(snapshot["plugins/chaos-engine/hooks/guard.py"])
+        self.assertIsNone(snapshot["plugins/chaos-engine/hooks/launch.js"])
+
+    def test_preflight_rejects_foreign_plugin_hook_bytes(self):
+        module = load(HOSTS, "chaos_engine_hosts_foreign_plugin_hooks")
+        before = {path: None for path in module.managed_paths()}
+        after = dict(before)
+        current = dict(after)
+        current["plugins/chaos-engine/hooks/guard.py"] = b"foreign-guard-bytes\n"
+        with self.assertRaisesRegex(ValueError, "host adapter drift detected"):
+            module.upgrade_before_images(Path("."), before, after, current)
+
+    def test_preflight_accepts_orchestrator_adapters_matching_candidate_desired(self):
+        module = load(HOSTS, "chaos_engine_hosts_orchestrator_desired")
+        before = {path: None for path in module.managed_paths()}
+        after = dict(before)
+        after[".claude/agents/chaos-engine-orchestrator.md"] = b"stale orchestrator\n"
+        after[".codex/agents/chaos-engine-orchestrator.toml"] = b"stale = true\n"
+        desired = module.desired_content(before, maven_runtime=None, project_name="proj")
+        current = dict(after)
+        current[".claude/agents/chaos-engine-orchestrator.md"] = desired[
+            ".claude/agents/chaos-engine-orchestrator.md"
+        ]
+        current[".codex/agents/chaos-engine-orchestrator.toml"] = desired[
+            ".codex/agents/chaos-engine-orchestrator.toml"
+        ]
+        for relative in (
+            ".claude/agents/chaos-engine-orchestrator.md",
+            ".codex/agents/chaos-engine-orchestrator.toml",
+        ):
+            self.assertIn(
+                "process-owner-scrum-master.md",
+                desired[relative].decode("utf-8"),
+            )
+        snapshot = module.upgrade_before_images(Path("."), before, after, current)
+        self.assertIsNone(snapshot[".claude/agents/chaos-engine-orchestrator.md"])
+        self.assertIsNone(snapshot[".codex/agents/chaos-engine-orchestrator.toml"])
+
+    def test_preflight_codex_interpreter_spelling_equivalence(self):
+        module = load(HOSTS, "chaos_engine_hosts_codex_interpreter_equivalence")
+        before = {path: None for path in module.managed_paths()}
+        managed = Path(
+            "/home/user/.local/share/chaos-engine-runtime/uv-tools/mempalace/bin/python"
+        )
+        after = dict(before)
+        after[".codex/config.toml"] = module.codex_content(None)
+        current = dict(after)
+        current[".codex/config.toml"] = module.codex_content(
+            None, managed_python=managed
+        )
+        snapshot = module.upgrade_before_images(Path("."), before, after, current)
+        self.assertEqual(b"", snapshot[".codex/config.toml"])
+
+        mutated = dict(current)
+        mutated[".codex/config.toml"] = mutated[".codex/config.toml"].replace(
+            b'"memory-mcp"', b'"memory-mcp-foreign"', 1
+        )
+        with self.assertRaisesRegex(ValueError, "Codex configuration collision"):
+            module.upgrade_before_images(Path("."), before, after, mutated)
+
     def test_tool_launcher_rejects_legacy_flat_runtime_without_active_pointer(self):
         module = load(TOOL, "chaos_engine_tool")
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -799,9 +799,27 @@ class InstallerUxTests(unittest.TestCase):
             if line.startswith("https://github.com/owner/repo/issues/new?")
         )
         query = urllib.parse.parse_qs(urllib.parse.urlsplit(report).query)
-        self.assertEqual(["failed at <path> token=<redacted>"], query["cause"])
+        self.assertEqual(["failed at [path] token=<redacted>"], query["cause"])
         self.assertNotIn("super-secret", output)
         self.assertNotIn(str(private_path), output)
+        self.assertNotIn("<path>", output)
+
+    def test_one_line_cause_redacts_media_user_mounts_without_html_tags(self):
+        cause = BOOTSTRAP.one_line_cause(
+            RuntimeError(
+                "ChaosEngine host adapter drift detected: "
+                "/media/x/OS/Users/y/proj/plugins/chaos-engine/hooks/guard.py"
+            )
+        )
+        self.assertIn("[path]", cause)
+        self.assertNotIn("<path>", cause)
+        self.assertNotIn("/media/x/OS", cause)
+        self.assertNotIn("/Users/y", cause)
+        windows = BOOTSTRAP.one_line_cause(
+            RuntimeError(r"failed at C:\Users\runner\work\project\state.json")
+        )
+        self.assertIn("[path]", windows)
+        self.assertNotIn(r"C:\Users", windows)
 
     def test_pr_gate_runs_fresh_installer_on_exact_three_os_matrix(self):
         workflow = (ROOT / ".github/workflows/pr-gate.yml").read_text(encoding="utf-8")

--- a/tests/scripts/test_omniroute_catalog.py
+++ b/tests/scripts/test_omniroute_catalog.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import tempfile
 import unittest
 import unittest.mock
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 
@@ -138,6 +140,10 @@ class OmniRouteCatalogTest(unittest.TestCase):
         self.assertIn("first installed implementer target: `claude`, then `opencode`, then", skill)
         self.assertIn("OMNIROUTE_ROTATE_ON_400=true", skill)
         self.assertIn("Thinking Budget on the OmniRoute host must be `passthrough`", skill)
+        self.assertIn("provider-exhaustion backoff", skill.casefold())
+        self.assertIn("exhausted_until", skill)
+        self.assertIn("user-local", skill.casefold())
+        self.assertIn("not a positive catalog cache", skill.casefold())
 
     def test_catalog_cli_does_not_forward_ambient_endpoint_key(self):
         seen = []
@@ -248,6 +254,111 @@ class OmniRouteCatalogTest(unittest.TestCase):
         self.assertTrue(RUNNER.diagnostic_is_stream_disconnected(
             "stream disconnected before completion: stream closed before response.completed"
         ))
+
+
+class OmniRouteExhaustionBackoffTest(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self.root.chmod(0o700)
+        self.state = self.root / "state"
+        self.state.mkdir(mode=0o700)
+
+    def test_records_exhaustion_skips_until_retry_and_expires(self):
+        cache_path = RUNNER.exhaustion_cache_path(self.state)
+        now = datetime(2030, 1, 1, tzinfo=UTC)
+        until = now + timedelta(hours=2)
+        RUNNER.record_provider_exhaustion(
+            "glm",
+            exhausted_until=until,
+            state_dir=self.state,
+            now=now,
+            reason="state=exhausted",
+        )
+        self.assertTrue(cache_path.is_file())
+        if cache_path.stat().st_mode & 0o777:
+            self.assertEqual(0o600, cache_path.stat().st_mode & 0o777)
+        catalog = [
+            {"id": "Tool Low", "provider": "glm"},
+            {"id": "Other Default", "provider": "beta"},
+        ]
+        quota = [
+            {"provider": "glm", "remaining": 40, "state": "available"},
+            {"provider": "beta", "remaining": 90, "state": "available"},
+        ]
+        skipped = RUNNER.select_live_candidates(
+            catalog,
+            quota,
+            required_capability="default",
+            exhaustion_cache=RUNNER.load_exhaustion_cache(self.state, now=now),
+        )
+        self.assertEqual(["beta/other-default"], [item["model"] for item in skipped])
+        expired = RUNNER.select_live_candidates(
+            catalog,
+            quota,
+            required_capability="default",
+            exhaustion_cache=RUNNER.load_exhaustion_cache(
+                self.state, now=until + timedelta(seconds=1)
+            ),
+        )
+        self.assertEqual(
+            ["beta/other-default", "glm/tool-low"],
+            [item["model"] for item in expired],
+        )
+
+    def test_candidates_path_applies_user_local_exhaustion_overlay(self):
+        now = datetime(2030, 1, 1, tzinfo=UTC)
+        RUNNER.record_provider_exhaustion(
+            "alpha",
+            exhausted_until=now + timedelta(minutes=30),
+            state_dir=self.state,
+            now=now,
+            reason="HTTP 429",
+        )
+
+        def fake_run(command, **_kwargs):
+            class Result:
+                stdout = ""
+                returncode = 0
+
+            if command[-2:] == ["usage", "quota"]:
+                Result.stdout = json.dumps(
+                    [
+                        {"provider": "alpha", "remaining": 7, "state": "available"},
+                        {"provider": "beta", "remaining": 9, "state": "available"},
+                    ]
+                )
+            elif "models" in command:
+                provider = command[-1]
+                Result.stdout = json.dumps(
+                    [{"id": f"{provider.title()} Low", "provider": provider}]
+                )
+            return Result()
+
+        with unittest.mock.patch.object(RUNNER.shutil, "which", return_value="/usr/bin/omniroute"):
+            with unittest.mock.patch.object(RUNNER.subprocess, "run", side_effect=fake_run):
+                with unittest.mock.patch.object(
+                    RUNNER, "default_state_path", return_value=self.state
+                ):
+                    with unittest.mock.patch.object(RUNNER, "_utc_now", return_value=now):
+                        result = RUNNER.candidates(required_capability="mechanical")
+        self.assertEqual("READY", result["state"])
+        self.assertEqual(["beta/beta-low"], [item["model"] for item in result["candidates"]])
+        self.assertFalse((Path.cwd() / "provider-exhaustion.json").exists())
+
+    def test_quota_exhaustion_signal_updates_cache(self):
+        now = datetime(2030, 1, 1, tzinfo=UTC)
+        RUNNER.update_exhaustion_cache_from_quota(
+            [
+                {"provider": "gamma", "remaining": 0, "state": "exhausted"},
+                {"provider": "beta", "remaining": 12, "state": "available"},
+            ],
+            state_dir=self.state,
+            now=now,
+            retry_after_seconds=3600,
+        )
+        cache = RUNNER.load_exhaustion_cache(self.state, now=now)
+        self.assertIn("gamma", cache.get("providers", {}))
+        self.assertNotIn("beta", cache.get("providers", {}))
         self.assertFalse(RUNNER.diagnostic_is_stream_disconnected("401 Unauthorized: Invalid API key"))
 
 

--- a/tests/scripts/test_omniroute_catalog.py
+++ b/tests/scripts/test_omniroute_catalog.py
@@ -254,6 +254,7 @@ class OmniRouteCatalogTest(unittest.TestCase):
         self.assertTrue(RUNNER.diagnostic_is_stream_disconnected(
             "stream disconnected before completion: stream closed before response.completed"
         ))
+        self.assertFalse(RUNNER.diagnostic_is_stream_disconnected("401 Unauthorized: Invalid API key"))
 
 
 class OmniRouteExhaustionBackoffTest(unittest.TestCase):
@@ -359,7 +360,94 @@ class OmniRouteExhaustionBackoffTest(unittest.TestCase):
         cache = RUNNER.load_exhaustion_cache(self.state, now=now)
         self.assertIn("gamma", cache.get("providers", {}))
         self.assertNotIn("beta", cache.get("providers", {}))
-        self.assertFalse(RUNNER.diagnostic_is_stream_disconnected("401 Unauthorized: Invalid API key"))
+
+    def test_production_429_diagnostic_writes_cache_and_candidates_skips(self):
+        now = datetime(2030, 1, 1, tzinfo=UTC)
+        until = now + timedelta(hours=2)
+        diagnostic = "exceeded retry limit, last status: 429 Too Many Requests"
+
+        def fake_run(command, **_kwargs):
+            class Result:
+                stdout = ""
+                returncode = 0
+
+            if command[-2:] == ["usage", "quota"]:
+                Result.stdout = json.dumps(
+                    [
+                        {"provider": "alpha", "remaining": 7, "state": "available"},
+                        {"provider": "beta", "remaining": 9, "state": "available"},
+                    ]
+                )
+            elif "models" in command:
+                provider = command[-1]
+                Result.stdout = json.dumps(
+                    [{"id": f"{provider.title()} Low", "provider": provider}]
+                )
+            return Result()
+
+        with unittest.mock.patch.object(RUNNER.shutil, "which", return_value="/usr/bin/omniroute"):
+            with unittest.mock.patch.object(RUNNER.subprocess, "run", side_effect=fake_run):
+                with unittest.mock.patch.object(
+                    RUNNER, "default_state_path", return_value=self.state
+                ):
+                    with unittest.mock.patch.object(RUNNER, "_utc_now", return_value=now):
+                        first = RUNNER.candidates(required_capability="mechanical")
+                        failed = first["candidates"][0]
+                        second = RUNNER.candidates(
+                            required_capability="mechanical",
+                            diagnostic=diagnostic,
+                            failed_identity_sha256=failed["identitySha256"],
+                            failed_provider=failed["provider"],
+                        )
+        self.assertEqual("beta/beta-low", failed["model"])
+        cache = RUNNER.load_exhaustion_cache(self.state, now=now)
+        self.assertIn(failed["identitySha256"], cache.get("identities", {}))
+        self.assertEqual(["alpha/alpha-low"], [item["model"] for item in second["candidates"]])
+        self.assertNotEqual(failed["identitySha256"], second["candidates"][0]["identitySha256"])
+        still_blocked = RUNNER.select_live_candidates(
+            [
+                {"id": "Alpha Low", "provider": "alpha"},
+                {"id": "Beta Low", "provider": "beta"},
+            ],
+            [
+                {"provider": "alpha", "remaining": 7, "state": "available"},
+                {"provider": "beta", "remaining": 9, "state": "available"},
+            ],
+            required_capability="mechanical",
+            exhaustion_cache=RUNNER.load_exhaustion_cache(self.state, now=now),
+        )
+        self.assertEqual(["alpha/alpha-low"], [item["model"] for item in still_blocked])
+        expired = RUNNER.select_live_candidates(
+            [
+                {"id": "Alpha Low", "provider": "alpha"},
+                {"id": "Beta Low", "provider": "beta"},
+            ],
+            [
+                {"provider": "alpha", "remaining": 7, "state": "available"},
+                {"provider": "beta", "remaining": 9, "state": "available"},
+            ],
+            required_capability="mechanical",
+            exhaustion_cache=RUNNER.load_exhaustion_cache(
+                self.state, now=until + timedelta(seconds=1)
+            ),
+        )
+        self.assertEqual(
+            ["beta/beta-low", "alpha/alpha-low"],
+            [item["model"] for item in expired],
+        )
+
+    def test_insufficient_balance_diagnostic_blocks_provider(self):
+        now = datetime(2030, 1, 1, tzinfo=UTC)
+        recorded = RUNNER.update_exhaustion_cache_from_diagnostic(
+            "ERROR: insufficient balance for provider alpha",
+            provider="alpha",
+            state_dir=self.state,
+            now=now,
+            retry_after_seconds=1800,
+        )
+        self.assertTrue(recorded)
+        cache = RUNNER.load_exhaustion_cache(self.state, now=now)
+        self.assertIn("alpha", cache.get("providers", {}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes installer failure when ChaosEngine is reinstalled/upgraded inside the SHAFT_ENGINE origin checkout with a stale host receipt but package-equal plugin hooks (issue #5554).

Also adds the owner-requested OmniRoute learned lesson: a user-local provider-exhaustion backoff cache so agents skip providers that still have free-quota cooldown, and update that cache when exhaustion is observed.

## Root cause

- `upgrade_before_images` treated package-equal `plugins/chaos-engine/hooks/*` as drift when they no longer matched the receipt and `.chaos-engine` core was missing.
- Issue Cause `.../media/mohab/OS` was a scrubbing artifact: `one_line_cause` used HTML-like `<path>`, which GitHub issue forms strip.

## Changes

- Accept exact-copy plugin hooks that match core, backup, or candidate package bytes.
- Align orchestrator adapters with process-owner load text; accept adapters equal to candidate desired.
- Equate Codex owned-block interpreter spellings (`python3`/`py -3` vs absolute managed python).
- Redact causes with non-HTML `[path]`, including `/media|mnt|Volumes/.../Users|home` mounts.
- OmniRoute skill + runner: XDG-state `provider-exhaustion.json` negative backoff overlay (not a catalog cache).

## Proof

```bash
python3 -m unittest \
  tests.scripts.test_chaos_engine_hosts \
  tests.scripts.test_chaos_engine_installer \
  tests.scripts.test_chaos_engine_installer_ux \
  tests.scripts.test_omniroute \
  tests.scripts.test_omniroute_catalog \
  -v
# Ran 387 tests — OK
python3 scripts/ci/validate_agent_setup.py --skip-external
# Agent setup is valid
```

Closes #5554