### PR TITLE
[CE] Fix #5667 hooks/mcps verify when managed Python is missing

### DIFF
--- a/chaos-engine/install.py
+++ b/chaos-engine/install.py
@@ -3759,6 +3759,213 @@ def status_with_dependencies(project: Path, *, active_probes: bool = False) -> d
             return result
 
 
+MANAGED_PYTHON_MISSING_DETAIL = "managed-python-missing"
+MANAGED_PYTHON_MISSING_CODE = "CE_MANAGED_PYTHON_MISSING"
+HOOKS_PROBE_FAILED_DETAIL = "hooks-probe-failed"
+HOOKS_PROBE_FAILED_CODE = "CE_HOOKS_PROBE_FAILED"
+
+
+def resolve_managed_python(
+    generation_path: str | None,
+    account_commands: dict[str, str] | None,
+    *,
+    windows: bool | None = None,
+) -> Path | None:
+    """Resolve a live MemPalace/account interpreter for hooks and MCP probes (#5680)."""
+    nt = os.name == "nt" if windows is None else bool(windows)
+    scripts = "Scripts" if nt else "bin"
+    names = (
+        ("python.exe", "python", "python3.exe", "python3")
+        if nt
+        else ("python", "python3")
+    )
+    if isinstance(generation_path, str) and generation_path.strip():
+        root = Path(generation_path) / "uv-tools" / "mempalace" / scripts
+        candidates: list[Path] = [root / name for name in names]
+        if nt:
+            for stem in ("python", "python3"):
+                for suffix in os.environ.get("PATHEXT", ".EXE;.CMD;.BAT;.COM").split(";"):
+                    if not suffix:
+                        continue
+                    candidates.append(root / f"{stem}{suffix}")
+                    candidates.append(root / f"{stem}{suffix.lower()}")
+        seen: set[str] = set()
+        for candidate in candidates:
+            key = str(candidate)
+            if key in seen:
+                continue
+            seen.add(key)
+            try:
+                resolved = candidate.resolve(strict=True)
+            except (OSError, RuntimeError):
+                continue
+            if resolved.is_file():
+                return resolved
+    if isinstance(account_commands, dict):
+        account_python = account_commands.get("python3")
+        if isinstance(account_python, str) and account_python.strip():
+            try:
+                candidate_python = Path(account_python).resolve(strict=True)
+            except (OSError, RuntimeError):
+                candidate_python = None
+            if candidate_python is not None and candidate_python.is_file():
+                return candidate_python
+    return None
+
+
+def managed_python_missing_fix_next() -> str:
+    """Operator fix-next when the managed probe interpreter is absent."""
+    cli = _doctor_python_cli()
+    return (
+        f"Restore the managed MemPalace Python interpreter via "
+        f"`{cli} .chaos-engine/install.py repair --project . --component tools` "
+        f"(or re-run the ChaosEngine install one-liner), then "
+        f"`{cli} .chaos-engine/install.py doctor --project .`."
+    )
+
+
+def apply_managed_python_missing(components: object) -> None:
+    """Name both hooks and mcps when the shared interpreter is missing (#5667)."""
+    if not isinstance(components, dict):
+        return
+    fix = managed_python_missing_fix_next()
+    for name in ("hooks", "mcps"):
+        item = components.get(name)
+        if not isinstance(item, dict):
+            continue
+        item["status"] = "recovery-required"
+        item["detail"] = MANAGED_PYTHON_MISSING_DETAIL
+        item["code"] = MANAGED_PYTHON_MISSING_CODE
+        item["fixNext"] = fix
+
+
+def heal_managed_python(
+    project: Path,
+    *,
+    generation_path: str | None,
+    account_commands: dict[str, str] | None,
+) -> Path | None:
+    """One deterministic attempt to restore the probe interpreter (#5680)."""
+    project = project.resolve()
+    refreshed = account_commands
+    account_receipt = project / ".chaos-engine-dependencies.json"
+    if account_receipt.is_file() and not is_link_or_reparse(account_receipt):
+        try:
+            payload = json.loads(account_receipt.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            payload = None
+        if isinstance(payload, dict) and isinstance(payload.get("commands"), dict):
+            refreshed = {
+                str(key): str(value)
+                for key, value in payload["commands"].items()
+                if isinstance(key, str) and isinstance(value, str)
+            }
+    resolved = resolve_managed_python(generation_path, refreshed)
+    if resolved is not None:
+        return resolved
+    if not (project / INSTALL_DIRECTORY).is_dir():
+        return None
+    pointer = project / ".chaos-engine-runtime-current.json"
+    runtime = project / ".chaos-engine-runtime"
+    has_repair_surface = (
+        (isinstance(generation_path, str) and Path(generation_path).is_dir())
+        or (refreshed is not None and bool(refreshed.get("python3")))
+        or pointer.is_file()
+        or runtime.is_dir()
+    )
+    if not has_repair_surface:
+        return None
+    try:
+        repair_component(project, "tools")
+    except Exception:
+        return resolve_managed_python(generation_path, refreshed)
+    refreshed_after = refreshed
+    if account_receipt.is_file() and not is_link_or_reparse(account_receipt):
+        try:
+            payload = json.loads(account_receipt.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            payload = None
+        if isinstance(payload, dict) and isinstance(payload.get("commands"), dict):
+            refreshed_after = {
+                str(key): str(value)
+                for key, value in payload["commands"].items()
+                if isinstance(key, str) and isinstance(value, str)
+            }
+    generation_after = generation_path
+    if pointer.is_file() and not is_link_or_reparse(pointer):
+        try:
+            pointer_payload = json.loads(pointer.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            pointer_payload = None
+        active = (
+            pointer_payload.get("active")
+            if isinstance(pointer_payload, dict)
+            else None
+        )
+        generation_id = active.get("generationId") if isinstance(active, dict) else None
+        if isinstance(generation_id, str) and generation_id.strip():
+            candidate = project / ".chaos-engine-runtime-generations" / generation_id
+            if candidate.is_dir():
+                generation_after = str(candidate)
+    return resolve_managed_python(generation_after, refreshed_after)
+
+
+def _attach_probe_fields(item: dict[str, object], probe: dict[str, object]) -> None:
+    """Copy bounded detail/code/fixNext from a probe result onto a component."""
+    fix_next = probe.get("fixNext")
+    detail = probe.get("detail")
+    if isinstance(fix_next, str) and fix_next.strip():
+        item["detail"] = fix_next.strip()
+        item["fixNext"] = fix_next.strip()
+    elif isinstance(detail, str) and re.fullmatch(r"[a-z][a-z0-9-]{0,63}", detail):
+        item["detail"] = detail
+    code = probe.get("code")
+    if isinstance(code, str) and re.fullmatch(r"[A-Z][A-Z0-9_]{0,63}", code):
+        item["code"] = code
+
+
+def apply_mcp_doctor_status(
+    result: dict[str, object],
+    components: object,
+    mcp_status: dict[str, object],
+) -> None:
+    """Map one MCP probe onto required mcps + overall doctor status (#5630/#5680)."""
+    mcp_status_value = str(mcp_status.get("status") or "recovery-required")
+    if not isinstance(components, dict) or not isinstance(components.get("mcps"), dict):
+        if mcp_status_value not in {"healthy", "compatible-legacy", "degraded", "sync-advisory"}:
+            result["status"] = "recovery-required"
+        return
+    mcps = components["mcps"]
+    if mcp_status_value == "healthy":
+        return
+    if mcp_status_value in {"compatible-legacy", "degraded", "sync-advisory"}:
+        # Memory origin/main write gate is advisory for required mcps (#5630).
+        mcps["status"] = "compatible-legacy"
+        _attach_probe_fields(mcps, mcp_status)
+        return
+    result["status"] = "recovery-required"
+    mcps["status"] = "recovery-required"
+    _attach_probe_fields(mcps, mcp_status)
+    if not mcps.get("fixNext"):
+        named = component_fix_next("mcps", mcps)
+        if named:
+            mcps["fixNext"] = named
+
+
+def apply_hooks_probe_failure(result: dict[str, object], components: object) -> None:
+    """Name a failed hook runtime probe (#5680)."""
+    result["status"] = "recovery-required"
+    if not isinstance(components, dict) or not isinstance(components.get("hooks"), dict):
+        return
+    hooks = components["hooks"]
+    hooks["status"] = "recovery-required"
+    hooks["detail"] = HOOKS_PROBE_FAILED_DETAIL
+    hooks["code"] = HOOKS_PROBE_FAILED_CODE
+    named = component_fix_next("hooks", hooks)
+    if named:
+        hooks["fixNext"] = named
+
+
 def doctor_with_dependencies(
     project: Path, *, verify_clients: bool = True
 ) -> dict[str, object]:
@@ -3774,6 +3981,8 @@ def doctor_with_dependencies(
     host_controller = load_installed_controller(target, "hosts")
     dependency = result.get("dependencies")
     generation_path = dependency.get("path") if isinstance(dependency, dict) else None
+    if not isinstance(generation_path, str):
+        generation_path = None
     account_commands = None
     account_receipt = project.resolve() / ".chaos-engine-dependencies.json"
     if account_receipt.is_file() and not is_link_or_reparse(account_receipt):
@@ -3793,58 +4002,27 @@ def doctor_with_dependencies(
             code = retrieval.get("code")
             if isinstance(code, str) and re.fullmatch(r"[a-z][a-z0-9-]{0,63}", code):
                 components["memory"]["code"] = code
-    scripts = "Scripts" if os.name == "nt" else "bin"
-    python_name = "python.exe" if os.name == "nt" else "python"
-    managed_python = (
-        Path(generation_path) / "uv-tools/mempalace" / scripts / python_name
-        if isinstance(generation_path, str) else None
-    )
-    if managed_python is None and account_commands is not None:
-        account_python = account_commands.get("python3")
-        if isinstance(account_python, str):
-            try:
-                candidate_python = Path(account_python).resolve(strict=True)
-            except (OSError, RuntimeError):
-                candidate_python = None
-            if candidate_python is not None and candidate_python.is_file():
-                managed_python = candidate_python
-    mcp_status = (
-        host_controller.mcp_runtime_status(project.resolve(), managed_python, account_commands)
-        if managed_python is not None else {"status": "recovery-required"}
-    )
-    mcp_status_value = str(mcp_status.get("status") or "recovery-required")
+    managed_python = resolve_managed_python(generation_path, account_commands)
+    if managed_python is None:
+        managed_python = heal_managed_python(
+            project.resolve(),
+            generation_path=generation_path,
+            account_commands=account_commands,
+        )
     components = result.get("components")
-    if mcp_status_value == "healthy":
-        pass
-    elif mcp_status_value in {"compatible-legacy", "degraded", "sync-advisory"}:
-        # Memory origin/main write gate during probe is advisory for required mcps
-        # (#5630); tool.py still hard-fails memory writes. Keep overall install
-        # verify from treating this alone as CE-INSTALL-FAILED recovery-required.
-        if isinstance(components, dict) and isinstance(components.get("mcps"), dict):
-            components["mcps"]["status"] = "compatible-legacy"
-            fix_next = mcp_status.get("fixNext")
-            detail = mcp_status.get("detail")
-            if isinstance(fix_next, str) and fix_next.strip():
-                components["mcps"]["detail"] = fix_next.strip()
-            elif isinstance(detail, str) and re.fullmatch(r"[a-z][a-z0-9-]{0,63}", detail):
-                components["mcps"]["detail"] = detail
-            code = mcp_status.get("code")
-            if isinstance(code, str) and re.fullmatch(r"[A-Z][A-Z0-9_]{0,63}", code):
-                components["mcps"]["code"] = code
+    if managed_python is None:
+        result["status"] = "recovery-required"
+        apply_managed_python_missing(components)
     else:
-        result["status"] = "recovery-required"
-        if isinstance(components, dict) and isinstance(components.get("mcps"), dict):
-            components["mcps"]["status"] = "recovery-required"
-            detail = mcp_status.get("detail")
-            if isinstance(detail, str) and re.fullmatch(r"[a-z][a-z0-9-]{0,63}", detail):
-                components["mcps"]["detail"] = detail
-    if managed_python is None or not host_controller.hook_runtime_healthy(
-        project.resolve(), managed_python
-    ):
-        result["status"] = "recovery-required"
-        components = result.get("components")
-        if isinstance(components, dict) and isinstance(components.get("hooks"), dict):
-            components["hooks"]["status"] = "recovery-required"
+        apply_mcp_doctor_status(
+            result,
+            components,
+            host_controller.mcp_runtime_status(
+                project.resolve(), managed_python, account_commands
+            ),
+        )
+        if not host_controller.hook_runtime_healthy(project.resolve(), managed_python):
+            apply_hooks_probe_failure(result, components)
     if not verify_clients:
         # Still attach activationProof from receipt when available (no live CLI probe).
         result.setdefault("activationProof", {})
@@ -4456,6 +4634,9 @@ def component_fix_next(name: str, item: dict[str, object]) -> str | None:
     impact = str(item.get("taskImpact") or "required")
     if status == "healthy" or (status == "absent" and impact == "optional"):
         return None
+    fix_next = item.get("fixNext")
+    if isinstance(fix_next, str) and fix_next.strip():
+        return fix_next.strip()
     detail = item.get("detail")
     if _looks_like_fix_next(detail):
         return str(detail).strip()
@@ -4469,6 +4650,14 @@ def component_fix_next(name: str, item: dict[str, object]) -> str | None:
         f"(or `{cli} .chaos-engine/bootstrap.py` from a source checkout), then "
         f"`{cli} .chaos-engine/install.py doctor --project .`."
     )
+    if code == MANAGED_PYTHON_MISSING_CODE or detail == MANAGED_PYTHON_MISSING_DETAIL:
+        return managed_python_missing_fix_next()
+    if code == HOOKS_PROBE_FAILED_CODE or detail == HOOKS_PROBE_FAILED_DETAIL:
+        return (
+            f"Run `{cli} .chaos-engine/install.py repair --project . --component hooks`, "
+            "reload/trust hooks in the active host, then "
+            f"`{cli} .chaos-engine/install.py doctor --project .`."
+        )
     if code == "CE_CORE_MISSING" or name == "core":
         return (
             "Rerun the ChaosEngine install one-liner to restore `.chaos-engine/` "

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "b8f892ef4b444d6ac7fbc72b097bcdd61f21c1f095437f1cf603789c8c3c90f5",
+      "harnessSha256": "e12c211315a74194e0f7d31ab9557caf16adfd782c18014a4ffc77ad5835bc2b",
       "treatmentSha256": {
-        "calibration": "43fd018273fc26e2957ffd76b61b949b3eb29ca80d22a5d9c09f6323fe9aef62",
-        "full-pilot": "b042694f63d7ea7520fc569d3029dc4ac5aa9bdf4103be0aa37534d945f6dbca"
+        "calibration": "3e7ae77782d64b45da475a05a452e2b0257d7d34a8e79f812a4f3beb7b8519fa",
+        "full-pilot": "3a98bd3d80e92711ef8a31212c472ac2507bdcc55b619004eb301642d3575298"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "b8f892ef4b444d6ac7fbc72b097bcdd61f21c1f095437f1cf603789c8c3c90f5"
+      harness_sha256: "e12c211315a74194e0f7d31ab9557caf16adfd782c18014a4ffc77ad5835bc2b"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "b8f892ef4b444d6ac7fbc72b097bcdd61f21c1f095437f1cf603789c8c3c90f5"
+      harness_sha256: "e12c211315a74194e0f7d31ab9557caf16adfd782c18014a4ffc77ad5835bc2b"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/tests/scripts/test_chaos_engine_installer.py
+++ b/tests/scripts/test_chaos_engine_installer.py
@@ -1921,6 +1921,283 @@ module.install_with_dependencies(project, source, "3" * 40)
                 str(retrieval_probe.call_args.args[1]["python3"]),
             )
 
+    def test_doctor_names_missing_managed_python_on_hooks_and_mcps(self):
+        """#5680 / #5667: never emit bare dual recovery-required without detail."""
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            MODULE.install_with_dependencies(
+                project,
+                SOURCE,
+                TEST_COMMIT,
+                provisioner=lambda *_args, **_kwargs: None,
+            )
+            hosts = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            original_load = MODULE.load_installed_controller
+            with mock.patch.object(
+                hosts, "retrieval_runtime_status", return_value={"status": "healthy"}
+            ), mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                side_effect=lambda root, name: (
+                    hosts if name == "hosts" else original_load(root, name)
+                ),
+            ):
+                result = MODULE.doctor_with_dependencies(project, verify_clients=False)
+
+            self.assertEqual("recovery-required", result["status"])
+            for name in ("hooks", "mcps"):
+                item = result["components"][name]
+                self.assertEqual("recovery-required", item["status"], name)
+                self.assertEqual("managed-python-missing", item.get("detail"), name)
+                self.assertEqual("CE_MANAGED_PYTHON_MISSING", item.get("code"), name)
+                fix = item.get("fixNext") or MODULE.component_fix_next(name, item)
+                self.assertIsInstance(fix, str, name)
+                self.assertTrue(fix.strip(), name)
+                self.assertIn("repair", fix.casefold())
+
+    def test_resolve_managed_python_falls_back_to_account_when_scripts_missing(self):
+        """Generation path alone must not skip account python when Scripts\\python.exe is gone."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            generation = root / "generation"
+            scripts = generation / "uv-tools/mempalace/Scripts"
+            scripts.mkdir(parents=True)
+            account_python = root / "account/python.exe"
+            account_python.parent.mkdir(parents=True)
+            account_python.write_text("fixture", encoding="utf-8")
+            resolved = MODULE.resolve_managed_python(
+                str(generation),
+                {"python3": str(account_python)},
+                windows=True,
+            )
+            self.assertEqual(account_python.resolve(), resolved)
+
+    def test_resolve_managed_python_prefers_existing_scripts_python_exe(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            generation = root / "generation"
+            scripts = generation / "uv-tools/mempalace/Scripts"
+            scripts.mkdir(parents=True)
+            interpreter = scripts / "python.exe"
+            interpreter.write_text("fixture", encoding="utf-8")
+            resolved = MODULE.resolve_managed_python(
+                str(generation),
+                {"python3": str(root / "other/python.exe")},
+                windows=True,
+            )
+            self.assertEqual(interpreter.resolve(), resolved)
+
+    def test_doctor_uses_account_python_when_generation_interpreter_missing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            project = root / "consumer"
+            project.mkdir()
+            account_python = root / "account/bin/python3"
+            account_python.parent.mkdir(parents=True)
+            account_python.write_text("fixture", encoding="utf-8")
+            generation = root / "generation"
+            (generation / "uv-tools/mempalace/bin").mkdir(parents=True)
+            load_controller = MODULE.load_dependency_controller
+
+            def load_account_controller(installed_root):
+                controller = AccountDependencyController(load_controller(installed_root))
+                install_account = controller.install_account_dependencies
+
+                def install_with_account_python(*args, **kwargs):
+                    receipt = install_account(*args, **kwargs)
+                    receipt["commands"]["python3"] = str(account_python.resolve())
+                    args[0].joinpath(".chaos-engine-dependencies.json").write_text(
+                        json.dumps(receipt), encoding="utf-8"
+                    )
+                    return receipt
+
+                controller.install_account_dependencies = install_with_account_python
+                return controller
+
+            with mock.patch.object(
+                MODULE, "load_dependency_controller", side_effect=load_account_controller
+            ):
+                MODULE.install_with_dependencies(project, SOURCE, TEST_COMMIT)
+
+            hosts = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            original_load = MODULE.load_installed_controller
+            with mock.patch.object(
+                hosts, "retrieval_runtime_status", return_value={"status": "healthy"}
+            ), mock.patch.object(
+                hosts,
+                "mcp_runtime_status",
+                return_value={"status": "healthy"},
+            ) as mcp_probe, mock.patch.object(
+                hosts, "hook_runtime_healthy", return_value=True
+            ) as hook_probe, mock.patch.object(
+                MODULE,
+                "resolve_managed_python",
+                wraps=MODULE.resolve_managed_python,
+            ), mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                side_effect=lambda root, name: (
+                    hosts if name == "hosts" else original_load(root, name)
+                ),
+            ), mock.patch.object(
+                MODULE,
+                "status_with_dependencies",
+                return_value={
+                    "status": "healthy",
+                    "commit": TEST_COMMIT,
+                    "distribution": "repository",
+                    "policySha256": "a" * 64,
+                    "kernel": {"status": "healthy"},
+                    "hosts": {"status": "healthy"},
+                    "dependencies": {
+                        "status": "healthy",
+                        "path": str(generation),
+                    },
+                    "components": {
+                        "hooks": {"status": "healthy", "taskImpact": "required"},
+                        "mcps": {"status": "healthy", "taskImpact": "required"},
+                        "memory": {"status": "healthy", "taskImpact": "required"},
+                    },
+                },
+            ):
+                # Re-read account commands from receipt written during install.
+                result = MODULE.doctor_with_dependencies(project, verify_clients=False)
+
+            self.assertNotEqual(
+                "managed-python-missing",
+                (result.get("components") or {}).get("hooks", {}).get("detail"),
+            )
+            self.assertEqual(
+                str(account_python.resolve()),
+                str(mcp_probe.call_args.args[1]),
+            )
+            self.assertEqual(
+                str(account_python.resolve()),
+                str(hook_probe.call_args.args[1]),
+            )
+
+    def test_doctor_keeps_memory_origin_main_desync_as_compatible_legacy_mcps(self):
+        """#5630 remains: Memory HEAD desync alone must not fail verify via mcps."""
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            account_python = Path(temporary) / "account/bin/python3"
+            account_python.parent.mkdir(parents=True)
+            account_python.write_text("fixture", encoding="utf-8")
+            load_controller = MODULE.load_dependency_controller
+
+            def load_account_controller(installed_root):
+                controller = AccountDependencyController(load_controller(installed_root))
+                install_account = controller.install_account_dependencies
+
+                def install_with_account_python(*args, **kwargs):
+                    receipt = install_account(*args, **kwargs)
+                    receipt["commands"]["python3"] = str(account_python.resolve())
+                    args[0].joinpath(".chaos-engine-dependencies.json").write_text(
+                        json.dumps(receipt), encoding="utf-8"
+                    )
+                    return receipt
+
+                controller.install_account_dependencies = install_with_account_python
+                return controller
+
+            with mock.patch.object(
+                MODULE, "load_dependency_controller", side_effect=load_account_controller
+            ):
+                MODULE.install_with_dependencies(project, SOURCE, TEST_COMMIT)
+
+            hosts = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            original_load = MODULE.load_installed_controller
+            with mock.patch.object(
+                hosts, "retrieval_runtime_status", return_value={"status": "healthy"}
+            ), mock.patch.object(
+                hosts,
+                "mcp_runtime_status",
+                return_value={
+                    "status": "compatible-legacy",
+                    "detail": "memory-origin-main-desync",
+                    "code": "CE_MEMORY_ORIGIN_MAIN_DESYNC",
+                    "fixNext": "git fetch origin main && git merge --ff-only origin/main",
+                },
+            ), mock.patch.object(
+                hosts, "hook_runtime_healthy", return_value=True
+            ), mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                side_effect=lambda root, name: (
+                    hosts if name == "hosts" else original_load(root, name)
+                ),
+            ):
+                result = MODULE.doctor_with_dependencies(project, verify_clients=False)
+
+            self.assertEqual(
+                "compatible-legacy", result["components"]["mcps"]["status"]
+            )
+            self.assertEqual(
+                "CE_MEMORY_ORIGIN_MAIN_DESYNC", result["components"]["mcps"].get("code")
+            )
+            self.assertNotEqual("recovery-required", result["components"]["mcps"]["status"])
+            self.assertNotEqual(
+                "recovery-required",
+                result["components"]["hooks"].get("status"),
+            )
+
+    def test_doctor_heal_restores_managed_python_before_naming_failure(self):
+        """Prefer one deterministic heal when the interpreter is missing (#5680)."""
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / "consumer"
+            project.mkdir()
+            MODULE.install_with_dependencies(
+                project,
+                SOURCE,
+                TEST_COMMIT,
+                provisioner=lambda *_args, **_kwargs: None,
+            )
+            healed = Path(temporary) / "healed/python"
+            healed.parent.mkdir(parents=True)
+            healed.write_text("fixture", encoding="utf-8")
+            hosts = MODULE.load_installed_controller(project / ".chaos-engine", "hosts")
+            original_load = MODULE.load_installed_controller
+            resolve_calls = {"n": 0}
+
+            def resolve_side_effect(*_args, **_kwargs):
+                resolve_calls["n"] += 1
+                if resolve_calls["n"] == 1:
+                    return None
+                return healed.resolve()
+
+            with mock.patch.object(
+                hosts, "retrieval_runtime_status", return_value={"status": "healthy"}
+            ), mock.patch.object(
+                hosts,
+                "mcp_runtime_status",
+                return_value={"status": "healthy"},
+            ) as mcp_probe, mock.patch.object(
+                hosts, "hook_runtime_healthy", return_value=True
+            ) as hook_probe, mock.patch.object(
+                MODULE, "resolve_managed_python", side_effect=resolve_side_effect
+            ), mock.patch.object(
+                MODULE,
+                "heal_managed_python",
+                return_value=healed.resolve(),
+            ) as heal, mock.patch.object(
+                MODULE,
+                "load_installed_controller",
+                side_effect=lambda root, name: (
+                    hosts if name == "hosts" else original_load(root, name)
+                ),
+            ):
+                result = MODULE.doctor_with_dependencies(project, verify_clients=False)
+
+            heal.assert_called_once()
+            self.assertNotEqual(
+                "managed-python-missing",
+                result["components"]["hooks"].get("detail"),
+            )
+            self.assertEqual(str(healed.resolve()), str(mcp_probe.call_args.args[1]))
+            self.assertEqual(str(healed.resolve()), str(hook_probe.call_args.args[1]))
+
     def test_status_maps_legacy_mempalace_classifier_without_launching(self):
         with tempfile.TemporaryDirectory() as temporary:
             project = Path(temporary).resolve() / "consumer"


### PR DESCRIPTION
## Summary

- Resolve managed MemPalace Python with an exists check, Windows `Scripts\python.exe` + PATHEXT variants, and account-receipt `python3` fallback (even when a generation path is present but the interpreter file is gone).
- Prefer one deterministic `repair --component tools` heal when a dependency surface exists, then re-resolve before probes.
- If still missing, mark both `hooks` and `mcps` `recovery-required` with `CE_MANAGED_PYTHON_MISSING` / `managed-python-missing` / `fixNext` (no bare dual fail). Failed hook probes get `CE_HOOKS_PROBE_FAILED`.
- Keep Memory `origin/main` desync as `compatible-legacy` for required `mcps` (#5630). Agent merge-handoff remains out of scope (#5679).

Fixes #5680
Fixes #5667

Refs epic #5669 (do not close).

## Proof

```text
python3 -m unittest \
  tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_doctor_names_missing_managed_python_on_hooks_and_mcps \
  tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_resolve_managed_python_falls_back_to_account_when_scripts_missing \
  tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_resolve_managed_python_prefers_existing_scripts_python_exe \
  tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_doctor_uses_account_python_when_generation_interpreter_missing \
  tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_doctor_heal_restores_managed_python_before_naming_failure \
  tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_doctor_keeps_memory_origin_main_desync_as_compatible_legacy_mcps \
  tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_doctor_uses_receipt_python_for_account_mcps_and_hooks \
  tests.scripts.test_chaos_engine_installer.ChaosEngineInstallerTest.test_doctor_rejects_an_mcp_runtime_that_cannot_initialize \
  tests.scripts.test_chaos_engine_installer_self_heal_5630 \
  -v
```

`python3 scripts/ci/validate_agent_setup.py --skip-external` — pass.
ChaosGauge digests refreshed after `install.py` change.

## Test plan

- [x] Focused installer doctor/resolve/heal unit tests
- [x] #5630 self-heal suite still green
- [ ] CI on this PR