### PR TITLE
[CE] One-command install golden path polish (#5570)

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -24,8 +24,8 @@ the project you want to manage:
 > Install or upgrade ChaosEngine in this project from the latest commit of the
 > official upstream. Change into the target project first. Run
 > `chaos-engine/install.ps1` on Windows (`irm ... | iex`) or
-> `chaos-engine/install.sh` on macOS/Linux (`curl -fsSL ... | bash -s -- <url>`).
-> Those wrappers read owner/repository from the invocation URL, then download
+> `chaos-engine/install.sh` on macOS/Linux (`curl -fsSL ... | bash -s -- <same-url>`).
+> Those wrappers read the upstream owner/name from the invocation URL, then download
 > `bootstrap.py` and run the full install: hooks, skills,
 > companions, Memory, MemPalace, Graphify CLI, and doctor. Do not stop until
 > the active doctor reports the resolved 40-character commit and every
@@ -58,14 +58,12 @@ configures, authenticates, or requires OmniRoute. Without a qualified local
 service, canonical [execution workflows](references/execution-workflows.md)
 continue through native implementers or `SOLO`.
 
-The Windows example below uses an `owner/repository` placeholder; replace it
-with the upstream that hosts the wrapper. The macOS/Linux example constructs
-the official upstream URL without embedding source identity in the portable
-payload. The scripts parse their invocation URL and do not copy that identity
-into the adopter payload. `CHAOS_ENGINE_REPOSITORY` remains a local-file
-override when the invocation URL cannot be parsed. Change into the target
-project or folder first; both scripts install into the current working
-directory.
+The canonical one-liners below use the official `ShaftHQ/SHAFT_ENGINE` upstream
+URLs. The scripts parse their invocation URL and do not copy that identity into
+the adopter payload. `CHAOS_ENGINE_REPOSITORY` remains a local-file override when
+the invocation URL cannot be parsed (for example when you run `install.sh` from a
+checked-out tree). Change into the target project or folder first; both scripts
+install into the current working directory.
 
 Windows PowerShell, using [install.ps1](install.ps1):
 
@@ -101,13 +99,13 @@ cache purge removes only exact receipt-verified cache content.
 POSIX:
 
 ```bash
-url="https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"; curl -fsSL "$url" | bash -s -- "$url" --with-maven-tools
+url="https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh"; curl -fsSL "$url" | bash -s -- "$url" --with-maven-tools
 ```
 
 PowerShell:
 
 ```powershell
-$installer = irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1"; & ([scriptblock]::Create($installer)) -WithMavenTools
+$installer = irm "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.ps1"; & ([scriptblock]::Create($installer)) -WithMavenTools
 ```
 
 Inspect the linked installer and [bootstrap.py](bootstrap.py) first when policy

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -73,9 +73,8 @@ flow resolves a configured upstream branch to an immutable commit, downloads
 only that commit's validated `chaos-engine/` subtree, and installs ChaosEngine
 inside the target project.
 
-The Windows example below uses an `owner/repository` placeholder; replace it
-with the upstream that hosts the wrapper. The macOS/Linux example uses the
-official SHAFT upstream. Source identity is not copied into the adopter payload.
+The canonical one-liners below use the official `ShaftHQ/SHAFT_ENGINE` upstream.
+Source identity is not copied into the adopter payload.
 `CHAOS_ENGINE_REPOSITORY` remains a local-file override when the invocation URL
 cannot be parsed. Change into the target project or folder first; both scripts
 install into the current working directory.

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -182,14 +182,27 @@ class InstallHealthError(RuntimeError):
 
     def __init__(self, phase: str, doctor: dict[str, object]):
         """Capture the failed phase and names of unhealthy components."""
-        super().__init__("ChaosEngine doctor did not report a healthy installation")
-        self.phase = phase
         components = doctor.get("components", {})
-        self.unhealthy = tuple(
+        unhealthy = tuple(
             name
             for name, value in components.items()
             if _component_blocks_health(value)
         ) if isinstance(components, dict) else ()
+        cli = "py -3" if os.name == "nt" else "python3"
+        if unhealthy:
+            detail = ", ".join(unhealthy)
+            super().__init__(
+                f"ChaosEngine doctor did not report a healthy installation "
+                f"(unhealthy: {detail}). Run: {cli} .chaos-engine/install.py doctor "
+                f"--project . --json"
+            )
+        else:
+            super().__init__(
+                "ChaosEngine doctor did not report a healthy installation. "
+                f"Run: {cli} .chaos-engine/install.py doctor --project . --json"
+            )
+        self.phase = phase
+        self.unhealthy = unhealthy
         commit = doctor.get("commit")
         self.observed_commit = commit if isinstance(commit, str) and COMMIT.fullmatch(commit) else None
         self.observed_components = observed_blocking_components(components)
@@ -537,12 +550,38 @@ class InstallReporter:
         *,
         repository: str,
     ) -> None:
-        del doctor, clients
+        commit = doctor.get("commit") if isinstance(doctor, dict) else None
+        if not isinstance(commit, str) or len(commit) != 40:
+            commit = None
+        doctor_status = doctor.get("status") if isinstance(doctor, dict) else None
+        if not isinstance(doctor_status, str) or not doctor_status:
+            doctor_status = "unknown"
+        components = doctor.get("components") if isinstance(doctor, dict) else None
+        healthy = 0
+        total = 0
+        if isinstance(components, dict):
+            for item in components.values():
+                if not isinstance(item, dict):
+                    continue
+                total += 1
+                if item.get("status") in {"healthy", "absent"}:
+                    healthy += 1
+        client_names = sorted(clients) if isinstance(clients, dict) else []
         self.close()
         self.stream.write(self._paint("  Summary", "36") + "\n")
         self.stream.write(
             "Installation Successful! You can now start a new agent session using Codex, Claude, Grok, Gemini, or Copilot. Just ask it to use chaos-engine and you should be good to go!\n"
         )
+        if commit is not None:
+            self.stream.write(f"Resolved commit: {commit}\n")
+        if total:
+            self.stream.write(
+                f"Doctor: {doctor_status} ({healthy}/{total} components healthy)\n"
+            )
+        else:
+            self.stream.write(f"Doctor: {doctor_status}\n")
+        if client_names:
+            self.stream.write(f"Clients: {', '.join(client_names)}\n")
         self.stream.write(f"{installer_user_guide_url(repository)}\n")
         self.stream.write(f"Full install trace: {install_trace_path(project).as_posix()}\n")
         self.stream.flush()
@@ -1052,6 +1091,29 @@ def emit_install_failure(
         print("Rerun the same install command to continue.", file=sys.stderr)
     else:
         print(f"{code}: {one_line_cause(error)}", file=sys.stderr)
+        cause = one_line_cause(error).casefold()
+        if isinstance(error, InstallHealthError) or "doctor did not report" in cause:
+            print(
+                "Next fix: run doctor (below), repair the listed unhealthy components, "
+                "then rerun the same install one-liner.",
+                file=sys.stderr,
+            )
+        elif "checksum" in cause:
+            print(
+                "Next fix: check network/proxy interference, then rerun the same install one-liner.",
+                file=sys.stderr,
+            )
+        elif "timed out" in cause or "temporary failure" in cause or "network" in cause:
+            print(
+                "Next fix: restore network connectivity, then rerun the same install one-liner.",
+                file=sys.stderr,
+            )
+        elif "python" in cause and ("not found" in cause or "required" in cause):
+            print(
+                "Next fix: install Python 3 (or leave it absent so the wrapper bootstraps uv), "
+                "then rerun the same install one-liner.",
+                file=sys.stderr,
+            )
     print(file=sys.stderr)
     print(f"Help: {installer_help_url(repository)}", file=sys.stderr)
     prefix = installer_cli_prefix(project)

--- a/chaos-engine/install.ps1
+++ b/chaos-engine/install.ps1
@@ -1,6 +1,6 @@
 # Install or upgrade ChaosEngine into the current directory.
 # Run this from the target project folder:
-#   irm "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.ps1" | iex
+#   irm "https://raw.githubusercontent.com/<owner>/<repository>/main/chaos-engine/install.ps1" | iex
 [CmdletBinding()]
 param(
     [switch]$ParseOnly,
@@ -193,7 +193,7 @@ function Resolve-ChaosEngineSource {
             BootstrapUrl = "https://raw.githubusercontent.com/$envRepository/$ref/chaos-engine/bootstrap.py"
         }
     }
-    throw "Put owner/repository in the install URL (or set CHAOS_ENGINE_REPOSITORY for a local file run)."
+    throw "Could not derive owner/repository from the install URL. Pipe the raw.githubusercontent.com/<owner>/<repository>/.../install.ps1 URL through irm|iex (see chaos-engine/INSTALL.md), or set CHAOS_ENGINE_REPOSITORY=<owner>/<repository> for a local file run."
 }
 
 function Read-ChaosEngineUrl([string]$Url) {
@@ -233,7 +233,7 @@ function Read-ChaosEngineUrl([string]$Url) {
             Start-Sleep -Seconds $delay
         }
     }
-    throw "unable to download ChaosEngine bootstrap"
+    throw "Unable to download ChaosEngine bootstrap (network or URL). Check connectivity, then rerun the irm one-liner."
 }
 
 if ($ParseOnly) {

--- a/chaos-engine/install.sh
+++ b/chaos-engine/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # Install or upgrade ChaosEngine into the current directory.
 # Run this from the target project folder:
-#   curl -fsSL "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh" | bash -s -- "https://raw.githubusercontent.com/owner/repository/main/chaos-engine/install.sh"
+#   curl -fsSL "https://raw.githubusercontent.com/<owner>/<repository>/main/chaos-engine/install.sh" | bash -s -- "https://raw.githubusercontent.com/<owner>/<repository>/main/chaos-engine/install.sh"
 set -eu
 
 # Brand and live progress belong to bootstrap.py so curl|bash cannot double-paint.
@@ -86,7 +86,7 @@ EOF
     printf '%s|%s|%s|%s\n' "$env_repository" "$ref" "chaos-engine" "https://raw.githubusercontent.com/${env_repository}/${ref}/chaos-engine/bootstrap.py"
     return 0
   fi
-  fail "Put owner/repository in the install URL (or set CHAOS_ENGINE_REPOSITORY for a local file run)."
+  fail "Could not derive owner/repository from the install URL. Pass the raw.githubusercontent.com/<owner>/<repository>/.../install.sh URL as $1 (see chaos-engine/INSTALL.md), or set CHAOS_ENGINE_REPOSITORY=<owner>/<repository> for a local file run."
 }
 
 with_maven_tools=
@@ -115,7 +115,7 @@ elif command -v wget >/dev/null 2>&1; then
     wget -q -O "$1" "$2"
   }
 else
-  fail "curl or wget is required to download the ChaosEngine bootstrap."
+  fail "curl or wget is required to download the ChaosEngine bootstrap. Install curl, then rerun the one-liner."
 fi
 
 source_record=$(resolve_source "${1:-}")

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "92544cb25290914299f1ff178ce380071d1038dd09d94a516785dfb385592874",
+      "harnessSha256": "c86079e0e89dc4ea1ad8fb66bb539bd817e7dd78dc11bc5f715ed26f99b2f231",
       "treatmentSha256": {
-        "calibration": "2b0b03be8bcafc809ca04b78426ac58f96f3d4e5550c4bdd4abb24916b27b71e",
-        "full-pilot": "034a950ecbf8a802990c4fa85c047efd45ca3821ff72aed54ba3440374c5beb5"
+        "calibration": "2412fc95d8bac15a42bcaac8136e13ae56ac1594936ddf9be5faea5c6f342f8b",
+        "full-pilot": "97329c54f2458875875a48b051811b118cf4099423e1026bd47b1996ff7f816d"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "92544cb25290914299f1ff178ce380071d1038dd09d94a516785dfb385592874"
+      harness_sha256: "c86079e0e89dc4ea1ad8fb66bb539bd817e7dd78dc11bc5f715ed26f99b2f231"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "92544cb25290914299f1ff178ce380071d1038dd09d94a516785dfb385592874"
+      harness_sha256: "c86079e0e89dc4ea1ad8fb66bb539bd817e7dd78dc11bc5f715ed26f99b2f231"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_install_wrappers.py
+++ b/tests/scripts/test_chaos_engine_install_wrappers.py
@@ -158,8 +158,30 @@ class ChaosEngineInstallWrapperTest(unittest.TestCase):
             self.assertNotRegex(document, r"\bhaftHQ\b")
             self.assertNotRegex(document, r"(?<!S)HAFT_ENGINE")
             self.assertNotIn("$env:CHAOS_ENGINE_REPOSITORY/main", document)
+            self.assertNotIn(PLACEHOLDER, document)
+
+    def test_wrapper_errors_name_exact_next_fix_without_embedding_source_identity(self):
+        powershell = POWERSHELL.read_text(encoding="utf-8")
+        shell = SHELL.read_text(encoding="utf-8")
+        self.assertIn(
+            "Could not derive owner/repository from the install URL",
+            powershell,
+        )
+        self.assertIn(
+            "Could not derive owner/repository from the install URL",
+            shell,
+        )
+        self.assertIn("chaos-engine/INSTALL.md", powershell)
+        self.assertIn("chaos-engine/INSTALL.md", shell)
+        self.assertIn("Install curl, then rerun the one-liner", shell)
+        self.assertIn("Check connectivity, then rerun the irm one-liner", powershell)
+        self.assertNotIn("ShaftHQ", powershell)
+        self.assertNotIn("ShaftHQ", shell)
+        self.assertNotIn("shaft", powershell.casefold())
+        self.assertNotIn("shaft", shell.casefold())
 
     def test_shaft_profile_keeps_the_real_url_without_an_env_preamble(self):
+
         profile = (
             ROOT / "chaos-engine/profiles/shaft/entrypoint.md"
         ).read_text(encoding="utf-8")

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -367,10 +367,18 @@ class InstallerUxTests(unittest.TestCase):
         reporter = BOOTSTRAP.InstallReporter(stream=stream)
         reporter.start("Activate clients")
         reporter.complete("Activate clients")
+        commit = "a" * 40
         reporter.success(
             Path("/project"),
-            {"components": {"memory": {"status": "healthy"}, "core": {"status": "healthy"}}},
-            {},
+            {
+                "commit": commit,
+                "status": "healthy",
+                "components": {
+                    "memory": {"status": "healthy"},
+                    "core": {"status": "healthy"},
+                },
+            },
+            {"codex": {"status": "healthy"}, "claude": {"status": "healthy"}},
             repository="ShaftHQ/SHAFT_ENGINE",
         )
         output = stream.getvalue()
@@ -379,6 +387,9 @@ class InstallerUxTests(unittest.TestCase):
             "Installation Successful! You can now start a new agent session using Codex, Claude, Grok, Gemini, or Copilot. Just ask it to use chaos-engine and you should be good to go!",
             output,
         )
+        self.assertIn(f"Resolved commit: {commit}", output)
+        self.assertIn("Doctor: healthy (2/2 components healthy)", output)
+        self.assertIn("Clients: claude, codex", output)
         self.assertIn("https://shafthq.github.io/docs/agentic/chaos-engine", output)
         self.assertIn(
             f"Full install trace: {Path('/project/.chaos-engine-state/install-trace.json').as_posix()}",
@@ -771,9 +782,12 @@ class InstallerUxTests(unittest.TestCase):
         stderr = io.StringIO()
         with unittest.mock.patch.object(BOOTSTRAP.sys, "stderr", stderr):
             BOOTSTRAP.emit_install_failure("CE-INSTALL-FAILED", error, "owner/repo")
+        output = stderr.getvalue()
+        self.assertIn("unhealthy: memory", output)
+        self.assertIn("Next fix: run doctor", output)
         report = [
             line
-            for line in stderr.getvalue().splitlines()
+            for line in output.splitlines()
             if line.startswith("https://github.com/owner/repo/issues/new?")
         ][0]
         query = urllib.parse.parse_qs(urllib.parse.urlsplit(report).query)


### PR DESCRIPTION
## Summary
- Canonical `INSTALL.md` / `README.md` one-liners and Maven-tools examples use only `ShaftHQ/SHAFT_ENGINE` URLs (no `owner/repository` placeholder confusion).
- Wrapper resolve/download errors name the exact next fix and point at `chaos-engine/INSTALL.md`, while remaining identity-neutral (no ShaftHQ/SHAFT embedding in portable `install.sh` / `install.ps1`).
- Success banner prints the resolved 40-character commit, doctor status with healthy-component counts, and activated clients.
- Doctor/health failures include a concrete next-fix line (platform-aware doctor CLI hint).
- Refresh ChaosGauge live harness tree digests / identities after `chaos-engine/` edits (Agent Guidance Gate).

Fixes #5570
Supersedes #5590 (same UX change; that PR failed Agent Guidance Gate on stale digests).

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_install_wrappers tests.scripts.test_chaos_engine_installer_ux tests.scripts.test_chaos_gauge_contracts`
- [ ] CI Agent Guidance Gate green on this PR