### PR TITLE
[CE] Uninstall/rollback clarity for first-time users

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -183,6 +183,35 @@ has a root `pom.xml`. On non-Maven projects it stays optional and absent does
 not make project health fail.
 
 
+
+## Uninstall / rollback (first-time recovery)
+
+Use these when a first install goes wrong and you need a clean retry.
+
+### Commands
+
+- doctor: python3 .chaos-engine/install.py doctor --project .
+- rollback: python3 .chaos-engine/install.py rollback --project .
+- uninstall: python3 .chaos-engine/install.py uninstall --project .
+
+On Windows, use py -3 instead of python3. Prefer rollback for a bad upgrade; prefer uninstall then the one-liner for a wiped or drifted tree.
+
+### What is removed vs retained
+
+Removed (receipt-owned): portable core tree; CE-owned host adapters; CE-owned dependency/runtime generations; CE install journals/locks.
+
+Retained: user-account packages; project knowledge data; shared Maven Tools MCP cache; unrelated project files.
+
+Mixed or unknown ownership fails closed. Knowledge stores are never deleted by uninstall or rollback.
+
+### Clean reinstall after a bad first run
+
+1. Run human doctor and follow each fix-next line.
+2. If rollback is available, rollback then rerun the Install one-liner.
+3. Otherwise uninstall, confirm retained knowledge data if needed, then rerun the Install one-liner.
+4. Restart open hosts and re-run doctor.
+
+
 ## Empty-project smoke (< 5 minutes)
 
 Reference profile: brand-new empty directory on **Ubuntu 22.04** with Python 3.13

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -124,6 +124,8 @@ path-unique local marketplace registration and cached plugin.
 
 Rollback and uninstall act only on receipt-owned ChaosEngine files. Mixed or
 unknown ownership fails closed instead of deleting unrelated project content.
+See [INSTALL.md — Uninstall / rollback](INSTALL.md#uninstall--rollback-first-time-recovery)
+for the removed-vs-retained table and clean-reinstall steps.
 
 ## Use it
 

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "0e45d8022143c8024e8577ae65d92ee2d76d7c490223067f2f4302ab0c755210",
+      "harnessSha256": "e1da1b458b464a695c3e09554c5a144a9e1c49e854c01fa2a2a8aa8ae88dfeee",
       "treatmentSha256": {
-        "calibration": "cfe1e5d93ab13f6fc7d84e292289c116f63d643a56fd696c8ed5d8fb90587120",
-        "full-pilot": "139f4147633e13a24c7e56e40dac9ece7e3d4b7a30a7bd23a9011df24df59e05"
+        "calibration": "207cd05513e7f3b2860bbfe9568cdd3517eca62a232a92ae4b83d1ea8f0c7b6b",
+        "full-pilot": "57d0911b5f29189fa5ca0184506a7651f83e5015497ba86d985184e86d5580fb"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "0e45d8022143c8024e8577ae65d92ee2d76d7c490223067f2f4302ab0c755210"
+      harness_sha256: "e1da1b458b464a695c3e09554c5a144a9e1c49e854c01fa2a2a8aa8ae88dfeee"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "0e45d8022143c8024e8577ae65d92ee2d76d7c490223067f2f4302ab0c755210"
+      harness_sha256: "e1da1b458b464a695c3e09554c5a144a9e1c49e854c01fa2a2a8aa8ae88dfeee"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_uninstall_clarity.py
+++ b/tests/scripts/test_chaos_engine_uninstall_clarity.py
@@ -1,0 +1,62 @@
+"""Uninstall/rollback clarity for first-time users (#5576)."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "chaos-engine"
+INSTALLER = SOURCE / "install.py"
+
+
+def load_install():
+    spec = importlib.util.spec_from_file_location("ce_uninstall_clarity", INSTALLER)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load install.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class UninstallClarityTests(unittest.TestCase):
+    def test_install_docs_name_removed_vs_retained(self):
+        text = (SOURCE / "INSTALL.md").read_text(encoding="utf-8")
+        self.assertIn("Uninstall / rollback (first-time recovery)", text)
+        self.assertIn("What is removed vs retained", text)
+        self.assertIn("Clean reinstall after a bad first run", text)
+        self.assertIn("user-account packages", text)
+        self.assertIn("project knowledge data", text)
+        self.assertIn("Maven Tools MCP cache", text)
+        self.assertIn("uninstall --project .", text)
+        self.assertIn("rollback --project .", text)
+
+    def test_fixture_uninstall_removes_core_keeps_knowledge_data(self):
+        module = load_install()
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            memory = project / ".memory"
+            memory.mkdir()
+            memory.joinpath("keep.txt").write_text("knowledge", encoding="utf-8")
+            graphify = project / "graphify-out"
+            graphify.mkdir()
+            graphify.joinpath("keep.txt").write_text("index", encoding="utf-8")
+            module.install_with_dependencies(
+                project,
+                SOURCE,
+                "c" * 40,
+                provisioner=lambda *_a, **_k: None,
+            )
+            self.assertTrue((project / ".chaos-engine/skills/chaos-engine/SKILL.md").is_file())
+            module.uninstall_with_dependencies(project)
+            self.assertFalse((project / ".chaos-engine").exists())
+            self.assertEqual("knowledge", memory.joinpath("keep.txt").read_text(encoding="utf-8"))
+            self.assertEqual("index", graphify.joinpath("keep.txt").read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- INSTALL.md adds **Uninstall / rollback (first-time recovery)** with commands, removed-vs-retained guidance, and clean reinstall steps.
- README links to that section.
- Fixture test: install → uninstall removes `.chaos-engine`, retains `.memory` / `graphify-out`.

Fixes #5576

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_uninstall_clarity -v`
- [ ] CI green