### PR TITLE
[CE] Hook exit-2 blocking fidelity across five hosts

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -45,6 +45,18 @@ Everything below is optional on first run: agent install instruction, payload
 details, OmniRoute, identity/portability, interactive flags, Maven Tools,
 uninstall/rollback, and empty-project smoke.
 
+Origin identity masters under `assets/brand/`, the origin adoption matrix
+`RESEARCH.md`, and `STANDALONE.md` stay in the source tree and are not copied
+into the adopter payload. The installer also merges receipt-bound LF attributes for canonical harness paths,
+so Windows Git checkouts retain the exact owned bytes while unrelated
+`.gitattributes` rules remain untouched.
+
+The canonical one-liners above use the official `ShaftHQ/SHAFT_ENGINE` upstream
+URLs. The scripts parse their invocation URL and do not copy that identity into
+the adopter payload. `CHAOS_ENGINE_REPOSITORY` remains a local-file override when
+the invocation URL cannot be parsed (for example when you run `install.sh` from a
+checked-out tree). Change into the target project or folder first; both scripts
+install into the current working directory.
 
 Python is not required before either command. The wrapper bootstraps Python as
 needed. The installer then discovers the invoking account's tools, resolves

--- a/chaos-engine/hooks/kernel.py
+++ b/chaos-engine/hooks/kernel.py
@@ -89,6 +89,14 @@ class HostCapability:
     strict_json_stdout: bool = True
     live_gate: bool = True
     static_surfaces: tuple[str, ...] = ()
+    # How a deny becomes a hard block on this host (parity with #5579).
+    hard_block_mechanism: str = "decision_json"
+    deny_exit_code: int = 2
+    # True when the host/process boundary reliably honors exit code 2 (or
+    # equivalent native deny). False hosts still emit deny payloads + exit 2
+    # from ChaosEngine; trust the adapter and surface blocking_gap to owners.
+    process_exit2_honored: bool = True
+    blocking_gap: str = ""
 
 
 def _aliases(supported: tuple[str, ...], **values: str) -> Mapping[str, str]:
@@ -108,11 +116,17 @@ HOST_CAPABILITIES: Mapping[str, HostCapability] = {
             sessionEnd="SessionEnd",
         ),
         CODEX_EVENTS,
+        hard_block_mechanism="permission_decision",
+        deny_exit_code=2,
+        process_exit2_honored=True,
     ),
     "claude": HostCapability(
         ("CLAUDE.md", ".claude/skills/chaos-engine/SKILL.md"),
         _aliases(CLAUDE_EVENTS),
         CLAUDE_EVENTS,
+        hard_block_mechanism="exit_2",
+        deny_exit_code=2,
+        process_exit2_honored=True,
     ),
     "gemini": HostCapability(
         ("GEMINI.md", ".gemini/skills/chaos-engine/SKILL.md"),
@@ -125,6 +139,9 @@ HOST_CAPABILITIES: Mapping[str, HostCapability] = {
             PreCompress="PreCompact",
         ),
         GEMINI_EVENTS,
+        hard_block_mechanism="decision_json",
+        deny_exit_code=2,
+        process_exit2_honored=True,
     ),
     "grok": HostCapability(
         ("AGENTS.md", ".grok/plugins/chaos-engine"),
@@ -144,6 +161,13 @@ HOST_CAPABILITIES: Mapping[str, HostCapability] = {
             session_end="SessionEnd",
         ),
         GROK_EVENTS,
+        hard_block_mechanism="decision_json",
+        deny_exit_code=2,
+        process_exit2_honored=False,
+        blocking_gap=(
+            "GAP-EXIT2: Grok may not honor process exit-2 as a hard block; "
+            "ChaosEngine still emits decision=block and exit 2 — verify adapter trust."
+        ),
     ),
     "copilot": HostCapability(
         ("AGENTS.md", ".github/copilot-instructions.md", ".github/skills/chaos-engine/SKILL.md"),
@@ -161,6 +185,13 @@ HOST_CAPABILITIES: Mapping[str, HostCapability] = {
         ),
         COPILOT_EVENTS,
         static_surfaces=("cloud", "ide"),
+        hard_block_mechanism="permission_decision",
+        deny_exit_code=2,
+        process_exit2_honored=False,
+        blocking_gap=(
+            "GAP-EXIT2: Copilot cloud/ide surfaces may not honor process exit-2; "
+            "denies use permissionDecision — verify host trust and static surfaces."
+        ),
     ),
 }
 

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -2342,6 +2342,24 @@ def installed_kernel_status(installed_root: Path) -> dict[str, object]:
                     "staticSurfaces": list(
                         getattr(kernel.HOST_CAPABILITIES[host], "static_surfaces", ())
                     ),
+                    "hardBlockMechanism": getattr(
+                        kernel.HOST_CAPABILITIES[host],
+                        "hard_block_mechanism",
+                        "decision_json",
+                    ),
+                    "denyExitCode": int(
+                        getattr(kernel.HOST_CAPABILITIES[host], "deny_exit_code", 2)
+                    ),
+                    "processExit2Honored": bool(
+                        getattr(
+                            kernel.HOST_CAPABILITIES[host],
+                            "process_exit2_honored",
+                            True,
+                        )
+                    ),
+                    "blockingGap": str(
+                        getattr(kernel.HOST_CAPABILITIES[host], "blocking_gap", "") or ""
+                    ),
                 }
                 for host in hosts
             },
@@ -3527,6 +3545,24 @@ def format_doctor_host_onboarding(clients: dict[str, object] | None = None) -> s
     )
 
 
+
+def format_blocking_fidelity_warnings(document: dict[str, object]) -> list[str]:
+    """Owner-visible warnings when a host may not honor exit-2 hard blocks (#5579)."""
+    lines: list[str] = []
+    kernel = document.get("kernel") if isinstance(document.get("kernel"), dict) else {}
+    capabilities = kernel.get("capabilities") if isinstance(kernel, dict) else None
+    if not isinstance(capabilities, dict):
+        return lines
+    for host, meta in sorted(capabilities.items()):
+        if not isinstance(meta, dict):
+            continue
+        gap = str(meta.get("blockingGap") or "").strip()
+        honored = meta.get("processExit2Honored", True)
+        if gap and honored is False:
+            lines.append(f"warning  host/{host}: {gap}")
+    return lines
+
+
 def format_health_report(document: dict[str, object], *, kind: str | None = None) -> str:
     """Render a short healthy summary or a scannable failure list with fix-next lines."""
     label = kind or str(document.get("kind") or "doctor")
@@ -3552,6 +3588,7 @@ def format_health_report(document: dict[str, object], *, kind: str | None = None
         lines.append(f"components: {healthy}/{total} healthy")
     if not failures:
         # Keep the happy path short for first-time users.
+        lines.extend(format_blocking_fidelity_warnings(document))
         return "\n".join(lines) + "\n"
     counts: dict[str, int] = {"error": 0, "warning": 0, "info": 0}
     for _name, _item, severity in failures:
@@ -3571,6 +3608,7 @@ def format_health_report(document: dict[str, object], *, kind: str | None = None
         fix = component_fix_next(name, item)
         if fix:
             lines.append(f"  fix-next: {fix}")
+    lines.extend(format_blocking_fidelity_warnings(document))
     return "\n".join(lines) + "\n"
 
 

--- a/chaos-engine/references/host-parity-matrix.md
+++ b/chaos-engine/references/host-parity-matrix.md
@@ -28,7 +28,7 @@ Legend: P = parity (outcome available), A = adapter-shaped equivalent, G = gap (
 
 | ID | Host(s) | Severity | Gap | Evidence / next |
 | --- | --- | --- | --- | --- |
-| GAP-EXIT2 | Grok, Copilot | high | Native exit-2 / hard-block semantics are thinner or host-gated vs Claude/Codex/Gemini; outcome relies on adapter + trust. | Tracked by #5579; kernel HOST_CAPABILITIES + hook configs. |
+| GAP-EXIT2 | Grok, Copilot | high | `HostCapability.process_exit2_honored=False`; ChaosEngine still returns deny exit 2 + native deny payload (`decision`/`permissionDecision`). Owner doctor surfaces `blockingGap`. | Proven by `tests/scripts/test_chaos_engine_exit2_fidelity.py`; fields on HOST_CAPABILITIES (#5579). |
 | GAP-SESSIONSTART | Grok, Copilot | medium | SessionStart locator-only / progressive disclosure is not proven equivalent; may inject more or less context. | Tracked by #5580. |
 | GAP-HOOK-TRUST | Grok | medium | Project hook trust (`/hooks-trust`, projectTrusted) can leave doctor recovery-required after install. | Host onboarding card + grok_runtime_status. |
 | GAP-MARKETPLACE-CLI | Claude, Codex | low | Marketplace/plugin auto-activation needs host CLI on PATH; absent CLI still installs adapters but activation is manual. | Onboarding cards. |

--- a/chaos-engine/references/lifecycle-hooks.md
+++ b/chaos-engine/references/lifecycle-hooks.md
@@ -33,6 +33,24 @@ receipt. Do not pretend a README sentence is a substitute. Hosts that ignore
 SessionStart output still apply companions through entrypoint load.
 ChaosEngine selects ultra through every supported host adapter.
 
+
+## Blocking fidelity (exit 2)
+
+Security and policy denies must hard-block. ChaosEngine always returns process
+exit code `2` with a host-adapted deny payload from `hooks/guard.py` via
+`hooks/lifecycle.py` (`adapt_hook_output` in `hooks/kernel.py`):
+
+| Host | Mechanism | Process exit-2 honored |
+| --- | --- | --- |
+| Claude | `decision=block` on stderr when exit is 2 | yes |
+| Codex | `permissionDecision=deny` in hookSpecificOutput | yes |
+| Gemini | `decision=block` (+ `launch.js` exit 2) | yes |
+| Grok | `decision=block` | **no** — GAP-EXIT2; doctor warns |
+| Copilot | `permissionDecision=deny` | **no** — GAP-EXIT2 (cloud/ide); doctor warns |
+
+See [Host Parity Matrix](host-parity-matrix.md) and `HostCapability` in
+`hooks/kernel.py`. Do not treat a README sentence as a substitute for a deny.
+
 ## Registration
 
 `hosts.py` writes the same command groups into the source-controlled,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "dc624b6ce2b7e2cb18bdbae1d1c1610cf6cbe7b7a5927023d7099d39cbc82f50",
+      "harnessSha256": "d05ecccdc6976382a9b368e5a247e6f66ba8ccdbd9e40f822f125ff44f6a6e20",
       "treatmentSha256": {
-        "calibration": "474c71ab827aa47ea833efc8e970a0d7b2a995bce5e4ce7af5c06f92dc392f4b",
-        "full-pilot": "6d9448515c249bd89c72ad37ddc56be9a307499f477bb125d575a276a40440b6"
+        "calibration": "061d4d000ab80f6adffe2c2bfa1c431454cbf3c699935d707c404203f50172fb",
+        "full-pilot": "834854548121a59e24038dbc9ef03072e9a4dc544014dedee74f27f54ee9c79d"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "d05ecccdc6976382a9b368e5a247e6f66ba8ccdbd9e40f822f125ff44f6a6e20",
+      "harnessSha256": "b05135bbbbc9f3b99447319c2efd46bd646ec8cb425fe12131e1b894e7bba42f",
       "treatmentSha256": {
-        "calibration": "061d4d000ab80f6adffe2c2bfa1c431454cbf3c699935d707c404203f50172fb",
-        "full-pilot": "834854548121a59e24038dbc9ef03072e9a4dc544014dedee74f27f54ee9c79d"
+        "calibration": "f13c8448d19a50eddb4a145169ce6c2b19e369cbf8a36a41896276a74ca7e642",
+        "full-pilot": "167f1722360c93994bd576f0e33d483ccb1ecb98b7d6dcf31f7e1ee78b9004bf"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "d05ecccdc6976382a9b368e5a247e6f66ba8ccdbd9e40f822f125ff44f6a6e20"
+      harness_sha256: "b05135bbbbc9f3b99447319c2efd46bd646ec8cb425fe12131e1b894e7bba42f"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "dc624b6ce2b7e2cb18bdbae1d1c1610cf6cbe7b7a5927023d7099d39cbc82f50"
+      harness_sha256: "d05ecccdc6976382a9b368e5a247e6f66ba8ccdbd9e40f822f125ff44f6a6e20"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "dc624b6ce2b7e2cb18bdbae1d1c1610cf6cbe7b7a5927023d7099d39cbc82f50"
+      harness_sha256: "d05ecccdc6976382a9b368e5a247e6f66ba8ccdbd9e40f822f125ff44f6a6e20"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "d05ecccdc6976382a9b368e5a247e6f66ba8ccdbd9e40f822f125ff44f6a6e20"
+      harness_sha256: "b05135bbbbc9f3b99447319c2efd46bd646ec8cb425fe12131e1b894e7bba42f"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_exit2_fidelity.py
+++ b/tests/scripts/test_chaos_engine_exit2_fidelity.py
@@ -1,0 +1,140 @@
+"""Hook exit-2 / hard-block fidelity across five hosts (#5579)."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "chaos-engine/references/host-parity-matrix.md"
+
+
+def load_module(name: str, relative: str):
+    path = ROOT / relative
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {relative}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class Exit2FidelityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.kernel = load_module("ce_kernel_exit2", "chaos-engine/hooks/kernel.py")
+        cls.lifecycle = load_module(
+            "ce_lifecycle_exit2", "chaos-engine/hooks/lifecycle.py"
+        )
+
+    def test_host_capability_declares_blocking_contract(self):
+        expected_honored = {
+            "claude": True,
+            "codex": True,
+            "gemini": True,
+            "grok": False,
+            "copilot": False,
+        }
+        expected_mechanism = {
+            "claude": "exit_2",
+            "codex": "permission_decision",
+            "gemini": "decision_json",
+            "grok": "decision_json",
+            "copilot": "permission_decision",
+        }
+        for host, capability in self.kernel.HOST_CAPABILITIES.items():
+            with self.subTest(host=host):
+                self.assertEqual(2, capability.deny_exit_code)
+                self.assertEqual(expected_mechanism[host], capability.hard_block_mechanism)
+                self.assertEqual(expected_honored[host], capability.process_exit2_honored)
+                if capability.process_exit2_honored:
+                    self.assertEqual("", capability.blocking_gap)
+                else:
+                    self.assertIn("GAP-EXIT2", capability.blocking_gap)
+
+    def test_protocol_deny_returns_exit_two_with_native_payload(self):
+        expected_deny = {
+            "codex": {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": "fixture-deny",
+                }
+            },
+            "claude": {"decision": "block", "reason": "fixture-deny"},
+            "gemini": {"decision": "block", "reason": "fixture-deny"},
+            "grok": {"decision": "block", "reason": "fixture-deny"},
+            "copilot": {
+                "permissionDecision": "deny",
+                "permissionDecisionReason": "fixture-deny",
+            },
+        }
+
+        def deny_callback(_event, _host):
+            print(json.dumps({"decision": "block", "reason": "fixture-deny"}))
+            return 2
+
+        for host in self.kernel.HOST_CAPABILITIES:
+            with self.subTest(host=host):
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    code = self.lifecycle.run_hook_protocol(
+                        json.dumps(
+                            {
+                                "hook_event_name": "PreToolUse",
+                                "tool_name": "Bash",
+                                "tool_input": {"command": "true"},
+                            }
+                        ),
+                        {"PreToolUse": deny_callback},
+                        normalize=self.kernel.normalize_hook_input,
+                        host_for_input=lambda _raw, selected=host: selected,
+                        adapt_output=self.kernel.adapt_hook_output,
+                    )
+                self.assertEqual(
+                    self.kernel.HOST_CAPABILITIES[host].deny_exit_code, code
+                )
+                rendered = stderr.getvalue() if host == "claude" else stdout.getvalue()
+                self.assertTrue(rendered.strip(), msg=f"empty payload host={host}")
+                payload = json.loads(rendered.strip().splitlines()[-1])
+                self.assertEqual(expected_deny[host], payload)
+
+    def test_matrix_documents_gap_exit2_for_thin_hosts(self):
+        text = MATRIX.read_text(encoding="utf-8")
+        self.assertIn("GAP-EXIT2", text)
+        self.assertIn("process_exit2_honored", text)
+        self.assertIn("test_chaos_engine_exit2_fidelity.py", text)
+
+    def test_doctor_surfaces_blocking_gap_warnings(self):
+        install = load_module("ce_install_exit2", "chaos-engine/install.py")
+        document = {
+            "kind": "doctor",
+            "status": "healthy",
+            "commit": "deadbeef",
+            "components": {},
+            "kernel": {
+                "status": "healthy",
+                "capabilities": {
+                    host: {
+                        "processExit2Honored": cap.process_exit2_honored,
+                        "blockingGap": cap.blocking_gap,
+                    }
+                    for host, cap in self.kernel.HOST_CAPABILITIES.items()
+                },
+            },
+        }
+        rendered = install.format_health_report(document)
+        self.assertIn("GAP-EXIT2", rendered)
+        self.assertIn("host/grok", rendered)
+        self.assertIn("host/copilot", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Declares `hard_block_mechanism`, `deny_exit_code`, `process_exit2_honored`, and `blocking_gap` on each `HostCapability`.
- Doctor JSON + human report surface GAP-EXIT2 for Grok/Copilot.
- Lifecycle-hooks + matrix document the contract; parity fixture proves exit 2 + native deny payloads for all five hosts.

Fixes #5579

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_exit2_fidelity -v`
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_kernel -v`
- [ ] CI green