### PR TITLE
fix(ci): re-enable skipped nightly E2E suites and harden cucumber

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -1,7 +1,11 @@
 name: E2E Tests
 
 concurrency:
-  group: e2e-tests-${{ github.ref }}
+  # Isolate schedule from workflow_dispatch. The previous group
+  # e2e-tests-${{ github.ref }} let a manual dispatch on main cancel an
+  # in-flight nightly via cancel-in-progress. Nightly keeps a stable
+  # group; each manual run uses its own run_id.
+  group: e2e-tests-${{ github.event_name == 'schedule' && 'nightly' || format('manual-{0}', github.run_id) }}
   cancel-in-progress: true
 
 on:
@@ -25,21 +29,15 @@ on:
         default: ''
       enableFlutterEmulatorE2E:
         description: >-
-          Opt-in flag for the Android_Flutter_Emulator_E2E job (issue #4197).
-          Renamed from enableFlutterE2E (issue #4294) to stop colliding in
-          name with the unrelated -Dshaft.enableFlutterE2E Maven system
-          property that gates FlutterTest.java (FlutterTest.java:24,31-36).
-          #4303 briefly hardcoded that property true in Android_Native_BrowserStack;
-          reverted back to self-skip by the fix for issue #4308 (the checked-in
-          flutter-demo.apk was never actually built with the required Flutter
-          Integration Driver server -- see issue #4313 for the real fix). The
-          rename stands regardless, so this input still only ever means one
-          thing: opt in to THIS emulator smoke-check job. This job never runs
-          on the nightly schedule (schedule triggers can't supply inputs); set
-          to 'true' on a manual dispatch to run it. It only proves an Appium
-          session opens against the real, pinned demo-app on an emulator -- it
-          does not run FlutterTest.java and does not exercise the fluent
-          Flutter API (see job comment).
+          Legacy opt-in flag for Android_Flutter_Emulator_E2E on manual
+          workflow_dispatch (issue #4197). Renamed from enableFlutterE2E
+          (issue #4294) to stop colliding with -Dshaft.enableFlutterE2E.
+          The job now also runs on the scheduled nightly (same selector as
+          sibling E2E jobs). On workflow_dispatch, leave jobs=all (or name
+          the job explicitly) to run it; this flag is retained for backward
+          compatibility and is no longer required to gate the nightly.
+          The job only proves an Appium session opens against the pinned
+          demo-app on an emulator -- it does not run FlutterTest.java.
         required: false
         default: 'false'
 
@@ -787,7 +785,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Android_Visual_Ocr_BrowserStack:
-    if: github.event_name == 'workflow_dispatch' && contains(format(',{0},', github.event.inputs.jobs), ',Android_Visual_Ocr_BrowserStack,')
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Visual_Ocr_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
@@ -846,7 +844,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   iOS_Visual_Ocr_BrowserStack:
-    if: github.event_name == 'workflow_dispatch' && contains(format(',{0},', github.event.inputs.jobs), ',iOS_Visual_Ocr_BrowserStack,')
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',iOS_Visual_Ocr_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 50
     outputs:
@@ -913,7 +911,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Android_Recording_BrowserStack:
-    if: github.event_name == 'workflow_dispatch' && contains(format(',{0},', github.event.inputs.jobs), ',Android_Recording_BrowserStack,')
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Recording_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -949,7 +947,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   iOS_Recording_BrowserStack:
-    if: github.event_name == 'workflow_dispatch' && contains(format(',{0},', github.event.inputs.jobs), ',iOS_Recording_BrowserStack,')
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',iOS_Recording_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 40
     outputs:
@@ -993,7 +991,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   Android_Evidence_BrowserStack:
-    if: github.event_name == 'workflow_dispatch' && contains(format(',{0},', github.event.inputs.jobs), ',Android_Evidence_BrowserStack,')
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Evidence_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -1029,7 +1027,7 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   iOS_Evidence_BrowserStack:
-    if: github.event_name == 'workflow_dispatch' && contains(format(',{0},', github.event.inputs.jobs), ',iOS_Evidence_BrowserStack,')
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',iOS_Evidence_BrowserStack,')
     runs-on: ubuntu-latest
     timeout-minutes: 40
     outputs:
@@ -1145,12 +1143,11 @@ jobs:
   # session opens locally. What it does NOT prove: that any of the fluent
   # API's calls behave correctly against a live Flutter widget tree -- wiring
   # that is explicitly deferred to a fast-follow ticket once both this job
-  # and issue 4017 have landed. Gated behind the enableFlutterEmulatorE2E
-  # workflow_dispatch input above (never runs on the nightly schedule) --
-  # see that input's description for the naming-collision history with
-  # -Dshaft.enableFlutterE2E.
+  # and issue 4017 have landed. Runs on the scheduled nightly and on
+  # workflow_dispatch when selected (same if: pattern as sibling jobs).
+  # enableFlutterEmulatorE2E remains as a legacy dispatch input only.
   Android_Flutter_Emulator_E2E:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.enableFlutterEmulatorE2E == 'true' && (github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Flutter_Emulator_E2E,'))
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Flutter_Emulator_E2E,')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -1308,7 +1305,11 @@ jobs:
   Ubuntu_Chrome_Cucumber_Grid:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Ubuntu_Chrome_Cucumber_Grid,')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Was 10m (#4082). Nightly 34087761845 hit the ceiling mid-mvn ("The
+    # operation was canceled.") and marked the whole E2E run cancelled.
+    # Successful nights finish in ~3m; 25m leaves headroom for grid flake
+    # without restoring the unbounded default.
+    timeout-minutes: 25
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}
@@ -1342,7 +1343,7 @@ jobs:
   MacOSX_Safari_Cucumber_BrowserStack:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',MacOSX_Safari_Cucumber_BrowserStack,')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     outputs:
       job: ${{ steps.post_test_report.outputs.job }}
       total: ${{ steps.post_test_report.outputs.total }}

--- a/tests/scripts/test_validate_workflow_timeouts.py
+++ b/tests/scripts/test_validate_workflow_timeouts.py
@@ -481,7 +481,9 @@ class MobileEvidenceAcceptanceWorkflowContractTest(unittest.TestCase):
         for job_name, (run_name, selector, guard_name, report, requires_ios_gate) in expected_jobs.items():
             job = workflow["jobs"][job_name]
             self.assertEqual(
-                "github.event_name == 'workflow_dispatch' && "
+                "github.event_name != 'workflow_dispatch' || "
+                "github.event.inputs.jobs == '' || "
+                "github.event.inputs.jobs == 'all' || "
                 f"contains(format(',{{0}},', github.event.inputs.jobs), ',{job_name},')",
                 job["if"],
             )

--- a/tests/scripts/test_visual_ocr_workflow.py
+++ b/tests/scripts/test_visual_ocr_workflow.py
@@ -12,7 +12,7 @@ ANDROID_TESTS = (Path(__file__).resolve().parents[2] / "shaft-engine" / "src" / 
 
 
 class VisualOcrWorkflowTest(unittest.TestCase):
-    def test_regular_android_nightly_excludes_manual_visual_ocr_acceptance(self):
+    def test_regular_android_nightly_excludes_dedicated_visual_ocr_acceptance(self):
         workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
         steps = workflow["jobs"]["Android_Native_BrowserStack"]["steps"]
         test_command = next(step["run"] for step in steps if "-Dtest=" in step.get("run", ""))
@@ -35,7 +35,7 @@ class VisualOcrWorkflowTest(unittest.TestCase):
             self.assertIsNotNone(annotation_and_method, method)
             self.assertIn('"visual-ocr-mobile-acceptance"', annotation_and_method.group("groups"))
 
-    def test_jobs_forward_manual_test_selector_and_keep_defaults(self):
+    def test_jobs_forward_dispatch_test_selector_and_keep_defaults(self):
         workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
         expected_defaults = {
             "Android_Visual_Ocr_BrowserStack":
@@ -46,7 +46,13 @@ class VisualOcrWorkflowTest(unittest.TestCase):
         }
 
         for job_name, expected_default in expected_defaults.items():
-            self.assertIn("github.event_name == 'workflow_dispatch'", workflow["jobs"][job_name]["if"])
+            self.assertEqual(
+                "github.event_name != 'workflow_dispatch' || "
+                "github.event.inputs.jobs == '' || "
+                "github.event.inputs.jobs == 'all' || "
+                f"contains(format(',{{0}},', github.event.inputs.jobs), ',{job_name},')",
+                workflow["jobs"][job_name]["if"],
+            )
             run_steps = [step["run"] for step in workflow["jobs"][job_name]["steps"] if "run" in step]
             test_command = next(command for command in run_steps if "-Dtest=" in command)
             self.assertIn("-DincludeVisualTestRuntime", test_command)


### PR DESCRIPTION
## Summary
Analyzed cancelled nightly [E2E run 34087761845](https://github.com/ShaftHQ/SHAFT_ENGINE/actions/runs/34087761845) and re-enabled suites that were never executing on schedule.

| Suite | Prior reason | Fix |
| --- | --- | --- |
| Android_Visual_Ocr_BrowserStack | `if:` required `workflow_dispatch` + explicit job name | Standard schedule-friendly `if:` |
| iOS_Visual_Ocr_BrowserStack | same | same |
| Android_Recording_BrowserStack | same | same |
| iOS_Recording_BrowserStack | same | same |
| Android_Evidence_BrowserStack | same | same |
| iOS_Evidence_BrowserStack | same | same |
| Android_Flutter_Emulator_E2E | `workflow_dispatch` + `enableFlutterEmulatorE2E=true` | Standard schedule-friendly `if:` (legacy input kept) |
| Ubuntu_Chrome_Cucumber_Grid | Job `timeout-minutes: 10` → cancelled mid-mvn (`The operation was canceled.`) → whole run `cancelled` | Raise timeout to 25m |
| MacOSX_Safari_Cucumber_BrowserStack | same tight 10m budget | Raise timeout to 25m |
| (concurrency) | `e2e-tests-${{ github.ref }}` + `cancel-in-progress` let dispatch cancel nightly | Separate schedule vs manual concurrency groups |

All workflow jobs already appeared in the run inventory (skipped ones still show up); none were missing from the YAML.

## Test plan
- [x] `scripts/ci/validate_workflow_timeouts.py` passes
- [ ] PR gate CI green
- [ ] Next scheduled E2E actually starts the previously skipped jobs (or manual `workflow_dispatch` with `jobs=all`)