### PR TITLE
[CE] Interactive first-run wizard (#5571)

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -114,6 +114,11 @@ an immutable commit and downloads only its validated `chaos-engine/` subtree;
 `portable` is already the default and need not be supplied. Restart any client
 that was open during installation so it loads its verified local plugin cache.
 
+Pass `--interactive` on macOS/Linux (PowerShell `-Interactive`) for the first-run
+wizard: it detects host CLIs, explains what will be installed (including Caveman +
+Ponytail companions), and prints a host-specific next-actions checklist before any
+download. The non-interactive one-liner path is unchanged.
+
 Set `CHAOS_ENGINE_BRANCH` to override the repository's configured default
 branch (otherwise `main`). The bootstrap resolves that mutable branch through
 the GitHub API, downloads the exact commit's declared harness files, rejects

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -609,6 +609,76 @@ def confirm_operation(operation: str, *, input_stream, output) -> None:
         raise InstallCancelled(f"ChaosEngine installation cancelled before {operation}")
 
 
+HOST_DETECT_COMMANDS = (
+    ("claude", "claude", "Claude Code"),
+    ("codex", "codex", "Codex"),
+    ("grok", "grok", "Grok"),
+    ("gemini", "gemini", "Gemini"),
+    ("copilot", "gh", "GitHub Copilot"),
+)
+
+HOST_NEXT_ACTIONS = {
+    "claude": "Open Claude Code in this project and ask it to use the chaos-engine skill.",
+    "codex": "Start a Codex session in this project and ask it to use chaos-engine.",
+    "grok": "Open Grok in this project and ask it to follow AGENTS.md / chaos-engine.",
+    "gemini": "Open Gemini CLI in this project and ask it to use the chaos-engine skill.",
+    "copilot": "Open this repo in an IDE with GitHub Copilot and ask Copilot to use chaos-engine.",
+}
+
+
+def detect_install_hosts(*, which=shutil.which) -> list[tuple[str, str, bool]]:
+    """Return (id, label, detected) for the five supported hosts."""
+    detected: list[tuple[str, str, bool]] = []
+    for host_id, command, label in HOST_DETECT_COMMANDS:
+        found = which(command) is not None
+        if host_id == "copilot" and not found:
+            # Copilot is IDE-hosted; treat a present `code`/`cursor` CLI as a soft signal.
+            found = which("code") is not None or which("cursor") is not None
+        detected.append((host_id, label, found))
+    return detected
+
+
+def run_first_run_wizard(
+    *,
+    project: Path,
+    repository: str,
+    with_maven_tools: bool,
+    input_stream,
+    output,
+    which=shutil.which,
+) -> None:
+    """Guide a first-time interactive install before any network work."""
+    hosts = detect_install_hosts(which=which)
+    present = [label for _host_id, label, found in hosts if found]
+    absent = [label for _host_id, label, found in hosts if not found]
+    output.write("ChaosEngine first-run wizard\n")
+    output.write(f"Project: {project}\n")
+    output.write(f"Upstream: {repository}\n")
+    output.write(
+        "This install will add the portable ChaosEngine core, lifecycle hooks, "
+        "Memory, MemPalace, Graphify CLI, five host adapters, and the Caveman + "
+        "Ponytail companion skills (on by default; your off-switches still win).\n"
+    )
+    if with_maven_tools:
+        output.write("Maven Tools MCP will also be installed for this project.\n")
+    if present:
+        output.write("Detected host CLIs: " + ", ".join(present) + "\n")
+    else:
+        output.write(
+            "No host CLIs detected yet (Claude Code, Codex, Grok, Gemini, or IDE). "
+            "Adapters still install for all five hosts.\n"
+        )
+    if absent:
+        output.write("Not detected on PATH: " + ", ".join(absent) + "\n")
+    output.write("Next after install:\n")
+    for host_id, label, found in hosts:
+        marker = "*" if found else "-"
+        output.write(f"  {marker} {label}: {HOST_NEXT_ACTIONS[host_id]}\n")
+    output.flush()
+    confirm_operation("Install companions (Caveman + Ponytail) with the core", input_stream=input_stream, output=output)
+    confirm_operation("Continue ChaosEngine install", input_stream=input_stream, output=output)
+
+
 @contextmanager
 def interactive_terminal():
     path = "CONIN$" if os.name == "nt" else os.path.join(os.sep, "dev", "tty")
@@ -887,6 +957,14 @@ def install_latest(
             terminal_input = None
     except OSError as error:
         raise RuntimeError("interactive mode requires a usable controlling terminal") from error
+    if terminal_input is not None:
+        run_first_run_wizard(
+            project=project,
+            repository=repository,
+            with_maven_tools=with_maven_tools,
+            input_stream=terminal_input,
+            output=reporter.stream,
+        )
     def confirm(name: str) -> None:
         if terminal_input is not None:
             confirm_operation(name, input_stream=terminal_input, output=reporter.stream)

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "c86079e0e89dc4ea1ad8fb66bb539bd817e7dd78dc11bc5f715ed26f99b2f231",
+      "harnessSha256": "9057f3238196e4dc16680938b9efca59375defec735a5583145c0edabd92951b",
       "treatmentSha256": {
-        "calibration": "2412fc95d8bac15a42bcaac8136e13ae56ac1594936ddf9be5faea5c6f342f8b",
-        "full-pilot": "97329c54f2458875875a48b051811b118cf4099423e1026bd47b1996ff7f816d"
+        "calibration": "495585921dd1f378d25c645c3bbbf0b3180830735d4b2198b57bc653a490bb37",
+        "full-pilot": "5c0b9d9a6225b922b39ccf6105d4f1cf1796edbe887ed8273f7d022250120c75"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "c86079e0e89dc4ea1ad8fb66bb539bd817e7dd78dc11bc5f715ed26f99b2f231"
+      harness_sha256: "9057f3238196e4dc16680938b9efca59375defec735a5583145c0edabd92951b"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "c86079e0e89dc4ea1ad8fb66bb539bd817e7dd78dc11bc5f715ed26f99b2f231"
+      harness_sha256: "9057f3238196e4dc16680938b9efca59375defec735a5583145c0edabd92951b"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -569,7 +569,70 @@ class InstallerUxTests(unittest.TestCase):
             )
         self.assertEqual("failed", trace["result"]["status"])
 
+    def test_detect_install_hosts_marks_path_clis(self):
+        mapping = {"claude": "/bin/claude", "codex": "/bin/codex"}
+
+        def which(name):
+            return mapping.get(name)
+
+        hosts = BOOTSTRAP.detect_install_hosts(which=which)
+        by_id = {host_id: found for host_id, _label, found in hosts}
+        self.assertTrue(by_id["claude"])
+        self.assertTrue(by_id["codex"])
+        self.assertFalse(by_id["grok"])
+        self.assertFalse(by_id["gemini"])
+        self.assertFalse(by_id["copilot"])
+
+    def test_first_run_wizard_explains_hosts_companions_and_next_actions(self):
+        stream = io.StringIO()
+        answers = io.StringIO("y\ny\n")
+        BOOTSTRAP.run_first_run_wizard(
+            project=Path("/project"),
+            repository="owner/repo",
+            with_maven_tools=True,
+            input_stream=answers,
+            output=stream,
+            which=lambda name: "/bin/claude" if name == "claude" else None,
+        )
+        output = stream.getvalue()
+        self.assertIn("ChaosEngine first-run wizard", output)
+        self.assertIn("Detected host CLIs: Claude Code", output)
+        self.assertIn("Caveman + Ponytail", output)
+        self.assertIn("Maven Tools MCP", output)
+        self.assertIn("Claude Code:", output)
+        self.assertIn("Codex:", output)
+        self.assertIn("Grok:", output)
+        self.assertIn("Gemini:", output)
+        self.assertIn("GitHub Copilot:", output)
+
+    def test_first_run_wizard_cancel_before_network_leaves_path_unchanged(self):
+        called = False
+
+        def opener(*_args, **_kwargs):
+            nonlocal called
+            called = True
+            raise AssertionError("network must not run")
+
+        class Terminal:
+            def __enter__(self):
+                return io.StringIO("n\n")
+
+            def __exit__(self, *_exc):
+                return False
+
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaises(BOOTSTRAP.InstallCancelled):
+                BOOTSTRAP.install_latest(
+                    Path(temporary),
+                    repository="owner/repo",
+                    interactive=True,
+                    terminal_factory=Terminal,
+                    opener=opener,
+                )
+        self.assertFalse(called)
+
     def test_wrappers_expose_and_forward_interactive_mode(self):
+
         shell = (ROOT / "chaos-engine/install.sh").read_text(encoding="utf-8")
         powershell = (ROOT / "chaos-engine/install.ps1").read_text(encoding="utf-8")
         self.assertIn('"--interactive"', shell)


### PR DESCRIPTION
## Summary
- `--interactive` / `-Interactive` now runs a first-run wizard **before any download**: detect Claude Code / Codex / Grok / Gemini / Copilot signals, explain core + Memory/MemPalace/Graphify + companions, confirm companions, print host-specific next-actions checklist.
- Non-interactive one-liner path unchanged.
- INSTALL.md documents the flag; ChaosGauge harness digests refreshed.

Fixes #5571

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_installer_ux tests.scripts.test_chaos_engine_install_wrappers tests.scripts.test_chaos_gauge_contracts`
- [ ] CI Agent Guidance Gate + fresh installer matrix