### PR TITLE
[CE] Scope tool.py origin/main sync gate to Memory tools

### DIFF
--- a/.chaos-engine/manifest.json
+++ b/.chaos-engine/manifest.json
@@ -175,7 +175,7 @@
     "skills/local-coding-delegate/SKILL.md": "9bb5740c1927a8906885e63fad48a057b2db3cafb23488ce741a36f39af0d15c",
     "skills/local-coding-delegate/scripts/probe_hardware.py": "b5e9b9ea6952f09a542a2522f2fa53300c2739b9ce706c85c2b21657d49d5df8",
     "skills/work-item/SKILL.md": "15dd0993c97cbb488ce748cd84f126deb584c8ee78fa1f92403d23a6905f5d03",
-    "tool.py": "c0b7606348e2d5a9cf6c65cf6f0143149008f759ae7f5ac6088e1aee011fe8db",
+    "tool.py": "6741c5267c5b13ee171d4f9ae9e2178a495223ceb9ae720e855dcc3a9fc8e6a6",
     "vendor/caveman/INVENTORY.md": "4d7542a4972c953797815aa965a70c2089619129b1465b6e4abbe13f598a9286",
     "vendor/caveman/LICENSE": "f0abc56b6f49ab2e285bb6e6723f028abb7ebd4fe0e242bbdc2b4dded0ace8b9",
     "vendor/caveman/PIN.json": "1fe745ee966f3ce936d69458639fc3602e701812a6d290767c492dac3634ef1b",

--- a/.chaos-engine/tool.py
+++ b/.chaos-engine/tool.py
@@ -11,10 +11,14 @@ from pathlib import Path
 
 
 TOOLS = {"uv", "mempalace", "mempalace-mcp", "graphify", "memory", "memory-mcp"}
+# Memory writes the shared origin/main store; advisory tools may still query when doctor-healthy.
+MEMORY_ORIGIN_MAIN_TOOLS = frozenset({"memory", "memory-mcp"})
+ADVISORY_ORIGIN_MAIN_TOOLS = frozenset({"mempalace", "mempalace-mcp", "graphify"})
+ORIGIN_MAIN_SYNC_FIX_NEXT = "git fetch origin main && git merge --ff-only origin/main"
 
 
 def shared_project_root(project: Path) -> Path:
-    """Resolve the primary checkout pinned to its current origin/main."""
+    """Resolve the primary checkout that owns shared MemPalace / Memory / Graphify state."""
     if not (project / "tools/repository-map/resolve_mempalace.py").is_file():
         return project.resolve()
     completed = subprocess.run(  # nosec B603 - fixed Git query, no shell.
@@ -27,7 +31,11 @@ def shared_project_root(project: Path) -> Path:
     common = Path(completed.stdout.strip())
     if not common.is_absolute():
         common = (project / common).resolve()
-    root = common.parent.resolve()
+    return common.parent.resolve()
+
+
+def origin_main_revisions(root: Path) -> tuple[str, str]:
+    """Return (HEAD, refs/remotes/origin/main) for the primary checkout."""
     revisions = subprocess.run(  # nosec B603 - fixed Git query, no shell.
         ["git", "rev-parse", "HEAD", "refs/remotes/origin/main"],
         cwd=root,
@@ -35,9 +43,35 @@ def shared_project_root(project: Path) -> Path:
         text=True,
         check=True,
     ).stdout.splitlines()
-    if len(revisions) != 2 or revisions[0] != revisions[1]:
-        raise ValueError("shared project Memory is not synchronized with origin/main")
-    return root
+    if len(revisions) != 2:
+        raise ValueError(
+            "primary checkout HEAD and origin/main could not both be resolved "
+            f"(not synchronized with origin/main). fix-next: {ORIGIN_MAIN_SYNC_FIX_NEXT}"
+        )
+    return revisions[0], revisions[1]
+
+
+def origin_main_desync_message(head: str, origin_main: str) -> str:
+    """Name HEAD != origin/main and print the fast-forward fix-next (#5591)."""
+    return (
+        f"primary checkout HEAD ({head}) != origin/main ({origin_main}) "
+        f"(not synchronized with origin/main). fix-next: {ORIGIN_MAIN_SYNC_FIX_NEXT}"
+    )
+
+
+def enforce_tool_origin_main_policy(project: Path, tool: str) -> None:
+    """Hard-fail Memory tools when HEAD != origin/main; soft-warn advisory tools."""
+    if not (project / "tools/repository-map/resolve_mempalace.py").is_file():
+        return
+    root = shared_project_root(project)
+    head, origin_main = origin_main_revisions(root)
+    if head == origin_main:
+        return
+    message = origin_main_desync_message(head, origin_main)
+    if tool in MEMORY_ORIGIN_MAIN_TOOLS:
+        raise ValueError(message)
+    if tool in ADVISORY_ORIGIN_MAIN_TOOLS:
+        print(f"warning: {message}", file=sys.stderr)
 
 
 def load_host_controller(installed_root: Path):
@@ -83,7 +117,9 @@ def resolve_command(
 ) -> list[str]:
     if tool not in TOOLS:
         raise ValueError(f"unsupported ChaosEngine tool: {tool}")
-    project = shared_project_root(installed_root.resolve().parent)
+    installed_project = installed_root.resolve().parent
+    project = shared_project_root(installed_project)
+    enforce_tool_origin_main_policy(installed_project, tool)
     path = installed_root / "dependencies.py"
     if not path.is_file():
         raise ValueError("ChaosEngine dependency controller could not be loaded")

--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -214,6 +214,31 @@ reference profile. Local/CI fixture helper:
 If doctor is not healthy, follow every `fix-next` line, then open a GitHub
 issue and paste the full doctor output (including fix-next lines).
 
+## Troubleshooting
+
+### `tool.py` says primary checkout HEAD != origin/main
+
+On the SHAFT_ENGINE monorepo (or any checkout that ships
+`tools/repository-map/resolve_mempalace.py`), ChaosEngine pins the shared
+**Memory** store to the primary checkout's `origin/main` revision.
+
+- `memory` / `memory-mcp` **hard-fail** when primary `HEAD` is not exactly
+  `refs/remotes/origin/main`, and print a `fix-next` line.
+- `mempalace` / `mempalace-mcp` / `graphify` **soft-warn** and still run when
+  their own doctor status is healthy, so advisory stores stay queryable on a
+  behind-main primary checkout or worktree.
+
+Fix the primary checkout (not a task worktree):
+
+```bash
+git fetch origin main && git merge --ff-only origin/main
+```
+
+Then rerun the tool, or confirm with
+`python3 .chaos-engine/install.py doctor --project .`
+(and `--fix-next-only` when scripting).
+
+
 ## Optional native Maven Tools MCP
 
 Do not put `docker run -i --rm` in a default stdio MCP configuration. Each

--- a/chaos-engine/tool.py
+++ b/chaos-engine/tool.py
@@ -11,10 +11,14 @@ from pathlib import Path
 
 
 TOOLS = {"uv", "mempalace", "mempalace-mcp", "graphify", "memory", "memory-mcp"}
+# Memory writes the shared origin/main store; advisory tools may still query when doctor-healthy.
+MEMORY_ORIGIN_MAIN_TOOLS = frozenset({"memory", "memory-mcp"})
+ADVISORY_ORIGIN_MAIN_TOOLS = frozenset({"mempalace", "mempalace-mcp", "graphify"})
+ORIGIN_MAIN_SYNC_FIX_NEXT = "git fetch origin main && git merge --ff-only origin/main"
 
 
 def shared_project_root(project: Path) -> Path:
-    """Resolve the primary checkout pinned to its current origin/main."""
+    """Resolve the primary checkout that owns shared MemPalace / Memory / Graphify state."""
     if not (project / "tools/repository-map/resolve_mempalace.py").is_file():
         return project.resolve()
     completed = subprocess.run(  # nosec B603 - fixed Git query, no shell.
@@ -27,7 +31,11 @@ def shared_project_root(project: Path) -> Path:
     common = Path(completed.stdout.strip())
     if not common.is_absolute():
         common = (project / common).resolve()
-    root = common.parent.resolve()
+    return common.parent.resolve()
+
+
+def origin_main_revisions(root: Path) -> tuple[str, str]:
+    """Return (HEAD, refs/remotes/origin/main) for the primary checkout."""
     revisions = subprocess.run(  # nosec B603 - fixed Git query, no shell.
         ["git", "rev-parse", "HEAD", "refs/remotes/origin/main"],
         cwd=root,
@@ -35,9 +43,35 @@ def shared_project_root(project: Path) -> Path:
         text=True,
         check=True,
     ).stdout.splitlines()
-    if len(revisions) != 2 or revisions[0] != revisions[1]:
-        raise ValueError("shared project Memory is not synchronized with origin/main")
-    return root
+    if len(revisions) != 2:
+        raise ValueError(
+            "primary checkout HEAD and origin/main could not both be resolved "
+            f"(not synchronized with origin/main). fix-next: {ORIGIN_MAIN_SYNC_FIX_NEXT}"
+        )
+    return revisions[0], revisions[1]
+
+
+def origin_main_desync_message(head: str, origin_main: str) -> str:
+    """Name HEAD != origin/main and print the fast-forward fix-next (#5591)."""
+    return (
+        f"primary checkout HEAD ({head}) != origin/main ({origin_main}) "
+        f"(not synchronized with origin/main). fix-next: {ORIGIN_MAIN_SYNC_FIX_NEXT}"
+    )
+
+
+def enforce_tool_origin_main_policy(project: Path, tool: str) -> None:
+    """Hard-fail Memory tools when HEAD != origin/main; soft-warn advisory tools."""
+    if not (project / "tools/repository-map/resolve_mempalace.py").is_file():
+        return
+    root = shared_project_root(project)
+    head, origin_main = origin_main_revisions(root)
+    if head == origin_main:
+        return
+    message = origin_main_desync_message(head, origin_main)
+    if tool in MEMORY_ORIGIN_MAIN_TOOLS:
+        raise ValueError(message)
+    if tool in ADVISORY_ORIGIN_MAIN_TOOLS:
+        print(f"warning: {message}", file=sys.stderr)
 
 
 def load_host_controller(installed_root: Path):
@@ -83,7 +117,9 @@ def resolve_command(
 ) -> list[str]:
     if tool not in TOOLS:
         raise ValueError(f"unsupported ChaosEngine tool: {tool}")
-    project = shared_project_root(installed_root.resolve().parent)
+    installed_project = installed_root.resolve().parent
+    project = shared_project_root(installed_project)
+    enforce_tool_origin_main_policy(installed_project, tool)
     path = installed_root / "dependencies.py"
     if not path.is_file():
         raise ValueError("ChaosEngine dependency controller could not be loaded")

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "4a7127e72a07c3b548b6cb28ad5c9d417ce9e5c309ee6180fd4095bca8a3b4ad",
+      "harnessSha256": "fec7282189c3d2cd82a12a3206d149c66f23270396463d8b763e6419ef37fed0",
       "treatmentSha256": {
-        "calibration": "0fe52094baa3833c744dbcdb4b4b120305c08a82b3919ee4c45b3cd802553c84",
-        "full-pilot": "36686b9e210f566f488294bf169c25f7eda76b7679366dda4e0683e7593bb88a"
+        "calibration": "dc3afa7cb784e1404ae2f72492e7e714404390ce12f9d9e5b6ade0bc84010bed",
+        "full-pilot": "aab8f0609a8710bc14d220f8c80f5ecdf03da711ab4634ed1e84eccd371109f7"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "4a7127e72a07c3b548b6cb28ad5c9d417ce9e5c309ee6180fd4095bca8a3b4ad"
+      harness_sha256: "fec7282189c3d2cd82a12a3206d149c66f23270396463d8b763e6419ef37fed0"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "4a7127e72a07c3b548b6cb28ad5c9d417ce9e5c309ee6180fd4095bca8a3b4ad"
+      harness_sha256: "fec7282189c3d2cd82a12a3206d149c66f23270396463d8b763e6419ef37fed0"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_dependencies.py
+++ b/tests/scripts/test_chaos_engine_dependencies.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import io
 import importlib.util
 import json
 import os
@@ -123,7 +124,7 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "recovery-required"):
                     module.mempalace_mcp_arguments(core, [])
 
-    def test_tool_launcher_uses_primary_checkout_only_at_origin_main(self):
+    def test_tool_launcher_uses_primary_checkout_without_sync_gate(self):
         module = load_tool()
         with tempfile.TemporaryDirectory() as temporary:
             worktree = Path(temporary)
@@ -133,26 +134,101 @@ class ChaosEngineDependenciesTest(unittest.TestCase):
             with mock.patch.object(
                 module.subprocess,
                 "run",
-                side_effect=(
-                    SimpleNamespace(stdout="/repo/.git\n"),
-                    SimpleNamespace(stdout="a" * 40 + "\n" + "a" * 40 + "\n"),
-                ),
+                return_value=SimpleNamespace(stdout="/repo/.git\n"),
             ):
                 self.assertEqual(Path("/repo"), module.shared_project_root(worktree))
 
-            with mock.patch.object(
-                module.subprocess,
-                "run",
-                side_effect=(
-                    SimpleNamespace(stdout="/repo/.git\n"),
-                    SimpleNamespace(stdout="a" * 40 + "\n" + "b" * 40 + "\n"),
-                ),
-            ):
-                with self.assertRaisesRegex(ValueError, "not synchronized with origin/main"):
-                    module.shared_project_root(worktree)
-
             resolver.unlink()
             self.assertEqual(worktree.resolve(), module.shared_project_root(worktree))
+
+    def test_tool_origin_main_policy_hard_fails_memory_with_fix_next(self):
+        module = load_tool()
+        with tempfile.TemporaryDirectory() as temporary:
+            worktree = Path(temporary)
+            resolver = worktree / "tools/repository-map/resolve_mempalace.py"
+            resolver.parent.mkdir(parents=True)
+            resolver.write_text("# fixture\n", encoding="utf-8")
+            head = "a" * 40
+            origin = "b" * 40
+            with mock.patch.object(
+                module,
+                "shared_project_root",
+                return_value=Path("/repo"),
+            ), mock.patch.object(
+                module,
+                "origin_main_revisions",
+                return_value=(head, origin),
+            ):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    r"HEAD \(" + head + r"\) != origin/main \(" + origin + r"\).*"
+                    r"not synchronized with origin/main.*"
+                    r"fix-next: git fetch origin main && git merge --ff-only origin/main",
+                ):
+                    module.enforce_tool_origin_main_policy(worktree, "memory")
+                with self.assertRaisesRegex(ValueError, "fix-next: git fetch origin main"):
+                    module.enforce_tool_origin_main_policy(worktree, "memory-mcp")
+
+    def test_tool_origin_main_policy_soft_warns_advisory_tools(self):
+        module = load_tool()
+        with tempfile.TemporaryDirectory() as temporary:
+            worktree = Path(temporary)
+            resolver = worktree / "tools/repository-map/resolve_mempalace.py"
+            resolver.parent.mkdir(parents=True)
+            resolver.write_text("# fixture\n", encoding="utf-8")
+            head = "a" * 40
+            origin = "b" * 40
+            with mock.patch.object(
+                module,
+                "shared_project_root",
+                return_value=Path("/repo"),
+            ), mock.patch.object(
+                module,
+                "origin_main_revisions",
+                return_value=(head, origin),
+            ):
+                for tool in ("mempalace", "mempalace-mcp", "graphify"):
+                    with mock.patch.object(module.sys, "stderr", new_callable=io.StringIO) as stderr:
+                        module.enforce_tool_origin_main_policy(worktree, tool)
+                        warning = stderr.getvalue()
+                        self.assertIn("warning:", warning)
+                        self.assertIn(f"HEAD ({head}) != origin/main ({origin})", warning)
+                        self.assertIn("fix-next: git fetch origin main && git merge --ff-only origin/main", warning)
+                # uv is neither Memory nor advisory: stay silent and proceed
+                with mock.patch.object(module.sys, "stderr", new_callable=io.StringIO) as stderr:
+                    module.enforce_tool_origin_main_policy(worktree, "uv")
+                    self.assertEqual("", stderr.getvalue())
+
+    def test_tool_origin_main_policy_skips_non_shaft_projects(self):
+        module = load_tool()
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            with mock.patch.object(module, "origin_main_revisions") as revisions:
+                module.enforce_tool_origin_main_policy(project, "memory")
+                revisions.assert_not_called()
+
+    def test_resolve_command_applies_origin_main_policy_before_dispatch(self):
+        module = load_tool()
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            core = project / ".chaos-engine"
+            core.mkdir()
+            (core / "dependencies.py").write_text(
+                "def active_dispatch(project, tool, arguments):\n"
+                "    return [tool, *arguments]\n",
+                encoding="utf-8",
+            )
+            resolver = project / "tools/repository-map/resolve_mempalace.py"
+            resolver.parent.mkdir(parents=True)
+            resolver.write_text("# fixture\n", encoding="utf-8")
+            with mock.patch.object(
+                module, "shared_project_root", return_value=project
+            ), mock.patch.object(
+                module, "enforce_tool_origin_main_policy"
+            ) as enforce:
+                command = module.resolve_command(core, "graphify", ["status"])
+            self.assertEqual(["graphify", "status"], command)
+            enforce.assert_called_once_with(project, "graphify")
 
     def test_tool_launcher_rejects_relative_resolver_output_before_resolve(self):
         module = load_tool()


### PR DESCRIPTION
## Summary
- `shared_project_root()` no longer hard-fails every tool when primary `HEAD` != `origin/main`.
- `memory` / `memory-mcp` still hard-fail, now naming `HEAD != origin/main` and printing `fix-next: git fetch origin main && git merge --ff-only origin/main`.
- `mempalace` / `mempalace-mcp` / `graphify` soft-warn and proceed so advisory stores stay usable on behind-main checkouts/worktrees (MemPalace single-writer invariant unchanged).
- INSTALL troubleshooting documents the policy; ChaosGauge digests refreshed.

Fixes #5591
Related #5586
Related #5569

## Test plan
- [x] `test_tool_launcher_uses_primary_checkout_without_sync_gate`
- [x] `test_tool_origin_main_policy_hard_fails_memory_with_fix_next`
- [x] `test_tool_origin_main_policy_soft_warns_advisory_tools`
- [x] `test_tool_origin_main_policy_skips_non_shaft_projects`
- [x] `test_resolve_command_applies_origin_main_policy_before_dispatch`
- [x] related tool launcher hosts/MCP tests
- [x] ChaosGauge `validate_experiment.py --write`
- [ ] CI green