### PR TITLE
[CE] Eval / parity fixture suite across hosts

### DIFF
--- a/.github/workflows/agent-plugin-acceptance.yml
+++ b/.github/workflows/agent-plugin-acceptance.yml
@@ -49,6 +49,7 @@ jobs:
             tests.scripts.test_chaos_engine_dependencies
             tests.scripts.test_chaos_engine_generation_runtime
             tests.scripts.test_chaos_engine_hook
+            tests.scripts.test_chaos_engine_eval_parity_fixtures
             tests.scripts.test_chaos_engine_hosts
             tests.scripts.test_chaos_engine_installer
             tests.scripts.test_chaos_engine_kernel

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -683,6 +683,7 @@ reports, caches, runtime indexes, or `graphify-out/`.
 
 
 - [Host Parity Matrix v0](references/host-parity-matrix.md) — five-host outcome matrix and measured gaps.
+- [Eval / parity fixtures](references/eval-parity-fixtures.md) — cross-host CE policy fixture suite + failure ratchet.
 
 
 - [Install or upgrade ChaosEngine](INSTALL.md)

--- a/chaos-engine/evals/parity-fixtures.json
+++ b/chaos-engine/evals/parity-fixtures.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": 1,
+  "package": "chaos-engine",
+  "description": "Minimal CE policy parity fixtures exercised across hosts via simulated hook runners (#5584).",
+  "hosts": [
+    "claude",
+    "codex",
+    "gemini",
+    "grok",
+    "copilot"
+  ],
+  "thresholds": {
+    "case_pass_rate": 1.0
+  },
+  "fixtures": [
+    {
+      "id": "deny-catastrophic-rm-rf-root",
+      "policy": "catastrophic-deny",
+      "ratchet": "hooks",
+      "event": {
+        "hook_event_name": "PreToolUse",
+        "session_id": "eval-deny-catastrophic",
+        "tool_name": "Bash",
+        "tool_input": {
+          "command": "rm -rf /"
+        }
+      },
+      "expect": {
+        "exit_code": 2,
+        "decision": "deny",
+        "reason_substrings": [
+          "destructive broad scope"
+        ]
+      }
+    },
+    {
+      "id": "allow-read-tool",
+      "policy": "non-mutation-allow",
+      "ratchet": "hooks",
+      "event": {
+        "hook_event_name": "PreToolUse",
+        "session_id": "eval-allow-read",
+        "tool_name": "Read",
+        "tool_input": {
+          "file_path": "README.md"
+        }
+      },
+      "expect": {
+        "exit_code": 0,
+        "decision": "allow"
+      }
+    },
+    {
+      "id": "sessionstart-locator-budget",
+      "policy": "sessionstart-locator",
+      "ratchet": "hooks",
+      "event": {
+        "hook_event_name": "SessionStart",
+        "session_id": "eval-sessionstart"
+      },
+      "expect": {
+        "exit_code": 0,
+        "context_max_bytes": 4096,
+        "context_must_include": [
+          "chaos-engine/vendor/caveman/skills/caveman/SKILL.md",
+          "chaos-engine/vendor/ponytail/skills/ponytail/SKILL.md"
+        ],
+        "identical_context_across_hosts": true
+      }
+    },
+    {
+      "id": "research-before-mutation-enforced",
+      "policy": "research-receipt-gate",
+      "ratchet": "hooks",
+      "env": {
+        "CHAOS_ENGINE_ENFORCE_RESEARCH_RECEIPT": "1"
+      },
+      "event": {
+        "hook_event_name": "PreToolUse",
+        "session_id": "eval-research-gate",
+        "tool_name": "Bash",
+        "tool_input": {
+          "command": "echo changed > out.txt"
+        }
+      },
+      "expect": {
+        "exit_code": 2,
+        "decision": "deny",
+        "reason_substrings": [
+          "Research receipt required"
+        ]
+      }
+    },
+    {
+      "id": "allow-safe-echo",
+      "policy": "non-mutation-allow",
+      "ratchet": "hooks",
+      "event": {
+        "hook_event_name": "PreToolUse",
+        "session_id": "eval-allow-echo",
+        "tool_name": "Bash",
+        "tool_input": {
+          "command": "echo hello"
+        }
+      },
+      "expect": {
+        "exit_code": 0,
+        "decision": "allow"
+      }
+    }
+  ]
+}

--- a/chaos-engine/references/eval-parity-fixtures.md
+++ b/chaos-engine/references/eval-parity-fixtures.md
@@ -1,0 +1,63 @@
+# Eval / parity fixture suite
+
+Minimal regression harness for ChaosEngine policy outcomes across the five
+hosts (Claude Code, Codex, Grok, Gemini, GitHub Copilot). Parent epic #5569 /
+issue #5584.
+
+Parity here means **same policy outcomes** under simulated hook runners — not
+UI chrome parity and not driving hosts as child processes.
+
+## Corpus and runner
+
+| Piece | Path |
+| --- | --- |
+| Fixture corpus | [`evals/parity-fixtures.json`](../evals/parity-fixtures.json) |
+| Documented runner | `python3 scripts/ci/chaos_engine_eval_parity.py` |
+| Machine report | `python3 scripts/ci/chaos_engine_eval_parity.py --json` |
+| Unittest | `python3 -m unittest tests.scripts.test_chaos_engine_eval_parity_fixtures -v` |
+
+Each fixture declares:
+
+- `event` — one provider-neutral lifecycle payload
+- `expect` — exit code, allow/deny, reason substrings, SessionStart budget
+- `ratchet` — where a failure must land (`hooks`, `skills`, or `matrix`)
+
+The runner loads `hooks/guard.py` through `lifecycle.run_hook_protocol` with
+`adapt_hook_output` for every host in the corpus. That is the simulated hook
+runner: identical CE policy, host-native deny/context payloads.
+
+## Fixture set (v0)
+
+| ID | Policy | Expected |
+| --- | --- | --- |
+| `deny-catastrophic-rm-rf-root` | catastrophic deny | exit 2 + native deny on all hosts |
+| `allow-read-tool` | non-mutation allow | exit 0, no deny payload |
+| `allow-safe-echo` | non-mutation allow | exit 0 for `echo hello` |
+| `sessionstart-locator-budget` | SessionStart locator | ≤4096 bytes, companion paths, identical context |
+| `research-before-mutation-enforced` | research receipt gate | deny until preflight when env enforced |
+
+## Failure ratchet (hooks / skills / matrix)
+
+Do **not** weaken a fixture to look green ([ethical-conduct](ethical-conduct.md)).
+
+When a fixture fails:
+
+1. **`ratchet: hooks`** — fix `hooks/guard.py`, `hooks/kernel.py`, or
+   `hooks/lifecycle.py` so the guarantee holds on every host adapter.
+2. **`ratchet: skills`** — if the gap is judgment (thoroughness, playbook
+   wording), update the routed skill / reference and keep the hook contract
+   unchanged.
+3. **`ratchet: matrix`** — if a host cannot honor the outcome, document a
+   severity-ranked gap in [host-parity-matrix](host-parity-matrix.md) and keep
+   the fixture asserting ChaosEngine's emitted contract (exit 2 + native deny).
+
+CI executes the suite through the Agent Guidance Gate
+(`eval-parity-contract` in `scripts/ci/harness_pr_gate.py`) and the scheduled
+exhaustive harness in `.github/workflows/agent-plugin-acceptance.yml`.
+
+## Related
+
+- [Host Parity Matrix](host-parity-matrix.md)
+- [Lifecycle hooks](lifecycle-hooks.md)
+- [Delivery phase gates](delivery-phase-gates.md)
+- [Zero-LLM catalog](zero-llm-catalog.md)

--- a/chaos-engine/references/host-parity-matrix.md
+++ b/chaos-engine/references/host-parity-matrix.md
@@ -41,3 +41,7 @@ Legend: P = parity (outcome available), A = adapter-shaped equivalent, G = gap (
 1. Update rows when adapter contracts or Host Parity Wave B issues land.
 2. Keep `scripts/ci/agent_harness_parity.json` as the machine-checked pin set.
 3. Prefer outcome language (P/A/G) over host UI chrome comparisons.
+4. Re-run the eval / parity fixture suite (`python3 scripts/ci/chaos_engine_eval_parity.py`;
+   see [eval-parity-fixtures](eval-parity-fixtures.md)) after hook or adapter changes.
+   Fixture failures ratchet into hooks, skills, or a documented matrix gap — never
+   weaken the fixture to look green.

--- a/chaos-engine/references/zero-llm-catalog.md
+++ b/chaos-engine/references/zero-llm-catalog.md
@@ -19,10 +19,13 @@ opening a host chat. Companion guidance: [script-first](script-first.md).
 | Token budget modes | `python3 -m unittest tests.scripts.test_chaos_engine_token_budget_modes -v` | ultra-lean < balanced < deep |
 | Cache status/purge | `... cache status|purge --component maven-tools-mcp ...` | Shared MCP cache without chat |
 | Rollback / uninstall | `... rollback|uninstall --project .` | Deterministic recovery |
-
-## New in this change (#5582)
-
-`--fix-next-only` is the shipped zero-LLM expansion: scripts and CI can scrape
-repair actions without parsing the full human doctor essay or invoking a model.
 | Research preflight marker | `python3 .chaos-engine/hooks/reflection.py research-preflight --session-id <id>` | Unblocks opt-in research-before-mutation gate |
+| Eval / parity fixtures | `python3 scripts/ci/chaos_engine_eval_parity.py` | Cross-host CE policy fixture suite (#5584) |
+
+## Notes
+
+`--fix-next-only` (#5582) lets scripts scrape repair actions without parsing the
+full human doctor essay or invoking a model. The eval runner (#5584) exercises
+fixture tasks under simulated hook runners; failures ratchet into hooks/skills
+per [eval-parity-fixtures](eval-parity-fixtures.md).
 

--- a/scripts/ci/chaos_engine_eval_parity.py
+++ b/scripts/ci/chaos_engine_eval_parity.py
@@ -155,7 +155,57 @@ def _run_one(
     }
 
 
-def evaluate_fixture(
+
+def _check_host_result(
+    *,
+    result: dict[str, Any],
+    expect: dict[str, Any],
+    kernel,
+    contexts: dict[str, str],
+) -> list[str]:
+    """Return failure strings for one host result against fixture expectations."""
+    failures: list[str] = []
+    host = result["host"]
+    if result["exit_code"] != expect.get("exit_code"):
+        failures.append(
+            f"{host}: exit_code={result['exit_code']} expected={expect.get('exit_code')}"
+        )
+        return failures
+    decision = expect.get("decision")
+    if decision == "deny":
+        if not _is_deny_payload(result["payload"], host):
+            failures.append(f"{host}: expected native deny payload, got {result['payload']!r}")
+        reason = _deny_reason(result["payload"], host)
+        for fragment in expect.get("reason_substrings") or []:
+            if fragment not in reason:
+                failures.append(f"{host}: reason missing {fragment!r} in {reason!r}")
+        capability = kernel.HOST_CAPABILITIES[host]
+        if result["exit_code"] != capability.deny_exit_code:
+            failures.append(
+                f"{host}: deny_exit_code mismatch capability={capability.deny_exit_code}"
+            )
+    elif decision == "allow":
+        if _is_deny_payload(result["payload"], host):
+            failures.append(f"{host}: unexpected deny payload {result['payload']!r}")
+    context = result["context"]
+    if expect.get("context_max_bytes") is not None:
+        if context is None:
+            failures.append(f"{host}: missing additionalContext")
+        else:
+            encoded = context.encode("utf-8")
+            if len(encoded) > int(expect["context_max_bytes"]):
+                failures.append(
+                    f"{host}: context {len(encoded)} bytes over budget "
+                    f"{expect['context_max_bytes']}"
+                )
+            for needle in expect.get("context_must_include") or []:
+                if needle not in context:
+                    failures.append(f"{host}: context missing {needle!r}")
+            contexts[host] = context
+    return failures
+
+
+def evaluate_fixture(  # noqa: MC0001  # Host-loop assertions stay auditable together.
     *,
     guard,
     lifecycle,
@@ -179,43 +229,11 @@ def evaluate_fixture(
     failures: list[str] = []
     contexts: dict[str, str] = {}
     for result in results:
-        host = result["host"]
-        if result["exit_code"] != expect.get("exit_code"):
-            failures.append(
-                f"{host}: exit_code={result['exit_code']} expected={expect.get('exit_code')}"
+        failures.extend(
+            _check_host_result(
+                result=result, expect=expect, kernel=kernel, contexts=contexts
             )
-            continue
-        decision = expect.get("decision")
-        if decision == "deny":
-            if not _is_deny_payload(result["payload"], host):
-                failures.append(f"{host}: expected native deny payload, got {result['payload']!r}")
-            reason = _deny_reason(result["payload"], host)
-            for fragment in expect.get("reason_substrings") or []:
-                if fragment not in reason:
-                    failures.append(f"{host}: reason missing {fragment!r} in {reason!r}")
-            capability = kernel.HOST_CAPABILITIES[host]
-            if result["exit_code"] != capability.deny_exit_code:
-                failures.append(
-                    f"{host}: deny_exit_code mismatch capability={capability.deny_exit_code}"
-                )
-        elif decision == "allow":
-            if _is_deny_payload(result["payload"], host):
-                failures.append(f"{host}: unexpected deny payload {result['payload']!r}")
-        context = result["context"]
-        if expect.get("context_max_bytes") is not None:
-            if context is None:
-                failures.append(f"{host}: missing additionalContext")
-            else:
-                encoded = context.encode("utf-8")
-                if len(encoded) > int(expect["context_max_bytes"]):
-                    failures.append(
-                        f"{host}: context {len(encoded)} bytes over budget "
-                        f"{expect['context_max_bytes']}"
-                    )
-                for needle in expect.get("context_must_include") or []:
-                    if needle not in context:
-                        failures.append(f"{host}: context missing {needle!r}")
-                contexts[host] = context
+        )
     if expect.get("identical_context_across_hosts") and contexts:
         unique = set(contexts.values())
         if len(unique) != 1:
@@ -243,7 +261,7 @@ def evaluate_suite(
             "passed": False,
             "defects": defects,
             "results": [],
-            "case_pass_rate": 0.0,
+            "case_pass_rate": 0.0,  # nosec B105 - pass-rate metric, not a credential.
         }
     guard = _load_module("ce_eval_parity_guard", "chaos-engine/hooks/guard.py")
     lifecycle = _load_module("ce_eval_parity_lifecycle", "chaos-engine/hooks/lifecycle.py")
@@ -268,7 +286,7 @@ def evaluate_suite(
         "passed": passed == total and total > 0,
         "defects": [],
         "results": results,
-        "case_pass_rate": (passed / total) if total else 0.0,
+        "case_pass_rate": (passed / total) if total else 0.0,  # nosec B105 - pass-rate metric, not a credential.
         "passed_count": passed,
         "total_count": total,
     }

--- a/scripts/ci/chaos_engine_eval_parity.py
+++ b/scripts/ci/chaos_engine_eval_parity.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Run ChaosEngine eval / parity fixtures across simulated host hook runners (#5584)."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest.mock
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_RELATIVE = Path("chaos-engine/evals/parity-fixtures.json")
+DEFAULT_HOSTS = ("claude", "codex", "gemini", "grok", "copilot")
+
+
+def _load_module(name: str, relative: str):
+    path = ROOT / relative
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {relative}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_fixtures(path: Path | None = None) -> dict[str, Any]:
+    target = path or (ROOT / FIXTURES_RELATIVE)
+    document = json.loads(target.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise ValueError("fixtures document must be an object")
+    return document
+
+
+def validate_fixtures(document: dict[str, Any]) -> list[str]:
+    defects: list[str] = []
+    if document.get("schema_version") != 1:
+        defects.append("schema_version must be 1")
+    if document.get("package") != "chaos-engine":
+        defects.append("package must be chaos-engine")
+    hosts = document.get("hosts")
+    if not isinstance(hosts, list) or sorted(hosts) != sorted(DEFAULT_HOSTS):
+        defects.append("hosts must list the five CE hosts exactly")
+    thresholds = document.get("thresholds")
+    if not isinstance(thresholds, dict) or thresholds.get("case_pass_rate") != 1.0:
+        defects.append("thresholds.case_pass_rate must be exactly 1.0")
+    fixtures = document.get("fixtures")
+    if not isinstance(fixtures, list) or not fixtures:
+        defects.append("fixtures must be a nonempty list")
+        return defects
+    seen: set[str] = set()
+    for index, fixture in enumerate(fixtures):
+        if not isinstance(fixture, dict):
+            defects.append(f"fixture {index} must be an object")
+            continue
+        identifier = fixture.get("id")
+        if not isinstance(identifier, str) or not identifier.strip():
+            defects.append(f"fixture {index} needs a nonempty id")
+        elif identifier in seen:
+            defects.append(f"duplicate fixture id {identifier}")
+        else:
+            seen.add(identifier)
+        if not isinstance(fixture.get("event"), dict):
+            defects.append(f"{identifier or index} needs an event object")
+        if not isinstance(fixture.get("expect"), dict):
+            defects.append(f"{identifier or index} needs an expect object")
+        if fixture.get("ratchet") not in {"hooks", "skills", "matrix"}:
+            defects.append(f"{identifier or index} ratchet must be hooks|skills|matrix")
+    return defects
+
+
+def _unwrap_context(payload: dict[str, Any]) -> str | None:
+    if "additionalContext" in payload:
+        return str(payload["additionalContext"])
+    specific = payload.get("hookSpecificOutput")
+    if isinstance(specific, dict) and "additionalContext" in specific:
+        return str(specific["additionalContext"])
+    return None
+
+
+def _is_deny_payload(payload: dict[str, Any], host: str) -> bool:
+    if host == "codex":
+        specific = payload.get("hookSpecificOutput")
+        return isinstance(specific, dict) and specific.get("permissionDecision") == "deny"
+    if host == "copilot":
+        return payload.get("permissionDecision") == "deny"
+    return payload.get("decision") in {"block", "deny"}
+
+
+def _deny_reason(payload: dict[str, Any], host: str) -> str:
+    if host == "codex":
+        specific = payload.get("hookSpecificOutput")
+        if isinstance(specific, dict):
+            return str(specific.get("permissionDecisionReason") or "")
+    if host == "copilot":
+        return str(payload.get("permissionDecisionReason") or "")
+    return str(payload.get("reason") or "")
+
+
+def _run_one(
+    *,
+    guard,
+    lifecycle,
+    kernel,
+    fixture: dict[str, Any],
+    host: str,
+    temporary: str,
+) -> dict[str, Any]:
+    env = {
+        **os.environ,
+        "TMPDIR": temporary,
+        "TEMP": temporary,
+        "TMP": temporary,
+        "CHAOS_ENGINE_HOST": host,
+    }
+    extra = fixture.get("env") or {}
+    if isinstance(extra, dict):
+        env.update({str(key): str(value) for key, value in extra.items()})
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with unittest.mock.patch.dict(os.environ, env, clear=False):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            code = lifecycle.run_hook_protocol(
+                json.dumps(fixture["event"]),
+                {event: guard._run_event for event in lifecycle.LIFECYCLE_EVENTS},
+                normalize=kernel.normalize_hook_input,
+                host_for_input=lambda _raw, selected=host: selected,
+                adapt_output=kernel.adapt_hook_output,
+            )
+    rendered = stderr.getvalue() if host == "claude" and code == 2 else stdout.getvalue()
+    payload: dict[str, Any] = {}
+    for line in reversed(rendered.strip().splitlines() if rendered.strip() else []):
+        try:
+            candidate = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict):
+            payload = candidate
+            break
+    return {
+        "host": host,
+        "exit_code": code,
+        "payload": payload,
+        "stdout": stdout.getvalue(),
+        "stderr": stderr.getvalue(),
+        "context": _unwrap_context(payload),
+    }
+
+
+def evaluate_fixture(
+    *,
+    guard,
+    lifecycle,
+    kernel,
+    fixture: dict[str, Any],
+    hosts: list[str],
+    temporary: str,
+) -> dict[str, Any]:
+    expect = fixture["expect"]
+    results = [
+        _run_one(
+            guard=guard,
+            lifecycle=lifecycle,
+            kernel=kernel,
+            fixture=fixture,
+            host=host,
+            temporary=temporary,
+        )
+        for host in hosts
+    ]
+    failures: list[str] = []
+    contexts: dict[str, str] = {}
+    for result in results:
+        host = result["host"]
+        if result["exit_code"] != expect.get("exit_code"):
+            failures.append(
+                f"{host}: exit_code={result['exit_code']} expected={expect.get('exit_code')}"
+            )
+            continue
+        decision = expect.get("decision")
+        if decision == "deny":
+            if not _is_deny_payload(result["payload"], host):
+                failures.append(f"{host}: expected native deny payload, got {result['payload']!r}")
+            reason = _deny_reason(result["payload"], host)
+            for fragment in expect.get("reason_substrings") or []:
+                if fragment not in reason:
+                    failures.append(f"{host}: reason missing {fragment!r} in {reason!r}")
+            capability = kernel.HOST_CAPABILITIES[host]
+            if result["exit_code"] != capability.deny_exit_code:
+                failures.append(
+                    f"{host}: deny_exit_code mismatch capability={capability.deny_exit_code}"
+                )
+        elif decision == "allow":
+            if _is_deny_payload(result["payload"], host):
+                failures.append(f"{host}: unexpected deny payload {result['payload']!r}")
+        context = result["context"]
+        if expect.get("context_max_bytes") is not None:
+            if context is None:
+                failures.append(f"{host}: missing additionalContext")
+            else:
+                encoded = context.encode("utf-8")
+                if len(encoded) > int(expect["context_max_bytes"]):
+                    failures.append(
+                        f"{host}: context {len(encoded)} bytes over budget "
+                        f"{expect['context_max_bytes']}"
+                    )
+                for needle in expect.get("context_must_include") or []:
+                    if needle not in context:
+                        failures.append(f"{host}: context missing {needle!r}")
+                contexts[host] = context
+    if expect.get("identical_context_across_hosts") and contexts:
+        unique = set(contexts.values())
+        if len(unique) != 1:
+            failures.append(f"context diverged across hosts: {sorted(contexts)}")
+    return {
+        "id": fixture["id"],
+        "policy": fixture.get("policy"),
+        "ratchet": fixture.get("ratchet"),
+        "passed": not failures,
+        "failures": failures,
+        "hosts": results,
+    }
+
+
+def evaluate_suite(
+    document: dict[str, Any] | None = None,
+    *,
+    root: Path | None = None,
+) -> dict[str, Any]:
+    del root  # reserved for future path overrides; fixtures load from package ROOT
+    document = document or load_fixtures()
+    defects = validate_fixtures(document)
+    if defects:
+        return {
+            "passed": False,
+            "defects": defects,
+            "results": [],
+            "case_pass_rate": 0.0,
+        }
+    guard = _load_module("ce_eval_parity_guard", "chaos-engine/hooks/guard.py")
+    lifecycle = _load_module("ce_eval_parity_lifecycle", "chaos-engine/hooks/lifecycle.py")
+    kernel = _load_module("ce_eval_parity_kernel", "chaos-engine/hooks/kernel.py")
+    hosts = [str(host) for host in document["hosts"]]
+    results: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="ce-eval-parity-") as temporary:
+        for fixture in document["fixtures"]:
+            results.append(
+                evaluate_fixture(
+                    guard=guard,
+                    lifecycle=lifecycle,
+                    kernel=kernel,
+                    fixture=fixture,
+                    hosts=hosts,
+                    temporary=temporary,
+                )
+            )
+    passed = sum(1 for row in results if row["passed"])
+    total = len(results)
+    return {
+        "passed": passed == total and total > 0,
+        "defects": [],
+        "results": results,
+        "case_pass_rate": (passed / total) if total else 0.0,
+        "passed_count": passed,
+        "total_count": total,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixtures",
+        type=Path,
+        default=ROOT / FIXTURES_RELATIVE,
+        help="path to parity-fixtures.json",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print machine-readable evaluation report",
+    )
+    args = parser.parse_args(argv)
+    document = load_fixtures(args.fixtures)
+    report = evaluate_suite(document)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        if report["defects"]:
+            print("fixture corpus defects:")
+            for defect in report["defects"]:
+                print(f"  - {defect}")
+        for row in report["results"]:
+            status = "PASS" if row["passed"] else "FAIL"
+            print(f"[{status}] {row['id']} (ratchet={row['ratchet']})")
+            for failure in row["failures"]:
+                print(f"    - {failure}")
+        print(
+            f"case_pass_rate={report['case_pass_rate']:.3f} "
+            f"({report.get('passed_count', 0)}/{report.get('total_count', 0)})"
+        )
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "3988c09f85a2feed078a51f47fae1775c49cdeded961a3e2c1048c2c156094d3",
+      "harnessSha256": "5ca1f5fb7007219bdf4330c46ae78d2d68cf3d0f7ecae2a97a2d7a6be1954790",
       "treatmentSha256": {
-        "calibration": "aae90fe2e9494033f718812ac6a072ae96c400faf241488d9b892ceddda954d8",
-        "full-pilot": "2c590acd59a417c5c78099254bd5f25348c73ac8f6b536a7882606d9872a359e"
+        "calibration": "4d31145d5cffc2e244137b5129a71cec9b29145fe1180e69a6178800db97b7bd",
+        "full-pilot": "03ffc9c21d837fd1a1f973e144f3e34c79c6c3039477067c6b7a21947944c4a3"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "3988c09f85a2feed078a51f47fae1775c49cdeded961a3e2c1048c2c156094d3"
+      harness_sha256: "5ca1f5fb7007219bdf4330c46ae78d2d68cf3d0f7ecae2a97a2d7a6be1954790"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "3988c09f85a2feed078a51f47fae1775c49cdeded961a3e2c1048c2c156094d3"
+      harness_sha256: "5ca1f5fb7007219bdf4330c46ae78d2d68cf3d0f7ecae2a97a2d7a6be1954790"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/harness_pr_gate.py
+++ b/scripts/ci/harness_pr_gate.py
@@ -93,6 +93,11 @@ CHECKS = {
         ("tests.scripts.test_chaos_engine_hook",),
         True,
     ),
+    "eval-parity-contract": Check(
+        "eval-parity-contract",
+        "lifecycle",
+        ("tests.scripts.test_chaos_engine_eval_parity_fixtures",),
+    ),
     "host-contract": Check(
         "host-contract", "hosts", ("tests.scripts.test_chaos_engine_hosts",), True
     ),
@@ -232,7 +237,7 @@ CHECKS = {
 
 SURFACE_CHECKS = {
     "kernel": ("kernel-contract",),
-    "lifecycle": ("lifecycle-contract", "protected-security"),
+    "lifecycle": ("lifecycle-contract", "eval-parity-contract", "protected-security"),
     "hosts": ("host-contract",),
     "guidance": (
         "guidance-contract",
@@ -286,8 +291,11 @@ SURFACE_PATTERNS = {
     ),
     "lifecycle": (
         "chaos-engine/hooks/*",
+        "chaos-engine/evals/*",
         "scripts/agents/guard.py",
+        "scripts/ci/chaos_engine_eval_parity.py",
         "tests/scripts/test_chaos_engine_hook.py",
+        "tests/scripts/test_chaos_engine_eval_parity_fixtures.py",
         "tests/scripts/test_guard*.py",
     ),
     "guidance": (

--- a/tests/scripts/test_chaos_engine_eval_parity_fixtures.py
+++ b/tests/scripts/test_chaos_engine_eval_parity_fixtures.py
@@ -1,0 +1,75 @@
+"""Eval / parity fixture suite across hosts (#5584)."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from scripts.ci.chaos_engine_eval_parity import (
+    evaluate_suite,
+    load_fixtures,
+    validate_fixtures,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "chaos-engine/references/eval-parity-fixtures.md"
+CORPUS = ROOT / "chaos-engine/evals/parity-fixtures.json"
+MATRIX = ROOT / "chaos-engine/references/host-parity-matrix.md"
+CATALOG = ROOT / "chaos-engine/references/zero-llm-catalog.md"
+
+
+class EvalParityFixturesTests(unittest.TestCase):
+    def test_corpus_schema_and_five_hosts(self):
+        document = load_fixtures(CORPUS)
+        defects = validate_fixtures(document)
+        self.assertEqual([], defects, msg=defects)
+        self.assertEqual(1, document["schema_version"])
+        self.assertGreaterEqual(len(document["fixtures"]), 4)
+        ids = {row["id"] for row in document["fixtures"]}
+        for required in (
+            "deny-catastrophic-rm-rf-root",
+            "allow-read-tool",
+            "sessionstart-locator-budget",
+            "research-before-mutation-enforced",
+        ):
+            self.assertIn(required, ids)
+
+    def test_documented_runner_and_ratchet_guidance(self):
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("scripts/ci/chaos_engine_eval_parity.py", text)
+        self.assertIn("Failure ratchet", text)
+        self.assertIn("ratchet: hooks", text)
+        self.assertIn("ratchet: skills", text)
+        self.assertIn("ratchet: matrix", text)
+        self.assertIn("ethical-conduct", text)
+        catalog = CATALOG.read_text(encoding="utf-8")
+        self.assertIn("chaos_engine_eval_parity.py", catalog)
+        matrix = MATRIX.read_text(encoding="utf-8")
+        self.assertIn("eval-parity-fixtures", matrix)
+
+    def test_suite_passes_under_simulated_hook_runners(self):
+        report = evaluate_suite(load_fixtures(CORPUS))
+        self.assertEqual([], report["defects"], msg=report["defects"])
+        failed = [row for row in report["results"] if not row["passed"]]
+        self.assertEqual(
+            [],
+            failed,
+            msg=json.dumps(failed, indent=2),
+        )
+        self.assertEqual(1.0, report["case_pass_rate"])
+        self.assertTrue(report["passed"])
+
+    def test_suite_covers_all_five_hosts_per_fixture(self):
+        report = evaluate_suite(load_fixtures(CORPUS))
+        for row in report["results"]:
+            hosts = {item["host"] for item in row["hosts"]}
+            self.assertEqual(
+                {"claude", "codex", "gemini", "grok", "copilot"},
+                hosts,
+                msg=row["id"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Minimal eval harness: `chaos-engine/evals/parity-fixtures.json` + `scripts/ci/chaos_engine_eval_parity.py` exercises CE policy fixtures under simulated hook runners across Claude/Codex/Gemini/Grok/Copilot.
- Documented runner + failure ratchet (`hooks` / `skills` / `matrix`) in `chaos-engine/references/eval-parity-fixtures.md`; linked from Host Parity Matrix, zero-LLM catalog, and README.
- CI: `eval-parity-contract` in Agent Guidance Gate (`harness_pr_gate.py`); scheduled exhaustive suite includes `tests.scripts.test_chaos_engine_eval_parity_fixtures`.
- ChaosGauge digests refreshed after `chaos-engine/` changes.

Part of epic #5569. Fixes #5584.

## Test plan
- [x] `python3 scripts/ci/chaos_engine_eval_parity.py` (5/5 PASS)
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_eval_parity_fixtures -v`
- [x] `python3 -m unittest tests.scripts.test_harness_pr_gate -v`
- [x] ChaosGauge `validate_experiment.py --write scripts/ci/chaos_gauge/experiment.json`
- [ ] CI green on PR