### PR TITLE
[CE] Heal wiped runtime + missing dependency receipt

### DIFF
--- a/chaos-engine/INSTALL.md
+++ b/chaos-engine/INSTALL.md
@@ -238,6 +238,33 @@ Then rerun the tool, or confirm with
 `python3 .chaos-engine/install.py doctor --project .`
 (and `--fix-next-only` when scripting).
 
+### Missing dependency receipt / wiped `.chaos-engine` runtime
+
+If `.chaos-engine/` was deleted or replaced, and/or
+`.chaos-engine-dependencies.json` is missing, tools fail closed:
+
+- `python3 chaos-engine/tool.py …` / `python3 .chaos-engine/tool.py …` prints
+  `dependency pointer is missing or invalid` (or a wiped-runtime controller
+  error) with a **fix-next** that names install/doctor, and exits **non-zero**.
+- `doctor` / `status` report `CE_CORE_MISSING` or `CE_WIPED_RUNTIME` when a
+  stale `.chaos-engine-hosts.json` (and/or `.chaos-engine-hosts.active-*`
+  anchor) no longer matches the installed core.
+
+**Heal (preferred):** rerun the official install one-liner from the Install
+section above. Install quarantines orphaned host receipt/anchors under
+`.chaos-engine-state/`, rematerializes `.chaos-engine/` from upstream or the
+local `chaos-engine/` source tree, recreates the dependency receipt, and
+rebinds hosts from the current core. No manual receipt surgery.
+
+Then confirm:
+
+```bash
+python3 .chaos-engine/install.py doctor --project .
+```
+
+Data directories (`mempalace.yaml`, `graphify-out`, `.memory`) are left in place
+when possible; heal restores tooling without requiring a full data rebuild.
+
 
 ## Optional native Maven Tools MCP
 

--- a/chaos-engine/dependencies.py
+++ b/chaos-engine/dependencies.py
@@ -2294,6 +2294,16 @@ def probe_active(
         execute(dispatch_command(generation, receipt, name, arguments), environment)
 
 
+def dependency_heal_fix_next() -> str:
+    """Actionable restore path when the dependency receipt/pointer is missing (#5586)."""
+    cli = "py -3" if os.name == "nt" else "python3"
+    return (
+        f"run the ChaosEngine install one-liner from INSTALL.md "
+        f"(or `{cli} chaos-engine/bootstrap.py` / `{cli} .chaos-engine/install.py install` "
+        f"from a source checkout), then `{cli} .chaos-engine/install.py doctor --project .`"
+    )
+
+
 def active_dispatch(project: Path, tool: str, arguments: list[str]) -> list[str]:
     """Resolve one account command, falling back to authenticated legacy generations."""
     project = project.absolute()
@@ -2308,14 +2318,28 @@ def active_dispatch(project: Path, tool: str, arguments: list[str]) -> list[str]
         if not resolved.is_file() or (os.name != "nt" and not os.access(resolved, os.X_OK)):
             raise ValueError(f"account dependency tool dispatch is unhealthy: {tool}")
         return [str(resolved), *arguments]
-    pointer = _read_pointer(project)
-    active = _validate_generation_record(pointer.get("active"))
-    generation, receipt = _authenticate_selected_generation(
-        project,
-        active,
-        active["specificationSha256"],
-        active["coreSha256"],
-    )
+    pointer_path = project / POINTER_NAME
+    if not (pointer_path.exists() or is_link_or_reparse(pointer_path)):
+        raise ValueError(
+            "dependency pointer is missing or invalid. "
+            f"fix-next: {dependency_heal_fix_next()}"
+        )
+    try:
+        pointer = _read_pointer(project)
+        active = _validate_generation_record(pointer.get("active"))
+        generation, receipt = _authenticate_selected_generation(
+            project,
+            active,
+            active["specificationSha256"],
+            active["coreSha256"],
+        )
+    except (OSError, ValueError) as error:
+        message = str(error)
+        if "fix-next:" in message.casefold():
+            raise
+        raise ValueError(
+            f"{message}. fix-next: {dependency_heal_fix_next()}"
+        ) from error
     return dispatch_command(generation, receipt, tool, arguments)
 
 

--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -504,48 +504,132 @@ def try_verify_install(target: Path) -> dict[str, object] | None:
         return None
 
 
+def account_dependency_receipt_missing(project: Path) -> bool:
+    """True when the account dependency receipt is absent or unsafe to read."""
+    path = project / ".chaos-engine-dependencies.json"
+    if is_link_or_reparse(path):
+        return True
+    return not path.is_file()
+
+
+def _installed_hosts_receipt_payload(project: Path) -> dict[str, object] | None:
+    """Return the installed-phase host receipt payload, else None."""
+    receipt = project / ".chaos-engine-hosts.json"
+    if not receipt.is_file() or is_link_or_reparse(receipt):
+        return None
+    try:
+        payload = json.loads(receipt.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if isinstance(payload, dict) and payload.get("phase") == "installed":
+        return payload
+    return None
+
+
 def missing_core_with_installed_hosts(project: Path) -> bool:
     """True when host receipt claims installed but the portable core tree is absent."""
     target = project / INSTALL_DIRECTORY
-    receipt = project / ".chaos-engine-hosts.json"
     if target.exists() or is_link_or_reparse(target):
         return False
-    if not receipt.is_file() or is_link_or_reparse(receipt):
-        return False
-    try:
-        payload = json.loads(receipt.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return False
-    return isinstance(payload, dict) and payload.get("phase") == "installed"
+    return _installed_hosts_receipt_payload(project) is not None
 
+
+def stale_host_state_after_wiped_runtime(project: Path) -> bool:
+    """True for rematerialized core with unbound host anchors (#5587).
+
+    Safe class requires a missing account dependency receipt. coreCommit mismatch
+    and live adapter drift alone are NOT enough (upgrade / fail-closed paths).
+    Quarantine when an active host anchor token does not match the installed
+    core hostToken — the wipe/rematerialize leftover that otherwise collides
+    after #5606 receipt-only quarantine.
+    """
+    if not account_dependency_receipt_missing(project):
+        return False
+    if missing_core_with_installed_hosts(project):
+        return True
+    target = project / INSTALL_DIRECTORY
+    if not target.exists() or is_link_or_reparse(target):
+        return False
+    if try_verify_install(target) is None:
+        return False
+    core_token = peek_host_token(target)
+    if core_token is None or not project.is_dir():
+        return False
+    for path in project.iterdir():
+        name = path.name
+        if not name.startswith(".chaos-engine-hosts.active-"):
+            continue
+        token = name[len(".chaos-engine-hosts.active-") :]
+        if re.fullmatch(r"[0-9a-f]{64}", token) is None:
+            return True
+        if token != core_token:
+            return True
+    return False
+
+
+def wiped_runtime_recovery_needed(project: Path) -> bool:
+    """Unified heal gate for missing-core and rematerialized-core stale hosts."""
+    return missing_core_with_installed_hosts(project) or stale_host_state_after_wiped_runtime(
+        project
+    )
+
+
+def _quarantine_state_path(state: Path, preferred: str) -> Path:
+    destination = state / preferred
+    if destination.exists() or is_link_or_reparse(destination):
+        stem = Path(preferred).stem
+        suffix = Path(preferred).suffix
+        destination = state / f"{stem}-{secrets.token_hex(4)}{suffix}"
+        if destination.exists() or is_link_or_reparse(destination):
+            raise ValueError(
+                f"ChaosEngine cannot quarantine orphaned host state: {destination}"
+            )
+    return destination
 
 
 def quarantine_orphaned_host_receipt(project: Path, reporter=None) -> Path | None:
-    """Move an installed host receipt aside when the portable core tree is gone.
+    """Move orphaned/stale host receipt (+ anchors) aside for safe reinstall.
 
-    A receipt with phase=installed makes hosts.install assume adapters/anchors
-    still exist. After a wiped `.chaos-engine`, that path fails; quarantining
-    lets curl|bash rematerialize core and reinstall hosts (#5606).
+    Covers (#5606): phase=installed host receipt with wiped `.chaos-engine`.
+    Extends (#5586/#5587): rematerialized core with missing dependency receipt and
+    stale host receipt/anchor (coreCommit or hostToken drift / verify failure).
+    Quarantining lets install rematerialize core and rebind hosts without
+    undocumented file surgery.
     """
-    if not missing_core_with_installed_hosts(project):
+    if not wiped_runtime_recovery_needed(project):
         return None
     receipt = project / ".chaos-engine-hosts.json"
-    reject_link_or_reparse(receipt)
     state = project / ".chaos-engine-state"
     state.mkdir(parents=True, exist_ok=True)
-    destination = state / "orphaned-hosts-receipt.json"
-    if destination.exists() or is_link_or_reparse(destination):
-        destination = state / f"orphaned-hosts-receipt-{secrets.token_hex(4)}.json"
-        if destination.exists() or is_link_or_reparse(destination):
-            raise ValueError(
-                f"ChaosEngine cannot quarantine orphaned host receipt: {destination}"
-            )
-    destination.write_bytes(receipt.read_bytes())
-    receipt.unlink()
+    destination: Path | None = None
+    if receipt.exists() or is_link_or_reparse(receipt):
+        reject_link_or_reparse(receipt)
+        destination = _quarantine_state_path(state, "orphaned-hosts-receipt.json")
+        destination.write_bytes(receipt.read_bytes())
+        receipt.unlink()
+    quarantined_anchors = 0
+    if project.is_dir():
+        for path in sorted(project.iterdir()):
+            name = path.name
+            if not (
+                name.startswith(".chaos-engine-hosts.active-")
+                or name.startswith(".chaos-engine-hosts.removing-")
+            ):
+                continue
+            reject_link_or_reparse(path)
+            moved = _quarantine_state_path(state, f"orphaned-{name}")
+            moved.write_bytes(path.read_bytes() if path.is_file() else b"")
+            if path.is_file():
+                path.unlink()
+            else:
+                remove_repairable_tree(path)
+            quarantined_anchors += 1
     if reporter is not None:
-        reporter.trace(
-            "quarantined orphaned host receipt; rematerializing .chaos-engine core"
-        )
+        detail = "quarantined orphaned host receipt"
+        if quarantined_anchors:
+            detail += f" and {quarantined_anchors} host anchor(s)"
+        detail += "; rematerializing/rebinding from current core"
+        reporter.trace(detail)
     return destination
 
 
@@ -569,6 +653,53 @@ def missing_core_recovery_status(project: Path) -> dict[str, object]:
                     "(or uninstall, then install fresh)"
                 ),
             }
+        },
+    }
+
+
+def wiped_runtime_recovery_status(project: Path) -> dict[str, object]:
+    """Doctor/status payload for rematerialized core + stale hosts (#5587)."""
+    target = project / INSTALL_DIRECTORY
+    commit = "wiped-runtime"
+    distribution = "wiped-runtime"
+    policy = "0" * 64
+    if target.exists() and not is_link_or_reparse(target):
+        manifest = try_verify_install(target)
+        if manifest is not None:
+            commit = str(manifest["source"]["commit"])  # type: ignore[index]
+            distribution = str(manifest["distribution"]["id"])  # type: ignore[index]
+            policy = str(manifest["distribution"]["policySha256"])  # type: ignore[index]
+    return {
+        "status": "recovery-required",
+        "commit": commit,
+        "distribution": distribution,
+        "policySha256": policy,
+        "kernel": {"status": "recovery-required"},
+        "hosts": {"status": "recovery-required"},
+        "dependencies": {"status": "recovery-required"},
+        "components": {
+            "hosts": {
+                "status": "recovery-required",
+                "code": "CE_WIPED_RUNTIME",
+                "taskImpact": "required",
+                "detail": (
+                    "wiped `.chaos-engine` / missing dependency receipt left a stale "
+                    "host receipt or anchor; rerun the ChaosEngine install one-liner "
+                    "to quarantine orphaned host state, restore the dependency "
+                    "receipt, and rebind hosts from the current core"
+                ),
+            },
+            "tools": {
+                "status": "recovery-required",
+                "code": "CE_DEPENDENCY_RECEIPT_MISSING",
+                "taskImpact": "required",
+                "detail": (
+                    "`.chaos-engine-dependencies.json` is missing; rerun the "
+                    "ChaosEngine install one-liner (or "
+                    "`python3 .chaos-engine/install.py install` from a source "
+                    "checkout) to restore the dependency receipt and runtime"
+                ),
+            },
         },
     }
 
@@ -1673,6 +1804,9 @@ def install(  # noqa: MC0001 - publication and compensation form one transaction
         _recover_transaction(project)
         if read_cross_rollback_journal(project) is not None:
             raise ValueError("rollback recovery is required before install")
+        # Heal wiped runtime leftovers before rematerializing core so a new
+        # hostToken is not published under a stale receipt/anchor (#5586/#5587).
+        quarantine_orphaned_host_receipt(project)
         current = inspect_current_install(target) if target.exists() else None
         if current is not None:
             current_commit = current["source"]["commit"]  # type: ignore[index]
@@ -2423,9 +2557,10 @@ def install_with_dependencies(  # noqa: MC0001 - owned resources share one compe
     )
     generation_mode = provisioner is None and not account_mode
     with project_lock(project):
-        # Heal: orphaned host receipt with wiped .chaos-engine must not block
-        # curl|bash reinstall. Quarantine after source validates, then
-        # `install()` rematerializes core (#5606).
+        # Heal: wiped .chaos-engine and/or rematerialized core with a stale
+        # host receipt/anchor + missing dependency receipt must not block
+        # curl|bash reinstall (#5606/#5586/#5587). Quarantine after source
+        # validates, then rematerialize core and rebind hosts.
         quarantine_orphaned_host_receipt(project, reporter=reporter)
         recover_account_rollback_journal(project)
         if read_cross_rollback_journal(project) is not None:
@@ -2879,6 +3014,8 @@ def status_with_dependencies(project: Path, *, active_probes: bool = False) -> d
             target = project / INSTALL_DIRECTORY
             if missing_core_with_installed_hosts(project):
                 return missing_core_recovery_status(project)
+            if stale_host_state_after_wiped_runtime(project):
+                return wiped_runtime_recovery_status(project)
             manifest = verify_install(target)
             state = (
                 "recovery-required"
@@ -3274,9 +3411,17 @@ def uninstall_with_dependencies(  # noqa: MC0001 - coordinated host, runtime, an
         prepared = False
         generation_prepared = False
         host_prepared = False
+        host_receipt_path = project / getattr(
+            host_controller, "RECEIPT_NAME", ".chaos-engine-hosts.json"
+        )
+        host_receipt_present = host_receipt_path.exists() or is_link_or_reparse(
+            host_receipt_path
+        )
         try:
-            host_controller.prepare_uninstall(project)
-            host_prepared = True
+            if host_receipt_present:
+                host_controller.prepare_uninstall(project)
+                host_prepared = True
+            # else: wiped-runtime quarantine already removed host state
             if generation_mode:
                 controller.prepare_generation_remove(
                     project,
@@ -3319,7 +3464,8 @@ def uninstall_with_dependencies(  # noqa: MC0001 - coordinated host, runtime, an
             controller.finalize_remove(runtime, specification)
         if generation_prepared:
             controller.finalize_generation_remove(project)
-        host_controller.finalize_uninstall(project)
+        if host_prepared:
+            host_controller.finalize_uninstall(project)
 
 
 def finalize_dependency_tombstone(removing: Path) -> None:
@@ -3503,6 +3649,13 @@ def component_fix_next(name: str, item: dict[str, object]) -> str | None:
             "Rerun the ChaosEngine install one-liner to restore `.chaos-engine/` "
             "under the existing project (orphaned host receipts are quarantined "
             "automatically). Or uninstall, then install fresh. " + reinstall
+        )
+    if code in {"CE_WIPED_RUNTIME", "CE_DEPENDENCY_RECEIPT_MISSING"}:
+        return (
+            "Rerun the ChaosEngine install one-liner to quarantine stale host "
+            "receipt/anchors, restore `.chaos-engine-dependencies.json`, and "
+            "rebind hosts from the current core (no manual receipt surgery). "
+            + reinstall
         )
     if name == "mempalace" and status == "migration-required":
         return (
@@ -3731,11 +3884,19 @@ def main() -> int:
     except (OSError, RuntimeError, ValueError) as error:
         message = str(error)
         diagnostic_code = "CE_DIAGNOSTIC_UNAVAILABLE"
+        project_arg = getattr(args, "project", None)
         if "manifest is missing or invalid" in message or (
-            getattr(args, "project", None) is not None
-            and missing_core_with_installed_hosts(Path(args.project))
+            project_arg is not None
+            and missing_core_with_installed_hosts(Path(project_arg))
         ):
             diagnostic_code = "CE_CORE_MISSING"
+        elif project_arg is not None and (
+            wiped_runtime_recovery_needed(Path(project_arg))
+            or "host receipt does not match the installed core" in message
+            or "receipt integrity drift" in message
+            or "host adapter drift" in message
+        ) and account_dependency_receipt_missing(Path(project_arg)):
+            diagnostic_code = "CE_WIPED_RUNTIME"
         if getattr(args, "json", False):
             print(
                 json.dumps(
@@ -3763,6 +3924,19 @@ def main() -> int:
                         {
                             "status": "recovery-required",
                             "code": "CE_CORE_MISSING",
+                            "taskImpact": "required",
+                        },
+                    ),
+                    file=sys.stderr,
+                )
+            elif diagnostic_code == "CE_WIPED_RUNTIME":
+                print(
+                    "fix-next: "
+                    + component_fix_next(
+                        "hosts",
+                        {
+                            "status": "recovery-required",
+                            "code": "CE_WIPED_RUNTIME",
                             "taskImpact": "required",
                         },
                     ),

--- a/chaos-engine/tool.py
+++ b/chaos-engine/tool.py
@@ -122,7 +122,13 @@ def resolve_command(
     enforce_tool_origin_main_policy(installed_project, tool)
     path = installed_root / "dependencies.py"
     if not path.is_file():
-        raise ValueError("ChaosEngine dependency controller could not be loaded")
+        cli = "py -3" if os.name == "nt" else "python3"
+        raise ValueError(
+            "ChaosEngine dependency controller could not be loaded "
+            f"(wiped or incomplete `.chaos-engine` runtime). fix-next: run the "
+            f"ChaosEngine install one-liner from INSTALL.md, then "
+            f"`{cli} .chaos-engine/install.py doctor --project .`"
+        )
     controller = runpy.run_path(str(path), run_name="_chaos_engine_runtime_dependencies")
     return controller["active_dispatch"](project, tool, arguments or [])
 

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "fec7282189c3d2cd82a12a3206d149c66f23270396463d8b763e6419ef37fed0",
+      "harnessSha256": "e1869ef4d450ade84343e796877ef4ef99571ac9a0516cdec2ffcd8c30d07eac",
       "treatmentSha256": {
-        "calibration": "dc3afa7cb784e1404ae2f72492e7e714404390ce12f9d9e5b6ade0bc84010bed",
-        "full-pilot": "aab8f0609a8710bc14d220f8c80f5ecdf03da711ab4634ed1e84eccd371109f7"
+        "calibration": "8fe582ea53104637982e58f24f233e35d427c6a5b311b80329c05e50f8b2dec5",
+        "full-pilot": "43023e4acbbc504b46762fa173b8f57b676b274e14deaeeb9ae9230c773f1bdc"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "fec7282189c3d2cd82a12a3206d149c66f23270396463d8b763e6419ef37fed0"
+      harness_sha256: "e1869ef4d450ade84343e796877ef4ef99571ac9a0516cdec2ffcd8c30d07eac"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "fec7282189c3d2cd82a12a3206d149c66f23270396463d8b763e6419ef37fed0"
+      harness_sha256: "e1869ef4d450ade84343e796877ef4ef99571ac9a0516cdec2ffcd8c30d07eac"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_missing_core_recovery.py
+++ b/tests/scripts/test_chaos_engine_missing_core_recovery.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 import sys
 import tempfile
 import unittest
@@ -13,7 +11,6 @@ from unittest import mock
 INSTALL = Path(__file__).resolve().parents[2] / "chaos-engine" / "install.py"
 SOURCE = INSTALL.parent
 DEPENDENCIES = SOURCE / "dependencies.py"
-TOOL = SOURCE / "tool.py"
 TEST_COMMIT = "1" * 40
 OTHER_COMMIT = "2" * 40
 
@@ -245,24 +242,10 @@ class MissingCoreRecoveryTest(unittest.TestCase):
             self.assertIn("doctor", message.casefold())
 
     def test_tool_py_exits_nonzero_with_heal_path(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary:
-            project = Path(temporary) / "proj"
-            project.mkdir()
-            # Invoke source tool.py against an empty project (no receipt/pointer).
-            # tool.py resolves project as parent of installed_root for non-monorepo.
-            env = os.environ.copy()
-            env["PYTHONDONTWRITEBYTECODE"] = "1"
-            completed = subprocess.run(
-                [sys.executable, str(TOOL), "mempalace", "--version"],
-                cwd=project,
-                capture_output=True,
-                text=True,
-                env=env,
-                check=False,
-            )
-            # tool.py uses Path(__file__).parent as installed_root; project becomes
-            # shared_project_root(parent of chaos-engine) = repo root, not cwd.
-            # Instead call active_dispatch-style via a copy of tool in the temp tree.
+        import importlib.util
+        import io
+        from contextlib import redirect_stderr
+
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary) / "proj"
             project.mkdir()
@@ -273,16 +256,23 @@ class MissingCoreRecoveryTest(unittest.TestCase):
                     (SOURCE / name).read_text(encoding="utf-8"),
                     encoding="utf-8",
                 )
-            completed = subprocess.run(
-                [sys.executable, str(runtime / "tool.py"), "mempalace", "--version"],
-                cwd=project,
-                capture_output=True,
-                text=True,
-                env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
-                check=False,
+            spec = importlib.util.spec_from_file_location(
+                "chaos_engine_tool_heal", runtime / "tool.py"
             )
-            self.assertNotEqual(0, completed.returncode)
-            combined = (completed.stdout + completed.stderr).casefold()
+            if spec is None or spec.loader is None:
+                raise AssertionError("failed to load tool.py under temp runtime")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            stderr = io.StringIO()
+            argv = sys.argv
+            try:
+                sys.argv = ["tool.py", "mempalace", "--version"]
+                with redirect_stderr(stderr):
+                    code = module.main()
+            finally:
+                sys.argv = argv
+            self.assertNotEqual(0, code)
+            combined = stderr.getvalue().casefold()
             self.assertIn("fix-next:", combined)
             self.assertTrue(
                 "dependency pointer is missing" in combined
@@ -299,7 +289,8 @@ class MissingCoreRecoveryTest(unittest.TestCase):
             },
         )
         self.assertIsNotNone(fix)
-        assert fix is not None
+        if fix is None:
+            raise AssertionError("expected wiped-runtime fix-next")
         lowered = fix.casefold()
         self.assertIn("install", lowered)
         self.assertIn("quarantine", lowered)

--- a/tests/scripts/test_chaos_engine_missing_core_recovery.py
+++ b/tests/scripts/test_chaos_engine_missing_core_recovery.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -9,7 +12,10 @@ from unittest import mock
 
 INSTALL = Path(__file__).resolve().parents[2] / "chaos-engine" / "install.py"
 SOURCE = INSTALL.parent
+DEPENDENCIES = SOURCE / "dependencies.py"
+TOOL = SOURCE / "tool.py"
 TEST_COMMIT = "1" * 40
+OTHER_COMMIT = "2" * 40
 
 
 class MissingCoreRecoveryTest(unittest.TestCase):
@@ -23,6 +29,15 @@ class MissingCoreRecoveryTest(unittest.TestCase):
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         cls.install = module
+
+        dep_spec = importlib.util.spec_from_file_location(
+            "chaos_engine_dependencies", DEPENDENCIES
+        )
+        if dep_spec is None or dep_spec.loader is None:
+            raise AssertionError("failed to load chaos-engine dependencies module")
+        dep_module = importlib.util.module_from_spec(dep_spec)
+        dep_spec.loader.exec_module(dep_module)
+        cls.dependencies = dep_module
 
     def test_detects_installed_receipt_without_core(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -43,6 +58,27 @@ class MissingCoreRecoveryTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary)
             self.assertFalse(self.install.missing_core_with_installed_hosts(project))
+
+    def test_missing_core_quarantine_also_moves_stale_anchors(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            (project / ".chaos-engine-hosts.json").write_text(
+                json.dumps({"phase": "installed", "schemaVersion": 1}),
+                encoding="utf-8",
+            )
+            stale = "b" * 64
+            (project / f".chaos-engine-hosts.active-{stale}").write_bytes(b"")
+            moved = self.install.quarantine_orphaned_host_receipt(project)
+            self.assertIsNotNone(moved)
+            self.assertFalse((project / ".chaos-engine-hosts.json").exists())
+            self.assertFalse((project / f".chaos-engine-hosts.active-{stale}").exists())
+            self.assertTrue(
+                list(
+                    (project / ".chaos-engine-state").glob(
+                        "orphaned-.chaos-engine-hosts.active-*"
+                    )
+                )
+            )
 
     def test_quarantine_moves_orphaned_receipt(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -72,6 +108,8 @@ class MissingCoreRecoveryTest(unittest.TestCase):
             self.assertEqual(project / ".chaos-engine", target)
             self.assertTrue((project / ".chaos-engine" / "install.py").is_file())
             self.assertFalse(self.install.missing_core_with_installed_hosts(project))
+            # install() quarantines before rematerialize so stale hosts do not linger
+            self.assertFalse((project / ".chaos-engine-hosts.json").exists())
 
     def test_install_with_dependencies_quarantines_before_provision(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -104,6 +142,168 @@ class MissingCoreRecoveryTest(unittest.TestCase):
             self.assertEqual(1, len(quarantined))
             mocked_install.assert_called_once()
             reporter.trace.assert_called()
+
+    def test_stale_host_receipt_after_rematerialized_core(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "proj"
+            project.mkdir()
+            target = self.install.install(project, SOURCE, TEST_COMMIT)
+            manifest = json.loads(
+                (target / "manifest.json").read_text(encoding="utf-8")
+            )
+            host_token = manifest["hostToken"]
+            stale_token = "a" * 64
+            # Authenticated-looking receipt is not required: anchor token mismatch
+            # against the rematerialized core hostToken is the wipe-class signal.
+            # coreCommit mismatch alone must NOT quarantine (upgrade path).
+            (project / ".chaos-engine-hosts.json").write_text(
+                json.dumps(
+                    {
+                        "phase": "installed",
+                        "schemaVersion": 1,
+                        "coreCommit": OTHER_COMMIT,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.assertFalse(self.install.stale_host_state_after_wiped_runtime(project))
+            (project / f".chaos-engine-hosts.active-{stale_token}").write_bytes(b"")
+            self.assertTrue(self.install.account_dependency_receipt_missing(project))
+            self.assertTrue(self.install.stale_host_state_after_wiped_runtime(project))
+            self.assertTrue(self.install.wiped_runtime_recovery_needed(project))
+            status = self.install.wiped_runtime_recovery_status(project)
+            self.assertEqual("CE_WIPED_RUNTIME", status["components"]["hosts"]["code"])
+            self.assertEqual(
+                "CE_DEPENDENCY_RECEIPT_MISSING",
+                status["components"]["tools"]["code"],
+            )
+            reporter = mock.Mock()
+            moved = self.install.quarantine_orphaned_host_receipt(
+                project, reporter=reporter
+            )
+            self.assertIsNotNone(moved)
+            self.assertFalse((project / ".chaos-engine-hosts.json").exists())
+            self.assertFalse(
+                (project / f".chaos-engine-hosts.active-{stale_token}").exists()
+            )
+            self.assertTrue(
+                list(
+                    (project / ".chaos-engine-state").glob(
+                        "orphaned-.chaos-engine-hosts.active-*"
+                    )
+                )
+            )
+            self.assertNotEqual(stale_token, host_token)
+            reporter.trace.assert_called()
+            self.assertFalse(self.install.wiped_runtime_recovery_needed(project))
+
+    def test_healthy_hosts_with_deps_receipt_are_not_quarantined(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "proj"
+            project.mkdir()
+            target = self.install.install(project, SOURCE, TEST_COMMIT)
+            manifest = json.loads(
+                (target / "manifest.json").read_text(encoding="utf-8")
+            )
+            commit = manifest["source"]["commit"]
+            (project / ".chaos-engine-dependencies.json").write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 2,
+                        "components": {},
+                        "commands": {},
+                        "checkedAt": "2026-01-01T00:00:00+00:00",
+                        "scope": "project",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (project / ".chaos-engine-hosts.json").write_text(
+                json.dumps(
+                    {
+                        "phase": "installed",
+                        "schemaVersion": 1,
+                        "coreCommit": commit,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            # deps present → never auto-quarantine even if verify would fail
+            self.assertFalse(self.install.stale_host_state_after_wiped_runtime(project))
+            self.assertIsNone(self.install.quarantine_orphaned_host_receipt(project))
+            self.assertTrue((project / ".chaos-engine-hosts.json").exists())
+
+    def test_active_dispatch_missing_pointer_prints_fix_next(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            with self.assertRaises(ValueError) as raised:
+                self.dependencies.active_dispatch(project, "mempalace", ["--version"])
+            message = str(raised.exception)
+            self.assertIn("dependency pointer is missing", message.casefold())
+            self.assertIn("fix-next:", message.casefold())
+            self.assertIn("install", message.casefold())
+            self.assertIn("doctor", message.casefold())
+
+    def test_tool_py_exits_nonzero_with_heal_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "proj"
+            project.mkdir()
+            # Invoke source tool.py against an empty project (no receipt/pointer).
+            # tool.py resolves project as parent of installed_root for non-monorepo.
+            env = os.environ.copy()
+            env["PYTHONDONTWRITEBYTECODE"] = "1"
+            completed = subprocess.run(
+                [sys.executable, str(TOOL), "mempalace", "--version"],
+                cwd=project,
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+            )
+            # tool.py uses Path(__file__).parent as installed_root; project becomes
+            # shared_project_root(parent of chaos-engine) = repo root, not cwd.
+            # Instead call active_dispatch-style via a copy of tool in the temp tree.
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "proj"
+            project.mkdir()
+            runtime = project / ".chaos-engine"
+            runtime.mkdir()
+            for name in ("tool.py", "dependencies.py", "hosts.py"):
+                (runtime / name).write_text(
+                    (SOURCE / name).read_text(encoding="utf-8"),
+                    encoding="utf-8",
+                )
+            completed = subprocess.run(
+                [sys.executable, str(runtime / "tool.py"), "mempalace", "--version"],
+                cwd=project,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+                check=False,
+            )
+            self.assertNotEqual(0, completed.returncode)
+            combined = (completed.stdout + completed.stderr).casefold()
+            self.assertIn("fix-next:", combined)
+            self.assertTrue(
+                "dependency pointer is missing" in combined
+                or "install" in combined
+            )
+
+    def test_component_fix_next_for_wiped_runtime(self) -> None:
+        fix = self.install.component_fix_next(
+            "hosts",
+            {
+                "status": "recovery-required",
+                "code": "CE_WIPED_RUNTIME",
+                "taskImpact": "required",
+            },
+        )
+        self.assertIsNotNone(fix)
+        assert fix is not None
+        lowered = fix.casefold()
+        self.assertIn("install", lowered)
+        self.assertIn("quarantine", lowered)
+        self.assertIn("dependencies.json", lowered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Expand orphaned-host quarantine (#5606) so install also moves stale `.chaos-engine-hosts.active-*` anchors when `.chaos-engine` is wiped/rematerialized and the dependency receipt is missing — prevents hostToken/anchor collision after core rematerialize.
- `tool.py` / `active_dispatch` print an actionable **fix-next** (install/doctor) and exit non-zero when the dependency pointer/receipt is missing.
- Doctor/status surfaces `CE_WIPED_RUNTIME` / `CE_DEPENDENCY_RECEIPT_MISSING` with the same one-liner heal; INSTALL.md troubleshooting documents the path.
- Safe gate: missing deps receipt + (missing core **or** unbound active anchor). Does not weaken ordinary adapter-drift / integrity fail-closed paths.

Fixes #5586
Fixes #5587
Related #5606 #5569

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_missing_core_recovery -v`
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_installer tests.scripts.test_chaos_engine_installer_ux tests.scripts.test_chaos_engine_uninstall_clarity`
- [x] ChaosGauge `validate_experiment.py --write scripts/ci/chaos_gauge/experiment.json`
- [ ] CI green
- [ ] Repro: wipe `.chaos-engine` + delete deps receipt leaving stale hosts receipt/anchor; rerun install one-liner; doctor healthy; `tool.py` heal message when pointer missing