### PR TITLE
fix(engine): keep failed-navigate Allure step when Safari screenshot hangs

### DIFF
--- a/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/browser/internal/BrowserActionsHelper.java
@@ -206,7 +206,18 @@ public class BrowserActionsHelper {
         CheckpointStatus status = Boolean.TRUE.equals(passFailStatus) ? CheckpointStatus.PASS : CheckpointStatus.FAIL;
         if (!isSilent) {
             if (driver != null && !message.equals("Capture page snapshot.")) {
-                attachments.add(new ScreenshotManager().takeScreenshot(driver, null, actionName, passFailStatus));
+                // Evidence capture must never suppress the action step itself. On Safari a
+                // hung mid-navigation page can make getScreenshotAs block until the HTTP
+                // client times out (~3m) and FailureReporter.fail would otherwise replace
+                // the navigate Allure step with "Failed to capture a screenshot" (#5528).
+                if (Boolean.FALSE.equals(passFailStatus)) {
+                    tryStopInFlightNavigation(driver);
+                }
+                try {
+                    attachments.add(new ScreenshotManager().takeScreenshot(driver, null, actionName, passFailStatus));
+                } catch (RuntimeException screenshotFailure) {
+                    ReportManagerHelper.logDiscrete(screenshotFailure);
+                }
                 logWithProfiledAttachments(actionName, message, attachments, status);
             } else if (!attachments.isEmpty()) {
                 logWithProfiledAttachments(actionName, message, attachments, status);
@@ -217,6 +228,14 @@ public class BrowserActionsHelper {
                     "", driver, message, firstThrowable(rootCauseException), Map.of(), summarizeAttachments(attachments));
         }
         return message;
+    }
+
+    private static void tryStopInFlightNavigation(WebDriver driver) {
+        try {
+            ((JavascriptExecutor) driver).executeScript("window.stop();");
+        } catch (RuntimeException ignored) {
+            ReportManagerHelper.logDiscrete(ignored);
+        }
     }
 
     private static Throwable firstThrowable(Exception[] exceptions) {

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/image/ScreenshotHelper.java
@@ -133,11 +133,18 @@ public class ScreenshotHelper {
                 ReportManagerHelper.logDiscrete(exception, Level.WARN);
                 ReportManagerHelper.logDiscrete("Could not take a screenshot after 5 attempts.", Level.WARN);
                 return null;
+            } else if (isHungDriverScreenshotFailure(exception)) {
+                // Hung mid-navigation sessions (Safari after a never-completing load) time out
+                // the WebDriver HTTP client. Soft-degrade so action reporting can still write
+                // its Allure step instead of being replaced by a screenshot failure (#5528).
+                ReportManagerHelper.logDiscrete(exception, Level.WARN);
+                ReportManagerHelper.logDiscrete("Could not take a screenshot; continuing without evidence.", Level.WARN);
+                return null;
             } else
                 // java.lang.RuntimeException: Unexpected result for screenshot command: com.google.common.collect.Maps$TransformedEntriesMap instance
-                if (exception.getMessage().contains("Permission denied to access property \"pageXOffset\" on cross-origin object")
+                if (exception.getMessage() != null && (exception.getMessage().contains("Permission denied to access property \"pageXOffset\" on cross-origin object")
                         || exception.getMessage().contains("not connected to DevTools")
-                        || exception.getMessage().contains("unhandled inspector error: {\"code\":-32000,\"message\":\"Unable to capture screenshot\"}")) {
+                        || exception.getMessage().contains("unhandled inspector error: {\"code\":-32000,\"message\":\"Unable to capture screenshot\"}"))) {
                     // Ubuntu_Firefox_Grid
                     // org.openqa.selenium.WebDriverException: SecurityError: Permission denied to access property "pageXOffset" on cross-origin object
                     // MacOSX_Chrome_Local
@@ -151,6 +158,21 @@ public class ScreenshotHelper {
                     return null;
                 }
         }
+    }
+
+    private static boolean isHungDriverScreenshotFailure(Throwable exception) {
+        for (Throwable cursor = exception; cursor != null; cursor = cursor.getCause()) {
+            if (cursor instanceof TimeoutException
+                    || cursor instanceof java.util.concurrent.TimeoutException
+                    || cursor instanceof java.net.http.HttpTimeoutException) {
+                return true;
+            }
+            String message = cursor.getMessage();
+            if (message != null && message.toLowerCase(java.util.Locale.ROOT).contains("request timed out")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @SuppressWarnings("unchecked")

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mockito;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chromium.HasCdp;
@@ -33,6 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class ScreenshotHelperCoverageUnitTest {
@@ -146,6 +148,18 @@ public class ScreenshotHelperCoverageUnitTest {
             ScreenshotHelper.takeViewportScreenshot(fatalDriver, 1);
 
             failureReporter.verify(() -> FailureReporter.fail(eq(ScreenshotHelper.class), anyString(), any(Throwable.class)));
+        }
+    }
+
+    @Test
+    public void takeViewportScreenshotShouldSoftFailOnHungDriverTimeout() {
+        WebDriver hungDriver = Mockito.mock(WebDriver.class, Mockito.withSettings().extraInterfaces(TakesScreenshot.class));
+        when(((TakesScreenshot) hungDriver).getScreenshotAs(OutputType.BYTES))
+                .thenThrow(new TimeoutException("java.net.http.HttpTimeoutException: request timed out"));
+
+        try (MockedStatic<FailureReporter> failureReporter = mockStatic(FailureReporter.class)) {
+            Assert.assertNull(ScreenshotHelper.takeViewportScreenshot(hungDriver, 1));
+            failureReporter.verifyNoInteractions();
         }
     }
 

--- a/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/gui/internal/image/ScreenshotHelperCoverageUnitTest.java
@@ -34,7 +34,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class ScreenshotHelperCoverageUnitTest {

--- a/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
+++ b/shaft-engine/src/test/java/com/shaft/tools/io/internal/AllureActionStepReportingTest.java
@@ -95,12 +95,15 @@ public class AllureActionStepReportingTest extends Tests {
     public void failedNavigateStillWritesExactlyOneFailedOrBrokenAllureStep() throws IOException {
         // SHAFT defaults pageLoadStrategy=none and readinessState=none, so get()
         // returns before the document exists. Recreate a driver that waits, then
-        // hit a URL that never writes an HTTP response. That is a navigation the
-        // driver cannot complete, not a 200 page whose body is "Invalid URL".
+        // hit the local TestPageServer never-respond URL (no live network). That
+        // is a navigation the driver cannot complete, not a 200 page whose body is
+        // "Invalid URL". Bound the withheld response: Safari forever mid-load made
+        // failure screenshots mask the navigate Allure step (#5528).
         driver.get().quit();
         SHAFT.Properties.web.set().pageLoadStrategy("normal");
         SHAFT.Properties.web.set().readinessState("complete");
         SHAFT.Properties.timeouts.set().pageLoadTimeout(2);
+        SHAFT.Properties.visuals.set().createAnimatedGif(false);
         driver.set(new SHAFT.GUI.WebDriver());
         driver.get().getDriver().manage().timeouts().pageLoadTimeout(Duration.ofSeconds(2));
         String url = TestPageServer.neverRespondUrl();

--- a/shaft-engine/src/test/java/testPackage/TestPageServer.java
+++ b/shaft-engine/src/test/java/testPackage/TestPageServer.java
@@ -31,8 +31,9 @@ public final class TestPageServer {
     }
 
     /**
-     * URL that accepts TCP and never writes an HTTP response, so a driver that
-     * actually waits for page load cannot complete navigation.
+     * URL that accepts TCP and withholds an HTTP response long enough for a driver
+     * with a short pageLoadTimeout to fail navigation, then drops the connection.
+     * Local-only fixture — no live network (#5528).
      */
     public static String neverRespondUrl() {
         ensureStarted();
@@ -89,7 +90,11 @@ public final class TestPageServer {
 
     private static void neverRespond(HttpExchange exchange) {
         try {
-            Thread.sleep(Long.MAX_VALUE);
+            // Hold past typical pageLoadTimeout used by failed-navigate proofs (2s) so
+            // Selenium raises TimeoutException on navigate, then drop the socket. A
+            // forever sleep left Safari mid-load; failure screenshots hung (~3m) and
+            // masked the navigate Allure step (#5528).
+            Thread.sleep(5_000L);
         } catch (InterruptedException interruptedException) {
             Thread.currentThread().interrupt();
         } finally {


### PR DESCRIPTION
## Summary
- Fixes nightly Local E2E flake on `MacOSX_Safari_Local_1` for `AllureActionStepReportingTest.failedNavigateStillWritesExactlyOneFailedOrBrokenAllureStep` (tracking #5528).
- Root cause: local `TestPageServer.neverRespondUrl()` left Safari mid-load after `pageLoadTimeout`; failure screenshots hung (~3m), `FailureReporter.fail` from `ScreenshotHelper` replaced the navigate Allure step (0 navigate steps observed).
- Soft-degrade hung-driver screenshot timeouts; always write the browser action Allure step even if evidence capture throws; `window.stop()` before failure screenshots; bound the local never-respond hold (no live `shafthq.github.io`).

Closes #5528

## Test plan
- [x] Added `ScreenshotHelperCoverageUnitTest.takeViewportScreenshotShouldSoftFailOnHungDriverTimeout`
- [ ] CI Local E2E / targeted Safari job for `AllureActionStepReportingTest.failedNavigateStillWritesExactlyOneFailedOrBrokenAllureStep`
- [ ] Confirm no live-site dependency in the failing proof (still uses `TestPageServer.neverRespondUrl()`)