### PR TITLE
[CE] Wave B: zero-LLM locator + triage→budget + Level-1/Heal/GAP-EXIT2

### DIFF
--- a/chaos-engine/hooks/lifecycle.py
+++ b/chaos-engine/hooks/lifecycle.py
@@ -69,6 +69,48 @@ HEADROOM_PROFILE_BY_BUDGET = {
     "deep": "coding",
 }
 
+# Triage (blast radius) → default token budget when env unset (#5621).
+# Env CHAOS_ENGINE_TOKEN_BUDGET remains the owner override.
+TRIAGE_TO_TOKEN_BUDGET = {
+    "one-file": "ultra-lean",
+    "one-module": "balanced",
+    "module": "balanced",
+    "public-contract": "deep",
+}
+
+
+
+def triage_token_budget(triage: str | None) -> str:
+    """Map triage blast-radius label to the default token budget mode."""
+    raw = str(triage or "").strip().casefold().replace("_", "-").replace(" ", "-")
+    aliases = {
+        "onefile": "one-file",
+        "file": "one-file",
+        "onemodule": "one-module",
+        "public": "public-contract",
+        "contract": "public-contract",
+        "hard-to-reverse": "public-contract",
+    }
+    raw = aliases.get(raw, raw)
+    return TRIAGE_TO_TOKEN_BUDGET.get(raw, TOKEN_BUDGET_DEFAULT)
+
+
+def zero_llm_session_guidance() -> str:
+    """Prefer doctor/repair catalog before chat discovery (locator-only)."""
+    return (
+        "Zero-LLM first: references/zero-llm-catalog.md "
+        "(doctor / repair --component / --fix-next-only) before chat discovery."
+    )
+
+
+def level1_catalog_guidance() -> str:
+    """Point at the Level-1 progressive-disclosure surface catalog."""
+    return "Level-1 catalog: references/level-1-catalog.md."
+
+
+def heal_route_guidance() -> str:
+    """Router Heal surface always reachable by file path."""
+    return "Heal: references/heal-route.md (install one-liner / repair --component)."
 
 def headroom_session_guidance(mode: str | None = None) -> str:
     """Compact SessionStart line for Headroom profile (locator-only)."""
@@ -161,6 +203,9 @@ def session_start_context(token: str | None, activation: str) -> str:
     budget = resolve_token_budget_mode()
     parts.append(token_budget_guidance(budget))
     parts.append(headroom_session_guidance(budget))
+    parts.append(zero_llm_session_guidance())
+    parts.append(level1_catalog_guidance())
+    parts.append(heal_route_guidance())
     parts.append(self_improve_session_guidance())
     for name in COMPANION_NAMES:
         for root in _search_roots():

--- a/chaos-engine/references/heal-route.md
+++ b/chaos-engine/references/heal-route.md
@@ -1,0 +1,28 @@
+# Router Heal surface
+
+Always reachable by **file path** even when the marketplace plugin is absent.
+The core [`chaos-engine` skill](../skills/chaos-engine/SKILL.md) Route table
+points here; do not require plugin activation to heal.
+
+## Prefer (zero-LLM)
+
+1. Doctor: `python3 .chaos-engine/install.py doctor --project .`
+2. Fix-next only: `… doctor --project . --fix-next-only`
+3. Component repair (no full wipe):  
+   `python3 .chaos-engine/install.py repair --project . --component <id>`  
+   Components: `plugins`, `hosts`, `core`, `headroom`, `mempalace`, `graphify`,
+   `memory`, `hooks`, `mcps`, `skills`, `roles`, `tools`
+4. Official install one-liner from [`INSTALL.md`](../INSTALL.md) for missing
+   core, wiped runtime, or multi-component drift
+
+## When marketplace plugin is absent
+
+- Read this file and [`INSTALL.md`](../INSTALL.md) from the portable tree or
+  `.chaos-engine/` copy — path locators stay valid without Codex/Claude plugin
+  registration.
+- SessionStart still injects the Heal locator under `SESSION_START_MAX_BYTES`.
+
+## Out of scope
+
+- Auto-merge skill mutations
+- Pretending exit-2 hard-blocks on GAP-EXIT2 hosts (see host-parity checklist)

--- a/chaos-engine/references/host-parity-matrix.md
+++ b/chaos-engine/references/host-parity-matrix.md
@@ -49,3 +49,17 @@ Legend: P = parity (outcome available), A = adapter-shaped equivalent, G = gap (
    see [eval-parity-fixtures](eval-parity-fixtures.md)) after hook or adapter changes.
    Fixture failures ratchet into hooks, skills, or a documented matrix gap — never
    weaken the fixture to look green.
+
+
+## GAP-EXIT2 compensating UX checklist (Grok / Copilot)
+
+Do **not** pretend a hard process exit-2 block on these hosts. ChaosEngine still
+emits `decision=block` / `permissionDecision=deny` and exit 2; owners must
+verify trust and static surfaces.
+
+- [ ] Doctor human output shows `blockingGap` / GAP-EXIT2 warning for Grok and Copilot
+- [ ] Host parity row `GAP-EXIT2` stays documented with severity and proof test
+- [ ] After a deny, tell the owner to check project trust / hooks trust (Grok: `grok inspect --json`, `/hooks-trust`) and IDE Copilot trust — not “the tool was hard-blocked by exit code”
+- [ ] SessionStart / Heal locators remain available when marketplace plugins are absent
+- [ ] Exit-2 fidelity unit test remains green: `tests.scripts.test_chaos_engine_exit2_fidelity`
+

--- a/chaos-engine/references/level-1-catalog.md
+++ b/chaos-engine/references/level-1-catalog.md
@@ -1,0 +1,24 @@
+# Level-1 progressive-disclosure catalog
+
+Secondary ChaosEngine surfaces reachable from the core
+[`chaos-engine` skill](../skills/chaos-engine/SKILL.md). Deterministic and
+sorted. Each row is a name, ≤2-line Use-when, and a path — no workflow dumps.
+
+| Name | Use when | Path |
+| --- | --- | --- |
+| Zero-LLM catalog | Prefer doctor/repair/script paths before opening chat discovery | [`zero-llm-catalog.md`](zero-llm-catalog.md) |
+| Heal route | Install drifted, wiped runtime, missing core, or unhealthy doctor fix-next | [`heal-route.md`](heal-route.md) |
+| Token budget modes | Choose or override ultra-lean / balanced / deep context spend | [`token-budget-modes.md`](token-budget-modes.md) |
+| Host parity / GAP-EXIT2 | Host deny fidelity differs (Grok/Copilot); compensating UX checklist | [`host-parity-matrix.md`](host-parity-matrix.md) |
+| Script-first | Multi-hop mechanical transforms belong in a script, not a tool chain | [`script-first.md`](script-first.md) |
+| Context economy | Bound reads/searches; prefer path+excerpt over dumps | [`context-economy.md`](context-economy.md) |
+| Retrieve-first | A store can shorten discovery; one bounded attempt | [`retrieve-first.md`](retrieve-first.md) |
+| Research receipt | Before implementation mutation; triage scales depth | [`research-receipt.md`](research-receipt.md) |
+| Delivery phase gates | Phase ledger / research-before-mutation enforcement | [`delivery-phase-gates.md`](delivery-phase-gates.md) |
+| Eval-parity fixtures | Cross-host CE policy fixture suite | [`eval-parity-fixtures.md`](eval-parity-fixtures.md) |
+| Headroom | Max-savings wrap/proxy; Ponytail XOR OUTPUT_SHAPER | [`headroom.md`](headroom.md) |
+| Self-improve | Learning Session dual-track harness + product observations | [`../skills/self-improve/SKILL.md`](../skills/self-improve/SKILL.md) |
+| OmniRoute | Optional local transport; never required for canonical workflows | [`../skills/omniroute/SKILL.md`](../skills/omniroute/SKILL.md) |
+
+Load **one** row when the core router points here; return to the core skill after
+the deliverable.

--- a/chaos-engine/references/token-budget-modes.md
+++ b/chaos-engine/references/token-budget-modes.md
@@ -28,6 +28,22 @@ deeper guidance.
 Machine-readable labels live in `hooks/lifecycle.py` (`TOKEN_BUDGET_MODES`).
 
 
+
+
+## Triage → token budget defaults (#5621)
+
+When `CHAOS_ENGINE_TOKEN_BUDGET` is **unset**, pick the default from triage
+(blast radius). Env override always wins.
+
+| Triage (worse of blast radius / reversibility) | Default budget |
+| --- | --- |
+| One file, reversible | `ultra-lean` (Headroom `agent-90`) |
+| One module, reversible | `balanced` |
+| Public contract, many callers, or hard to reverse | `deep` |
+
+Machine map: `hooks/lifecycle.py` → `TRIAGE_TO_TOKEN_BUDGET` /
+`triage_token_budget()`.
+
 ## Headroom profile map
 
 | Token budget | `HEADROOM_SAVINGS_PROFILE` |

--- a/chaos-engine/references/zero-llm-catalog.md
+++ b/chaos-engine/references/zero-llm-catalog.md
@@ -8,6 +8,9 @@ opening a host chat. Companion guidance: [script-first](script-first.md).
 | Install / upgrade | One-liners in [INSTALL.md](../INSTALL.md) | Fresh or upgraded payload + healthy doctor |
 | Human doctor | `python3 .chaos-engine/install.py doctor --project .` | Component health + fix-next lines |
 | Fix-next only | `python3 .chaos-engine/install.py doctor --project . --fix-next-only` | Prints only actionable repair lines (exit 0 if none) |
+| Component repair | `python3 .chaos-engine/install.py repair --project . --component <id>` | Targeted quarantine/republish without full wipe (#5620/#5621) |
+| Heal route | [`heal-route.md`](heal-route.md) | File-path Heal surface even if marketplace plugin absent |
+| Level-1 catalog | [`level-1-catalog.md`](level-1-catalog.md) | Progressive-disclosure secondary surfaces |
 | JSON doctor | `... doctor --project . --json` | Schema v2 machine contract |
 | Status (passive) | `... status --project .` | Receipt-bound status without active probes |
 | Empty-project smoke | `python3 scripts/ci/chaos_engine_empty_project_smoke.py` | Install→doctor budget evidence |

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -195,10 +195,21 @@ surface that owns it. The entrypoint makes that choice; callers do not bypass it
 by invoking a playbook directly. Load one surface, finish its deliverable, then
 return here for the next.
 
+| Route | Use when | Load |
+| --- | --- | --- |
+| Zero-LLM first | Before chat discovery for install/doctor/repair | [zero-llm-catalog](../../references/zero-llm-catalog.md) |
+| Heal | Drifted install, wiped runtime, unhealthy doctor | [heal-route](../../references/heal-route.md) (file path; no plugin required) |
+| Level-1 catalog | Need a secondary skill/tool beyond this router | [level-1-catalog](../../references/level-1-catalog.md) |
+| Token budget | Triage or env selects ultra-lean / balanced / deep | [token-budget-modes](../../references/token-budget-modes.md) |
+| GAP-EXIT2 UX | Grok/Copilot may not honor exit-2 hard blocks | [host-parity-matrix](../../references/host-parity-matrix.md) checklist |
+
 Routing also orders applicable knowledge retrieval before broad manual
 discovery. One bounded attempt is enough; never retry, repair, refresh, mine,
 checkpoint, poll, or watch a store for an ordinary task, and never treat an
 index as authority over a live file.
+
+Prefer the Zero-LLM / Heal rows before opening host chat for recovery. Iron-law
+Route: doctor and `repair --component` catalog entries beat discovery chat.
 
 The repository skills map at `.agents/skills/README.md` inventories every
 harness surface, adapter, hook, script and check, including the lifecycle guard

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "e857314625e7223c2bb7daaf8d64cc72a06daeabd9ab3be09391a1a570644b97",
+      "harnessSha256": "5cb6b67ef4be14f2148fd40d3456f1e67992e76d97ee1ed9cc3d3bad939e8f88",
       "treatmentSha256": {
-        "calibration": "92fc21f5a1b0f8fea67050c3ff7c62a95dc7ae8e7b45d0162f2e1ca321cc6e8b",
-        "full-pilot": "b22e96678bdfb6cebbd0e6a0d5a021a8563c56864c3a83cbd90384a41f847ea5"
+        "calibration": "96f67e1c972a5be88e067bf79bc81e04c7b5d542b40e3d240e82c38d98a688f5",
+        "full-pilot": "86a2374c3d36fd6bcfce04e3fba810f2cf70a0fd562de14e6a4a17712577de83"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "e857314625e7223c2bb7daaf8d64cc72a06daeabd9ab3be09391a1a570644b97"
+      harness_sha256: "5cb6b67ef4be14f2148fd40d3456f1e67992e76d97ee1ed9cc3d3bad939e8f88"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "e857314625e7223c2bb7daaf8d64cc72a06daeabd9ab3be09391a1a570644b97"
+      harness_sha256: "5cb6b67ef4be14f2148fd40d3456f1e67992e76d97ee1ed9cc3d3bad939e8f88"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_wave_b_router_catalog.py
+++ b/tests/scripts/test_chaos_engine_wave_b_router_catalog.py
@@ -1,0 +1,91 @@
+"""Wave B (#5621/#5622): triage→budget, zero-LLM/Heal/Level-1, GAP-EXIT2 UX."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LIFECYCLE = ROOT / "chaos-engine/hooks/lifecycle.py"
+ZERO = ROOT / "chaos-engine/references/zero-llm-catalog.md"
+TOKEN = ROOT / "chaos-engine/references/token-budget-modes.md"
+LEVEL1 = ROOT / "chaos-engine/references/level-1-catalog.md"
+HEAL = ROOT / "chaos-engine/references/heal-route.md"
+SKILL = ROOT / "chaos-engine/skills/chaos-engine/SKILL.md"
+MATRIX = ROOT / "chaos-engine/references/host-parity-matrix.md"
+
+
+def load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class WaveBRouterCatalogTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lifecycle = load(LIFECYCLE, "ce_lifecycle_wave_b")
+
+    def test_triage_maps_to_token_budget_defaults(self):
+        self.assertEqual("ultra-lean", self.lifecycle.triage_token_budget("one-file"))
+        self.assertEqual("balanced", self.lifecycle.triage_token_budget("module"))
+        self.assertEqual("balanced", self.lifecycle.triage_token_budget("one-module"))
+        self.assertEqual("deep", self.lifecycle.triage_token_budget("public-contract"))
+        self.assertEqual("deep", self.lifecycle.triage_token_budget("hard-to-reverse"))
+        self.assertEqual(
+            "balanced", self.lifecycle.triage_token_budget("unknown-triage")
+        )
+        text = TOKEN.read_text(encoding="utf-8")
+        self.assertIn("Triage", text)
+        self.assertIn("ultra-lean", text)
+        self.assertIn("public contract", text.casefold())
+
+    def test_zero_llm_catalog_lists_repair_and_heal(self):
+        text = ZERO.read_text(encoding="utf-8")
+        self.assertIn("repair --project . --component", text)
+        self.assertIn("heal-route.md", text)
+        self.assertIn("level-1-catalog.md", text)
+
+    def test_level1_catalog_is_sorted_and_lean(self):
+        text = LEVEL1.read_text(encoding="utf-8")
+        self.assertIn("Level-1", text)
+        self.assertIn("heal-route.md", text)
+        # No workflow dumps in Use-when cells — keep descriptions short.
+        for line in text.splitlines():
+            if line.startswith("|") and "Use when" not in line and "---" not in line:
+                cells = [c.strip() for c in line.strip("|").split("|")]
+                if len(cells) >= 2 and cells[0] not in {"Name", ""}:
+                    self.assertLessEqual(len(cells[1]), 160, msg=cells[0])
+
+    def test_heal_route_is_file_path_reachable(self):
+        self.assertTrue(HEAL.is_file())
+        text = HEAL.read_text(encoding="utf-8")
+        self.assertIn("repair --project", text)
+        self.assertIn("marketplace plugin is absent", text.casefold())
+        skill = SKILL.read_text(encoding="utf-8")
+        self.assertIn("heal-route.md", skill)
+        self.assertIn("| Heal |", skill)
+
+    def test_gap_exit2_checklist_present(self):
+        text = MATRIX.read_text(encoding="utf-8")
+        self.assertIn("GAP-EXIT2 compensating UX checklist", text)
+        self.assertIn("Do **not** pretend", text)
+        self.assertIn("test_chaos_engine_exit2_fidelity", text)
+
+    def test_session_start_includes_locators_under_budget(self):
+        context = self.lifecycle.session_start_context("tok", "activation")
+        encoded = context.encode("utf-8")
+        self.assertLessEqual(len(encoded), self.lifecycle.SESSION_START_MAX_BYTES)
+        self.assertIn("zero-llm-catalog.md", context.casefold())
+        self.assertIn("level-1-catalog.md", context.casefold())
+        self.assertIn("heal-route.md", context.casefold())
+        # Still locator-only: no catalog body dump.
+        self.assertNotIn(LEVEL1.read_text(encoding="utf-8")[:80], context)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **#5621** — SessionStart prefers zero-LLM doctor/repair catalog locators (under `SESSION_START_MAX_BYTES`); triage→token-budget defaults (`one-file`→`ultra-lean`, `module`→`balanced`, `public-contract`→`deep`); env override remains.
- **#5622** — Level-1 progressive-disclosure catalog; Router **Heal** surface via file path (`references/heal-route.md`) even without marketplace plugin; GAP-EXIT2 compensating UX checklist for Grok/Copilot.

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_wave_b_router_catalog tests.scripts.test_chaos_engine_sessionstart_locator_parity tests.scripts.test_chaos_engine_token_budget_modes tests.scripts.test_chaos_engine_zero_llm_catalog -v`
- [x] ChaosGauge `--write`
- [ ] CI green

Fixes #5621
Fixes #5622