### PR TITLE
[CE] Delivery workflow phase gates as hooks

### DIFF
--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -349,7 +349,7 @@ usable without Mermaid; unknown source entries fail the inventory validator.
 | io | Portable runtime standard-library dependency. | chaos-engine/hooks/lifecycle.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | json | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | msvcrt | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hooks/kernel.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
-| os | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py, chaos-engine/tool.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
+| os | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py, chaos-engine/tool.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | pathlib | Portable runtime standard-library dependency. | chaos-engine/bootstrap.py, chaos-engine/dependencies.py, chaos-engine/hooks/guard.py, chaos-engine/hooks/kernel.py, chaos-engine/hooks/lifecycle.py, chaos-engine/hooks/reflection.py, chaos-engine/hosts.py, chaos-engine/install.py, chaos-engine/learning.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py, chaos-engine/skills/omniroute/scripts/runner.py, chaos-engine/tool.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | platform | Portable runtime standard-library dependency. | chaos-engine/dependencies.py, chaos-engine/hosts.py, chaos-engine/skills/local-coding-delegate/scripts/probe_hardware.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
 | posixpath | Portable runtime standard-library dependency. | chaos-engine/hooks/guard.py | required | Windows, Linux, macOS | resolved latest stable Python | Python runtime | affected command fails closed |
@@ -672,6 +672,9 @@ affected check first, then the nearest broader gate. Never commit generated
 reports, caches, runtime indexes, or `graphify-out/`.
 
 ## Read next
+
+- [Delivery phase gates](references/delivery-phase-gates.md) — hooks vs skills map + research-before-mutation.
+
 
 - [Zero-LLM catalog](references/zero-llm-catalog.md) — deterministic doctor/install/repair paths.
 

--- a/chaos-engine/hooks/guard.py
+++ b/chaos-engine/hooks/guard.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import hashlib
 import importlib.util
 import posixpath
@@ -503,6 +504,23 @@ def _event_context(event_name: str, token: object) -> str:
     return context
 
 
+
+def _research_before_mutation_reason(event_name: str, mutation: bool, session_id: str) -> str | None:
+    """Opt-in hard gate: deny mutations until research-preflight is recorded (#5583)."""
+    if event_name != "PreToolUse" or not mutation:
+        return None
+    flag = str(os.environ.get("CHAOS_ENGINE_ENFORCE_RESEARCH_RECEIPT") or "").strip().casefold()
+    if flag not in {"1", "true", "yes", "on"}:
+        return None
+    if not session_id or reflection.has_research_preflight(session_id):
+        return None
+    return (
+        "Research receipt required before mutation "
+        "(set CHAOS_ENGINE_ENFORCE_RESEARCH_RECEIPT; "
+        "record via hooks/reflection.py research-preflight)."
+    )
+
+
 def _run_event(event: dict, _host: str) -> int:
     tool_input = event.get("tool_input", {}) if isinstance(event, dict) else {}
     tool_name = str(event.get("tool_name", "")) if isinstance(event, dict) else ""
@@ -531,6 +549,14 @@ def _run_event(event: dict, _host: str) -> int:
         kernel_report = _kernel.evaluate_session(normalized_kernel_event, kernel_journal)
     if kernel_report.decision == "deny":
         print(json.dumps({"decision": "block", "reason": kernel_report.reason}))
+        return 2
+    research_reason = _research_before_mutation_reason(
+        event_name,
+        bool(normalized_kernel_event.stateful_mutation),
+        session_id,
+    )
+    if research_reason:
+        print(json.dumps({"decision": "block", "reason": research_reason}))
         return 2
     if event_name == "SessionStart":
         token = reflection.record_session_start(session_id)

--- a/chaos-engine/hooks/reflection.py
+++ b/chaos-engine/hooks/reflection.py
@@ -523,6 +523,40 @@ def record_receipt(session_id: str, receipt: dict, session_token: str) -> dict:
     return entry
 
 
+
+def has_research_preflight(session_id: str) -> bool:
+    """True when the session ledger already recorded research-preflight (#5583)."""
+    if not isinstance(session_id, str) or not session_id.strip():
+        return False
+    path = ledger_path(session_id)
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            continue
+        if isinstance(entry, dict) and entry.get("kind") == "research-preflight":
+            return True
+    return False
+
+
+def record_research_preflight(session_id: str, note: str = "research-receipt") -> bool:
+    """Append a minimal research-preflight marker (zero-LLM; #5583)."""
+    if not isinstance(session_id, str) or not session_id.strip():
+        return False
+    return append_entry(
+        session_id,
+        {
+            "kind": "research-preflight",
+            "note": str(note)[:120],
+            "schemaVersion": SCHEMA_VERSION,
+        },
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="operation", required=True)
@@ -543,8 +577,24 @@ def main(argv: list[str] | None = None) -> int:
     non_attempt.add_argument("--agent-id")
     non_attempt.add_argument("--failure-id", required=True)
     non_attempt.add_argument("--reason", required=True, choices=sorted(NON_ATTEMPT_REASONS))
+    research = commands.add_parser(
+        "research-preflight",
+        help="record research-before-mutation preflight (CHAOS_ENGINE_ENFORCE_RESEARCH_RECEIPT)",
+    )
+    research.add_argument("--session-id", required=True)
+    research.add_argument("--agent-id")
+    research.add_argument("--note", default="research-receipt")
     arguments = parser.parse_args(argv)
     session_id = scope_session_id(arguments.session_id, arguments.agent_id)
+    if arguments.operation == "research-preflight":
+        recorded = record_research_preflight(session_id, arguments.note)
+        print(
+            json.dumps(
+                {"recorded": recorded, "kind": "research-preflight"},
+                separators=(",", ":"),
+            )
+        )
+        return 0 if recorded else 1
     if arguments.operation == "trigger":
         try:
             recorded = record_trigger(session_id, arguments.trigger, arguments.fingerprint)

--- a/chaos-engine/references/delivery-phase-gates.md
+++ b/chaos-engine/references/delivery-phase-gates.md
@@ -1,0 +1,42 @@
+# Delivery workflow phase gates
+
+Maps the ChaosEngine delivery loop to **hooks** (machine-checkable) vs **skills**
+(judgment). Parent epic #5569 / issue #5583.
+
+| Phase | Guarantee owner | Hook / surface | Skill judgment |
+| --- | --- | --- | --- |
+| Triage / consult | Skill | — | [consult-first](consult-first.md), router skill |
+| Research receipt | Hook when enforced | PreToolUse research-before-mutation gate | [research-receipt](research-receipt.md) |
+| Implement (Do) | Hook | PreToolUse session identity, catastrophic deny, worktree | playbooks / roles |
+| Check | Skill + tests | PostToolUse records outcomes | consolidated proof commands |
+| Optional adversarial | Skill | — | independent PR review |
+| Learning Session | Hook | Stop requires terminal Learning Session | [learning](../learning.py) |
+
+## Research-before-mutation (enforced path)
+
+By default, research-before-mutation remains skill guidance so mechanical
+one-file work stays unblocked.
+
+Owners who want a hard guarantee set:
+
+```text
+export CHAOS_ENGINE_ENFORCE_RESEARCH_RECEIPT=1
+```
+
+When set, `hooks/guard.py` denies **PreToolUse** stateful mutations until the
+session ledger records a `research-preflight` entry. Record one with the
+zero-LLM CLI:
+
+```text
+python3 .chaos-engine/hooks/reflection.py research-preflight --session-id "$SESSION"
+```
+
+Hosts that honor exit-2 / native deny (`HostCapability.process_exit2_honored`)
+hard-block; others still emit deny payloads (see [host-parity-matrix](host-parity-matrix.md)
+GAP-EXIT2).
+
+## Invariants
+
+- Skills still own thoroughness of the eight-step receipt content.
+- Hooks only prove that a preflight marker exists before mutation when enforced.
+- Safety denials and session-identity rules remain higher priority than this gate.

--- a/chaos-engine/references/research-receipt.md
+++ b/chaos-engine/references/research-receipt.md
@@ -1,5 +1,7 @@
 # Research receipt
 
+Phase-gate map: [delivery-phase-gates.md](delivery-phase-gates.md).
+
 Load this before the first implementation mutation, except mechanical one-file
 reversible work: name the eight steps, then record store irrelevance without
 querying. Default and most-intelligent work query a store only when it can

--- a/chaos-engine/references/zero-llm-catalog.md
+++ b/chaos-engine/references/zero-llm-catalog.md
@@ -24,3 +24,5 @@ opening a host chat. Companion guidance: [script-first](script-first.md).
 
 `--fix-next-only` is the shipped zero-LLM expansion: scripts and CI can scrape
 repair actions without parsing the full human doctor essay or invoking a model.
+| Research preflight marker | `python3 .chaos-engine/hooks/reflection.py research-preflight --session-id <id>` | Unblocks opt-in research-before-mutation gate |
+

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "e1869ef4d450ade84343e796877ef4ef99571ac9a0516cdec2ffcd8c30d07eac",
+      "harnessSha256": "3988c09f85a2feed078a51f47fae1775c49cdeded961a3e2c1048c2c156094d3",
       "treatmentSha256": {
-        "calibration": "8fe582ea53104637982e58f24f233e35d427c6a5b311b80329c05e50f8b2dec5",
-        "full-pilot": "43023e4acbbc504b46762fa173b8f57b676b274e14deaeeb9ae9230c773f1bdc"
+        "calibration": "aae90fe2e9494033f718812ac6a072ae96c400faf241488d9b892ceddda954d8",
+        "full-pilot": "2c590acd59a417c5c78099254bd5f25348c73ac8f6b536a7882606d9872a359e"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "e1869ef4d450ade84343e796877ef4ef99571ac9a0516cdec2ffcd8c30d07eac"
+      harness_sha256: "3988c09f85a2feed078a51f47fae1775c49cdeded961a3e2c1048c2c156094d3"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "e1869ef4d450ade84343e796877ef4ef99571ac9a0516cdec2ffcd8c30d07eac"
+      harness_sha256: "3988c09f85a2feed078a51f47fae1775c49cdeded961a3e2c1048c2c156094d3"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_delivery_phase_gates.py
+++ b/tests/scripts/test_chaos_engine_delivery_phase_gates.py
@@ -1,0 +1,82 @@
+"""Delivery phase gates + opt-in research-before-mutation (#5583)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "chaos-engine/references/delivery-phase-gates.md"
+
+
+def load_module(name: str, relative: str):
+    path = ROOT / relative
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class DeliveryPhaseGatesTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.reflection = load_module("ce_reflection_gates", "chaos-engine/hooks/reflection.py")
+
+    def test_documentation_maps_phases_and_enforcement_env(self):
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("Research receipt", text)
+        self.assertIn("CHAOS_ENGINE_ENFORCE_RESEARCH_RECEIPT", text)
+        self.assertIn("research-preflight", text)
+
+    def test_research_preflight_marker_round_trip(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            with mock.patch.dict(os.environ, {"TMPDIR": temporary, "TEMP": temporary}):
+                session = "research-gate-session"
+                self.assertFalse(self.reflection.has_research_preflight(session))
+                self.assertTrue(self.reflection.record_research_preflight(session))
+                self.assertTrue(self.reflection.has_research_preflight(session))
+
+    def test_guard_denies_mutation_until_preflight_when_enforced(self):
+        # Load guard after reflection helpers exist
+        guard = load_module("ce_guard_gates", "chaos-engine/hooks/guard.py")
+        with tempfile.TemporaryDirectory() as temporary:
+            env = {
+                **os.environ,
+                "TMPDIR": temporary,
+                "TEMP": temporary,
+                "CHAOS_ENGINE_ENFORCE_RESEARCH_RECEIPT": "1",
+                "CHAOS_ENGINE_HOST": "claude",
+            }
+            event = {
+                "hook_event_name": "PreToolUse",
+                "session_id": "enforce-research",
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo changed > out.txt"},
+            }
+            with mock.patch.dict(os.environ, env, clear=False):
+                code = guard._run_event(event, "claude")
+                self.assertEqual(2, code)
+                self.reflection.record_research_preflight("enforce-research")
+                # After preflight, catastrophic/other rules may still apply; echo redirect
+                # is a mutation but should pass research gate. Capture stdout.
+                import io
+                from contextlib import redirect_stdout
+
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    code2 = guard._run_event(event, "claude")
+                # May still deny for session/worktree reasons; ensure reason is NOT research
+                if code2 == 2:
+                    payload = json.loads(buf.getvalue().strip().splitlines()[-1])
+                    self.assertNotIn("Research receipt required", payload.get("reason", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_chaos_engine_delivery_phase_gates.py
+++ b/tests/scripts/test_chaos_engine_delivery_phase_gates.py
@@ -8,8 +8,8 @@ import os
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
-from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[2]
 DOC = ROOT / "chaos-engine/references/delivery-phase-gates.md"
@@ -37,7 +37,7 @@ class DeliveryPhaseGatesTests(unittest.TestCase):
 
     def test_research_preflight_marker_round_trip(self):
         with tempfile.TemporaryDirectory() as temporary:
-            with mock.patch.dict(os.environ, {"TMPDIR": temporary, "TEMP": temporary}):
+            with unittest.mock.patch.dict(os.environ, {"TMPDIR": temporary, "TEMP": temporary}):
                 session = "research-gate-session"
                 self.assertFalse(self.reflection.has_research_preflight(session))
                 self.assertTrue(self.reflection.record_research_preflight(session))
@@ -60,7 +60,7 @@ class DeliveryPhaseGatesTests(unittest.TestCase):
                 "tool_name": "Bash",
                 "tool_input": {"command": "echo changed > out.txt"},
             }
-            with mock.patch.dict(os.environ, env, clear=False):
+            with unittest.mock.patch.dict(os.environ, env, clear=False):
                 code = guard._run_event(event, "claude")
                 self.assertEqual(2, code)
                 self.reflection.record_research_preflight("enforce-research")


### PR DESCRIPTION
## Summary
- Document delivery-loop phase ownership (hooks vs skills) in `chaos-engine/references/delivery-phase-gates.md`.
- Opt-in hard research-before-mutation gate via `CHAOS_ENGINE_ENFORCE_RESEARCH_RECEIPT` + zero-LLM `reflection.py research-preflight` ledger marker (`hooks/guard.py`).
- Contract tests for docs, marker round-trip, and PreToolUse deny-until-preflight.

Part of epic #5569. Fixes #5583.

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_delivery_phase_gates -v`
- [x] ChaosGauge digests refreshed via `validate_experiment.py --write`
- [ ] CI green on PR