### PR TITLE
[CE] Heal missing core under orphaned host receipt

### DIFF
--- a/.github/ISSUE_TEMPLATE/chaos-engine-installer.yml
+++ b/.github/ISSUE_TEMPLATE/chaos-engine-installer.yml
@@ -36,6 +36,25 @@ body:
     attributes:
       label: Platform
   - type: input
+    id: hosts_receipt
+    attributes:
+      label: Hosts receipt
+      description: present/absent for `.chaos-engine-hosts.json`
+  - type: input
+    id: core_dir
+    attributes:
+      label: Core dir
+      description: present/absent for `.chaos-engine/`
+  - type: input
+    id: install_py
+    attributes:
+      label: install.py
+      description: present/absent for `.chaos-engine/install.py`
+  - type: input
+    id: install_trace
+    attributes:
+      label: Install trace path
+  - type: input
     id: status_command
     attributes:
       label: Status command

--- a/.github/ISSUE_TEMPLATE/chaos-engine-installer.yml
+++ b/.github/ISSUE_TEMPLATE/chaos-engine-installer.yml
@@ -54,6 +54,11 @@ body:
     id: install_trace
     attributes:
       label: Install trace path
+  - type: textarea
+    id: install_trace_snippet
+    attributes:
+      label: Install trace snippet
+      description: Last lines from install-trace.json when present
   - type: input
     id: status_command
     attributes:

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -1322,7 +1322,31 @@ def emit_install_failure(
                 "then rerun the same install one-liner.",
                 file=sys.stderr,
             )
+        elif "core is missing" in cause or "ce_core_missing" in cause:
+            print(
+                "Next fix: rerun the same install one-liner so ChaosEngine can restore "
+                ".chaos-engine under the existing host receipt (or uninstall, then install).",
+                file=sys.stderr,
+            )
     print(file=sys.stderr)
+    if project is not None:
+        try:
+            root = Path(project).resolve()
+            receipt = root / ".chaos-engine-hosts.json"
+            core = root / ".chaos-engine"
+            install_py = core / "install.py"
+            print(
+                "Filesystem: "
+                f"hosts_receipt={'present' if receipt.is_file() else 'absent'}; "
+                f"core_dir={'present' if core.is_dir() else 'absent'}; "
+                f"install_py={'present' if install_py.is_file() else 'absent'}",
+                file=sys.stderr,
+            )
+            trace = root / ".chaos-engine-state" / "install-trace.json"
+            if trace.is_file():
+                print(f"Install trace: {trace}", file=sys.stderr)
+        except OSError:
+            pass
     print(f"Help: {installer_help_url(repository)}", file=sys.stderr)
     prefix = installer_cli_prefix(project)
     status_command = f"{prefix} status --project . --json" if prefix else None
@@ -1376,6 +1400,32 @@ def emit_install_failure(
             ):
                 candidate_detail_labels.append(f"{name}:{detail}")
         candidate_component_details = ",".join(candidate_detail_labels)
+        hosts_receipt = "unknown"
+        core_dir = "unknown"
+        install_py = "unknown"
+        install_trace = "not available"
+        install_trace_snippet = "not available"
+        if project is not None:
+            try:
+                root = Path(project).resolve()
+                hosts_receipt = (
+                    "present" if (root / ".chaos-engine-hosts.json").is_file() else "absent"
+                )
+                core_dir = "present" if (root / ".chaos-engine").is_dir() else "absent"
+                install_py = (
+                    "present"
+                    if (root / ".chaos-engine" / "install.py").is_file()
+                    else "absent"
+                )
+                trace = install_trace_path(root)
+                if trace.is_file():
+                    install_trace = trace.as_posix()
+                    raw = trace.read_text(encoding="utf-8")
+                    lines = [line.strip() for line in raw.splitlines() if line.strip()]
+                    snippet = " | ".join(lines[-6:])[:400]
+                    install_trace_snippet = redact_secrets(snippet) if snippet else "not available"
+            except OSError:
+                pass
         body = "\n".join(
             (
                 f"Error code: {code}",
@@ -1398,6 +1448,11 @@ def emit_install_failure(
                     if reporter and reporter.history
                     else "none"
                 ),
+                f"Hosts receipt: {hosts_receipt}",
+                f"Core dir: {core_dir}",
+                f"install.py: {install_py}",
+                f"Install trace: {install_trace}",
+                f"Install trace snippet: {install_trace_snippet}",
                 f"Platform: {sys.platform}",
                 f"Status command: {status_command}",
                 f"Doctor command: {doctor_command}",
@@ -1416,6 +1471,11 @@ def emit_install_failure(
                 "candidate_components": candidate_components,
                 "candidate_component_details": candidate_component_details,
                 "platform": sys.platform,
+                "hosts_receipt": hosts_receipt,
+                "core_dir": core_dir,
+                "install_py": install_py,
+                "install_trace": install_trace,
+                "install_trace_snippet": install_trace_snippet,
                 "status_command": status_command or "",
                 "doctor_command": doctor_command or "",
             }

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -1346,6 +1346,7 @@ def emit_install_failure(
             if trace.is_file():
                 print(f"Install trace: {trace}", file=sys.stderr)
         except OSError:
+            # Best-effort diagnostics only; path resolution/stat failures must not hide the install error.
             pass
     print(f"Help: {installer_help_url(repository)}", file=sys.stderr)
     prefix = installer_cli_prefix(project)
@@ -1430,6 +1431,7 @@ def emit_install_failure(
                             snippet,
                         )
             except OSError:
+                # Best-effort diagnostics only; path resolution/stat failures must not hide the install error.
                 pass
         body = "\n".join(
             (

--- a/chaos-engine/bootstrap.py
+++ b/chaos-engine/bootstrap.py
@@ -1423,7 +1423,12 @@ def emit_install_failure(
                     raw = trace.read_text(encoding="utf-8")
                     lines = [line.strip() for line in raw.splitlines() if line.strip()]
                     snippet = " | ".join(lines[-6:])[:400]
-                    install_trace_snippet = redact_secrets(snippet) if snippet else "not available"
+                    if snippet:
+                        install_trace_snippet = re.sub(
+                            r"(?i)\b(token|secret|password|api_key)=\S+",
+                            lambda match: f"{match.group(1)}=<redacted>",
+                            snippet,
+                        )
             except OSError:
                 pass
         body = "\n".join(

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -519,6 +519,36 @@ def missing_core_with_installed_hosts(project: Path) -> bool:
     return isinstance(payload, dict) and payload.get("phase") == "installed"
 
 
+
+def quarantine_orphaned_host_receipt(project: Path, reporter=None) -> Path | None:
+    """Move an installed host receipt aside when the portable core tree is gone.
+
+    A receipt with phase=installed makes hosts.install assume adapters/anchors
+    still exist. After a wiped `.chaos-engine`, that path fails; quarantining
+    lets curl|bash rematerialize core and reinstall hosts (#5606).
+    """
+    if not missing_core_with_installed_hosts(project):
+        return None
+    receipt = project / ".chaos-engine-hosts.json"
+    reject_link_or_reparse(receipt)
+    state = project / ".chaos-engine-state"
+    state.mkdir(parents=True, exist_ok=True)
+    destination = state / "orphaned-hosts-receipt.json"
+    if destination.exists() or is_link_or_reparse(destination):
+        destination = state / f"orphaned-hosts-receipt-{secrets.token_hex(4)}.json"
+        if destination.exists() or is_link_or_reparse(destination):
+            raise ValueError(
+                f"ChaosEngine cannot quarantine orphaned host receipt: {destination}"
+            )
+    destination.write_bytes(receipt.read_bytes())
+    receipt.unlink()
+    if reporter is not None:
+        reporter.trace(
+            "quarantined orphaned host receipt; rematerializing .chaos-engine core"
+        )
+    return destination
+
+
 def missing_core_recovery_status(project: Path) -> dict[str, object]:
     del project  # project identity is implied by the caller lock scope
     return {
@@ -535,7 +565,8 @@ def missing_core_recovery_status(project: Path) -> dict[str, object]:
                 "code": "CE_CORE_MISSING",
                 "detail": (
                     "host receipt is installed but .chaos-engine core is missing; "
-                    "restore .chaos-engine or uninstall/reinstall before provisioning"
+                    "rerun the ChaosEngine install one-liner to restore core "
+                    "(or uninstall, then install fresh)"
                 ),
             }
         },
@@ -2382,11 +2413,6 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
     confirmer=None,
 ) -> Path:
     project = project.resolve()
-    if missing_core_with_installed_hosts(project):
-        raise ValueError(
-            "ChaosEngine host receipt is installed but .chaos-engine core is missing; "
-            "restore .chaos-engine or uninstall before provisioning dependencies"
-        )
     source = source.absolute()
     reject_link_or_reparse(source)
     source = source.resolve()
@@ -2397,6 +2423,10 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
     )
     generation_mode = provisioner is None and not account_mode
     with project_lock(project):
+        # Heal: orphaned host receipt with wiped .chaos-engine must not block
+        # curl|bash reinstall. Quarantine after source validates, then
+        # `install()` rematerializes core (#5606).
+        quarantine_orphaned_host_receipt(project, reporter=reporter)
         recover_account_rollback_journal(project)
         if read_cross_rollback_journal(project) is not None:
             raise ValueError("rollback recovery is required before install")
@@ -3470,9 +3500,9 @@ def component_fix_next(name: str, item: dict[str, object]) -> str | None:
     )
     if code == "CE_CORE_MISSING" or name == "core":
         return (
-            "Restore the `.chaos-engine/` core tree or reinstall; if the runtime "
-            "was wiped while host receipts remain, uninstall/reinstall after "
-            "clearing orphaned host state. " + reinstall
+            "Rerun the ChaosEngine install one-liner to restore `.chaos-engine/` "
+            "under the existing project (orphaned host receipts are quarantined "
+            "automatically). Or uninstall, then install fresh. " + reinstall
         )
     if name == "mempalace" and status == "migration-required":
         return (

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "23ba2ff054b589ea74b5c07c53a87a1aa4c8b2a0b669b4f11fa4f47013ccafe4",
+      "harnessSha256": "bf1fb653a8ee833453205ce85cbada531f5b9804f9c388fba28461746a64f246",
       "treatmentSha256": {
-        "calibration": "40afc7ab0a89ff266dd8548681d3de69f7a56560eb4070db92ba185adc8723bd",
-        "full-pilot": "a5767aeec7e7b7e3269dd45dcd9c92155e320a0ce522e50ca23681f08c5eef7f"
+        "calibration": "6f8ccf4daa0bef91458ead28039b2314d9ed31996cfa071616ac7344508c0f39",
+        "full-pilot": "abff572069299808620201d2ea8685d040736358afe22b4284cd09f002d5c5cd"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "bf1fb653a8ee833453205ce85cbada531f5b9804f9c388fba28461746a64f246",
+      "harnessSha256": "4a7127e72a07c3b548b6cb28ad5c9d417ce9e5c309ee6180fd4095bca8a3b4ad",
       "treatmentSha256": {
-        "calibration": "6f8ccf4daa0bef91458ead28039b2314d9ed31996cfa071616ac7344508c0f39",
-        "full-pilot": "abff572069299808620201d2ea8685d040736358afe22b4284cd09f002d5c5cd"
+        "calibration": "0fe52094baa3833c744dbcdb4b4b120305c08a82b3919ee4c45b3cd802553c84",
+        "full-pilot": "36686b9e210f566f488294bf169c25f7eda76b7679366dda4e0683e7593bb88a"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "2db2ef997269d6107e132171260898dc188f89e437cca8a89b8f6bafb6f98d5a",
+      "harnessSha256": "23ba2ff054b589ea74b5c07c53a87a1aa4c8b2a0b669b4f11fa4f47013ccafe4",
       "treatmentSha256": {
-        "calibration": "a7ef4335085b5b84c064630a4ff9b81005ca1bd211f15bd192362fa4151b2994",
-        "full-pilot": "a34825015b8455fb0be2baf33195bb69498f779cc50dbcd3d7d35344ffc477bd"
+        "calibration": "40afc7ab0a89ff266dd8548681d3de69f7a56560eb4070db92ba185adc8723bd",
+        "full-pilot": "a5767aeec7e7b7e3269dd45dcd9c92155e320a0ce522e50ca23681f08c5eef7f"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "2db2ef997269d6107e132171260898dc188f89e437cca8a89b8f6bafb6f98d5a"
+      harness_sha256: "23ba2ff054b589ea74b5c07c53a87a1aa4c8b2a0b669b4f11fa4f47013ccafe4"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "bf1fb653a8ee833453205ce85cbada531f5b9804f9c388fba28461746a64f246"
+      harness_sha256: "4a7127e72a07c3b548b6cb28ad5c9d417ce9e5c309ee6180fd4095bca8a3b4ad"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "23ba2ff054b589ea74b5c07c53a87a1aa4c8b2a0b669b4f11fa4f47013ccafe4"
+      harness_sha256: "bf1fb653a8ee833453205ce85cbada531f5b9804f9c388fba28461746a64f246"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "bf1fb653a8ee833453205ce85cbada531f5b9804f9c388fba28461746a64f246"
+      harness_sha256: "4a7127e72a07c3b548b6cb28ad5c9d417ce9e5c309ee6180fd4095bca8a3b4ad"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "2db2ef997269d6107e132171260898dc188f89e437cca8a89b8f6bafb6f98d5a"
+      harness_sha256: "23ba2ff054b589ea74b5c07c53a87a1aa4c8b2a0b669b4f11fa4f47013ccafe4"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "23ba2ff054b589ea74b5c07c53a87a1aa4c8b2a0b669b4f11fa4f47013ccafe4"
+      harness_sha256: "bf1fb653a8ee833453205ce85cbada531f5b9804f9c388fba28461746a64f246"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_bootstrap.py
+++ b/tests/scripts/test_chaos_engine_bootstrap.py
@@ -535,6 +535,29 @@ class ChaosEngineBootstrapTest(unittest.TestCase):
             )
             installer.rollback.assert_called_once_with(project.resolve())
 
+    
+    def test_install_failure_issue_query_includes_filesystem_diagnostics(self):
+        module = load()
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            (project / ".chaos-engine-hosts.json").write_text("{}", encoding="utf-8")
+            stderr = io.StringIO()
+            with mock.patch.object(module.sys, "stderr", stderr):
+                module.emit_install_failure(
+                    "CE-INSTALL-FAILED",
+                    ValueError(
+                        "ChaosEngine host receipt is installed but .chaos-engine core is missing"
+                    ),
+                    "Example/Project",
+                    project=project,
+                )
+            text = stderr.getvalue()
+            self.assertIn("hosts_receipt=present", text)
+            self.assertIn("core_dir=absent", text)
+            self.assertIn("install_py=absent", text)
+            self.assertIn("Next fix: rerun the same install one-liner", text)
+            self.assertIn("hosts_receipt=present", text.split("issues/new?", 1)[1])
+
     def test_upgrade_health_failure_issue_query_includes_sha_and_safe_components(self):
         module = load()
         error = module.InstallHealthError(

--- a/tests/scripts/test_chaos_engine_installer_ux.py
+++ b/tests/scripts/test_chaos_engine_installer_ux.py
@@ -974,7 +974,7 @@ class InstallerUxTests(unittest.TestCase):
         self.assertIn("(advisory)", rendered)
         self.assertNotIn("[error] maven-tools-mcp", rendered)
         self.assertGreaterEqual(rendered.count("fix-next:"), 3)
-        self.assertIn("Restore the `.chaos-engine/` core tree", rendered)
+        self.assertIn("Rerun the ChaosEngine install one-liner to restore", rendered)
         self.assertIn("Reinstall ChaosEngine hooks", rendered)
 
     def test_doctor_human_includes_host_onboarding_cards(self):

--- a/tests/scripts/test_chaos_engine_missing_core_recovery.py
+++ b/tests/scripts/test_chaos_engine_missing_core_recovery.py
@@ -82,29 +82,27 @@ class MissingCoreRecoveryTest(unittest.TestCase):
                 encoding="utf-8",
             )
             reporter = mock.Mock()
+            # Source validates first; quarantine runs under the project lock,
+            # then install() rematerializes core. Stop at install() to prove
+            # the receipt was already moved aside.
             with mock.patch.object(
-                self.install, "install", return_value=project / ".chaos-engine"
+                self.install,
+                "install",
+                side_effect=RuntimeError("stop-after-quarantine"),
             ) as mocked_install:
-                # Stop after core install by raising from load path used next —
-                # quarantine must happen before install() is invoked.
-                with mock.patch.object(
-                    self.install,
-                    "load_dependency_controller",
-                    side_effect=RuntimeError("stop-after-quarantine"),
-                ):
-                    with self.assertRaisesRegex(RuntimeError, "stop-after-quarantine"):
-                        self.install.install_with_dependencies(
-                            project,
-                            SOURCE,
-                            TEST_COMMIT,
-                            reporter=reporter,
-                        )
+                with self.assertRaisesRegex(RuntimeError, "stop-after-quarantine"):
+                    self.install.install_with_dependencies(
+                        project,
+                        SOURCE,
+                        TEST_COMMIT,
+                        reporter=reporter,
+                    )
             self.assertFalse((project / ".chaos-engine-hosts.json").exists())
             quarantined = list(
                 (project / ".chaos-engine-state").glob("orphaned-hosts-receipt*.json")
             )
             self.assertEqual(1, len(quarantined))
-            mocked_install.assert_not_called()
+            mocked_install.assert_called_once()
             reporter.trace.assert_called()
 
 

--- a/tests/scripts/test_chaos_engine_missing_core_recovery.py
+++ b/tests/scripts/test_chaos_engine_missing_core_recovery.py
@@ -4,9 +4,12 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 INSTALL = Path(__file__).resolve().parents[2] / "chaos-engine" / "install.py"
+SOURCE = INSTALL.parent
+TEST_COMMIT = "1" * 40
 
 
 class MissingCoreRecoveryTest(unittest.TestCase):
@@ -32,8 +35,78 @@ class MissingCoreRecoveryTest(unittest.TestCase):
             status = self.install.missing_core_recovery_status(project)
             self.assertEqual("recovery-required", status["status"])
             self.assertEqual("CE_CORE_MISSING", status["components"]["core"]["code"])
+            detail = status["components"]["core"]["detail"]
+            self.assertIn("rerun", detail.casefold())
+            self.assertIn("restore", detail.casefold())
 
     def test_absent_receipt_is_not_missing_core(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary)
             self.assertFalse(self.install.missing_core_with_installed_hosts(project))
+
+    def test_quarantine_moves_orphaned_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            receipt = project / ".chaos-engine-hosts.json"
+            receipt.write_text(
+                json.dumps({"phase": "installed", "schemaVersion": 1}),
+                encoding="utf-8",
+            )
+            moved = self.install.quarantine_orphaned_host_receipt(project)
+            self.assertIsNotNone(moved)
+            assert moved is not None
+            self.assertTrue(moved.is_file())
+            self.assertFalse(receipt.exists())
+            self.assertFalse(self.install.missing_core_with_installed_hosts(project))
+
+    def test_install_rematerializes_core_under_orphaned_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "proj"
+            project.mkdir()
+            (project / ".chaos-engine-hosts.json").write_text(
+                json.dumps({"phase": "installed", "schemaVersion": 1}),
+                encoding="utf-8",
+            )
+            self.assertTrue(self.install.missing_core_with_installed_hosts(project))
+            target = self.install.install(project, SOURCE, TEST_COMMIT)
+            self.assertEqual(project / ".chaos-engine", target)
+            self.assertTrue((project / ".chaos-engine" / "install.py").is_file())
+            self.assertFalse(self.install.missing_core_with_installed_hosts(project))
+
+    def test_install_with_dependencies_quarantines_before_provision(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "proj"
+            project.mkdir()
+            (project / ".chaos-engine-hosts.json").write_text(
+                json.dumps({"phase": "installed", "schemaVersion": 1}),
+                encoding="utf-8",
+            )
+            reporter = mock.Mock()
+            with mock.patch.object(
+                self.install, "install", return_value=project / ".chaos-engine"
+            ) as mocked_install:
+                # Stop after core install by raising from load path used next —
+                # quarantine must happen before install() is invoked.
+                with mock.patch.object(
+                    self.install,
+                    "load_dependency_controller",
+                    side_effect=RuntimeError("stop-after-quarantine"),
+                ):
+                    with self.assertRaisesRegex(RuntimeError, "stop-after-quarantine"):
+                        self.install.install_with_dependencies(
+                            project,
+                            SOURCE,
+                            TEST_COMMIT,
+                            reporter=reporter,
+                        )
+            self.assertFalse((project / ".chaos-engine-hosts.json").exists())
+            quarantined = list(
+                (project / ".chaos-engine-state").glob("orphaned-hosts-receipt*.json")
+            )
+            self.assertEqual(1, len(quarantined))
+            mocked_install.assert_not_called()
+            reporter.trace.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `install_with_dependencies` no longer hard-fails when `.chaos-engine-hosts.json` says `installed` but `.chaos-engine/` is gone (`CE-INSTALL-FAILED` / Provision dependencies).
- Quarantines the orphaned host receipt under `.chaos-engine-state/`, then rematerializes core so curl|bash reinstall can proceed and hosts reinstall cleanly.
- Enrich `CE-INSTALL-FAILED` stderr + GitHub issue deep-link with filesystem diagnostics (`hosts_receipt` / `core_dir` / `install.py` / install trace) and a missing-core next-fix hint.
- Doctor fix-next copy for `CE_CORE_MISSING` points at the same one-liner heal.

Fixes #5606
Related #5586 #5587

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_missing_core_recovery -v`
- [x] `ChaosEngineBootstrapTest.test_install_failure_issue_query_includes_filesystem_diagnostics`
- [x] ChaosGauge `validate_experiment.py --write`
- [ ] CI green
- [ ] Repro: orphaned hosts receipt + missing `.chaos-engine`, rerun official install one-liner