### PR TITLE
docs(ce): self-improve master plan + Top 10 (post-#5641)

### DIFF
--- a/chaos-engine/profiles/shaft/references/routing.md
+++ b/chaos-engine/profiles/shaft/references/routing.md
@@ -122,3 +122,10 @@ syntax, tool names, or CLI flags from this file.
 UI routes preserve native technology: desktop surfaces use IDE and JVM
 inspection with renderer evidence; web surfaces use browser evidence and an
 accessibility audit.
+
+
+## Self-improve roadmap (profile)
+
+When running a Learning Session or planning harness/product self-enhance work,
+load [self-improve master plan](self-improve-master-plan.md). Cited online
+research lives in [self-improve research synthesis](self-improve-research-synthesis.md).

--- a/chaos-engine/profiles/shaft/references/self-improve-master-plan.md
+++ b/chaos-engine/profiles/shaft/references/self-improve-master-plan.md
@@ -1,0 +1,220 @@
+# ChaosEngine Self-Improve Master Plan
+
+**Owner:** Mohab Mohie / ShaftHQ/SHAFT_ENGINE  
+**Dated (Africa/Cairo):** 2026-09-08  
+**Base tip:** `77a273d2a8` — `fix(ce): enforce Learning Session after every delivery (harness parity) (#5641)`  
+**Supersedes:** prior optimization top-10 at analysis SHA `0961058e66` / `/workspace/chaos-engine-top10-optimizations.md` (ideas #1–#10 landed as #5619–#5625 under epic #5618).  
+**Method:** tip deep-read of `skills/self-improve/**`, `learning.py`, Stop/Learning Session hooks, token/parity/delivery refs; online harness synthesis; optional Grok CLI consult (`/tmp/ce-self-improve-consult.txt`).  
+**Constraint:** NEVER Cursor Cloud Agents; merge commits only; portable overlay parity across Codex / Claude / Grok CLI / Gemini / Copilot / Grok Bot.
+
+---
+
+> Research synthesis (cited URLs): [self-improve-research-synthesis.md](self-improve-research-synthesis.md).
+
+## 0. Locked prefs (do not reopen)
+
+| Pref | Status |
+| --- | --- |
+| NO native Task Observer / always-on observation | **Locked reject** (#5643; research-adopt-reject) |
+| Lean self-improve: SessionStart locator-only; Learning Session on delivery Stop | **Shipped** (#5641 / #5613) |
+| Harness parity across six hosts (overlay, not agent memory) | **Shipped policy** (#5645 / host-parity-matrix) |
+| One-command install/configure/update | **Shipped north star** (#5618 / #5620) |
+| Headroom `agent-90` default; Caveman + Ponytail | **Shipped** (#5613 / token-budget-modes) |
+| Issues-first self-improve; eval-gated draft skill PRs **opt-in later** | **Locked** (#5618 fork #5) |
+| Merge commits only | **Locked** |
+
+---
+
+## 1. Current-state assessment (post-#5641)
+
+### 1.1 What CE can already self-enhance
+
+| Loop | Product (SHAFT) | Harness (CE overlay) | Token profile |
+| --- | --- | --- | --- |
+| Capture | Dual-track Learning Session → `learning.py` queue → GitHub issues | Same path; categories allow-list; privacy gates | Heavy only on delivery Stop |
+| Enforce learn | Stop / delivery-complete owes Learning Session even if `chaos-engine/` untouched | Portable `learning_session.py` finalize + monorepo controller | Hook = 0 context unless block reason |
+| Discover surfaces | Level-1 catalog + router Heal / zero-LLM | SessionStart locators under `SESSION_START_MAX_BYTES=4096` | ↓ always-on |
+| Health / heal | Installer/doctor/repair components | `status ⊆ doctor`, `activationProof`, `repair --component` | Zero-LLM |
+| Delivery gates | Triage-scaled research + phase ledger | Stop Learning Session; catastrophic deny | Soft vs hard by triage |
+| Memory | Owner wake pack locator; retrieve orchestrator | Soft-degrade Memory/MemPalace/Graphify | No SessionStart prose dump |
+| Eval | Product CI / ChaosGauge | Eval-parity fixtures + host matrix | CI, not chat |
+
+### 1.2 Dual-track self-improve ability (honest)
+
+**Strengths**
+
+- Stop-gated Learning Session is **deterministic** (hook), not prompt hope — aligns with industry “hooks = 100% enforce, 0 context unless output.”
+- Issues-first + privacy-gated `learning.py` is a durable LogAct-like append log (queue → GitHub), not transcript hoarding.
+- Progressive disclosure skeleton exists: Level-1 catalog, locator SessionStart, on-demand self-improve refs.
+- Optimization program #5618 children (#5619–#5625) closed the prior top-10 (health truth, repair, zero-LLM locator, L1 catalog, triage research+ledger, wake+retrieve, eval-parity+portable finalize).
+
+**Gaps (self-improve-specific — this plan’s focus)**
+
+1. **No closed-loop metrics:** queued → submitted → adopted/rejected → estimatedTokens delta is not machine-summarized for doctor/zero-LLM.
+2. **No once-per-task heuristic retrieve:** lessons live in issues/`.memory` but are not ERL-style top-k retrieved at triage (still avoid every-turn injection).
+3. **Verification dumps still risk token rot:** Check/Stop paths lack a universal silent-on-success / errors-only wrapper contract.
+4. **Skill body bloat risk:** no SkillOpt-style compression/eval gate before growing SKILL.md (L2 <500 lines discipline is documented, not automated).
+5. **CLI vs MCP preference** is tribal in places; HumanLayer lesson not yet an iron-law + zero-LLM catalog row.
+6. **Significance filter for mid-session capture** is skill-discipline only — easy to miss under Caveman ultra (without becoming Task Observer).
+7. **Phase-2 eval-gated draft skill PRs** still deferred (correct) but needs a ready gate checklist.
+8. **Product-track playbook** thinner than harness track (taxonomy exists; SHAFT-specific acceptance/eval linkage weak).
+9. **GAP-EXIT2** still soft on Grok/Copilot — compensating UX exists; not a self-improve blocker but limits Stop-gate fidelity.
+10. **Periodic meta-optimize** (supervisor over shared logs) not scheduled — only per-delivery Learning Session.
+
+### 1.3 Gap analysis vs #5641
+
+| #5641 deliverable | Status | Remaining self-improve work |
+| --- | --- | --- |
+| Merge/delivery → Learning Session owed | Shipped | Metrics that prove sessions actually queue/submit |
+| Docs forbid CE-untouched skip | Shipped | Product-track yield reporting |
+| Harness parity in overlay | Shipped | Encode new lessons as hooks/skills/scripts, never agent-only memory |
+| SessionStart locator-only | Shipped | Keep; add **locator** to heuristic index only (no prose) |
+| Unit tests for merge→Stop | Shipped | Expand fixtures for metrics + silent-verify + heuristic retrieve |
+
+**Verdict:** #5641 closed the **enforcement** gap. This plan closes the **yield / token-efficiency / closed-loop** gap for both product and harness.
+
+---
+
+## 3. Master roadmap waves (self-improve next)
+
+Dependency order. **Do not** re-implement #5619–#5625.
+
+```
+Wave S0 — Measure (zero/low LLM)
+  [#1 Learning metrics closed loop]
+
+Wave S1 — Token sinks on the hot path
+  [#2 Silent-on-success verify] → [#5 CLI-over-MCP iron law]
+       ↘ [#3 ERL once-per-task heuristics]
+
+Wave S2 — Capture quality without Observer
+  [#4 Significance-filtered mid-session capture] → [#6 SkillOpt compress audit]
+
+Wave S3 — Isolation & product yield
+  [#7 Subagent research firewall guidance] → [#10 Product-track playbook + ChaosGauge link]
+
+Wave S4 — Close the mutate loop (opt-in)
+  [#9 Periodic meta-optimize] → [#8 Eval-gated draft skill PRs (opt-in)]
+```
+
+**Out of scope forever (unless prefs unlock):** always-on SessionStart full skill/frontmatter scan; native Task Observer; auto-merge skill mutations; pretending GAP-EXIT2 hard process blocks.
+
+---
+
+## 4. Top 10 recommendations (ranked)
+
+Each item: why · token impact · dependency · proposed CE shape · Task Observer accept/reject.
+
+### 1. Learning metrics closed loop (queued → adopted → token delta)
+
+- **Why:** LogAct shows shared structured logs + light supervisor yield more unique work at lower tokens. CE already appends via `learning.py` / `.memory` / phase ledger but does not summarize adoption.
+- **Token impact:** ↓↓ (zero-LLM doctor/CLI; avoids re-discovering known lessons)
+- **Dependency:** none (S0)
+- **CE shape:** `learning.py metrics|summary` + `doctor --json.learningMetrics` fields: queued, submitted, open/closed issues, estimatedTokens sum, optional adopt/reject labels; link issue numbers only.
+- **vs Task Observer:** **Reject Observer.** Metrics are offline/zero-LLM over existing logs.
+
+### 2. Silent-on-success / errors-only verification wrappers
+
+- **Why:** HumanLayer: green test dumps rotate agents into the dumb zone; success must add **zero** context.
+- **Token impact:** ↓↓↓ on Check/Stop
+- **Dependency:** after #1 optional; independent OK
+- **CE shape:** `references/silent-verify.md` + thin `scripts`/`chaos-engine` helper used by delivery Check + optional Stop verify; exit 0 → no stdout; fail → stderr + exit 2 where honored.
+- **vs Task Observer:** **Reject Observer.** Pure hook/script back-pressure.
+
+### 3. ERL-style heuristic retrieve once per task (not every turn)
+
+- **Why:** ERL: post-task heuristics + top-k inject at **new task start** beats always-on observation.
+- **Token impact:** ↓ always-on; slight ↑ once at triage (bounded top-k, privacy-safe)
+- **Dependency:** prefers #1 metrics for ranking; wake pack / retrieve patterns (#5624)
+- **CE shape:** `.chaos-engine-state/heuristics/` or Memory category; SessionStart **locator only**; triage/router calls `retrieve.py heuristics --top 3` once; never PreToolUse spam.
+- **vs Task Observer:** **Reject Observer.** Adopt ERL retrieve-once; reject continuous scan (#5643).
+
+### 4. Significance-filtered mid-session capture (skill + optional soft PostToolUse)
+
+- **Why:** Under Caveman ultra, dual-track capture is easy to miss until Stop; need cheap friction marks without full observation protocol.
+- **Token impact:** ↓ vs batching failures; ↑ tiny if soft hook emits one-line marks
+- **Dependency:** taxonomy + learning.py; must not load self-improve refs mid-turn
+- **CE shape:** optional PostToolUse recorder for deny/fail signatures → state file; Learning Session reads marks. Default off or ultra-cheap. Significance filter: errors, repeated denials, doctor recovery — not every edit.
+- **vs Task Observer:** **Reject Observer.** Filter + deferred heavy path only.
+
+### 5. CLI-over-MCP preference (iron law + zero-LLM catalog)
+
+- **Why:** HumanLayer: CLI in training data beats MCP schema tax for gh/git/docker/db.
+- **Token impact:** ↓↓ system prompt + tool-result size
+- **Dependency:** zero-llm-catalog / Level-1 (#5621/#5622)
+- **CE shape:** router iron-law row + catalog entries; MCP only when no equivalent CLI; Headroom/MCP remain for compression/proxy cases.
+- **vs Task Observer:** N/A (tooling policy).
+
+### 6. SkillOpt-style SKILL.md compression audit (propose, don’t auto-apply)
+
+- **Why:** Red Hat ACE / SkillOpt: ~90% volume cut with quality preserved in experiments; L2 &lt;500 lines.
+- **Token impact:** ↓↓ on skill activation
+- **Dependency:** eval-parity (#5625); metrics #1 help prioritize which skills
+- **CE shape:** offline CLI proposing compressed SKILL.md + refs split; CI eval gate; issues-first PR by human. No live auto-edit.
+- **vs Task Observer:** **Reject auto-mutate.** Aligns with issues-first / opt-in draft PRs later.
+
+### 7. Subagent / context-firewall guidance for research & explore
+
+- **Why:** HumanLayer + capitalandcompute: isolation keeps parent in smart zone; explore noise stays in child.
+- **Token impact:** ↓ parent context (child spend may ↑ — net quality win)
+- **Dependency:** host adapters; local-coding-delegate / omniroute optional
+- **CE shape:** short Level-1 + router rule: research/multi-file explore → subagent/Task when host supports; return filepath:line citations only.
+- **vs Task Observer:** N/A.
+
+### 8. Eval-gated draft skill PRs — **opt-in phase 2**
+
+- **Why:** Hermes/SkillOpt closed loops need eval; CE locked issues-first until ready.
+- **Token impact:** ↑ CI only; ↓ bad skill merges long-term
+- **Dependency:** #1 metrics, #6 compress, #5625 fixtures green, portable finalize stable
+- **CE shape:** flag `CHAOS_ENGINE_SELF_IMPROVE_DRAFT_PR=1`; draft PR from staged branch after eval-parity + unit tests; never auto-merge.
+- **vs Task Observer:** **Reject Observer.** Opt-in mutate path only after eval.
+
+### 9. Periodic meta-optimize over shared logs (not continuous)
+
+- **Why:** LogAct supervisor: periodic introspection of shared logs beats per-turn gossip.
+- **Token impact:** ↓ vs continuous; bounded scheduled LLM or zero-LLM cluster
+- **Dependency:** #1 metrics; Learning Session history
+- **CE shape:** operator `/learning meta` or weekly script clustering open learning issues + `.memory` facts → ranked backlog issue; no SessionStart involvement.
+- **vs Task Observer:** **Reject Observer.** Periodic only.
+
+### 10. Product-track self-improve playbook (SHAFT + ChaosGauge)
+
+- **Why:** Dual-track requires equal product discipline; recent #5644/#5646/#5647 show product lessons already valuable.
+- **Token impact:** ↓ rediscovery; slight ↑ at Learning Session when product work occurred
+- **Dependency:** taxonomy; metrics #1; silent-verify #2 for product Check
+- **CE shape:** `skills/self-improve/references/product-track.md` — issue templates, link tests/ChaosGauge, prefer CLI/doctor/silent-verify product fixes over essay tickets.
+- **vs Task Observer:** **Reject Observer.** Delivery-Stop capture only.
+
+---
+
+## 5. Accept / reject matrix (Task Observer principles)
+
+| Principle | Decision | CE encoding |
+| --- | --- | --- |
+| Always-on SessionStart full scan | **REJECT** | Locator-only; `SESSION_START_MAX_BYTES` |
+| Continuous observation every turn | **REJECT** | #5643; research-adopt-reject |
+| Lean core + on-demand refs | **ACCEPT** | self-improve SKILL + references |
+| Capture vs review split | **ACCEPT** | queue now; human/CI apply later |
+| Dual-track harness + product | **ACCEPT** | taxonomy + Learning Session checklist |
+| Auto-stage / auto-install skill patches | **REJECT** (phase-2 draft PR opt-in only) | learning.py issues-first |
+| Weekly auto-mutate live skills | **REJECT** | meta-optimize proposes backlog only |
+| Post-delivery Learning Session gate | **ACCEPT** | #5641 Stop hooks |
+| ERL retrieve-once heuristics | **ACCEPT (adapted)** | Top 10 #3 |
+| LogAct metrics / periodic supervisor | **ACCEPT (adapted)** | Top 10 #1 #9 |
+| Silent-on-success verify | **ACCEPT** | Top 10 #2 |
+
+---
+
+## 6. Implementation notes (when executing children)
+
+1. Prefer **one condensed PR per wave** (S0→S4); children under the epic; `Fixes #<child>` never the epic.
+2. Every lasting behavior → portable `chaos-engine/` (hooks/skills/scripts/doctor) + host adapters as needed — **harness parity**.
+3. Expand eval-parity fixtures when adding gates; never weaken fixtures.
+4. Keep Headroom `agent-90` / Ponytail XOR OUTPUT_SHAPER / Caveman ultra.
+5. No Cursor Cloud Agents for implementation workstreams.
+
+---
+
+## 9. Supersession notice
+
+The 2026-09-07 dependency-ranked top-10 (health plane → repair → zero-LLM locator → L1 catalog → research ledger → wake/retrieve → Headroom/budget → eval-gated improve → fixtures → Heal/GAP-EXIT2) is **complete** via #5619–#5625 + #5641. **Do not reopen those tickets.** Track new work from **§4 Top 10** under the self-improve epic filed alongside this document.

--- a/chaos-engine/profiles/shaft/references/self-improve-research-synthesis.md
+++ b/chaos-engine/profiles/shaft/references/self-improve-research-synthesis.md
@@ -1,0 +1,109 @@
+# ChaosEngine Self-Improve — Research Synthesis
+
+Companion to [self-improve-master-plan.md](self-improve-master-plan.md).
+Dated (Africa/Cairo): 2026-09-08. Citations only — no always-on injection.
+
+## 2. Online research synthesis (cited)
+
+### 2.1 Context surfaces — put the right thing on the right primitive
+
+Sources:
+
+- https://amux.io/guides/context-engineering/
+- https://capitalandcompute.net/blog/claude-code-harness-guide/
+- https://next.redhat.com/2026/07/28/building-skills-for-ai-agents-pitfalls-and-best-practices/
+- https://agentskills.io/specification
+
+| Surface | Load | Enforce | CE mapping |
+| --- | --- | --- | --- |
+| AGENTS/CLAUDE.md | Every turn | Soft ~70% | Keep lean (&lt;~200–500 lines); pointers only |
+| Hooks | Event; **0 context unless output** | Hard 100% | Safety, Learning Session Stop, research gate |
+| Skills | Name+desc always; body on demand | Soft | Router + self-improve + companions |
+| Subagents | On spawn; isolated | Soft | Research/explore firewall |
+| Memory/stores | Locator / on demand | Soft | Wake pack locator; retrieve orchestrator |
+| MCP | Names cheap; schemas deferred | Tools | Prefer CLI when training-data CLI exists |
+
+**CE accept:** hooks for must-happen; skills for judgment; lean host md files.  
+**CE reject:** stuffing safety or Learning Session duty into AGENTS.md alone.
+
+### 2.2 HumanLayer harness lessons
+
+Sources:
+
+- https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents
+- https://www.humanlayer.dev/blog/context-efficient-backpressure
+- https://www.humanlayer.dev/blog/advanced-context-engineering
+- https://www.humanlayer.dev/blog/writing-a-good-claude-md
+
+1. **CLI over MCP** when CLI is in training data (gh, git, docker, …) — lower schema tax + composability (`jq`/`rg`).
+2. **Subagents for context isolation**, not role-play org charts.
+3. **Verification silent-on-success / errors-only** — swallow green test dumps; exit 2 on failure to re-engage.
+4. Hooks for control flow; Stop hooks for completion gates (maps directly to #5641).
+
+### 2.3 Hooks economics
+
+Sources: capitalandcompute harness guide; Anthropic hooks docs (`code.claude.com/docs/en/hooks-guide`); CE lifecycle-hooks.
+
+- SessionStart / Stop / PreToolUse run **outside** the conversation budget.
+- Stop is the right place for Learning Session and verify gates.
+- Aligns with CE: locator SessionStart; Learning Session on Stop (#5641); no always-on observer.
+
+### 2.4 Self-improve **without** always-on Task Observer
+
+Sources:
+
+- https://arxiv.org/pdf/2603.24639v2 (ERL — Experiential Reflective Learning)
+- https://arxiv.org/pdf/2604.17091 (GenericAgent density / layered memory)
+- https://arxiv.org/html/2604.07988 (LogAct shared logs + supervisor)
+- CE `research-adopt-reject.md` + #5643
+
+| Pattern | Token-safe shape for CE | Reject |
+| --- | --- | --- |
+| ERL heuristics | Post-task extract → store; **retrieve top-k once at task start** (locator + bounded) | Inject every turn / full SessionStart scan |
+| GenericAgent L0/L1 | Wake pack + Level-1 catalog; L2/L3 on demand | Always-on L2/L3 dumps |
+| LogAct supervisor | Shared structured logs (phase ledger, learning queue, `.memory`) → periodic meta-optimize | Continuous Task Observer |
+| SkillOpt | Offline compress SKILL.md (~90% volume cut reported by Red Hat ACE) with eval gate | Auto-mutate live skills |
+
+### 2.5 Maximum output, minimal / zero tokens — governing factors
+
+1. **Deterministic scripts & hooks** before LLM narration (Red Hat: scripts cut RCA cost ~26%).
+2. **Progressive disclosure** (L1/L2/L3) — description is the router.
+3. **Silent success** on verify (HumanLayer).
+4. **Fewer sharper tools / CLI&gt;MCP** (HumanLayer; Vercel tool-thinning lesson in prior dossier).
+5. **Shared logs → unique work** (LogAct: +17% work / −41% tokens with supervisor over logs — aspirational, not a CE claim of identical gains).
+6. **Measure then mutate** — metrics before growing prompts.
+7. **Issues-first durable encode** — portable overlay parity (#5645).
+
+Supporting dossier: `/workspace/agentic-harness-research.md` (Winder, Goose, OpenHands, Hermes, agentskills.io, Gu system-scaling).
+
+---
+
+## 7. Key online sources used
+
+1. https://amux.io/guides/context-engineering/
+2. https://capitalandcompute.net/blog/claude-code-harness-guide/
+3. https://next.redhat.com/2026/07/28/building-skills-for-ai-agents-pitfalls-and-best-practices/
+4. https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents
+5. https://www.humanlayer.dev/blog/context-efficient-backpressure
+6. https://www.humanlayer.dev/blog/advanced-context-engineering
+7. https://agentskills.io/specification
+8. https://arxiv.org/pdf/2603.24639v2 (ERL)
+9. https://arxiv.org/pdf/2604.17091 (GenericAgent)
+10. https://arxiv.org/html/2604.07988 (LogAct)
+11. https://github.com/microsoft/SkillOpt
+12. https://code.claude.com/docs/en/hooks-guide
+13. https://winder.ai/ai-agent-harness-comparison/ (prior dossier)
+14. Local: `/workspace/agentic-harness-research.md`, `/workspace/chaos-engine-top10-optimizations.md` (superseded)
+
+---
+
+## 8. Consult notes (optional Grok CLI)
+
+Captured `/tmp/ce-self-improve-consult.txt` (model host frontier model). Alignment with this plan:
+
+- Measure first (LogAct counters) before growing prompts.
+- Silent verify + CLI&gt;MCP + SkillOpt propose-only + ERL once-per-task.
+- Reaffirm reject always-on scanners / weekly auto-mutate.
+- Ordering tip from consult: metrics → silent verify → CLI&gt;MCP → submit hygiene → SkillOpt → ERL → eval ratchet → GAP-EXIT2 UX.
+
+---

--- a/chaos-engine/references/level-1-catalog.md
+++ b/chaos-engine/references/level-1-catalog.md
@@ -18,7 +18,7 @@ sorted. Each row is a name, ≤2-line Use-when, and a path — no workflow dumps
 | Eval-parity fixtures | Cross-host CE policy fixture suite | [`eval-parity-fixtures.md`](eval-parity-fixtures.md) |
 | Headroom | Max-savings wrap/proxy; Ponytail XOR OUTPUT_SHAPER | [`headroom.md`](headroom.md) |
 | Self-improve | Learning Session dual-track harness + product observations | [`../skills/self-improve/SKILL.md`](../skills/self-improve/SKILL.md) |
-| Self-improve master plan | Next-wave self-improve roadmap + Top 10 (post-#5641); supersedes 2026-09-07 opt top-10 | [`self-improve-master-plan.md`](self-improve-master-plan.md) |
+| Self-improve master plan | Next-wave self-improve roadmap + Top 10 (post-Learning Session Stop gate); profile may extend under `profiles/<product>/references/` | [`self-improve-master-plan.md`](self-improve-master-plan.md) |
 | OmniRoute | Optional local transport; never required for canonical workflows | [`../skills/omniroute/SKILL.md`](../skills/omniroute/SKILL.md) |
 
 Load **one** row when the core router points here; return to the core skill after

--- a/chaos-engine/references/level-1-catalog.md
+++ b/chaos-engine/references/level-1-catalog.md
@@ -18,6 +18,7 @@ sorted. Each row is a name, ≤2-line Use-when, and a path — no workflow dumps
 | Eval-parity fixtures | Cross-host CE policy fixture suite | [`eval-parity-fixtures.md`](eval-parity-fixtures.md) |
 | Headroom | Max-savings wrap/proxy; Ponytail XOR OUTPUT_SHAPER | [`headroom.md`](headroom.md) |
 | Self-improve | Learning Session dual-track harness + product observations | [`../skills/self-improve/SKILL.md`](../skills/self-improve/SKILL.md) |
+| Self-improve master plan | Next-wave self-improve roadmap + Top 10 (post-#5641); supersedes 2026-09-07 opt top-10 | [`self-improve-master-plan.md`](self-improve-master-plan.md) |
 | OmniRoute | Optional local transport; never required for canonical workflows | [`../skills/omniroute/SKILL.md`](../skills/omniroute/SKILL.md) |
 
 Load **one** row when the core router points here; return to the core skill after

--- a/chaos-engine/references/self-improve-master-plan.md
+++ b/chaos-engine/references/self-improve-master-plan.md
@@ -1,0 +1,323 @@
+# ChaosEngine Self-Improve Master Plan
+
+**Owner:** Mohab Mohie / ShaftHQ/SHAFT_ENGINE  
+**Dated (Africa/Cairo):** 2026-09-08  
+**Base tip:** `77a273d2a8` — `fix(ce): enforce Learning Session after every delivery (harness parity) (#5641)`  
+**Supersedes:** prior optimization top-10 at analysis SHA `0961058e66` / `/workspace/chaos-engine-top10-optimizations.md` (ideas #1–#10 landed as #5619–#5625 under epic #5618).  
+**Method:** tip deep-read of `skills/self-improve/**`, `learning.py`, Stop/Learning Session hooks, token/parity/delivery refs; online harness synthesis; optional Grok CLI consult (`/tmp/ce-self-improve-consult.txt`).  
+**Constraint:** NEVER Cursor Cloud Agents; merge commits only; portable overlay parity across Codex / Claude / Grok CLI / Gemini / Copilot / Grok Bot.
+
+---
+
+## 0. Locked prefs (do not reopen)
+
+| Pref | Status |
+| --- | --- |
+| NO native Task Observer / always-on observation | **Locked reject** (#5643; research-adopt-reject) |
+| Lean self-improve: SessionStart locator-only; Learning Session on delivery Stop | **Shipped** (#5641 / #5613) |
+| Harness parity across six hosts (overlay, not agent memory) | **Shipped policy** (#5645 / host-parity-matrix) |
+| One-command install/configure/update | **Shipped north star** (#5618 / #5620) |
+| Headroom `agent-90` default; Caveman + Ponytail | **Shipped** (#5613 / token-budget-modes) |
+| Issues-first self-improve; eval-gated draft skill PRs **opt-in later** | **Locked** (#5618 fork #5) |
+| Merge commits only | **Locked** |
+
+---
+
+## 1. Current-state assessment (post-#5641)
+
+### 1.1 What CE can already self-enhance
+
+| Loop | Product (SHAFT) | Harness (CE overlay) | Token profile |
+| --- | --- | --- | --- |
+| Capture | Dual-track Learning Session → `learning.py` queue → GitHub issues | Same path; categories allow-list; privacy gates | Heavy only on delivery Stop |
+| Enforce learn | Stop / delivery-complete owes Learning Session even if `chaos-engine/` untouched | Portable `learning_session.py` finalize + monorepo controller | Hook = 0 context unless block reason |
+| Discover surfaces | Level-1 catalog + router Heal / zero-LLM | SessionStart locators under `SESSION_START_MAX_BYTES=4096` | ↓ always-on |
+| Health / heal | Installer/doctor/repair components | `status ⊆ doctor`, `activationProof`, `repair --component` | Zero-LLM |
+| Delivery gates | Triage-scaled research + phase ledger | Stop Learning Session; catastrophic deny | Soft vs hard by triage |
+| Memory | Owner wake pack locator; retrieve orchestrator | Soft-degrade Memory/MemPalace/Graphify | No SessionStart prose dump |
+| Eval | Product CI / ChaosGauge | Eval-parity fixtures + host matrix | CI, not chat |
+
+### 1.2 Dual-track self-improve ability (honest)
+
+**Strengths**
+
+- Stop-gated Learning Session is **deterministic** (hook), not prompt hope — aligns with industry “hooks = 100% enforce, 0 context unless output.”
+- Issues-first + privacy-gated `learning.py` is a durable LogAct-like append log (queue → GitHub), not transcript hoarding.
+- Progressive disclosure skeleton exists: Level-1 catalog, locator SessionStart, on-demand self-improve refs.
+- Optimization program #5618 children (#5619–#5625) closed the prior top-10 (health truth, repair, zero-LLM locator, L1 catalog, triage research+ledger, wake+retrieve, eval-parity+portable finalize).
+
+**Gaps (self-improve-specific — this plan’s focus)**
+
+1. **No closed-loop metrics:** queued → submitted → adopted/rejected → estimatedTokens delta is not machine-summarized for doctor/zero-LLM.
+2. **No once-per-task heuristic retrieve:** lessons live in issues/`.memory` but are not ERL-style top-k retrieved at triage (still avoid every-turn injection).
+3. **Verification dumps still risk token rot:** Check/Stop paths lack a universal silent-on-success / errors-only wrapper contract.
+4. **Skill body bloat risk:** no SkillOpt-style compression/eval gate before growing SKILL.md (L2 <500 lines discipline is documented, not automated).
+5. **CLI vs MCP preference** is tribal in places; HumanLayer lesson not yet an iron-law + zero-LLM catalog row.
+6. **Significance filter for mid-session capture** is skill-discipline only — easy to miss under Caveman ultra (without becoming Task Observer).
+7. **Phase-2 eval-gated draft skill PRs** still deferred (correct) but needs a ready gate checklist.
+8. **Product-track playbook** thinner than harness track (taxonomy exists; SHAFT-specific acceptance/eval linkage weak).
+9. **GAP-EXIT2** still soft on Grok/Copilot — compensating UX exists; not a self-improve blocker but limits Stop-gate fidelity.
+10. **Periodic meta-optimize** (supervisor over shared logs) not scheduled — only per-delivery Learning Session.
+
+### 1.3 Gap analysis vs #5641
+
+| #5641 deliverable | Status | Remaining self-improve work |
+| --- | --- | --- |
+| Merge/delivery → Learning Session owed | Shipped | Metrics that prove sessions actually queue/submit |
+| Docs forbid CE-untouched skip | Shipped | Product-track yield reporting |
+| Harness parity in overlay | Shipped | Encode new lessons as hooks/skills/scripts, never agent-only memory |
+| SessionStart locator-only | Shipped | Keep; add **locator** to heuristic index only (no prose) |
+| Unit tests for merge→Stop | Shipped | Expand fixtures for metrics + silent-verify + heuristic retrieve |
+
+**Verdict:** #5641 closed the **enforcement** gap. This plan closes the **yield / token-efficiency / closed-loop** gap for both product and harness.
+
+---
+
+## 2. Online research synthesis (cited)
+
+### 2.1 Context surfaces — put the right thing on the right primitive
+
+Sources:
+
+- https://amux.io/guides/context-engineering/
+- https://capitalandcompute.net/blog/claude-code-harness-guide/
+- https://next.redhat.com/2026/07/28/building-skills-for-ai-agents-pitfalls-and-best-practices/
+- https://agentskills.io/specification
+
+| Surface | Load | Enforce | CE mapping |
+| --- | --- | --- | --- |
+| AGENTS/CLAUDE.md | Every turn | Soft ~70% | Keep lean (&lt;~200–500 lines); pointers only |
+| Hooks | Event; **0 context unless output** | Hard 100% | Safety, Learning Session Stop, research gate |
+| Skills | Name+desc always; body on demand | Soft | Router + self-improve + companions |
+| Subagents | On spawn; isolated | Soft | Research/explore firewall |
+| Memory/stores | Locator / on demand | Soft | Wake pack locator; retrieve orchestrator |
+| MCP | Names cheap; schemas deferred | Tools | Prefer CLI when training-data CLI exists |
+
+**CE accept:** hooks for must-happen; skills for judgment; lean host md files.  
+**CE reject:** stuffing safety or Learning Session duty into AGENTS.md alone.
+
+### 2.2 HumanLayer harness lessons
+
+Sources:
+
+- https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents
+- https://www.humanlayer.dev/blog/context-efficient-backpressure
+- https://www.humanlayer.dev/blog/advanced-context-engineering
+- https://www.humanlayer.dev/blog/writing-a-good-claude-md
+
+1. **CLI over MCP** when CLI is in training data (gh, git, docker, …) — lower schema tax + composability (`jq`/`rg`).
+2. **Subagents for context isolation**, not role-play org charts.
+3. **Verification silent-on-success / errors-only** — swallow green test dumps; exit 2 on failure to re-engage.
+4. Hooks for control flow; Stop hooks for completion gates (maps directly to #5641).
+
+### 2.3 Hooks economics
+
+Sources: capitalandcompute harness guide; Anthropic hooks docs (`code.claude.com/docs/en/hooks-guide`); CE lifecycle-hooks.
+
+- SessionStart / Stop / PreToolUse run **outside** the conversation budget.
+- Stop is the right place for Learning Session and verify gates.
+- Aligns with CE: locator SessionStart; Learning Session on Stop (#5641); no always-on observer.
+
+### 2.4 Self-improve **without** always-on Task Observer
+
+Sources:
+
+- https://arxiv.org/pdf/2603.24639v2 (ERL — Experiential Reflective Learning)
+- https://arxiv.org/pdf/2604.17091 (GenericAgent density / layered memory)
+- https://arxiv.org/html/2604.07988 (LogAct shared logs + supervisor)
+- CE `research-adopt-reject.md` + #5643
+
+| Pattern | Token-safe shape for CE | Reject |
+| --- | --- | --- |
+| ERL heuristics | Post-task extract → store; **retrieve top-k once at task start** (locator + bounded) | Inject every turn / full SessionStart scan |
+| GenericAgent L0/L1 | Wake pack + Level-1 catalog; L2/L3 on demand | Always-on L2/L3 dumps |
+| LogAct supervisor | Shared structured logs (phase ledger, learning queue, `.memory`) → periodic meta-optimize | Continuous Task Observer |
+| SkillOpt | Offline compress SKILL.md (~90% volume cut reported by Red Hat ACE) with eval gate | Auto-mutate live skills |
+
+### 2.5 Maximum output, minimal / zero tokens — governing factors
+
+1. **Deterministic scripts & hooks** before LLM narration (Red Hat: scripts cut RCA cost ~26%).
+2. **Progressive disclosure** (L1/L2/L3) — description is the router.
+3. **Silent success** on verify (HumanLayer).
+4. **Fewer sharper tools / CLI&gt;MCP** (HumanLayer; Vercel tool-thinning lesson in prior dossier).
+5. **Shared logs → unique work** (LogAct: +17% work / −41% tokens with supervisor over logs — aspirational, not a CE claim of identical gains).
+6. **Measure then mutate** — metrics before growing prompts.
+7. **Issues-first durable encode** — portable overlay parity (#5645).
+
+Supporting dossier: `/workspace/agentic-harness-research.md` (Winder, Goose, OpenHands, Hermes, agentskills.io, Gu system-scaling).
+
+---
+
+## 3. Master roadmap waves (self-improve next)
+
+Dependency order. **Do not** re-implement #5619–#5625.
+
+```
+Wave S0 — Measure (zero/low LLM)
+  [#1 Learning metrics closed loop]
+
+Wave S1 — Token sinks on the hot path
+  [#2 Silent-on-success verify] → [#5 CLI-over-MCP iron law]
+       ↘ [#3 ERL once-per-task heuristics]
+
+Wave S2 — Capture quality without Observer
+  [#4 Significance-filtered mid-session capture] → [#6 SkillOpt compress audit]
+
+Wave S3 — Isolation & product yield
+  [#7 Subagent research firewall guidance] → [#10 Product-track playbook + ChaosGauge link]
+
+Wave S4 — Close the mutate loop (opt-in)
+  [#9 Periodic meta-optimize] → [#8 Eval-gated draft skill PRs (opt-in)]
+```
+
+**Out of scope forever (unless prefs unlock):** always-on SessionStart full skill/frontmatter scan; native Task Observer; auto-merge skill mutations; pretending GAP-EXIT2 hard process blocks.
+
+---
+
+## 4. Top 10 recommendations (ranked)
+
+Each item: why · token impact · dependency · proposed CE shape · Task Observer accept/reject.
+
+### 1. Learning metrics closed loop (queued → adopted → token delta)
+
+- **Why:** LogAct shows shared structured logs + light supervisor yield more unique work at lower tokens. CE already appends via `learning.py` / `.memory` / phase ledger but does not summarize adoption.
+- **Token impact:** ↓↓ (zero-LLM doctor/CLI; avoids re-discovering known lessons)
+- **Dependency:** none (S0)
+- **CE shape:** `learning.py metrics|summary` + `doctor --json.learningMetrics` fields: queued, submitted, open/closed issues, estimatedTokens sum, optional adopt/reject labels; link issue numbers only.
+- **vs Task Observer:** **Reject Observer.** Metrics are offline/zero-LLM over existing logs.
+
+### 2. Silent-on-success / errors-only verification wrappers
+
+- **Why:** HumanLayer: green test dumps rotate agents into the dumb zone; success must add **zero** context.
+- **Token impact:** ↓↓↓ on Check/Stop
+- **Dependency:** after #1 optional; independent OK
+- **CE shape:** `references/silent-verify.md` + thin `scripts`/`chaos-engine` helper used by delivery Check + optional Stop verify; exit 0 → no stdout; fail → stderr + exit 2 where honored.
+- **vs Task Observer:** **Reject Observer.** Pure hook/script back-pressure.
+
+### 3. ERL-style heuristic retrieve once per task (not every turn)
+
+- **Why:** ERL: post-task heuristics + top-k inject at **new task start** beats always-on observation.
+- **Token impact:** ↓ always-on; slight ↑ once at triage (bounded top-k, privacy-safe)
+- **Dependency:** prefers #1 metrics for ranking; wake pack / retrieve patterns (#5624)
+- **CE shape:** `.chaos-engine-state/heuristics/` or Memory category; SessionStart **locator only**; triage/router calls `retrieve.py heuristics --top 3` once; never PreToolUse spam.
+- **vs Task Observer:** **Reject Observer.** Adopt ERL retrieve-once; reject continuous scan (#5643).
+
+### 4. Significance-filtered mid-session capture (skill + optional soft PostToolUse)
+
+- **Why:** Under Caveman ultra, dual-track capture is easy to miss until Stop; need cheap friction marks without full observation protocol.
+- **Token impact:** ↓ vs batching failures; ↑ tiny if soft hook emits one-line marks
+- **Dependency:** taxonomy + learning.py; must not load self-improve refs mid-turn
+- **CE shape:** optional PostToolUse recorder for deny/fail signatures → state file; Learning Session reads marks. Default off or ultra-cheap. Significance filter: errors, repeated denials, doctor recovery — not every edit.
+- **vs Task Observer:** **Reject Observer.** Filter + deferred heavy path only.
+
+### 5. CLI-over-MCP preference (iron law + zero-LLM catalog)
+
+- **Why:** HumanLayer: CLI in training data beats MCP schema tax for gh/git/docker/db.
+- **Token impact:** ↓↓ system prompt + tool-result size
+- **Dependency:** zero-llm-catalog / Level-1 (#5621/#5622)
+- **CE shape:** router iron-law row + catalog entries; MCP only when no equivalent CLI; Headroom/MCP remain for compression/proxy cases.
+- **vs Task Observer:** N/A (tooling policy).
+
+### 6. SkillOpt-style SKILL.md compression audit (propose, don’t auto-apply)
+
+- **Why:** Red Hat ACE / SkillOpt: ~90% volume cut with quality preserved in experiments; L2 &lt;500 lines.
+- **Token impact:** ↓↓ on skill activation
+- **Dependency:** eval-parity (#5625); metrics #1 help prioritize which skills
+- **CE shape:** offline CLI proposing compressed SKILL.md + refs split; CI eval gate; issues-first PR by human. No live auto-edit.
+- **vs Task Observer:** **Reject auto-mutate.** Aligns with issues-first / opt-in draft PRs later.
+
+### 7. Subagent / context-firewall guidance for research & explore
+
+- **Why:** HumanLayer + capitalandcompute: isolation keeps parent in smart zone; explore noise stays in child.
+- **Token impact:** ↓ parent context (child spend may ↑ — net quality win)
+- **Dependency:** host adapters; local-coding-delegate / omniroute optional
+- **CE shape:** short Level-1 + router rule: research/multi-file explore → subagent/Task when host supports; return filepath:line citations only.
+- **vs Task Observer:** N/A.
+
+### 8. Eval-gated draft skill PRs — **opt-in phase 2**
+
+- **Why:** Hermes/SkillOpt closed loops need eval; CE locked issues-first until ready.
+- **Token impact:** ↑ CI only; ↓ bad skill merges long-term
+- **Dependency:** #1 metrics, #6 compress, #5625 fixtures green, portable finalize stable
+- **CE shape:** flag `CHAOS_ENGINE_SELF_IMPROVE_DRAFT_PR=1`; draft PR from staged branch after eval-parity + unit tests; never auto-merge.
+- **vs Task Observer:** **Reject Observer.** Opt-in mutate path only after eval.
+
+### 9. Periodic meta-optimize over shared logs (not continuous)
+
+- **Why:** LogAct supervisor: periodic introspection of shared logs beats per-turn gossip.
+- **Token impact:** ↓ vs continuous; bounded scheduled LLM or zero-LLM cluster
+- **Dependency:** #1 metrics; Learning Session history
+- **CE shape:** operator `/learning meta` or weekly script clustering open learning issues + `.memory` facts → ranked backlog issue; no SessionStart involvement.
+- **vs Task Observer:** **Reject Observer.** Periodic only.
+
+### 10. Product-track self-improve playbook (SHAFT + ChaosGauge)
+
+- **Why:** Dual-track requires equal product discipline; recent #5644/#5646/#5647 show product lessons already valuable.
+- **Token impact:** ↓ rediscovery; slight ↑ at Learning Session when product work occurred
+- **Dependency:** taxonomy; metrics #1; silent-verify #2 for product Check
+- **CE shape:** `skills/self-improve/references/product-track.md` — issue templates, link tests/ChaosGauge, prefer CLI/doctor/silent-verify product fixes over essay tickets.
+- **vs Task Observer:** **Reject Observer.** Delivery-Stop capture only.
+
+---
+
+## 5. Accept / reject matrix (Task Observer principles)
+
+| Principle | Decision | CE encoding |
+| --- | --- | --- |
+| Always-on SessionStart full scan | **REJECT** | Locator-only; `SESSION_START_MAX_BYTES` |
+| Continuous observation every turn | **REJECT** | #5643; research-adopt-reject |
+| Lean core + on-demand refs | **ACCEPT** | self-improve SKILL + references |
+| Capture vs review split | **ACCEPT** | queue now; human/CI apply later |
+| Dual-track harness + product | **ACCEPT** | taxonomy + Learning Session checklist |
+| Auto-stage / auto-install skill patches | **REJECT** (phase-2 draft PR opt-in only) | learning.py issues-first |
+| Weekly auto-mutate live skills | **REJECT** | meta-optimize proposes backlog only |
+| Post-delivery Learning Session gate | **ACCEPT** | #5641 Stop hooks |
+| ERL retrieve-once heuristics | **ACCEPT (adapted)** | Top 10 #3 |
+| LogAct metrics / periodic supervisor | **ACCEPT (adapted)** | Top 10 #1 #9 |
+| Silent-on-success verify | **ACCEPT** | Top 10 #2 |
+
+---
+
+## 6. Implementation notes (when executing children)
+
+1. Prefer **one condensed PR per wave** (S0→S4); children under the epic; `Fixes #<child>` never the epic.
+2. Every lasting behavior → portable `chaos-engine/` (hooks/skills/scripts/doctor) + host adapters as needed — **harness parity**.
+3. Expand eval-parity fixtures when adding gates; never weaken fixtures.
+4. Keep Headroom `agent-90` / Ponytail XOR OUTPUT_SHAPER / Caveman ultra.
+5. No Cursor Cloud Agents for implementation workstreams.
+
+---
+
+## 7. Key online sources used
+
+1. https://amux.io/guides/context-engineering/
+2. https://capitalandcompute.net/blog/claude-code-harness-guide/
+3. https://next.redhat.com/2026/07/28/building-skills-for-ai-agents-pitfalls-and-best-practices/
+4. https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents
+5. https://www.humanlayer.dev/blog/context-efficient-backpressure
+6. https://www.humanlayer.dev/blog/advanced-context-engineering
+7. https://agentskills.io/specification
+8. https://arxiv.org/pdf/2603.24639v2 (ERL)
+9. https://arxiv.org/pdf/2604.17091 (GenericAgent)
+10. https://arxiv.org/html/2604.07988 (LogAct)
+11. https://github.com/microsoft/SkillOpt
+12. https://code.claude.com/docs/en/hooks-guide
+13. https://winder.ai/ai-agent-harness-comparison/ (prior dossier)
+14. Local: `/workspace/agentic-harness-research.md`, `/workspace/chaos-engine-top10-optimizations.md` (superseded)
+
+---
+
+## 8. Consult notes (optional Grok CLI)
+
+Captured `/tmp/ce-self-improve-consult.txt` (model `grok-4.5`). Alignment with this plan:
+
+- Measure first (LogAct counters) before growing prompts.
+- Silent verify + CLI&gt;MCP + SkillOpt propose-only + ERL once-per-task.
+- Reaffirm reject always-on scanners / weekly auto-mutate.
+- Ordering tip from consult: metrics → silent verify → CLI&gt;MCP → submit hygiene → SkillOpt → ERL → eval ratchet → GAP-EXIT2 UX.
+
+---
+
+## 9. Supersession notice
+
+The 2026-09-07 dependency-ranked top-10 (health plane → repair → zero-LLM locator → L1 catalog → research ledger → wake/retrieve → Headroom/budget → eval-gated improve → fixtures → Heal/GAP-EXIT2) is **complete** via #5619–#5625 + #5641. **Do not reopen those tickets.** Track new work from **§4 Top 10** under the self-improve epic filed alongside this document.

--- a/chaos-engine/references/self-improve-master-plan.md
+++ b/chaos-engine/references/self-improve-master-plan.md
@@ -1,323 +1,63 @@
-# ChaosEngine Self-Improve Master Plan
+# ChaosEngine Self-Improve Master Plan (portable)
 
-**Owner:** Mohab Mohie / ShaftHQ/SHAFT_ENGINE  
 **Dated (Africa/Cairo):** 2026-09-08  
-**Base tip:** `77a273d2a8` — `fix(ce): enforce Learning Session after every delivery (harness parity) (#5641)`  
-**Supersedes:** prior optimization top-10 at analysis SHA `0961058e66` / `/workspace/chaos-engine-top10-optimizations.md` (ideas #1–#10 landed as #5619–#5625 under epic #5618).  
-**Method:** tip deep-read of `skills/self-improve/**`, `learning.py`, Stop/Learning Session hooks, token/parity/delivery refs; online harness synthesis; optional Grok CLI consult (`/tmp/ce-self-improve-consult.txt`).  
-**Constraint:** NEVER Cursor Cloud Agents; merge commits only; portable overlay parity across Codex / Claude / Grok CLI / Gemini / Copilot / Grok Bot.
+**Base tip context:** Learning Session Stop gate after every delivery (harness parity).  
+**Supersedes:** 2026-09-07 optimization top-10 (landed as installer/heal/router/memory/learn program children).
 
----
+Adopter products that ship a profile-specific copy (for example under
+`profiles/<product>/references/`) may extend this plan with product-track
+detail. This portable file stays free of product-locked tokens.
 
-## 0. Locked prefs (do not reopen)
+## Locked prefs
 
 | Pref | Status |
 | --- | --- |
-| NO native Task Observer / always-on observation | **Locked reject** (#5643; research-adopt-reject) |
-| Lean self-improve: SessionStart locator-only; Learning Session on delivery Stop | **Shipped** (#5641 / #5613) |
-| Harness parity across six hosts (overlay, not agent memory) | **Shipped policy** (#5645 / host-parity-matrix) |
-| One-command install/configure/update | **Shipped north star** (#5618 / #5620) |
-| Headroom `agent-90` default; Caveman + Ponytail | **Shipped** (#5613 / token-budget-modes) |
-| Issues-first self-improve; eval-gated draft skill PRs **opt-in later** | **Locked** (#5618 fork #5) |
-| Merge commits only | **Locked** |
-
----
-
-## 1. Current-state assessment (post-#5641)
-
-### 1.1 What CE can already self-enhance
-
-| Loop | Product (SHAFT) | Harness (CE overlay) | Token profile |
-| --- | --- | --- | --- |
-| Capture | Dual-track Learning Session → `learning.py` queue → GitHub issues | Same path; categories allow-list; privacy gates | Heavy only on delivery Stop |
-| Enforce learn | Stop / delivery-complete owes Learning Session even if `chaos-engine/` untouched | Portable `learning_session.py` finalize + monorepo controller | Hook = 0 context unless block reason |
-| Discover surfaces | Level-1 catalog + router Heal / zero-LLM | SessionStart locators under `SESSION_START_MAX_BYTES=4096` | ↓ always-on |
-| Health / heal | Installer/doctor/repair components | `status ⊆ doctor`, `activationProof`, `repair --component` | Zero-LLM |
-| Delivery gates | Triage-scaled research + phase ledger | Stop Learning Session; catastrophic deny | Soft vs hard by triage |
-| Memory | Owner wake pack locator; retrieve orchestrator | Soft-degrade Memory/MemPalace/Graphify | No SessionStart prose dump |
-| Eval | Product CI / ChaosGauge | Eval-parity fixtures + host matrix | CI, not chat |
-
-### 1.2 Dual-track self-improve ability (honest)
-
-**Strengths**
-
-- Stop-gated Learning Session is **deterministic** (hook), not prompt hope — aligns with industry “hooks = 100% enforce, 0 context unless output.”
-- Issues-first + privacy-gated `learning.py` is a durable LogAct-like append log (queue → GitHub), not transcript hoarding.
-- Progressive disclosure skeleton exists: Level-1 catalog, locator SessionStart, on-demand self-improve refs.
-- Optimization program #5618 children (#5619–#5625) closed the prior top-10 (health truth, repair, zero-LLM locator, L1 catalog, triage research+ledger, wake+retrieve, eval-parity+portable finalize).
-
-**Gaps (self-improve-specific — this plan’s focus)**
-
-1. **No closed-loop metrics:** queued → submitted → adopted/rejected → estimatedTokens delta is not machine-summarized for doctor/zero-LLM.
-2. **No once-per-task heuristic retrieve:** lessons live in issues/`.memory` but are not ERL-style top-k retrieved at triage (still avoid every-turn injection).
-3. **Verification dumps still risk token rot:** Check/Stop paths lack a universal silent-on-success / errors-only wrapper contract.
-4. **Skill body bloat risk:** no SkillOpt-style compression/eval gate before growing SKILL.md (L2 <500 lines discipline is documented, not automated).
-5. **CLI vs MCP preference** is tribal in places; HumanLayer lesson not yet an iron-law + zero-LLM catalog row.
-6. **Significance filter for mid-session capture** is skill-discipline only — easy to miss under Caveman ultra (without becoming Task Observer).
-7. **Phase-2 eval-gated draft skill PRs** still deferred (correct) but needs a ready gate checklist.
-8. **Product-track playbook** thinner than harness track (taxonomy exists; SHAFT-specific acceptance/eval linkage weak).
-9. **GAP-EXIT2** still soft on Grok/Copilot — compensating UX exists; not a self-improve blocker but limits Stop-gate fidelity.
-10. **Periodic meta-optimize** (supervisor over shared logs) not scheduled — only per-delivery Learning Session.
-
-### 1.3 Gap analysis vs #5641
-
-| #5641 deliverable | Status | Remaining self-improve work |
-| --- | --- | --- |
-| Merge/delivery → Learning Session owed | Shipped | Metrics that prove sessions actually queue/submit |
-| Docs forbid CE-untouched skip | Shipped | Product-track yield reporting |
-| Harness parity in overlay | Shipped | Encode new lessons as hooks/skills/scripts, never agent-only memory |
-| SessionStart locator-only | Shipped | Keep; add **locator** to heuristic index only (no prose) |
-| Unit tests for merge→Stop | Shipped | Expand fixtures for metrics + silent-verify + heuristic retrieve |
-
-**Verdict:** #5641 closed the **enforcement** gap. This plan closes the **yield / token-efficiency / closed-loop** gap for both product and harness.
-
----
-
-## 2. Online research synthesis (cited)
-
-### 2.1 Context surfaces — put the right thing on the right primitive
-
-Sources:
-
-- https://amux.io/guides/context-engineering/
-- https://capitalandcompute.net/blog/claude-code-harness-guide/
-- https://next.redhat.com/2026/07/28/building-skills-for-ai-agents-pitfalls-and-best-practices/
-- https://agentskills.io/specification
-
-| Surface | Load | Enforce | CE mapping |
-| --- | --- | --- | --- |
-| AGENTS/CLAUDE.md | Every turn | Soft ~70% | Keep lean (&lt;~200–500 lines); pointers only |
-| Hooks | Event; **0 context unless output** | Hard 100% | Safety, Learning Session Stop, research gate |
-| Skills | Name+desc always; body on demand | Soft | Router + self-improve + companions |
-| Subagents | On spawn; isolated | Soft | Research/explore firewall |
-| Memory/stores | Locator / on demand | Soft | Wake pack locator; retrieve orchestrator |
-| MCP | Names cheap; schemas deferred | Tools | Prefer CLI when training-data CLI exists |
-
-**CE accept:** hooks for must-happen; skills for judgment; lean host md files.  
-**CE reject:** stuffing safety or Learning Session duty into AGENTS.md alone.
-
-### 2.2 HumanLayer harness lessons
-
-Sources:
-
-- https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents
-- https://www.humanlayer.dev/blog/context-efficient-backpressure
-- https://www.humanlayer.dev/blog/advanced-context-engineering
-- https://www.humanlayer.dev/blog/writing-a-good-claude-md
-
-1. **CLI over MCP** when CLI is in training data (gh, git, docker, …) — lower schema tax + composability (`jq`/`rg`).
-2. **Subagents for context isolation**, not role-play org charts.
-3. **Verification silent-on-success / errors-only** — swallow green test dumps; exit 2 on failure to re-engage.
-4. Hooks for control flow; Stop hooks for completion gates (maps directly to #5641).
-
-### 2.3 Hooks economics
-
-Sources: capitalandcompute harness guide; Anthropic hooks docs (`code.claude.com/docs/en/hooks-guide`); CE lifecycle-hooks.
-
-- SessionStart / Stop / PreToolUse run **outside** the conversation budget.
-- Stop is the right place for Learning Session and verify gates.
-- Aligns with CE: locator SessionStart; Learning Session on Stop (#5641); no always-on observer.
-
-### 2.4 Self-improve **without** always-on Task Observer
-
-Sources:
-
-- https://arxiv.org/pdf/2603.24639v2 (ERL — Experiential Reflective Learning)
-- https://arxiv.org/pdf/2604.17091 (GenericAgent density / layered memory)
-- https://arxiv.org/html/2604.07988 (LogAct shared logs + supervisor)
-- CE `research-adopt-reject.md` + #5643
-
-| Pattern | Token-safe shape for CE | Reject |
-| --- | --- | --- |
-| ERL heuristics | Post-task extract → store; **retrieve top-k once at task start** (locator + bounded) | Inject every turn / full SessionStart scan |
-| GenericAgent L0/L1 | Wake pack + Level-1 catalog; L2/L3 on demand | Always-on L2/L3 dumps |
-| LogAct supervisor | Shared structured logs (phase ledger, learning queue, `.memory`) → periodic meta-optimize | Continuous Task Observer |
-| SkillOpt | Offline compress SKILL.md (~90% volume cut reported by Red Hat ACE) with eval gate | Auto-mutate live skills |
-
-### 2.5 Maximum output, minimal / zero tokens — governing factors
-
-1. **Deterministic scripts & hooks** before LLM narration (Red Hat: scripts cut RCA cost ~26%).
-2. **Progressive disclosure** (L1/L2/L3) — description is the router.
-3. **Silent success** on verify (HumanLayer).
-4. **Fewer sharper tools / CLI&gt;MCP** (HumanLayer; Vercel tool-thinning lesson in prior dossier).
-5. **Shared logs → unique work** (LogAct: +17% work / −41% tokens with supervisor over logs — aspirational, not a CE claim of identical gains).
-6. **Measure then mutate** — metrics before growing prompts.
-7. **Issues-first durable encode** — portable overlay parity (#5645).
-
-Supporting dossier: `/workspace/agentic-harness-research.md` (Winder, Goose, OpenHands, Hermes, agentskills.io, Gu system-scaling).
-
----
-
-## 3. Master roadmap waves (self-improve next)
-
-Dependency order. **Do not** re-implement #5619–#5625.
-
-```
-Wave S0 — Measure (zero/low LLM)
-  [#1 Learning metrics closed loop]
-
-Wave S1 — Token sinks on the hot path
-  [#2 Silent-on-success verify] → [#5 CLI-over-MCP iron law]
-       ↘ [#3 ERL once-per-task heuristics]
-
-Wave S2 — Capture quality without Observer
-  [#4 Significance-filtered mid-session capture] → [#6 SkillOpt compress audit]
-
-Wave S3 — Isolation & product yield
-  [#7 Subagent research firewall guidance] → [#10 Product-track playbook + ChaosGauge link]
-
-Wave S4 — Close the mutate loop (opt-in)
-  [#9 Periodic meta-optimize] → [#8 Eval-gated draft skill PRs (opt-in)]
-```
-
-**Out of scope forever (unless prefs unlock):** always-on SessionStart full skill/frontmatter scan; native Task Observer; auto-merge skill mutations; pretending GAP-EXIT2 hard process blocks.
-
----
-
-## 4. Top 10 recommendations (ranked)
-
-Each item: why · token impact · dependency · proposed CE shape · Task Observer accept/reject.
-
-### 1. Learning metrics closed loop (queued → adopted → token delta)
-
-- **Why:** LogAct shows shared structured logs + light supervisor yield more unique work at lower tokens. CE already appends via `learning.py` / `.memory` / phase ledger but does not summarize adoption.
-- **Token impact:** ↓↓ (zero-LLM doctor/CLI; avoids re-discovering known lessons)
-- **Dependency:** none (S0)
-- **CE shape:** `learning.py metrics|summary` + `doctor --json.learningMetrics` fields: queued, submitted, open/closed issues, estimatedTokens sum, optional adopt/reject labels; link issue numbers only.
-- **vs Task Observer:** **Reject Observer.** Metrics are offline/zero-LLM over existing logs.
-
-### 2. Silent-on-success / errors-only verification wrappers
-
-- **Why:** HumanLayer: green test dumps rotate agents into the dumb zone; success must add **zero** context.
-- **Token impact:** ↓↓↓ on Check/Stop
-- **Dependency:** after #1 optional; independent OK
-- **CE shape:** `references/silent-verify.md` + thin `scripts`/`chaos-engine` helper used by delivery Check + optional Stop verify; exit 0 → no stdout; fail → stderr + exit 2 where honored.
-- **vs Task Observer:** **Reject Observer.** Pure hook/script back-pressure.
-
-### 3. ERL-style heuristic retrieve once per task (not every turn)
-
-- **Why:** ERL: post-task heuristics + top-k inject at **new task start** beats always-on observation.
-- **Token impact:** ↓ always-on; slight ↑ once at triage (bounded top-k, privacy-safe)
-- **Dependency:** prefers #1 metrics for ranking; wake pack / retrieve patterns (#5624)
-- **CE shape:** `.chaos-engine-state/heuristics/` or Memory category; SessionStart **locator only**; triage/router calls `retrieve.py heuristics --top 3` once; never PreToolUse spam.
-- **vs Task Observer:** **Reject Observer.** Adopt ERL retrieve-once; reject continuous scan (#5643).
-
-### 4. Significance-filtered mid-session capture (skill + optional soft PostToolUse)
-
-- **Why:** Under Caveman ultra, dual-track capture is easy to miss until Stop; need cheap friction marks without full observation protocol.
-- **Token impact:** ↓ vs batching failures; ↑ tiny if soft hook emits one-line marks
-- **Dependency:** taxonomy + learning.py; must not load self-improve refs mid-turn
-- **CE shape:** optional PostToolUse recorder for deny/fail signatures → state file; Learning Session reads marks. Default off or ultra-cheap. Significance filter: errors, repeated denials, doctor recovery — not every edit.
-- **vs Task Observer:** **Reject Observer.** Filter + deferred heavy path only.
-
-### 5. CLI-over-MCP preference (iron law + zero-LLM catalog)
-
-- **Why:** HumanLayer: CLI in training data beats MCP schema tax for gh/git/docker/db.
-- **Token impact:** ↓↓ system prompt + tool-result size
-- **Dependency:** zero-llm-catalog / Level-1 (#5621/#5622)
-- **CE shape:** router iron-law row + catalog entries; MCP only when no equivalent CLI; Headroom/MCP remain for compression/proxy cases.
-- **vs Task Observer:** N/A (tooling policy).
-
-### 6. SkillOpt-style SKILL.md compression audit (propose, don’t auto-apply)
-
-- **Why:** Red Hat ACE / SkillOpt: ~90% volume cut with quality preserved in experiments; L2 &lt;500 lines.
-- **Token impact:** ↓↓ on skill activation
-- **Dependency:** eval-parity (#5625); metrics #1 help prioritize which skills
-- **CE shape:** offline CLI proposing compressed SKILL.md + refs split; CI eval gate; issues-first PR by human. No live auto-edit.
-- **vs Task Observer:** **Reject auto-mutate.** Aligns with issues-first / opt-in draft PRs later.
-
-### 7. Subagent / context-firewall guidance for research & explore
-
-- **Why:** HumanLayer + capitalandcompute: isolation keeps parent in smart zone; explore noise stays in child.
-- **Token impact:** ↓ parent context (child spend may ↑ — net quality win)
-- **Dependency:** host adapters; local-coding-delegate / omniroute optional
-- **CE shape:** short Level-1 + router rule: research/multi-file explore → subagent/Task when host supports; return filepath:line citations only.
-- **vs Task Observer:** N/A.
-
-### 8. Eval-gated draft skill PRs — **opt-in phase 2**
-
-- **Why:** Hermes/SkillOpt closed loops need eval; CE locked issues-first until ready.
-- **Token impact:** ↑ CI only; ↓ bad skill merges long-term
-- **Dependency:** #1 metrics, #6 compress, #5625 fixtures green, portable finalize stable
-- **CE shape:** flag `CHAOS_ENGINE_SELF_IMPROVE_DRAFT_PR=1`; draft PR from staged branch after eval-parity + unit tests; never auto-merge.
-- **vs Task Observer:** **Reject Observer.** Opt-in mutate path only after eval.
-
-### 9. Periodic meta-optimize over shared logs (not continuous)
-
-- **Why:** LogAct supervisor: periodic introspection of shared logs beats per-turn gossip.
-- **Token impact:** ↓ vs continuous; bounded scheduled LLM or zero-LLM cluster
-- **Dependency:** #1 metrics; Learning Session history
-- **CE shape:** operator `/learning meta` or weekly script clustering open learning issues + `.memory` facts → ranked backlog issue; no SessionStart involvement.
-- **vs Task Observer:** **Reject Observer.** Periodic only.
-
-### 10. Product-track self-improve playbook (SHAFT + ChaosGauge)
-
-- **Why:** Dual-track requires equal product discipline; recent #5644/#5646/#5647 show product lessons already valuable.
-- **Token impact:** ↓ rediscovery; slight ↑ at Learning Session when product work occurred
-- **Dependency:** taxonomy; metrics #1; silent-verify #2 for product Check
-- **CE shape:** `skills/self-improve/references/product-track.md` — issue templates, link tests/ChaosGauge, prefer CLI/doctor/silent-verify product fixes over essay tickets.
-- **vs Task Observer:** **Reject Observer.** Delivery-Stop capture only.
-
----
-
-## 5. Accept / reject matrix (Task Observer principles)
-
-| Principle | Decision | CE encoding |
-| --- | --- | --- |
-| Always-on SessionStart full scan | **REJECT** | Locator-only; `SESSION_START_MAX_BYTES` |
-| Continuous observation every turn | **REJECT** | #5643; research-adopt-reject |
-| Lean core + on-demand refs | **ACCEPT** | self-improve SKILL + references |
-| Capture vs review split | **ACCEPT** | queue now; human/CI apply later |
-| Dual-track harness + product | **ACCEPT** | taxonomy + Learning Session checklist |
-| Auto-stage / auto-install skill patches | **REJECT** (phase-2 draft PR opt-in only) | learning.py issues-first |
-| Weekly auto-mutate live skills | **REJECT** | meta-optimize proposes backlog only |
-| Post-delivery Learning Session gate | **ACCEPT** | #5641 Stop hooks |
-| ERL retrieve-once heuristics | **ACCEPT (adapted)** | Top 10 #3 |
-| LogAct metrics / periodic supervisor | **ACCEPT (adapted)** | Top 10 #1 #9 |
-| Silent-on-success verify | **ACCEPT** | Top 10 #2 |
-
----
-
-## 6. Implementation notes (when executing children)
-
-1. Prefer **one condensed PR per wave** (S0→S4); children under the epic; `Fixes #<child>` never the epic.
-2. Every lasting behavior → portable `chaos-engine/` (hooks/skills/scripts/doctor) + host adapters as needed — **harness parity**.
-3. Expand eval-parity fixtures when adding gates; never weaken fixtures.
-4. Keep Headroom `agent-90` / Ponytail XOR OUTPUT_SHAPER / Caveman ultra.
-5. No Cursor Cloud Agents for implementation workstreams.
-
----
-
-## 7. Key online sources used
-
-1. https://amux.io/guides/context-engineering/
-2. https://capitalandcompute.net/blog/claude-code-harness-guide/
-3. https://next.redhat.com/2026/07/28/building-skills-for-ai-agents-pitfalls-and-best-practices/
-4. https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents
-5. https://www.humanlayer.dev/blog/context-efficient-backpressure
-6. https://www.humanlayer.dev/blog/advanced-context-engineering
-7. https://agentskills.io/specification
-8. https://arxiv.org/pdf/2603.24639v2 (ERL)
-9. https://arxiv.org/pdf/2604.17091 (GenericAgent)
-10. https://arxiv.org/html/2604.07988 (LogAct)
-11. https://github.com/microsoft/SkillOpt
-12. https://code.claude.com/docs/en/hooks-guide
-13. https://winder.ai/ai-agent-harness-comparison/ (prior dossier)
-14. Local: `/workspace/agentic-harness-research.md`, `/workspace/chaos-engine-top10-optimizations.md` (superseded)
-
----
-
-## 8. Consult notes (optional Grok CLI)
-
-Captured `/tmp/ce-self-improve-consult.txt` (model `grok-4.5`). Alignment with this plan:
-
-- Measure first (LogAct counters) before growing prompts.
-- Silent verify + CLI&gt;MCP + SkillOpt propose-only + ERL once-per-task.
-- Reaffirm reject always-on scanners / weekly auto-mutate.
-- Ordering tip from consult: metrics → silent verify → CLI&gt;MCP → submit hygiene → SkillOpt → ERL → eval ratchet → GAP-EXIT2 UX.
-
----
-
-## 9. Supersession notice
-
-The 2026-09-07 dependency-ranked top-10 (health plane → repair → zero-LLM locator → L1 catalog → research ledger → wake/retrieve → Headroom/budget → eval-gated improve → fixtures → Heal/GAP-EXIT2) is **complete** via #5619–#5625 + #5641. **Do not reopen those tickets.** Track new work from **§4 Top 10** under the self-improve epic filed alongside this document.
+| NO native Task Observer / always-on observation | Locked reject |
+| SessionStart locator-only; Learning Session on delivery Stop | Shipped |
+| Harness parity across supported hosts via portable overlay | Shipped policy |
+| One-command install/configure/update | Shipped north star |
+| Headroom max-savings default; Caveman + Ponytail | Shipped |
+| Issues-first; eval-gated draft skill PRs opt-in later | Locked |
+| Merge commits only | Locked |
+
+## Current ability (summary)
+
+CE already self-enhances **harness** and **product** via dual-track Learning
+Session → `learning.py` → GitHub issues, enforced on Stop after delivery.
+Optimization program children closed health truth, component repair, zero-LLM
+locators, Level-1 catalog, triage research + phase ledger, wake pack +
+retrieve, eval-parity + portable Learning Session finalizer.
+
+**Remaining gap:** yield metrics, token sinks on Check/Stop, once-per-task
+heuristic retrieve, significance-filtered capture, SkillOpt-style compression
+proposals, CLI-over-MCP iron law, periodic meta-optimize, product-track
+playbook depth, opt-in eval-gated draft PRs.
+
+## Top 10 (dependency order)
+
+1. **Learning metrics closed loop** (queued→adopted→token delta) — LogAct-aligned; zero-LLM — ↓↓ tokens — **Reject** Task Observer
+2. **Silent-on-success / errors-only verify** — HumanLayer — ↓↓↓ on Check/Stop — hooks/scripts
+3. **ERL heuristic retrieve once per task** — not every turn; SessionStart locator only — ↓ always-on
+4. **Significance-filtered mid-session capture** — deferred heavy path — **Reject** Observer
+5. **CLI-over-MCP iron law** + zero-LLM catalog — ↓↓ schema tax
+6. **SkillOpt-style SKILL.md compression audit** — propose only; eval gate — ↓↓ activation tokens
+7. **Subagent context-firewall guidance** for research/explore — ↓ parent context
+8. **Eval-gated draft skill PRs** — opt-in phase 2 only
+9. **Periodic meta-optimize** over shared logs — not continuous
+10. **Product-track self-improve playbook** — delivery-Stop capture; link product evals
+
+## Waves
+
+`S0 #1 → S1 #2,#5,#3 → S2 #4,#6 → S3 #7,#10 → S4 #9,#8`
+
+## Governing online lessons (cite full URLs in profile companion when present)
+
+- Context surfaces: hooks = 100% enforce / 0 context unless output; skills = progressive disclosure; keep host md lean — https://amux.io/guides/context-engineering/ ; https://capitalandcompute.net/blog/claude-code-harness-guide/ ; https://next.redhat.com/2026/07/28/building-skills-for-ai-agents-pitfalls-and-best-practices/
+- HumanLayer: CLI over MCP when CLI is in training data; subagents for isolation; silent-on-success verify — https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents ; https://www.humanlayer.dev/blog/context-efficient-backpressure
+- ERL / GenericAgent / LogAct — https://arxiv.org/pdf/2603.24639v2 ; https://arxiv.org/pdf/2604.17091 ; https://arxiv.org/html/2604.07988
+- SkillOpt — https://github.com/microsoft/SkillOpt
+- Hooks guide — https://code.claude.com/docs/en/hooks-guide
+
+## Reject
+
+Always-on SessionStart full scan; continuous Task Observer; auto-merge skill mutations.

--- a/chaos-engine/skills/self-improve/SKILL.md
+++ b/chaos-engine/skills/self-improve/SKILL.md
@@ -25,6 +25,7 @@ Lean CE-native skill informed by Task Observer methodology
 Details: [references/observation-taxonomy.md](references/observation-taxonomy.md).
 Activation: [references/activation.md](references/activation.md).
 Adopt/reject research: [references/research-adopt-reject.md](references/research-adopt-reject.md).
+Roadmap: [../../references/self-improve-master-plan.md](../../references/self-improve-master-plan.md).
 
 ## How (wraps learning.py)
 

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "221350d340ff0b25fe09d3833d6eb0ca80b4adf89a239405b36594590e64d02c",
+      "harnessSha256": "8f3bd9e64b479173d263cfdcad8afe12b8f6b97745c04c6a609f426dbd0a17b4",
       "treatmentSha256": {
-        "calibration": "aee1f3dd4dc1b89f259fd396e03e276e768f1bb2c878722147f612f30bc44ec6",
-        "full-pilot": "c12471d8723542c91dda842c6fa1a9b0a96fe952daf7963063cb2b76a5ff8153"
+        "calibration": "4d456f43009d978925d53e9adda89c6503886709b44280ac047c1f8e25875d12",
+        "full-pilot": "f2f73e35056ebe1222687e5f4a267fa49fa28f9c45a8a196181eb95fa58e3349"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "8f3bd9e64b479173d263cfdcad8afe12b8f6b97745c04c6a609f426dbd0a17b4",
+      "harnessSha256": "9371c94271839041fbc95246c9d917770035f64b2f8fb2e76ee48b0f96468658",
       "treatmentSha256": {
-        "calibration": "4d456f43009d978925d53e9adda89c6503886709b44280ac047c1f8e25875d12",
-        "full-pilot": "f2f73e35056ebe1222687e5f4a267fa49fa28f9c45a8a196181eb95fa58e3349"
+        "calibration": "69f44a4d3e01553a1b91e7be05a50b2c8e09996d1a7bc8a8fe8b4db320f2f98e",
+        "full-pilot": "a745aca946ccd605f327b835d1a6976fd525d5e9933467b3c08abc4b194fba0f"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "221350d340ff0b25fe09d3833d6eb0ca80b4adf89a239405b36594590e64d02c"
+      harness_sha256: "8f3bd9e64b479173d263cfdcad8afe12b8f6b97745c04c6a609f426dbd0a17b4"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "8f3bd9e64b479173d263cfdcad8afe12b8f6b97745c04c6a609f426dbd0a17b4"
+      harness_sha256: "9371c94271839041fbc95246c9d917770035f64b2f8fb2e76ee48b0f96468658"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "8f3bd9e64b479173d263cfdcad8afe12b8f6b97745c04c6a609f426dbd0a17b4"
+      harness_sha256: "9371c94271839041fbc95246c9d917770035f64b2f8fb2e76ee48b0f96468658"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "221350d340ff0b25fe09d3833d6eb0ca80b4adf89a239405b36594590e64d02c"
+      harness_sha256: "8f3bd9e64b479173d263cfdcad8afe12b8f6b97745c04c6a609f426dbd0a17b4"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset


### PR DESCRIPTION
## Summary
- Durable **ChaosEngine self-improve master plan** at `chaos-engine/references/self-improve-master-plan.md` (current-state post-#5641, online research synthesis with cited URLs, gap analysis, roadmap waves, **Top 10** ranked by dependency/impact/token cost).
- Supersedes the landed 2026-09-07 optimization top-10 (#5619–#5625 / epic #5618).
- Tiny discoverability: Level-1 catalog row + self-improve skill pointer.
- Epic checklist: #5651

## Test plan
- [x] Doc-only; skim plan for locked prefs (no Task Observer; issues-first; locator SessionStart)
- [ ] CI green
- [ ] Auto-merge --merge when green