### PR TITLE
[CE] Host Parity Matrix v0 artifact + measured gaps

### DIFF
--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -673,6 +673,9 @@ reports, caches, runtime indexes, or `graphify-out/`.
 
 ## Read next
 
+- [Host Parity Matrix v0](references/host-parity-matrix.md) — five-host outcome matrix and measured gaps.
+
+
 - [Install or upgrade ChaosEngine](INSTALL.md)
 - [Canonical ChaosEngine entrypoint](skills/chaos-engine/SKILL.md)
 - [Lifecycle hooks](references/lifecycle-hooks.md)

--- a/chaos-engine/references/host-parity-matrix.md
+++ b/chaos-engine/references/host-parity-matrix.md
@@ -1,0 +1,43 @@
+# Host Parity Matrix v0
+
+Living adapter-outcome matrix for ChaosEngine across Claude Code, Codex, Grok, Gemini, and GitHub Copilot.
+
+Parity means the same workflow *outcomes* on all five hosts (not UI chrome parity).
+Machine-checkable capability pins also live in `scripts/ci/agent_harness_parity.json`.
+
+Legend: P = parity (outcome available), A = adapter-shaped equivalent, G = gap (see below), N = not applicable.
+
+
+## Matrix
+
+| Surface | Claude Code | Codex | Grok | Gemini | Copilot |
+| --- | --- | --- | --- | --- | --- |
+| Install / doctor human UX | P | P | P | P | P |
+| Host onboarding / activation path | A marketplace/plugin | A marketplace/plugin | A file/hook | A file/hook | A file/hook |
+| Router skill (`chaos-engine`) | P | P | P | P | P |
+| Lifecycle hooks | A | A | A | A | A |
+| Exit-2 / blocking denial fidelity | A | A | G | A | G |
+| SessionStart locator-only / progressive disclosure | A | A | G | A | G |
+| Skills discovery | A | A | A | A | A |
+| Companions (Caveman + Ponytail) | P | P | P | P | P |
+| Retrieval soft-degrade (Memory/MemPalace/Graphify) | P | P | P | P | P |
+| Work-item to merge playbook | P | P | P | P | P |
+| Learning Session | P | P | P | P | P |
+
+## Measured gaps (severity)
+
+| ID | Host(s) | Severity | Gap | Evidence / next |
+| --- | --- | --- | --- | --- |
+| GAP-EXIT2 | Grok, Copilot | high | Native exit-2 / hard-block semantics are thinner or host-gated vs Claude/Codex/Gemini; outcome relies on adapter + trust. | Tracked by #5579; kernel HOST_CAPABILITIES + hook configs. |
+| GAP-SESSIONSTART | Grok, Copilot | medium | SessionStart locator-only / progressive disclosure is not proven equivalent; may inject more or less context. | Tracked by #5580. |
+| GAP-HOOK-TRUST | Grok | medium | Project hook trust (`/hooks-trust`, projectTrusted) can leave doctor recovery-required after install. | Host onboarding card + grok_runtime_status. |
+| GAP-MARKETPLACE-CLI | Claude, Codex | low | Marketplace/plugin auto-activation needs host CLI on PATH; absent CLI still installs adapters but activation is manual. | Onboarding cards. |
+| GAP-COPILOT-DETECT | Copilot | low | Detection is soft (`gh` / `code` / `cursor`); IDE/cloud hosting is outside install probes. | Onboarding card. |
+| GAP-GEMINI-NODE | Gemini | low | Hook launcher needs Node.js; unsupported native events remain explicit capability gaps. | Onboarding card + launch.js. |
+
+
+## How to refresh
+
+1. Update rows when adapter contracts or Host Parity Wave B issues land.
+2. Keep `scripts/ci/agent_harness_parity.json` as the machine-checked pin set.
+3. Prefer outcome language (P/A/G) over host UI chrome comparisons.

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "b3d9b73463f1d17a7a51235d196675ad8f93c6096b32a958afaba71dfaad8e78",
+      "harnessSha256": "dc624b6ce2b7e2cb18bdbae1d1c1610cf6cbe7b7a5927023d7099d39cbc82f50",
       "treatmentSha256": {
-        "calibration": "1814703e033632d6f5e430dbb8a7fe577d4dfb4d43b41de23faee7bb99159d35",
-        "full-pilot": "c21763fc41ca0406087885f8796e6ed04ca8c882d5598826c2eff67582456cb8"
+        "calibration": "474c71ab827aa47ea833efc8e970a0d7b2a995bce5e4ce7af5c06f92dc392f4b",
+        "full-pilot": "6d9448515c249bd89c72ad37ddc56be9a307499f477bb125d575a276a40440b6"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "b3d9b73463f1d17a7a51235d196675ad8f93c6096b32a958afaba71dfaad8e78"
+      harness_sha256: "dc624b6ce2b7e2cb18bdbae1d1c1610cf6cbe7b7a5927023d7099d39cbc82f50"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "b3d9b73463f1d17a7a51235d196675ad8f93c6096b32a958afaba71dfaad8e78"
+      harness_sha256: "dc624b6ce2b7e2cb18bdbae1d1c1610cf6cbe7b7a5927023d7099d39cbc82f50"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_host_parity_matrix.py
+++ b/tests/scripts/test_chaos_engine_host_parity_matrix.py
@@ -1,0 +1,36 @@
+"""Host Parity Matrix v0 artifact (#5578)."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "chaos-engine/references/host-parity-matrix.md"
+
+
+class HostParityMatrixTests(unittest.TestCase):
+    def test_matrix_covers_five_hosts_and_lists_gaps(self):
+        text = MATRIX.read_text(encoding="utf-8")
+        self.assertTrue(MATRIX.is_file())
+        for host in ("Claude Code", "Codex", "Grok", "Gemini", "Copilot"):
+            self.assertIn(host, text)
+        for surface in (
+            "Install / doctor human UX",
+            "Router skill",
+            "Lifecycle hooks",
+            "Exit-2",
+            "SessionStart",
+            "Companions",
+            "Retrieval soft-degrade",
+            "Learning Session",
+        ):
+            self.assertIn(surface, text)
+        self.assertIn("Measured gaps", text)
+        self.assertIn("GAP-EXIT2", text)
+        self.assertIn("severity", text.casefold())
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Adds `chaos-engine/references/host-parity-matrix.md` covering install/doctor, router, hooks, exit-2, SessionStart, skills, companions, retrieval, delivery, learning.
- Lists measured gaps with severity; links from README; unit test locks the artifact.

Fixes #5578

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_host_parity_matrix -v`
- [ ] CI green