### PR TITLE
[CE] Zero-LLM catalog + doctor --fix-next-only

### DIFF
--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -673,6 +673,9 @@ reports, caches, runtime indexes, or `graphify-out/`.
 
 ## Read next
 
+- [Zero-LLM catalog](references/zero-llm-catalog.md) — deterministic doctor/install/repair paths.
+
+
 - [Token budget modes](references/token-budget-modes.md) — ultra-lean | balanced | deep.
 
 

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -3388,6 +3388,11 @@ def parser() -> argparse.ArgumentParser:
         command.add_argument("--project", required=True, type=Path)
         if name in {"status", "doctor"}:
             command.add_argument("--json", action="store_true")
+            command.add_argument(
+                "--fix-next-only",
+                action="store_true",
+                help="Print only fix-next repair lines (zero-LLM / script-first).",
+            )
     explain = commands.add_parser("explain")
     explain.add_argument("event")
     explain.add_argument("--project", required=True, type=Path)
@@ -3563,6 +3568,30 @@ def format_blocking_fidelity_warnings(document: dict[str, object]) -> list[str]:
     return lines
 
 
+
+def format_fix_next_only(document: dict[str, object]) -> str:
+    """Emit only actionable fix-next lines for unhealthy components (#5582)."""
+    components = document.get("components")
+    lines: list[str] = []
+    if isinstance(components, dict):
+        for name in sorted(str(item) for item in components):
+            item = components[name]
+            if not isinstance(item, dict):
+                continue
+            if _component_severity(item) == "ok":
+                continue
+            fix = component_fix_next(name, item)
+            if fix:
+                lines.append(f"{name}: {fix}")
+    lines.extend(
+        line.split("warning  ", 1)[-1]
+        if line.startswith("warning  ")
+        else line
+        for line in format_blocking_fidelity_warnings(document)
+    )
+    return ("\n".join(lines) + "\n") if lines else ""
+
+
 def format_health_report(document: dict[str, object], *, kind: str | None = None) -> str:
     """Render a short healthy summary or a scannable failure list with fix-next lines."""
     label = kind or str(document.get("kind") or "doctor")
@@ -3615,6 +3644,8 @@ def format_health_report(document: dict[str, object], *, kind: str | None = None
 def validate_install_options(args: argparse.Namespace) -> None:
     if getattr(args, "skip_tools", False) and getattr(args, "with_maven_tools", False):
         raise ValueError("--with-maven-tools cannot be combined with --skip-tools")
+    if getattr(args, "json", False) and getattr(args, "fix_next_only", False):
+        raise ValueError("--fix-next-only cannot be combined with --json")
 
 
 def main() -> int:
@@ -3718,7 +3749,10 @@ def main() -> int:
     if args.command in {"status", "doctor"} and not getattr(args, "json", False):
         if not isinstance(result, dict):
             raise TypeError("doctor/status result must be an object")
-        print(format_health_report(result, kind=args.command), end="")
+        if getattr(args, "fix_next_only", False):
+            print(format_fix_next_only(result), end="")
+        else:
+            print(format_health_report(result, kind=args.command), end="")
         if args.command == "doctor":
             clients = result.get("clients")
             print(

--- a/chaos-engine/references/script-first.md
+++ b/chaos-engine/references/script-first.md
@@ -1,5 +1,7 @@
 # Script first
 
+Catalog of shipped zero-LLM paths: [zero-llm-catalog.md](zero-llm-catalog.md).
+
 Load this when an investigation would otherwise become a long chain of
 overlapping tool calls. Prefer one deterministic program or focused test over
 fifteen hops that restate the same question.

--- a/chaos-engine/references/zero-llm-catalog.md
+++ b/chaos-engine/references/zero-llm-catalog.md
@@ -1,0 +1,26 @@
+# Zero-LLM / script-first catalog
+
+Deterministic ChaosEngine paths that never require an LLM. Prefer these before
+opening a host chat. Companion guidance: [script-first](script-first.md).
+
+| Path | Command / entry | Proves / repairs |
+| --- | --- | --- |
+| Install / upgrade | One-liners in [INSTALL.md](../INSTALL.md) | Fresh or upgraded payload + healthy doctor |
+| Human doctor | `python3 .chaos-engine/install.py doctor --project .` | Component health + fix-next lines |
+| Fix-next only | `python3 .chaos-engine/install.py doctor --project . --fix-next-only` | Prints only actionable repair lines (exit 0 if none) |
+| JSON doctor | `... doctor --project . --json` | Schema v2 machine contract |
+| Status (passive) | `... status --project .` | Receipt-bound status without active probes |
+| Empty-project smoke | `python3 scripts/ci/chaos_engine_empty_project_smoke.py` | Install→doctor budget evidence |
+| ChaosGauge digests | `python3 scripts/ci/chaos_gauge/validate_experiment.py --write ...` | Harness digest refresh after CE changes |
+| README inventory | `python3 scripts/ci/validate_chaos_engine_readme.py` | Stdlib / surface inventory drift |
+| Kernel contract | `python3 -m unittest tests.scripts.test_chaos_engine_kernel -v` | Host capability + adapt_hook_output |
+| Exit-2 fidelity | `python3 -m unittest tests.scripts.test_chaos_engine_exit2_fidelity -v` | Deny exit code + native payloads |
+| SessionStart budget | `python3 -m unittest tests.scripts.test_chaos_engine_sessionstart_locator_parity -v` | Locator-only ≤4096 bytes |
+| Token budget modes | `python3 -m unittest tests.scripts.test_chaos_engine_token_budget_modes -v` | ultra-lean < balanced < deep |
+| Cache status/purge | `... cache status|purge --component maven-tools-mcp ...` | Shared MCP cache without chat |
+| Rollback / uninstall | `... rollback|uninstall --project .` | Deterministic recovery |
+
+## New in this change (#5582)
+
+`--fix-next-only` is the shipped zero-LLM expansion: scripts and CI can scrape
+repair actions without parsing the full human doctor essay or invoking a model.

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "63cb8689c281616ae3f0391f8cf1739ebaf65c92d87ac7b874e7b1c9f3ab58dd",
+      "harnessSha256": "2db2ef997269d6107e132171260898dc188f89e437cca8a89b8f6bafb6f98d5a",
       "treatmentSha256": {
-        "calibration": "4297ce814b160e886bd96cd779a60b752ee507c6ce737644a4fcbdbfdb4927b2",
-        "full-pilot": "5314a5b0eb82146d207a8f011c99dd9e094ac61e99d583a36cdf23b405a910a5"
+        "calibration": "a7ef4335085b5b84c064630a4ff9b81005ca1bd211f15bd192362fa4151b2994",
+        "full-pilot": "a34825015b8455fb0be2baf33195bb69498f779cc50dbcd3d7d35344ffc477bd"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "63cb8689c281616ae3f0391f8cf1739ebaf65c92d87ac7b874e7b1c9f3ab58dd"
+      harness_sha256: "2db2ef997269d6107e132171260898dc188f89e437cca8a89b8f6bafb6f98d5a"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "63cb8689c281616ae3f0391f8cf1739ebaf65c92d87ac7b874e7b1c9f3ab58dd"
+      harness_sha256: "2db2ef997269d6107e132171260898dc188f89e437cca8a89b8f6bafb6f98d5a"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_zero_llm_catalog.py
+++ b/tests/scripts/test_chaos_engine_zero_llm_catalog.py
@@ -1,0 +1,59 @@
+"""Zero-LLM catalog + doctor --fix-next-only (#5582)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CATALOG = ROOT / "chaos-engine/references/zero-llm-catalog.md"
+
+
+def load_install():
+    path = ROOT / "chaos-engine/install.py"
+    spec = importlib.util.spec_from_file_location("ce_install_zero_llm", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ZeroLlmCatalogTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.install = load_install()
+
+    def test_catalog_lists_doctor_and_fix_next_only(self):
+        text = CATALOG.read_text(encoding="utf-8")
+        self.assertIn("--fix-next-only", text)
+        self.assertIn("doctor --project", text)
+        self.assertIn("zero-llm", text.casefold())
+
+    def test_format_fix_next_only_emits_component_lines(self):
+        document = {
+            "components": {
+                "core": {
+                    "status": "recovery-required",
+                    "taskImpact": "required",
+                    "code": "CE_CORE_MISSING",
+                },
+                "memory": {"status": "healthy", "taskImpact": "advisory"},
+            }
+        }
+        rendered = self.install.format_fix_next_only(document)
+        self.assertIn("core:", rendered)
+        self.assertNotIn("memory:", rendered)
+        self.assertNotIn("ChaosEngine doctor:", rendered)
+
+    def test_fix_next_only_rejects_json_combo(self):
+        args = self.install.parser().parse_args(
+            ["doctor", "--project", ".", "--json", "--fix-next-only"]
+        )
+        with self.assertRaises(ValueError):
+            self.install.validate_install_options(args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `references/zero-llm-catalog.md` listing deterministic install/doctor/repair/test paths.
- Ships `doctor|status --fix-next-only` (scrapable repair lines; incompatible with `--json`).

Fixes #5582

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_zero_llm_catalog -v`
- [ ] CI green