### PR TITLE
[CE] Auto-close epic #5569 when all sub-issues are closed

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,6 +49,7 @@ changing that token silently breaks both distribution publishers.
 | `publish-shaft-mcp.yml` | published GitHub release, manual | Publishes MCP images and registry metadata. |
 | `deploy-shaft-mcp.yml` | successful MCP distribution workflow, manual | Deploys configured MCP services and records optional-provider handoffs. |
 | `codecoverage-failure-notifier.yml` | completed coverage-producing workflow on `main` | Consolidates coverage failure artifacts into one manually closed tracking issue. |
+| `epic-autoclose.yml` | issue closed, manual | Closes eligible CE program epics (#5569 or `ce-program-epic`) when every GitHub sub-issue is closed. |
 | `e2eTests.yml` | nightly, manual | Broad hosted database, API, browser, mobile, visual, video, Cucumber, and JUnit coverage. |
 | `e2eLocalTests.yml` | nightly, manual | Windows and macOS local browser and desktop coverage. |
 | `lambdatestTests.yml` | manual | Serial LambdaTest app upload plus native and desktop suites. |

--- a/.github/workflows/agent-plugin-acceptance.yml
+++ b/.github/workflows/agent-plugin-acceptance.yml
@@ -50,6 +50,7 @@ jobs:
             tests.scripts.test_chaos_engine_generation_runtime
             tests.scripts.test_chaos_engine_hook
             tests.scripts.test_chaos_engine_eval_parity_fixtures
+            tests.scripts.test_epic_autoclose
             tests.scripts.test_chaos_engine_hosts
             tests.scripts.test_chaos_engine_installer
             tests.scripts.test_chaos_engine_kernel

--- a/.github/workflows/epic-autoclose.yml
+++ b/.github/workflows/epic-autoclose.yml
@@ -1,0 +1,79 @@
+# Auto-close CE program epics when every GitHub sub-issue is closed (#5585).
+# Eligible epics: issue #5569, or any issue labeled `ce-program-epic`.
+# Convention: subtasks are GitHub sub-issues; delivery PRs use Fixes ##child.
+name: Epic Autoclose
+
+on:
+  issues:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Triggering (just-closed) issue number to evaluate
+        required: true
+        type: string
+      dry_run:
+        description: Print decision only; do not close the epic
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: epic-autoclose-${{ github.event.issue.number || inputs.issue_number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  unit-tests:
+    name: Epic Autoclose Unit Tests
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7.0.1
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.13"
+      - name: Run epic autoclose unit tests
+        run: python3 -m unittest tests.scripts.test_epic_autoclose -v
+
+  autoclose:
+    name: Close eligible epic when children are done
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7.0.1
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: "3.13"
+      - name: Normalize GitHub auth env
+        run: |
+          # shellcheck source=/dev/null
+          source scripts/ci/github-auth-env.sh
+      - name: Evaluate and optionally close parent epic
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ISSUE="${{ inputs.issue_number }}"
+            DRY_FLAG=""
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              DRY_FLAG="--dry-run"
+            fi
+          else
+            ISSUE="${{ github.event.issue.number }}"
+            DRY_FLAG=""
+          fi
+          python3 scripts/ci/epic_autoclose.py \
+            --repository "${{ github.repository }}" \
+            --issue "${ISSUE}" \
+            ${DRY_FLAG}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -357,6 +357,8 @@ jobs:
               # makes the omission an oversight rather than a decision.
               - 'scripts/ci/validate_workflow_timeouts.py'
               - 'tests/scripts/test_validate_workflow_timeouts.py'
+              - 'scripts/ci/epic_autoclose.py'
+              - 'tests/scripts/test_epic_autoclose.py'
 
   docs-boundary:
     name: Documentation Boundary Gate
@@ -823,6 +825,7 @@ jobs:
         run: >-
           python3 -m unittest
           tests.scripts.test_validate_workflow_timeouts
+          tests.scripts.test_epic_autoclose
           tests.scripts.test_intellij_verify_retry
           tests.scripts.test_assert_intellij_marketplace_receipt
           tests.scripts.test_validate_shaft_pilot_release

--- a/chaos-engine/references/work-github-planning.md
+++ b/chaos-engine/references/work-github-planning.md
@@ -96,3 +96,21 @@ gh issue edit <tracker> --body-file updated-tracker-body.md
 gh issue comment <tracker> --body "Landed via PR #<pr>. Remaining: #<subtask>."
 gh issue close <tracker>
 ```
+
+
+## 3c. GitHub sub-issues + CE program epic auto-close
+
+CE program epics (currently #5569, or any issue labeled `ce-program-epic`) track
+delivery through **GitHub native sub-issues**, not checkbox prose alone.
+
+- File each subtask as a real issue and attach it as a sub-issue of the epic.
+- Delivery PRs close **children only**: one `Fixes #<child>` / `Closes #<child>`
+  line per completed subtask. Never put a closing keyword on the epic number.
+- Workflow `.github/workflows/epic-autoclose.yml` runs on `issues: closed`. It
+  no-ops unless the closed issue's parent is an eligible epic **and** every
+  tracked sub-issue is closed; then it closes the epic with a receipt comment.
+- Follow-ons that must keep the epic open must be attached as sub-issues. An
+  open issue that is only mentioned in prose (for example a later wave that is
+  not a formal sub-issue) does **not** block auto-close.
+- Manual dry-run: `python3 scripts/ci/epic_autoclose.py --issue <n> --dry-run`
+  or Actions → Epic Autoclose → workflow_dispatch with `dry_run=true`.

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "5ca1f5fb7007219bdf4330c46ae78d2d68cf3d0f7ecae2a97a2d7a6be1954790",
+      "harnessSha256": "48529363e0448fd44c23fee3778b6c27ba75cabfca2d9cc00fba6e92da07d4be",
       "treatmentSha256": {
-        "calibration": "4d31145d5cffc2e244137b5129a71cec9b29145fe1180e69a6178800db97b7bd",
-        "full-pilot": "03ffc9c21d837fd1a1f973e144f3e34c79c6c3039477067c6b7a21947944c4a3"
+        "calibration": "84d372cf203bf2f5e92ac75ec1af6b587baa2574603ed975fa15da9073840125",
+        "full-pilot": "622b8da0991c1e571cbb62aafd1b506ef13f02ee6db3264402051eef2689f99d"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "5ca1f5fb7007219bdf4330c46ae78d2d68cf3d0f7ecae2a97a2d7a6be1954790"
+      harness_sha256: "48529363e0448fd44c23fee3778b6c27ba75cabfca2d9cc00fba6e92da07d4be"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "5ca1f5fb7007219bdf4330c46ae78d2d68cf3d0f7ecae2a97a2d7a6be1954790"
+      harness_sha256: "48529363e0448fd44c23fee3778b6c27ba75cabfca2d9cc00fba6e92da07d4be"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/epic_autoclose.py
+++ b/scripts/ci/epic_autoclose.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Auto-close CE program epics when every GitHub sub-issue is closed (#5585).
+"""
+Auto-close CE program epics when every GitHub sub-issue is closed (#5585).
 
 Convention (see chaos-engine/references/work-github-planning.md):
 - CE program epics use GitHub native sub-issues under the epic.
@@ -132,7 +133,8 @@ def is_eligible_epic(issue: IssueRef) -> bool:
 
 
 def decide(*, parent: IssueRef | None, children: Sequence[IssueRef]) -> Decision:
-    """Decide whether the parent epic should close given its sub-issues.
+    """
+    Decide whether the parent epic should close given its sub-issues.
 
     Never force-closes while any tracked child remains open. Epics with zero
     sub-issues are a no-op (avoids closing a mislabeled issue with no children).
@@ -394,7 +396,8 @@ def main(argv: list[str] | None = None) -> int:
     print(json.dumps(payload, indent=2, sort_keys=True))
     if not decision.should_close:
         return 0
-    assert decision.epic is not None  # noqa: S101 - guarded by should_close
+    if decision.epic is None:
+        raise RuntimeError("close_epic decision missing epic payload")
     comment = close_comment(
         epic=decision.epic,
         children=decision.closed_children,

--- a/scripts/ci/epic_autoclose.py
+++ b/scripts/ci/epic_autoclose.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Auto-close CE program epics when every GitHub sub-issue is closed (#5585).
+
+Convention (see chaos-engine/references/work-github-planning.md):
+- CE program epics use GitHub native sub-issues under the epic.
+- An epic is eligible when its number is in KNOWN_EPIC_NUMBERS (currently #5569)
+  or it carries the ``ce-program-epic`` label.
+- Child delivery PRs use ``Fixes #<child>`` / ``Closes #<child>`` — never the epic.
+- On ``issues: closed`` for a child, this script no-ops unless the parent epic is
+  eligible and every tracked sub-issue is closed; then it closes the epic.
+
+Pure decision helpers are network-free so unit tests can fixture GraphQL shapes.
+Live I/O goes through injectable callables (default: ``gh`` CLI).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess  # nosec B404 - fixed list-args gh invocations, never shell=True
+import sys
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+EPIC_LABEL = "ce-program-epic"
+KNOWN_EPIC_NUMBERS = frozenset({5569})
+
+PARENT_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      number
+      title
+      state
+      labels(first: 50) { nodes { name } }
+      parent {
+        number
+        title
+        state
+        labels(first: 50) { nodes { name } }
+      }
+    }
+  }
+}
+""".strip()
+
+SUB_ISSUES_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      number
+      title
+      state
+      labels(first: 50) { nodes { name } }
+      subIssues(first: 100) {
+        nodes { number title state }
+      }
+    }
+  }
+}
+""".strip()
+
+
+@dataclass(frozen=True)
+class IssueRef:
+    """Minimal issue identity used by the autoclose decision."""
+
+    number: int
+    title: str
+    state: str
+    labels: tuple[str, ...] = ()
+
+    @property
+    def is_closed(self) -> bool:
+        return self.state.upper() == "CLOSED"
+
+
+@dataclass(frozen=True)
+class Decision:
+    """Outcome of evaluating whether an epic should close."""
+
+    action: str
+    epic: IssueRef | None
+    open_children: tuple[IssueRef, ...]
+    closed_children: tuple[IssueRef, ...]
+    reason: str
+
+    @property
+    def should_close(self) -> bool:
+        return self.action == "close_epic"
+
+
+def issue_from_graphql_node(node: dict | None) -> IssueRef | None:
+    """Parse one GraphQL issue node into an IssueRef."""
+    if not isinstance(node, dict):
+        return None
+    number = node.get("number")
+    title = node.get("title")
+    state = node.get("state")
+    if not isinstance(number, int) or number < 1:
+        return None
+    if not isinstance(title, str) or not isinstance(state, str):
+        return None
+    labels_payload = node.get("labels") or {}
+    label_nodes = labels_payload.get("nodes") if isinstance(labels_payload, dict) else None
+    labels: list[str] = []
+    if isinstance(label_nodes, list):
+        for item in label_nodes:
+            if isinstance(item, dict) and isinstance(item.get("name"), str):
+                labels.append(item["name"])
+    return IssueRef(number=number, title=title, state=state, labels=tuple(labels))
+
+
+def parse_sub_issues(nodes: object) -> tuple[IssueRef, ...]:
+    """Parse ``subIssues.nodes`` into IssueRef tuples (skips malformed rows)."""
+    if not isinstance(nodes, list):
+        return ()
+    children: list[IssueRef] = []
+    for node in nodes:
+        parsed = issue_from_graphql_node(node if isinstance(node, dict) else None)
+        if parsed is not None:
+            children.append(parsed)
+    return tuple(children)
+
+
+def is_eligible_epic(issue: IssueRef) -> bool:
+    """True when the issue is the known CE epic or carries ``ce-program-epic``."""
+    if issue.number in KNOWN_EPIC_NUMBERS:
+        return True
+    return EPIC_LABEL in issue.labels
+
+
+def decide(*, parent: IssueRef | None, children: Sequence[IssueRef]) -> Decision:
+    """Decide whether the parent epic should close given its sub-issues.
+
+    Never force-closes while any tracked child remains open. Epics with zero
+    sub-issues are a no-op (avoids closing a mislabeled issue with no children).
+    """
+    if parent is None:
+        return Decision(
+            action="noop_no_parent",
+            epic=None,
+            open_children=(),
+            closed_children=(),
+            reason="closed issue has no GitHub parent sub-issue link",
+        )
+    if not is_eligible_epic(parent):
+        return Decision(
+            action="noop_ineligible",
+            epic=parent,
+            open_children=(),
+            closed_children=(),
+            reason=(
+                f"#{parent.number} is not an eligible CE program epic "
+                f"(need number in {sorted(KNOWN_EPIC_NUMBERS)} or label '{EPIC_LABEL}')"
+            ),
+        )
+    if parent.is_closed:
+        return Decision(
+            action="noop_already_closed",
+            epic=parent,
+            open_children=(),
+            closed_children=tuple(children),
+            reason=f"epic #{parent.number} is already closed",
+        )
+    if not children:
+        return Decision(
+            action="noop_no_children",
+            epic=parent,
+            open_children=(),
+            closed_children=(),
+            reason=f"epic #{parent.number} has no tracked GitHub sub-issues",
+        )
+    open_children = tuple(child for child in children if not child.is_closed)
+    closed_children = tuple(child for child in children if child.is_closed)
+    if open_children:
+        open_list = ", ".join(f"#{child.number}" for child in open_children)
+        return Decision(
+            action="noop_open_children",
+            epic=parent,
+            open_children=open_children,
+            closed_children=closed_children,
+            reason=f"epic #{parent.number} still has open sub-issues: {open_list}",
+        )
+    return Decision(
+        action="close_epic",
+        epic=parent,
+        open_children=(),
+        closed_children=closed_children,
+        reason=(
+            f"all {len(closed_children)} sub-issues of epic #{parent.number} are closed"
+        ),
+    )
+
+
+def close_comment(*, epic: IssueRef, children: Sequence[IssueRef], trigger: int) -> str:
+    """Build the comment posted when the epic is auto-closed."""
+    child_list = ", ".join(f"#{child.number}" for child in children) or "(none)"
+    return (
+        f"Auto-closed by `epic-autoclose` (#5585): all {len(children)} GitHub "
+        f"sub-issues under this CE program epic are closed.\n\n"
+        f"- Trigger: close of #{trigger}\n"
+        f"- Children: {child_list}\n"
+        f"- Convention: subtasks use GitHub sub-issues; delivery PRs use "
+        f"`Fixes #<child>` (never the epic). See "
+        f"`chaos-engine/references/work-github-planning.md`.\n"
+    )
+
+
+def _run_gh(args: list[str], *, runner: Callable[..., subprocess.CompletedProcess]) -> str:
+    """Run ``gh`` with fixed list args and return stdout, or raise RuntimeError."""
+    completed = runner(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if completed.returncode:
+        detail = (completed.stderr or completed.stdout or "").strip()
+        raise RuntimeError(detail or f"gh exited {completed.returncode}")
+    return completed.stdout
+
+
+def graphql(
+    query: str,
+    variables: dict,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess],
+) -> dict:
+    """Execute a GitHub GraphQL query via ``gh api graphql``."""
+    args = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for key, value in variables.items():
+        if isinstance(value, int):
+            args.extend(["-F", f"{key}={value}"])
+        else:
+            args.extend(["-f", f"{key}={value}"])
+    raw = _run_gh(args, runner=runner)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"GraphQL returned invalid JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise RuntimeError("GraphQL returned a non-object payload")
+    if payload.get("errors"):
+        raise RuntimeError(json.dumps(payload["errors"]))
+    return payload
+
+
+def fetch_parent_context(
+    owner: str,
+    name: str,
+    issue_number: int,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess],
+) -> tuple[IssueRef | None, IssueRef | None]:
+    """Return (closed_issue, parent_epic_or_none) for the triggering issue."""
+    payload = graphql(
+        PARENT_QUERY,
+        {"owner": owner, "name": name, "number": issue_number},
+        runner=runner,
+    )
+    issue_node = (
+        ((payload.get("data") or {}).get("repository") or {}).get("issue")
+    )
+    closed = issue_from_graphql_node(issue_node if isinstance(issue_node, dict) else None)
+    parent_node = issue_node.get("parent") if isinstance(issue_node, dict) else None
+    parent = issue_from_graphql_node(parent_node if isinstance(parent_node, dict) else None)
+    return closed, parent
+
+
+def fetch_epic_children(
+    owner: str,
+    name: str,
+    epic_number: int,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess],
+) -> tuple[IssueRef, tuple[IssueRef, ...]]:
+    """Return (epic, children) refreshed from GraphQL subIssues."""
+    payload = graphql(
+        SUB_ISSUES_QUERY,
+        {"owner": owner, "name": name, "number": epic_number},
+        runner=runner,
+    )
+    issue_node = (
+        ((payload.get("data") or {}).get("repository") or {}).get("issue")
+    )
+    epic = issue_from_graphql_node(issue_node if isinstance(issue_node, dict) else None)
+    if epic is None:
+        raise RuntimeError(f"epic #{epic_number} not found in {owner}/{name}")
+    nodes = ()
+    if isinstance(issue_node, dict):
+        sub = issue_node.get("subIssues") or {}
+        if isinstance(sub, dict):
+            nodes = parse_sub_issues(sub.get("nodes"))
+    return epic, nodes
+
+
+def close_issue(
+    owner: str,
+    name: str,
+    number: int,
+    comment: str,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess],
+) -> None:
+    """Close an issue with a comment via ``gh issue close``."""
+    _run_gh(
+        [
+            "gh",
+            "issue",
+            "close",
+            str(number),
+            "--repo",
+            f"{owner}/{name}",
+            "--comment",
+            comment,
+        ],
+        runner=runner,
+    )
+
+
+def evaluate_closed_issue(
+    owner: str,
+    name: str,
+    issue_number: int,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess],
+) -> Decision:
+    """Fetch live parent/children and decide whether to close the epic."""
+    _closed, parent = fetch_parent_context(owner, name, issue_number, runner=runner)
+    if parent is None:
+        return decide(parent=None, children=())
+    epic, children = fetch_epic_children(owner, name, parent.number, runner=runner)
+    return decide(parent=epic, children=children)
+
+
+def split_repository(repository: str) -> tuple[str, str]:
+    """Parse ``owner/name`` into a pair."""
+    parts = repository.split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(f"repository must be owner/name, got {repository!r}")
+    return parts[0], parts[1]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", "ShaftHQ/SHAFT_ENGINE"),
+        help="owner/name repository slug (default: $GITHUB_REPOSITORY or ShaftHQ/SHAFT_ENGINE)",
+    )
+    parser.add_argument(
+        "--issue",
+        type=int,
+        required=True,
+        help="number of the issue that just closed (trigger)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the decision JSON and do not close anything",
+    )
+    parser.add_argument(
+        "--decision-only",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    owner, name = split_repository(args.repository)
+    runner = subprocess.run
+    decision = evaluate_closed_issue(owner, name, args.issue, runner=runner)
+    payload = {
+        "action": decision.action,
+        "reason": decision.reason,
+        "epic": None
+        if decision.epic is None
+        else {
+            "number": decision.epic.number,
+            "title": decision.epic.title,
+            "state": decision.epic.state,
+            "labels": list(decision.epic.labels),
+        },
+        "open_children": [child.number for child in decision.open_children],
+        "closed_children": [child.number for child in decision.closed_children],
+        "trigger_issue": args.issue,
+        "dry_run": bool(args.dry_run),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if not decision.should_close:
+        return 0
+    assert decision.epic is not None  # noqa: S101 - guarded by should_close
+    comment = close_comment(
+        epic=decision.epic,
+        children=decision.closed_children,
+        trigger=args.issue,
+    )
+    if args.dry_run:
+        print(f"dry-run: would close #{decision.epic.number} with comment:\n{comment}")
+        return 0
+    close_issue(owner, name, decision.epic.number, comment, runner=runner)
+    print(f"closed epic #{decision.epic.number}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, ValueError, OSError) as error:
+        print(f"epic-autoclose error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/tests/scripts/test_epic_autoclose.py
+++ b/tests/scripts/test_epic_autoclose.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 import os
 import subprocess  # nosec B404 - fixed list-args CLI invocations in tests only
+import sys
 import unittest
-from unittest import mock
+import unittest.mock
 
 from scripts.ci.epic_autoclose import (
     EPIC_LABEL,
@@ -106,7 +107,7 @@ class ParseTests(unittest.TestCase):
             "labels": {"nodes": [{"name": EPIC_LABEL}, {"name": "enhancement"}]},
         }
         parsed = issue_from_graphql_node(node)
-        assert parsed is not None
+        self.assertIsNotNone(parsed)
         self.assertEqual((EPIC_LABEL, "enhancement"), parsed.labels)
 
     def test_parse_sub_issues_skips_malformed(self):
@@ -222,9 +223,9 @@ class EvaluateIntegrationTests(unittest.TestCase):
             closed_children=(_issue(5585, "autoclose", "CLOSED"),),
             reason="all closed",
         )
-        with mock.patch(
+        with unittest.mock.patch(
             "scripts.ci.epic_autoclose.evaluate_closed_issue", return_value=decision_payload
-        ), mock.patch("scripts.ci.epic_autoclose.close_issue") as close_mock:
+        ), unittest.mock.patch("scripts.ci.epic_autoclose.close_issue") as close_mock:
             code = main(
                 ["--repository", "ShaftHQ/SHAFT_ENGINE", "--issue", "5585", "--dry-run"]
             )
@@ -235,7 +236,7 @@ class EvaluateIntegrationTests(unittest.TestCase):
 class CliSmokeTests(unittest.TestCase):
     def test_cli_help(self):
         completed = subprocess.run(  # nosec B603
-            ["python3", CLI, "--help"],
+            [sys.executable, CLI, "--help"],
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,

--- a/tests/scripts/test_epic_autoclose.py
+++ b/tests/scripts/test_epic_autoclose.py
@@ -1,0 +1,250 @@
+"""Unit tests for CE program epic auto-close (#5585)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # nosec B404 - fixed list-args CLI invocations in tests only
+import unittest
+from unittest import mock
+
+from scripts.ci.epic_autoclose import (
+    EPIC_LABEL,
+    KNOWN_EPIC_NUMBERS,
+    Decision,
+    IssueRef,
+    close_comment,
+    decide,
+    evaluate_closed_issue,
+    is_eligible_epic,
+    issue_from_graphql_node,
+    main,
+    parse_sub_issues,
+    split_repository,
+)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CLI = os.path.join(REPO_ROOT, "scripts", "ci", "epic_autoclose.py")
+
+
+def _issue(number: int, title: str, state: str, labels: tuple[str, ...] = ()) -> IssueRef:
+    return IssueRef(number=number, title=title, state=state, labels=labels)
+
+
+class EligibilityTests(unittest.TestCase):
+    def test_known_epic_5569_is_eligible_without_label(self):
+        self.assertIn(5569, KNOWN_EPIC_NUMBERS)
+        self.assertTrue(is_eligible_epic(_issue(5569, "Epic: CE", "OPEN")))
+
+    def test_label_makes_other_issue_eligible(self):
+        self.assertTrue(
+            is_eligible_epic(_issue(9999, "Epic: other", "OPEN", (EPIC_LABEL,)))
+        )
+
+    def test_unrelated_issue_is_not_eligible(self):
+        self.assertFalse(is_eligible_epic(_issue(42, "random", "OPEN", ("enhancement",))))
+
+
+class DecideTests(unittest.TestCase):
+    def test_noop_when_no_parent(self):
+        decision = decide(parent=None, children=())
+        self.assertEqual("noop_no_parent", decision.action)
+        self.assertFalse(decision.should_close)
+
+    def test_noop_when_parent_ineligible(self):
+        parent = _issue(100, "not an epic", "OPEN")
+        decision = decide(parent=parent, children=(_issue(101, "child", "CLOSED"),))
+        self.assertEqual("noop_ineligible", decision.action)
+        self.assertFalse(decision.should_close)
+
+    def test_noop_when_epic_already_closed(self):
+        parent = _issue(5569, "Epic: CE", "CLOSED")
+        decision = decide(parent=parent, children=(_issue(5585, "autoclose", "CLOSED"),))
+        self.assertEqual("noop_already_closed", decision.action)
+
+    def test_noop_when_epic_has_no_children(self):
+        parent = _issue(5569, "Epic: CE", "OPEN")
+        decision = decide(parent=parent, children=())
+        self.assertEqual("noop_no_children", decision.action)
+
+    def test_noop_while_any_child_open_including_follow_ons(self):
+        parent = _issue(5569, "Epic: CE", "OPEN", (EPIC_LABEL,))
+        children = (
+            _issue(5584, "eval", "CLOSED"),
+            _issue(5585, "autoclose", "CLOSED"),
+            _issue(5613, "headroom", "OPEN"),  # must block autoclose if tracked
+        )
+        decision = decide(parent=parent, children=children)
+        self.assertEqual("noop_open_children", decision.action)
+        self.assertEqual((5613,), tuple(c.number for c in decision.open_children))
+        self.assertFalse(decision.should_close)
+
+    def test_close_when_all_tracked_children_closed(self):
+        parent = _issue(5569, "Epic: CE", "OPEN")
+        children = (
+            _issue(5584, "eval", "CLOSED"),
+            _issue(5585, "autoclose", "CLOSED"),
+        )
+        decision = decide(parent=parent, children=children)
+        self.assertEqual("close_epic", decision.action)
+        self.assertTrue(decision.should_close)
+        self.assertIn("2 sub-issues", decision.reason)
+
+    def test_labeled_epic_closes_same_as_known_number(self):
+        parent = _issue(7000, "Epic: next wave", "OPEN", (EPIC_LABEL,))
+        children = (_issue(7001, "child", "CLOSED"),)
+        decision = decide(parent=parent, children=children)
+        self.assertEqual("close_epic", decision.action)
+
+
+class ParseTests(unittest.TestCase):
+    def test_issue_from_graphql_node_reads_labels(self):
+        node = {
+            "number": 5569,
+            "title": "Epic: CE",
+            "state": "OPEN",
+            "labels": {"nodes": [{"name": EPIC_LABEL}, {"name": "enhancement"}]},
+        }
+        parsed = issue_from_graphql_node(node)
+        assert parsed is not None
+        self.assertEqual((EPIC_LABEL, "enhancement"), parsed.labels)
+
+    def test_parse_sub_issues_skips_malformed(self):
+        nodes = [
+            {"number": 1, "title": "ok", "state": "CLOSED"},
+            {"number": "bad", "title": "x", "state": "OPEN"},
+            None,
+        ]
+        parsed = parse_sub_issues(nodes)
+        self.assertEqual((1,), tuple(item.number for item in parsed))
+
+    def test_split_repository(self):
+        self.assertEqual(("ShaftHQ", "SHAFT_ENGINE"), split_repository("ShaftHQ/SHAFT_ENGINE"))
+        with self.assertRaises(ValueError):
+            split_repository("not-a-slug")
+
+
+class CommentTests(unittest.TestCase):
+    def test_close_comment_lists_children_and_trigger(self):
+        epic = _issue(5569, "Epic: CE", "OPEN")
+        children = (_issue(5584, "a", "CLOSED"), _issue(5585, "b", "CLOSED"))
+        body = close_comment(epic=epic, children=children, trigger=5585)
+        self.assertIn("#5585", body)
+        self.assertIn("#5584", body)
+        self.assertIn("GitHub sub-issues", body)
+        self.assertIn("work-github-planning.md", body)
+
+
+class EvaluateIntegrationTests(unittest.TestCase):
+    def test_evaluate_closed_issue_closes_only_when_children_closed(self):
+        parent_payload = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "number": 5585,
+                        "title": "autoclose",
+                        "state": "CLOSED",
+                        "labels": {"nodes": []},
+                        "parent": {
+                            "number": 5569,
+                            "title": "Epic: CE",
+                            "state": "OPEN",
+                            "labels": {"nodes": [{"name": "enhancement"}]},
+                        },
+                    }
+                }
+            }
+        }
+        children_payload = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "number": 5569,
+                        "title": "Epic: CE",
+                        "state": "OPEN",
+                        "labels": {"nodes": []},
+                        "subIssues": {
+                            "nodes": [
+                                {"number": 5584, "title": "eval", "state": "CLOSED"},
+                                {"number": 5585, "title": "autoclose", "state": "CLOSED"},
+                            ]
+                        },
+                    }
+                }
+            }
+        }
+        open_child_payload = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "number": 5569,
+                        "title": "Epic: CE",
+                        "state": "OPEN",
+                        "labels": {"nodes": []},
+                        "subIssues": {
+                            "nodes": [
+                                {"number": 5585, "title": "autoclose", "state": "CLOSED"},
+                                {"number": 5613, "title": "headroom", "state": "OPEN"},
+                            ]
+                        },
+                    }
+                }
+            }
+        }
+
+        def runner_factory(second_payload):
+            calls = {"n": 0}
+
+            def runner(args, **_kwargs):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    return subprocess.CompletedProcess(args, 0, json.dumps(parent_payload), "")
+                return subprocess.CompletedProcess(args, 0, json.dumps(second_payload), "")
+
+            return runner
+
+        close_decision = evaluate_closed_issue(
+            "ShaftHQ", "SHAFT_ENGINE", 5585, runner=runner_factory(children_payload)
+        )
+        self.assertEqual("close_epic", close_decision.action)
+
+        blocked = evaluate_closed_issue(
+            "ShaftHQ", "SHAFT_ENGINE", 5585, runner=runner_factory(open_child_payload)
+        )
+        self.assertEqual("noop_open_children", blocked.action)
+        self.assertEqual((5613,), tuple(c.number for c in blocked.open_children))
+
+    def test_main_dry_run_does_not_close(self):
+        decision_payload = Decision(
+            action="close_epic",
+            epic=_issue(5569, "Epic: CE", "OPEN"),
+            open_children=(),
+            closed_children=(_issue(5585, "autoclose", "CLOSED"),),
+            reason="all closed",
+        )
+        with mock.patch(
+            "scripts.ci.epic_autoclose.evaluate_closed_issue", return_value=decision_payload
+        ), mock.patch("scripts.ci.epic_autoclose.close_issue") as close_mock:
+            code = main(
+                ["--repository", "ShaftHQ/SHAFT_ENGINE", "--issue", "5585", "--dry-run"]
+            )
+        self.assertEqual(0, code)
+        close_mock.assert_not_called()
+
+
+class CliSmokeTests(unittest.TestCase):
+    def test_cli_help(self):
+        completed = subprocess.run(  # nosec B603
+            ["python3", CLI, "--help"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode)
+        self.assertIn("--dry-run", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `.github/workflows/epic-autoclose.yml` + `scripts/ci/epic_autoclose.py` to close eligible CE program epics when **every** GitHub sub-issue is closed.
- Eligible epics: `#5569` and issues labeled `ce-program-epic` (label applied to the epic).
- No-op while any tracked child remains open (including follow-ons that are formal sub-issues). Non-sub-issue mentions (e.g. #5613) do not block.
- Document convention in `chaos-engine/references/work-github-planning.md` §3c; epic #5569 body references the automation.
- Wire unit tests into PR Gate workflow-timeouts leg + scheduled exhaustive suite; refresh ChaosGauge digests.

Part of epic #5569. Fixes #5585.

## Checks
- [x] `python3 -m unittest tests.scripts.test_epic_autoclose -v` (17 tests)
- [x] Live dry evaluate: close of #5584 → `noop_open_children` (open `#5585`)
- [x] Simulated all-children-closed → `close_epic` for #5569
- [x] `validate_workflow_timeouts.py`
- [x] ChaosGauge `validate_experiment.py --write`
- [ ] CI green on PR

## Continuation
After merge, closing #5585 should fire the Action and auto-close #5569 (all other formal sub-issues already closed; #5613 is not a sub-issue).