### PR TITLE
ci(e2e): force matched Chrome download on MacOSX_Chrome_Local

### DIFF
--- a/.github/workflows/e2eLocalTests.yml
+++ b/.github/workflows/e2eLocalTests.yml
@@ -478,7 +478,7 @@ jobs:
           mvn -pl shaft-visual -am -e install "-DskipTests" "-Dgpg.skip"
       - name: Run tests
         continue-on-error: true
-        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=chrome" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
+        run: mvn -pl shaft-engine -am -e test "-DincludeVisualTestRuntime" "-DdefaultElementIdentificationTimeout=5" "-DsetParallelMode=NONE" "-DretryMaximumNumberOfAttempts=1" "-DexecutionAddress=local" "-DtargetOperatingSystem=MAC" "-DtargetBrowserName=chrome" "-DforceBrowserDownload=true" "-DheadlessExecution=true" "-DgenerateAllureReportArchive=true" "-Dtest=${{ github.event.inputs.tests != '' && github.event.inputs.tests || env.GLOBAL_TESTING_SCOPE }}"
       - name: Post-Test Report and Check
         id: post_test_report
         if: always()


### PR DESCRIPTION
## Summary
Enable `-DforceBrowserDownload=true` for `MacOSX_Chrome_Local` so Selenium Manager provisions a matched Chrome-for-Testing + ChromeDriver pair (avoids `ChromeDriver only supports Chrome version …` skew on macOS runners).

## Notes
- Rebased onto main; dropped the obsolete `BrowserActionsHelper` patch — the fuller Safari failed-navigate Allure fix already merged in #5567.
- Nightly Local E2E owns confirmation; agents do not manually rerun the full matrix.

## Related
- #5528 (primary Allure/Safari root cause fixed in #5567; this is residual Mac Chrome driver-match hardening)
