### PR TITLE
docs(ce): add approved one-screen Scrum status report format

### DIFF
--- a/.chaos-engine/references/process-owner-scrum-master.md
+++ b/.chaos-engine/references/process-owner-scrum-master.md
@@ -42,6 +42,18 @@ MUST publish Evidence-backed status using artifacts, exit codes, logs, or
 diff observations. Status tables and handoffs reject narrative-only progress.
 Assignment alone is not progress.
 
+### Status report format
+
+When asked for a status report, keep it to one screen and use this shape:
+
+1. **RAG line** — `green` / `amber` / `red`, program name, and time.
+2. **Where we are** — one paragraph on current position.
+3. **Checklist** — sections `Done`, `In progress`, and `To do`.
+4. **Risks and Decisions** — close with open risks and decisions needed.
+
+Evidence still binds every claim. Do not invent scheduled routines for status;
+publish on ask or on the existing follow-through inspection cadence.
+
 ## Targeted research triggers
 
 Online research to optimize orchestrator or Scrum practice is allowed only for

--- a/.chaos-engine/references/roles.md
+++ b/.chaos-engine/references/roles.md
@@ -22,7 +22,8 @@ related work into the fewest PRs, and keeps working until in-scope work is
 delivered. Follow [orchestrator follow-through](orchestrator-follow-through.md).
 Load [process-owner / Scrum-master](process-owner-scrum-master.md) in
 orchestrated mode. Its standing Scrum-master duty is to automatically inspect
-and adapt live work on that policy's scope-selected cadence.
+and adapt live work on that policy's scope-selected cadence. Status reports
+use the [status report format](process-owner-scrum-master.md#status-report-format).
 
 ## Implementer
 

--- a/chaos-engine/references/process-owner-scrum-master.md
+++ b/chaos-engine/references/process-owner-scrum-master.md
@@ -42,6 +42,18 @@ MUST publish Evidence-backed status using artifacts, exit codes, logs, or
 diff observations. Status tables and handoffs reject narrative-only progress.
 Assignment alone is not progress.
 
+### Status report format
+
+When asked for a status report, keep it to one screen and use this shape:
+
+1. **RAG line** — `green` / `amber` / `red`, program name, and time.
+2. **Where we are** — one paragraph on current position.
+3. **Checklist** — sections `Done`, `In progress`, and `To do`.
+4. **Risks and Decisions** — close with open risks and decisions needed.
+
+Evidence still binds every claim. Do not invent scheduled routines for status;
+publish on ask or on the existing follow-through inspection cadence.
+
 ## Targeted research triggers
 
 Online research to optimize orchestrator or Scrum practice is allowed only for

--- a/chaos-engine/references/roles.md
+++ b/chaos-engine/references/roles.md
@@ -22,7 +22,8 @@ related work into the fewest PRs, and keeps working until in-scope work is
 delivered. Follow [orchestrator follow-through](orchestrator-follow-through.md).
 Load [process-owner / Scrum-master](process-owner-scrum-master.md) in
 orchestrated mode. Its standing Scrum-master duty is to automatically inspect
-and adapt live work on that policy's scope-selected cadence.
+and adapt live work on that policy's scope-selected cadence. Status reports
+use the [status report format](process-owner-scrum-master.md#status-report-format).
 
 ## Implementer
 

--- a/scripts/ci/chaos_gauge/experiment.json
+++ b/scripts/ci/chaos_gauge/experiment.json
@@ -68,10 +68,10 @@
       "effort": "medium",
       "repositoryRevision": "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c",
       "harness": "chaos-engine",
-      "harnessSha256": "b8f892ef4b444d6ac7fbc72b097bcdd61f21c1f095437f1cf603789c8c3c90f5",
+      "harnessSha256": "c7a14d9eb0fdefaab8995eb45cc8b0ddd4a33dcee6296ca93c246310873e38b7",
       "treatmentSha256": {
-        "calibration": "43fd018273fc26e2957ffd76b61b949b3eb29ca80d22a5d9c09f6323fe9aef62",
-        "full-pilot": "b042694f63d7ea7520fc569d3029dc4ac5aa9bdf4103be0aa37534d945f6dbca"
+        "calibration": "97ef746832be3fb981031c07f04d8f4c0734c69b7ce7a5c99b775dc1184507f4",
+        "full-pilot": "18a501491a3fef4caeb8d4a8b30e26238f5861f515fd2da2ccbfa251295d485a"
       },
       "imageDigest": "python:3.12.11-slim@sha256:47ae396f09c1303b8653019811a8498470603d7ffefc29cb07c88f1f8cb3d19f",
       "timeoutSeconds": 1800,

--- a/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/chaos-engine.yaml
@@ -23,7 +23,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "b8f892ef4b444d6ac7fbc72b097bcdd61f21c1f095437f1cf603789c8c3c90f5"
+      harness_sha256: "c7a14d9eb0fdefaab8995eb45cc8b0ddd4a33dcee6296ca93c246310873e38b7"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset

--- a/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
+++ b/scripts/ci/chaos_gauge/job-configs/full-pilot-chaos-engine.yaml
@@ -22,7 +22,7 @@ agents:
       reasoning_effort: medium
       harness_source: chaos-engine
       harness_commit: "0b148b6c14dd5ff4b5fdcd99169e2295ef56413c"
-      harness_sha256: "b8f892ef4b444d6ac7fbc72b097bcdd61f21c1f095437f1cf603789c8c3c90f5"
+      harness_sha256: "c7a14d9eb0fdefaab8995eb45cc8b0ddd4a33dcee6296ca93c246310873e38b7"
       adapter_sha256: "3d081c632519b2fb9d6df271b198e4e1404cfd26bc68072e3104131c352db3bd"
 datasets:
   - path: scripts/ci/chaos_gauge/dataset


### PR DESCRIPTION
## Summary
- Add the approved one-screen status-report format to `chaos-engine/references/process-owner-scrum-master.md` (mirrored in `.chaos-engine/`): RAG line (green/amber/red + program + time), one where-we-are paragraph, Done / In progress / To do checklists, then Risks and Decisions.
- Add a one-line pointer from `chaos-engine/references/roles.md` (Orchestrator → Scrum-master duty).
- Harness parity via portable overlay only. Explicitly no new scheduled routines for status.

## Test plan
- [x] `python3 -m unittest tests.scripts.test_process_owner_scrum_master -v`
- [x] `python3 scripts/ci/validate_agent_setup.py --skip-external`
- [ ] CI green; merge only with merge commits (`gh pr merge --auto --merge`) once checks pass