### PR TITLE
fix(security): pin Tomcat 11.0.25 in report-aggregate

### DIFF
--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -20,6 +20,29 @@
         <skipPublishing>true</skipPublishing>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Dependabot attributes tomcat-embed-core alerts to this module via shaft-mcp.
+                 Pin here so the report-aggregate graph resolves 11.0.25 without waiting on
+                 a published shaft-mcp POM. Keep in sync with shaft-mcp/pom.xml. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>11.0.25</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>11.0.25</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>11.0.25</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
## Summary
Mirrors the Tomcat 11.0.25 `dependencyManagement` pins from `shaft-mcp` into `report-aggregate` so Dependabot clears the remaining alerts attributed to that manifest.

## Test plan
- [ ] CI green
- [ ] Dependabot alerts 227-229 close
