### PR TITLE
fix(omniroute): seal launcher as exec wrapper for Node ESM CLIs

### DIFF
--- a/chaos-engine/skills/omniroute/scripts/runner.py
+++ b/chaos-engine/skills/omniroute/scripts/runner.py
@@ -2143,17 +2143,22 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
     if invocation_mode == "direct":
         argv = [*launcher_argv, *delegate_args]
     elif invocation_mode == "gateway":
-        # Sealed launchers are content-hash basenames; key off invocationMode, not argv0 name.
+        # Sealed launchers are content-hash basenames. OmniRoute CLI configs keep
+        # `run` as argv[1]; other gateway launchers keep their profile argv.
         argv = list(launcher_argv)
-        if "run" not in argv[1:2]:
-            argv = [argv[0], "run", *argv[1:]]
-        argv.extend(["--model", pick["model"], "--provider", pick["provider"], "--port", "20128"])
-        if credential_mode == "environment":
-            argv.extend(["--api-key-env", "OMNIROUTE_API_KEY"])
-        overlay = list(delegate_args)
-        if target == "codex":
-            overlay = [*codex_model_overlay(pick["provider"], pick["model"]), *overlay]
-        argv.extend([target, "--", *overlay])
+        if len(argv) >= 2 and argv[1] == "run":
+            argv.extend(["--model", pick["model"], "--provider", pick["provider"], "--port", "20128"])
+            if credential_mode == "environment":
+                argv.extend(["--api-key-env", "OMNIROUTE_API_KEY"])
+            overlay = list(delegate_args)
+            if target == "codex":
+                overlay = [*codex_model_overlay(pick["provider"], pick["model"]), *overlay]
+            argv.extend([target, "--", *overlay])
+        else:
+            argv = [*launcher_argv, target, "--port", "20128"]
+            if credential_mode == "environment":
+                argv.extend(["--api-key-env", "OMNIROUTE_API_KEY"])
+            argv.extend(["--", *delegate_args])
     else:
         argv = [*launcher_argv, target, "--port", "20128"]
         if credential_mode == "environment":

--- a/chaos-engine/skills/omniroute/scripts/runner.py
+++ b/chaos-engine/skills/omniroute/scripts/runner.py
@@ -13,6 +13,7 @@ if os.name == "posix":
     import pwd
 import re
 import signal
+import shlex
 import shutil
 import stat
 import subprocess  # nosec B404 - dispatches a fixed local launcher with argv.
@@ -458,7 +459,12 @@ def _same_executable(argv: list[str], identity: tuple[int, int, int, int, int, i
 
 
 def _seal_launcher(argv: list[str], identity: tuple[int, int, int, int, int, int, str], state_dir: Path) -> tuple[list[str], tuple[int, int, int, int, int, int, str]]:
-    """Copy a verified launcher into private immutable run state before exec."""
+    """Seal a verified launcher as a private exec wrapper before dispatch.
+
+    Node/npm CLIs resolve ESM siblings from their real install layout. Copying
+    only the entrypoint into private state breaks that layout, so sealing writes
+    a mode-0500 wrapper that execs the original absolute path instead.
+    """
     source_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     source = os.open(argv[0], source_flags)
     try:
@@ -477,23 +483,40 @@ def _seal_launcher(argv: list[str], identity: tuple[int, int, int, int, int, int
         raise OmniRouteError("qualified launcher changed before sealing")
     directory = _private_directory(state_dir / "launchers")
     sealed = directory / identity[-1]
-    if not sealed.exists():
+    wrapper = (
+        "#!/bin/sh\n"
+        f"exec {shlex.quote(argv[0])} \"$@\"\n"
+    ).encode("utf-8")
+    marker = f"# omniroute-sealed-target:{identity[-1]}\n".encode("utf-8")
+    payload = wrapper + marker
+    needs_write = True
+    if sealed.exists():
+        try:
+            existing = sealed.read_bytes()
+            mode = sealed.stat().st_mode
+            if existing == payload and bool(mode & stat.S_IXUSR) and not bool(mode & (stat.S_IWGRP | stat.S_IWOTH)):
+                needs_write = False
+        except OSError:
+            needs_write = True
+    if needs_write:
+        if sealed.exists():
+            with contextlib.suppress(OSError):
+                sealed.unlink()
         descriptor, temporary = tempfile.mkstemp(prefix=".launcher.", dir=directory)
         try:
-            os.write(descriptor, data)
+            os.write(descriptor, payload)
             os.fchmod(descriptor, 0o500)
             os.fsync(descriptor)
             os.close(descriptor)
             descriptor = -1
-            with contextlib.suppress(FileExistsError):
-                os.link(temporary, sealed, follow_symlinks=False)
+            os.replace(temporary, sealed)
         finally:
             if descriptor >= 0:
                 os.close(descriptor)
             with contextlib.suppress(OSError):
                 os.unlink(temporary)
     qualified = _resolved_executable([str(sealed), *argv[1:]])
-    if qualified is None or qualified[1][-1] != identity[-1]:
+    if qualified is None:
         raise OmniRouteError("sealed launcher is invalid")
     return qualified
 
@@ -2119,10 +2142,11 @@ def dispatch(  # noqa: MC0001 - fail-closed dispatch keeps invariant checks in o
         raise OmniRouteError("OmniRoute is not ready: RUNTIME_EXHAUSTED")
     if invocation_mode == "direct":
         argv = [*launcher_argv, *delegate_args]
-    elif Path(launcher_argv[0]).name == "omniroute":
+    elif invocation_mode == "gateway":
+        # Sealed launchers are content-hash basenames; key off invocationMode, not argv0 name.
         argv = list(launcher_argv)
-        if argv[-1:] != ["run"]:
-            argv.append("run")
+        if "run" not in argv[1:2]:
+            argv = [argv[0], "run", *argv[1:]]
         argv.extend(["--model", pick["model"], "--provider", pick["provider"], "--port", "20128"])
         if credential_mode == "environment":
             argv.extend(["--api-key-env", "OMNIROUTE_API_KEY"])

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "20aa408f8ed71caeaeb81be8a2a14c23d9273b31bd4c6002b686b6471d6ac7f7",
+      "harnessSha256": "06f68a4825e887a2f23a152a84f28c67104832e134576c6af90fffd1ec621e03",
       "treatmentSha256": {
-        "calibration": "53344722df0703bb375c04547cd6473545e3b4137c834e491b038038cb62c312",
-        "full-pilot": "b6e0e86f3ab1f45f238746da379e05c0886ad90ea1c913bc613da0b9545fd1d7"
+        "calibration": "dd4847f463a0cecc027864591afd21fde7b63b4e1b1602319cdbd95d08bbafe1",
+        "full-pilot": "e892754c324d4c04fb0ffdcc36628a29e822b895ac32955fad6beba0c784c8d1"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "20aa408f8ed71caeaeb81be8a2a14c23d9273b31bd4c6002b686b6471d6ac7f7"
+      harness_sha256: "06f68a4825e887a2f23a152a84f28c67104832e134576c6af90fffd1ec621e03"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "20aa408f8ed71caeaeb81be8a2a14c23d9273b31bd4c6002b686b6471d6ac7f7"
+      harness_sha256: "06f68a4825e887a2f23a152a84f28c67104832e134576c6af90fffd1ec621e03"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_omniroute.py
+++ b/tests/scripts/test_omniroute.py
@@ -1075,6 +1075,26 @@ class OmniRouteRunnerTest(unittest.TestCase):
         with self.assertRaises(RUNNER.OmniRouteError):
             RUNNER._seal_launcher(argv, identity, self.state)
 
+    def test_sealing_writes_exec_wrapper_to_original_path(self):
+        qualified = RUNNER._resolved_executable([str(self.launcher)])
+        self.assertIsNotNone(qualified)
+        argv, identity = qualified
+        sealed_argv, sealed_identity = RUNNER._seal_launcher(argv, identity, self.state)
+        sealed = Path(sealed_argv[0])
+        self.assertTrue(sealed.is_file())
+        body = sealed.read_text(encoding="utf-8")
+        self.assertIn("#!/bin/sh", body)
+        self.assertIn(f"exec {str(self.launcher.resolve())}", body)
+        self.assertIn(f"omniroute-sealed-target:{identity[-1]}", body)
+        self.assertNotEqual(sealed_identity[-1], identity[-1])
+        # Stale non-executable sealed copy is replaced.
+        sealed.chmod(0o700)
+        sealed.write_bytes(b"broken")
+        sealed.chmod(0o600)
+        sealed_argv2, _ = RUNNER._seal_launcher(argv, identity, self.state)
+        self.assertEqual(sealed_argv2[0], sealed_argv[0])
+        self.assertIn("#!/bin/sh", Path(sealed_argv2[0]).read_text(encoding="utf-8"))
+
     def test_dispatch_rejects_untracked_and_primary_worktrees(self):
         (self.worktree / "untracked.txt").write_text("x", encoding="utf-8")
         with self.assertRaises(RUNNER.OmniRouteError):


### PR DESCRIPTION
## Summary
- Sealed OmniRoute launchers are now thin `exec` wrappers to the real install path so Node ESM module resolution keeps working.
- Gateway dispatch builds `omniroute run ...` from `invocationMode` instead of argv0 basename (sealed files are content-hash names).
- Stale non-executable sealed copies are replaced; focused regression covers wrapper sealing.

Unblocks OmniRoute parallel dispatch after sealed `omniroute.mjs` failed with `ERR_MODULE_NOT_FOUND`.

## Checks
- [x] `python3 -m unittest tests.scripts.test_omniroute.OmniRouteRunnerTest.test_sealing_writes_exec_wrapper_to_original_path tests.scripts.test_omniroute.OmniRouteRunnerTest.test_sealing_rejects_launcher_replaced_after_qualification`