### PR TITLE
[CE] Doctor UX: human-readable health + fix-next steps

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -173,7 +173,10 @@ non-Git directory. ChaosEngine installs project-locally and does not infer its
 upstream from the consumer repository.
 
 `status` and `doctor` report every component with its `owner`, `scope`,
-`lifecycle`, and `taskImpact`. Memory, MemPalace, and Graphify are advisory to
+`lifecycle`, and `taskImpact`. Without `--json`, `doctor` (and `status`) print a
+short human summary when healthy, or a scannable failure list with one
+`fix-next` action per unhealthy component. Pass `--json` for the stable
+schema v2 machine contract. Memory, MemPalace, and Graphify are advisory to
 ordinary tasks but remain strict in `doctor`; an unhealthy selected store still
 returns `recovery-required`. Maven Tools MCP is auto-installed when the project
 has a root `pom.xml`. On non-Maven projects it stays optional and absent does

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -111,8 +111,9 @@ path-unique local marketplace registration and cached plugin.
   run the portable bootstrap. This deliberate reinstall prevents old
   repository-specific payloads from surviving in the rollback backup.
 - **Inspect:** run
-  `python .chaos-engine/install.py status --project . --json`. JSON schema v2
-  is deterministic and omits paths and credential-shaped fields.
+  `python .chaos-engine/install.py doctor --project .` for a short human health
+  summary (with `fix-next` on failures), or add `--json` / use `status` for the
+  deterministic schema v2 contract (omits paths and credential-shaped fields).
 - **Explain:** run
   `python .chaos-engine/install.py explain Stop --project . --host codex --json`
   to evaluate one event without reading ambient session state.

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -3390,6 +3390,172 @@ def parser() -> argparse.ArgumentParser:
     return result
 
 
+def _doctor_python_cli() -> str:
+    """Return the platform-local interpreter token used in fix-next commands."""
+    return "py -3" if os.name == "nt" else "python3"
+
+
+def _component_severity(item: dict[str, object]) -> str:
+    """Map one component record to a scannable severity for human doctor output."""
+    status = str(item.get("status") or "unknown")
+    impact = str(item.get("taskImpact") or "required")
+    if status == "healthy":
+        return "ok"
+    if status == "absent" and impact == "optional":
+        return "ok"
+    if status == "compatible-legacy":
+        return "info"
+    if status == "migration-required":
+        return "warning"
+    if impact == "advisory":
+        return "warning"
+    if impact == "optional":
+        return "info"
+    return "error"
+
+
+def _looks_like_fix_next(detail: object) -> bool:
+    if not isinstance(detail, str):
+        return False
+    lowered = detail.casefold()
+    return any(
+        token in lowered
+        for token in ("run ", "rerun ", "restore ", "reinstall", "install ", "`", "python")
+    ) and len(detail) <= 320
+
+
+def component_fix_next(name: str, item: dict[str, object]) -> str | None:
+    """Return one actionable fix-next string for an unhealthy component, else None."""
+    status = str(item.get("status") or "")
+    impact = str(item.get("taskImpact") or "required")
+    if status == "healthy" or (status == "absent" and impact == "optional"):
+        return None
+    detail = item.get("detail")
+    if _looks_like_fix_next(detail):
+        return str(detail).strip()
+    reason = item.get("reason")
+    if _looks_like_fix_next(reason):
+        return str(reason).strip()
+    code = item.get("code")
+    cli = _doctor_python_cli()
+    reinstall = (
+        f"Re-run the ChaosEngine install one-liner from INSTALL.md "
+        f"(or `{cli} .chaos-engine/bootstrap.py` from a source checkout), then "
+        f"`{cli} .chaos-engine/install.py doctor --project .`."
+    )
+    if code == "CE_CORE_MISSING" or name == "core":
+        return (
+            "Restore the `.chaos-engine/` core tree or reinstall; if the runtime "
+            "was wiped while host receipts remain, uninstall/reinstall after "
+            "clearing orphaned host state. " + reinstall
+        )
+    if name == "mempalace" and status == "migration-required":
+        return (
+            "Supply a fresh or valid SQLite-exact MemPalace palace "
+            "(operator-owned migration; ChaosEngine will not convert legacy "
+            "Chroma state). Then rerun doctor."
+        )
+    if name in {"tools", "memory", "mempalace", "graphify"} and status in {
+        "recovery-required",
+        "absent",
+        "broken",
+    }:
+        return (
+            f"Repair the `{name}` dependency/runtime (receipt + managed tools), "
+            f"then rerun `{cli} .chaos-engine/install.py doctor --project .`. "
+            + reinstall
+        )
+    if name == "hooks":
+        return (
+            "Reinstall ChaosEngine hooks, then reload/trust hooks in the active "
+            "host (for Grok: `grok inspect --json`, `/hooks-trust` if needed) "
+            f"and rerun `{cli} .chaos-engine/install.py doctor --project .`."
+        )
+    if name == "plugins" or name == "skills" or name == "roles":
+        return (
+            "Reinstall so project marketplace/plugins and skill adapters are "
+            f"republished, restart the client, then rerun "
+            f"`{cli} .chaos-engine/install.py doctor --project .`."
+        )
+    if name == "mcps":
+        return (
+            "Repair MCP launchers (`.mcp.json` / Codex config) via reinstall, "
+            f"then rerun `{cli} .chaos-engine/install.py doctor --project .`."
+        )
+    if name in {"retrieval-config", "projection-policy", "playbooks"}:
+        return (
+            f"Restore missing `{name}` files via reinstall, then rerun "
+            f"`{cli} .chaos-engine/install.py doctor --project .`."
+        )
+    if name == "maven-tools-mcp":
+        return (
+            "For Maven projects, rerun install with Maven Tools enabled "
+            "(`--with-maven-tools` or root `pom.xml`); otherwise optional absence "
+            "is fine."
+        )
+    if status == "migration-required":
+        return (
+            f"Complete the operator-owned migration for `{name}`, then rerun "
+            f"`{cli} .chaos-engine/install.py doctor --project .`."
+        )
+    if status == "compatible-legacy":
+        return (
+            f"`{name}` is compatible-legacy: uninstall then reinstall the portable "
+            "bootstrap when you are ready to leave the legacy payload."
+        )
+    return (
+        f"Inspect `{name}` (`status={status}`), repair or reinstall, then rerun "
+        f"`{cli} .chaos-engine/install.py doctor --project .`."
+    )
+
+
+def format_health_report(document: dict[str, object], *, kind: str | None = None) -> str:
+    """Render a short healthy summary or a scannable failure list with fix-next lines."""
+    label = kind or str(document.get("kind") or "doctor")
+    status = str(document.get("status") or "unknown")
+    commit = document.get("commit")
+    commit_text = commit if isinstance(commit, str) and commit else "unknown"
+    components = document.get("components")
+    rows: list[tuple[str, dict[str, object], str]] = []
+    if isinstance(components, dict):
+        for name in sorted(str(item) for item in components):
+            item = components[name]
+            if not isinstance(item, dict):
+                continue
+            rows.append((name, item, _component_severity(item)))
+    healthy = sum(1 for _n, _i, severity in rows if severity == "ok")
+    total = len(rows)
+    failures = [(name, item, severity) for name, item, severity in rows if severity != "ok"]
+    lines = [
+        f"ChaosEngine {label}: {status}",
+        f"commit: {commit_text}",
+    ]
+    if total:
+        lines.append(f"components: {healthy}/{total} healthy")
+    if not failures:
+        # Keep the happy path short for first-time users.
+        return "\n".join(lines) + "\n"
+    counts: dict[str, int] = {"error": 0, "warning": 0, "info": 0}
+    for _name, _item, severity in failures:
+        counts[severity] = counts.get(severity, 0) + 1
+    summary = ", ".join(
+        f"{counts[key]} {key}" for key in ("error", "warning", "info") if counts.get(key)
+    )
+    lines.append(f"issues: {summary}")
+    lines.append("")
+    for name, item, severity in failures:
+        status_text = str(item.get("status") or "unknown")
+        impact = str(item.get("taskImpact") or "")
+        impact_suffix = f" ({impact})" if impact and impact != "required" else ""
+        code = item.get("code")
+        code_suffix = f" code={code}" if isinstance(code, str) and code else ""
+        lines.append(f"[{severity}] {name} — {status_text}{impact_suffix}{code_suffix}")
+        fix = component_fix_next(name, item)
+        if fix:
+            lines.append(f"  fix-next: {fix}")
+    return "\n".join(lines) + "\n"
+
+
 def validate_install_options(args: argparse.Namespace) -> None:
     if getattr(args, "skip_tools", False) and getattr(args, "with_maven_tools", False):
         raise ValueError("--with-maven-tools cannot be combined with --skip-tools")
@@ -3446,14 +3612,14 @@ def main() -> int:
             uninstall_with_dependencies(args.project)
             result = {"status": "uninstalled"}
     except (OSError, RuntimeError, ValueError) as error:
+        message = str(error)
+        diagnostic_code = "CE_DIAGNOSTIC_UNAVAILABLE"
+        if "manifest is missing or invalid" in message or (
+            getattr(args, "project", None) is not None
+            and missing_core_with_installed_hosts(Path(args.project))
+        ):
+            diagnostic_code = "CE_CORE_MISSING"
         if getattr(args, "json", False):
-            message = str(error)
-            diagnostic_code = "CE_DIAGNOSTIC_UNAVAILABLE"
-            if "manifest is missing or invalid" in message or (
-                getattr(args, "project", None) is not None
-                and missing_core_with_installed_hosts(Path(args.project))
-            ):
-                diagnostic_code = "CE_CORE_MISSING"
             print(
                 json.dumps(
                     {
@@ -3470,8 +3636,34 @@ def main() -> int:
                 )
             )
         else:
-            print(str(error), file=sys.stderr)
+            print(f"ChaosEngine {args.command}: Blocked", file=sys.stderr)
+            print(f"reason: {message}", file=sys.stderr)
+            if diagnostic_code == "CE_CORE_MISSING":
+                print(
+                    "fix-next: "
+                    + component_fix_next(
+                        "core",
+                        {
+                            "status": "recovery-required",
+                            "code": "CE_CORE_MISSING",
+                            "taskImpact": "required",
+                        },
+                    ),
+                    file=sys.stderr,
+                )
+            elif args.command in {"status", "doctor"}:
+                cli = _doctor_python_cli()
+                print(
+                    f"fix-next: repair the install, then rerun "
+                    f"`{cli} .chaos-engine/install.py {args.command} --project .`.",
+                    file=sys.stderr,
+                )
         return 1
+    if args.command in {"status", "doctor"} and not getattr(args, "json", False):
+        if not isinstance(result, dict):
+            raise TypeError("doctor/status result must be an object")
+        print(format_health_report(result, kind=args.command), end="")
+        return 0
     print(json.dumps(result, sort_keys=True, separators=(",", ":")))
     return 0
 

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "9057f3238196e4dc16680938b9efca59375defec735a5583145c0edabd92951b",
+      "harnessSha256": "81fded2b9112c4bfa72c27d08d396d8f24d61e897bb11f8ca1413d7b6b8121be",
       "treatmentSha256": {
-        "calibration": "495585921dd1f378d25c645c3bbbf0b3180830735d4b2198b57bc653a490bb37",
-        "full-pilot": "5c0b9d9a6225b922b39ccf6105d4f1cf1796edbe887ed8273f7d022250120c75"
+        "calibration": "9b7941d350727a62a82d277b5e727be619b80681fa0e489ebdddc5dc90741429",
+        "full-pilot": "b3a4f362237482f6ec7dbf86d06231a283b404953aedd8f11f2d3b6b3213829f"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "9057f3238196e4dc16680938b9efca59375defec735a5583145c0edabd92951b"
+      harness_sha256: "81fded2b9112c4bfa72c27d08d396d8f24d61e897bb11f8ca1413d7b6b8121be"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "9057f3238196e4dc16680938b9efca59375defec735a5583145c0edabd92951b"
+      harness_sha256: "81fded2b9112c4bfa72c27d08d396d8f24d61e897bb11f8ca1413d7b6b8121be"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -27,6 +27,7 @@ def load(name: str, path: Path):
 
 
 BOOTSTRAP = load("chaos_engine_bootstrap_ux", ROOT / "chaos-engine/bootstrap.py")
+INSTALL = load("chaos_engine_install_ux", ROOT / "chaos-engine/install.py")
 
 
 class InstallerUxTests(unittest.TestCase):
@@ -918,6 +919,128 @@ class InstallerUxTests(unittest.TestCase):
         self.assertNotIn("tests.scripts.test_chaos_engine_live_installer_acceptance", block)
         summary = workflow[workflow.index("  summary:"):]
         self.assertIn("- chaos-installer-acceptance", summary)
+
+    def test_doctor_human_healthy_report_stays_short(self):
+        document = {
+            "schemaVersion": 2,
+            "identity": "chaos-engine",
+            "kind": "doctor",
+            "status": "healthy",
+            "commit": "a" * 40,
+            "components": {
+                "core": {"status": "healthy", "taskImpact": "required"},
+                "hooks": {"status": "healthy", "taskImpact": "required"},
+                "maven-tools-mcp": {"status": "absent", "taskImpact": "optional"},
+            },
+        }
+        rendered = INSTALL.format_health_report(document)
+        self.assertIn("ChaosEngine doctor: healthy", rendered)
+        self.assertIn("components: 3/3 healthy", rendered)
+        self.assertNotIn("fix-next", rendered)
+        self.assertNotIn("[error]", rendered)
+        self.assertLessEqual(len(rendered.splitlines()), 4)
+
+    def test_doctor_human_broken_fixture_prints_fix_next(self):
+        document = {
+            "schemaVersion": 2,
+            "identity": "chaos-engine",
+            "kind": "doctor",
+            "status": "recovery-required",
+            "commit": "b" * 40,
+            "components": {
+                "core": {
+                    "status": "recovery-required",
+                    "taskImpact": "required",
+                    "code": "CE_CORE_MISSING",
+                },
+                "hooks": {"status": "recovery-required", "taskImpact": "required"},
+                "memory": {"status": "recovery-required", "taskImpact": "advisory"},
+                "maven-tools-mcp": {"status": "absent", "taskImpact": "optional"},
+            },
+        }
+        rendered = INSTALL.format_health_report(document)
+        self.assertIn("ChaosEngine doctor: recovery-required", rendered)
+        self.assertIn("components: 1/4 healthy", rendered)
+        self.assertIn("[error] core", rendered)
+        self.assertIn("code=CE_CORE_MISSING", rendered)
+        self.assertIn("[error] hooks", rendered)
+        self.assertIn("[warning] memory", rendered)
+        self.assertIn("(advisory)", rendered)
+        self.assertNotIn("[error] maven-tools-mcp", rendered)
+        self.assertGreaterEqual(rendered.count("fix-next:"), 3)
+        self.assertIn("Restore the `.chaos-engine/` core tree", rendered)
+        self.assertIn("Reinstall ChaosEngine hooks", rendered)
+
+    def test_doctor_cli_human_default_and_json_flag(self):
+        healthy = {
+            "schemaVersion": 2,
+            "identity": INSTALL.CANONICAL_IDENTITY,
+            "kind": "doctor",
+            "status": "healthy",
+            "commit": "c" * 40,
+            "distribution": "portable",
+            "policySha256": "0" * 64,
+            "kernel": {"status": "healthy"},
+            "hosts": {"status": "healthy"},
+            "dependencies": {"status": "healthy"},
+            "components": {"core": {"status": "healthy", "taskImpact": "required"}},
+            "clients": {},
+        }
+        broken = {
+            **healthy,
+            "status": "recovery-required",
+            "components": {
+                "hooks": {"status": "recovery-required", "taskImpact": "required"},
+            },
+        }
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with unittest.mock.patch.object(
+            INSTALL, "status_json", return_value=healthy
+        ), unittest.mock.patch.object(
+            INSTALL.sys, "stdout", stdout
+        ), unittest.mock.patch.object(
+            INSTALL.sys, "stderr", stderr
+        ), unittest.mock.patch.object(
+            INSTALL.sys,
+            "argv",
+            ["install.py", "doctor", "--project", "."],
+        ):
+            self.assertEqual(0, INSTALL.main())
+        human = stdout.getvalue()
+        self.assertIn("ChaosEngine doctor: healthy", human)
+        self.assertNotIn('"schemaVersion"', human)
+        self.assertEqual("", stderr.getvalue())
+
+        stdout = io.StringIO()
+        with unittest.mock.patch.object(
+            INSTALL, "status_json", return_value=broken
+        ), unittest.mock.patch.object(
+            INSTALL.sys, "stdout", stdout
+        ), unittest.mock.patch.object(
+            INSTALL.sys,
+            "argv",
+            ["install.py", "doctor", "--project", "."],
+        ):
+            self.assertEqual(0, INSTALL.main())
+        failing = stdout.getvalue()
+        self.assertIn("fix-next:", failing)
+        self.assertIn("[error] hooks", failing)
+
+        stdout = io.StringIO()
+        with unittest.mock.patch.object(
+            INSTALL, "status_json", return_value=healthy
+        ), unittest.mock.patch.object(
+            INSTALL.sys, "stdout", stdout
+        ), unittest.mock.patch.object(
+            INSTALL.sys,
+            "argv",
+            ["install.py", "doctor", "--project", ".", "--json"],
+        ):
+            self.assertEqual(0, INSTALL.main())
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual("doctor", payload["kind"])
+        self.assertEqual("healthy", payload["status"])
 
     def test_confirmation_callbacks_reach_dependencies_maven_and_activation(self):
         bootstrap = (ROOT / "chaos-engine/bootstrap.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- `doctor` / `status` without `--json` now print a short human health report: overall status, commit, healthy count.
- Unhealthy runs list only failing components with severity (`error`/`warning`/`info`) and **one actionable `fix-next` per failure** (probe dumps stay behind `--json`).
- Healthy doctor stays ≤4 lines; optional absent components stay silent.
- INSTALL.md / README.md document the human vs `--json` contract; ChaosGauge harness digests refreshed.
- Cross-linked heal scope remains in #5586 / #5587 / #5591 (thin recovery wording only in doctor output).

Fixes #5572

## Independent review
Second-pass on the diff before merge request:
- Diagnostic JSON schema v2 field allowlist unchanged; human formatting is CLI-only.
- Optional `maven-tools-mcp` absent does not emit fix-next / severity noise.
- Platform CLI token matches bootstrap (`py -3` / `python3`).

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_installer_ux tests.scripts.test_chaos_gauge_contracts -q`
- [ ] CI green on this PR