### PR TITLE
[CE] SessionStart locator-only / progressive disclosure parity

### DIFF
--- a/chaos-engine/hooks/lifecycle.py
+++ b/chaos-engine/hooks/lifecycle.py
@@ -11,6 +11,8 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 
 COMPANION_NAMES = ("caveman", "ponytail")
+# Hard budget for SessionStart additionalContext (#5580). Locators only.
+SESSION_START_MAX_BYTES = 4096
 ULTRA_SELECTOR = (
     "ChaosEngine companion intensity: caveman=ultra; ponytail=ultra. "
     "Off only: stop caveman, stop ponytail, or normal mode."

--- a/chaos-engine/references/host-parity-matrix.md
+++ b/chaos-engine/references/host-parity-matrix.md
@@ -17,7 +17,7 @@ Legend: P = parity (outcome available), A = adapter-shaped equivalent, G = gap (
 | Router skill (`chaos-engine`) | P | P | P | P | P |
 | Lifecycle hooks | A | A | A | A | A |
 | Exit-2 / blocking denial fidelity | A | A | G | A | G |
-| SessionStart locator-only / progressive disclosure | A | A | G | A | G |
+| SessionStart locator-only / progressive disclosure | A | A | A | A | A |
 | Skills discovery | A | A | A | A | A |
 | Companions (Caveman + Ponytail) | P | P | P | P | P |
 | Retrieval soft-degrade (Memory/MemPalace/Graphify) | P | P | P | P | P |
@@ -29,7 +29,7 @@ Legend: P = parity (outcome available), A = adapter-shaped equivalent, G = gap (
 | ID | Host(s) | Severity | Gap | Evidence / next |
 | --- | --- | --- | --- | --- |
 | GAP-EXIT2 | Grok, Copilot | high | `HostCapability.process_exit2_honored=False`; ChaosEngine still returns deny exit 2 + native deny payload (`decision`/`permissionDecision`). Owner doctor surfaces `blockingGap`. | Proven by `tests/scripts/test_chaos_engine_exit2_fidelity.py`; fields on HOST_CAPABILITIES (#5579). |
-| GAP-SESSIONSTART | Grok, Copilot | medium | SessionStart locator-only / progressive disclosure is not proven equivalent; may inject more or less context. | Tracked by #5580. |
+| GAP-SESSIONSTART | — (cleared) | info | ChaosEngine emits identical locator-only SessionStart context (`SESSION_START_MAX_BYTES`=4096) on all five hosts; residual risk is a host ignoring SessionStart output (companions still load via entrypoint). | Proven by `tests/scripts/test_chaos_engine_sessionstart_locator_parity.py` (#5580). |
 | GAP-HOOK-TRUST | Grok | medium | Project hook trust (`/hooks-trust`, projectTrusted) can leave doctor recovery-required after install. | Host onboarding card + grok_runtime_status. |
 | GAP-MARKETPLACE-CLI | Claude, Codex | low | Marketplace/plugin auto-activation needs host CLI on PATH; absent CLI still installs adapters but activation is manual. | Onboarding cards. |
 | GAP-COPILOT-DETECT | Copilot | low | Detection is soft (`gh` / `code` / `cursor`); IDE/cloud hosting is outside install probes. | Onboarding card. |

--- a/chaos-engine/references/lifecycle-hooks.md
+++ b/chaos-engine/references/lifecycle-hooks.md
@@ -34,6 +34,18 @@ SessionStart output still apply companions through entrypoint load.
 ChaosEngine selects ultra through every supported host adapter.
 
 
+
+## SessionStart locator-only budget
+
+SessionStart must inject compact locators (entrypoint activation, reflection
+token, companion intensity, Caveman/Ponytail paths) — never full skill bodies
+or retrieval store dumps. The portable builder is
+`hooks/lifecycle.py:session_start_context`; the byte budget is
+`SESSION_START_MAX_BYTES` (4096). Progressive disclosure: agents read skill
+files from those paths when needed. Hosts that ignore SessionStart still load
+companions through the entrypoint. See
+[Host Parity Matrix](host-parity-matrix.md).
+
 ## Blocking fidelity (exit 2)
 
 Security and policy denies must hard-block. ChaosEngine always returns process

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "b05135bbbbc9f3b99447319c2efd46bd646ec8cb425fe12131e1b894e7bba42f",
+      "harnessSha256": "7798046e7c0aa54dc082fe5206b75995183271471daf68e4fa462dfa4884c634",
       "treatmentSha256": {
-        "calibration": "f13c8448d19a50eddb4a145169ce6c2b19e369cbf8a36a41896276a74ca7e642",
-        "full-pilot": "167f1722360c93994bd576f0e33d483ccb1ecb98b7d6dcf31f7e1ee78b9004bf"
+        "calibration": "20da727b1d0a1912d7e204f1687f169ef0257163407742b8522bfab3ab6a6aa4",
+        "full-pilot": "3cff5398acf273f86e695c51e1f195f632cece82ddf1cdbaf8a2590ac02632a5"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "b05135bbbbc9f3b99447319c2efd46bd646ec8cb425fe12131e1b894e7bba42f"
+      harness_sha256: "7798046e7c0aa54dc082fe5206b75995183271471daf68e4fa462dfa4884c634"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "b05135bbbbc9f3b99447319c2efd46bd646ec8cb425fe12131e1b894e7bba42f"
+      harness_sha256: "7798046e7c0aa54dc082fe5206b75995183271471daf68e4fa462dfa4884c634"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_sessionstart_locator_parity.py
+++ b/tests/scripts/test_chaos_engine_sessionstart_locator_parity.py
@@ -1,0 +1,119 @@
+"""SessionStart locator-only / progressive disclosure parity (#5580)."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MATRIX = ROOT / "chaos-engine/references/host-parity-matrix.md"
+
+
+def load_module(name: str, relative: str):
+    path = ROOT / relative
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {relative}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def unwrap_context(payload: dict) -> str:
+    if "additionalContext" in payload:
+        return str(payload["additionalContext"])
+    specific = payload.get("hookSpecificOutput")
+    if isinstance(specific, dict) and "additionalContext" in specific:
+        return str(specific["additionalContext"])
+    raise AssertionError(f"no additionalContext in {payload!r}")
+
+
+class SessionStartLocatorParityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.kernel = load_module("ce_kernel_ss", "chaos-engine/hooks/kernel.py")
+        cls.lifecycle = load_module("ce_lifecycle_ss", "chaos-engine/hooks/lifecycle.py")
+        cls.caveman = (
+            ROOT / "chaos-engine/vendor/caveman/skills/caveman/SKILL.md"
+        ).read_text(encoding="utf-8")
+        cls.ponytail = (
+            ROOT / "chaos-engine/vendor/ponytail/skills/ponytail/SKILL.md"
+        ).read_text(encoding="utf-8")
+
+    def test_builder_stays_under_byte_budget_and_omits_skill_bodies(self):
+        context = self.lifecycle.session_start_context("token-fixture", "activation")
+        encoded = context.encode("utf-8")
+        self.assertLessEqual(len(encoded), self.lifecycle.SESSION_START_MAX_BYTES)
+        # Soft token smoke (~4 chars/token): keep well under a 1k-token dump.
+        self.assertLessEqual(len(encoded) // 4, 512)
+        self.assertNotIn(self.caveman, context)
+        self.assertNotIn(self.ponytail, context)
+        for name in ("caveman", "ponytail"):
+            self.assertIn(
+                f"chaos-engine/vendor/{name}/skills/{name}/SKILL.md", context
+            )
+        self.assertIn("companion intensity", context.casefold())
+
+    def test_every_host_adapts_identical_locator_context(self):
+        token = "parity-session-token"
+        activation = "ChaosEngine activation"
+        base_context = self.lifecycle.session_start_context(token, activation)
+
+        def session_callback(_event, _host):
+            print(json.dumps({"additionalContext": base_context}))
+            return 0
+
+        contexts: dict[str, str] = {}
+        for host in sorted(self.kernel.HOST_CAPABILITIES):
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                code = self.lifecycle.run_hook_protocol(
+                    json.dumps(
+                        {
+                            "hook_event_name": "SessionStart",
+                            "session_id": "ss-parity",
+                        }
+                    ),
+                    {"SessionStart": session_callback},
+                    normalize=self.kernel.normalize_hook_input,
+                    host_for_input=lambda _raw, selected=host: selected,
+                    adapt_output=self.kernel.adapt_hook_output,
+                )
+            self.assertEqual(0, code)
+            rendered = stdout.getvalue().strip()
+            self.assertTrue(rendered, msg=f"empty SessionStart payload host={host}")
+            payload = json.loads(rendered.splitlines()[-1])
+            context = unwrap_context(payload)
+            encoded = json.dumps(payload).encode("utf-8")
+            self.assertLessEqual(
+                len(encoded),
+                self.lifecycle.SESSION_START_MAX_BYTES,
+                msg=f"host={host} over budget",
+            )
+            self.assertNotIn(self.caveman, context)
+            self.assertNotIn(self.ponytail, context)
+            contexts[host] = context
+
+        # Progressive disclosure contract: every host gets the same locators.
+        unique = set(contexts.values())
+        self.assertEqual(1, len(unique), msg=contexts)
+
+    def test_matrix_sessionstart_row_is_green(self):
+        text = MATRIX.read_text(encoding="utf-8")
+        self.assertIn(
+            "| SessionStart locator-only / progressive disclosure | A | A | A | A | A |",
+            text,
+        )
+        self.assertIn("test_chaos_engine_sessionstart_locator_parity.py", text)
+        self.assertIn("SESSION_START_MAX_BYTES", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `SESSION_START_MAX_BYTES` and a five-host protocol smoke proving identical locator-only SessionStart context (no skill bodies).
- Greens the Host Parity Matrix SessionStart row; clears GAP-SESSIONSTART to an info residual (host ignore).
- Documents the budget in lifecycle-hooks.

Fixes #5580

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_sessionstart_locator_parity -v`
- [ ] CI green