### PR TITLE
[CE] INSTALL/README first-run golden path above the fold

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -9,61 +9,13 @@
 # Install or upgrade ChaosEngine
 
 ChaosEngine is a portable, provider-neutral working contract for software
-agents. It routes work through research, planning, focused playbooks, empirical
-verification, independent adversarial review, and a durable learning session.
+agents. This page is the installation reference. See [`README.md`](README.md) for purpose and operating loop, and [`skills/chaos-engine/SKILL.md`](skills/chaos-engine/SKILL.md) for the always-loaded contract.
 
-This page is the direct installation reference. Start with the human-facing
-[`README.md`](README.md) for the purpose, operating loop, trust boundaries, and
-portable layout. The canonical operating model lives in
-[`skills/chaos-engine/SKILL.md`](skills/chaos-engine/SKILL.md), and the reusable
-vector masters and application rules live in the [identity guide](assets/brand/BRAND.md).
+## Golden path (first run)
 
-Give the following instruction to a coding agent while its working directory is
-the project you want to manage:
-
-> Install or upgrade ChaosEngine in this project from the latest commit of the
-> official upstream. Change into the target project first. Run
-> `chaos-engine/install.ps1` on Windows (`irm ... | iex`) or
-> `chaos-engine/install.sh` on macOS/Linux (`curl -fsSL ... | bash -s -- <same-url>`).
-> Those wrappers read the upstream owner/name from the invocation URL, then download
-> `bootstrap.py` and run the full install: hooks, skills,
-> companions, Memory, MemPalace, Graphify CLI, and doctor. Do not stop until
-> the active doctor reports the resolved 40-character commit and every
-> required component healthy. Treat the installed ChaosEngine skill as the
-> canonical harness and route any existing agent guidance through it without
-> deleting unrelated user content.
-
-That agent instruction owns the complete flow: the bootstrap installs the
-neutral core, latest compatible stable account tools, Memory and isolated MemPalace MCP servers,
-Graphify CLI, skills, playbooks, five role adapters, ChaosEngine lifecycle
-hooks, the pinned Caveman and Ponytail companion skills and hooks, the MIT license
-and third-party notices, Codex and Claude plugin manifests/marketplaces for
-ChaosEngine plus those companions, retrieval configuration, and runtime ignore
-rules. Companion skills install with the core and load by default at runtime;
-user off-switches still win. When a detected client
-requires marketplace registration, the agent registers the project marketplace
-and installs `chaos-engine`, `caveman`, and `ponytail` at project local scope,
-then runs active `doctor` probes. Generated indexes, caches, receipts, and runtimes
-remain untracked; canonical configuration and adapters remain trackable. A successful install prints a first-session brief naming what landed, what stayed untracked, and three next actions (open a host, load `chaos-engine`, run a sample task). Install success and human `doctor` also print five **host onboarding cards** (Claude Code/Codex marketplace+plugin vs Grok/Gemini/Copilot file/hook injection), each with an explicit gap line.
-Origin identity masters under `assets/brand/`, the origin adoption matrix
-`RESEARCH.md`, and `STANDALONE.md` stay in the source tree and are not copied
-into the adopter payload. The installer also merges receipt-bound LF attributes for canonical harness paths,
-so Windows Git checkouts retain the exact owned bytes while unrelated
-`.gitattributes` rules remain untouched.
-
-The payload includes the optional
-[`omniroute` skill](skills/omniroute/SKILL.md) and its standard-library runner.
-This copies integration capability only: installation never installs, starts,
-configures, authenticates, or requires OmniRoute. Without a qualified local
-service, canonical [execution workflows](references/execution-workflows.md)
-continue through native implementers or `SOLO`.
-
-The canonical one-liners below use the official `ShaftHQ/SHAFT_ENGINE` upstream
-URLs. The scripts parse their invocation URL and do not copy that identity into
-the adopter payload. `CHAOS_ENGINE_REPOSITORY` remains a local-file override when
-the invocation URL cannot be parsed (for example when you run `install.sh` from a
-checked-out tree). Change into the target project or folder first; both scripts
-install into the current working directory.
+1. Change into the project directory you want ChaosEngine to manage.
+2. Run exactly one of these one-liners (Python is not required beforehand).
+3. When it finishes, run human doctor and confirm it reports healthy.
 
 Windows PowerShell, using [install.ps1](install.ps1):
 
@@ -76,6 +28,23 @@ macOS or Linux, using [install.sh](install.sh):
 ```bash
 curl -fsSL "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh" | bash -s -- "https://raw.githubusercontent.com/ShaftHQ/SHAFT_ENGINE/main/chaos-engine/install.sh"
 ```
+
+Verify:
+
+```text
+python3 .chaos-engine/install.py doctor --project .
+```
+
+On Windows use py -3 instead of python3. A successful install also prints a
+first-session brief and five host onboarding cards. You can stop reading here
+for a normal first install.
+
+## Advanced topics
+
+Everything below is optional on first run: agent install instruction, payload
+details, OmniRoute, identity/portability, interactive flags, Maven Tools,
+uninstall/rollback, and empty-project smoke.
+
 
 Python is not required before either command. The wrapper bootstraps Python as
 needed. The installer then discovers the invoking account's tools, resolves

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -68,6 +68,8 @@ guidance out of the always-loaded context until it is needed.
 
 ## Install
 
+**First run:** change into your project, run the one-liner below, then `python3 .chaos-engine/install.py doctor --project .` (Windows: `py -3`). Stop there unless you need advanced flags — details live in [INSTALL.md § Golden path](INSTALL.md#golden-path-first-run).
+
 Start with the full [installation and upgrade guide](INSTALL.md). The safest
 flow resolves a configured upstream branch to an immutable commit, downloads
 only that commit's validated `chaos-engine/` subtree, and installs ChaosEngine

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "e1da1b458b464a695c3e09554c5a144a9e1c49e854c01fa2a2a8aa8ae88dfeee",
+      "harnessSha256": "b3d9b73463f1d17a7a51235d196675ad8f93c6096b32a958afaba71dfaad8e78",
       "treatmentSha256": {
-        "calibration": "207cd05513e7f3b2860bbfe9568cdd3517eca62a232a92ae4b83d1ea8f0c7b6b",
-        "full-pilot": "57d0911b5f29189fa5ca0184506a7651f83e5015497ba86d985184e86d5580fb"
+        "calibration": "1814703e033632d6f5e430dbb8a7fe577d4dfb4d43b41de23faee7bb99159d35",
+        "full-pilot": "c21763fc41ca0406087885f8796e6ed04ca8c882d5598826c2eff67582456cb8"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "e1da1b458b464a695c3e09554c5a144a9e1c49e854c01fa2a2a8aa8ae88dfeee"
+      harness_sha256: "b3d9b73463f1d17a7a51235d196675ad8f93c6096b32a958afaba71dfaad8e78"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "e1da1b458b464a695c3e09554c5a144a9e1c49e854c01fa2a2a8aa8ae88dfeee"
+      harness_sha256: "b3d9b73463f1d17a7a51235d196675ad8f93c6096b32a958afaba71dfaad8e78"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_install_golden_path.py
+++ b/tests/scripts/test_chaos_engine_install_golden_path.py
@@ -1,0 +1,30 @@
+"""INSTALL/README first-run golden path stays above the fold (#5577)."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class InstallGoldenPathTests(unittest.TestCase):
+    def test_install_golden_path_precedes_advanced_topics(self):
+        text = (ROOT / "chaos-engine/INSTALL.md").read_text(encoding="utf-8")
+        self.assertIn("## Golden path (first run)", text)
+        self.assertIn("## Advanced topics", text)
+        self.assertLess(text.index("## Golden path (first run)"), text.index("## Advanced topics"))
+        self.assertLess(text.index("## Golden path (first run)"), text.index("## Uninstall / rollback"))
+        # Reader can install without reading past golden path: one-liners appear before Advanced.
+        self.assertLess(text.index("install.ps1"), text.index("## Advanced topics"))
+        self.assertLess(text.index("install.sh"), text.index("## Advanced topics"))
+
+    def test_readme_points_at_golden_path(self):
+        text = (ROOT / "chaos-engine/README.md").read_text(encoding="utf-8")
+        self.assertIn("Golden path", text)
+        self.assertIn("INSTALL.md#golden-path-first-run", text)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- INSTALL.md opens with **Golden path (first run)** then **Advanced topics**.
- README Install points at the golden path anchor.
- One-liner URL uniqueness contract preserved.

Fixes #5577

## Test plan
- [x] golden-path + documented one-liner unit tests
- [ ] CI green