### PR TITLE
[CE] Post-install first-session brief + next actions

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -44,7 +44,7 @@ user off-switches still win. When a detected client
 requires marketplace registration, the agent registers the project marketplace
 and installs `chaos-engine`, `caveman`, and `ponytail` at project local scope,
 then runs active `doctor` probes. Generated indexes, caches, receipts, and runtimes
-remain untracked; canonical configuration and adapters remain trackable.
+remain untracked; canonical configuration and adapters remain trackable. A successful install prints a first-session brief naming what landed, what stayed untracked, and three next actions (open a host, load `chaos-engine`, run a sample task).
 Origin identity masters under `assets/brand/`, the origin adoption matrix
 `RESEARCH.md`, and `STANDALONE.md` stay in the source tree and are not copied
 into the adopter payload. The installer also merges receipt-bound LF attributes for canonical harness paths,

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -582,6 +582,7 @@ class InstallReporter:
             self.stream.write(f"Doctor: {doctor_status}\n")
         if client_names:
             self.stream.write(f"Clients: {', '.join(client_names)}\n")
+        self.stream.write(format_first_session_brief(clients=clients if isinstance(clients, dict) else {}))
         self.stream.write(f"{installer_user_guide_url(repository)}\n")
         self.stream.write(f"Full install trace: {install_trace_path(project).as_posix()}\n")
         self.stream.flush()
@@ -600,6 +601,36 @@ class InstallReporter:
             self.stream.write("\n")
             self.stream.flush()
         self._lines = 0
+
+
+
+def format_first_session_brief(*, clients: dict[str, object] | None = None) -> str:
+    """Return the post-install first-session brief (landed / untracked / next 3)."""
+    client_names = sorted(clients) if isinstance(clients, dict) else []
+    if client_names:
+        open_host = (
+            "Open one activated host ("
+            + ", ".join(client_names)
+            + ") in this project."
+        )
+    else:
+        open_host = (
+            "Open any supported host in this project "
+            "(Codex, Claude Code, Grok, Gemini, or GitHub Copilot)."
+        )
+    lines = [
+        "First-session brief:",
+        "  Landed: portable core (`.chaos-engine/`), lifecycle hooks, five host adapters,",
+        "    Caveman + Ponytail companions, Memory / MemPalace / Graphify store tooling.",
+        "  Untracked: generated indexes, caches, receipts, and runtimes",
+        "    (`.chaos-engine-runtime*`, dependency/host receipts, `graphify-out`, local tool caches).",
+        "    Canonical adapters and config stay trackable.",
+        "  Next:",
+        f"    1. {open_host}",
+        "    2. Ask the agent to load / use the `chaos-engine` skill.",
+        "    3. Run a small sample task (for example: ask doctor status, or a one-file reversible edit).",
+    ]
+    return "\n".join(lines) + "\n"
 
 
 def confirm_operation(operation: str, *, input_stream, output) -> None:

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "81fded2b9112c4bfa72c27d08d396d8f24d61e897bb11f8ca1413d7b6b8121be",
+      "harnessSha256": "095f447e66393cf941fca94527e57853880614045837609672165d895e366eb8",
       "treatmentSha256": {
-        "calibration": "9b7941d350727a62a82d277b5e727be619b80681fa0e489ebdddc5dc90741429",
-        "full-pilot": "b3a4f362237482f6ec7dbf86d06231a283b404953aedd8f11f2d3b6b3213829f"
+        "calibration": "c12a561f3464ce08323d542c8c1e7ae904b1c0adb70e9ce080c3448d992af380",
+        "full-pilot": "a30f1520c1b55c97bc44d61a26754eca8200a2d84a24106c9af861567ab09553"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "81fded2b9112c4bfa72c27d08d396d8f24d61e897bb11f8ca1413d7b6b8121be"
+      harness_sha256: "095f447e66393cf941fca94527e57853880614045837609672165d895e366eb8"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "81fded2b9112c4bfa72c27d08d396d8f24d61e897bb11f8ca1413d7b6b8121be"
+      harness_sha256: "095f447e66393cf941fca94527e57853880614045837609672165d895e366eb8"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -398,6 +398,12 @@ class InstallerUxTests(unittest.TestCase):
         )
         self.assertNotIn("Owned managed dependencies", output)
         self.assertNotIn("Continue working in", output)
+        self.assertIn("First-session brief:", output)
+        self.assertIn("Landed: portable core", output)
+        self.assertIn("Untracked: generated indexes", output)
+        self.assertIn("Open one activated host (claude, codex)", output)
+        self.assertIn("Ask the agent to load / use the `chaos-engine` skill.", output)
+        self.assertIn("Run a small sample task", output)
 
     def test_trace_persists_every_event_beyond_live_tty_limit(self):
         reporter = BOOTSTRAP.InstallReporter(stream=io.StringIO())
@@ -1041,6 +1047,22 @@ class InstallerUxTests(unittest.TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertEqual("doctor", payload["kind"])
         self.assertEqual("healthy", payload["status"])
+
+    def test_first_session_brief_lists_landed_untracked_and_three_next_actions(self):
+        with_clients = BOOTSTRAP.format_first_session_brief(
+            clients={"codex": {"status": "healthy"}}
+        )
+        self.assertIn("First-session brief:", with_clients)
+        self.assertIn("Landed:", with_clients)
+        self.assertIn("Untracked:", with_clients)
+        self.assertIn("Next:", with_clients)
+        self.assertIn("Open one activated host (codex)", with_clients)
+        self.assertIn("chaos-engine", with_clients)
+        self.assertIn("sample task", with_clients)
+        generic = BOOTSTRAP.format_first_session_brief(clients={})
+        self.assertIn("Open any supported host", generic)
+        # Brief must stay concise for first-time users.
+        self.assertLessEqual(len(with_clients.splitlines()), 12)
 
     def test_confirmation_callbacks_reach_dependencies_maven_and_activation(self):
         bootstrap = (ROOT / "chaos-engine/bootstrap.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Successful install now prints a **First-session brief**: what landed (core, hooks, companions, stores), what stayed untracked, and three next actions (open host, load `chaos-engine`, run a sample task).
- Shared through `bootstrap.py` so `install.sh` / `install.ps1` / Python paths all get it.
- INSTALL.md notes the brief; ChaosGauge digests refreshed.

Fixes #5573

## Independent review
- Brief stays ≤12 lines; activated clients customize the “open host” line.
- No wrapper identity changes; portable install path unchanged.

## Test plan
- [x] UX unit tests for brief + success CTA
- [ ] CI green