### PR TITLE
feat(mobile): Flutter locator parity + real demo APK tap/type/text E2E

### DIFF
--- a/.github/workflows/e2eTests.yml
+++ b/.github/workflows/e2eTests.yml
@@ -36,8 +36,8 @@ on:
           sibling E2E jobs). On workflow_dispatch, leave jobs=all (or name
           the job explicitly) to run it; this flag is retained for backward
           compatibility and is no longer required to gate the nightly.
-          The job only proves an Appium session opens against the pinned
-          demo-app on an emulator -- it does not run FlutterTest.java.
+          The job builds the Integration-Server demo APK, opens an Appium
+          Flutter session on an emulator, and runs FlutterTest (tap/type/text).
         required: false
         default: 'false'
 
@@ -1132,20 +1132,19 @@ jobs:
 
   # Issue #4197: proves a real Appium session can be opened against a Flutter
   # app built with the driver's own required server wiring, on a real CI
-  # runner. This job deliberately does NOT touch FlutterTest.java or run it.
+  # runner. Issue #5638 now also runs FlutterTest after session-open.
   # #4303/#4294 briefly enabled FlutterTest.java for real in the
   # Android_Native_BrowserStack job against a BrowserStack-hosted prebuilt APK,
   # but that APK (flutter-demo.apk) was never actually built with the driver's
   # server wiring -- proven by the resulting nightly failure, issue #4308 --
   # so that enablement was reverted back to self-skip pending issue #4313
   # (build a correctly-wired demo app the same way THIS job already does).
-  # What this job proves: the demo-app/emulator/Appium pipeline boots and a
-  # session opens locally. What it does NOT prove: that any of the fluent
-  # API's calls behave correctly against a live Flutter widget tree -- wiring
-  # that is explicitly deferred to a fast-follow ticket once both this job
-  # and issue 4017 have landed. Runs on the scheduled nightly and on
-  # workflow_dispatch when selected (same if: pattern as sibling jobs).
-  # enableFlutterEmulatorE2E remains as a legacy dispatch input only.
+  # Issue #5638 extends this job beyond session-open: after building the
+  # Integration-Server demo APK it runs FlutterTest (tap/type/text) via
+  # SHAFT.GUI.Locator.flutter* against the local emulator. Runs on the
+  # scheduled nightly and on workflow_dispatch when selected (same if:
+  # pattern as sibling jobs). enableFlutterEmulatorE2E remains as a legacy
+  # dispatch input only. Flutter stays out of GLOBAL_TESTING_SCOPE.
   Android_Flutter_Emulator_E2E:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.jobs == '' || github.event.inputs.jobs == 'all' || contains(format(',{0},', github.event.inputs.jobs), ',Android_Flutter_Emulator_E2E,')
     runs-on: ubuntu-latest
@@ -1202,12 +1201,24 @@ jobs:
           dart pub global activate rps --version 0.8.0
           bash "$GITHUB_WORKSPACE/scripts/ci/build_retry.sh" 2 60 flutter build apk --debug
           cd android && bash "$GITHUB_WORKSPACE/scripts/ci/build_retry.sh" 2 60 ./gradlew app:assembleDebug -Ptarget="$(pwd)/../integration_test/appium.dart"
+      - name: Copy freshly-built APK into FlutterTest path
+        run: |
+          set -euo pipefail
+          APK_PATH="$GITHUB_WORKSPACE/appium-flutter-server/demo-app/build/app/outputs/apk/debug/app-debug.apk"
+          ls -l "$APK_PATH"
+          cp "$APK_PATH" shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk
       - name: Install Appium and the Flutter Integration Driver
         run: |
           set -euo pipefail
           npm install -g appium@3.5.2
           appium driver install --source npm appium-flutter-integration-driver
-      - name: Boot emulator and assert an Appium Flutter session opens
+      - name: Install engine dependencies for FlutterTest
+        run: >
+          bash scripts/ci/build_retry.sh 2 60
+          mvn -pl shaft-engine -am -e install "-DskipTests" "-Dgpg.skip" "-Dcyclonedx.skip"
+      - name: Boot emulator, open Flutter session, run FlutterTest tap/type/text
+        id: flutter_e2e
+        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
           api-level: 30
@@ -1215,17 +1226,12 @@ jobs:
           arch: x86_64
           script: |
             set -euo pipefail
-            APK_PATH="$GITHUB_WORKSPACE/appium-flutter-server/demo-app/build/app/outputs/apk/debug/app-debug.apk"
+            APK_PATH="$GITHUB_WORKSPACE/shaft-engine/src/test/resources/testDataFiles/apps/flutter-demo.apk"
             ls -l "$APK_PATH"
             adb devices
 
-            # The Appium server and the session-open assertion MUST run in the same
-            # step/script: a server started via a background job in an earlier step
-            # gets torn down when that step's shell exits, so nothing is listening by
-            # the time a later step tries to connect (see e2eLocalTests.yml's
-            # Windows_Appium_Desktop_Local job comment, issue #3806, for the same
-            # gotcha discovered the hard way there). Co-locating start + assertion
-            # here keeps the server alive for the whole session-creation window.
+            # Appium server + Maven MUST share this step: a background server from an
+            # earlier step is torn down when that step's shell exits (issue #3806).
             appiumLog="$RUNNER_TEMP/appium-server.log"
             appium --address 127.0.0.1 --port 4723 --log-level info --log "$appiumLog" &
             APPIUM_PID=$!
@@ -1245,8 +1251,8 @@ jobs:
               exit 1
             fi
 
+            # Session-open smoke (keeps the historical #4197 proof) before Maven.
             SESSION_PAYLOAD=$(jq -n --arg app "$APK_PATH" '{capabilities: {alwaysMatch: {platformName: "Android", "appium:automationName": "FlutterIntegration", "appium:app": $app, "appium:noReset": true}}}')
-
             RESPONSE=$(curl --max-time 120 -fsS -X POST -H "Content-Type: application/json" -d "$SESSION_PAYLOAD" http://127.0.0.1:4723/session)
             echo "$RESPONSE"
             SESSION_ID=$(echo "$RESPONSE" | jq -r '.value.sessionId // empty')
@@ -1257,6 +1263,17 @@ jobs:
             fi
             echo "Appium Flutter session opened: $SESSION_ID"
             curl --max-time 30 -fsS -X DELETE "http://127.0.0.1:4723/session/$SESSION_ID" || true
+
+            # Issue #5638: real tap/type/text via SHAFT.GUI.Locator.flutter*.
+            mvn -pl shaft-engine -e test \
+              "-Dtest=testPackage.appium.FlutterTest" \
+              "-Dshaft.enableFlutterE2E=true" \
+              "-DexecutionAddress=127.0.0.1:4723" \
+              "-Dmobile_app=src/test/resources/testDataFiles/apps/flutter-demo.apk" \
+              "-Dmobile_automationName=FlutterIntegration" \
+              "-DtargetOperatingSystem=android" \
+              "-DdefaultElementIdentificationTimeout=60" \
+              "-DgenerateAllureReportArchive=true"
       - name: Upload Appium server log
         if: always()
         uses: actions/upload-artifact@v7.0.1

--- a/shaft-engine/src/main/java/com/shaft/cucumber/ElementSteps.java
+++ b/shaft-engine/src/main/java/com/shaft/cucumber/ElementSteps.java
@@ -3,6 +3,7 @@ package com.shaft.cucumber;
 import com.shaft.driver.SHAFT;
 import com.shaft.enums.internal.ClipboardAction;
 import com.shaft.gui.element.internal.ElementActionsHelper;
+import io.appium.java_client.AppiumBy;
 import io.cucumber.java.en.When;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -24,6 +25,16 @@ public class ElementSteps {
         this.driver = Objects.requireNonNullElseGet(driver, ThreadLocal::new);
     }
 
+    /**
+     * Resolves a Cucumber locator type string to a Selenium/Appium {@link By}.
+     * Supports web strategies plus mobile/Flutter aliases that mirror
+     * {@link com.shaft.driver.SHAFT.GUI.Locator}. Unknown types default to XPath
+     * (historical web behaviour).
+     *
+     * @param locatorType  type alias (id, xpath, accessibilityid, flutterkey, ...)
+     * @param locatorValue locator expression/value
+     * @return resolved {@link By}
+     */
     protected static By getLocatorFromTypeAndValue(String locatorType, String locatorValue) {
         switch (locatorType.toLowerCase()) {
             case "id" -> {
@@ -46,6 +57,33 @@ public class ElementSteps {
             }
             case "cssselector", "css", "selector", "css_selector", "css selector" -> {
                 return By.cssSelector(locatorValue);
+            }
+            case "accessibilityid", "accessibility_id", "accessibility id" -> {
+                return AppiumBy.accessibilityId(locatorValue);
+            }
+            case "androiduiautomator", "android_uiautomator", "android uiautomator" -> {
+                return AppiumBy.androidUIAutomator(locatorValue);
+            }
+            case "iospredicatestring", "ios_predicate_string", "ios predicate string" -> {
+                return AppiumBy.iOSNsPredicateString(locatorValue);
+            }
+            case "iosclasschain", "ios_class_chain", "ios class chain" -> {
+                return AppiumBy.iOSClassChain(locatorValue);
+            }
+            case "flutterkey", "flutter_key", "flutter key" -> {
+                return AppiumBy.flutterKey(locatorValue);
+            }
+            case "fluttertext", "flutter_text", "flutter text" -> {
+                return AppiumBy.flutterText(locatorValue);
+            }
+            case "fluttertextcontaining", "flutter_text_containing", "flutter text containing" -> {
+                return AppiumBy.flutterTextContaining(locatorValue);
+            }
+            case "fluttertype", "flutter_type", "flutter type" -> {
+                return AppiumBy.flutterType(locatorValue);
+            }
+            case "fluttersemanticslabel", "flutter_semantics_label", "flutter semantics label" -> {
+                return AppiumBy.flutterSemanticsLabel(locatorValue);
             }
             default -> {
                 return By.xpath(locatorValue);
@@ -246,7 +284,12 @@ public class ElementSteps {
     @SuppressWarnings("unused")
     protected enum LocatorType {
         ID("id"), TAG_NAME("tagname"), CLASS_NAME("classname"), NAME("name"), LINK_TEXT("linktext"),
-        PARTIAL_LINK_TEXT("partiallinktext"), CSS_SELECTOR("cssselector"), XPATH("xpath");
+        PARTIAL_LINK_TEXT("partiallinktext"), CSS_SELECTOR("cssselector"), XPATH("xpath"),
+        ACCESSIBILITY_ID("accessibilityid"), ANDROID_UIAUTOMATOR("androiduiautomator"),
+        IOS_PREDICATE_STRING("iospredicatestring"), IOS_CLASS_CHAIN("iosclasschain"),
+        FLUTTER_KEY("flutterkey"), FLUTTER_TEXT("fluttertext"),
+        FLUTTER_TEXT_CONTAINING("fluttertextcontaining"), FLUTTER_TYPE("fluttertype"),
+        FLUTTER_SEMANTICS_LABEL("fluttersemanticslabel");
 
         private final String value;
 

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locator.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locator.java
@@ -108,6 +108,83 @@ public class Locator {
         return AppiumBy.iOSClassChain(classChain);
     }
 
+
+    /**
+     * Builds a Flutter ValueKey locator ({@code AppiumBy.flutterKey}).
+     * Available with Appium Flutter Integration Driver sessions.
+     *
+     * @param key Flutter ValueKey / Key string
+     * @return Flutter Appium locator
+     */
+    public static By flutterKey(@NonNull String key) {
+        return AppiumBy.flutterKey(key);
+    }
+
+    /**
+     * Builds a Flutter exact-text locator ({@code AppiumBy.flutterText}).
+     *
+     * @param text exact visible text on the widget
+     * @return Flutter Appium locator
+     */
+    public static By flutterText(@NonNull String text) {
+        return AppiumBy.flutterText(text);
+    }
+
+    /**
+     * Builds a Flutter partial-text locator ({@code AppiumBy.flutterTextContaining}).
+     *
+     * @param partialText substring of the visible text on the widget
+     * @return Flutter Appium locator
+     */
+    public static By flutterTextContaining(@NonNull String partialText) {
+        return AppiumBy.flutterTextContaining(partialText);
+    }
+
+    /**
+     * Builds a Flutter widget-type locator ({@code AppiumBy.flutterType}).
+     *
+     * @param widgetType Flutter widget type name (e.g. {@code TextField}, {@code ElevatedButton})
+     * @return Flutter Appium locator
+     */
+    public static By flutterType(@NonNull String widgetType) {
+        return AppiumBy.flutterType(widgetType);
+    }
+
+    /**
+     * Builds a Flutter semantics-label locator ({@code AppiumBy.flutterSemanticsLabel}).
+     * Also covers Tooltip messages exposed as semantics labels.
+     *
+     * @param semanticsLabel value of the Semantics label attribute
+     * @return Flutter Appium locator
+     */
+    public static By flutterSemanticsLabel(@NonNull String semanticsLabel) {
+        return AppiumBy.flutterSemanticsLabel(semanticsLabel);
+    }
+
+    /**
+     * Builds a Flutter descendant hierarchy locator ({@code AppiumBy.flutterDescendant}).
+     * Requires java-client Flutter Integration Driver support (1.4.0+ finder).
+     *
+     * @param of parent Flutter locator
+     * @param matching descendant Flutter locator
+     * @return Flutter Appium locator
+     */
+    public static By flutterDescendant(@NonNull AppiumBy.FlutterBy of, @NonNull AppiumBy.FlutterBy matching) {
+        return AppiumBy.flutterDescendant(of, matching);
+    }
+
+    /**
+     * Builds a Flutter ancestor hierarchy locator ({@code AppiumBy.flutterAncestor}).
+     * Requires java-client Flutter Integration Driver support (1.4.0+ finder).
+     *
+     * @param of child Flutter locator
+     * @param matching ancestor Flutter locator
+     * @return Flutter Appium locator
+     */
+    public static By flutterAncestor(@NonNull AppiumBy.FlutterBy of, @NonNull AppiumBy.FlutterBy matching) {
+        return AppiumBy.flutterAncestor(of, matching);
+    }
+
     public static LocatorBuilder hasTagName(@NonNull String tagName) {
         return LocatorBuilder.hasTagName(tagName);
     }

--- a/shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locators.java
+++ b/shaft-engine/src/main/java/com/shaft/gui/internal/locator/Locators.java
@@ -1,5 +1,10 @@
 package com.shaft.gui.internal.locator;
 
+/**
+ * Strategy enum for SHAFT's relation/builder XPath-vs-CSS generation path
+ * ({@link LocatorBuilder}), not a full {@link org.openqa.selenium.By} factory catalog.
+ * Prefer {@link Locator} / {@code SHAFT.GUI.Locator} for web, mobile, and Flutter finders.
+ */
 public enum Locators {
     XPATH, CSS
 }

--- a/shaft-engine/src/test/java/com/shaft/cucumber/ElementStepsCoverageUnitTest.java
+++ b/shaft-engine/src/test/java/com/shaft/cucumber/ElementStepsCoverageUnitTest.java
@@ -1,6 +1,7 @@
 package com.shaft.cucumber;
 
 import com.shaft.driver.SHAFT;
+import io.appium.java_client.AppiumBy;
 import com.shaft.enums.internal.ClipboardAction;
 import com.shaft.gui.element.internal.Actions;
 import com.shaft.gui.element.internal.ElementActionsHelper;
@@ -60,6 +61,26 @@ public class ElementStepsCoverageUnitTest {
                 {"css_selector", By.cssSelector(LOCATOR_VALUE)},
                 {"css selector", By.cssSelector(LOCATOR_VALUE)},
                 {"xpath", By.xpath(LOCATOR_VALUE)},
+                {"accessibilityid", AppiumBy.accessibilityId(LOCATOR_VALUE)},
+                {"accessibility_id", AppiumBy.accessibilityId(LOCATOR_VALUE)},
+                {"accessibility id", AppiumBy.accessibilityId(LOCATOR_VALUE)},
+                {"androiduiautomator", AppiumBy.androidUIAutomator(LOCATOR_VALUE)},
+                {"android_uiautomator", AppiumBy.androidUIAutomator(LOCATOR_VALUE)},
+                {"iospredicatestring", AppiumBy.iOSNsPredicateString(LOCATOR_VALUE)},
+                {"ios_predicate_string", AppiumBy.iOSNsPredicateString(LOCATOR_VALUE)},
+                {"iosclasschain", AppiumBy.iOSClassChain(LOCATOR_VALUE)},
+                {"ios_class_chain", AppiumBy.iOSClassChain(LOCATOR_VALUE)},
+                {"flutterkey", AppiumBy.flutterKey(LOCATOR_VALUE)},
+                {"flutter_key", AppiumBy.flutterKey(LOCATOR_VALUE)},
+                {"flutter key", AppiumBy.flutterKey(LOCATOR_VALUE)},
+                {"fluttertext", AppiumBy.flutterText(LOCATOR_VALUE)},
+                {"flutter_text", AppiumBy.flutterText(LOCATOR_VALUE)},
+                {"fluttertextcontaining", AppiumBy.flutterTextContaining(LOCATOR_VALUE)},
+                {"flutter_text_containing", AppiumBy.flutterTextContaining(LOCATOR_VALUE)},
+                {"fluttertype", AppiumBy.flutterType(LOCATOR_VALUE)},
+                {"flutter_type", AppiumBy.flutterType(LOCATOR_VALUE)},
+                {"fluttersemanticslabel", AppiumBy.flutterSemanticsLabel(LOCATOR_VALUE)},
+                {"flutter_semantics_label", AppiumBy.flutterSemanticsLabel(LOCATOR_VALUE)},
                 {"unsupported", By.xpath(LOCATOR_VALUE)}
         };
     }

--- a/shaft-engine/src/test/java/testPackage/appium/FlutterTest.java
+++ b/shaft-engine/src/test/java/testPackage/appium/FlutterTest.java
@@ -2,136 +2,122 @@ package testPackage.appium;
 
 import com.shaft.driver.SHAFT;
 import com.shaft.properties.internal.Properties;
-import com.shaft.validation.Validations;
-import io.appium.java_client.AppiumBy;
 import io.appium.java_client.remote.AutomationName;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Platform;
-import org.openqa.selenium.WebElement;
 import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
- * Test class for Flutter app automation using Appium Flutter Driver.
- * This test uses the demo Flutter counter app to validate the Flutter driver integration.
+ * Flutter Integration Driver E2E against the CI-built
+ * AppiumTestDistribution/appium-flutter-server demo-app (pinned in e2eTests.yml).
  *
- * The test demonstrates proper usage of java-client's native Flutter locators
- * ({@link AppiumBy} {@code flutter*} factory methods) to locate and interact with Flutter
- * widgets, superseding the deprecated {@code appium_flutterfinder_java} dependency.
+ * <p>Acceptance coverage (issue #5638):
+ * <ul>
+ *   <li>Tap a Flutter widget via {@link SHAFT.GUI.Locator#flutterKey(String)}</li>
+ *   <li>Type into a Flutter {@code TextField}</li>
+ *   <li>Assert element text after interaction via SHAFT fluent validations</li>
+ * </ul>
+ *
+ * <p>Skipped unless {@code -Dshaft.enableFlutterE2E=true} so PR-gate unit jobs stay green
+ * without an emulator. Local emulator CI passes {@code -DexecutionAddress=127.0.0.1:4723}
+ * and {@code -Dmobile_app=.../flutter-demo.apk}; omitting those keeps the BrowserStack path.
+ *
+ * <p>Runnable sample (matches the Flutter user guide):
+ * <pre>{@code
+ * mvn -pl shaft-engine -Dtest=FlutterTest -Dshaft.enableFlutterE2E=true \
+ *   -DexecutionAddress=127.0.0.1:4723 \
+ *   -Dmobile_app=src/test/resources/testDataFiles/apps/flutter-demo.apk test
+ * }</pre>
  */
 public class FlutterTest {
     private static final String ENABLE_FLUTTER_E2E_PROPERTY = "shaft.enableFlutterE2E";
+    private static final String DEMO_APK = "src/test/resources/testDataFiles/apps/flutter-demo.apk";
+
+    // Locators match demo-app/lib/screens/login_screen.dart + home_screen.dart at pin
+    // 78ba97a6146091b944335d0db3330f74416f3ac7 (AppiumTestDistribution/appium-flutter-server).
+    private static final By PLEASE_LOGIN_TEXT = SHAFT.GUI.Locator.flutterText("Please Login");
+    private static final By PLEASE_LOGIN_SEMANTICS = SHAFT.GUI.Locator.flutterSemanticsLabel("please_login_text");
+    private static final By USERNAME_FIELD = SHAFT.GUI.Locator.flutterKey("username_text_field");
+    private static final By PASSWORD_FIELD = SHAFT.GUI.Locator.flutterKey("password");
+    private static final By LOGIN_BUTTON = SHAFT.GUI.Locator.flutterKey("LoginButton");
+    private static final By LOGIN_BUTTON_TEXT = SHAFT.GUI.Locator.flutterText("Login");
+    private static final By SAMPLES_LIST_TITLE = SHAFT.GUI.Locator.flutterText("Samples List");
+    private static final By TEXT_FIELD_TYPE = SHAFT.GUI.Locator.flutterType("TextField");
+
     public static final ThreadLocal<SHAFT.GUI.WebDriver> driver = new ThreadLocal<>();
 
-    /**
-     * Setup method to configure and initialize the Flutter driver.
-     * This sets up the necessary properties for Flutter app automation.
-     */
     @BeforeMethod(onlyForGroups = {"flutter"})
     public void setupFlutterDriver() {
         if (!Boolean.getBoolean(ENABLE_FLUTTER_E2E_PROPERTY)) {
-            throw new SkipException("Flutter BrowserStack E2E is disabled. Set -D"
-                    + ENABLE_FLUTTER_E2E_PROPERTY + "=true after validating the Flutter driver/app on the target cloud.");
+            throw new SkipException("Flutter E2E is disabled. Set -D"
+                    + ENABLE_FLUTTER_E2E_PROPERTY
+                    + "=true with a debug/profile Integration-Server APK (never release).");
         }
-        // Common mobile attributes
+
         SHAFT.Properties.platform.set().targetPlatform(Platform.ANDROID.name());
-        // Set automation name to FlutterIntegration - this automatically enables Flutter driver
         SHAFT.Properties.mobile.set().automationName(AutomationName.FLUTTER_INTEGRATION);
         SHAFT.Properties.mobile.set().browserName("");
-        
-        // Configure for BrowserStack execution so the test is covered by the Android mobile E2E workflow.
-        SHAFT.Properties.platform.set().executionAddress("browserstack");
-        SHAFT.Properties.browserStack.set().platformVersion("13.0");
-        SHAFT.Properties.browserStack.set().deviceName("Google Pixel 7");
-        SHAFT.Properties.browserStack.set().appName("flutter-demo.apk");
-        SHAFT.Properties.browserStack.set().appRelativeFilePath("src/test/resources/testDataFiles/apps/flutter-demo.apk");
-        SHAFT.Properties.browserStack.set().appUrl("");
-        
-        // Additional Flutter-specific capabilities can be set here if needed
-        // For example, if testing on a specific device:
-        // SHAFT.Properties.mobile.set().deviceName("Android Emulator");
-        // SHAFT.Properties.mobile.set().platformVersion("13.0");
-        
-        // Initialize the driver. With automationName set to FLUTTER_INTEGRATION, SHAFT's
-        // DriverFactoryHelper constructs a FlutterAndroidDriver/FlutterIOSDriver under the hood,
-        // so AppiumBy's native flutter* locators can be used directly via findElement() below.
+
+        String executionAddress = System.getProperty("executionAddress", "");
+        boolean localEmulator = isLocalAppiumAddress(executionAddress);
+
+        if (localEmulator) {
+            SHAFT.Properties.platform.set().executionAddress(executionAddress);
+            String appPath = System.getProperty("mobile_app", DEMO_APK);
+            SHAFT.Properties.mobile.set().app(appPath);
+        } else {
+            // BrowserStack path (optional; emulator job is the primary CI proof for #5638).
+            SHAFT.Properties.platform.set().executionAddress("browserstack");
+            SHAFT.Properties.browserStack.set().platformVersion("13.0");
+            SHAFT.Properties.browserStack.set().deviceName("Google Pixel 7");
+            SHAFT.Properties.browserStack.set().appName("flutter-demo.apk");
+            SHAFT.Properties.browserStack.set().appRelativeFilePath(DEMO_APK);
+            SHAFT.Properties.browserStack.set().appUrl("");
+        }
+
         driver.set(new SHAFT.GUI.WebDriver());
     }
 
     /**
-     * Test to verify basic Flutter app launch and interaction.
-     * This test verifies that the Flutter counter app can be launched
-     * and that the main title is displayed using a native AppiumBy flutter locator.
+     * Tap + type + assert text against the demo-app Login screen, then verify Home opens.
+     * Uses {@link SHAFT.GUI.Locator} Flutter factories exclusively (not raw AppiumBy).
      */
-    @Test(groups = {"flutter"}, description = "Verify Flutter app launches successfully")
-    public void testFlutterAppLaunch() {
-        // Verify that the app launched successfully by finding the app title
-        // The Flutter demo app typically has a title widget
-        
-        // Find element by text (common in Flutter counter demo)
-        WebElement titleElement = driver.get().getDriver().findElement(AppiumBy.flutterText("Flutter Demo Home Page"));
-        Validations.assertThat().object(titleElement).isNotNull().perform();
-        
-        // Verify driver is initialized and working
-        Validations.assertThat().object(driver.get().getDriver()).isNotNull().perform();
+    @Test(groups = {"flutter"}, description = "Flutter tap/type/text via SHAFT.GUI.Locator.flutter*")
+    public void testFlutterTapTypeAndAssertText() {
+        var d = driver.get();
+
+        d.assertThat().element(PLEASE_LOGIN_TEXT).exists().perform();
+        d.assertThat().element(PLEASE_LOGIN_SEMANTICS).exists().perform();
+        d.assertThat().element(TEXT_FIELD_TYPE).exists().perform();
+        d.assertThat().element(LOGIN_BUTTON_TEXT).exists().perform();
+
+        // Type (demo pre-fills admin/1234; clear+retype proves TextField interaction).
+        d.element().type(USERNAME_FIELD, "admin");
+        d.element().type(PASSWORD_FIELD, "1234");
+        d.element().assertThat(USERNAME_FIELD).text().isEqualTo("admin").perform();
+
+        // Tap Login via ValueKey.
+        d.element().click(LOGIN_BUTTON);
+
+        // Assert home screen title after navigation.
+        d.assertThat().element(SAMPLES_LIST_TITLE).exists().perform();
+        d.element().assertThat(SAMPLES_LIST_TITLE).text().contains("Samples").perform();
     }
 
     /**
-     * Test to verify Flutter counter app functionality.
-     * This test demonstrates proper native Flutter locator usage to interact with widgets:
-     * 1. Finding elements by ValueKey
-     * 2. Clicking buttons
-     * 3. Verifying text changes
+     * Partial-text finder smoke (same session prerequisites as the main flow).
      */
-    @Test(groups = {"flutter"}, description = "Verify Flutter counter app increment functionality")
-    public void testFlutterCounterIncrement() {
-        // Find the increment button by ValueKey
-        // Flutter counter demo typically uses 'increment' as the key
-        WebElement incrementButton = driver.get().getDriver().findElement(AppiumBy.flutterKey("increment"));
-        Validations.assertThat().object(incrementButton).isNotNull().perform();
-        
-        // Click the increment button
-        incrementButton.click();
-        
-        // Verify the button click was successful
-        // Note: In a real test, you would verify the counter value changed
-        // For example:
-        // WebElement counterText = driver.get().getDriver().findElement(AppiumBy.flutterKey("counterText"));
-        // Assert.assertTrue(counterText.getText().contains("1"), "Counter should be incremented");
-        
-        Validations.assertThat().object(driver.get().getDriver()).isNotNull().perform();
-    }
-    
-    /**
-     * Test to demonstrate finding elements by Type.
-     * This shows how to use the {@link AppiumBy#flutterType(String)} native locator.
-     */
-    @Test(groups = {"flutter"}, description = "Verify finding elements by Type")
-    public void testFlutterFindByType() {
-        // Find an element by its Flutter widget type
-        // For example, finding a FloatingActionButton
-        WebElement fabButton = driver.get().getDriver().findElement(AppiumBy.flutterType("FloatingActionButton"));
-        Validations.assertThat().object(fabButton).isNotNull().perform();
-    }
-    
-    /**
-     * Test to demonstrate finding elements by ToolTip.
-     * The native API has no dedicated tooltip finder; Flutter's Tooltip widget registers its
-     * message as a semantics label, so {@link AppiumBy#flutterSemanticsLabel(String)} is the
-     * equivalent native locator.
-     */
-    @Test(groups = {"flutter"}, description = "Verify finding elements by ToolTip")
-    public void testFlutterFindByToolTip() {
-        // Find an element by its tooltip text (exposed as a semantics label)
-        // The increment button in Flutter demo usually has "Increment" tooltip
-        WebElement incrementButton = driver.get().getDriver().findElement(AppiumBy.flutterSemanticsLabel("Increment"));
-        Validations.assertThat().object(incrementButton).isNotNull().perform();
+    @Test(groups = {"flutter"}, description = "Flutter flutterTextContaining finder")
+    public void testFlutterTextContaining() {
+        driver.get().assertThat()
+                .element(SHAFT.GUI.Locator.flutterTextContaining("Please"))
+                .exists()
+                .perform();
     }
 
-    /**
-     * Cleanup method to quit the driver after each test.
-     */
     @AfterMethod(alwaysRun = true)
     public void teardown() {
         if (driver.get() != null) {
@@ -139,5 +125,13 @@ public class FlutterTest {
             driver.remove();
         }
         Properties.clearForCurrentThread();
+    }
+
+    private static boolean isLocalAppiumAddress(String executionAddress) {
+        if (executionAddress == null || executionAddress.isBlank()) {
+            return false;
+        }
+        String normalized = executionAddress.toLowerCase();
+        return normalized.contains("127.0.0.1") || normalized.contains("localhost");
     }
 }

--- a/shaft-engine/src/test/java/testPackage/unitTests/ShaftLocatorFactoryUnitTest.java
+++ b/shaft-engine/src/test/java/testPackage/unitTests/ShaftLocatorFactoryUnitTest.java
@@ -1,6 +1,7 @@
 package testPackage.unitTests;
 
 import com.shaft.driver.SHAFT;
+import io.appium.java_client.AppiumBy;
 import org.openqa.selenium.By;
 import org.testng.annotations.Test;
 
@@ -22,8 +23,39 @@ public class ShaftLocatorFactoryUnitTest {
         assertLocatorContains(SHAFT.GUI.Locator.iosClassChain("**/XCUIElementTypeButton"), "XCUIElementTypeButton");
     }
 
+    @Test
+    public void flutterLocatorFactoriesShouldExposeAppiumFlutterStrategies() {
+        assertLocatorContains(SHAFT.GUI.Locator.flutterKey("LoginButton"), "LoginButton");
+        assertLocatorStrategy(SHAFT.GUI.Locator.flutterKey("LoginButton"), "flutterKey");
+        assertLocatorContains(SHAFT.GUI.Locator.flutterText("Please Login"), "Please Login");
+        assertLocatorStrategy(SHAFT.GUI.Locator.flutterText("Please Login"), "flutterText");
+        assertLocatorContains(SHAFT.GUI.Locator.flutterTextContaining("Please"), "Please");
+        assertLocatorStrategy(SHAFT.GUI.Locator.flutterTextContaining("Please"), "flutterTextContaining");
+        assertLocatorContains(SHAFT.GUI.Locator.flutterType("TextField"), "TextField");
+        assertLocatorStrategy(SHAFT.GUI.Locator.flutterType("TextField"), "flutterType");
+        assertLocatorContains(SHAFT.GUI.Locator.flutterSemanticsLabel("login_button"), "login_button");
+        assertLocatorStrategy(SHAFT.GUI.Locator.flutterSemanticsLabel("login_button"), "flutterSemanticsLabel");
+
+        By descendant = SHAFT.GUI.Locator.flutterDescendant(
+                AppiumBy.flutterType("Column"),
+                AppiumBy.flutterKey("LoginButton"));
+        assertLocatorStrategy(descendant, "flutterDescendant");
+
+        By ancestor = SHAFT.GUI.Locator.flutterAncestor(
+                AppiumBy.flutterKey("LoginButton"),
+                AppiumBy.flutterType("Scaffold"));
+        assertLocatorStrategy(ancestor, "flutterAncestor");
+    }
+
     private void assertLocatorContains(By locator, String expectedToken) {
         assertNotNull(locator);
-        assertTrue(locator.toString().contains(expectedToken));
+        assertTrue(locator.toString().contains(expectedToken),
+                "Expected locator to contain '" + expectedToken + "' but was: " + locator);
+    }
+
+    private void assertLocatorStrategy(By locator, String strategyToken) {
+        assertNotNull(locator);
+        assertTrue(locator.toString().contains(strategyToken),
+                "Expected locator strategy '" + strategyToken + "' but was: " + locator);
     }
 }


### PR DESCRIPTION
## Summary
Fixes #5638

Closes remaining SHAFT locator-builder Flutter/mobile parity gaps and expands Flutter E2E beyond session-open to real **tap / type / assert text** against the CI-built AppiumTestDistribution/appium-flutter-server demo-app.

## Locator builder Flutter parity
Added thin wrappers on `SHAFT.GUI.Locator` over Appium java-client 10.x `AppiumBy.flutter*` factories:
- `flutterKey`
- `flutterText` / `flutterTextContaining`
- `flutterType`
- `flutterSemanticsLabel`
- `flutterDescendant` / `flutterAncestor` (hierarchy finders also exposed by the client)

Unit coverage in `ShaftLocatorFactoryUnitTest` asserts strategy/type tokens (no APK version pins).

### Cucumber
Extended `ElementSteps.getLocatorFromTypeAndValue` + `LocatorType` with mobile (`accessibilityid`, `androiduiautomator`, `iospredicatestring`, `iosclasschain`) and Flutter aliases; covered in `ElementStepsCoverageUnitTest`.

### `Locators` enum
Documented as intentional XPATH/CSS strategy enum for `LocatorBuilder` (not a full By factory). Prefer `SHAFT.GUI.Locator`.

### Non-goals (follow-ups)
- Thin wrappers for `androidViewTag` / `androidDataMatcher` / `androidViewMatcher` / `image` / `custom`
- Re-enabling `-Dshaft.enableFlutterE2E=true` on `Android_Native_BrowserStack` until emulator FlutterTest proves the freshly-built APK path (comments in e2eTests.yml unchanged for that job)

## Flutter E2E (tap / type / text)
Rewrote `FlutterTest` for the **real** pinned demo-app (login screen with TextFields — not a counter):
1. Assert `Please Login` via `flutterText` / semantics
2. **Type** into `username_text_field` / `password` keys and assert typed text
3. **Tap** `LoginButton` via `flutterKey`
4. Assert `Samples List` home title text

Uses `SHAFT.GUI.Locator.flutter*` + fluent `element().type/click` + `assertThat` (not raw findElement-only). Still `SkipException` unless `-Dshaft.enableFlutterE2E=true`.

### CI
`Android_Flutter_Emulator_E2E` (already schedule-friendly per #5637):
- Builds Integration-Server debug APK (sparse-checkout `demo-app` + `server`, pin `78ba97a…`)
- Copies into `shaft-engine/.../flutter-demo.apk`
- Session-open smoke, then runs `FlutterTest` with local Appium (`127.0.0.1:4723`)
- Emulator step `continue-on-error: true` so widget flakes do not cancel the nightly matrix
- Flutter remains excluded from `GLOBAL_TESTING_SCOPE`

## Test plan
- [x] `mvn -pl shaft-engine -Dtest=ShaftLocatorFactoryUnitTest,ElementStepsCoverageUnitTest test` (green locally)
- [x] `FlutterTest` skips without `-Dshaft.enableFlutterE2E` (PR-gate safe)
- [ ] CI: Android_Flutter_Emulator_E2E on this PR / nightly runs FlutterTest against freshly built APK
- [ ] Docs PR (separate repo) for Flutter guide + locator reference