### PR TITLE
feat(ce): S3 self-improve — context firewall + product-track playbook

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -157,6 +157,7 @@ sends you there; the rest by
 - [TDD](../../chaos-engine/references/tdd.md)
 - [TDD failure modes](../../chaos-engine/references/tdd-failure-modes.md)
 - [context economy](../../chaos-engine/references/context-economy.md)
+- [context firewall](../../chaos-engine/references/context-firewall.md)
 - [script first](../../chaos-engine/references/script-first.md)
 - [LICENSE](../../chaos-engine/LICENSE)
 - [third-party notices](../../chaos-engine/THIRD_PARTY_NOTICES.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ Harness parity (permanent): lasting behavior and policy — including Learning
 Session after every delivery — must live in the portable ChaosEngine overlay
 (hooks, skills, installer/doctor, host guidance adapters), never only in one
 agent's memory or routines. Unchanged `chaos-engine/` files are not a valid
-Learning Session skip.
+Learning Session skip. Research/explore isolation follows
+[context firewall](chaos-engine/references/context-firewall.md) (all hosts).
 
 ## Repository safety
 

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -684,6 +684,8 @@ reports, caches, runtime indexes, or `graphify-out/`.
 
 
 - [Zero-LLM catalog](references/zero-llm-catalog.md) — deterministic doctor/install/repair paths.
+- [Context firewall](references/context-firewall.md) — research/explore subagent isolation; distillate only.
+- [Product-track self-improve](skills/self-improve/references/product-track.md) — SHAFT + ChaosGauge Learning Session playbook.
 
 
 - [Token budget modes](references/token-budget-modes.md) — ultra-lean | balanced | deep.

--- a/chaos-engine/README.md
+++ b/chaos-engine/README.md
@@ -685,7 +685,7 @@ reports, caches, runtime indexes, or `graphify-out/`.
 
 - [Zero-LLM catalog](references/zero-llm-catalog.md) — deterministic doctor/install/repair paths.
 - [Context firewall](references/context-firewall.md) — research/explore subagent isolation; distillate only.
-- [Product-track self-improve](skills/self-improve/references/product-track.md) — SHAFT + ChaosGauge Learning Session playbook.
+- [Product-track self-improve](skills/self-improve/references/product-track.md) — product issues/evals + ChaosGauge Learning Session playbook.
 
 
 - [Token budget modes](references/token-budget-modes.md) — ultra-lean | balanced | deep.

--- a/chaos-engine/profiles/shaft/references/product-track.md
+++ b/chaos-engine/profiles/shaft/references/product-track.md
@@ -1,0 +1,29 @@
+# Product-track self-improve (SHAFT + ChaosGauge)
+
+Profile extension of the portable
+[product-track playbook](../../../skills/self-improve/references/product-track.md).
+
+## SHAFT filing cues
+
+| Lesson class | Prefer |
+| --- | --- |
+| Engine / public API regression | Focused `shaft-engine` (or affected `shaft-*`) unittest + silent-verify |
+| Doctor / CLI repair gap | `shaft-doctor` / `shaft-cli` path — not a new MCP essay surface |
+| Agent effectiveness on product tasks | Link closest ChaosGauge public task under `scripts/ci/chaos_gauge/` |
+| IntelliJ plugin | Focused plugin check; keep docs PR separate when docs-only |
+
+## Routing
+
+Product authoring still hands off to `shaft-developer` via
+[shaft routing](routing.md). This playbook only covers Learning Session →
+issue/eval encoding after delivery.
+
+## Proof examples
+
+```bash
+py -3 -m unittest <focused_module> -v
+python3 scripts/ci/chaos_gauge/validate_experiment.py scripts/ci/chaos_gauge/experiment.json
+python3 scripts/ci/harness_pr_gate.py --base "$(git merge-base HEAD origin/main)" --head "$(git rev-parse HEAD)" --write-generated
+```
+
+Reject Task Observer; Delivery-Stop / Learning Session only.

--- a/chaos-engine/profiles/shaft/references/routing.md
+++ b/chaos-engine/profiles/shaft/references/routing.md
@@ -129,5 +129,5 @@ accessibility audit.
 When running a Learning Session or planning harness/product self-enhance work,
 load [self-improve master plan](self-improve-master-plan.md). Cited online
 research lives in [self-improve research synthesis](self-improve-research-synthesis.md).
-Product lessons → SHAFT issues/evals: [product-track playbook](../../../skills/self-improve/references/product-track.md).
+Product lessons → SHAFT issues/evals: [product-track playbook](product-track.md) (portable base: [self-improve product-track](../../../skills/self-improve/references/product-track.md)).
 Research/explore isolation: [context firewall](../../../references/context-firewall.md).

--- a/chaos-engine/profiles/shaft/references/routing.md
+++ b/chaos-engine/profiles/shaft/references/routing.md
@@ -129,3 +129,5 @@ accessibility audit.
 When running a Learning Session or planning harness/product self-enhance work,
 load [self-improve master plan](self-improve-master-plan.md). Cited online
 research lives in [self-improve research synthesis](self-improve-research-synthesis.md).
+Product lessons → SHAFT issues/evals: [product-track playbook](../../../skills/self-improve/references/product-track.md).
+Research/explore isolation: [context firewall](../../../references/context-firewall.md).

--- a/chaos-engine/references/context-economy.md
+++ b/chaos-engine/references/context-economy.md
@@ -36,7 +36,8 @@ transcript unless the user asked for the raw body.
 ## Distill, then continue
 
 - A subagent returns a distillate: what changed, what was proved, what remains.
-  It does not return its transcript.
+  It does not return its transcript. Research / multi-file explore follows the
+  [context firewall](context-firewall.md) (`filepath:line` + distillate only).
 - Structured notes belong at session end or after repeated failure, through the
   existing learning session. They are not a running diary.
 - On failure, change the premise or the discriminating observation. Do not

--- a/chaos-engine/references/context-firewall.md
+++ b/chaos-engine/references/context-firewall.md
@@ -1,0 +1,61 @@
+# Context firewall (research / explore)
+
+HumanLayer pattern: use an **isolated subagent** (or host Task / equivalent)
+for research and multi-file explore so explore noise stays in the child and
+the parent stays in the smart zone. **Not** Task Observer — spawn only when
+the work needs isolation; never always-on observation.
+
+## When to spawn
+
+Spawn a research/explore subagent when **any** of:
+
+- Multi-file or cross-module discovery before a decision
+- Broad web / doc / codebase survey that would dump large tool output
+- Parallel explore of competing approaches
+- Host supports subagents / Task / local-coding-delegate for bounded labor
+
+Stay on the parent thread when:
+
+- One-file reversible read with a known path
+- Mechanical inventory already specified by the orchestrator
+- Host has **no** subagent/Task primitive (then apply the return contract
+  yourself: distill in-place; do not paste transcripts forward)
+
+## Return contract (parent receives only)
+
+1. **Distillate** — what changed / what was proved / what remains (≤~½ page)
+2. **Citations** — `path:line` (or URL + date for online) that support the claim
+3. **Decision inputs** — steelman of rejected approach when comparing options
+4. **Never** — raw tool transcripts, full file dumps, or multi-thousand-line logs
+
+Spill large artifacts to disk; tell the parent the path + one discriminating fact
+([context economy](context-economy.md)).
+
+## Router rule (all hosts)
+
+`research / multi-file explore → subagent|Task when host supports → return
+filepath:line + distillate only`.
+
+Encode lasting behavior in this Level-1 ref +
+[chaos-engine skill](../skills/chaos-engine/SKILL.md) /
+[delegation](delegation.md) — never Grok-Bot-only memory.
+
+Optional local labor: [local-coding-delegate](../skills/local-coding-delegate/SKILL.md)
+or [OmniRoute](../skills/omniroute/SKILL.md) when the decider chooses them;
+missing optional transport never weakens this firewall.
+
+## Token economics
+
+| Surface | Cost |
+| --- | --- |
+| Parent | ↓ (no explore dumps) |
+| Child | may ↑ — net quality win |
+| SessionStart | unchanged (locator only) |
+| Always-on Observer | **Reject** |
+
+## Verify (zero-LLM / docs)
+
+```bash
+test -f chaos-engine/references/context-firewall.md
+rg -n "context-firewall|filepath:line|Task Observer" chaos-engine/references/level-1-catalog.md chaos-engine/skills/chaos-engine/SKILL.md
+```

--- a/chaos-engine/references/delegation.md
+++ b/chaos-engine/references/delegation.md
@@ -27,6 +27,16 @@ Spec-exact repetitive edits, inventory, formatting, deterministic
 transformation, and log or result triage. The `helper` adapters carry the
 mechanical-helper role from [roles](roles.md) to both subagent hosts.
 
+
+## Research / explore firewall
+
+For research or multi-file explore, prefer an isolated subagent (or host Task)
+over dumping explore noise into the parent. Return contract and when-to-spawn
+rules live in [context firewall](context-firewall.md). Isolation is for context
+economy (HumanLayer), not org-chart role-play. Hosts without subagents distill
+in-place under the same return contract. Never treat this as always-on
+observation.
+
 ## Main-thread duties
 
 Orchestrator retains decomposition, architecture, consultation, assignment,

--- a/chaos-engine/references/level-1-catalog.md
+++ b/chaos-engine/references/level-1-catalog.md
@@ -14,6 +14,7 @@ sorted. Each row is a name, ≤2-line Use-when, and a path — no workflow dumps
 | Silent verify | Check/Stop green must add zero context; fail with one line | [`silent-verify.md`](silent-verify.md) |
 | Significance capture | Mid-session friction marks only; Learning Session drain | [`significance-capture.md`](significance-capture.md) |
 | Skill compress audit | Propose-only SKILL.md bloat audit; never auto-apply | [`skill-compress-audit.md`](skill-compress-audit.md) |
+| Context firewall | Research / multi-file explore → isolated subagent; filepath:line distillate only | [`context-firewall.md`](context-firewall.md) |
 | Context economy | Bound reads/searches; prefer path+excerpt over dumps | [`context-economy.md`](context-economy.md) |
 | Retrieve-first | A store can shorten discovery; one bounded attempt | [`retrieve-first.md`](retrieve-first.md) |
 | Research receipt | Before implementation mutation; triage scales depth | [`research-receipt.md`](research-receipt.md) |

--- a/chaos-engine/references/research-receipt.md
+++ b/chaos-engine/references/research-receipt.md
@@ -1,6 +1,7 @@
 # Research receipt
 
 Phase-gate map: [delivery-phase-gates.md](delivery-phase-gates.md).
+Broad research / multi-file explore: [context firewall](context-firewall.md).
 
 Load this before the first implementation mutation, except mechanical one-file
 reversible work: name the eight steps, then record store irrelevance without

--- a/chaos-engine/skills/chaos-engine/SKILL.md
+++ b/chaos-engine/skills/chaos-engine/SKILL.md
@@ -65,7 +65,11 @@ including one-file reversible work.
 
 Load the [research receipt](../../references/research-receipt.md) before the
 first implementation mutation. Mechanical one-file reversible work names its
-eight steps, then records store irrelevance without querying.
+eight steps, then records store irrelevance without querying. For research or
+multi-file explore, apply the [context firewall](../../references/context-firewall.md):
+spawn an isolated subagent/Task when the host supports it; return
+`filepath:line` citations and a distillate only — never raw transcripts.
+**Reject** always-on Task Observer.
 
 ## Red flags
 
@@ -200,6 +204,7 @@ return here for the next.
 | Zero-LLM first | Before chat discovery for install/doctor/repair | [zero-llm-catalog](../../references/zero-llm-catalog.md) |
 | Heal | Drifted install, wiped runtime, unhealthy doctor | [heal-route](../../references/heal-route.md) (file path; no plugin required) |
 | Level-1 catalog | Need a secondary skill/tool beyond this router | [level-1-catalog](../../references/level-1-catalog.md) |
+| Context firewall | Research / multi-file explore needs isolation | [context-firewall](../../references/context-firewall.md) |
 | Token budget | Triage or env selects ultra-lean / balanced / deep | [token-budget-modes](../../references/token-budget-modes.md) |
 | GAP-EXIT2 UX | Grok/Copilot may not honor exit-2 hard blocks | [host-parity-matrix](../../references/host-parity-matrix.md) checklist |
 

--- a/chaos-engine/skills/self-improve/SKILL.md
+++ b/chaos-engine/skills/self-improve/SKILL.md
@@ -23,9 +23,12 @@ Lean CE-native skill informed by Task Observer methodology
 2. **Product** — enhancements for the product under development (queued issues).
 
 Details: [references/observation-taxonomy.md](references/observation-taxonomy.md).
+Product track: [references/product-track.md](references/product-track.md)
+(SHAFT issues/evals + ChaosGauge link; CLI/doctor/silent-verify over essay tickets).
 Activation: [references/activation.md](references/activation.md).
 Adopt/reject research: [references/research-adopt-reject.md](references/research-adopt-reject.md).
 Roadmap: [../../references/self-improve-master-plan.md](../../references/self-improve-master-plan.md).
+Research/explore isolation (harness): [../../references/context-firewall.md](../../references/context-firewall.md).
 
 ## How (wraps learning.py)
 

--- a/chaos-engine/skills/self-improve/SKILL.md
+++ b/chaos-engine/skills/self-improve/SKILL.md
@@ -24,7 +24,7 @@ Lean CE-native skill informed by Task Observer methodology
 
 Details: [references/observation-taxonomy.md](references/observation-taxonomy.md).
 Product track: [references/product-track.md](references/product-track.md)
-(SHAFT issues/evals + ChaosGauge link; CLI/doctor/silent-verify over essay tickets).
+(product issues/evals + ChaosGauge link; CLI/doctor/silent-verify over essay tickets).
 Activation: [references/activation.md](references/activation.md).
 Adopt/reject research: [references/research-adopt-reject.md](references/research-adopt-reject.md).
 Roadmap: [../../references/self-improve-master-plan.md](../../references/self-improve-master-plan.md).

--- a/chaos-engine/skills/self-improve/references/observation-taxonomy.md
+++ b/chaos-engine/skills/self-improve/references/observation-taxonomy.md
@@ -26,3 +26,5 @@ Every Learning Session should attempt:
 1. At least one **harness** observation (or explicit "nothing durable").
 2. At least one **product** enhancement candidate when product work occurred
    (or explicit "nothing durable").
+
+Product filing playbook: [product-track.md](product-track.md).

--- a/chaos-engine/skills/self-improve/references/product-track.md
+++ b/chaos-engine/skills/self-improve/references/product-track.md
@@ -1,13 +1,17 @@
-# Product-track self-improve playbook (SHAFT + ChaosGauge)
+# Product-track self-improve playbook
 
 Dual-track Learning Session already queues **product** lessons via
-`learning.py`. This playbook turns those lessons into durable SHAFT work —
-issues, focused tests, and ChaosGauge linkage — at harness-track economics:
+`learning.py`. This playbook turns those lessons into durable product work —
+issues, focused tests, and product-eval linkage — at harness-track economics:
 prefer **CLI / doctor / silent-verify** paths over MCP essay tickets.
 
 Load on Learning Session product review or when filing a product follow-on.
 **Reject Task Observer** — capture only on delivery Stop / explicit operator
 request ([activation](activation.md)).
+
+Adopter products may ship a profile-specific extension under
+`profiles/<product>/references/product-track.md` with product-locked issue
+templates and eval identities. This portable file stays free of product tokens.
 
 ## When a product lesson is durable
 
@@ -16,8 +20,8 @@ Queue / file when the session produced a concrete product gap:
 | Signal | Prefer |
 | --- | --- |
 | Broken public API / regression | Issue + focused unit/IT + silent-verify Check |
-| Missing doctor / CLI repair path | Issue targeting `shaft-doctor` / CLI — not an MCP essay |
-| Flaky or missing eval coverage | Issue linking ChaosGauge task identity or eval-parity fixture |
+| Missing doctor / CLI repair path | Issue targeting doctor / CLI — not an MCP essay |
+| Flaky or missing eval coverage | Issue linking product eval / ChaosGauge task identity when applicable |
 | Docs-only product truth drift | Separate docs PR (repo rule); still queue the lesson |
 | Nothing durable | Report `product queued 0` / `nothing durable` — valid |
 
@@ -34,14 +38,14 @@ Product follow-on from Learning Session (epic or delivery PR: #<n>).
 <one paragraph; privacy-safe>
 
 ## Acceptance
-- [ ] Focused test or ChaosGauge/eval link proves the gap
+- [ ] Focused test or product-eval/ChaosGauge link proves the gap
 - [ ] Prefer CLI/doctor/silent-verify path over new MCP surface
 - [ ] Proof command listed (silent on success)
 
 ## Proof
 \`\`\`bash
 # example — replace with the real smallest check
-py -3 -m unittest <focused_module> -v
+python3 -m unittest <focused_module> -v
 # or: python3 scripts/ci/chaos_gauge/validate_experiment.py …
 \`\`\`
 ```
@@ -49,23 +53,17 @@ py -3 -m unittest <focused_module> -v
 File with `gh issue create` (CLI-over-MCP). Attach as sub-issue of the owning
 epic when one exists. Delivery PRs `Fixes #<child>` — never the program epic.
 
-## ChaosGauge linkage
+## ChaosGauge / product-eval linkage
 
 When the lesson is about agent/harness **effectiveness on product tasks**
 (diagnosis, repair, recovery, safety, delivery):
 
-1. Name the closest public ChaosGauge task identity under
-   `scripts/ci/chaos_gauge/` (or note “needs new task” without inventing digests).
-2. Prefer refreshing pins via
-   `python3 scripts/ci/harness_pr_gate.py --write-generated` after `chaos-engine/`
-   tree changes — do not hand-edit digests.
-3. For SHAFT product modules (engine, MCP, doctor, IntelliJ), prefer focused
-   Maven/unittest proof first; ChaosGauge is the agent-effectiveness layer,
-   not a substitute for module tests.
-
-Profile routing for SHAFT product authoring remains
-[shaft routing](../../../profiles/shaft/references/routing.md) /
-`shaft-developer` — this playbook does not restate locator or test syntax.
+1. Name the closest public ChaosGauge task identity under the repo's ChaosGauge
+   tree (or note “needs new task” without inventing digests).
+2. Prefer refreshing pins via the repo's harness PR gate `--write-generated`
+   after overlay tree changes — do not hand-edit digests.
+3. Prefer focused module tests first; ChaosGauge is the agent-effectiveness
+   layer, not a substitute for product unit/integration proof.
 
 ## Economics (same as harness track)
 

--- a/chaos-engine/skills/self-improve/references/product-track.md
+++ b/chaos-engine/skills/self-improve/references/product-track.md
@@ -1,0 +1,86 @@
+# Product-track self-improve playbook (SHAFT + ChaosGauge)
+
+Dual-track Learning Session already queues **product** lessons via
+`learning.py`. This playbook turns those lessons into durable SHAFT work —
+issues, focused tests, and ChaosGauge linkage — at harness-track economics:
+prefer **CLI / doctor / silent-verify** paths over MCP essay tickets.
+
+Load on Learning Session product review or when filing a product follow-on.
+**Reject Task Observer** — capture only on delivery Stop / explicit operator
+request ([activation](activation.md)).
+
+## When a product lesson is durable
+
+Queue / file when the session produced a concrete product gap:
+
+| Signal | Prefer |
+| --- | --- |
+| Broken public API / regression | Issue + focused unit/IT + silent-verify Check |
+| Missing doctor / CLI repair path | Issue targeting `shaft-doctor` / CLI — not an MCP essay |
+| Flaky or missing eval coverage | Issue linking ChaosGauge task identity or eval-parity fixture |
+| Docs-only product truth drift | Separate docs PR (repo rule); still queue the lesson |
+| Nothing durable | Report `product queued 0` / `nothing durable` — valid |
+
+Privacy: use `learning.py queue` only — no secrets, absolute paths, raw
+transcripts ([observation taxonomy](observation-taxonomy.md)).
+
+## Issue template (product child)
+
+```markdown
+## Parent
+Product follow-on from Learning Session (epic or delivery PR: #<n>).
+
+## Problem
+<one paragraph; privacy-safe>
+
+## Acceptance
+- [ ] Focused test or ChaosGauge/eval link proves the gap
+- [ ] Prefer CLI/doctor/silent-verify path over new MCP surface
+- [ ] Proof command listed (silent on success)
+
+## Proof
+\`\`\`bash
+# example — replace with the real smallest check
+py -3 -m unittest <focused_module> -v
+# or: python3 scripts/ci/chaos_gauge/validate_experiment.py …
+\`\`\`
+```
+
+File with `gh issue create` (CLI-over-MCP). Attach as sub-issue of the owning
+epic when one exists. Delivery PRs `Fixes #<child>` — never the program epic.
+
+## ChaosGauge linkage
+
+When the lesson is about agent/harness **effectiveness on product tasks**
+(diagnosis, repair, recovery, safety, delivery):
+
+1. Name the closest public ChaosGauge task identity under
+   `scripts/ci/chaos_gauge/` (or note “needs new task” without inventing digests).
+2. Prefer refreshing pins via
+   `python3 scripts/ci/harness_pr_gate.py --write-generated` after `chaos-engine/`
+   tree changes — do not hand-edit digests.
+3. For SHAFT product modules (engine, MCP, doctor, IntelliJ), prefer focused
+   Maven/unittest proof first; ChaosGauge is the agent-effectiveness layer,
+   not a substitute for module tests.
+
+Profile routing for SHAFT product authoring remains
+[shaft routing](../../../profiles/shaft/references/routing.md) /
+`shaft-developer` — this playbook does not restate locator or test syntax.
+
+## Economics (same as harness track)
+
+| Prefer | Avoid |
+| --- | --- |
+| `gh`, doctor, `silent_verify.py`, focused unittest | MCP wrappers for the same job |
+| One issue + one proof command | Essay tickets without acceptance/proof |
+| Delivery-Stop Learning Session | Mid-turn product Observer |
+| CLI `--fix-next-only` / catalog rows | Chat discovery of known repair paths |
+
+See [zero-llm-catalog](../../../references/zero-llm-catalog.md) and
+[silent-verify](../../../references/silent-verify.md).
+
+## Learning Session report line
+
+Always end product review with counts the root can paste:
+
+`harness queued N / product queued N / nothing durable`

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "1c91d892550e91598decea348a18ec5f2a7d28f8cd8fd324ced242ed29458181",
+      "harnessSha256": "6132464c1dc96348c9f279f791e75f66ce90a8124763a184fc5e5bef1b88ea51",
       "treatmentSha256": {
-        "calibration": "51673a857b58b7235e4e0e398732c1e6fb13849a4172b9849f71833664cb3b25",
-        "full-pilot": "9e935c3a4362034dab4e630a0de942cc7331fbb612e5bb2cd833832d07167550"
+        "calibration": "2644c011e2bcc4d5a78e0f72f877898b8769044f9db850652947ebe1dd20dcb6",
+        "full-pilot": "dde4139f4abbb679f5c098e43fa0a06ba46c444a7a249737a146df1de20b076a"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "6132464c1dc96348c9f279f791e75f66ce90a8124763a184fc5e5bef1b88ea51",
+      "harnessSha256": "4e185760fa54c9832b37b346f07ff7840fefd3b92aa3aee1d167db6458298572",
       "treatmentSha256": {
-        "calibration": "2644c011e2bcc4d5a78e0f72f877898b8769044f9db850652947ebe1dd20dcb6",
-        "full-pilot": "dde4139f4abbb679f5c098e43fa0a06ba46c444a7a249737a146df1de20b076a"
+        "calibration": "2930e7b2daf73e4e07d9721a4abcc6542a4399365262927513e1c7004b578f28",
+        "full-pilot": "969004fb1242b176eba9402dc14e51d915a18c0fbed72b58879d300d5367381e"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "6132464c1dc96348c9f279f791e75f66ce90a8124763a184fc5e5bef1b88ea51"
+      harness_sha256: "4e185760fa54c9832b37b346f07ff7840fefd3b92aa3aee1d167db6458298572"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "1c91d892550e91598decea348a18ec5f2a7d28f8cd8fd324ced242ed29458181"
+      harness_sha256: "6132464c1dc96348c9f279f791e75f66ce90a8124763a184fc5e5bef1b88ea51"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "6132464c1dc96348c9f279f791e75f66ce90a8124763a184fc5e5bef1b88ea51"
+      harness_sha256: "4e185760fa54c9832b37b346f07ff7840fefd3b92aa3aee1d167db6458298572"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "1c91d892550e91598decea348a18ec5f2a7d28f8cd8fd324ced242ed29458181"
+      harness_sha256: "6132464c1dc96348c9f279f791e75f66ce90a8124763a184fc5e5bef1b88ea51"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_s3_self_improve.py
+++ b/tests/scripts/test_chaos_engine_s3_self_improve.py
@@ -8,6 +8,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 FIREWALL = ROOT / "chaos-engine/references/context-firewall.md"
 PRODUCT = ROOT / "chaos-engine/skills/self-improve/references/product-track.md"
+PROFILE_PRODUCT = ROOT / "chaos-engine/profiles/shaft/references/product-track.md"
 LEVEL1 = ROOT / "chaos-engine/references/level-1-catalog.md"
 CE_SKILL = ROOT / "chaos-engine/skills/chaos-engine/SKILL.md"
 SI_SKILL = ROOT / "chaos-engine/skills/self-improve/SKILL.md"
@@ -50,9 +51,13 @@ class S3SelfImproveTests(unittest.TestCase):
             "gh issue create",
         ):
             self.assertIn(needle, body)
-        # Prefer CLI economics over MCP essay tickets
         self.assertIn("essay", body.lower())
         self.assertIn("MCP", body)
+        self.assertNotIn("shaft", body.casefold())
+        self.assertTrue(PROFILE_PRODUCT.is_file())
+        profile = PROFILE_PRODUCT.read_text(encoding="utf-8")
+        self.assertIn("SHAFT", profile)
+        self.assertIn("ChaosGauge", profile)
 
     def test_overlay_wiring_all_hosts(self):
         level1 = LEVEL1.read_text(encoding="utf-8")

--- a/tests/scripts/test_chaos_engine_s3_self_improve.py
+++ b/tests/scripts/test_chaos_engine_s3_self_improve.py
@@ -1,0 +1,100 @@
+"""Wave S3 (#5661/#5662): context-firewall guidance + product-track playbook."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FIREWALL = ROOT / "chaos-engine/references/context-firewall.md"
+PRODUCT = ROOT / "chaos-engine/skills/self-improve/references/product-track.md"
+LEVEL1 = ROOT / "chaos-engine/references/level-1-catalog.md"
+CE_SKILL = ROOT / "chaos-engine/skills/chaos-engine/SKILL.md"
+SI_SKILL = ROOT / "chaos-engine/skills/self-improve/SKILL.md"
+AGENTS = ROOT / "AGENTS.md"
+DELEGATION = ROOT / "chaos-engine/references/delegation.md"
+CONTEXT = ROOT / "chaos-engine/references/context-economy.md"
+ROUTING = ROOT / "chaos-engine/profiles/shaft/references/routing.md"
+TAXONOMY = ROOT / "chaos-engine/skills/self-improve/references/observation-taxonomy.md"
+RECEIPT = ROOT / "chaos-engine/references/research-receipt.md"
+
+
+class S3SelfImproveTests(unittest.TestCase):
+    def test_context_firewall_doc_invariants(self):
+        self.assertTrue(FIREWALL.is_file())
+        body = FIREWALL.read_text(encoding="utf-8")
+        for needle in (
+            "filepath:line",
+            "Task Observer",
+            "subagent",
+            "distillate",
+            "Reject",
+            "all hosts",
+        ):
+            self.assertIn(needle, body)
+        # Must not authorize always-on observation
+        self.assertNotIn("always-on Observer accept", body)
+        self.assertIn("never always-on", body.lower())
+
+    def test_product_track_playbook_invariants(self):
+        self.assertTrue(PRODUCT.is_file())
+        body = PRODUCT.read_text(encoding="utf-8")
+        for needle in (
+            "ChaosGauge",
+            "silent-verify",
+            "doctor",
+            "CLI",
+            "learning.py",
+            "Reject Task Observer",
+            "harness queued N / product queued N",
+            "gh issue create",
+        ):
+            self.assertIn(needle, body)
+        # Prefer CLI economics over MCP essay tickets
+        self.assertIn("essay", body.lower())
+        self.assertIn("MCP", body)
+
+    def test_overlay_wiring_all_hosts(self):
+        level1 = LEVEL1.read_text(encoding="utf-8")
+        self.assertIn("context-firewall.md", level1)
+        self.assertIn("Context firewall", level1)
+
+        skill = CE_SKILL.read_text(encoding="utf-8")
+        self.assertIn("context-firewall.md", skill)
+        self.assertIn("filepath:line", skill)
+
+        agents = AGENTS.read_text(encoding="utf-8")
+        self.assertIn("context-firewall.md", agents)
+
+        delegation = DELEGATION.read_text(encoding="utf-8")
+        self.assertIn("context-firewall.md", delegation)
+        self.assertIn("Research / explore firewall", delegation)
+
+        context = CONTEXT.read_text(encoding="utf-8")
+        self.assertIn("context-firewall.md", context)
+
+        receipt = RECEIPT.read_text(encoding="utf-8")
+        self.assertIn("context-firewall.md", receipt)
+
+        si = SI_SKILL.read_text(encoding="utf-8")
+        self.assertIn("product-track.md", si)
+        self.assertIn("context-firewall.md", si)
+
+        tax = TAXONOMY.read_text(encoding="utf-8")
+        self.assertIn("product-track.md", tax)
+
+        routing = ROUTING.read_text(encoding="utf-8")
+        self.assertIn("product-track.md", routing)
+        self.assertIn("context-firewall.md", routing)
+
+    def test_no_observer_language_in_new_docs(self):
+        for path in (FIREWALL, PRODUCT):
+            lower = path.read_text(encoding="utf-8").lower()
+            self.assertIn("reject", lower)
+            self.assertIn("task observer", lower)
+            # Must not instruct continuous observation
+            self.assertNotIn("always-on sessionstart full scan", lower)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Wave **S3** for epic #5651 Top 10 **#7** and **#10** (never closes the epic):

- **#7 / #5661** — Portable **context firewall** for research / multi-file explore: isolated subagent/Task when host supports; parent receives `filepath:line` + distillate only. Wired through Level-1 catalog, chaos-engine skill router, delegation, context-economy, research-receipt, thin AGENTS pointer, shaft routing. **Reject Task Observer.**
- **#10 / #5662** — **Product-track** self-improve playbook (`skills/self-improve/references/product-track.md`): Learning Session product lessons → SHAFT issues/evals + ChaosGauge linkage; prefer CLI/doctor/silent-verify over MCP essay tickets. Delivery-Stop capture only.

ChaosGauge digests refreshed via `validate_experiment.py --write`.

## Test plan
- [x] `python3 -m unittest tests.scripts.test_chaos_engine_s3_self_improve -v`
- [ ] CI green; merge commits only (`gh pr merge --auto --merge`)

Fixes #5661 Fixes #5662