### PR TITLE
[CE] Token budget modes (ultra-lean | balanced | deep)

### DIFF
--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -349,7 +349,7 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 | io | Portable runtime standard-library dependency. | chaos-engine/hooks/lifecycle.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | json | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | msvcrt | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hooks/kernel.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
-| os | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py, chaos-engine/tool.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
+| os | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py, chaos-engine/tool.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | pathlib | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py, chaos-engine/tool.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | platform | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hosts.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | posixpath | Portable runtime standard-library dependency. | chaos-engine/hooks/guard.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
@@ -672,6 +672,9 @@ affected check first, then the nearest broader gate. Never commit generated
 reports, caches, runtime indexes, or `graphify-out/`.
 
 ## Read next
+
+- [Token budget modes](references/token-budget-modes.md) — ultra-lean | balanced | deep.
+
 
 - [Host Parity Matrix v0](references/host-parity-matrix.md) — five-host outcome matrix and measured gaps.
 

--- a/chaos-engine/hooks/lifecycle.py
+++ b/chaos-engine/hooks/lifecycle.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import io
 import json
 import sys
@@ -13,6 +14,55 @@ from pathlib import Path
 COMPANION_NAMES = ("caveman", "ponytail")
 # Hard budget for SessionStart additionalContext (#5580). Locators only.
 SESSION_START_MAX_BYTES = 4096
+TOKEN_BUDGET_DEFAULT = "balanced"
+TOKEN_BUDGET_MODES = {
+    "ultra-lean": {
+        "read_line_budget": 80,
+        "guidance": (
+            "Token budget ultra-lean: ≤80-line excerpts; one search; script-first. "
+            "Details: chaos-engine/references/token-budget-modes.md"
+        ),
+    },
+    "balanced": {
+        "read_line_budget": 200,
+        "guidance": (
+            "Token budget balanced (default): ≤200-line excerpts; narrow once after "
+            "truncation; prefer path+excerpt over dumps; script-first when multi-hop. "
+            "Details: chaos-engine/references/token-budget-modes.md"
+        ),
+    },
+    "deep": {
+        "read_line_budget": 400,
+        "guidance": (
+            "Token budget deep: ≤400-line excerpts; allow a second discriminating pass "
+            "before deciding; spill large tool output to disk; still prefer script-first "
+            "for mechanical transforms; keep safety and negation intact. "
+            "Details: chaos-engine/references/token-budget-modes.md"
+        ),
+    },
+}
+
+
+def resolve_token_budget_mode(environ: Mapping[str, str] | None = None) -> str:
+    """Return the owner-selected token budget mode (default balanced)."""
+    env = environ if environ is not None else os.environ
+    raw = str(env.get("CHAOS_ENGINE_TOKEN_BUDGET") or TOKEN_BUDGET_DEFAULT).strip().casefold()
+    # Accept common aliases
+    aliases = {"lean": "ultra-lean", "ultra_lean": "ultra-lean", "default": "balanced"}
+    raw = aliases.get(raw, raw)
+    if raw not in TOKEN_BUDGET_MODES:
+        return TOKEN_BUDGET_DEFAULT
+    return raw
+
+
+def token_budget_guidance(mode: str | None = None) -> str:
+    """Return the compact guidance string for a mode (fixture + SessionStart)."""
+    selected = mode or TOKEN_BUDGET_DEFAULT
+    if selected not in TOKEN_BUDGET_MODES:
+        selected = TOKEN_BUDGET_DEFAULT
+    return str(TOKEN_BUDGET_MODES[selected]["guidance"])
+
+
 ULTRA_SELECTOR = (
     "ChaosEngine companion intensity: caveman=ultra; ponytail=ultra. "
     "Off only: stop caveman, stop ponytail, or normal mode."
@@ -87,6 +137,7 @@ def session_start_context(token: str | None, activation: str) -> str:
     if token:
         parts.append(f"Reflection session token (never track it): {token}")
     parts.append(ULTRA_SELECTOR)
+    parts.append(token_budget_guidance(resolve_token_budget_mode()))
     for name in COMPANION_NAMES:
         for root in _search_roots():
             path = next(

--- a/chaos-engine/references/context-economy.md
+++ b/chaos-engine/references/context-economy.md
@@ -1,5 +1,7 @@
 # Context economy
 
+Owner-selectable budgets: [token budget modes](token-budget-modes.md) (`ultra-lean` | `balanced` | `deep`).
+
 Load this when a task will make many tool calls, return large outputs, or run
 long enough that context rot becomes the next failure mode. Host compaction is
 the host's job. This page teaches the agent how to stay under it.

--- a/chaos-engine/references/token-budget-modes.md
+++ b/chaos-engine/references/token-budget-modes.md
@@ -1,0 +1,28 @@
+# Token budget modes
+
+Owner-selectable context budgets for ChaosEngine sessions. Set
+`CHAOS_ENGINE_TOKEN_BUDGET` to one of `ultra-lean`, `balanced` (default), or
+`deep` before starting a host session. SessionStart echoes the active mode as
+one compact locator line; agents load this page only when the mode requires
+deeper guidance.
+
+| Mode | Intent | Read/search bound | When to use |
+| --- | --- | --- | --- |
+| `ultra-lean` | Minimum tokens that still preserve safety | Prefer ≤80-line excerpts; one discriminating search | Routine edits, doctor/status, single-file fixes |
+| `balanced` | Default high-signal set | Prefer ≤200-line excerpts; narrow once after truncation | Normal delivery work (default) |
+| `deep` | Broader evidence before deciding | Prefer ≤400-line excerpts; allow a second discriminating pass | Incidents, unfamiliar subsystems, adversarial review |
+
+## Invariants (all modes)
+
+- Safety, negation, attribution, and hard blocks never shrink with the budget.
+- Prefer [script-first](script-first.md) and [context economy](context-economy.md) before spending the budget.
+- SessionStart stays locator-only under `SESSION_START_MAX_BYTES` regardless of mode.
+- Progressive disclosure: do not dump this whole page into the transcript; follow the active mode row.
+
+## How hosts pick it up
+
+1. Export `CHAOS_ENGINE_TOKEN_BUDGET=ultra-lean` (or `balanced` / `deep`).
+2. Start or restart the host so SessionStart re-runs.
+3. Confirm the SessionStart line names the mode; if unset, ChaosEngine uses `balanced`.
+
+Machine-readable labels live in `hooks/lifecycle.py` (`TOKEN_BUDGET_MODES`).

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -55,7 +55,7 @@ Retrieval depth reads off the same answer. Load
 [retrieve-first](../../references/retrieve-first.md) before broad manual discovery
 when a store can shorten the task, and at completion to keep the stores from
 drifting. Bound tool reads and prefer one script over a long tool chain:
-[context economy](../../references/context-economy.md) and
+[context economy](../../references/context-economy.md) / [token budget modes](../../references/token-budget-modes.md) and
 [script first](../../references/script-first.md).
 When this entrypoint was loaded through a role adapter, load
 [retrieve-first](../../references/retrieve-first.md) before task-specific discovery,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "7798046e7c0aa54dc082fe5206b75995183271471daf68e4fa462dfa4884c634",
+      "harnessSha256": "63cb8689c281616ae3f0391f8cf1739ebaf65c92d87ac7b874e7b1c9f3ab58dd",
       "treatmentSha256": {
-        "calibration": "20da727b1d0a1912d7e204f1687f169ef0257163407742b8522bfab3ab6a6aa4",
-        "full-pilot": "3cff5398acf273f86e695c51e1f195f632cece82ddf1cdbaf8a2590ac02632a5"
+        "calibration": "4297ce814b160e886bd96cd779a60b752ee507c6ce737644a4fcbdbfdb4927b2",
+        "full-pilot": "5314a5b0eb82146d207a8f011c99dd9e094ac61e99d583a36cdf23b405a910a5"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "7798046e7c0aa54dc082fe5206b75995183271471daf68e4fa462dfa4884c634"
+      harness_sha256: "63cb8689c281616ae3f0391f8cf1739ebaf65c92d87ac7b874e7b1c9f3ab58dd"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "7798046e7c0aa54dc082fe5206b75995183271471daf68e4fa462dfa4884c634"
+      harness_sha256: "63cb8689c281616ae3f0391f8cf1739ebaf65c92d87ac7b874e7b1c9f3ab58dd"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_token_budget_modes.py
+++ b/tests/scripts/test_chaos_engine_token_budget_modes.py
@@ -1,0 +1,84 @@
+"""Token budget modes ultra-lean | balanced | deep (#5581)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "chaos-engine/references/token-budget-modes.md"
+
+
+def load_lifecycle():
+    path = ROOT / "chaos-engine/hooks/lifecycle.py"
+    spec = importlib.util.spec_from_file_location("ce_lifecycle_budget", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TokenBudgetModesTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lifecycle = load_lifecycle()
+
+    def test_default_is_balanced_and_modes_are_documented(self):
+        self.assertEqual("balanced", self.lifecycle.TOKEN_BUDGET_DEFAULT)
+        self.assertEqual(
+            {"ultra-lean", "balanced", "deep"},
+            set(self.lifecycle.TOKEN_BUDGET_MODES),
+        )
+        text = DOC.read_text(encoding="utf-8")
+        for mode in ("ultra-lean", "balanced", "deep"):
+            self.assertIn(f"`{mode}`", text)
+        self.assertIn("CHAOS_ENGINE_TOKEN_BUDGET", text)
+
+    def test_ultra_lean_guidance_is_demonstrably_smaller(self):
+        lean = self.lifecycle.token_budget_guidance("ultra-lean")
+        balanced = self.lifecycle.token_budget_guidance("balanced")
+        deep = self.lifecycle.token_budget_guidance("deep")
+        self.assertLess(len(lean), len(balanced))
+        self.assertLess(len(balanced), len(deep))
+        self.assertLess(
+            self.lifecycle.TOKEN_BUDGET_MODES["ultra-lean"]["read_line_budget"],
+            self.lifecycle.TOKEN_BUDGET_MODES["balanced"]["read_line_budget"],
+        )
+        self.assertLess(
+            self.lifecycle.TOKEN_BUDGET_MODES["balanced"]["read_line_budget"],
+            self.lifecycle.TOKEN_BUDGET_MODES["deep"]["read_line_budget"],
+        )
+
+    def test_session_start_respects_env_mode_under_byte_budget(self):
+        for mode in ("ultra-lean", "balanced", "deep"):
+            with self.subTest(mode=mode):
+                previous = os.environ.get("CHAOS_ENGINE_TOKEN_BUDGET")
+                os.environ["CHAOS_ENGINE_TOKEN_BUDGET"] = mode
+                try:
+                    context = self.lifecycle.session_start_context("t", "activation")
+                finally:
+                    if previous is None:
+                        os.environ.pop("CHAOS_ENGINE_TOKEN_BUDGET", None)
+                    else:
+                        os.environ["CHAOS_ENGINE_TOKEN_BUDGET"] = previous
+                self.assertIn("token budget", context.casefold())
+                self.assertIn(mode, context.casefold())
+                self.assertLessEqual(
+                    len(context.encode("utf-8")),
+                    self.lifecycle.SESSION_START_MAX_BYTES,
+                )
+
+    def test_unknown_env_falls_back_to_balanced(self):
+        self.assertEqual(
+            "balanced",
+            self.lifecycle.resolve_token_budget_mode(
+                {"CHAOS_ENGINE_TOKEN_BUDGET": "nope"}
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Documents `ultra-lean` | `balanced` (default) | `deep` via `CHAOS_ENGINE_TOKEN_BUDGET`.
- Injects a compact SessionStart mode line; fixture proves ultra-lean guidance is smaller than balanced and deep.
- Links from context-economy, skill router, and README.

Fixes #5581

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_token_budget_modes -v`
- [ ] CI green